### PR TITLE
MM-452 Bounded remediation evidence bundles

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/226-canonical-remediation-submissions"
+  "feature_directory": "specs/227-remediation-evidence-bundles"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-451",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1674"
+  "jira_issue_key": "MM-452",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1677"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md
@@ -1,0 +1,67 @@
+# MM-452 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-452
+- Board scope: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Build bounded artifact-first remediation evidence bundles and tools
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: Synthesized from the trusted `jira.get_issue` MCP response because the response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-452 from MM board
+Summary: Build bounded artifact-first remediation evidence bundles and tools
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-452 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-452: Build bounded artifact-first remediation evidence bundles and tools
+
+User Story
+As a remediation runtime, I receive a bounded MoonMind-owned evidence bundle and typed evidence tools so I can diagnose a target execution without scraping UI pages or embedding unbounded logs in workflow history.
+
+Source Document
+docs/Tasks/TaskRemediation.md
+
+Source Title
+Task Remediation
+
+Source Sections
+- 9. Evidence and context model
+- 5.3 Control remains separate from observation
+- 6. Core invariants
+
+Coverage IDs
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+
+Acceptance Criteria
+- A remediation run receives a reports/remediation_context.json artifact containing the specified v1 schema fields and artifact_type remediation.context.
+- Full logs and diagnostics remain behind refs or typed read APIs; durable context contains only bounded summaries/excerpts.
+- Evidence tools can read referenced artifacts/logs through normal artifact and task-run policy checks.
+- Live follow is available only when target state, taskRunId support, and policy allow it; cursor state survives retries where possible.
+- When live follow is unavailable, the remediator can still diagnose from merged/stdout/stderr logs, diagnostics, summaries, and artifacts with evidence degradation recorded.
+- Before any side-effecting action request is submitted, the runtime re-reads current target health and target-change guard inputs.
+
+Requirements
+- The context builder is the stable entrypoint for target evidence.
+- Live logs are observation only and never the source of truth or control channel.
+- Missing evidence degrades the task rather than causing unbounded waits.
+
+Implementation Notes
+- Preserve MM-452 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Scope the implementation to bounded artifact-first remediation evidence bundles and typed evidence tool access.
+- Use existing task remediation, artifact, live log, diagnostics, task-run policy, and guard-input surfaces where possible.
+- Do not scrape UI pages, embed unbounded logs in workflow history, or treat live logs as a source of truth or control channel.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-452-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-452-code-review-transition.md
@@ -1,0 +1,24 @@
+# MM-452 Code Review Transition
+
+## Source
+
+- Jira issue: `MM-452`
+- Pull request handoff artifact: `artifacts/jira-orchestrate-pr.json`
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1677
+- Trusted tool surface: `MOONMIND_URL` `/mcp/tools`
+
+## Actions
+
+- Verified `artifacts/jira-orchestrate-pr.json` contains `jira_issue_key = MM-452` and a non-empty GitHub pull request URL.
+- Fetched MM-452 through `jira.get_issue`; current status before transition was `In Progress`.
+- Added a Jira-visible comment through `jira.add_comment`:
+  `Pull request for MM-452 is ready for Code Review: https://github.com/MoonLadderStudios/MoonMind/pull/1677`
+- Fetched available transitions through `jira.get_transitions`.
+- Matched `Code Review` against transition name and target status.
+- Applied transition id `51` through `jira.transition_issue`.
+- Re-fetched MM-452 through `jira.get_issue`.
+
+## Result
+
+- Confirmed Jira status: `Code Review`
+- Comment id: `10953`

--- a/moonmind/workflows/temporal/__init__.py
+++ b/moonmind/workflows/temporal/__init__.py
@@ -94,6 +94,7 @@ from moonmind.workflows.temporal.remediation_context import (
     RemediationContextError,
 )
 from moonmind.workflows.temporal.remediation_tools import (
+    RemediationActionRequestPreparation,
     RemediationEvidenceToolError,
     RemediationEvidenceToolService,
     RemediationLiveFollowEvent,
@@ -102,6 +103,7 @@ from moonmind.workflows.temporal.remediation_tools import (
     RemediationLogReadResult,
     RemediationLogReader,
     RemediationLogStream,
+    RemediationTargetHealthSnapshot,
 )
 from moonmind.workflows.temporal.service import (
     TemporalExecutionError,
@@ -149,6 +151,7 @@ __all__ = [
     "REMEDIATION_CONTEXT_ARTIFACT_NAME",
     "REMEDIATION_CONTEXT_LINK_TYPE",
     "REMEDIATION_CONTEXT_SCHEMA_VERSION",
+    "RemediationActionRequestPreparation",
     "RemediationContextBuildResult",
     "RemediationContextBuilder",
     "RemediationContextError",
@@ -160,6 +163,7 @@ __all__ = [
     "RemediationLogReadResult",
     "RemediationLogReader",
     "RemediationLogStream",
+    "RemediationTargetHealthSnapshot",
     "SANDBOX_FLEET",
     "SANDBOX_TASK_QUEUE",
     "S3TemporalArtifactStore",

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -56,6 +56,30 @@ class RemediationLiveFollowResult:
     resume_cursor: dict[str, Any] | None
 
 
+@dataclass(frozen=True, slots=True)
+class RemediationTargetHealthSnapshot:
+    """Fresh bounded target health used to guard side-effecting action requests."""
+
+    workflow_id: str
+    pinned_run_id: str
+    current_run_id: str
+    state: str
+    close_status: str | None
+    title: str | None
+    summary: str | None
+    target_run_changed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationActionRequestPreparation:
+    """Side-effect-free pre-action read of current target health."""
+
+    remediation_workflow_id: str
+    action_kind: str
+    target: RemediationTargetHealthSnapshot
+    context_target: dict[str, Any]
+
+
 class RemediationLogReader(Protocol):
     """Read bounded historical logs for a target task run."""
 
@@ -240,6 +264,59 @@ class RemediationEvidenceToolService:
             await self._cursor_recorder(link.remediation_workflow_id, result.resume_cursor)
         return result
 
+    async def prepare_action_request(
+        self,
+        *,
+        remediation_workflow_id: str,
+        action_kind: str,
+        principal: str = "service:remediation-tools",
+    ) -> RemediationActionRequestPreparation:
+        """Re-read current target health before a side-effecting action request.
+
+        This method does not execute actions. It provides the typed freshness guard
+        that action submission code must consume before invoking any future
+        side-effecting remediation action surface.
+        """
+
+        normalized_action_kind = _required_string(action_kind, "actionKind")
+        link = await self._load_link(remediation_workflow_id)
+        context = await self._read_context_payload(link=link, principal=principal)
+        target = await self._session.get(
+            db_models.TemporalExecutionCanonicalRecord,
+            link.target_workflow_id,
+        )
+        if target is None:
+            raise RemediationEvidenceToolError(
+                f"Target execution {link.target_workflow_id} was not found."
+            )
+        context_target = context.get("target")
+        context_target_mapping = (
+            dict(context_target) if isinstance(context_target, Mapping) else {}
+        )
+        return RemediationActionRequestPreparation(
+            remediation_workflow_id=link.remediation_workflow_id,
+            action_kind=normalized_action_kind,
+            target=RemediationTargetHealthSnapshot(
+                workflow_id=target.workflow_id,
+                pinned_run_id=link.target_run_id,
+                current_run_id=target.run_id,
+                state=_enum_value(target.state) or "",
+                close_status=_enum_value(target.close_status),
+                title=_string_or_none(
+                    target.memo.get("title")
+                    if isinstance(target.memo, Mapping)
+                    else None
+                ),
+                summary=_string_or_none(
+                    target.memo.get("summary")
+                    if isinstance(target.memo, Mapping)
+                    else None
+                ),
+                target_run_changed=target.run_id != link.target_run_id,
+            ),
+            context_target=context_target_mapping,
+        )
+
     async def _load_link(
         self, remediation_workflow_id: str
     ) -> db_models.TemporalExecutionRemediationLink:
@@ -420,7 +497,15 @@ def _string_or_none(value: Any) -> str | None:
     return normalized or None
 
 
+def _enum_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", value)
+    return _string_or_none(enum_value)
+
+
 __all__ = [
+    "RemediationActionRequestPreparation",
     "RemediationEvidenceToolError",
     "RemediationEvidenceToolService",
     "RemediationLiveFollowEvent",
@@ -429,4 +514,5 @@ __all__ = [
     "RemediationLogReadResult",
     "RemediationLogReader",
     "RemediationLogStream",
+    "RemediationTargetHealthSnapshot",
 ]

--- a/specs/227-remediation-evidence-bundles/checklists/requirements.md
+++ b/specs/227-remediation-evidence-bundles/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Remediation Evidence Bundles
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request. The brief points to `docs/Tasks/TaskRemediation.md`, which is treated as runtime source requirements.
+- Existing adjacent feature directories `specs/221-remediation-context-artifacts` and `specs/222-remediation-evidence-tools` are completed for prior Jira slices, but no valid MM-452 feature directory existed, so orchestration resumed from the Specify stage.

--- a/specs/227-remediation-evidence-bundles/contracts/remediation-evidence-bundles.md
+++ b/specs/227-remediation-evidence-bundles/contracts/remediation-evidence-bundles.md
@@ -1,0 +1,29 @@
+# Contract: Remediation Evidence Bundles
+
+## Service Boundary
+
+`RemediationEvidenceToolService` exposes the trusted remediation evidence boundary:
+
+- `get_context(remediation_workflow_id, principal?) -> dict`
+- `read_target_artifact(remediation_workflow_id, artifact_ref, principal?) -> bytes`
+- `read_target_logs(remediation_workflow_id, task_run_id, stream, cursor?, tail_lines?, principal?) -> RemediationLogReadResult`
+- `follow_target_logs(remediation_workflow_id, task_run_id?, from_sequence?, principal?) -> RemediationLiveFollowResult`
+- `prepare_action_request(remediation_workflow_id, action_kind, principal?) -> RemediationActionRequestPreparation`
+
+## Preconditions
+
+- A `TemporalExecutionRemediationLink` exists for the remediation workflow.
+- A linked `remediation.context` artifact exists before evidence reads.
+- Artifact/log/live-follow reads are limited to context-declared refs and taskRunIds.
+- `prepare_action_request` validates the same linked context before reading current target health.
+
+## Failure Behavior
+
+- Missing links, missing context artifacts, invalid context artifacts, target mismatches, undeclared refs, unsupported streams, unsupported live follow, and missing target records fail fast with `RemediationEvidenceToolError`.
+- Missing optional evidence is represented as bounded degradation in the context, not as an unbounded wait.
+
+## Non-Goals
+
+- No raw storage access.
+- No raw shell, SQL, Docker, or credential access.
+- No side-effecting action execution registry in this story.

--- a/specs/227-remediation-evidence-bundles/data-model.md
+++ b/specs/227-remediation-evidence-bundles/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Remediation Evidence Bundles
+
+## Remediation Context Artifact
+
+- `schemaVersion`: context schema version, currently `v1`.
+- `remediationWorkflowId`: remediation execution identity.
+- `target`: pinned target workflow/run identity plus current-at-build title, summary, state, and close status.
+- `selectedSteps`: bounded selected step/task-run selectors.
+- `evidence`: context-declared artifact refs and taskRunIds.
+- `liveFollow`: optional follow mode, support flag, taskRunId, and resume cursor.
+- `policies`: authority, action, evidence, approval, and lock policy snapshots.
+- `boundedness`: explicit max tail lines/taskRunIds and flags proving raw bodies are excluded.
+
+Validation rules:
+- Must be linked to the remediation execution as `remediation.context`.
+- Must not include raw log bodies, artifact contents, presigned URLs, storage keys, local paths, or secret-like raw fields.
+- Must bound taskRunIds and tail lines.
+
+## Evidence Reference
+
+- `artifact_id`/`artifactId`: artifact identifier, not a storage grant.
+- `taskRunId`: task-run identifier declared by the context.
+- `kind`: optional semantic marker such as input or target evidence.
+
+Validation rules:
+- Reads are allowed only when refs are declared in the linked context.
+- Artifact and task-run policy checks still apply.
+
+## Live Follow Cursor
+
+- `sequence`: last observed event sequence.
+
+Validation rules:
+- Used only when live follow is supported and policy-allowed.
+- Cursor is compact and persisted outside raw log bodies.
+
+## Target Health Guard Snapshot
+
+- `workflow_id`: target execution identity.
+- `pinned_run_id`: run ID persisted on the remediation link.
+- `current_run_id`: current run ID from the target execution projection.
+- `state`: current target state.
+- `close_status`: current target close status.
+- `title` and `summary`: bounded current target display context.
+- `target_run_changed`: true when current run differs from the pinned run.
+
+Validation rules:
+- Must be read from current target state immediately before action request preparation.
+- Does not execute the action.

--- a/specs/227-remediation-evidence-bundles/plan.md
+++ b/specs/227-remediation-evidence-bundles/plan.md
@@ -20,13 +20,13 @@ Implement MM-452 by treating the existing remediation context builder and typed 
 | FR-007 | implemented_verified | undeclared evidence rejection and no raw privileged surface | preserve | focused unit |
 | FR-008 | implemented_verified | live-follow gating by supported/mode/taskRunId | preserve | focused unit |
 | FR-009 | implemented_verified | live-follow cursor recorder and unsupported follow rejection | preserve | focused unit |
-| FR-010 | missing | no pre-action health guard existed before this story | add side-effect-free preparation method | focused unit |
+| FR-010 | implemented_verified | `RemediationEvidenceToolService.prepare_action_request`; focused guard test | no new implementation | focused unit |
 | FR-011 | implemented_verified | sanitized context assertions and restricted artifact metadata | preserve | focused unit |
 | FR-012 | implemented_verified | missing target and optional evidence degradation tests | preserve | focused unit |
 | SC-001-SC-005 | implemented_verified | existing context/evidence unit tests | preserve | focused unit |
-| SC-006 | missing | no test asserted current target health re-read | add focused unit | focused unit |
-| SC-007 | implemented_unverified | MM-452 preserved in new spec only | preserve across all artifacts and final report | traceability check |
-| DESIGN-REQ-006-DESIGN-REQ-009 | partial | context/tool surfaces exist; freshness guard missing | add guard and verification evidence | focused unit |
+| SC-006 | implemented_verified | `test_remediation_evidence_tools_prepare_action_request_rereads_target_health` | no new implementation | focused unit |
+| SC-007 | implemented_verified | MM-452 preserved in spec, plan, tasks, quickstart, and verification | no new implementation | traceability check |
+| DESIGN-REQ-006-DESIGN-REQ-009 | implemented_verified | context/tool surfaces plus freshness guard test | no new implementation | focused unit |
 | DESIGN-REQ-022-DESIGN-REQ-023 | implemented_verified | policy-mediated evidence access and bounded degradation tests | preserve | focused unit |
 
 ## Technical Context

--- a/specs/227-remediation-evidence-bundles/plan.md
+++ b/specs/227-remediation-evidence-bundles/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Remediation Evidence Bundles
+
+**Branch**: `227-remediation-evidence-bundles` | **Date**: 2026-04-22 | **Spec**: `specs/227-remediation-evidence-bundles/spec.md`
+**Input**: Single-story runtime feature specification from `specs/227-remediation-evidence-bundles/spec.md`, generated from the MM-452 Jira preset brief in `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md`.
+
+## Summary
+
+Implement MM-452 by treating the existing remediation context builder and typed evidence tool service as the artifact-first evidence boundary, then adding the missing side-effect guard read before action submission. Existing slices already generate bounded `remediation.context` artifacts and typed artifact/log/live-follow reads. The remaining runtime work is a side-effect-free `prepare_action_request` path that validates the linked context and re-reads current target health plus pinned-vs-current run identity before any future action executor submits work.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `RemediationContextBuilder.build_context`, existing context tests | preserve | focused unit |
+| FR-002 | implemented_verified | context payload assertions for target, selectors, policies, liveFollow | preserve | focused unit |
+| FR-003 | implemented_verified | context payload uses refs and boundedness flags | preserve | focused unit |
+| FR-004 | implemented_verified | tail/task-run clamps and sanitized policy payload | preserve | focused unit |
+| FR-005 | implemented_verified | `RemediationEvidenceToolService` context/artifact/log/live-follow methods | preserve | focused unit |
+| FR-006 | implemented_verified | link/context checks, declared artifact/taskRunId checks | preserve | focused unit |
+| FR-007 | implemented_verified | undeclared evidence rejection and no raw privileged surface | preserve | focused unit |
+| FR-008 | implemented_verified | live-follow gating by supported/mode/taskRunId | preserve | focused unit |
+| FR-009 | implemented_verified | live-follow cursor recorder and unsupported follow rejection | preserve | focused unit |
+| FR-010 | missing | no pre-action health guard existed before this story | add side-effect-free preparation method | focused unit |
+| FR-011 | implemented_verified | sanitized context assertions and restricted artifact metadata | preserve | focused unit |
+| FR-012 | implemented_verified | missing target and optional evidence degradation tests | preserve | focused unit |
+| SC-001-SC-005 | implemented_verified | existing context/evidence unit tests | preserve | focused unit |
+| SC-006 | missing | no test asserted current target health re-read | add focused unit | focused unit |
+| SC-007 | implemented_unverified | MM-452 preserved in new spec only | preserve across all artifacts and final report | traceability check |
+| DESIGN-REQ-006-DESIGN-REQ-009 | partial | context/tool surfaces exist; freshness guard missing | add guard and verification evidence | focused unit |
+| DESIGN-REQ-022-DESIGN-REQ-023 | implemented_verified | policy-mediated evidence access and bounded degradation tests | preserve | focused unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, existing Temporal artifact service, remediation link/context models  
+**Storage**: Existing `TemporalExecutionRemediationLink`, `TemporalExecutionCanonicalRecord`, and Temporal artifact tables only; no new persistent tables  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+**Integration Testing**: `./tools/test_integration.sh` for compose-backed `integration_ci` where Docker is available  
+**Target Platform**: MoonMind Temporal control-plane/runtime service boundary  
+**Project Type**: Python service modules plus unit/integration tests  
+**Performance Goals**: Evidence context and guard reads stay bounded and ref-based; no unbounded log or artifact bodies in workflow history  
+**Constraints**: No raw Jira credentials, no raw storage paths/URLs/secrets in durable evidence, no action execution registry in this story, no new tables  
+**Scale/Scope**: One independently testable remediation runtime evidence story
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Adds a thin MoonMind evidence/guard boundary over existing runtime records.
+- II. One-Click Agent Deployment: PASS. No new service dependency.
+- III. Avoid Vendor Lock-In: PASS. No provider-specific behavior.
+- IV. Own Your Data: PASS. Evidence remains MoonMind-owned artifacts and projections.
+- V. Skills Are First-Class: PASS. The typed service boundary is reusable by remediation skills.
+- VI. Replaceability: PASS. The guard is a compact service method, not a cognitive scaffold.
+- VII. Runtime Configurability: PASS. Evidence and action policy refs remain payload/context-driven.
+- VIII. Modular Architecture: PASS. Changes stay in remediation temporal boundary modules and tests.
+- IX. Resilient by Default: PASS. Missing evidence and target records fail fast or degrade explicitly.
+- X. Continuous Improvement: PASS. Verification artifacts record remaining risk and evidence.
+- XI. Spec-Driven Development: PASS. MM-452 artifacts define and trace the work.
+- XII. Docs Separation: PASS. Jira input and implementation plan stay under `docs/tmp` and `specs/`.
+- XIII. Pre-release Compatibility: PASS. Adds the canonical guard surface without compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/227-remediation-evidence-bundles/
+├── checklists/requirements.md
+├── contracts/remediation-evidence-bundles.md
+├── data-model.md
+├── plan.md
+├── quickstart.md
+├── research.md
+├── spec.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── remediation_context.py
+├── remediation_tools.py
+└── __init__.py
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+```
+
+**Structure Decision**: Extend the existing Temporal remediation context/evidence service modules because MM-452 is a runtime boundary story, not a new API transport or storage subsystem.
+
+## Complexity Tracking
+
+None.

--- a/specs/227-remediation-evidence-bundles/quickstart.md
+++ b/specs/227-remediation-evidence-bundles/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Remediation Evidence Bundles
+
+## Focused Unit Verification
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Expected result:
+- Python remediation context/evidence tests pass.
+- Frontend unit phase invoked by the unit runner passes.
+
+## Traceability Check
+
+```bash
+rg -n "MM-452|DESIGN-REQ-006|DESIGN-REQ-007|DESIGN-REQ-008|DESIGN-REQ-009|DESIGN-REQ-022|DESIGN-REQ-023|prepare_action_request" specs/227-remediation-evidence-bundles docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md moonmind/workflows/temporal/remediation_tools.py tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Expected result:
+- MM-452 appears in source artifacts.
+- All source design IDs are preserved.
+- The pre-action target health guard is present in code and tests.
+
+## Integration Verification
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected result when Docker is available:
+- Compose-backed `integration_ci` suite passes.

--- a/specs/227-remediation-evidence-bundles/research.md
+++ b/specs/227-remediation-evidence-bundles/research.md
@@ -1,0 +1,41 @@
+# Research: Remediation Evidence Bundles
+
+## Classification
+
+Decision: MM-452 is a single-story runtime feature request.
+Evidence: The Jira brief has one actor, one goal, one source document, and one bounded acceptance set around remediation evidence bundles and tools.
+Rationale: It does not require story splitting; the source design path is an implementation design document but the selected mode is runtime, so it is treated as source requirements.
+Alternatives considered: Treating `docs/Tasks/TaskRemediation.md` as broad design was rejected because the Jira brief selected only sections 5.3, 6, and 9 with a single remediation runtime story.
+Test implications: Unit tests cover the service boundary; integration verification remains the compose-backed suite when available.
+
+## Existing Context Builder
+
+Decision: Context artifact generation is implemented and verified.
+Evidence: `moonmind/workflows/temporal/remediation_context.py`; `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_context_builder_creates_bounded_linked_artifact`.
+Rationale: The builder creates `reports/remediation_context.json`, links it to the remediation execution, records the link ref, clamps evidence hints, filters unsafe refs, and stores compact metadata.
+Alternatives considered: Rebuilding the context artifact path was rejected because existing MM-432 work is complete and matches MM-452's artifact-first entrypoint.
+Test implications: Keep existing unit coverage in the focused command.
+
+## Existing Typed Evidence Tools
+
+Decision: Context reads, target artifact reads, bounded log reads, and live follow are implemented and verified.
+Evidence: `moonmind/workflows/temporal/remediation_tools.py`; tests for declared artifact/log access and live-follow gating/cursor handoff.
+Rationale: The service requires a linked context artifact, validates context target identity, allows only context-declared artifacts/taskRunIds, clamps tail lines, and records live-follow cursors.
+Alternatives considered: Adding a new transport was rejected; docs allow internal APIs, activities, or MCP tools, and the service boundary is sufficient for this runtime story.
+Test implications: Existing unit tests remain the primary proof for FR-005 through FR-009.
+
+## Pre-Action Freshness Guard
+
+Decision: Add a side-effect-free `prepare_action_request` method.
+Evidence: Before this story, no remediation evidence service method re-read target health and pinned-vs-current run identity before action submission.
+Rationale: MM-452 explicitly requires re-reading current target health and target-change guard inputs before side-effecting actions. A preparation method satisfies the guard without introducing the out-of-scope action execution registry.
+Alternatives considered: Implementing action execution was rejected because action execution is outside MM-452 and would expand scope beyond evidence bundles/tools.
+Test implications: Add a focused unit test proving target state/run changes after context creation are reflected in the preparation result.
+
+## Validation Strategy
+
+Decision: Run the focused unit runner for remediation context/evidence behavior and record compose-backed integration as not run unless Docker is available.
+Evidence: The affected code is a service boundary already covered by async DB/artifact tests.
+Rationale: The focused unit file exercises persistence, artifact service behavior, policy checks, and guard reads without requiring external credentials.
+Alternatives considered: Full integration suite was deferred unless Docker is available because the change does not alter HTTP routing or Temporal workflow signatures.
+Test implications: Final verification must include the focused unit command and note integration status explicitly.

--- a/specs/227-remediation-evidence-bundles/spec.md
+++ b/specs/227-remediation-evidence-bundles/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Remediation Evidence Bundles
+
+**Feature Branch**: `227-remediation-evidence-bundles`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-452 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-452 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-452
+- Board scope: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Build bounded artifact-first remediation evidence bundles and tools
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: Synthesized from the trusted `jira.get_issue` MCP response because the response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-452 from MM board
+Summary: Build bounded artifact-first remediation evidence bundles and tools
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-452 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-452: Build bounded artifact-first remediation evidence bundles and tools
+
+User Story
+As a remediation runtime, I receive a bounded MoonMind-owned evidence bundle and typed evidence tools so I can diagnose a target execution without scraping UI pages or embedding unbounded logs in workflow history.
+
+Source Document
+docs/Tasks/TaskRemediation.md
+
+Source Title
+Task Remediation
+
+Source Sections
+- 9. Evidence and context model
+- 5.3 Control remains separate from observation
+- 6. Core invariants
+
+Coverage IDs
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+
+Acceptance Criteria
+- A remediation run receives a reports/remediation_context.json artifact containing the specified v1 schema fields and artifact_type remediation.context.
+- Full logs and diagnostics remain behind refs or typed read APIs; durable context contains only bounded summaries/excerpts.
+- Evidence tools can read referenced artifacts/logs through normal artifact and task-run policy checks.
+- Live follow is available only when target state, taskRunId support, and policy allow it; cursor state survives retries where possible.
+- When live follow is unavailable, the remediator can still diagnose from merged/stdout/stderr logs, diagnostics, summaries, and artifacts with evidence degradation recorded.
+- Before any side-effecting action request is submitted, the runtime re-reads current target health and target-change guard inputs.
+
+Requirements
+- The context builder is the stable entrypoint for target evidence.
+- Live logs are observation only and never the source of truth or control channel.
+- Missing evidence degrades the task rather than causing unbounded waits.
+
+Implementation Notes
+- Preserve MM-452 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Scope the implementation to bounded artifact-first remediation evidence bundles and typed evidence tool access.
+- Use existing task remediation, artifact, live log, diagnostics, task-run policy, and guard-input surfaces where possible.
+- Do not scrape UI pages, embed unbounded logs in workflow history, or treat live logs as a source of truth or control channel.
+
+Needs Clarification
+- None
+```
+
+## User Story - Diagnose From Bounded Remediation Evidence
+
+**Summary**: As a remediation runtime, I want a bounded MoonMind-owned evidence bundle and typed evidence tools so that I can diagnose a target execution without scraping UI pages or embedding unbounded logs in workflow history.
+
+**Goal**: A remediation run starts diagnosis from a durable `remediation.context` artifact and can read only referenced artifacts and logs through typed, policy-checked evidence tools, with live follow used only as an optional observation surface.
+
+**Independent Test**: Create or simulate a target execution and linked remediation execution, generate the remediation context, then verify the runtime can read the context, declared artifacts, bounded logs, and optional live-follow data while undeclared evidence, unsupported live follow, raw storage access, and stale side-effect assumptions are rejected or degraded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run with a valid target link, **When** evidence preparation runs, **Then** it receives a `reports/remediation_context.json` artifact with `artifact_type` `remediation.context` before diagnosis begins.
+2. **Given** the context references target artifacts or task-run logs, **When** the remediation runtime reads evidence, **Then** typed evidence tools allow only context-declared refs through normal artifact and task-run policy checks.
+3. **Given** target logs or diagnostics are large, **When** durable context is created, **Then** full bodies remain behind refs or typed read APIs and the context stores only bounded summaries, excerpts, selectors, and policies.
+4. **Given** the target supports live follow and policy allows it, **When** the runtime follows logs, **Then** the follow operation returns resumable cursor state without treating the live stream as the source of truth.
+5. **Given** live follow is unavailable, unsupported, or policy-blocked, **When** diagnosis begins, **Then** the runtime can still use merged/stdout/stderr logs, diagnostics, summaries, and artifacts with explicit evidence degradation recorded.
+6. **Given** the runtime is about to request a side-effecting action, **When** it prepares the action request, **Then** it re-reads the current bounded target health and target-change guard inputs instead of acting only on the pinned context snapshot.
+
+### Edge Cases
+
+- Missing optional artifact refs or diagnostics are recorded as bounded degradation rather than causing unbounded waits.
+- Requests for undeclared artifacts or taskRunIds are rejected even if the caller knows a real identifier.
+- Live follow requests fail fast when the target state, taskRunId support, cursor, or policy does not allow follow.
+- Durable context and tool responses never expose presigned URLs, raw storage keys, absolute local filesystem paths, raw credentials, or unbounded log bodies.
+- The log timeline is never accepted as a control channel for intervention.
+
+## Assumptions
+
+- The MM-452 story intentionally spans the already separated context-builder and evidence-tool runtime surfaces because the Jira brief asks for artifact-first bundles and typed evidence access as one operator-visible remediation capability.
+- Side-effecting administrative action execution remains outside this story, except for verifying the required fresh target-health and target-change guard read before action requests.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-006** (`docs/Tasks/TaskRemediation.md` section 9.2): Remediation diagnosis must start from a MoonMind-owned `reports/remediation_context.json` artifact with type `remediation.context`. Scope: in scope, mapped to FR-001 and FR-002.
+- **DESIGN-REQ-007** (`docs/Tasks/TaskRemediation.md` sections 6 and 9.4): Large logs, diagnostics, provider snapshots, and evidence bodies must stay behind refs or observability APIs rather than entering workflow history or durable context unbounded. Scope: in scope, mapped to FR-003 and FR-004.
+- **DESIGN-REQ-008** (`docs/Tasks/TaskRemediation.md` section 9.5): Remediation runtimes must use typed MoonMind-owned evidence tools instead of scraping Mission Control pages or receiving raw storage access. Scope: in scope, mapped to FR-005, FR-006, and FR-007.
+- **DESIGN-REQ-009** (`docs/Tasks/TaskRemediation.md` sections 5.3, 9.6, and 9.7): Live logs are passive observation only; live follow is optional and resumable when allowed, and side-effecting action requests must re-read current target health and target-change guards before acting. Scope: in scope, mapped to FR-008, FR-009, and FR-010.
+- **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` sections 6 and 9.5): Evidence access must remain server-mediated through artifact/task-run policy checks and must not expose presigned URLs, raw storage keys, raw local paths, or secrets. Scope: in scope, mapped to FR-006 and FR-011.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` section 6): Failure to resolve evidence must degrade, escalate, or fail with a bounded reason rather than waiting indefinitely. Scope: in scope, mapped to FR-012.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a remediation context preparation path that creates or resolves a `reports/remediation_context.json` artifact before remediation diagnosis begins.
+- **FR-002**: The context artifact MUST identify itself as `artifact_type` `remediation.context` and include the target identity, selected evidence selectors, compact summaries, policy snapshots, and live-follow cursor state when available.
+- **FR-003**: The durable context MUST keep full logs, diagnostics, provider snapshots, and evidence bodies behind artifact refs or typed observability refs.
+- **FR-004**: The durable context MUST include only bounded summaries, excerpts, selectors, policies, and refs for large evidence.
+- **FR-005**: The system MUST expose typed evidence operations for reading the remediation context, referenced target artifacts, bounded target logs, and optional live target logs.
+- **FR-006**: Evidence operations MUST enforce the persisted remediation link, context-declared evidence refs, taskRunId selectors, and normal artifact/task-run policy checks before returning data.
+- **FR-007**: Evidence operations MUST reject undeclared artifacts, undeclared taskRunIds, raw storage access, raw host shell access, raw SQL access, raw Docker access, and raw credential access.
+- **FR-008**: Live follow MUST be available only when the target is follow-capable, the selected taskRunId supports follow, and policy allows follow.
+- **FR-009**: Live follow results MUST include resumable cursor state when follow succeeds and MUST degrade to bounded artifact/log evidence when follow is unavailable.
+- **FR-010**: Before submitting any side-effecting action request, the runtime MUST re-read current target health and target-change guard inputs.
+- **FR-011**: Durable context and evidence responses MUST NOT expose presigned URLs, raw storage keys, absolute local filesystem paths, raw credentials, secret-bearing config bundles, or unbounded log bodies.
+- **FR-012**: Missing optional evidence, unavailable diagnostics, historical merged-log-only evidence, and unavailable live follow MUST produce explicit bounded degradation or fail-fast validation rather than unbounded waits.
+
+### Key Entities
+
+- **Remediation Context Artifact**: A bounded artifact-first bundle that gives remediation runtimes stable target identity, selectors, refs, summaries, policies, and live-follow cursor state.
+- **Evidence Reference**: A context-declared artifact or task-run reference that can be read only through server-mediated policy checks.
+- **Live Follow Cursor**: A compact resume marker that lets live observation continue across retries without storing raw log bodies in durable context.
+- **Target Health Guard Snapshot**: A fresh bounded view of target status and change guards read immediately before side-effecting action requests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove a remediation run receives a `remediation.context` artifact before diagnosis and that the artifact is linked to the remediation execution.
+- **SC-002**: Tests prove context payloads and durable workflow data contain refs and bounded summaries rather than raw logs, storage paths, URLs, secrets, or unbounded diagnostics.
+- **SC-003**: Tests prove evidence tools allow declared artifact/log reads and reject undeclared artifact IDs and taskRunIds.
+- **SC-004**: Tests prove live follow succeeds only under target, taskRunId, and policy support and returns cursor state when supported.
+- **SC-005**: Tests prove unavailable live follow and missing optional evidence produce explicit bounded degradation or fail-fast validation.
+- **SC-006**: Tests prove side-effecting action request preparation re-reads current target health or target-change guards before any action is submitted.
+- **SC-007**: Traceability verification confirms MM-452 and DESIGN-REQ-006 through DESIGN-REQ-009, DESIGN-REQ-022, and DESIGN-REQ-023 are preserved in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/227-remediation-evidence-bundles/tasks.md
+++ b/specs/227-remediation-evidence-bundles/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Remediation Evidence Bundles
+
+**Input**: `specs/227-remediation-evidence-bundles/spec.md`  
+**Plan**: `specs/227-remediation-evidence-bundles/plan.md`  
+**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`  
+**Integration Test Command**: `./tools/test_integration.sh`
+
+## Source Traceability
+
+MM-452 is preserved in `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md` and `spec.md`. Tasks cover FR-001 through FR-012, SC-001 through SC-007, and DESIGN-REQ-006 through DESIGN-REQ-009, DESIGN-REQ-022, and DESIGN-REQ-023.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm MM-452 source input and classify it as a single-story runtime request in `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md` and `specs/227-remediation-evidence-bundles/spec.md`.
+- [X] T002 Inspect adjacent completed MoonSpec artifacts `specs/221-remediation-context-artifacts` and `specs/222-remediation-evidence-tools` before planning new work.
+- [X] T003 Review source design sections 5.3, 6, and 9 in `docs/Tasks/TaskRemediation.md`.
+
+## Phase 2: Foundational
+
+- [X] T004 Confirm existing remediation context and evidence tool boundaries in `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py`.
+- [X] T005 Confirm existing focused test harness in `tests/unit/workflows/temporal/test_remediation_context.py`.
+
+## Phase 3: Story
+
+Story: A remediation runtime diagnoses from bounded artifact-first evidence and typed evidence tools, and re-reads current target health before side-effecting action requests.
+
+- [X] T006 Verify existing context artifact tests cover FR-001 through FR-004, FR-011, FR-012, SC-001, SC-002, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-022, and DESIGN-REQ-023 in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [X] T007 Verify existing typed evidence tests cover FR-005 through FR-009, SC-003, SC-004, DESIGN-REQ-008, and live-follow portions of DESIGN-REQ-009 in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [X] T008 Add failing unit coverage for pre-action current target health and target-change guard reads in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, SC-006, and DESIGN-REQ-009.
+- [X] T009 Implement `RemediationActionRequestPreparation` and `RemediationTargetHealthSnapshot` in `moonmind/workflows/temporal/remediation_tools.py`.
+- [X] T010 Implement `RemediationEvidenceToolService.prepare_action_request` in `moonmind/workflows/temporal/remediation_tools.py` to validate linked context and re-read current target health without executing actions.
+- [X] T011 Export the preparation and target-health models from `moonmind/workflows/temporal/__init__.py`.
+
+## Phase 4: Alignment And Verification
+
+- [X] T012 Run focused unit verification for remediation context/evidence behavior.
+- [X] T013 Run traceability check for MM-452 and source design IDs across specs, Jira input, code, and tests.
+- [X] T014 Record final verification evidence in `specs/227-remediation-evidence-bundles/verification.md`.
+
+## Dependencies And Order
+
+T001-T003 precede planning and implementation. T008 must fail or identify the missing guard before T009-T011. T012-T014 run after implementation.
+
+## Parallel Work
+
+T006 and T007 can be reviewed in parallel because they inspect existing verified behavior. T009 and T011 touch different files but T011 depends on the public names introduced by T009.

--- a/specs/227-remediation-evidence-bundles/tasks.md
+++ b/specs/227-remediation-evidence-bundles/tasks.md
@@ -24,23 +24,30 @@ MM-452 is preserved in `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orche
 
 Story: A remediation runtime diagnoses from bounded artifact-first evidence and typed evidence tools, and re-reads current target health before side-effecting action requests.
 
+Independent test: Create or simulate a target execution and linked remediation execution, generate the remediation context, then verify declared context/artifact/log/live-follow reads and pre-action target-health guard behavior while rejecting undeclared or unsafe evidence.
+
+Unit test plan: Use `tests/unit/workflows/temporal/test_remediation_context.py` for context generation, typed evidence access, live-follow gating, and pre-action guard behavior.
+
+Integration test plan: Use `./tools/test_integration.sh` for compose-backed `integration_ci` validation when Docker is available; if Docker is unavailable in the managed container, record the exact blocker in `verification.md`.
+
 - [X] T006 Verify existing context artifact tests cover FR-001 through FR-004, FR-011, FR-012, SC-001, SC-002, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-022, and DESIGN-REQ-023 in `tests/unit/workflows/temporal/test_remediation_context.py`.
 - [X] T007 Verify existing typed evidence tests cover FR-005 through FR-009, SC-003, SC-004, DESIGN-REQ-008, and live-follow portions of DESIGN-REQ-009 in `tests/unit/workflows/temporal/test_remediation_context.py`.
 - [X] T008 Add failing unit coverage for pre-action current target health and target-change guard reads in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, SC-006, and DESIGN-REQ-009.
-- [X] T009 Implement `RemediationActionRequestPreparation` and `RemediationTargetHealthSnapshot` in `moonmind/workflows/temporal/remediation_tools.py`.
-- [X] T010 Implement `RemediationEvidenceToolService.prepare_action_request` in `moonmind/workflows/temporal/remediation_tools.py` to validate linked context and re-read current target health without executing actions.
-- [X] T011 Export the preparation and target-health models from `moonmind/workflows/temporal/__init__.py`.
+- [X] T009 Confirm compose-backed integration validation path or blocker for `./tools/test_integration.sh` in `specs/227-remediation-evidence-bundles/verification.md` covering acceptance scenarios 1-6.
+- [X] T010 Implement `RemediationActionRequestPreparation` and `RemediationTargetHealthSnapshot` in `moonmind/workflows/temporal/remediation_tools.py`.
+- [X] T011 Implement `RemediationEvidenceToolService.prepare_action_request` in `moonmind/workflows/temporal/remediation_tools.py` to validate linked context and re-read current target health without executing actions.
+- [X] T012 Export the preparation and target-health models from `moonmind/workflows/temporal/__init__.py`.
 
 ## Phase 4: Alignment And Verification
 
-- [X] T012 Run focused unit verification for remediation context/evidence behavior.
-- [X] T013 Run traceability check for MM-452 and source design IDs across specs, Jira input, code, and tests.
-- [X] T014 Record final verification evidence in `specs/227-remediation-evidence-bundles/verification.md`.
+- [X] T013 Run focused unit verification for remediation context/evidence behavior.
+- [X] T014 Run traceability check for MM-452 and source design IDs across specs, Jira input, code, and tests.
+- [X] T015 Run final `/moonspec-verify` and record verification evidence in `specs/227-remediation-evidence-bundles/verification.md`.
 
 ## Dependencies And Order
 
-T001-T003 precede planning and implementation. T008 must fail or identify the missing guard before T009-T011. T012-T014 run after implementation.
+T001-T003 precede planning and implementation. T008 must fail or identify the missing guard before T010-T012. T009 records integration availability before final verification. T013-T015 run after implementation.
 
 ## Parallel Work
 
-T006 and T007 can be reviewed in parallel because they inspect existing verified behavior. T009 and T011 touch different files but T011 depends on the public names introduced by T009.
+T006 and T007 can be reviewed in parallel because they inspect existing verified behavior. T010 and T012 touch different files but T012 depends on the public names introduced by T010.

--- a/specs/227-remediation-evidence-bundles/verification.md
+++ b/specs/227-remediation-evidence-bundles/verification.md
@@ -1,0 +1,53 @@
+# Verification: Remediation Evidence Bundles
+
+**Date**: 2026-04-22
+**Verdict**: FULLY_IMPLEMENTED
+**Original Request Source**: `spec.md` `Input`, MM-452 Jira preset brief, and `docs/tmp/jira-orchestration-inputs/MM-452-moonspec-orchestration-input.md`
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` | PASS | 6 Python remediation tests passed; frontend unit phase also passed with 11 files / 361 tests. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3734 Python tests, 16 subtests, and 361 frontend tests passed on rerun. |
+| Integration | `./tools/test_integration.sh` | NOT RUN | Docker socket is unavailable in this managed container: `/var/run/docker.sock` does not exist. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001-FR-004 | `RemediationContextBuilder`; `test_remediation_context_builder_creates_bounded_linked_artifact` | VERIFIED | Context artifact is created, linked, bounded, and ref-based. |
+| FR-005-FR-007 | `RemediationEvidenceToolService`; `test_remediation_evidence_tools_read_only_context_declared_evidence` | VERIFIED | Typed reads require linked context and declared refs/taskRunIds. |
+| FR-008-FR-009 | `follow_target_logs`; `test_remediation_evidence_tools_gate_live_follow_by_context_policy` | VERIFIED | Live follow is policy/context gated and returns cursor handoff. |
+| FR-010 | `prepare_action_request`; `test_remediation_evidence_tools_prepare_action_request_rereads_target_health` | VERIFIED | Current target health and pinned-vs-current run identity are re-read before action request preparation. |
+| FR-011-FR-012 | Context builder sanitization and missing-target tests | VERIFIED | Unsafe raw access is excluded; missing evidence/target cases are bounded failures. |
+
+## Source Design Coverage
+
+| Source ID | Evidence | Status |
+| --- | --- | --- |
+| DESIGN-REQ-006 | `reports/remediation_context.json` artifact generation and tests | VERIFIED |
+| DESIGN-REQ-007 | Bounded refs/summaries and raw-body exclusion assertions | VERIFIED |
+| DESIGN-REQ-008 | Typed context/artifact/log/live-follow service methods and tests | VERIFIED |
+| DESIGN-REQ-009 | Live follow as observation plus `prepare_action_request` freshness guard | VERIFIED |
+| DESIGN-REQ-022 | Server-mediated artifact/log policy checks and no raw storage access | VERIFIED |
+| DESIGN-REQ-023 | Missing evidence degradation and fail-fast validation | VERIFIED |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status |
+| --- | --- | --- |
+| Context artifact before diagnosis | Context builder test | VERIFIED |
+| Typed reads for declared refs | Evidence read test | VERIFIED |
+| Large evidence behind refs | Context payload/boundedness assertions | VERIFIED |
+| Optional live follow with cursor | Live-follow test | VERIFIED |
+| Live follow unavailable degradation | Context default unsupported state and live-follow rejection | VERIFIED |
+| Pre-action target health re-read | Action preparation test | VERIFIED |
+
+## Constitution
+
+All relevant constitution checks remain PASS: no new storage, no raw credential exposure, no workflow payload expansion, no compatibility alias, and no docs/tmp migration narrative added to canonical docs.
+
+## Residual Risk
+
+The new action preparation method is a guard surface only; the future side-effecting action executor must consume it before submitting actions.

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import (
     Base,
+    MoonMindWorkflowState,
     TemporalArtifactLink,
     TemporalArtifactStatus,
     TemporalExecutionCanonicalRecord,
@@ -614,6 +615,100 @@ async def test_remediation_evidence_tools_gate_live_follow_by_context_policy(
             await tools.follow_target_logs(
                 remediation_workflow_id=remediation.workflow_id,
                 task_run_id="tr_other",
+            )
+
+
+@pytest.mark.asyncio
+async def test_remediation_evidence_tools_prepare_action_request_rereads_target_health(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        mock_client_adapter.start_workflow.side_effect = [
+            SimpleNamespace(run_id="target-run"),
+            SimpleNamespace(run_id="remediation-run"),
+        ]
+        execution_service = TemporalExecutionService(
+            session, client_adapter=mock_client_adapter
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        target = await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target before action",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+            summary="Initial target summary",
+        )
+        remediation = await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {
+                    "remediation": {
+                        "target": {
+                            "workflowId": target.workflow_id,
+                            "taskRunIds": ["tr_action"],
+                        },
+                        "actionPolicyRef": "admin_healer_default",
+                    },
+                }
+            },
+            idempotency_key=None,
+        )
+        builder = RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        await builder.build_context(remediation_workflow_id=remediation.workflow_id)
+
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.run_id = "target-run-after-context"
+        target_source.state = MoonMindWorkflowState.EXECUTING
+        target_source.memo = {
+            **target_source.memo,
+            "summary": "Fresh target summary",
+        }
+        await session.commit()
+
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        preparation = await tools.prepare_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="terminate_session",
+        )
+
+        assert preparation.remediation_workflow_id == remediation.workflow_id
+        assert preparation.action_kind == "terminate_session"
+        assert preparation.context_target["runId"] == "target-run"
+        assert preparation.target.workflow_id == target.workflow_id
+        assert preparation.target.pinned_run_id == "target-run"
+        assert preparation.target.current_run_id == "target-run-after-context"
+        assert preparation.target.target_run_changed is True
+        assert preparation.target.state == "executing"
+        assert preparation.target.summary == "Fresh target summary"
+
+        with pytest.raises(RemediationEvidenceToolError, match="actionKind is required"):
+            await tools.prepare_action_request(
+                remediation_workflow_id=remediation.workflow_id,
+                action_kind=" ",
             )
 
 


### PR DESCRIPTION
## Summary
- Jira issue: MM-452
- Active MoonSpec feature path: specs/227-remediation-evidence-bundles
- Preserve the MM-452 Jira preset brief as the canonical MoonSpec input.
- Add bounded remediation action preparation that re-reads current target health and target-change guard inputs before side-effecting action requests.
- Add unit coverage for the pre-action target health reread behavior and export the new remediation evidence models.

## MoonSpec Verification
- Verification verdict: FULLY_IMPLEMENTED
- Spec: specs/227-remediation-evidence-bundles/spec.md
- Verification report: specs/227-remediation-evidence-bundles/verification.md

## Tests Run
- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
- NOT RUN: ./tools/test_integration.sh because Docker socket is unavailable in the managed container (/var/run/docker.sock does not exist).

## Remaining Risks
- Integration verification is still pending in an environment with Docker access.
- The new action preparation method is a guard surface only; future side-effecting action execution must consume it before submitting remediation actions.