### PR TITLE
MM-453 Enforce remediation authority boundaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/227-remediation-evidence-bundles"
+  "feature_directory": "specs/228-remediation-authority-boundaries"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-452",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1677"
+  "jira_issue_key": "MM-453",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1679"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,37 @@
 [
   {
-    "id": 3122397775,
+    "id": 3122759438,
     "disposition": "addressed",
-    "rationale": "Allowed known service-managed preview_artifact_id metadata during report link validation and added a regression for linking restricted report artifacts after preview creation."
+    "rationale": "Changed remediation action idempotency caching to include request-shaping fields so a reused key with a different action kind or dry-run flag is evaluated independently."
   },
   {
-    "id": 4152948692,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary without a distinct actionable request."
-  },
-  {
-    "id": 3122402310,
+    "id": 3122759452,
     "disposition": "addressed",
-    "rationale": "Simplified top-level report metadata validation by removing the redundant post-whitelist secret-key check while preserving unsafe unknown-key rejection."
+    "rationale": "Added explicit supported authority mode validation so stale or unknown stored authority modes are denied before any allow path."
   },
   {
-    "id": 4152954022,
+    "id": 4153367196,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary; its single actionable item is tracked by comment 3122402310."
+    "rationale": "Automated review summary only; the actionable child review comments are classified separately."
+  },
+  {
+    "id": 3122774747,
+    "disposition": "addressed",
+    "rationale": "Guarded the admin-auto risk comparison so malformed catalog entries with null risk do not raise KeyError."
+  },
+  {
+    "id": 3122774771,
+    "disposition": "addressed",
+    "rationale": "Updated the absolute-path redaction regex to cover single-segment absolute paths and removed the redundant optional segment."
+  },
+  {
+    "id": 4153386617,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary only; the actionable child review comments are classified separately."
+  },
+  {
+    "id": 3122774796,
+    "disposition": "addressed",
+    "rationale": "Added a defensive null guard after sensitive-text redaction before applying regex substitutions."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-453-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-453-moonspec-orchestration-input.md
@@ -1,0 +1,89 @@
+# MM-453 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-453
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Enforce remediation authority modes, permissions, and redaction boundaries
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-453 from MM project
+Summary: Enforce remediation authority modes, permissions, and redaction boundaries
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-453 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-453: Enforce remediation authority modes, permissions, and redaction boundaries
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 10. Security and authority model
+  - 6. Core invariants
+  - 4. Non-goals
+- Coverage IDs:
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+  - DESIGN-REQ-024
+
+User Story
+As a platform security owner, I can configure remediation authority through explicit modes, permissions, and named security profiles so privileged troubleshooting never implies raw host access or secret disclosure.
+
+Acceptance Criteria
+- `observe_only` remediation can read evidence and produce diagnoses but cannot execute side-effecting actions.
+- `approval_gated` remediation can propose or dry-run actions but requires recorded approval before side effects.
+- `admin_auto` remediation can execute only allowlisted actions within policy and still respects high-risk approval rules.
+- Audit records include both requesting user/workflow and the execution principal used for privileged actions.
+- A user with target view permission alone cannot launch admin remediation or approve high-risk actions.
+- Generated context, logs, summaries, diagnostics, and artifacts do not contain raw secrets or durable raw storage/file access material.
+
+Requirements
+- Authority is policy/profile based, not implicit root or ordinary runtime access.
+- Unauthorized direct fetches do not leak execution existence.
+- Secret redaction rules apply even to admin remediation.
+
+Relevant Implementation Notes
+- Preserve MM-453 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation authority modes, permission boundaries, redaction behavior, and non-goals.
+- Model remediation authority with explicit modes: `observe_only`, `approval_gated`, and `admin_auto`.
+- Elevated remediation must execute through a named admin remediation principal or security profile rather than the ordinary user runtime.
+- Distinguish permissions to view a target execution, create a remediation task, request an admin remediation profile, approve high-risk actions, and inspect remediation audit history.
+- Keep administrative actions typed and allowlisted; remediation must not imply arbitrary host shell access, Docker daemon access, SQL/database editing, or any command the model suggests.
+- Keep evidence, artifact, and log access server-mediated through refs, read capability handles, redacted previews, or typed observability APIs.
+- Never place raw secrets, presigned storage URLs, storage backend keys, absolute local filesystem paths, or raw secret-bearing config bundles in durable remediation context, logs, summaries, diagnostics, or artifacts.
+- Ensure side-effecting remediation actions are idempotent or safely keyed, and keep high-risk actions subject to explicit approval policy even under `admin_auto`.
+- Preserve redaction-safe visibility: unauthorized direct fetches must not leak execution existence, and admin remediation artifacts must still follow redaction-safe display rules.
+
+Non-Goals
+- Arbitrary raw shell access on the MoonMind host.
+- Unrestricted Docker daemon access from the remediation runtime.
+- Arbitrary SQL or direct database row editing by the agent.
+- Silent import of another task's entire workflow history into `initialParameters`.
+- Cross-task managed-session reuse.
+- Treating every failed task as automatically eligible for an admin healer.
+- Bypassing the Secrets System or artifact redaction rules.
+- Treating Live Logs as the source of truth or as a control channel.
+
+Validation
+- Verify each supported authority mode enforces its side-effect permissions: `observe_only`, `approval_gated`, and `admin_auto`.
+- Verify side-effecting actions require recorded approval when policy or risk classification requires it.
+- Verify audit records include both the requesting user or workflow and the execution principal/security profile used for privileged actions.
+- Verify target view permission alone is insufficient to launch admin remediation or approve high-risk actions.
+- Verify generated context, logs, summaries, diagnostics, and artifacts redact raw secrets and do not expose durable raw storage or filesystem access material.
+- Verify unauthorized direct fetches do not leak execution existence.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-453 blocks MM-452, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-453 is blocked by MM-454, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-453-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-453-code-review-transition.md
@@ -1,0 +1,27 @@
+# MM-453 Code Review Transition
+
+Date: 2026-04-22
+
+## Pull Request Gate
+
+- Handoff artifact: `artifacts/jira-orchestrate-pr.json`
+- Confirmed Jira issue key: `MM-453`
+- Confirmed pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1679
+
+## Jira Tool Evidence
+
+- Trusted tool surface: `MOONMIND_URL` `/mcp/tools`
+- Trusted issue fetch tool: `jira.get_issue`
+- Initial status from trusted fetch: `In Progress`
+- Trusted transition discovery tool: `jira.get_transitions`
+- Matched requested status `Code Review` against available transition name and target status.
+- Selected transition ID from Jira response: `51`
+- Added Jira-visible pull request reference with `jira.add_comment`; comment ID `10955`.
+- Applied transition with trusted transition tool: `jira.transition_issue`.
+- Re-fetched `MM-453` with `jira.get_issue`.
+- Confirmed final status: `Code Review`
+
+## Notes
+
+- No raw Jira credentials were used.
+- The issue was not transitioned until after the PR URL was confirmed in the local handoff artifact.

--- a/moonmind/workflows/temporal/__init__.py
+++ b/moonmind/workflows/temporal/__init__.py
@@ -93,6 +93,14 @@ from moonmind.workflows.temporal.remediation_context import (
     RemediationContextBuilder,
     RemediationContextError,
 )
+from moonmind.workflows.temporal.remediation_actions import (
+    RemediationActionAuthorityResult,
+    RemediationActionAuthorityService,
+    RemediationActionDecision,
+    RemediationActionRisk,
+    RemediationPermissionSet,
+    RemediationSecurityProfile,
+)
 from moonmind.workflows.temporal.remediation_tools import (
     RemediationActionRequestPreparation,
     RemediationEvidenceToolError,
@@ -151,7 +159,11 @@ __all__ = [
     "REMEDIATION_CONTEXT_ARTIFACT_NAME",
     "REMEDIATION_CONTEXT_LINK_TYPE",
     "REMEDIATION_CONTEXT_SCHEMA_VERSION",
+    "RemediationActionAuthorityResult",
+    "RemediationActionAuthorityService",
+    "RemediationActionDecision",
     "RemediationActionRequestPreparation",
+    "RemediationActionRisk",
     "RemediationContextBuildResult",
     "RemediationContextBuilder",
     "RemediationContextError",
@@ -163,6 +175,8 @@ __all__ = [
     "RemediationLogReadResult",
     "RemediationLogReader",
     "RemediationLogStream",
+    "RemediationPermissionSet",
+    "RemediationSecurityProfile",
     "RemediationTargetHealthSnapshot",
     "SANDBOX_FLEET",
     "SANDBOX_TASK_QUEUE",

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -1,0 +1,515 @@
+"""Remediation action authority decisions.
+
+This module intentionally evaluates whether a remediation action may proceed; it
+does not execute host, container, SQL, provider, or storage operations.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db import models as db_models
+from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
+
+RemediationActionRisk = Literal["low", "medium", "high"]
+RemediationActionDecision = Literal[
+    "allowed",
+    "approval_required",
+    "dry_run_only",
+    "denied",
+]
+
+_RISK_ORDER: dict[str, int] = {"low": 1, "medium": 2, "high": 3}
+_RAW_ACCESS_ACTION_KINDS = frozenset(
+    {
+        "raw_host_shell",
+        "host_shell",
+        "docker_daemon",
+        "raw_docker",
+        "sql_database",
+        "raw_sql",
+        "storage_key_read",
+        "raw_storage",
+    }
+)
+_ACTION_CATALOG: dict[str, dict[str, Any]] = {
+    "restart_worker": {"risk": "medium", "enabled": True},
+    "terminate_session": {"risk": "high", "enabled": True},
+}
+_DEFAULT_AUTO_ALLOWED_RISK = "medium"
+_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"(?:/[A-Za-z0-9._:@+-]+){2,}(?:/[A-Za-z0-9._:@+-]+)?"
+)
+_PRESIGNED_URL_PATTERN = re.compile(
+    r"https?://[^\s\"']*(?:token|signature|x-amz-signature|credential)[^\s\"']*",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationPermissionSet:
+    """Compact caller permissions for remediation action decisions."""
+
+    can_view_target: bool = False
+    can_create_remediation: bool = False
+    can_request_admin_profile: bool = False
+    can_approve_high_risk: bool = False
+    can_inspect_audit: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationSecurityProfile:
+    """Named elevated execution identity used for privileged remediation."""
+
+    profile_ref: str
+    execution_principal: str
+    allowed_action_kinds: Sequence[str] = field(default_factory=tuple)
+    enabled: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationActionAuthorityResult:
+    """Result of evaluating one remediation action request."""
+
+    remediation_workflow_id: str
+    target_workflow_id: str | None
+    authority_mode: str | None
+    action_kind: str
+    risk: RemediationActionRisk | None
+    decision: RemediationActionDecision
+    reason: str
+    idempotency_key: str
+    security_profile_ref: str | None
+    approval_ref: str | None
+    executable: bool
+    redacted_parameters: Mapping[str, Any]
+    audit: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "remediationWorkflowId": self.remediation_workflow_id,
+            "targetWorkflowId": self.target_workflow_id,
+            "authorityMode": self.authority_mode,
+            "actionKind": self.action_kind,
+            "risk": self.risk,
+            "decision": self.decision,
+            "reason": self.reason,
+            "idempotencyKey": self.idempotency_key,
+            "securityProfileRef": self.security_profile_ref,
+            "approvalRef": self.approval_ref,
+            "executable": self.executable,
+            "redactedParameters": dict(self.redacted_parameters),
+            "audit": dict(self.audit),
+        }
+
+
+class RemediationActionAuthorityService:
+    """Evaluate remediation action requests against authority boundaries."""
+
+    def __init__(self, *, session: AsyncSession) -> None:
+        self._session = session
+        self._decisions: dict[tuple[str, str], RemediationActionAuthorityResult] = {}
+
+    async def evaluate_action_request(
+        self,
+        *,
+        remediation_workflow_id: str,
+        action_kind: str,
+        parameters: Mapping[str, Any] | None,
+        dry_run: bool,
+        idempotency_key: str,
+        requesting_principal: str,
+        permissions: RemediationPermissionSet,
+        security_profile: RemediationSecurityProfile | None = None,
+        approval_ref: str | None = None,
+    ) -> RemediationActionAuthorityResult:
+        workflow_id = str(remediation_workflow_id or "").strip()
+        idem = str(idempotency_key or "").strip()
+        normalized_action = str(action_kind or "").strip()
+        cache_key = (workflow_id, idem)
+        if workflow_id and idem and cache_key in self._decisions:
+            return self._decisions[cache_key]
+
+        if not workflow_id:
+            return self._result(
+                remediation_workflow_id="",
+                target_workflow_id=None,
+                authority_mode=None,
+                action_kind=normalized_action,
+                risk=None,
+                decision="denied",
+                reason="remediation_workflow_id_required",
+                idempotency_key=idem,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if not idem:
+            return self._result(
+                remediation_workflow_id=workflow_id,
+                target_workflow_id=None,
+                authority_mode=None,
+                action_kind=normalized_action,
+                risk=None,
+                decision="denied",
+                reason="idempotency_key_required",
+                idempotency_key=idem,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+
+        link = await self._session.get(
+            db_models.TemporalExecutionRemediationLink,
+            workflow_id,
+        )
+        if link is None:
+            result = self._result(
+                remediation_workflow_id=workflow_id,
+                target_workflow_id=None,
+                authority_mode=None,
+                action_kind=normalized_action,
+                risk=None,
+                decision="denied",
+                reason="remediation_link_not_found",
+                idempotency_key=idem,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+                summary="Remediation link was not found.",
+            )
+            self._decisions[cache_key] = result
+            return result
+
+        result = self._evaluate_with_link(
+            link=link,
+            action_kind=normalized_action,
+            parameters=parameters,
+            dry_run=dry_run,
+            idempotency_key=idem,
+            requesting_principal=requesting_principal,
+            permissions=permissions,
+            security_profile=security_profile,
+            approval_ref=approval_ref,
+        )
+        self._decisions[cache_key] = result
+        return result
+
+    def _evaluate_with_link(
+        self,
+        *,
+        link: db_models.TemporalExecutionRemediationLink,
+        action_kind: str,
+        parameters: Mapping[str, Any] | None,
+        dry_run: bool,
+        idempotency_key: str,
+        requesting_principal: str,
+        permissions: RemediationPermissionSet,
+        security_profile: RemediationSecurityProfile | None,
+        approval_ref: str | None,
+    ) -> RemediationActionAuthorityResult:
+        authority_mode = str(link.authority_mode or "observe_only").strip()
+        action_info = _ACTION_CATALOG.get(action_kind)
+        raw_access = action_kind in _RAW_ACCESS_ACTION_KINDS or action_kind.startswith(
+            "raw_"
+        )
+        risk = (
+            action_info.get("risk")
+            if action_info is not None and action_info.get("risk") in _RISK_ORDER
+            else None
+        )
+
+        if raw_access:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="raw_access_action_denied",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if not action_kind or action_info is None or not action_info.get("enabled", False):
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="unsupported_action_kind",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if not permissions.can_view_target:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="target_view_permission_required",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if dry_run:
+            decision: RemediationActionDecision = (
+                "dry_run_only" if authority_mode == "observe_only" else "allowed"
+            )
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision=decision,
+                reason="dry_run",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if authority_mode == "observe_only":
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="observe_only_rejects_side_effects",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+
+        profile_error = _security_profile_error(
+            security_profile=security_profile,
+            permissions=permissions,
+            action_kind=action_kind,
+        )
+        if profile_error is not None:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason=profile_error,
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+
+        if authority_mode == "approval_gated" and not approval_ref:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="approval_required",
+                reason="approval_gated_requires_approval",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if risk == "high" and not approval_ref:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="approval_required",
+                reason="high_risk_requires_approval",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        if approval_ref and risk == "high" and not permissions.can_approve_high_risk:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="high_risk_approval_permission_required",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+
+        auto_allowed_risk = _DEFAULT_AUTO_ALLOWED_RISK
+        if authority_mode == "admin_auto" and not approval_ref:
+            if _RISK_ORDER[str(risk)] > _RISK_ORDER[auto_allowed_risk]:
+                return self._linked_result(
+                    link=link,
+                    action_kind=action_kind,
+                    risk=risk,
+                    decision="approval_required",
+                    reason="risk_exceeds_auto_policy",
+                    idempotency_key=idempotency_key,
+                    requesting_principal=requesting_principal,
+                    security_profile=security_profile,
+                    approval_ref=approval_ref,
+                    parameters=parameters,
+                )
+
+        return self._linked_result(
+            link=link,
+            action_kind=action_kind,
+            risk=risk,
+            decision="allowed",
+            reason="allowed",
+            idempotency_key=idempotency_key,
+            requesting_principal=requesting_principal,
+            security_profile=security_profile,
+            approval_ref=approval_ref,
+            parameters=parameters,
+        )
+
+    def _linked_result(
+        self,
+        *,
+        link: db_models.TemporalExecutionRemediationLink,
+        action_kind: str,
+        risk: RemediationActionRisk | None,
+        decision: RemediationActionDecision,
+        reason: str,
+        idempotency_key: str,
+        requesting_principal: str,
+        security_profile: RemediationSecurityProfile | None,
+        approval_ref: str | None,
+        parameters: Mapping[str, Any] | None,
+    ) -> RemediationActionAuthorityResult:
+        return self._result(
+            remediation_workflow_id=link.remediation_workflow_id,
+            target_workflow_id=link.target_workflow_id,
+            authority_mode=link.authority_mode,
+            action_kind=action_kind,
+            risk=risk,
+            decision=decision,
+            reason=reason,
+            idempotency_key=idempotency_key,
+            requesting_principal=requesting_principal,
+            security_profile=security_profile,
+            approval_ref=approval_ref,
+            parameters=parameters,
+        )
+
+    @staticmethod
+    def _result(
+        *,
+        remediation_workflow_id: str,
+        target_workflow_id: str | None,
+        authority_mode: str | None,
+        action_kind: str,
+        risk: RemediationActionRisk | None,
+        decision: RemediationActionDecision,
+        reason: str,
+        idempotency_key: str,
+        requesting_principal: str,
+        security_profile: RemediationSecurityProfile | None,
+        approval_ref: str | None,
+        parameters: Mapping[str, Any] | None,
+        summary: str | None = None,
+    ) -> RemediationActionAuthorityResult:
+        redacted_parameters = _redact_payload(parameters or {})
+        execution_principal = (
+            security_profile.execution_principal if security_profile else None
+        )
+        audit = {
+            "requestingPrincipal": _redact_text(requesting_principal),
+            "executionPrincipal": _redact_text(execution_principal),
+            "decision": decision,
+            "reason": reason,
+            "summary": _redact_text(
+                summary or f"{action_kind or 'action'} decision: {reason}"
+            ),
+        }
+        return RemediationActionAuthorityResult(
+            remediation_workflow_id=remediation_workflow_id,
+            target_workflow_id=target_workflow_id,
+            authority_mode=authority_mode,
+            action_kind=action_kind,
+            risk=risk,
+            decision=decision,
+            reason=reason,
+            idempotency_key=idempotency_key,
+            security_profile_ref=security_profile.profile_ref
+            if security_profile
+            else None,
+            approval_ref=approval_ref,
+            executable=decision == "allowed",
+            redacted_parameters=redacted_parameters,
+            audit=audit,
+        )
+
+
+def _security_profile_error(
+    *,
+    security_profile: RemediationSecurityProfile | None,
+    permissions: RemediationPermissionSet,
+    action_kind: str,
+) -> str | None:
+    if not permissions.can_request_admin_profile:
+        return "admin_profile_permission_required"
+    if security_profile is None:
+        return "security_profile_required"
+    if not security_profile.enabled:
+        return "security_profile_disabled"
+    if action_kind not in set(security_profile.allowed_action_kinds):
+        return "security_profile_action_not_allowed"
+    return None
+
+
+def _redact_payload(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    redacted = redact_sensitive_payload(value)
+    if isinstance(redacted, Mapping):
+        return _scrub_paths(redacted)
+    return {}
+
+
+def _scrub_paths(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, Mapping):
+        return {str(key): _scrub_paths(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_scrub_paths(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_paths(item) for item in value)
+    return value
+
+
+def _redact_text(value: str | None) -> str:
+    redacted = redact_sensitive_text(value)
+    redacted = _PRESIGNED_URL_PATTERN.sub("[REDACTED_URL]", redacted)
+    redacted = _ABSOLUTE_PATH_PATTERN.sub("[REDACTED_PATH]", redacted)
+    return redacted
+
+
+__all__ = [
+    "RemediationActionAuthorityResult",
+    "RemediationActionAuthorityService",
+    "RemediationActionDecision",
+    "RemediationActionRisk",
+    "RemediationPermissionSet",
+    "RemediationSecurityProfile",
+]

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -42,8 +42,11 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
     "terminate_session": {"risk": "high", "enabled": True},
 }
 _DEFAULT_AUTO_ALLOWED_RISK = "medium"
+_SUPPORTED_AUTHORITY_MODES = frozenset(
+    {"observe_only", "approval_gated", "admin_auto"}
+)
 _ABSOLUTE_PATH_PATTERN = re.compile(
-    r"(?:/[A-Za-z0-9._:@+-]+){2,}(?:/[A-Za-z0-9._:@+-]+)?"
+    r"/(?:[A-Za-z0-9._:@+-]+/)*[A-Za-z0-9._:@+-]+"
 )
 _PRESIGNED_URL_PATTERN = re.compile(
     r"https?://[^\s\"']*(?:token|signature|x-amz-signature|credential)[^\s\"']*",
@@ -131,7 +134,7 @@ class RemediationActionAuthorityService:
         workflow_id = str(remediation_workflow_id or "").strip()
         idem = str(idempotency_key or "").strip()
         normalized_action = str(action_kind or "").strip()
-        cache_key = (workflow_id, idem)
+        cache_key = (workflow_id, idem, normalized_action, dry_run)
         if workflow_id and idem and cache_key in self._decisions:
             return self._decisions[cache_key]
 
@@ -266,6 +269,19 @@ class RemediationActionAuthorityService:
                 approval_ref=approval_ref,
                 parameters=parameters,
             )
+        if authority_mode not in _SUPPORTED_AUTHORITY_MODES:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="unsupported_authority_mode",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
         if dry_run:
             decision: RemediationActionDecision = (
                 "dry_run_only" if authority_mode == "observe_only" else "allowed"
@@ -357,7 +373,10 @@ class RemediationActionAuthorityService:
 
         auto_allowed_risk = _DEFAULT_AUTO_ALLOWED_RISK
         if authority_mode == "admin_auto" and not approval_ref:
-            if _RISK_ORDER[str(risk)] > _RISK_ORDER[auto_allowed_risk]:
+            if (
+                risk is not None
+                and _RISK_ORDER[str(risk)] > _RISK_ORDER[auto_allowed_risk]
+            ):
                 return self._linked_result(
                     link=link,
                     action_kind=action_kind,
@@ -500,6 +519,8 @@ def _scrub_paths(value: Any) -> Any:
 
 def _redact_text(value: str | None) -> str:
     redacted = redact_sensitive_text(value)
+    if redacted is None:
+        return ""
     redacted = _PRESIGNED_URL_PATTERN.sub("[REDACTED_URL]", redacted)
     redacted = _ABSOLUTE_PATH_PATTERN.sub("[REDACTED_PATH]", redacted)
     return redacted

--- a/specs/228-remediation-authority-boundaries/checklists/requirements.md
+++ b/specs/228-remediation-authority-boundaries/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Remediation Authority Boundaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request. The brief points to `docs/Tasks/TaskRemediation.md`, which is treated as runtime source requirements.
+- Existing adjacent feature directories cover related remediation slices, but no valid MM-453 feature directory existed, so orchestration resumed from the Specify stage.

--- a/specs/228-remediation-authority-boundaries/contracts/remediation-authority-boundaries.md
+++ b/specs/228-remediation-authority-boundaries/contracts/remediation-authority-boundaries.md
@@ -1,0 +1,86 @@
+# Contract: Remediation Authority Boundaries
+
+## Service Boundary
+
+`RemediationActionAuthorityService.evaluate_action_request(...)` evaluates one remediation action request and returns a deterministic decision. It does not directly invoke host, Docker, SQL, provider, or storage operations.
+
+### Request
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation-workflow",
+  "actionKind": "terminate_session",
+  "parameters": {
+    "reason": "session is wedged"
+  },
+  "dryRun": false,
+  "idempotencyKey": "workflow-action-1",
+  "requestingPrincipal": "user:operator",
+  "permissions": {
+    "canViewTarget": true,
+    "canCreateRemediation": true,
+    "canRequestAdminProfile": true,
+    "canApproveHighRisk": false,
+    "canInspectAudit": false
+  },
+  "securityProfile": {
+    "profileRef": "admin_healer",
+    "executionPrincipal": "service:admin-healer",
+    "allowedActionKinds": ["restart_worker", "terminate_session"],
+    "enabled": true
+  },
+  "approvalRef": null
+}
+```
+
+### Response
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation-workflow",
+  "targetWorkflowId": "mm:target-workflow",
+  "authorityMode": "admin_auto",
+  "actionKind": "terminate_session",
+  "risk": "high",
+  "decision": "approval_required",
+  "reason": "high_risk_requires_approval",
+  "idempotencyKey": "workflow-action-1",
+  "securityProfileRef": "admin_healer",
+  "approvalRef": null,
+  "executable": false,
+  "redactedParameters": {
+    "reason": "session is wedged"
+  },
+  "audit": {
+    "requestingPrincipal": "user:operator",
+    "executionPrincipal": "service:admin-healer",
+    "decision": "approval_required",
+    "summary": "terminate_session requires approval"
+  }
+}
+```
+
+## Decision Semantics
+
+- `observe_only` returns `dry_run_only` for dry runs and `denied` for side-effecting execution.
+- `approval_gated` returns `approval_required` unless a valid `approvalRef` is supplied by a caller with high-risk approval permission when required.
+- `admin_auto` returns `allowed` only when the action is enabled, policy-permitted, profile-permitted, and not blocked by risk policy.
+- High-risk actions return `approval_required` or `denied` according to policy, even under `admin_auto`.
+- Unknown action kinds, disabled actions, unsupported profiles, unauthorized callers, missing idempotency keys, and invalid approvals fail closed.
+- Duplicate idempotency keys return the same decision payload for the same remediation workflow and action request.
+
+## Redaction Contract
+
+The response and audit payload must redact or reject:
+
+- raw secrets and token-like assignments,
+- private key blocks,
+- presigned URLs,
+- raw storage keys,
+- absolute local filesystem paths,
+- raw secret-bearing config bundles,
+- action kinds that imply raw host shell, Docker daemon, or SQL/database access.
+
+## Traceability
+
+All implementation and verification artifacts for this contract must preserve Jira issue key `MM-453` and source requirement IDs `DESIGN-REQ-010`, `DESIGN-REQ-011`, and `DESIGN-REQ-024`.

--- a/specs/228-remediation-authority-boundaries/data-model.md
+++ b/specs/228-remediation-authority-boundaries/data-model.md
@@ -1,0 +1,110 @@
+# Data Model: Remediation Authority Boundaries
+
+## Remediation Authority Decision
+
+Represents the result of evaluating whether a remediation action request may proceed.
+
+Fields:
+
+- `remediation_workflow_id`: Workflow ID of the remediation execution.
+- `target_workflow_id`: Workflow ID of the linked target execution.
+- `authority_mode`: One of `observe_only`, `approval_gated`, or `admin_auto`.
+- `action_kind`: Typed remediation action kind.
+- `risk`: `low`, `medium`, or `high`.
+- `decision`: `allowed`, `approval_required`, `dry_run_only`, or `denied`.
+- `reason`: Stable reason code for the decision.
+- `idempotency_key`: Deterministic caller-provided key for duplicate suppression.
+- `security_profile_ref`: Named profile used for elevated actions when applicable.
+- `approval_ref`: Approval evidence identifier when execution is approved.
+- `audit`: Compact redacted audit payload.
+- `redacted_parameters`: Action parameters after secret and raw-access redaction.
+
+Validation rules:
+
+- `action_kind` is required and must be in the allowlisted policy catalog.
+- `idempotency_key` is required for executable side-effecting actions.
+- `observe_only` can never produce an executable `allowed` decision.
+- `approval_gated` requires `approval_ref` for side-effecting execution.
+- `admin_auto` requires a permitted security profile for side-effecting execution.
+- High-risk actions require approval unless policy disables them entirely.
+- Denied and approval-required decisions must include a reason.
+- Audit payloads must not contain raw secrets, presigned URLs, storage keys, absolute local paths, or secret-bearing config bundles.
+
+## Remediation Permission Set
+
+Compact caller authority used for the decision.
+
+Fields:
+
+- `can_view_target`: Caller can view the target execution.
+- `can_create_remediation`: Caller can create basic remediation tasks.
+- `can_request_admin_profile`: Caller can request an elevated security profile.
+- `can_approve_high_risk`: Caller can approve high-risk action execution.
+- `can_inspect_audit`: Caller can inspect privileged remediation audit history.
+
+Validation rules:
+
+- Target view alone does not imply any other permission.
+- Admin profile use requires `can_request_admin_profile`.
+- High-risk approval requires `can_approve_high_risk`.
+- Audit inspection requires `can_inspect_audit`.
+
+## Remediation Security Profile
+
+Named privileged execution identity for elevated remediation actions.
+
+Fields:
+
+- `profile_ref`: Stable profile identifier.
+- `execution_principal`: Principal recorded in audit output.
+- `allowed_action_kinds`: Action kinds this profile may execute.
+- `enabled`: Whether this profile may currently be used.
+
+Validation rules:
+
+- Elevated action execution requires an enabled profile.
+- The profile must allow the requested action kind.
+- Audit output must include both the requestor and `execution_principal`.
+
+## Remediation Action Policy
+
+Named policy that maps action kinds to risk and approval behavior.
+
+Fields:
+
+- `policy_ref`: Stable policy identifier.
+- `allowed_actions`: Mapping of action kind to risk and enabled state.
+- `auto_allowed_risk`: Highest risk level allowed without approval.
+- `disabled_actions`: Action kinds blocked regardless of authority mode.
+
+Validation rules:
+
+- Unknown policies fail closed.
+- Unknown or disabled action kinds fail closed.
+- Risk values outside `low`, `medium`, and `high` fail closed.
+- High-risk actions cannot be made silently executable by `admin_auto`.
+
+## Remediation Action Audit
+
+Redacted review evidence for a remediation action decision.
+
+Fields:
+
+- `requesting_principal`: User or workflow that requested the action.
+- `execution_principal`: Security profile principal used for execution, if any.
+- `remediation_workflow_id`: Remediation execution.
+- `target_workflow_id`: Target execution.
+- `authority_mode`: Evaluated authority mode.
+- `action_kind`: Requested action.
+- `risk`: Evaluated risk.
+- `decision`: Decision result.
+- `reason`: Reason code.
+- `approval_ref`: Approval evidence when present.
+- `idempotency_key`: Duplicate-suppression key.
+- `summary`: Redacted bounded summary.
+
+Validation rules:
+
+- Audit is emitted for allowed, approval-required, dry-run-only, and denied decisions.
+- Audit includes requestor and execution principal for privileged actions.
+- Audit summaries are bounded and redacted.

--- a/specs/228-remediation-authority-boundaries/plan.md
+++ b/specs/228-remediation-authority-boundaries/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Remediation Authority Boundaries
+
+**Branch**: `228-remediation-authority-boundaries` | **Date**: 2026-04-22 | **Spec**: `specs/228-remediation-authority-boundaries/spec.md`
+**Input**: Single-story feature specification from `/specs/228-remediation-authority-boundaries/spec.md`
+
+## Summary
+
+Implement MM-453 by adding the missing runtime authority boundary for remediation actions. Existing remediation create/link code validates target identity, supported authority modes, and action policy refs; existing context/evidence tools preserve server-mediated evidence access and fresh target health reads. This story adds a narrow typed remediation action authority service that evaluates authority mode, caller permissions, security profile, action risk, approval records, idempotency keys, and redaction-safe outputs before any side-effecting remediation action is accepted as executable. Tests are service-boundary unit tests plus an integration-style service flow that exercises create/link/context/action preparation together without raw host, Docker, SQL, or storage access.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `ALLOWED_REMEDIATION_AUTHORITY_MODES` in `moonmind/workflows/temporal/service.py`; unsupported-mode unit test exists | add focused verification in authority boundary tests | unit |
+| FR-002 | partial | `observe_only` is persisted on remediation links; no action execution gate exists | add action authority service rejection for side effects | unit + integration |
+| FR-003 | missing | no approval-gated action execution contract found | add proposal/dry-run/approval validation | unit + integration |
+| FR-004 | partial | `actionPolicyRef` allowlist exists; no action allowlist execution gate found | add allowlisted action evaluation under policy/profile | unit |
+| FR-005 | missing | no high-risk action gating implementation found | add high-risk approval policy enforcement | unit |
+| FR-006 | missing | no `securityProfileRef` validation or persisted profile evidence found | add named security profile requirement for elevated execution | unit |
+| FR-007 | partial | owner visibility checks exist for remediation target references; no distinct launch/approve/audit permission model found | add compact permission model to authority decisions | unit |
+| FR-008 | missing | no admin-remediation permission checks beyond target ownership found | reject admin launch/profile/approval/audit without explicit permissions | unit |
+| FR-009 | partial | generic intervention audit exists; remediation link has summary/outcome fields; no privileged remediation audit record shape found | add typed remediation action audit record output | unit |
+| FR-010 | missing | no typed side-effecting remediation action registry found | add typed allowlisted action decision surface | unit |
+| FR-011 | missing | no remediation action idempotency ledger found | add in-memory/service-level deterministic idempotency result for persisted action requests in this slice | unit |
+| FR-012 | partial | unsupported authority and action policy fail closed; profiles/approvals not yet validated | extend fail-closed validation to profiles and approvals | unit |
+| FR-013 | implemented_unverified | no raw host/Docker/SQL surface is exposed by current remediation services | add regression assertions that authority service does not expose raw execution channels | unit |
+| FR-014 | implemented_verified | `RemediationEvidenceToolService` gates artifacts/logs through context refs and artifact service | no new implementation; preserve via regression | unit |
+| FR-015 | implemented_unverified | artifact/log redaction helpers exist; remediation context excludes raw bodies; no action-output redaction test found | redact action request/result/audit payloads | unit |
+| FR-016 | implemented_unverified | target reference owner check returns unauthorized without record details | add direct-fetch authority regression | unit |
+| FR-017 | missing | no stronger-authority redaction override test found | enforce redaction after authority decision | unit |
+| FR-018 | implemented_verified | evidence tools expose live follow as read-only observation and action preparation separately | no new implementation; preserve via regression | unit |
+| SC-001 | partial | create-time mode validation exists | add authority decision tests for all modes | unit |
+| SC-002 | missing | no approval-gated/admin action tests found | add action execution decision tests | unit |
+| SC-003 | missing | no high-risk approval tests found | add risk-gated tests | unit |
+| SC-004 | missing | no distinct admin permission tests found | add permission matrix tests | unit |
+| SC-005 | partial | generic audit exists; no remediation action audit shape | add audit output tests | unit |
+| SC-006 | partial | context/evidence redaction exists; no action result redaction | add redaction tests | unit |
+| SC-007 | partial | unsupported mode/action policy fail closed; other cases missing | add fail-closed tests | unit |
+| SC-008 | missing | this artifact set is new | preserve MM-453 and source IDs through tasks/verification | final verify |
+| DESIGN-REQ-010 | partial | authority modes are accepted and persisted | enforce mode semantics at action boundary | unit + integration |
+| DESIGN-REQ-011 | partial | action policy ref validation exists; named principal/profile, approval, and audit behavior missing | implement security profile, permission, approval, risk, audit, and idempotency decision contract | unit + integration |
+| DESIGN-REQ-024 | partial | evidence access is server-mediated; action output redaction and no-raw-access assertions missing | add redaction and no-raw-channel enforcement tests | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, Pydantic v2 style validation patterns, existing Temporal execution service, existing remediation context/evidence services  
+**Storage**: Existing `execution_remediation_links` row fields and artifact-backed action/audit payloads; no new database table for this slice  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`  
+**Integration Testing**: Service-boundary flow in `tests/unit/workflows/temporal/test_remediation_context.py`; no compose-backed integration needed because this slice does not cross external services  
+**Target Platform**: Linux server / Docker Compose deployment  
+**Project Type**: FastAPI control plane plus Temporal workflow service boundary  
+**Performance Goals**: Action authority evaluation remains bounded to one remediation link lookup, one context read when needed, and compact policy/profile checks  
+**Constraints**: Runtime mode; preserve MM-453 traceability; do not expose raw host shell, Docker daemon, SQL, presigned URLs, storage keys, local paths, or raw secrets; do not change Temporal workflow payload shapes  
+**Scale/Scope**: One remediation execution linked to one target execution; one action request decision at a time with deterministic idempotency key handling
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The action boundary orchestrates allowed remediation tools without changing agent cognition.
+- II. One-Click Agent Deployment: PASS. No new service dependency or secret is introduced.
+- III. Avoid Vendor Lock-In: PASS. Remediation authority is provider-neutral.
+- IV. Own Your Data: PASS. Decisions and audit payloads remain MoonMind-owned local artifacts/metadata.
+- V. Skills Are First-Class and Easy to Add: PASS. The typed boundary can be consumed by remediation skills without changing instruction bundles.
+- VI. Replaceable Scaffolding / Tests Anchor: PASS. A thin service contract is covered by focused boundary tests.
+- VII. Runtime Configurability: PASS. Behavior is driven by authority mode, policy refs, approvals, and security profile inputs.
+- VIII. Modular Architecture: PASS. Work stays in remediation temporal service modules and tests.
+- IX. Resilient by Default: PASS. Unsupported or unauthorized actions fail closed; idempotency keys prevent duplicate side effects.
+- X. Continuous Improvement: PASS. Audit records make remediation decisions reviewable.
+- XI. Spec-Driven Development: PASS. This plan follows one MM-453 story with traceable requirements.
+- XII. Canonical Documentation Separation: PASS. Desired-state docs remain unchanged; implementation artifacts live under `specs/`.
+- XIII. Pre-release Compatibility Policy: PASS. Adds the canonical runtime boundary without aliases or hidden compatibility transforms.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/228-remediation-authority-boundaries/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-authority-boundaries.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/temporal/
+├── remediation_actions.py
+├── remediation_context.py
+├── remediation_tools.py
+└── service.py
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+```
+
+**Structure Decision**: Add the authority decision surface as a new Temporal remediation boundary module and cover it through the existing remediation context/evidence test file so the full linked remediation flow stays visible in one unit-test area.
+
+## Complexity Tracking
+
+None.

--- a/specs/228-remediation-authority-boundaries/quickstart.md
+++ b/specs/228-remediation-authority-boundaries/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Remediation Authority Boundaries
+
+## Intent
+
+Validate MM-453 in runtime mode. The implementation must enforce remediation authority modes, permissions, security profiles, high-risk approvals, idempotency, audit output, and redaction boundaries before any side-effecting remediation action is considered executable.
+
+## Focused Unit Tests
+
+Run the focused remediation test file:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Expected coverage:
+
+- `observe_only` allows diagnosis/dry-run style decisions but rejects side-effecting execution.
+- `approval_gated` requires recorded approval before side-effecting execution.
+- `admin_auto` can allow policy/profile-permitted low and medium risk actions.
+- High-risk actions require approval or are denied according to policy even under `admin_auto`.
+- Target view permission alone cannot request admin profile use, approve high-risk actions, or inspect privileged audit output.
+- Action decisions include redacted audit payloads with requestor and execution principal.
+- Duplicate idempotency keys return the same decision and avoid duplicate executable outcomes.
+- Raw host shell, Docker daemon, SQL/database, storage-key, local-path, and raw-secret access are denied or redacted.
+
+## Full Unit Suite
+
+Before finalizing:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Integration Strategy
+
+No compose-backed integration is expected for this slice. The service-boundary test should create a target execution, create a remediation execution with authority policy, build context, prepare a side-effecting action request, and evaluate the action authority decision through local fixtures.
+
+## Manual Verification
+
+1. Confirm `specs/228-remediation-authority-boundaries/spec.md` preserves MM-453 and `DESIGN-REQ-010`, `DESIGN-REQ-011`, and `DESIGN-REQ-024`.
+2. Confirm action decisions never expose raw secrets, storage keys, presigned URLs, absolute local paths, raw host shell commands, Docker daemon access, or SQL/database edit access.
+3. Confirm final verification reports MM-453 traceability and runtime-mode behavior.

--- a/specs/228-remediation-authority-boundaries/research.md
+++ b/specs/228-remediation-authority-boundaries/research.md
@@ -1,0 +1,57 @@
+# Research: Remediation Authority Boundaries
+
+## Classification
+
+Decision: Treat MM-453 as a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-453-moonspec-orchestration-input.md` contains one user story, one source design, one bounded acceptance set, and runtime-mode constraints.
+Rationale: The story can be independently validated by creating remediation action authority decisions and checking allowed, gated, audited, rejected, and redacted outcomes.
+Alternatives considered: Broad technical design was rejected because the Jira brief already selected one story from `docs/Tasks/TaskRemediation.md`; existing feature directory was rejected because no `specs/*` artifact referenced MM-453.
+Test implications: Unit and service-boundary integration-style tests are required.
+
+## Authority Mode Gap
+
+Decision: Existing create-time validation is partial; action-boundary enforcement is missing.
+Evidence: `moonmind/workflows/temporal/service.py` defines `ALLOWED_REMEDIATION_AUTHORITY_MODES` and rejects unsupported modes. `tests/unit/workflows/temporal/test_temporal_service.py` covers unsupported modes and link persistence. No side-effecting remediation action authority module exists.
+Rationale: Accepting and persisting a mode is not enough to prove mode semantics for side-effecting actions.
+Alternatives considered: Reusing generic execution interventions was rejected because remediation actions require their own authority and audit boundary.
+Test implications: Add tests for `observe_only`, `approval_gated`, and `admin_auto` action decisions.
+
+## Permission And Security Profile Model
+
+Decision: Add compact service-boundary permission and security profile inputs for action decisions.
+Evidence: Target owner checks exist through `_can_reference_dependency_target`, but no separate permission model for admin profile request, high-risk approval, or audit inspection was found. `docs/Tasks/TaskRemediation.md` section 10.3 requires these permissions to be distinct.
+Rationale: The feature requires target view permission to be insufficient for admin remediation and high-risk approvals.
+Alternatives considered: Inferring admin authority from target ownership was rejected because it violates the security model.
+Test implications: Add permission matrix tests for view-only, admin remediation, high-risk approval, and audit permissions.
+
+## Action Policy And Risk Gating
+
+Decision: Add a typed policy evaluation surface with low/medium/high action risk and approval requirements.
+Evidence: `ALLOWED_REMEDIATION_ACTION_POLICY_REFS` validates `admin_healer_default`; no action registry or high-risk approval gate exists. `RemediationEvidenceToolService.prepare_action_request` already re-reads target health but intentionally does not execute actions.
+Rationale: The new authority boundary should consume the fresh target-health preparation and decide whether a side-effecting action may execute, must wait for approval, or must be denied.
+Alternatives considered: Executing actions directly in evidence tools was rejected because those tools are intentionally read-only plus pre-action preparation.
+Test implications: Add unit tests for allowed low/medium actions, high-risk approval requirements, disabled actions, and unsupported action kinds.
+
+## Idempotency And Audit
+
+Decision: Represent each action decision with a deterministic request key, result status, audit payload, and redacted summary while avoiding a new persistent table in this slice.
+Evidence: `execution_remediation_links` already has compact latest action fields; `docs/Tasks/SkillAndPlanEvolution.md` and `docs/Tasks/TaskRemediation.md` require idempotent side effects and reviewable audit evidence.
+Rationale: This story can validate action authority and duplicate request behavior without introducing the full future action ledger table.
+Alternatives considered: Adding a database ledger now was rejected because the Jira brief asks for authority boundaries, not the full action registry storage slice.
+Test implications: Add tests proving duplicate idempotency keys return the same decision and do not create duplicate executable results.
+
+## Redaction And No-Raw-Access Boundaries
+
+Decision: Redact action parameters, action results, and audit payloads through existing logging redaction helpers and explicitly reject raw access action kinds.
+Evidence: `moonmind/utils/logging.py` provides secret redaction helpers. Existing remediation context and evidence tools avoid raw bodies and raw storage access, but no action-output redaction test exists.
+Rationale: Stronger authority must not override secret redaction or expose host, Docker, SQL, storage, path, or credential access.
+Alternatives considered: Trusting callers to redact was rejected because the boundary must be safe by default.
+Test implications: Add tests with token-like and private-key-like payloads, raw access action names, and unauthorized direct fetch inputs.
+
+## Test Strategy
+
+Decision: Keep verification in `tests/unit/workflows/temporal/test_remediation_context.py` with focused tests for the new action authority module and one end-to-end service-boundary flow.
+Evidence: Existing remediation context, evidence, and create/link tests are already in this file and use local async DB and artifact fixtures.
+Rationale: The story stays inside the Temporal service/activity boundary and does not require compose-backed services.
+Alternatives considered: Adding a new integration_ci suite was rejected because no Docker-backed or external provider seam is introduced.
+Test implications: Run targeted unit tests during implementation and full `./tools/test_unit.sh` before finalization when feasible.

--- a/specs/228-remediation-authority-boundaries/spec.md
+++ b/specs/228-remediation-authority-boundaries/spec.md
@@ -1,0 +1,194 @@
+# Feature Specification: Remediation Authority Boundaries
+
+**Feature Branch**: `228-remediation-authority-boundaries`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-453 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-453-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-453 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-453
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Enforce remediation authority modes, permissions, and redaction boundaries
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-453 from MM project
+Summary: Enforce remediation authority modes, permissions, and redaction boundaries
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-453 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-453: Enforce remediation authority modes, permissions, and redaction boundaries
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 10. Security and authority model
+  - 6. Core invariants
+  - 4. Non-goals
+- Coverage IDs:
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+  - DESIGN-REQ-024
+
+User Story
+As a platform security owner, I can configure remediation authority through explicit modes, permissions, and named security profiles so privileged troubleshooting never implies raw host access or secret disclosure.
+
+Acceptance Criteria
+- `observe_only` remediation can read evidence and produce diagnoses but cannot execute side-effecting actions.
+- `approval_gated` remediation can propose or dry-run actions but requires recorded approval before side effects.
+- `admin_auto` remediation can execute only allowlisted actions within policy and still respects high-risk approval rules.
+- Audit records include both requesting user/workflow and the execution principal used for privileged actions.
+- A user with target view permission alone cannot launch admin remediation or approve high-risk actions.
+- Generated context, logs, summaries, diagnostics, and artifacts do not contain raw secrets or durable raw storage/file access material.
+
+Requirements
+- Authority is policy/profile based, not implicit root or ordinary runtime access.
+- Unauthorized direct fetches do not leak execution existence.
+- Secret redaction rules apply even to admin remediation.
+
+Relevant Implementation Notes
+- Preserve MM-453 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation authority modes, permission boundaries, redaction behavior, and non-goals.
+- Model remediation authority with explicit modes: `observe_only`, `approval_gated`, and `admin_auto`.
+- Elevated remediation must execute through a named admin remediation principal or security profile rather than the ordinary user runtime.
+- Distinguish permissions to view a target execution, create a remediation task, request an admin remediation profile, approve high-risk actions, and inspect remediation audit history.
+- Keep administrative actions typed and allowlisted; remediation must not imply arbitrary host shell access, Docker daemon access, SQL/database editing, or any command the model suggests.
+- Keep evidence, artifact, and log access server-mediated through refs, read capability handles, redacted previews, or typed observability APIs.
+- Never place raw secrets, presigned storage URLs, storage backend keys, absolute local filesystem paths, or raw secret-bearing config bundles in durable remediation context, logs, summaries, diagnostics, or artifacts.
+- Ensure side-effecting remediation actions are idempotent or safely keyed, and keep high-risk actions subject to explicit approval policy even under `admin_auto`.
+- Preserve redaction-safe visibility: unauthorized direct fetches must not leak execution existence, and admin remediation artifacts must still follow redaction-safe display rules.
+
+Non-Goals
+- Arbitrary raw shell access on the MoonMind host.
+- Unrestricted Docker daemon access from the remediation runtime.
+- Arbitrary SQL or direct database row editing by the agent.
+- Silent import of another task's entire workflow history into `initialParameters`.
+- Cross-task managed-session reuse.
+- Treating every failed task as automatically eligible for an admin healer.
+- Bypassing the Secrets System or artifact redaction rules.
+- Treating Live Logs as the source of truth or as a control channel.
+
+Validation
+- Verify each supported authority mode enforces its side-effect permissions: `observe_only`, `approval_gated`, and `admin_auto`.
+- Verify side-effecting actions require recorded approval when policy or risk classification requires it.
+- Verify audit records include both the requesting user or workflow and the execution principal/security profile used for privileged actions.
+- Verify target view permission alone is insufficient to launch admin remediation or approve high-risk actions.
+- Verify generated context, logs, summaries, diagnostics, and artifacts redact raw secrets and do not expose durable raw storage or filesystem access material.
+- Verify unauthorized direct fetches do not leak execution existence.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-453 blocks MM-452, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-453 is blocked by MM-454, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## User Story - Govern Remediation Authority
+
+**Summary**: As a platform security owner, I want remediation authority controlled by explicit modes, permissions, and named security profiles so that privileged troubleshooting never implies raw host access or secret disclosure.
+
+**Goal**: Remediation can diagnose and act only within the authority granted by its selected mode, caller permissions, security profile, approval policy, and redaction rules.
+
+**Independent Test**: Configure remediation submissions and action requests for each authority mode, permission level, and risk level, then verify the system allows, gates, audits, rejects, or redacts the request according to the selected mode and security policy without exposing raw secrets or durable raw access material.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run is configured as `observe_only`, **When** it reads evidence and produces diagnosis output, **Then** those read-only operations are allowed and all side-effecting action requests are rejected before execution.
+2. **Given** a remediation run is configured as `approval_gated`, **When** it proposes or dry-runs a side-effecting action, **Then** the proposal is allowed but execution requires a recorded approval before any side effect occurs.
+3. **Given** a remediation run is configured as `admin_auto`, **When** it requests an allowlisted action, **Then** the action may execute only within policy and high-risk actions still follow explicit approval policy.
+4. **Given** a remediation action is executed through elevated authority, **When** audit evidence is recorded, **Then** the record identifies both the requesting user or workflow and the execution principal or security profile used for the privileged action.
+5. **Given** a user has permission to view the target execution only, **When** the user attempts to launch admin remediation or approve a high-risk action, **Then** the request is denied without granting additional authority.
+6. **Given** remediation context, logs, summaries, diagnostics, or artifacts are generated, **When** they are stored or displayed, **Then** raw secrets and durable raw storage or filesystem access material are omitted or redacted.
+
+### Edge Cases
+
+- Unsupported, blank, or unknown authority modes are rejected instead of defaulting to stronger authority.
+- A missing, disabled, or unauthorized security profile prevents elevated remediation from launching or executing privileged actions.
+- High-risk action classification cannot be bypassed by selecting `admin_auto`.
+- Unauthorized direct fetches fail without revealing whether the target execution exists.
+- Existing evidence and log access remains server-mediated and never becomes a direct storage grant.
+- Nested remediation and cross-task session reuse remain disabled unless policy explicitly enables them outside this story.
+
+## Assumptions
+
+- The MM-453 story is a single runtime feature slice focused on authority, permission, audit, and redaction enforcement for remediation, not on building remediation evidence bundles or action registry internals covered by adjacent Jira slices.
+- Existing remediation create, evidence, artifact, audit, and action surfaces are the expected product surfaces to enforce this behavior; this spec defines observable behavior rather than requiring a new top-level workflow.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-010** (`docs/Tasks/TaskRemediation.md` section 10.1): Remediation authority must be represented by explicit modes: `observe_only`, `approval_gated`, and `admin_auto`, each with distinct read, proposal, approval, and execution behavior. Scope: in scope, mapped to FR-001 through FR-005.
+- **DESIGN-REQ-011** (`docs/Tasks/TaskRemediation.md` sections 6, 10.2, 10.3, and 10.6): Privileged remediation must use named execution principals or security profiles, enforce distinct permissions for viewing, launching, approving, and auditing, keep actions typed and allowlisted, and preserve high-risk approval requirements. Scope: in scope, mapped to FR-006 through FR-012.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskRemediation.md` sections 4, 6, 10.4, 10.5, and 10.7): Remediation must not bypass secrets, artifact redaction, server-mediated evidence access, visibility scoping, or non-goals such as raw host, Docker, SQL, or workflow-history access. Scope: in scope, mapped to FR-013 through FR-018.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST accept only supported remediation authority modes: `observe_only`, `approval_gated`, and `admin_auto`.
+- **FR-002**: `observe_only` remediation MUST allow authorized evidence reads and diagnosis output while rejecting all side-effecting action execution.
+- **FR-003**: `approval_gated` remediation MUST allow action proposals and dry runs while requiring a recorded approval before side-effecting execution.
+- **FR-004**: `admin_auto` remediation MUST execute only allowlisted actions that are permitted by the selected policy and security profile.
+- **FR-005**: High-risk actions MUST follow explicit approval policy even when remediation authority mode is `admin_auto`.
+- **FR-006**: Elevated remediation MUST require a named execution principal or security profile before privileged action execution.
+- **FR-007**: The system MUST separately enforce permission to view a target execution, create a remediation task, request an admin remediation profile, approve high-risk actions, and inspect remediation audit history.
+- **FR-008**: Target view permission alone MUST NOT authorize launching admin remediation, requesting an admin security profile, approving high-risk actions, or inspecting privileged audit history.
+- **FR-009**: Remediation audit records MUST identify the requesting user or workflow and the execution principal or security profile used for privileged actions.
+- **FR-010**: Side-effecting remediation actions MUST be typed, allowlisted, and validated against the active authority mode, action policy, security profile, and risk classification before execution.
+- **FR-011**: Duplicate or retried side-effecting action requests MUST be safely keyed or rejected so retries do not create duplicate destructive effects.
+- **FR-012**: Unsupported authority modes, missing security profiles, disabled profiles, and unauthorized approvals MUST fail closed with explicit validation results.
+- **FR-013**: Remediation MUST NOT provide arbitrary host shell access, unrestricted Docker daemon access, arbitrary SQL/database editing, cross-task managed-session reuse, or silent import of another task's full workflow history.
+- **FR-014**: Evidence, artifact, and log access for remediation MUST remain server-mediated through authorized refs, read handles, redacted previews, or typed observability views.
+- **FR-015**: Durable remediation context, workflow payloads, run summaries, logs, diagnostics, and artifacts MUST NOT contain raw secrets, raw storage keys, presigned storage URLs, absolute local filesystem paths, or raw secret-bearing config bundles.
+- **FR-016**: Unauthorized direct fetches MUST fail without revealing whether the target execution exists.
+- **FR-017**: Stronger remediation authority MUST NOT override secret redaction, audit, visibility, or secret-reference rules.
+- **FR-018**: Live Logs MUST remain an observation surface and MUST NOT become the source of truth or control channel for remediation intervention.
+
+### Key Entities
+
+- **Authority Mode**: The declared remediation authority level controlling read-only diagnosis, gated action execution, or policy-limited automatic execution.
+- **Security Profile**: A named privileged execution identity or profile used for elevated remediation actions.
+- **Approval Record**: Evidence that a permitted approver authorized a side-effecting or high-risk remediation action.
+- **Remediation Audit Record**: Durable evidence linking the requestor, workflow, authority mode, security profile, action, risk level, approval state, and outcome.
+- **Redaction Boundary**: The visibility and secret-handling constraint that prevents raw secrets and durable raw access material from entering remediation outputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove all three authority modes enforce their allowed and rejected operation classes.
+- **SC-002**: Tests prove side-effecting action execution under `approval_gated` requires a recorded approval and under `admin_auto` remains limited to allowlisted, policy-permitted actions.
+- **SC-003**: Tests prove high-risk actions require approval or are disabled according to policy even under `admin_auto`.
+- **SC-004**: Tests prove target view permission alone cannot launch admin remediation, request an admin profile, approve high-risk actions, or inspect privileged audit history.
+- **SC-005**: Tests prove audit records include both the requesting user or workflow and the execution principal or security profile for privileged actions.
+- **SC-006**: Tests prove remediation context, summaries, logs, diagnostics, artifacts, and durable payloads do not expose raw secrets, raw storage keys, presigned storage URLs, absolute local filesystem paths, or raw secret-bearing config bundles.
+- **SC-007**: Tests prove unsupported modes, missing profiles, unauthorized approvals, and unauthorized direct fetches fail closed without leaking target execution existence.
+- **SC-008**: Traceability verification confirms MM-453 and DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-024 are preserved in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/228-remediation-authority-boundaries/tasks.md
+++ b/specs/228-remediation-authority-boundaries/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Remediation Authority Boundaries
+
+**Input**: Design documents from `/specs/228-remediation-authority-boundaries/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: TDD-first runtime implementation. Add focused unit and service-boundary tests in the existing remediation context test file before adding the new production authority boundary.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Integration tests: service-boundary flow in `tests/unit/workflows/temporal/test_remediation_context.py`; no compose-backed integration required for this slice
+- Final verification: `/moonspec-verify`
+
+**Source Traceability**: The original MM-453 Jira preset brief is preserved in `specs/228-remediation-authority-boundaries/spec.md`. Tasks cover FR-001 through FR-018, SC-001 through SC-008, and DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-024.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active MM-453 feature artifacts exist in `specs/228-remediation-authority-boundaries/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-authority-boundaries.md`, and `quickstart.md`.
+- [X] T002 Confirm the MM-453 source preset brief and Jira key are preserved in `specs/228-remediation-authority-boundaries/spec.md`.
+- [X] T003 Record the branch-gated agent-context script limitation from `.specify/scripts/bash/update-agent-context.sh` in final verification notes if it remains unavailable.
+
+## Phase 2: Foundational
+
+- [X] T004 Review existing remediation mode and action policy validation in `moonmind/workflows/temporal/service.py` for FR-001, FR-004, FR-012, DESIGN-REQ-010, and DESIGN-REQ-011.
+- [X] T005 Review existing evidence and action-preparation boundaries in `moonmind/workflows/temporal/remediation_tools.py` for FR-014 and FR-018.
+- [X] T006 Review existing redaction helpers in `moonmind/utils/logging.py` for FR-015 and FR-017.
+
+## Phase 3: Govern Remediation Authority
+
+**Summary**: Enforce remediation authority through explicit modes, permissions, named security profiles, high-risk approvals, idempotency, audit output, and redaction before side-effecting remediation actions are executable.
+
+**Independent Test**: Configure remediation submissions and action requests for each authority mode, permission level, and risk level, then verify the system allows, gates, audits, rejects, or redacts the request according to the selected mode and security policy without exposing raw secrets or durable raw access material.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013, FR-014, FR-015, FR-016, FR-017, FR-018, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, SC-008, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-024.
+
+**Unit Test Plan**: Add tests for authority-mode decisions, profile validation, permission matrix behavior, action allowlist/risk policy, idempotency, audit output, redaction, fail-closed inputs, and raw-access denials.
+
+**Integration Test Plan**: Add a service-boundary flow that creates a target execution, creates a remediation execution with authority policy, builds context, prepares a side-effecting action request, and evaluates the action authority decision.
+
+- [X] T007 Add failing unit tests for `observe_only`, `approval_gated`, and `admin_auto` decision semantics in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-001 through FR-005, SC-001 through SC-003, and DESIGN-REQ-010.
+- [X] T008 Add failing unit tests for security profile and permission matrix enforcement in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-006 through FR-008, SC-004, and DESIGN-REQ-011.
+- [X] T009 Add failing unit tests for typed action allowlist, high-risk approval requirements, unsupported actions, and fail-closed validation in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, FR-012, SC-007, and DESIGN-REQ-011.
+- [X] T010 Add failing unit tests for idempotency and remediation action audit output in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-009, FR-011, SC-005, and DESIGN-REQ-011.
+- [X] T011 Add failing unit tests for redaction, raw-access denial, and no unauthorized direct-fetch leakage in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-013, FR-015, FR-016, FR-017, SC-006, SC-007, and DESIGN-REQ-024.
+- [X] T012 Add failing service-boundary integration-style test in `tests/unit/workflows/temporal/test_remediation_context.py` covering context build, action preparation, and authority decision flow for FR-002 through FR-006 and SC-001 through SC-003.
+- [X] T013 Confirm the focused tests from T007 through T012 fail for the expected missing behavior before production code changes.
+- [X] T014 Implement typed remediation action authority models and policy catalog in `moonmind/workflows/temporal/remediation_actions.py` for FR-001, FR-004, FR-005, FR-010, and FR-012.
+- [X] T015 Implement authority mode, permission, security profile, approval, high-risk, and idempotency evaluation in `moonmind/workflows/temporal/remediation_actions.py` for FR-002 through FR-011 and DESIGN-REQ-010 through DESIGN-REQ-011.
+- [X] T016 Implement audit and redaction output handling in `moonmind/workflows/temporal/remediation_actions.py` for FR-009, FR-013, FR-015, FR-017, and DESIGN-REQ-024.
+- [X] T017 Export the remediation action authority service from `moonmind/workflows/temporal/__init__.py` for contract visibility.
+- [X] T018 Run focused unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`.
+- [X] T019 Story validation: verify MM-453 acceptance scenarios, FR-001 through FR-018, SC-001 through SC-008, and DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-024 against focused test results.
+
+## Final Phase: Polish And Verification
+
+- [X] T020 Run artifact alignment for `specs/228-remediation-authority-boundaries/spec.md`, `plan.md`, and `tasks.md`.
+- [X] T021 Run full unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T022 Run `/moonspec-verify` by auditing implementation against `specs/228-remediation-authority-boundaries/spec.md` and record the result.
+
+## Dependencies And Execution Order
+
+1. Setup tasks T001-T003 complete before foundational review.
+2. Foundational tasks T004-T006 complete before writing red tests.
+3. Test tasks T007-T012 complete and T013 confirms expected failures before implementation.
+4. Implementation tasks T014-T017 complete before focused verification T018.
+5. Story validation T019 completes before polish and final verification T020-T022.
+
+## Implementation Strategy
+
+Implement the smallest typed authority service that satisfies MM-453 without introducing a raw action executor or new persistent table. Existing create/link/context/evidence behavior remains in place; this story adds the missing decision boundary that future action execution must consume.

--- a/specs/228-remediation-authority-boundaries/verification.md
+++ b/specs/228-remediation-authority-boundaries/verification.md
@@ -1,0 +1,79 @@
+# MoonSpec Verification Report
+
+**Feature**: Remediation Authority Boundaries  
+**Spec**: `/work/agent_jobs/mm:9264acdd-813d-419c-a587-9a24117637f9/repo/specs/228-remediation-authority-boundaries/spec.md`  
+**Original Request Source**: `spec.md` Input and preserved MM-453 Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused unit and service-boundary | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` | PASS | 12 Python remediation tests passed; runner also completed 365 frontend tests. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3753 Python tests passed, 1 xpassed, 16 subtests passed; 365 frontend tests passed. Existing warnings only. |
+| Integration | Service-boundary remediation flow in focused unit command | PASS | Compose-backed integration was not required by the plan because this slice does not cross external services. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/workflows/temporal/remediation_actions.py:19`, `:55`, `:112`; `tests/unit/workflows/temporal/test_remediation_context.py:843` | VERIFIED | Supported authority decision contract covers the accepted modes already validated at create time. |
+| FR-002 | `remediation_actions.py:270`, `:286`; `test_remediation_context.py:843` | VERIFIED | `observe_only` allows dry-run style decisions and rejects executable side effects. |
+| FR-003 | `remediation_actions.py:319`; `test_remediation_context.py:883` | VERIFIED | `approval_gated` returns `approval_required` until approval evidence is supplied. |
+| FR-004 | `remediation_actions.py:40`, `:300`, `:375`; `test_remediation_context.py:926` | VERIFIED | `admin_auto` allows only cataloged/profile-permitted actions. |
+| FR-005 | `remediation_actions.py:332`, `:345`, `:360`; `test_remediation_context.py:978` | VERIFIED | High-risk action requests require approval or are denied without approval permission. |
+| FR-006 | `remediation_actions.py:66`, `:466`; `test_remediation_context.py:951` | VERIFIED | Elevated execution requires an enabled named profile. |
+| FR-007 | `remediation_actions.py:55`, `:257`, `:466`; `test_remediation_context.py:938` | VERIFIED | Permission dimensions are modeled separately and checked before execution. |
+| FR-008 | `remediation_actions.py:466`; `test_remediation_context.py:938` | VERIFIED | Target view alone cannot use admin profile authority. |
+| FR-009 | `remediation_actions.py:438`; `test_remediation_context.py:909`, `:1035` | VERIFIED | Audit output includes requestor and execution principal for privileged decisions. |
+| FR-010 | `remediation_actions.py:28`, `:40`, `:231`, `:244`; `test_remediation_context.py:1039` | VERIFIED | Action kinds are typed, allowlisted, and raw access kinds are denied. |
+| FR-011 | `remediation_actions.py:135`; `test_remediation_context.py:993` | VERIFIED | Duplicate idempotency keys return the same decision result within the authority boundary. |
+| FR-012 | `remediation_actions.py:139`, `:154`, `:174`, `:244`, `:466`; tests at `:938` and `:1039` | VERIFIED | Invalid inputs fail closed with explicit reason codes. |
+| FR-013 | `remediation_actions.py:1`, `:28`, `:231`; `test_remediation_context.py:1039` | VERIFIED | Raw host/Docker/SQL/storage action kinds are denied. |
+| FR-014 | Existing `RemediationEvidenceToolService` tests plus `test_remediation_context.py:1079` | VERIFIED | Evidence/action preparation remains server-mediated before the authority decision. |
+| FR-015 | `remediation_actions.py:483`, `:502`; `test_remediation_context.py:993` | VERIFIED | Parameters and audit output redact secrets, bearer tokens, URLs, and local paths. |
+| FR-016 | `remediation_actions.py:174`; `test_remediation_context.py:1064` | VERIFIED | Missing remediation links fail without leaking the requested target. |
+| FR-017 | `remediation_actions.py:433`, `:483`; `test_remediation_context.py:993` | VERIFIED | Redaction is applied after authority evaluation, including admin decisions. |
+| FR-018 | `moonmind/workflows/temporal/remediation_tools.py` and `test_remediation_context.py:1079` | VERIFIED | Live/evidence tools remain observation/preparation surfaces and do not execute actions. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| observe_only read/dry-run only | `test_remediation_context.py:843` | VERIFIED | Executable side effect is denied. |
+| approval_gated requires recorded approval | `test_remediation_context.py:883` | VERIFIED | Pending and approved branches are covered. |
+| admin_auto allows only policy/profile-permitted actions | `test_remediation_context.py:926` | VERIFIED | Medium action allowed, disabled profile denied. |
+| Audit records include requestor and execution principal | `test_remediation_context.py:909`, `:993` | VERIFIED | Audit fields are asserted. |
+| View-only user cannot launch/admin-approve | `test_remediation_context.py:938` | VERIFIED | View-only permission is insufficient for profile use. |
+| Generated outputs redact raw secrets/access material | `test_remediation_context.py:993` | VERIFIED | Token, bearer header, and local path are absent from serialized output. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-010 | `remediation_actions.py:270`, `:286`, `:319`, `:375`; tests `:843`, `:883`, `:926` | VERIFIED | Authority modes enforce distinct decision semantics. |
+| DESIGN-REQ-011 | `remediation_actions.py:55`, `:66`, `:300`, `:332`, `:438`, `:466`; tests `:883`, `:926`, `:993` | VERIFIED | Security profile, permission, risk, approval, idempotency, and audit behavior are covered. |
+| DESIGN-REQ-024 | `remediation_actions.py:1`, `:28`, `:483`, `:502`; tests `:993`, `:1039` | VERIFIED | Raw access channels are denied and sensitive output is redacted. |
+| Constitution IX | `remediation_actions.py:135`, `:174`, `:231`, `:244`; tests `:993`, `:1039` | VERIFIED | Decisions are fail-closed and idempotency-keyed. |
+| Constitution XI | `specs/228-remediation-authority-boundaries/spec.md`, `plan.md`, `tasks.md`, this report | VERIFIED | Work remained spec-driven with MM-453 traceability. |
+
+## Original Request Alignment
+
+- The input was classified as a single-story runtime feature request.
+- The implementation uses the MM-453 Jira preset brief as the canonical MoonSpec orchestration input.
+- Runtime behavior was implemented rather than documentation-only changes.
+- Existing artifacts were inspected first; no pre-existing MM-453 feature directory existed, so the workflow resumed from Specify.
+- MM-453 and source IDs are preserved in spec, plan, tasks, contracts, quickstart, tests, and this verification report.
+
+## Gaps
+
+- None blocking.
+
+## Remaining Work
+
+- None for MM-453.
+
+## Decision
+
+- The MM-453 remediation authority boundary story is fully implemented and verified.

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -24,6 +24,7 @@ from moonmind.workflows.temporal import (
     LocalTemporalArtifactStore,
     TemporalArtifactRepository,
     TemporalArtifactService,
+    remediation_actions,
 )
 from moonmind.workflows.temporal.remediation_context import (
     RemediationContextBuilder,
@@ -991,6 +992,91 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
 
 @pytest.mark.asyncio
+async def test_remediation_action_authority_rejects_unsupported_authority_mode(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        link = await session.get(
+            TemporalExecutionRemediationLink,
+            remediation.workflow_id,
+        )
+        assert link is not None
+        link.authority_mode = "stale_typo"
+        await session.commit()
+
+        service = RemediationActionAuthorityService(session=session)
+        result = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="unsupported-authority",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert result.decision == "denied"
+        assert result.reason == "unsupported_authority_mode"
+        assert result.executable is False
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_cache_keys_include_request_shape(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        allowed = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="same-idempotency-key",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        high_risk = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="terminate_session",
+            parameters={},
+            dry_run=False,
+            idempotency_key="same-idempotency-key",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        dry_run = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=True,
+            idempotency_key="same-idempotency-key",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert allowed.decision == "allowed"
+        assert high_risk.decision == "approval_required"
+        assert high_risk.reason == "high_risk_requires_approval"
+        assert dry_run.decision == "allowed"
+        assert dry_run is not allowed
+
+
+@pytest.mark.asyncio
 async def test_remediation_action_authority_redacts_audits_and_deduplicates(
     tmp_path, mock_client_adapter
 ):
@@ -1034,6 +1120,19 @@ async def test_remediation_action_authority_redacts_audits_and_deduplicates(
         assert "Bearer" not in serialized
         assert result.audit["requestingPrincipal"] == "user:operator"
         assert result.audit["executionPrincipal"] == "service:admin-healer"
+
+
+def test_remediation_action_redaction_handles_null_and_single_segment_paths(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        remediation_actions,
+        "redact_sensitive_text",
+        lambda value: None if value is None else str(value),
+    )
+
+    assert remediation_actions._redact_text(None) == ""
+    assert remediation_actions._redact_text("/tmp") == "[REDACTED_PATH]"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -29,6 +29,11 @@ from moonmind.workflows.temporal.remediation_context import (
     RemediationContextBuilder,
     RemediationContextError,
 )
+from moonmind.workflows.temporal.remediation_actions import (
+    RemediationActionAuthorityService,
+    RemediationPermissionSet,
+    RemediationSecurityProfile,
+)
 from moonmind.workflows.temporal.remediation_tools import (
     RemediationEvidenceToolError,
     RemediationEvidenceToolService,
@@ -37,6 +42,82 @@ from moonmind.workflows.temporal.remediation_tools import (
     RemediationLogReadResult,
 )
 from moonmind.workflows.temporal.service import TemporalExecutionService
+
+
+async def _create_target_and_remediation(
+    session: AsyncSession,
+    mock_client_adapter,
+    *,
+    owner_id=None,
+    authority_mode: str = "observe_only",
+    action_policy_ref: str = "admin_healer_default",
+):
+    owner = owner_id or uuid4()
+    mock_client_adapter.start_workflow.side_effect = [
+        SimpleNamespace(run_id="target-run"),
+        SimpleNamespace(run_id="remediation-run"),
+    ]
+    execution_service = TemporalExecutionService(
+        session, client_adapter=mock_client_adapter
+    )
+    target = await execution_service.create_execution(
+        workflow_type="MoonMind.Run",
+        owner_id=owner,
+        title="Target",
+        input_artifact_ref=None,
+        plan_artifact_ref=None,
+        manifest_artifact_ref=None,
+        failure_policy=None,
+        initial_parameters={},
+        idempotency_key=None,
+    )
+    remediation = await execution_service.create_execution(
+        workflow_type="MoonMind.Run",
+        owner_id=owner,
+        title="Remediate target",
+        input_artifact_ref=None,
+        plan_artifact_ref=None,
+        manifest_artifact_ref=None,
+        failure_policy=None,
+        initial_parameters={
+            "task": {
+                "remediation": {
+                    "target": {"workflowId": target.workflow_id},
+                    "authorityMode": authority_mode,
+                    "actionPolicyRef": action_policy_ref,
+                    "approvalPolicy": {
+                        "mode": "risk_gated",
+                        "autoAllowedRisk": "medium",
+                    },
+                }
+            }
+        },
+        idempotency_key=None,
+    )
+    return target, remediation
+
+
+def _admin_permissions(**overrides):
+    data = {
+        "can_view_target": True,
+        "can_create_remediation": True,
+        "can_request_admin_profile": True,
+        "can_approve_high_risk": False,
+        "can_inspect_audit": False,
+    }
+    data.update(overrides)
+    return RemediationPermissionSet(**data)
+
+
+def _admin_profile(**overrides):
+    data = {
+        "profile_ref": "admin_healer",
+        "execution_principal": "service:admin-healer",
+        "allowed_action_kinds": ("restart_worker", "terminate_session"),
+        "enabled": True,
+    }
+    data.update(overrides)
+    return RemediationSecurityProfile(**data)
 
 
 @pytest.fixture
@@ -757,3 +838,284 @@ async def test_remediation_context_builder_rejects_missing_target_record(
                 remediation_workflow_id=remediation.workflow_id,
                 principal="service:remediation-context",
             )
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_enforces_authority_modes(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="observe_only",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        dry_run = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={"reason": "diagnose only"},
+            dry_run=True,
+            idempotency_key="observe-dry-run",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert dry_run.decision == "dry_run_only"
+        assert dry_run.executable is False
+
+        denied = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={"reason": "side effect"},
+            dry_run=False,
+            idempotency_key="observe-execute",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert denied.decision == "denied"
+        assert denied.reason == "observe_only_rejects_side_effects"
+        assert denied.executable is False
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_requires_approval_for_gated_mode(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="approval_gated",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        pending = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="gated-pending",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert pending.decision == "approval_required"
+        assert pending.reason == "approval_gated_requires_approval"
+        assert pending.executable is False
+
+        approved = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="gated-approved",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(can_approve_high_risk=True),
+            security_profile=_admin_profile(),
+            approval_ref="approval://ops/1",
+        )
+        assert approved.decision == "allowed"
+        assert approved.executable is True
+        assert approved.audit["requestingPrincipal"] == "user:operator"
+        assert approved.audit["executionPrincipal"] == "service:admin-healer"
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_enforces_profile_permissions_and_risk(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        view_only = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="view-only",
+            requesting_principal="user:viewer",
+            permissions=RemediationPermissionSet(can_view_target=True),
+            security_profile=_admin_profile(),
+        )
+        assert view_only.decision == "denied"
+        assert view_only.reason == "admin_profile_permission_required"
+
+        disabled_profile = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="disabled-profile",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(enabled=False),
+        )
+        assert disabled_profile.decision == "denied"
+        assert disabled_profile.reason == "security_profile_disabled"
+
+        allowed = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="medium-allowed",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert allowed.decision == "allowed"
+        assert allowed.risk == "medium"
+        assert allowed.executable is True
+
+        high_risk = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="terminate_session",
+            parameters={},
+            dry_run=False,
+            idempotency_key="high-risk",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert high_risk.decision == "approval_required"
+        assert high_risk.reason == "high_risk_requires_approval"
+        assert high_risk.executable is False
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_redacts_audits_and_deduplicates(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        result = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={
+                "token": "raw-secret-token",
+                "path": "/work/agent_jobs/mm:secret/repo/.env",
+                "note": "Authorization: Bearer raw-secret-token",
+            },
+            dry_run=False,
+            idempotency_key="dedupe-redact",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        duplicate = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+            parameters={"token": "different-secret"},
+            dry_run=False,
+            idempotency_key="dedupe-redact",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert duplicate is result
+        serialized = json.dumps(result.to_dict(), sort_keys=True)
+        assert "raw-secret-token" not in serialized
+        assert "/work/agent_jobs" not in serialized
+        assert "Bearer" not in serialized
+        assert result.audit["requestingPrincipal"] == "user:operator"
+        assert result.audit["executionPrincipal"] == "service:admin-healer"
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_denies_raw_access_and_unknown_targets(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        raw_access = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="raw_host_shell",
+            parameters={"command": "docker ps"},
+            dry_run=False,
+            idempotency_key="raw-shell",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert raw_access.decision == "denied"
+        assert raw_access.reason == "raw_access_action_denied"
+
+        missing = await service.evaluate_action_request(
+            remediation_workflow_id="mm:missing-remediation",
+            action_kind="restart_worker",
+            parameters={},
+            dry_run=False,
+            idempotency_key="missing-target",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+        assert missing.decision == "denied"
+        assert missing.reason == "remediation_link_not_found"
+        assert "missing-remediation" not in missing.audit["summary"]
+
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_uses_prepared_action_context(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        builder = RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        await builder.build_context(remediation_workflow_id=remediation.workflow_id)
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        preparation = await tools.prepare_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="restart_worker",
+        )
+
+        service = RemediationActionAuthorityService(session=session)
+        decision = await service.evaluate_action_request(
+            remediation_workflow_id=preparation.remediation_workflow_id,
+            action_kind=preparation.action_kind,
+            parameters={"targetState": preparation.target.state},
+            dry_run=False,
+            idempotency_key="prepared-action",
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert preparation.target.workflow_id == target.workflow_id
+        assert decision.decision == "allowed"
+        assert decision.target_workflow_id == target.workflow_id


### PR DESCRIPTION
## Summary
- Add MM-453 MoonSpec artifacts and preserved Jira orchestration input for remediation authority boundaries.
- Add `RemediationActionAuthorityService` with explicit authority mode, permission, profile, risk, approval, idempotency, audit, and redaction decisions.
- Cover authority behavior with focused remediation context tests, including service-boundary flow, raw-access denial, redaction, and duplicate request handling.

## Jira
- MM-453

## Active MoonSpec Feature Path
- `specs/228-remediation-authority-boundaries`

## Verification Verdict
- FULLY_IMPLEMENTED (`specs/228-remediation-authority-boundaries/verification.md`)

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining Risks
- None for MM-453. Compose-backed integration was not required by the MoonSpec plan because this slice does not cross external services.