### PR TITLE
MM-454 add remediation action registry contracts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/228-remediation-authority-boundaries"
+  "feature_directory": "specs/229-remediation-action-registry"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-453",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1679"
+  "jira_issue_key": "MM-454",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1682"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,32 @@
 [
   {
-    "id": 3122759438,
+    "id": 3123186074,
     "disposition": "addressed",
-    "rationale": "Changed remediation action idempotency caching to include request-shaping fields so a reused key with a different action kind or dry-run flag is evaluated independently."
+    "rationale": "Dry-run results now suppress verificationRequired and verificationHint even when the policy decision is allowed."
   },
   {
-    "id": 3122759452,
-    "disposition": "addressed",
-    "rationale": "Added explicit supported authority mode validation so stale or unknown stored authority modes are denied before any allow path."
-  },
-  {
-    "id": 4153367196,
+    "id": 4153825059,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable child review comments are classified separately."
+    "rationale": "Top-level bot review summary only; its actionable dry-run feedback is covered by inline comments 3123186074 and 3123186102."
   },
   {
-    "id": 3122774747,
+    "id": 3123186102,
     "disposition": "addressed",
-    "rationale": "Guarded the admin-auto risk comparison so malformed catalog entries with null risk do not raise KeyError."
+    "rationale": "Result status mapping now returns no_op for dry_run reason before allowed/rejected decision mapping."
   },
   {
-    "id": 3122774771,
+    "id": 3123194064,
     "disposition": "addressed",
-    "rationale": "Updated the absolute-path redaction regex to cover single-segment absolute paths and removed the redundant optional segment."
+    "rationale": "Admin-auto dry-run decisions now serialize result.status as no_op instead of applied."
   },
   {
-    "id": 4153386617,
+    "id": 3123194071,
+    "disposition": "addressed",
+    "rationale": "Allowed action inputMetadata is now deep-copied before being returned to callers."
+  },
+  {
+    "id": 4153832883,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable child review comments are classified separately."
-  },
-  {
-    "id": 3122774796,
-    "disposition": "addressed",
-    "rationale": "Added a defensive null guard after sensitive-text redaction before applying regex substitutions."
+    "rationale": "Top-level bot review boilerplate only; its actionable deep-copy and dry-run comments are covered by inline comments 3123194064 and 3123194071."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-454-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-454-moonspec-orchestration-input.md
@@ -1,0 +1,92 @@
+# MM-454 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-454
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Provide a typed remediation action registry with audited request and result contracts
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-454 from MM project
+Summary: Provide a typed remediation action registry with audited request and result contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-454 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-454: Provide a typed remediation action registry with audited request and result contracts
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 11. Remediation action registry
+  - 10.6 High-risk actions
+  - 17. Recommended v1
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a remediation task, I can request only typed, allowlisted administrative actions and receive durable request/result artifacts with risk, precondition, idempotency, verification, and audit data.
+
+Acceptance Criteria
+- `list_allowed_actions` returns only policy-compatible typed action kinds with risk and input metadata.
+- `execute_action` validates action kind, target class, inputs, risk policy, preconditions, and idempotency key before invoking owning control-plane code.
+- Action request artifacts include `schemaVersion`, `actionId`, `actionKind`, `requester`, target workflow/run/resource, `riskTier`, `dryRun`, `idempotencyKey`, and bounded params.
+- Action result artifacts include status, `appliedAt` when applicable, before/after refs, `verificationRequired`, `verificationHint`, and bounded `sideEffects`.
+- Unsupported raw host, SQL, Docker, volume, network, secret-reading, or redaction-bypass operations fail fast and are audited as rejected.
+- V1 registry scope matches the recommended small action set unless a supported action is unavailable, in which case it is omitted rather than exposed as raw access.
+
+Requirements
+- Administrative actions are MoonMind-owned typed capabilities.
+- Managed-session and Docker workload actions go through their owning control planes.
+- Every side-effecting action declares risk and verification requirements.
+
+Relevant Implementation Notes
+- Preserve MM-454 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation action registry behavior, high-risk action handling, and recommended v1 scope.
+- Expose remediation actions through MoonMind-owned typed capabilities such as `remediation.list_allowed_actions()` and `remediation.execute_action(actionKind, params, dryRun?)`; do not require the remediation runtime to use UI scraping or raw administrative access.
+- Model registry entries as allowlisted action kinds with explicit target type, allowed inputs, risk tier, preconditions, idempotency rules, verification requirements, and audit payload shape.
+- Include the recommended v1 action set where supported: `execution.pause`, `execution.resume`, `execution.request_rerun_same_workflow`, `session.interrupt_turn`, `session.clear`, `provider_profile.evict_stale_lease`, and `session.restart_container` only when implemented through the owning plane.
+- Keep `execution.start_fresh_rerun`, `execution.cancel`, `execution.force_terminate`, `session.cancel`, `session.terminate`, `workload.restart_helper_container`, and `workload.reap_orphan_container` aligned with the canonical registry semantics if they are included or deferred.
+- Treat high-risk actions with explicit `low`, `medium`, or `high` risk tiers, and let approval policy decide whether each action is auto-allowed, requires operator approval, or is disabled.
+- Request artifacts must use a durable v1 contract that records schema version, action identity, action kind, requester, target workflow/run/resource, risk, dry-run mode, idempotency key, and bounded parameters.
+- Result artifacts must use a durable v1 contract that records status, application timestamp when applicable, before/after refs, verification requirement, verification hint, and bounded side effects.
+- Supported result status values should include `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, and `failed`.
+- Reject unsupported raw host shell, arbitrary SQL, arbitrary Docker image/run, arbitrary volume mount, arbitrary network egress change, decrypted secret read, and redaction-bypass requests as typed audited rejections.
+- Ensure side-effecting action execution validates action kind, target class, input shape, risk policy, preconditions, idempotency key, and ownership/control-plane routing before invoking the owning service.
+- Verify action effects through target-specific checks such as lease state after stale lease eviction, session identity and continuity boundary after container restart, and target run state/runId rollover after same-workflow rerun requests.
+
+Non-Goals
+- Arbitrary raw host shell access.
+- Arbitrary SQL or direct database editing by the remediation runtime.
+- Arbitrary Docker daemon, image, volume, or network access.
+- Reading decrypted secret contents.
+- Bypassing artifact redaction rules.
+- Exposing unsupported actions as raw access fallbacks.
+
+Validation
+- Verify `list_allowed_actions` returns only policy-compatible typed actions with risk and input metadata for the active policy/profile.
+- Verify `execute_action` rejects unsupported action kinds, wrong target classes, malformed inputs, failed preconditions, missing/duplicate unsafe idempotency keys, and policy-disallowed risk tiers before invoking owning control-plane code.
+- Verify action request artifacts include the required v1 fields and keep params bounded.
+- Verify action result artifacts include the required v1 fields, bounded side effects, and verification guidance.
+- Verify high-risk actions require approval or are disabled according to policy.
+- Verify unsupported raw host, SQL, Docker, volume, network, secret-reading, and redaction-bypass requests fail fast and are audited as rejected.
+- Verify managed-session and Docker workload actions route through their owning control planes rather than direct host/runtime access.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-454 blocks MM-453, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-454 is blocked by MM-455, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -112,6 +113,7 @@ class RemediationActionAuthorityResult:
     def to_dict(self) -> dict[str, Any]:
         result_status = _result_status(self.decision, self.reason)
         verification_hint = _verification_hint(self.action_kind)
+        verification_required = self.executable and self.reason != "dry_run"
         return {
             "schemaVersion": "v1",
             "remediationWorkflowId": self.remediation_workflow_id,
@@ -147,8 +149,8 @@ class RemediationActionAuthorityResult:
                 "appliedAt": None,
                 "beforeStateRef": None,
                 "afterStateRef": None,
-                "verificationRequired": self.executable,
-                "verificationHint": verification_hint if self.executable else None,
+                "verificationRequired": verification_required,
+                "verificationHint": verification_hint if verification_required else None,
                 "sideEffects": [],
             },
             "audit": dict(self.audit),
@@ -190,7 +192,7 @@ class RemediationActionAuthorityService:
                     "actionKind": action_kind,
                     "riskTier": action_info["risk"],
                     "targetType": action_info["target_type"],
-                    "inputMetadata": dict(action_info.get("input_metadata") or {}),
+                    "inputMetadata": deepcopy(action_info.get("input_metadata") or {}),
                     "verificationRequired": True,
                     "verificationHint": action_info["verification_hint"],
                 }
@@ -620,6 +622,8 @@ def _verification_hint(action_kind: str) -> str | None:
 
 
 def _result_status(decision: RemediationActionDecision, reason: str) -> str:
+    if reason == "dry_run":
+        return "no_op"
     if decision == "allowed":
         return "applied"
     if decision == "approval_required":

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -38,8 +38,24 @@ _RAW_ACCESS_ACTION_KINDS = frozenset(
     }
 )
 _ACTION_CATALOG: dict[str, dict[str, Any]] = {
-    "restart_worker": {"risk": "medium", "enabled": True},
-    "terminate_session": {"risk": "high", "enabled": True},
+    "restart_worker": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "workload_container",
+        "input_metadata": {
+            "reason": {"type": "string", "required": False},
+        },
+        "verification_hint": "verify helper container health and target state",
+    },
+    "terminate_session": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "managed_session",
+        "input_metadata": {
+            "reason": {"type": "string", "required": False},
+        },
+        "verification_hint": "verify session termination state and target run status",
+    },
 }
 _DEFAULT_AUTO_ALLOWED_RISK = "medium"
 _SUPPORTED_AUTHORITY_MODES = frozenset(
@@ -94,7 +110,10 @@ class RemediationActionAuthorityResult:
     audit: Mapping[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
+        result_status = _result_status(self.decision, self.reason)
+        verification_hint = _verification_hint(self.action_kind)
         return {
+            "schemaVersion": "v1",
             "remediationWorkflowId": self.remediation_workflow_id,
             "targetWorkflowId": self.target_workflow_id,
             "authorityMode": self.authority_mode,
@@ -107,6 +126,31 @@ class RemediationActionAuthorityResult:
             "approvalRef": self.approval_ref,
             "executable": self.executable,
             "redactedParameters": dict(self.redacted_parameters),
+            "request": {
+                "schemaVersion": "v1",
+                "actionId": self.idempotency_key,
+                "actionKind": self.action_kind,
+                "requester": self.audit.get("requestingPrincipal"),
+                "target": {
+                    "workflowId": self.target_workflow_id,
+                    "resourceKind": _target_type(self.action_kind),
+                },
+                "riskTier": self.risk,
+                "dryRun": self.reason == "dry_run",
+                "idempotencyKey": self.idempotency_key,
+                "params": dict(self.redacted_parameters),
+            },
+            "result": {
+                "schemaVersion": "v1",
+                "actionId": self.idempotency_key,
+                "status": result_status,
+                "appliedAt": None,
+                "beforeStateRef": None,
+                "afterStateRef": None,
+                "verificationRequired": self.executable,
+                "verificationHint": verification_hint if self.executable else None,
+                "sideEffects": [],
+            },
             "audit": dict(self.audit),
         }
 
@@ -117,6 +161,41 @@ class RemediationActionAuthorityService:
     def __init__(self, *, session: AsyncSession) -> None:
         self._session = session
         self._decisions: dict[tuple[str, str], RemediationActionAuthorityResult] = {}
+
+    def list_allowed_actions(
+        self,
+        *,
+        permissions: RemediationPermissionSet,
+        security_profile: RemediationSecurityProfile | None,
+    ) -> tuple[Mapping[str, Any], ...]:
+        """Return enabled action metadata allowed by caller permissions and profile."""
+
+        if (
+            not permissions.can_view_target
+            or not permissions.can_request_admin_profile
+            or security_profile is None
+            or not security_profile.enabled
+        ):
+            return ()
+
+        allowed_by_profile = set(security_profile.allowed_action_kinds)
+        actions: list[Mapping[str, Any]] = []
+        for action_kind, action_info in _ACTION_CATALOG.items():
+            if not action_info.get("enabled", False):
+                continue
+            if action_kind not in allowed_by_profile:
+                continue
+            actions.append(
+                {
+                    "actionKind": action_kind,
+                    "riskTier": action_info["risk"],
+                    "targetType": action_info["target_type"],
+                    "inputMetadata": dict(action_info.get("input_metadata") or {}),
+                    "verificationRequired": True,
+                    "verificationHint": action_info["verification_hint"],
+                }
+            )
+        return tuple(actions)
 
     async def evaluate_action_request(
         self,
@@ -524,6 +603,36 @@ def _redact_text(value: str | None) -> str:
     redacted = _PRESIGNED_URL_PATTERN.sub("[REDACTED_URL]", redacted)
     redacted = _ABSOLUTE_PATH_PATTERN.sub("[REDACTED_PATH]", redacted)
     return redacted
+
+
+def _target_type(action_kind: str) -> str | None:
+    action_info = _ACTION_CATALOG.get(action_kind)
+    if action_info is None:
+        return None
+    return str(action_info.get("target_type") or "")
+
+
+def _verification_hint(action_kind: str) -> str | None:
+    action_info = _ACTION_CATALOG.get(action_kind)
+    if action_info is None:
+        return None
+    return str(action_info.get("verification_hint") or "")
+
+
+def _result_status(decision: RemediationActionDecision, reason: str) -> str:
+    if decision == "allowed":
+        return "applied"
+    if decision == "approval_required":
+        return "approval_required"
+    if reason in {
+        "target_view_permission_required",
+        "security_profile_action_not_allowed",
+        "unsupported_authority_mode",
+    }:
+        return "precondition_failed"
+    if decision in {"denied", "dry_run_only"}:
+        return "rejected"
+    return "failed"
 
 
 __all__ = [

--- a/specs/229-remediation-action-registry/checklists/requirements.md
+++ b/specs/229-remediation-action-registry/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Remediation Action Registry
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime mode selected by user.
+- Input classified as a single-story feature request because the MM-454 brief has one actor, one bounded action-registry capability, one source design slice, and no independent sibling stories requiring breakdown.

--- a/specs/229-remediation-action-registry/contracts/remediation-action-registry.md
+++ b/specs/229-remediation-action-registry/contracts/remediation-action-registry.md
@@ -1,0 +1,96 @@
+# Contract: Remediation Action Registry
+
+## `list_allowed_actions`
+
+Input:
+
+```json
+{
+  "permissions": {
+    "canViewTarget": true,
+    "canRequestAdminProfile": true
+  },
+  "securityProfile": {
+    "profileRef": "admin_healer",
+    "enabled": true,
+    "allowedActionKinds": ["restart_worker", "terminate_session"]
+  }
+}
+```
+
+Output:
+
+```json
+[
+  {
+    "actionKind": "restart_worker",
+    "riskTier": "medium",
+    "targetType": "workload_container",
+    "inputMetadata": {
+      "reason": {"type": "string", "required": false}
+    },
+    "verificationRequired": true,
+    "verificationHint": "verify helper container health and target state"
+  }
+]
+```
+
+Rules:
+- Return only enabled action kinds allowed by caller permissions and security profile.
+- Return an empty list when permissions/profile do not authorize administrative action discovery.
+- Do not return raw host, SQL, Docker daemon, storage-key, network, or secret-reading capabilities.
+
+## `evaluate_action_request`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "actionKind": "restart_worker",
+  "parameters": {"reason": "stale helper"},
+  "dryRun": false,
+  "idempotencyKey": "mm:remediation:run:restart_worker:target",
+  "requestingPrincipal": "workflow:remediator",
+  "permissions": {"canViewTarget": true, "canRequestAdminProfile": true},
+  "securityProfile": {"profileRef": "admin_healer", "executionPrincipal": "service:admin-healer"},
+  "approvalRef": null
+}
+```
+
+Output:
+
+```json
+{
+  "schemaVersion": "v1",
+  "decision": "allowed",
+  "executable": true,
+  "request": {
+    "schemaVersion": "v1",
+    "actionKind": "restart_worker",
+    "riskTier": "medium",
+    "dryRun": false,
+    "idempotencyKey": "mm:remediation:run:restart_worker:target"
+  },
+  "result": {
+    "schemaVersion": "v1",
+    "status": "applied",
+    "verificationRequired": true,
+    "verificationHint": "verify helper container health and target state",
+    "sideEffects": []
+  },
+  "audit": {
+    "requestingPrincipal": "workflow:remediator",
+    "executionPrincipal": "service:admin-healer",
+    "decision": "allowed",
+    "reason": "allowed"
+  }
+}
+```
+
+Rules:
+- Validate remediation link, action kind, permissions, profile, risk, approval, idempotency key, dry-run state, and params before any action can be executable.
+- High-risk actions without required approval return `approval_required` and `executable: false`.
+- Unsupported raw access requests return `denied` and `executable: false`.
+- Duplicate requests with the same remediation workflow, idempotency key, action kind, and dry-run state return the original decision.
+- Outputs must be redaction-safe before durable storage or display.

--- a/specs/229-remediation-action-registry/data-model.md
+++ b/specs/229-remediation-action-registry/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Remediation Action Registry
+
+## Action Registry Entry
+
+Represents one enabled typed remediation action kind.
+
+Fields:
+- `actionKind`: Stable action kind string.
+- `riskTier`: One of `low`, `medium`, or `high`.
+- `targetType`: Target resource class the action can affect.
+- `inputMetadata`: Bounded metadata describing accepted params and required fields.
+- `verificationRequired`: Whether successful execution requires follow-up verification.
+- `verificationHint`: Compact guidance for verifying the action result.
+
+Validation:
+- Entries are available only when enabled and allowed by the active security profile.
+- Unsupported future actions are omitted until an owning control-plane path exists.
+
+## Action Request
+
+Represents one remediation action evaluation request.
+
+Fields:
+- `schemaVersion`: `v1`.
+- `actionId`: Stable action/request identity, currently derived from idempotency key for decision output.
+- `actionKind`: Typed action kind.
+- `requester`: Requesting user, workflow, or principal.
+- `target`: Target workflow/run/resource identity.
+- `riskTier`: Declared risk tier from the registry.
+- `dryRun`: Whether the request must avoid side effects.
+- `idempotencyKey`: Stable retry key.
+- `params`: Redacted bounded params.
+
+Validation:
+- Missing idempotency key fails closed.
+- Unknown or raw action kinds fail closed.
+- Params are redacted before serialization.
+
+## Action Result
+
+Represents the bounded result/decision envelope for one evaluated action.
+
+Fields:
+- `schemaVersion`: `v1`.
+- `actionId`: Matches request identity.
+- `status`: Closed status such as `applied`, `approval_required`, `precondition_failed`, `rejected`, or `failed`.
+- `appliedAt`: Present only when an owning executor applies an action.
+- `beforeStateRef`: Optional bounded ref to pre-action state.
+- `afterStateRef`: Optional bounded ref to post-action state.
+- `verificationRequired`: Whether follow-up verification is required.
+- `verificationHint`: Compact verification guidance.
+- `sideEffects`: Bounded side-effect descriptors.
+
+Validation:
+- Denied and approval-required decisions are not executable.
+- Executable decisions include verification guidance.
+
+## Action Audit Record
+
+Represents durable review evidence for an action decision.
+
+Fields:
+- `requestingPrincipal`: Redacted caller identity.
+- `executionPrincipal`: Redacted privileged principal when present.
+- `decision`: `allowed`, `approval_required`, `dry_run_only`, or `denied`.
+- `reason`: Stable decision reason.
+- `summary`: Redacted compact summary.
+
+Validation:
+- Raw secrets, bearer headers, presigned URLs, storage keys, and absolute local filesystem paths are redacted.

--- a/specs/229-remediation-action-registry/plan.md
+++ b/specs/229-remediation-action-registry/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Remediation Action Registry
+
+**Branch**: `229-remediation-action-registry` | **Date**: 2026-04-22 | **Spec**: `specs/229-remediation-action-registry/spec.md`
+**Input**: Single-story feature specification from `/specs/229-remediation-action-registry/spec.md`
+
+## Summary
+
+Implement MM-454 by completing the typed remediation action registry boundary. Existing remediation link, context, evidence, and authority-mode code already evaluate side-effecting action requests through `RemediationActionAuthorityService`; this story adds the missing registry listing contract and v1-shaped request/result serialization while preserving the existing no-raw-execution boundary. Unit and service-boundary tests cover policy-compatible listing, action validation, high-risk approval gating, idempotency, audit redaction, raw access denial, missing target handling, and prepared-action integration.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workflows/temporal/remediation_actions.py` evaluates typed action kinds and denies raw access; tests deny `raw_host_shell` | complete | unit |
+| FR-002 | implemented_verified | `list_allowed_actions()` returns enabled profile-compatible actions with risk/input metadata | complete | unit |
+| FR-003 | implemented_verified | unsupported/blank action path returns `unsupported_action_kind`; existing tests cover unsupported actions | complete | unit |
+| FR-004 | implemented_verified | `evaluate_action_request()` validates link, permissions, profile, approval, risk, dry-run, and idempotency | complete | unit + service-boundary |
+| FR-005 | implemented_verified | allowed execution requires mode/profile/policy/risk approval checks | complete | unit |
+| FR-006 | implemented_verified | high-risk `terminate_session` returns `approval_required` without approval | complete | unit |
+| FR-007 | implemented_verified | request-shape cache keys include workflow, idempotency key, action, and dry-run state | complete | unit |
+| FR-008 | implemented_verified | `to_dict()` emits v1 request envelope with action identity, requester, target, risk, dry-run, idempotency, and bounded params | complete | unit |
+| FR-009 | implemented_verified | `to_dict()` emits v1 result envelope with status, refs, verification fields, and side effects | complete | unit |
+| FR-010 | implemented_verified | result status mapping covers applied, approval_required, precondition_failed, rejected, and failed-style fallback | complete | unit |
+| FR-011 | implemented_verified | audit includes requesting principal, execution principal, decision, reason, and redacted summary | complete | unit |
+| FR-012 | implemented_verified | redaction tests cover secrets, headers, paths, and missing-target summary leakage | complete | unit |
+| FR-013 | implemented_verified | action metadata and result envelope include verification hints for executable decisions | complete | unit |
+| FR-014 | implemented_verified | action catalog exposes only enabled supported actions; unavailable future actions are not listed | complete | unit |
+| FR-015 | implemented_verified | service remains an authority decision boundary and does not execute Docker/host operations | complete | unit inspection |
+| FR-016 | implemented_verified | raw host and raw-prefixed actions are denied before execution | complete | unit |
+| FR-017 | implemented_verified | missing link, missing idempotency key, missing target-view permission, disabled profile, and missing approvals fail closed | complete | unit |
+| FR-018 | implemented_verified | MM-454 is preserved in spec, plan, tasks, quickstart, and final report | complete | final verify |
+| SC-001 | implemented_verified | `test_remediation_action_authority_lists_policy_compatible_actions` | complete | unit |
+| SC-002 | implemented_verified | authority validation tests in `test_remediation_context.py` | complete | unit |
+| SC-003 | implemented_verified | high-risk approval assertions for `terminate_session` | complete | unit |
+| SC-004 | implemented_verified | duplicate/idempotency test returns the original result | complete | unit |
+| SC-005 | implemented_verified | v1 payload assertions in profile/risk test | complete | unit |
+| SC-006 | implemented_verified | raw-access rejection test | complete | unit |
+| SC-007 | implemented_verified | redaction and missing-target tests | complete | unit |
+| SC-008 | implemented_verified | MoonSpec artifacts preserve MM-454 and DESIGN-REQ mappings | complete | final verify |
+| DESIGN-REQ-012 | implemented_verified | typed catalog metadata and authority decision service | complete | unit |
+| DESIGN-REQ-013 | implemented_verified | v1 request/result/audit serialization | complete | unit |
+| DESIGN-REQ-023 | implemented_verified | disabled/unsupported/unavailable actions denied or omitted without raw fallback | complete | unit |
+| DESIGN-REQ-024 | implemented_verified | raw access kinds denied and redaction enforced | complete | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, existing Temporal execution/remediation services, Pydantic-adjacent schema conventions through typed dataclasses  
+**Storage**: Existing `execution_remediation_links` rows plus compact in-process idempotency cache for service evaluation; no new persistent table  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`  
+**Integration Testing**: Service-boundary flow in `tests/unit/workflows/temporal/test_remediation_context.py`; no compose-backed integration required because the story does not cross external services or credentials  
+**Target Platform**: Linux server / Docker Compose deployment  
+**Project Type**: FastAPI control plane plus Temporal workflow service boundary  
+**Performance Goals**: Action listing and evaluation remain bounded to local catalog/profile checks plus one remediation-link lookup for evaluation  
+**Constraints**: Runtime mode; preserve MM-454 traceability; no raw host shell, Docker daemon, arbitrary SQL, raw storage, secret read, or redaction bypass; do not introduce new persistent storage  
+**Scale/Scope**: One remediation execution linked to one target execution; one action request decision at a time with deterministic idempotency handling
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The registry gates MoonMind-owned actions without replacing agent behavior.
+- II. One-Click Agent Deployment: PASS. No new service, external credential, or deployment dependency is introduced.
+- III. Avoid Vendor Lock-In: PASS. Action decisions are provider-neutral and behind MoonMind runtime boundaries.
+- IV. Own Your Data: PASS. Request/result/audit payloads are local bounded data structures.
+- V. Skills Are First-Class and Easy to Add: PASS. Remediation skills can consume typed action metadata without mutable instruction-bundle changes.
+- VI. Replaceable Scaffolding / Tests Anchor: PASS. The boundary is thin and covered by focused tests.
+- VII. Runtime Configurability: PASS. Decisions are driven by profile, permissions, authority mode, risk, and approval inputs.
+- VIII. Modular Architecture: PASS. Changes stay in `remediation_actions.py` and the existing remediation test module.
+- IX. Resilient by Default: PASS. Unsupported or unauthorized actions fail closed and idempotency prevents duplicate decisions for retries.
+- X. Continuous Improvement: PASS. Audit payloads make remediation decisions reviewable.
+- XI. Spec-Driven Development: PASS. This plan follows the MM-454 one-story spec.
+- XII. Canonical Documentation Separation: PASS. Canonical docs remain unchanged; runtime work and temporary Jira input are separated.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility alias layer or fallback raw access path is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/229-remediation-action-registry/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-action-registry.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/temporal/
+└── remediation_actions.py
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+```
+
+**Structure Decision**: Keep the action registry as a narrow Temporal remediation service-boundary module and test it inside the existing remediation context test file so link/context/action behavior remains visible in one local test area.
+
+## Complexity Tracking
+
+None.

--- a/specs/229-remediation-action-registry/quickstart.md
+++ b/specs/229-remediation-action-registry/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart: Remediation Action Registry
+
+## Validation Commands
+
+Run the focused MM-454 unit/service-boundary validation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Run the red/green focused checks used during implementation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -k 'lists_policy_compatible_actions or enforces_profile_permissions_and_risk'
+```
+
+## Expected Coverage
+
+The tests should verify:
+- policy-compatible action listing returns typed risk/input metadata;
+- action requests validate links, permissions, profile state, risk, approval, and idempotency;
+- high-risk actions require approval;
+- unsupported raw access fails closed;
+- duplicate requests reuse the original decision;
+- request/result/audit payloads are v1-shaped and redaction-safe;
+- prepared action context can be evaluated against the authority service.

--- a/specs/229-remediation-action-registry/research.md
+++ b/specs/229-remediation-action-registry/research.md
@@ -1,0 +1,49 @@
+# Research: Remediation Action Registry
+
+## Input Classification
+
+Decision: The MM-454 brief is a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-454-moonspec-orchestration-input.md` defines one actor, one user story, one source document slice, one validation set, and no sibling stories requiring splitting.
+Rationale: The story is independently testable by evaluating typed remediation action requests and durable decision outputs.
+Alternatives considered: Treating `docs/Tasks/TaskRemediation.md` as a broad design was rejected because the Jira brief already selected sections 11, 10.6, and 17 for one action-registry slice.
+Test implications: Unit and service-boundary tests are sufficient for the selected slice; broader remediation workflows belong to adjacent specs.
+
+## DESIGN-REQ-012 Typed Action Registry
+
+Decision: Implement and verify typed action metadata in `RemediationActionAuthorityService.list_allowed_actions()` and `_ACTION_CATALOG`.
+Evidence: `moonmind/workflows/temporal/remediation_actions.py`; `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_action_authority_lists_policy_compatible_actions`.
+Rationale: A local catalog keeps v1 scope explicit and omits unsupported future actions instead of exposing raw access.
+Alternatives considered: A database-backed registry was rejected for this slice because the brief does not require new persistent storage and the current policy/profile inputs are compact.
+Test implications: Unit tests verify filtering by permissions/profile and returned risk/input metadata.
+
+## DESIGN-REQ-013 Request And Result Contracts
+
+Decision: Serialize v1 request/result/audit envelopes from `RemediationActionAuthorityResult.to_dict()`.
+Evidence: `to_dict()` includes `schemaVersion`, `request`, `result`, and `audit`; profile/risk tests assert these fields.
+Rationale: The authority service is not the owning executor, but it can produce the durable bounded contract that downstream execution/audit publishing consumes.
+Alternatives considered: Adding a new artifact writer was deferred because the current story is the registry decision contract, not artifact persistence plumbing.
+Test implications: Unit tests assert required request/result fields and audit principal preservation.
+
+## DESIGN-REQ-023 Bounded Degradation
+
+Decision: Unsupported, disabled, missing-link, and unauthorized actions fail closed through explicit decisions; unsupported future actions are omitted from action listing.
+Evidence: Existing tests cover missing links, unsupported modes/actions, disabled profiles, and idempotency.
+Rationale: Bounded denial is safer than attempting raw fallback behavior.
+Alternatives considered: Returning all recommended future actions with disabled flags was rejected because the brief says unavailable actions should be omitted rather than exposed as raw access.
+Test implications: Unit tests cover denied decisions and allowed listing output.
+
+## DESIGN-REQ-024 Raw Access And Redaction
+
+Decision: Keep raw host, Docker, SQL, raw storage, and redaction-bypass action kinds outside the catalog and deny known raw access names before profile validation.
+Evidence: `_RAW_ACCESS_ACTION_KINDS`, raw-prefix check, redaction helpers, and tests for raw host shell and redaction-sensitive params.
+Rationale: Denying raw access at the registry boundary preserves the source design non-goals.
+Alternatives considered: Allowing operators to pass arbitrary command params was rejected as contrary to MM-454 and source non-goals.
+Test implications: Unit tests assert raw access rejection and absence of raw secrets/paths in serialized output.
+
+## Integration Strategy
+
+Decision: Use service-boundary unit tests rather than compose-backed integration for this story.
+Evidence: The registry does not call external providers, Docker, Temporal workers, or credentialed services; it reads local remediation link rows and pure profile/permission inputs.
+Rationale: The required integration behavior is the boundary between persisted remediation link data, prepared action context, and action authority evaluation, which the existing async database test harness covers.
+Alternatives considered: Compose-backed integration was rejected because it would add runtime cost without exercising a new external boundary.
+Test implications: `./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` is the required command.

--- a/specs/229-remediation-action-registry/spec.md
+++ b/specs/229-remediation-action-registry/spec.md
@@ -1,0 +1,199 @@
+# Feature Specification: Remediation Action Registry
+
+**Feature Branch**: `229-remediation-action-registry`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-454 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-454-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-454 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-454
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Provide a typed remediation action registry with audited request and result contracts
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-454 from MM project
+Summary: Provide a typed remediation action registry with audited request and result contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-454 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-454: Provide a typed remediation action registry with audited request and result contracts
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 11. Remediation action registry
+  - 10.6 High-risk actions
+  - 17. Recommended v1
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a remediation task, I can request only typed, allowlisted administrative actions and receive durable request/result artifacts with risk, precondition, idempotency, verification, and audit data.
+
+Acceptance Criteria
+- `list_allowed_actions` returns only policy-compatible typed action kinds with risk and input metadata.
+- `execute_action` validates action kind, target class, inputs, risk policy, preconditions, and idempotency key before invoking owning control-plane code.
+- Action request artifacts include `schemaVersion`, `actionId`, `actionKind`, `requester`, target workflow/run/resource, `riskTier`, `dryRun`, `idempotencyKey`, and bounded params.
+- Action result artifacts include status, `appliedAt` when applicable, before/after refs, `verificationRequired`, `verificationHint`, and bounded `sideEffects`.
+- Unsupported raw host, SQL, Docker, volume, network, secret-reading, or redaction-bypass operations fail fast and are audited as rejected.
+- V1 registry scope matches the recommended small action set unless a supported action is unavailable, in which case it is omitted rather than exposed as raw access.
+
+Requirements
+- Administrative actions are MoonMind-owned typed capabilities.
+- Managed-session and Docker workload actions go through their owning control planes.
+- Every side-effecting action declares risk and verification requirements.
+
+Relevant Implementation Notes
+- Preserve MM-454 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation action registry behavior, high-risk action handling, and recommended v1 scope.
+- Expose remediation actions through MoonMind-owned typed capabilities such as `remediation.list_allowed_actions()` and `remediation.execute_action(actionKind, params, dryRun?)`; do not require the remediation runtime to use UI scraping or raw administrative access.
+- Model registry entries as allowlisted action kinds with explicit target type, allowed inputs, risk tier, preconditions, idempotency rules, verification requirements, and audit payload shape.
+- Include the recommended v1 action set where supported: `execution.pause`, `execution.resume`, `execution.request_rerun_same_workflow`, `session.interrupt_turn`, `session.clear`, `provider_profile.evict_stale_lease`, and `session.restart_container` only when implemented through the owning plane.
+- Keep `execution.start_fresh_rerun`, `execution.cancel`, `execution.force_terminate`, `session.cancel`, `session.terminate`, `workload.restart_helper_container`, and `workload.reap_orphan_container` aligned with the canonical registry semantics if they are included or deferred.
+- Treat high-risk actions with explicit `low`, `medium`, or `high` risk tiers, and let approval policy decide whether each action is auto-allowed, requires operator approval, or is disabled.
+- Request artifacts must use a durable v1 contract that records schema version, action identity, action kind, requester, target workflow/run/resource, risk, dry-run mode, idempotency key, and bounded parameters.
+- Result artifacts must use a durable v1 contract that records status, application timestamp when applicable, before/after refs, verification requirement, verification hint, and bounded side effects.
+- Supported result status values should include `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, and `failed`.
+- Reject unsupported raw host shell, arbitrary SQL, arbitrary Docker image/run, arbitrary volume mount, arbitrary network egress change, decrypted secret read, and redaction-bypass requests as typed audited rejections.
+- Ensure side-effecting action execution validates action kind, target class, input shape, risk policy, preconditions, idempotency key, and ownership/control-plane routing before invoking the owning service.
+- Verify action effects through target-specific checks such as lease state after stale lease eviction, session identity and continuity boundary after container restart, and target run state/runId rollover after same-workflow rerun requests.
+
+Non-Goals
+- Arbitrary raw host shell access.
+- Arbitrary SQL or direct database editing by the remediation runtime.
+- Arbitrary Docker daemon, image, volume, or network access.
+- Reading decrypted secret contents.
+- Bypassing artifact redaction rules.
+- Exposing unsupported actions as raw access fallbacks.
+
+Validation
+- Verify `list_allowed_actions` returns only policy-compatible typed actions with risk and input metadata for the active policy/profile.
+- Verify `execute_action` rejects unsupported action kinds, wrong target classes, malformed inputs, failed preconditions, missing/duplicate unsafe idempotency keys, and policy-disallowed risk tiers before invoking owning control-plane code.
+- Verify action request artifacts include the required v1 fields and keep params bounded.
+- Verify action result artifacts include the required v1 fields, bounded side effects, and verification guidance.
+- Verify high-risk actions require approval or are disabled according to policy.
+- Verify unsupported raw host, SQL, Docker, volume, network, secret-reading, and redaction-bypass requests fail fast and are audited as rejected.
+- Verify managed-session and Docker workload actions route through their owning control planes rather than direct host/runtime access.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-454 blocks MM-453, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-454 is blocked by MM-455, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## User Story - Request Typed Remediation Actions
+
+**Summary**: As a remediation task, I want to request only typed, allowlisted administrative actions and receive durable request/result artifacts so that remediation can act through audited MoonMind-owned capabilities instead of raw host, Docker, SQL, storage, network, or secret access.
+
+**Goal**: A remediation action request is evaluated through a typed registry that exposes only policy-compatible action kinds, validates the request before execution, records bounded request/result/audit data, and rejects unsupported raw-access operations.
+
+**Independent Test**: Create a linked remediation execution for a target run, evaluate allowed, approval-gated, high-risk, unsupported, raw-access, duplicate, and redaction-sensitive action requests, then verify the decisions, executable flags, risk handling, idempotency behavior, and audit payloads match the active policy/profile without exposing raw access material.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run has a policy-compatible action profile, **When** it lists or evaluates allowed actions, **Then** only typed action kinds compatible with the policy/profile are available with risk and input metadata.
+2. **Given** a side-effecting action request includes an action kind, target, params, dry-run mode, requester, and idempotency key, **When** the registry evaluates it, **Then** action kind, target class, input shape, risk policy, preconditions, profile authorization, and idempotency are validated before any owning control-plane action can run.
+3. **Given** an action request is accepted, **When** durable evidence is produced, **Then** request and result/audit payloads identify schema version, action identity, action kind, requester, target workflow/run/resource, risk tier, dry-run state, idempotency key, bounded params, status, verification guidance, and bounded side effects where applicable.
+4. **Given** a high-risk action is requested without required approval, **When** the registry evaluates it, **Then** execution is not allowed and the result requires approval or reports policy denial.
+5. **Given** a raw host, SQL, Docker, volume, network, secret-reading, storage-key, or redaction-bypass operation is requested, **When** the registry evaluates it, **Then** the operation fails fast as a typed audited rejection.
+6. **Given** the recommended v1 action set is only partly implemented by owning control planes, **When** allowed actions are derived, **Then** unavailable actions are omitted instead of exposed through raw access fallbacks.
+
+### Edge Cases
+
+- Blank, unknown, disabled, or unsupported action kinds are denied with explicit reasons.
+- Missing remediation links, missing idempotency keys, and missing target-view permission fail closed without leaking target existence.
+- Duplicate requests with the same remediation workflow, idempotency key, action kind, and dry-run state return the original decision rather than reapplying side effects.
+- Security profiles that are absent, disabled, or not authorized for the action prevent execution.
+- Dry-run requests produce non-side-effecting decisions even when the action kind is otherwise valid.
+- Redaction-sensitive params, principals, URLs, and local paths are scrubbed from durable outputs.
+
+## Assumptions
+
+- The MM-454 story is a single runtime feature slice focused on action registry request/result decision contracts, not on implementing every owning control-plane action in the full future registry.
+- Existing remediation authority and evidence stories cover evidence-bundle creation, server-mediated evidence access, and authority-mode submission semantics; this story covers action request evaluation and durable decision outputs.
+- Actions are evaluated as MoonMind-owned typed capabilities first; individual execution adapters can be connected only after the typed request is accepted.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-012** (`docs/Tasks/TaskRemediation.md` section 11.2): The initial remediation action registry must expose typed canonical action families and every action kind must declare target type, allowed inputs, risk tier, preconditions, idempotency rules, verification requirements, and audit payload shape. Scope: in scope, mapped to FR-001 through FR-007.
+- **DESIGN-REQ-013** (`docs/Tasks/TaskRemediation.md` sections 11.4 through 11.6): Action request and result evidence must use durable bounded contracts that include action identity, requester, target, risk, dry-run, idempotency, status, before/after refs, verification requirements, hints, and side effects. Scope: in scope, mapped to FR-008 through FR-013.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` sections 6, 9.5, and 17): Missing or unavailable supported actions must degrade by omission or bounded denial rather than unbounded waits or raw access fallback. Scope: in scope, mapped to FR-014 and FR-015.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskRemediation.md` sections 4, 10.7, and 11.7): The registry must explicitly reject arbitrary host shell, SQL, Docker, volume, network, decrypted secret, raw storage, and redaction-bypass operations. Scope: in scope, mapped to FR-016 through FR-018.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose remediation action evaluation through typed MoonMind-owned action kinds rather than raw host, Docker, SQL, storage, network, or secret access.
+- **FR-002**: The registry MUST return only policy-compatible enabled action kinds for the active remediation policy/profile and MUST include risk and input metadata for each returned kind.
+- **FR-003**: The registry MUST deny blank, unknown, disabled, or unsupported action kinds before any side-effecting execution can occur.
+- **FR-004**: The registry MUST validate remediation link identity, target class, target-view permission, action kind, dry-run state, params, risk policy, security profile authorization, approval requirement, and idempotency key before returning an executable decision.
+- **FR-005**: Side-effecting actions MUST be executable only when the selected authority mode, policy, profile, approval state, and risk tier allow execution.
+- **FR-006**: High-risk actions MUST require approval or be disabled according to policy and MUST NOT become executable merely because the remediation mode allows automatic administration.
+- **FR-007**: Duplicate or retried action requests with the same remediation workflow, idempotency key, action kind, and dry-run state MUST return a deterministic original decision rather than applying a second side effect.
+- **FR-008**: Action request evidence MUST include schema version, action identity, action kind, requester, target workflow/run/resource, risk tier, dry-run state, idempotency key, and bounded parameters.
+- **FR-009**: Action result evidence MUST include status, application timestamp when applicable, before/after refs when applicable, verification requirement, verification hint, and bounded side effects.
+- **FR-010**: Supported action result statuses MUST include `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, and `failed` or an equivalent closed set that maps these outcomes without ambiguity.
+- **FR-011**: The audit payload for each evaluated action MUST identify the requesting principal or workflow, execution principal or security profile when present, decision, denial/approval reason, and redacted summary.
+- **FR-012**: Request, result, and audit payloads MUST redact raw secrets, secret-bearing headers, presigned URLs, storage keys, and absolute local filesystem paths before durable storage or display.
+- **FR-013**: Accepted action requests MUST carry verification requirements or hints appropriate to the action kind and target class.
+- **FR-014**: The v1 action set MUST include only action kinds that have a supported owning control-plane path; unavailable recommended actions MUST be omitted or denied rather than exposed as raw access.
+- **FR-015**: Managed-session and Docker workload actions MUST route through their owning control planes when supported and MUST NOT grant direct Docker daemon or host shell capability to the remediation runtime.
+- **FR-016**: Raw host shell, arbitrary SQL, arbitrary Docker image/run, arbitrary volume mount, arbitrary network egress change, decrypted secret read, raw storage key read, and redaction-bypass requests MUST fail fast as audited typed rejections.
+- **FR-017**: Missing remediation links, missing idempotency keys, missing target-view permission, disabled profiles, unauthorized profiles, and missing approvals MUST fail closed with explicit validation results.
+- **FR-018**: Durable registry decisions MUST preserve MM-454 traceability through spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Action Registry Entry**: A typed allowlisted remediation capability with action kind, target type, allowed inputs, risk tier, preconditions, idempotency rule, verification requirement, and audit payload shape.
+- **Action Request**: A bounded command envelope for one remediation action evaluation, including requester, target, action kind, params, dry-run state, risk, approval/profile evidence, and idempotency key.
+- **Action Result**: A bounded outcome envelope for one evaluated action, including status, application metadata, before/after refs, verification guidance, and side effects.
+- **Action Audit Record**: Redaction-safe durable evidence of who requested the action, which execution principal/profile would execute it, and why the registry allowed, gated, or denied it.
+- **Idempotency Key**: A stable request key that prevents retries from duplicating side effects.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove allowed-action evaluation exposes only enabled typed action kinds compatible with policy/profile and includes risk metadata.
+- **SC-002**: Tests prove action evaluation denies unsupported action kinds, missing links, missing idempotency keys, missing permissions, disabled profiles, and unauthorized profile/action combinations before execution.
+- **SC-003**: Tests prove high-risk actions require approval or are denied according to policy.
+- **SC-004**: Tests prove duplicate action requests with the same idempotency key and request shape return the original decision.
+- **SC-005**: Tests prove request/result/audit payloads include requester, execution profile/principal, target identity, action kind, risk, decision/status, and verification guidance where applicable.
+- **SC-006**: Tests prove raw host, SQL, Docker, volume, network, secret-reading, storage-key, and redaction-bypass action attempts fail fast as audited rejections.
+- **SC-007**: Tests prove durable action outputs redact raw secrets, secret-bearing headers, presigned URLs, storage keys, and absolute local filesystem paths.
+- **SC-008**: Traceability verification confirms MM-454 and DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-023, and DESIGN-REQ-024 are preserved in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/229-remediation-action-registry/tasks.md
+++ b/specs/229-remediation-action-registry/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
 - Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -96,7 +96,7 @@
 - [X] T019 [P] Align `specs/229-remediation-action-registry/spec.md` with the MM-454 Jira brief and source design mappings (SC-008).
 - [X] T020 [P] Align `specs/229-remediation-action-registry/plan.md`, `research.md`, `data-model.md`, `contracts/remediation-action-registry.md`, and `quickstart.md` with implementation evidence (SC-008).
 - [X] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and record result (FR-001 through FR-018).
-- [X] T022 Run `/speckit.verify`-style verification by inspecting spec, plan, tasks, code, and tests for MM-454 completion.
+- [X] T022 Run `/moonspec-verify`-style verification by inspecting spec, plan, tasks, code, and tests for MM-454 completion.
 
 ---
 

--- a/specs/229-remediation-action-registry/tasks.md
+++ b/specs/229-remediation-action-registry/tasks.md
@@ -9,6 +9,13 @@
 
 **Source Traceability**: Tasks reference FR-001 through FR-018, SC-001 through SC-008, and DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-023, DESIGN-REQ-024.
 
+**Traceability Inventory**:
+
+- Functional requirements: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013, FR-014, FR-015, FR-016, FR-017, FR-018.
+- Success criteria: SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, SC-008.
+- Source design requirements: DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-023, DESIGN-REQ-024.
+
+
 **Test Commands**:
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
@@ -142,7 +149,7 @@ Task: "Add failing unit assertions for v1 request/result/audit serialization in 
 3. Add failing tests for the missing list and durable payload contracts.
 4. Implement only the missing service methods/serialization fields.
 5. Rerun focused tests, then the full remediation context test file.
-6. Complete final `/speckit.verify`-style verification against MM-454.
+6. Complete final `/moonspec-verify`-style verification against MM-454.
 
 ---
 

--- a/specs/229-remediation-action-registry/tasks.md
+++ b/specs/229-remediation-action-registry/tasks.md
@@ -1,0 +1,153 @@
+# Tasks: Remediation Action Registry
+
+**Input**: Design documents from `/specs/229-remediation-action-registry/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and service-boundary integration-style tests are REQUIRED. Tests were added first for the missing MM-454 contract gaps, confirmed red, then production code was updated until they passed.
+
+**Organization**: Tasks are grouped by phase around the single MM-454 story.
+
+**Source Traceability**: Tasks reference FR-001 through FR-018, SC-001 through SC-008, and DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-023, DESIGN-REQ-024.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Path Conventions
+
+- Runtime code: `moonmind/workflows/temporal/`
+- Unit/service-boundary tests: `tests/unit/workflows/temporal/`
+- MoonSpec artifacts: `specs/229-remediation-action-registry/`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing project structure and active feature artifacts.
+
+- [X] T001 Create `specs/229-remediation-action-registry/` with `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/remediation-action-registry.md`, and `tasks.md` for MM-454.
+- [X] T002 Set active feature pointer in `.specify/feature.json` to `specs/229-remediation-action-registry`.
+- [X] T003 [P] Confirm existing runtime module path `moonmind/workflows/temporal/remediation_actions.py` for FR-001 through FR-018.
+- [X] T004 [P] Confirm existing test module path `tests/unit/workflows/temporal/test_remediation_context.py` for unit and service-boundary validation.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Verify the existing remediation link and action authority foundation used by the story.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T005 Verify remediation link fixtures create target/remediation records for authority evaluation in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-004, FR-017).
+- [X] T006 Verify `RemediationPermissionSet` and `RemediationSecurityProfile` model the caller permissions and privileged profile inputs in `moonmind/workflows/temporal/remediation_actions.py` (FR-004, FR-005, DESIGN-REQ-012).
+- [X] T007 Verify the action authority service remains a decision boundary and does not execute host, Docker, SQL, storage, provider, or network operations in `moonmind/workflows/temporal/remediation_actions.py` (FR-001, FR-015, FR-016, DESIGN-REQ-024).
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Request Typed Remediation Actions
+
+**Summary**: As a remediation task, I want to request only typed, allowlisted administrative actions and receive durable request/result artifacts so that remediation can act through audited MoonMind-owned capabilities instead of raw access.
+
+**Independent Test**: Create a linked remediation execution, evaluate allowed, approval-gated, high-risk, unsupported, raw-access, duplicate, and redaction-sensitive action requests, then verify decisions, executable flags, risk handling, idempotency behavior, and audit payloads.
+
+**Traceability**: FR-001 through FR-018, SC-001 through SC-008, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-023, DESIGN-REQ-024
+
+**Test Plan**:
+
+- Unit: action metadata filtering, authority decisions, idempotency, status mapping, redaction helpers, fail-closed behavior.
+- Integration: async DB-backed service-boundary flow from remediation link/context preparation to action authority evaluation.
+
+### Unit Tests (write first)
+
+- [X] T008 [P] Add failing unit test for policy-compatible action listing in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-002, SC-001, DESIGN-REQ-012).
+- [X] T009 [P] Add failing unit assertions for v1 request/result/audit serialization in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-013, SC-005, DESIGN-REQ-013).
+- [X] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -k 'lists_policy_compatible_actions or enforces_profile_permissions_and_risk'` and confirm T008-T009 fail for missing `list_allowed_actions` and missing `schemaVersion`.
+
+### Integration Tests (write first)
+
+- [X] T011 [P] Preserve existing async DB-backed action authority tests for observe-only, approval-gated, admin-auto, high-risk, unsupported mode, idempotency, redaction, raw access, and prepared action context in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-004 through FR-017, SC-002 through SC-007).
+- [X] T012 Run the focused service-boundary test command and confirm the newly added contract tests fail before implementation in `tests/unit/workflows/temporal/test_remediation_context.py` (DESIGN-REQ-012, DESIGN-REQ-013).
+
+### Implementation
+
+- [X] T013 Add enabled action catalog metadata for risk, target type, input metadata, and verification hint in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-013, DESIGN-REQ-012).
+- [X] T014 Implement `RemediationActionAuthorityService.list_allowed_actions()` in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-014, SC-001).
+- [X] T015 Add v1 request/result serialization to `RemediationActionAuthorityResult.to_dict()` in `moonmind/workflows/temporal/remediation_actions.py` (FR-008 through FR-013, DESIGN-REQ-013).
+- [X] T016 Add result status, target type, and verification hint helpers in `moonmind/workflows/temporal/remediation_actions.py` (FR-009, FR-010, FR-013).
+- [X] T017 Preserve raw access denial, missing-link fail-closed behavior, idempotency cache keys, and redaction behavior in `moonmind/workflows/temporal/remediation_actions.py` (FR-007, FR-012, FR-016, FR-017, DESIGN-REQ-023, DESIGN-REQ-024).
+- [X] T018 Rerun the focused red/green test command and verify it passes (SC-001, SC-005).
+
+**Checkpoint**: The story is implemented at the remediation action authority boundary and covered by unit/service-boundary tests.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the completed story without broadening scope.
+
+- [X] T019 [P] Align `specs/229-remediation-action-registry/spec.md` with the MM-454 Jira brief and source design mappings (SC-008).
+- [X] T020 [P] Align `specs/229-remediation-action-registry/plan.md`, `research.md`, `data-model.md`, `contracts/remediation-action-registry.md`, and `quickstart.md` with implementation evidence (SC-008).
+- [X] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and record result (FR-001 through FR-018).
+- [X] T022 Run `/speckit.verify`-style verification by inspecting spec, plan, tasks, code, and tests for MM-454 completion.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish (Phase 4)**: Depends on Story completion and passing focused tests.
+
+### Within The Story
+
+- T008-T009 must be written before T013-T016.
+- T010 must confirm the expected red state before production edits.
+- T013-T016 must complete before T018.
+- T021-T022 run after implementation and artifact alignment.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel.
+- T008 and T009 can run in parallel.
+- T019 and T020 can run in parallel.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+Task: "Add failing unit test for policy-compatible action listing in tests/unit/workflows/temporal/test_remediation_context.py"
+Task: "Add failing unit assertions for v1 request/result/audit serialization in tests/unit/workflows/temporal/test_remediation_context.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Create the missing MM-454 MoonSpec artifacts.
+2. Confirm the existing remediation action boundary and tests.
+3. Add failing tests for the missing list and durable payload contracts.
+4. Implement only the missing service methods/serialization fields.
+5. Rerun focused tests, then the full remediation context test file.
+6. Complete final `/speckit.verify`-style verification against MM-454.
+
+---
+
+## Notes
+
+- The story intentionally does not add raw action execution.
+- The service remains an authority and contract boundary; owning control planes execute supported actions after a typed request is accepted.
+- Unavailable future recommended actions are omitted rather than exposed through raw access fallback.

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -121,6 +121,26 @@ def _admin_profile(**overrides):
     return RemediationSecurityProfile(**data)
 
 
+def test_remediation_action_authority_lists_policy_compatible_actions():
+    service = RemediationActionAuthorityService(session=object())
+
+    denied = service.list_allowed_actions(
+        permissions=RemediationPermissionSet(can_view_target=True),
+        security_profile=_admin_profile(),
+    )
+    assert denied == ()
+
+    allowed = service.list_allowed_actions(
+        permissions=_admin_permissions(),
+        security_profile=_admin_profile(allowed_action_kinds=("restart_worker",)),
+    )
+
+    assert [item["actionKind"] for item in allowed] == ["restart_worker"]
+    assert allowed[0]["riskTier"] == "medium"
+    assert allowed[0]["targetType"] == "workload_container"
+    assert allowed[0]["inputMetadata"]["reason"]["required"] is False
+
+
 @pytest.fixture
 def mock_client_adapter():
     adapter = MagicMock()
@@ -975,6 +995,16 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
         assert allowed.decision == "allowed"
         assert allowed.risk == "medium"
         assert allowed.executable is True
+        payload = allowed.to_dict()
+        assert payload["schemaVersion"] == "v1"
+        assert payload["request"]["actionKind"] == "restart_worker"
+        assert payload["request"]["riskTier"] == "medium"
+        assert payload["request"]["dryRun"] is False
+        assert payload["result"]["status"] == "applied"
+        assert payload["result"]["verificationRequired"] is True
+        assert payload["result"]["verificationHint"]
+        assert payload["result"]["sideEffects"] == []
+        assert payload["audit"]["executionPrincipal"] == "service:admin-healer"
 
         high_risk = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -140,6 +140,13 @@ def test_remediation_action_authority_lists_policy_compatible_actions():
     assert allowed[0]["targetType"] == "workload_container"
     assert allowed[0]["inputMetadata"]["reason"]["required"] is False
 
+    allowed[0]["inputMetadata"]["reason"]["required"] = True
+    listed_again = service.list_allowed_actions(
+        permissions=_admin_permissions(),
+        security_profile=_admin_profile(allowed_action_kinds=("restart_worker",)),
+    )
+    assert listed_again[0]["inputMetadata"]["reason"]["required"] is False
+
 
 @pytest.fixture
 def mock_client_adapter():
@@ -885,6 +892,11 @@ async def test_remediation_action_authority_enforces_authority_modes(
         )
         assert dry_run.decision == "dry_run_only"
         assert dry_run.executable is False
+        dry_run_payload = dry_run.to_dict()
+        assert dry_run_payload["request"]["dryRun"] is True
+        assert dry_run_payload["result"]["status"] == "no_op"
+        assert dry_run_payload["result"]["verificationRequired"] is False
+        assert dry_run_payload["result"]["verificationHint"] is None
 
         denied = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
@@ -1104,6 +1116,11 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         assert high_risk.reason == "high_risk_requires_approval"
         assert dry_run.decision == "allowed"
         assert dry_run is not allowed
+        dry_run_payload = dry_run.to_dict()
+        assert dry_run_payload["request"]["dryRun"] is True
+        assert dry_run_payload["result"]["status"] == "no_op"
+        assert dry_run_payload["result"]["verificationRequired"] is False
+        assert dry_run_payload["result"]["verificationHint"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Jira
- Issue: MM-454

## MoonSpec
- Active feature path: `specs/229-remediation-action-registry`
- Verification verdict: FULLY_IMPLEMENTED

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` - PASS
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS (`3762 passed`, `1 xpassed`, frontend `365 passed`)

## Remaining Risks
- None identified.
