### PR TITLE
MM-463 Sensitive report access retention

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/230-mission-control-report-presentation"
+  "feature_directory": "specs/231-sensitive-report-access-retention"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-462",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1681"
+  "jira_issue_key": "MM-463",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1684"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,12 @@
 [
   {
-    "id": 3123155677,
+    "id": 3123466318,
     "disposition": "addressed",
-    "rationale": "Changed latest primary report selection to trust the server-filtered latest report response instead of re-filtering returned artifacts by their first report link."
+    "rationale": "Changed _strongest_retention_class to rank the provided values directly and added an EPHEMERAL unpin regression test."
   },
   {
-    "id": 4153793713,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable inline Codex comment is classified separately."
-  },
-  {
-    "id": 3123174860,
+    "id": 4154120748,
     "disposition": "addressed",
-    "rationale": "Refactored artifact response normalization to cast each raw artifact/link once as Record<string, unknown>, reducing repeated type assertions."
-  },
-  {
-    "id": 4153813759,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable inline Gemini comment is classified separately."
+    "rationale": "Duplicate summary review for the same _strongest_retention_class issue; addressed by the helper fix and regression test."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md
@@ -1,0 +1,71 @@
+# MM-463 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-463
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Sensitive Report Access and Retention
+- Labels: `moonmind-workflow-mm-ba49b1c2-6312-465a-bf68-0d46b37886cf`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-463 from MM project
+Summary: Sensitive Report Access and Retention
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-463 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-463: Sensitive Report Access and Retention
+
+Short Name
+sensitive-report-access-retention
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 7. Consumer and producer invariants, 14. Security and access model, 15. Retention guidance
+- Coverage IDs: DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-022
+
+User Story
+As an operator, I can rely on report artifacts to use existing authorization, preview, retention, pinning, and deletion behavior so sensitive reports remain useful without widening raw access.
+
+Acceptance Criteria
+- Given a sensitive report has restricted raw access, then Mission Control uses preview/default-read behavior where available and does not assume full download is allowed.
+- Given `report.primary` or `report.summary` artifacts are created, then their default retention policy is long unless product policy overrides it.
+- Given `report.structured` or `report.evidence` artifacts are created, then their retention follows standard or long policy based on the report family and audit needs.
+- Given a final report is important to retain, then it can be pinned or unpinned through existing artifact APIs.
+- Deleting a report artifact uses artifact-system-native soft/hard deletion and does not implicitly delete unrelated runtime stdout, stderr, diagnostics, or other observability artifacts.
+
+Requirements
+- Reuse the existing artifact authorization model for report artifacts and evidence.
+- Support preview artifacts and `default_read_ref` for sensitive report presentation.
+- Apply recommended retention mappings for primary, summary, structured, evidence, and related observability artifacts.
+- Keep deletion artifact-system-native without undefined cascading into unrelated observability artifacts.
+
+Relevant Implementation Notes
+- Keep report artifact access within the existing artifact authorization, preview, and default-read boundaries.
+- Do not add report-specific raw download assumptions for sensitive report artifacts.
+- Use existing artifact APIs for pinning, unpinning, soft deletion, and hard deletion.
+- Preserve separation between report artifact lifecycle behavior and unrelated runtime observability artifacts such as stdout, stderr, diagnostics, and logs.
+- Preserve MM-463 and coverage IDs DESIGN-REQ-015, DESIGN-REQ-016, and DESIGN-REQ-022 in downstream MoonSpec artifacts and final implementation evidence.
+
+Non-Goals
+- Widening raw artifact access for sensitive reports.
+- Creating report-specific authorization, retention, pinning, or deletion systems separate from the existing artifact system.
+- Cascading report deletion into unrelated runtime stdout, stderr, diagnostics, logs, or other observability artifacts.
+
+Validation
+- Verify sensitive report presentation uses preview/default-read behavior where available and does not require raw download access.
+- Verify `report.primary` and `report.summary` artifacts default to long retention unless policy overrides them.
+- Verify `report.structured` and `report.evidence` artifacts follow standard or long retention based on report family and audit needs.
+- Verify final report artifacts can be pinned and unpinned through existing artifact APIs.
+- Verify report artifact deletion uses artifact-system-native soft/hard deletion without implicitly deleting unrelated runtime observability artifacts.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -192,6 +192,10 @@ def _derive_retention(
     if explicit is not None:
         return explicit
     link = (link_type or "").strip().lower()
+    if link in {"report.primary", "report.summary"}:
+        return db_models.TemporalArtifactRetentionClass.LONG
+    if link in {"report.structured", "report.evidence"}:
+        return db_models.TemporalArtifactRetentionClass.STANDARD
     if link in {"output.logs", "debug.trace"}:
         return db_models.TemporalArtifactRetentionClass.EPHEMERAL
     if link in {"input.instructions", "input.plan", "input.manifest"}:
@@ -199,6 +203,22 @@ def _derive_retention(
     if link in {"output.primary", "output.patch", "output.summary"}:
         return db_models.TemporalArtifactRetentionClass.STANDARD
     return db_models.TemporalArtifactRetentionClass.STANDARD
+
+
+def _strongest_retention_class(
+    values: Iterable[db_models.TemporalArtifactRetentionClass],
+) -> db_models.TemporalArtifactRetentionClass:
+    rank = {
+        db_models.TemporalArtifactRetentionClass.EPHEMERAL: 0,
+        db_models.TemporalArtifactRetentionClass.STANDARD: 1,
+        db_models.TemporalArtifactRetentionClass.LONG: 2,
+        db_models.TemporalArtifactRetentionClass.PINNED: 3,
+    }
+    strongest = db_models.TemporalArtifactRetentionClass.STANDARD
+    for value in values:
+        if rank[value] > rank[strongest]:
+            strongest = value
+    return strongest
 
 
 def _normalized_content_type(value: object | None) -> str:
@@ -1845,9 +1865,12 @@ class TemporalArtifactService:
         self._assert_mutation_access(artifact, principal=principal)
         await self._repository.unpin_artifact(artifact_id)
         if artifact.retention_class is db_models.TemporalArtifactRetentionClass.PINNED:
-            artifact.retention_class = db_models.TemporalArtifactRetentionClass.STANDARD
+            links = await self._repository.list_links(artifact_id)
+            artifact.retention_class = _strongest_retention_class(
+                _derive_retention(None, link.link_type) for link in links
+            )
             artifact.expires_at = _expires_at_for_retention(
-                db_models.TemporalArtifactRetentionClass.STANDARD,
+                artifact.retention_class,
                 datetime.now(UTC),
             )
         await self._repository.commit()

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -214,11 +214,11 @@ def _strongest_retention_class(
         db_models.TemporalArtifactRetentionClass.LONG: 2,
         db_models.TemporalArtifactRetentionClass.PINNED: 3,
     }
-    strongest = db_models.TemporalArtifactRetentionClass.STANDARD
-    for value in values:
-        if rank[value] > rank[strongest]:
-            strongest = value
-    return strongest
+    return max(
+        values,
+        key=lambda value: rank[value],
+        default=db_models.TemporalArtifactRetentionClass.STANDARD,
+    )
 
 
 def _normalized_content_type(value: object | None) -> str:

--- a/specs/231-sensitive-report-access-retention/checklists/requirements.md
+++ b/specs/231-sensitive-report-access-retention/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Sensitive Report Access and Retention
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-22  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: MM-463 is classified as a single-story runtime feature request.
+- PASS: DESIGN-REQ-015, DESIGN-REQ-016, and DESIGN-REQ-022 are mapped to functional requirements and success criteria.

--- a/specs/231-sensitive-report-access-retention/contracts/sensitive-report-access-retention.md
+++ b/specs/231-sensitive-report-access-retention/contracts/sensitive-report-access-retention.md
@@ -1,0 +1,33 @@
+# Contract: Sensitive Report Access and Retention
+
+## Artifact Service Boundary
+
+The story is implemented through existing artifact service calls and HTTP routes:
+
+- Create artifact: `TemporalArtifactService.create(...)` and `POST /api/artifacts`
+- Complete artifact: `write_complete(...)` and `PUT /api/artifacts/{artifact_id}/content`
+- Metadata/read policy: `get_metadata(...)` and `GET /api/artifacts/{artifact_id}`
+- Raw download: `presign_download(...)`, `read(...)`, and download routes
+- Pin: `pin(...)` and `POST /api/artifacts/{artifact_id}/pin`
+- Unpin: `unpin(...)` and `DELETE /api/artifacts/{artifact_id}/pin`
+- Delete: `soft_delete(...)`, lifecycle sweep, and `DELETE /api/artifacts/{artifact_id}`
+
+## Expected Behavior
+
+- A restricted report artifact with a generated preview returns metadata with:
+  - `raw_access_allowed=false` for callers without raw access.
+  - `preview_artifact_ref` set when a preview exists.
+  - `default_read_ref` pointing at the preview artifact.
+- Raw read and presign calls fail for callers without restricted raw access.
+- Report retention defaults:
+  - `report.primary` -> `long`
+  - `report.summary` -> `long`
+  - `report.structured` -> `standard` unless explicitly overridden
+  - `report.evidence` -> `standard` unless explicitly overridden
+- Pinning sets retention to `pinned`.
+- Unpinning restores report-derived retention based on existing report links.
+- Deleting one report artifact does not mutate unrelated observability artifacts linked to the same execution.
+
+## Compatibility Notes
+
+MoonMind is pre-release. This change updates internal default retention behavior directly and does not add compatibility aliases or alternate link semantics.

--- a/specs/231-sensitive-report-access-retention/data-model.md
+++ b/specs/231-sensitive-report-access-retention/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Sensitive Report Access and Retention
+
+## Temporal Artifact
+
+- Existing durable artifact metadata row.
+- Relevant fields:
+  - `artifact_id`: immutable artifact identifier.
+  - `status`: `pending_upload`, `complete`, `failed`, or `deleted`.
+  - `retention_class`: `ephemeral`, `standard`, `long`, or `pinned`.
+  - `redaction_level`: controls raw access and preview behavior.
+  - `metadata_json.preview_artifact_id`: optional pointer to a preview artifact used by `default_read_ref`.
+  - `expires_at`, `deleted_at`, `hard_deleted_at`: lifecycle timestamps.
+
+## Artifact Link
+
+- Existing execution-to-artifact relationship.
+- Relevant fields:
+  - `namespace`, `workflow_id`, `run_id`: execution identity.
+  - `link_type`: report or observability classification.
+  - `label`: optional display label.
+- Report link types in scope:
+  - `report.primary`
+  - `report.summary`
+  - `report.structured`
+  - `report.evidence`
+- Observability link types must remain independent:
+  - `runtime.stdout`
+  - `runtime.stderr`
+  - `runtime.merged_logs`
+  - `runtime.diagnostics`
+  - `debug.trace`
+
+## Artifact Pin
+
+- Existing pin row that protects an artifact from lifecycle deletion.
+- Relevant fields:
+  - `artifact_id`
+  - `pinned_by_principal`
+  - `pinned_at`
+  - `reason`
+
+## State Transitions
+
+1. Create `report.primary` or `report.summary` without explicit retention -> `retention_class=long`.
+2. Create `report.structured` or `report.evidence` without explicit retention -> `retention_class=standard`.
+3. Pin report artifact -> `retention_class=pinned`, `expires_at=None`.
+4. Unpin report artifact -> recompute default retention from existing report link; `report.primary` returns to `long`.
+5. Soft delete report artifact -> `status=deleted`, `deleted_at` set, pin removed.
+6. Hard delete report artifact -> existing lifecycle path marks `hard_deleted_at`/`tombstoned_at`; unrelated artifacts are not traversed or mutated.

--- a/specs/231-sensitive-report-access-retention/plan.md
+++ b/specs/231-sensitive-report-access-retention/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Sensitive Report Access and Retention
+
+**Branch**: `run-jira-orchestrate-for-mm-463-sensitive-report-access-retention` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story feature specification from `specs/231-sensitive-report-access-retention/spec.md`
+
+## Summary
+
+Implement MM-463 by tightening existing Temporal artifact service behavior for report artifacts: preserve preview/default-read behavior for restricted report content, derive report-aware retention defaults from `report.*` link types, restore report-derived retention after unpin, and prove report deletion stays artifact-native without cascading into unrelated observability artifacts. Existing authorization, preview creation, pin/unpin, soft-delete/hard-delete, and report-link validation already exist; the planned code change is narrow retention derivation plus focused unit and integration coverage.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `TemporalArtifactService._assert_read_access`, `_assert_raw_access`, and report contract validation already apply to report artifacts. | Add report-specific access/default-read verification. | unit |
+| FR-002 | implemented_unverified | `get_read_policy` selects preview `default_read_ref` when raw access is not allowed and `preview_artifact_id` exists. | Add restricted report metadata/default-read test. | unit |
+| FR-003 | implemented_unverified | `read`, `read_chunks`, `read_path`, and `presign_download` call `_assert_raw_access`. | Add restricted report raw-denial test. | unit |
+| FR-004 | missing | `_derive_retention` currently returns `standard` for unspecified `report.primary`. | Add failing test and derive `long`. | unit |
+| FR-005 | missing | `_derive_retention` currently returns `standard` for unspecified `report.summary`. | Add failing test and derive `long`. | unit |
+| FR-006 | implemented_unverified | Existing default for unspecified report structured/evidence is `standard`, which satisfies standard-or-long. | Add explicit regression proving non-observability retention. | unit |
+| FR-007 | partial | `pin` sets `pinned`; `unpin` currently restores generic `standard`, not link-derived report retention. | Add failing test and restore link-derived retention after unpin. | unit |
+| FR-008 | implemented_unverified | `soft_delete`, `hard_delete`, and `sweep_lifecycle` use existing artifact lifecycle path. | Add report deletion integration regression. | integration_ci |
+| FR-009 | implemented_unverified | Deletion operates on one artifact ID and does not traverse links, but no report-specific regression exists. | Add integration test with report and runtime observability artifacts on one execution. | integration_ci |
+| FR-010 | implemented_unverified | MM-463 preserved in `spec.md` and orchestration input. | Preserve through plan, tasks, verification, and traceability command. | traceability |
+| DESIGN-REQ-015 | implemented_unverified | Existing auth and preview/default-read service behavior. | Add report-focused access coverage. | unit |
+| DESIGN-REQ-016 | partial | Pin exists; report default retention and unpin restoration are incomplete. | Derive report retention and restore on unpin. | unit |
+| DESIGN-REQ-022 | implemented_unverified | Existing lifecycle deletes by artifact ID only. | Add report deletion/no-cascade integration coverage. | integration_ci |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, Pydantic v2 models, existing Temporal artifact service and report artifact contract helpers  
+**Storage**: Existing temporal artifact tables and artifact store only; no new persistent storage  
+**Unit Testing**: `pytest` through `./tools/test_unit.sh`; focused command `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py`  
+**Integration Testing**: `pytest` integration_ci through `./tools/test_integration.sh`; focused local command `pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -m integration_ci -q --tb=short` when compose is unavailable  
+**Target Platform**: MoonMind API/Temporal artifact service runtime  
+**Project Type**: Backend service/library  
+**Performance Goals**: No additional storage queries on artifact create; unpin may inspect existing links for one artifact only  
+**Constraints**: Do not introduce a report-specific storage plane, authorization model, lifecycle model, or cascading deletion behavior  
+**Scale/Scope**: One runtime story scoped to Temporal artifact service behavior for report access and retention
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing artifact service behavior.
+- II. One-Click Agent Deployment: PASS. No new external dependency.
+- III. Avoid Vendor Lock-In: PASS. Report behavior is provider-neutral artifact metadata and links.
+- IV. Own Your Data: PASS. Reports remain in operator-controlled artifact storage.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill runtime changes.
+- VI. Replaceable AI Scaffolding: PASS. Adds deterministic service behavior and tests.
+- VII. Runtime Configurability: PASS. Product policy can still explicitly override retention.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay within artifact service and tests.
+- IX. Resilient by Default: PASS. Lifecycle operations remain idempotent and artifact-native.
+- X. Facilitate Continuous Improvement: PASS. Verification will record traceable MM-463 evidence.
+- XI. Spec-Driven Development: PASS. Spec, plan, tasks, and verification drive implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime work stays in code; volatile orchestration input remains under `docs/tmp`.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases are introduced; internal retention behavior is updated directly.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/231-sensitive-report-access-retention/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── sensitive-report-access-retention.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── artifacts.py
+└── report_artifacts.py
+
+tests/unit/workflows/temporal/
+├── test_artifacts.py
+└── test_artifact_authorization.py
+
+tests/integration/temporal/
+└── test_temporal_artifact_lifecycle.py
+```
+
+**Structure Decision**: Implement the story at the existing artifact service boundary. Keep report metadata validation in `report_artifacts.py`, retention/lifecycle behavior in `artifacts.py`, and tests in the established unit and integration suites.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/231-sensitive-report-access-retention/quickstart.md
+++ b/specs/231-sensitive-report-access-retention/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Sensitive Report Access and Retention
+
+## Focused Unit Validation
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py
+```
+
+## Focused Integration Validation
+
+```bash
+pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -m integration_ci -q --tb=short
+```
+
+Use `./tools/test_integration.sh` for the full hermetic integration_ci suite when Docker Compose is available.
+
+## Traceability Validation
+
+```bash
+rg -n "MM-463|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-022" specs/231-sensitive-report-access-retention docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md
+```
+
+## Expected Results
+
+- Restricted report metadata uses preview/default-read behavior without raw download access.
+- `report.primary` and `report.summary` default to `long` retention.
+- `report.structured` and `report.evidence` default to `standard` unless explicitly overridden.
+- Pin then unpin restores report-derived retention.
+- Deleting a report artifact leaves unrelated runtime observability artifacts intact.

--- a/specs/231-sensitive-report-access-retention/research.md
+++ b/specs/231-sensitive-report-access-retention/research.md
@@ -1,0 +1,49 @@
+# Research: Sensitive Report Access and Retention
+
+## FR-001/FR-003/DESIGN-REQ-015 - Existing Authorization Boundary
+
+Decision: Treat report artifacts as ordinary temporal artifacts for read and raw-download authorization.
+Evidence: `TemporalArtifactService._assert_read_access`, `_assert_raw_access`, `read`, and `presign_download` already apply to every artifact, including report links.
+Rationale: The source design explicitly says reports use the existing artifact authorization model rather than a report-specific one.
+Alternatives considered: Add report-specific access rules. Rejected because it would widen scope and risk conflicting with the artifact contract.
+Test implications: Unit tests should exercise restricted report artifacts through the existing service.
+
+## FR-002/DESIGN-REQ-015 - Preview And Default Read
+
+Decision: Verify existing `get_read_policy` behavior for restricted report artifacts with generated previews.
+Evidence: `write_complete` calls `_create_preview_if_required`; `get_read_policy` returns preview `default_read_ref` when raw access is not allowed.
+Rationale: This matches the report design without new API shape.
+Alternatives considered: Store a report-specific default read field. Rejected because `default_read_ref` already exists.
+Test implications: Unit test metadata/default-read policy for a restricted `report.primary`.
+
+## FR-004/FR-005/DESIGN-REQ-016 - Primary And Summary Retention
+
+Decision: Derive `long` retention for `report.primary` and `report.summary` when retention is not explicitly provided.
+Evidence: `_derive_retention` currently maps only generic output/debug/input link types and otherwise falls back to `standard`.
+Rationale: MM-463 and `docs/Artifacts/ReportArtifacts.md` §15.1 require primary and summary reports to default to long retention.
+Alternatives considered: Require producers to pass explicit retention. Rejected because the story requires default mappings.
+Test implications: Unit tests should fail first for current `standard` behavior, then pass after retention mapping is added.
+
+## FR-006/DESIGN-REQ-016 - Structured And Evidence Retention
+
+Decision: Keep default `standard` retention for `report.structured` and `report.evidence`, while allowing explicit `long` overrides.
+Evidence: The source brief allows standard or long based on report family and audit needs.
+Rationale: `standard` is the least surprising safe default when no product policy or explicit retention is provided, and it stays distinct from observability retention such as logs/diagnostics.
+Alternatives considered: Make all report artifacts `long`. Rejected because the source explicitly permits standard for structured/evidence.
+Test implications: Unit tests should verify structured/evidence defaults are `standard` and explicit `long` remains honored.
+
+## FR-007/DESIGN-REQ-016 - Unpin Restoration
+
+Decision: After unpinning a report artifact, restore retention from existing artifact links rather than always falling back to generic `standard`.
+Evidence: `TemporalArtifactService.unpin` currently resets pinned artifacts to `standard`.
+Rationale: A pinned `report.primary` should return to report-derived `long` retention after unpin.
+Alternatives considered: Store previous retention in the pin record. Rejected because the existing link type is enough to recompute the default and avoids schema changes.
+Test implications: Unit test pin/unpin on `report.primary`.
+
+## FR-008/FR-009/DESIGN-REQ-022 - Artifact-Native Deletion
+
+Decision: Preserve existing soft/hard delete behavior and add a report-specific no-cascade regression.
+Evidence: `soft_delete` and `hard_delete` operate on one artifact ID; existing lifecycle tests cover generic deletion and pinned skip.
+Rationale: The story requires confidence that report deletion does not delete unrelated observability artifacts.
+Alternatives considered: Add report-specific deletion code. Rejected because deletion must remain artifact-system-native.
+Test implications: Integration test creates one report and one runtime observability artifact on the same execution, deletes the report, and verifies observability remains complete/readable.

--- a/specs/231-sensitive-report-access-retention/spec.md
+++ b/specs/231-sensitive-report-access-retention/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Sensitive Report Access and Retention
+
+**Feature Branch**: `231-sensitive-report-access-retention`  
+**Created**: 2026-04-22  
+**Status**: Draft  
+**Input**:
+
+```text
+Use the Jira preset brief for MM-463 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-463 from MM project
+Summary: Sensitive Report Access and Retention
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-463 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-463: Sensitive Report Access and Retention
+
+Short Name
+sensitive-report-access-retention
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 7. Consumer and producer invariants, 14. Security and access model, 15. Retention guidance
+- Coverage IDs: DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-022
+
+User Story
+As an operator, I can rely on report artifacts to use existing authorization, preview, retention, pinning, and deletion behavior so sensitive reports remain useful without widening raw access.
+
+Acceptance Criteria
+- Given a sensitive report has restricted raw access, then Mission Control uses preview/default-read behavior where available and does not assume full download is allowed.
+- Given `report.primary` or `report.summary` artifacts are created, then their default retention policy is long unless product policy overrides it.
+- Given `report.structured` or `report.evidence` artifacts are created, then their retention follows standard or long policy based on the report family and audit needs.
+- Given a final report is important to retain, then it can be pinned or unpinned through existing artifact APIs.
+- Deleting a report artifact uses artifact-system-native soft/hard deletion and does not implicitly delete unrelated runtime stdout, stderr, diagnostics, or other observability artifacts.
+
+Requirements
+- Reuse the existing artifact authorization model for report artifacts and evidence.
+- Support preview artifacts and `default_read_ref` for sensitive report presentation.
+- Apply recommended retention mappings for primary, summary, structured, evidence, and related observability artifacts.
+- Keep deletion artifact-system-native without undefined cascading into unrelated observability artifacts.
+
+Relevant Implementation Notes
+- Keep report artifact access within the existing artifact authorization, preview, and default-read boundaries.
+- Do not add report-specific raw download assumptions for sensitive report artifacts.
+- Use existing artifact APIs for pinning, unpinning, soft deletion, and hard deletion.
+- Preserve separation between report artifact lifecycle behavior and unrelated runtime observability artifacts such as stdout, stderr, diagnostics, and logs.
+- Preserve MM-463 and coverage IDs DESIGN-REQ-015, DESIGN-REQ-016, and DESIGN-REQ-022 in downstream MoonSpec artifacts and final implementation evidence.
+
+Non-Goals
+- Widening raw artifact access for sensitive reports.
+- Creating report-specific authorization, retention, pinning, or deletion systems separate from the existing artifact system.
+- Cascading report deletion into unrelated runtime stdout, stderr, diagnostics, logs, or other observability artifacts.
+
+Validation
+- Verify sensitive report presentation uses preview/default-read behavior where available and does not require raw download access.
+- Verify `report.primary` and `report.summary` artifacts default to long retention unless policy overrides them.
+- Verify `report.structured` and `report.evidence` artifacts follow standard or long retention based on report family and audit needs.
+- Verify final report artifacts can be pinned and unpinned through existing artifact APIs.
+- Verify report artifact deletion uses artifact-system-native soft/hard deletion without implicitly deleting unrelated runtime observability artifacts.
+
+Needs Clarification
+- None
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable operator story and does not require processing multiple specs.
+- Selected mode: Runtime.
+- Source design: `docs/Artifacts/ReportArtifacts.md` is treated as runtime source requirements because the Jira brief points at implementation behavior, not documentation-only work.
+- Resume decision: No existing Moon Spec artifacts for MM-463 were found under `specs/`; specification is the first incomplete stage.
+
+## User Story - Preserve Sensitive Report Access and Retention
+
+**Summary**: As an operator, I want sensitive report artifacts to use existing artifact authorization, preview, retention, pinning, and deletion behavior so reports remain useful without widening raw access.
+
+**Goal**: Report artifacts preserve safe read behavior, report-aware retention defaults, ordinary pin/unpin controls, and artifact-native deletion while keeping unrelated logs and diagnostics separate.
+
+**Independent Test**: Create sensitive report artifacts through the artifact service, verify restricted raw access exposes preview/default-read metadata without granting raw download, verify report link types derive the expected retention defaults, verify pin/unpin keeps report retention semantics, and verify deleting a report artifact does not delete unrelated observability artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sensitive report artifact has restricted raw access and a preview artifact, **When** a caller can read metadata but cannot access the raw artifact, **Then** the artifact metadata exposes the preview as `default_read_ref` and raw download remains denied.
+2. **Given** a `report.primary` or `report.summary` artifact is created without an explicit retention override, **When** it is linked to an execution, **Then** its default retention class is `long`.
+3. **Given** a `report.structured` or `report.evidence` artifact is created without an explicit retention override, **When** it is linked to an execution, **Then** its default retention class is either `standard` or `long` according to report policy and remains distinct from observability retention.
+4. **Given** a final report artifact is pinned and later unpinned, **When** the existing artifact API completes both mutations, **Then** the artifact returns to its report-derived retention class rather than a generic default.
+5. **Given** a report artifact and unrelated runtime observability artifacts are linked to the same execution, **When** the report artifact is deleted, **Then** only the report artifact enters deleted state and unrelated stdout, stderr, diagnostics, or log artifacts remain intact.
+
+### Edge Cases
+
+- A report artifact has restricted raw content but no preview artifact yet.
+- A report artifact is explicitly created with a product-policy retention override.
+- An artifact is linked as a report after being created with generic retention.
+- A pinned report artifact is already deleted or has no active pin when unpin is requested.
+- A report deletion happens while the execution still has related evidence and observability artifacts.
+
+## Assumptions
+
+- Existing authorization rules determine which principals can read metadata and which principals can read raw artifact bytes.
+- Product policy may still explicitly override retention at artifact creation time.
+- `report.structured` and `report.evidence` default to `standard` unless producers or policy choose `long`; `report.primary` and `report.summary` default to `long`.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-015 | `docs/Artifacts/ReportArtifacts.md` §7, §14 | Sensitive reports must use existing artifact authorization and preview/default-read behavior instead of widening raw access. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-016 | `docs/Artifacts/ReportArtifacts.md` §15 | Report primary and summary artifacts default to long retention; structured and evidence artifacts retain standard or long policy based on report/audit needs; final reports can be pinned and unpinned through the existing artifact API. | In scope | FR-004, FR-005, FR-006, FR-007 |
+| DESIGN-REQ-022 | `docs/Artifacts/ReportArtifacts.md` §7, §15.3 | Report deletion remains artifact-system-native and must not implicitly delete unrelated runtime stdout, stderr, diagnostics, logs, or other observability artifacts. | In scope | FR-008, FR-009 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST keep sensitive report artifacts under the existing artifact authorization model.
+- **FR-002**: The system MUST expose a preview artifact as `default_read_ref` when a caller can read report metadata but cannot access restricted raw report bytes and a preview is available.
+- **FR-003**: The system MUST deny raw report download or presign operations when the caller lacks restricted raw access.
+- **FR-004**: The system MUST derive `long` retention for `report.primary` artifacts when no explicit retention override is provided.
+- **FR-005**: The system MUST derive `long` retention for `report.summary` artifacts when no explicit retention override is provided.
+- **FR-006**: The system MUST derive a non-observability retention class of `standard` or `long` for `report.structured` and `report.evidence` artifacts when no explicit retention override is provided.
+- **FR-007**: The system MUST allow final report artifacts to be pinned and unpinned through the existing artifact API while restoring report-derived retention after unpin.
+- **FR-008**: The system MUST soft-delete and hard-delete report artifacts through the existing artifact lifecycle path.
+- **FR-009**: The system MUST NOT implicitly delete unrelated runtime stdout, stderr, diagnostics, logs, provider snapshots, or session continuity artifacts when deleting a report artifact.
+- **FR-010**: Moon Spec artifacts, verification evidence, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-463.
+
+### Key Entities
+
+- **Sensitive Report Artifact**: A report artifact whose raw bytes may be restricted while metadata and preview/default-read behavior remain available to authorized readers.
+- **Report Retention Class**: The retention class derived from report link type or explicit policy, including `long`, `standard`, and `pinned`.
+- **Artifact Pin**: Existing artifact lifecycle state that protects an artifact from automatic deletion until it is unpinned.
+- **Observability Artifact**: Runtime stdout, stderr, merged logs, diagnostics, provider snapshots, or session continuity artifacts that remain separate from curated report deletion.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A restricted report artifact with a preview returns a `default_read_ref` pointing at that preview for a metadata-readable caller without raw access.
+- **SC-002**: 100% of newly created `report.primary` and `report.summary` artifacts without explicit retention overrides receive `long` retention.
+- **SC-003**: `report.structured` and `report.evidence` artifacts without explicit retention overrides receive `standard` or `long` retention and never inherit observability-style retention such as logs or diagnostics.
+- **SC-004**: Pinning then unpinning a report-primary artifact restores the report-derived retention class.
+- **SC-005**: Deleting one report artifact changes only that artifact's status and leaves unrelated observability artifacts for the same execution readable and undeleted.
+- **SC-006**: MM-463 appears in the spec, plan, tasks, verification evidence, and publish metadata for traceability.

--- a/specs/231-sensitive-report-access-retention/tasks.md
+++ b/specs/231-sensitive-report-access-retention/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Sensitive Report Access and Retention
+
+**Input**: `specs/231-sensitive-report-access-retention/spec.md`  
+**Plan**: `specs/231-sensitive-report-access-retention/plan.md`  
+**Unit Test Command**: `./tools/test_unit.sh`  
+**Focused Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py`  
+**Focused Integration Test Command**: `pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -m integration_ci -q --tb=short`  
+**Integration Test Command**: `./tools/test_integration.sh`
+
+## Source Traceability
+
+- Jira: MM-463
+- Story: Preserve sensitive report access and retention.
+- Story count: exactly one independently testable story from `spec.md`.
+- Independent test: create sensitive report artifacts and validate preview/default-read behavior, report-aware retention defaults, pin/unpin restoration, and no deletion cascade to observability artifacts.
+- Requirements: FR-001 through FR-010; SC-001 through SC-006.
+- Source design coverage: DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-022.
+- Requirement statuses from plan: FR-004 and FR-005 are missing; FR-007 is partial; FR-001, FR-002, FR-003, FR-006, FR-008, FR-009, FR-010, DESIGN-REQ-015, and DESIGN-REQ-022 are implemented_unverified; DESIGN-REQ-016 is partial.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature context points to `specs/231-sensitive-report-access-retention` in `.specify/feature.json` (MM-463).
+- [X] T002 Inspect existing artifact service retention, preview/default-read, pin/unpin, and deletion behavior in `moonmind/workflows/temporal/artifacts.py` (FR-001 through FR-009).
+- [X] T003 Inspect existing report contract helpers in `moonmind/workflows/temporal/report_artifacts.py` and artifact tests in `tests/unit/workflows/temporal/test_artifacts.py`, `tests/unit/workflows/temporal/test_artifact_authorization.py`, and `tests/integration/temporal/test_temporal_artifact_lifecycle.py` (DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-022).
+
+## Phase 2: Foundational Tests
+
+Unit test plan: focused artifact service tests cover report retention defaults, pin/unpin restoration, restricted raw denial, and preview/default-read policy.
+
+Integration test plan: a compose-compatible lifecycle regression covers report deletion with unrelated observability artifacts linked to the same execution.
+
+- [X] T004 [P] Add failing unit test in `tests/unit/workflows/temporal/test_artifacts.py` proving `report.primary` and `report.summary` default to `long` retention without explicit override (FR-004, FR-005, SC-002, DESIGN-REQ-016).
+- [X] T005 [P] Add unit regression in `tests/unit/workflows/temporal/test_artifacts.py` proving `report.structured` and `report.evidence` default to `standard` and explicit `long` retention is honored (FR-006, SC-003, DESIGN-REQ-016).
+- [X] T006 [P] Add failing unit test in `tests/unit/workflows/temporal/test_artifacts.py` proving pin then unpin of `report.primary` restores report-derived `long` retention (FR-007, SC-004, DESIGN-REQ-016).
+- [X] T007 [P] Add unit test in `tests/unit/workflows/temporal/test_artifact_authorization.py` proving restricted report metadata uses preview `default_read_ref` for a metadata-readable caller without raw access and raw presign remains denied (FR-001, FR-002, FR-003, SC-001, DESIGN-REQ-015).
+- [X] T008 [P] Add integration regression in `tests/integration/temporal/test_temporal_artifact_lifecycle.py` proving deleting a report artifact does not delete unrelated runtime observability artifacts for the same execution (FR-008, FR-009, SC-005, DESIGN-REQ-022).
+- [X] T009 Run focused tests for T004-T008 and capture red-first evidence before production changes. Red-first evidence: `pytest tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py tests/integration/temporal/test_temporal_artifact_lifecycle.py -q --tb=short` failed before production changes with `report.primary`/`report.summary` retaining `standard` instead of `long`.
+
+## Phase 3: Implementation
+
+- [X] T010 Update `_derive_retention` in `moonmind/workflows/temporal/artifacts.py` so `report.primary` and `report.summary` default to `long`, while `report.structured` and `report.evidence` default to `standard` unless explicitly overridden (FR-004, FR-005, FR-006).
+- [X] T011 Update `TemporalArtifactService.unpin` in `moonmind/workflows/temporal/artifacts.py` to restore retention from existing artifact link types when a pinned report artifact is unpinned (FR-007).
+- [X] T012 Keep deletion code artifact-native in `moonmind/workflows/temporal/artifacts.py`; only change deletion code if T008 exposes a report-specific cascade defect (FR-008, FR-009).
+
+## Phase 4: Validation
+
+- [X] T013 Run `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py` and fix failures (FR-001 through FR-007). Evidence: 46 Python tests passed; the unit runner also completed 367 frontend tests.
+- [X] T014 Run `pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -m integration_ci -q --tb=short` and fix failures, or run `./tools/test_integration.sh` when Docker Compose is required and available (FR-008, FR-009). Evidence: included in focused pytest command; final post-fix result was 48 passed.
+- [X] T015 Run traceability check `rg -n "MM-463|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-022" specs/231-sensitive-report-access-retention docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md` (FR-010, SC-006).
+- [X] T016 Run final `./tools/test_unit.sh` unless blocked by environment constraints. Evidence: 3,766 Python tests passed, 1 xpassed, 16 subtests passed; 367 frontend tests passed.
+
+## Phase 5: Verify
+
+- [X] T017 Run `/speckit.verify` equivalent through `moonspec-verify` for `specs/231-sensitive-report-access-retention/spec.md` and record verdict in `specs/231-sensitive-report-access-retention/verification.md`.
+- [X] T018 Mark completed tasks `[X]` only after implementation and verification evidence exists.
+
+## Dependencies And Order
+
+1. Setup tasks T001-T003.
+2. Failing tests T004-T009.
+3. Implementation T010-T012.
+4. Focused and final validation T013-T016.
+5. Final verification T017-T018.
+
+## Parallel Work
+
+- T004-T008 can be authored in parallel because they touch different test cases.
+- T010 and T011 can be implemented after red-first evidence exists.
+
+## Implementation Strategy
+
+Start with service-boundary tests. Keep authorization, preview, pin, and deletion APIs unchanged unless tests expose a defect. The expected production change is limited to retention derivation and unpin restoration; deletion should remain artifact-native.

--- a/specs/231-sensitive-report-access-retention/verification.md
+++ b/specs/231-sensitive-report-access-retention/verification.md
@@ -1,0 +1,72 @@
+# MoonSpec Verification Report
+
+**Feature**: Sensitive Report Access and Retention  
+**Spec**: `/work/agent_jobs/mm:6b921011-c08d-4b47-80c3-d00f5b3d0074/repo/specs/231-sensitive-report-access-retention/spec.md`  
+**Original Request Source**: `spec.md` Input and `docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Red-first focused | `pytest tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py tests/integration/temporal/test_temporal_artifact_lifecycle.py -q --tb=short` | PASS after expected red-first failure | Failed before implementation on `report.primary`/`report.summary` retaining `standard`; passed after implementation with 48 passed. |
+| Focused unit | `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py` | PASS | 46 Python tests passed; runner also completed 367 frontend tests. |
+| Focused integration | `pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -m integration_ci -q --tb=short` | PASS | Covered as part of the focused red/post-fix command. |
+| Traceability | `rg -n "MM-463|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-022" specs/231-sensitive-report-access-retention docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md` | PASS | Jira key and source design IDs are preserved. |
+| Full unit | `./tools/test_unit.sh` | PASS | 3,766 Python tests passed, 1 xpassed, 16 subtests passed; 367 frontend tests passed. |
+| MoonSpec prerequisite script | `scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | NOT RUN | Script path is not present in this checkout. Artifact presence was verified directly. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/workflows/temporal/artifacts.py` existing read/raw access boundary; `tests/unit/workflows/temporal/test_artifact_authorization.py:131` | VERIFIED | Report artifacts remain under the existing artifact authorization model. |
+| FR-002 | `get_read_policy` behavior in `artifacts.py`; `tests/unit/workflows/temporal/test_artifact_authorization.py:163` | VERIFIED | Restricted report metadata exposes preview `default_read_ref` for a metadata-readable caller without raw access. |
+| FR-003 | `presign_download` raw access check; `tests/unit/workflows/temporal/test_artifact_authorization.py:175` | VERIFIED | Raw presign remains denied without restricted raw access. |
+| FR-004 | `moonmind/workflows/temporal/artifacts.py:195`; `tests/unit/workflows/temporal/test_artifacts.py:385` | VERIFIED | `report.primary` defaults to `long` retention. |
+| FR-005 | `moonmind/workflows/temporal/artifacts.py:195`; `tests/unit/workflows/temporal/test_artifacts.py:385` | VERIFIED | `report.summary` defaults to `long` retention. |
+| FR-006 | `moonmind/workflows/temporal/artifacts.py:197`; `tests/unit/workflows/temporal/test_artifacts.py:414` | VERIFIED | `report.structured` and `report.evidence` default to `standard`; explicit `long` is honored. |
+| FR-007 | `moonmind/workflows/temporal/artifacts.py:1867`; `tests/unit/workflows/temporal/test_artifacts.py:458` | VERIFIED | Pin/unpin restores report-derived `long` retention for `report.primary`. |
+| FR-008 | Existing `soft_delete`/lifecycle path; `tests/integration/temporal/test_temporal_artifact_lifecycle.py:113` | VERIFIED | Report deletion uses artifact-native soft delete. |
+| FR-009 | `tests/integration/temporal/test_temporal_artifact_lifecycle.py:72` | VERIFIED | Deleting a report artifact leaves unrelated runtime stdout complete and readable. |
+| FR-010 | Traceability command output; this report | VERIFIED | MM-463 is preserved in spec, plan, tasks, verification, and orchestration input. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Restricted report preview/default read | `tests/unit/workflows/temporal/test_artifact_authorization.py:131` | VERIFIED | Covers metadata-readable caller without raw access. |
+| Primary/summary long retention | `tests/unit/workflows/temporal/test_artifacts.py:385` | VERIFIED | Covers both link types. |
+| Structured/evidence standard-or-long retention | `tests/unit/workflows/temporal/test_artifacts.py:414` | VERIFIED | Covers default standard and explicit long override. |
+| Pin/unpin final report | `tests/unit/workflows/temporal/test_artifacts.py:458` | VERIFIED | Covers pinned then restored retention. |
+| Delete report without observability cascade | `tests/integration/temporal/test_temporal_artifact_lifecycle.py:72` | VERIFIED | Covers same execution with `report.primary` and `runtime.stdout`. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-015 | `tests/unit/workflows/temporal/test_artifact_authorization.py:131` | VERIFIED | Sensitive report access uses existing authorization and preview/default-read behavior. |
+| DESIGN-REQ-016 | `moonmind/workflows/temporal/artifacts.py:195`, `moonmind/workflows/temporal/artifacts.py:1867`, `tests/unit/workflows/temporal/test_artifacts.py:385` | VERIFIED | Report retention defaults and pin/unpin behavior are covered. |
+| DESIGN-REQ-022 | `tests/integration/temporal/test_temporal_artifact_lifecycle.py:72` | VERIFIED | Report deletion remains artifact-native and non-cascading. |
+| Constitution XI | `spec.md`, `plan.md`, `tasks.md`, tests, this report | VERIFIED | Spec-driven artifacts and implementation evidence are present. |
+| Constitution XIII | `moonmind/workflows/temporal/artifacts.py:195` | VERIFIED | Internal retention behavior updated directly without compatibility aliases. |
+
+## Original Request Alignment
+
+- PASS: The Jira preset brief for MM-463 is the canonical input and is preserved.
+- PASS: Runtime mode was used; source design requirements from `docs/Artifacts/ReportArtifacts.md` were treated as runtime behavior.
+- PASS: Input was classified as a single-story feature request and resumed from the missing specification stage.
+- PASS: Implementation covers sensitive report access, retention defaults, pin/unpin, and deletion boundaries.
+
+## Gaps
+
+- None.
+
+## Remaining Work
+
+- None.
+
+## Decision
+
+- The MM-463 MoonSpec story is fully implemented and verified.

--- a/tests/integration/temporal/test_temporal_artifact_lifecycle.py
+++ b/tests/integration/temporal/test_temporal_artifact_lifecycle.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base, TemporalArtifactStatus
 from moonmind.workflows.temporal.artifacts import (
+    ExecutionRef,
     LocalTemporalArtifactStore,
     TemporalArtifactRepository,
     TemporalArtifactService,
@@ -66,3 +67,60 @@ async def test_lifecycle_soft_then_hard_delete(tmp_path: Path) -> None:
             )
             refreshed = await service._repository.get_artifact(artifact.artifact_id)
             assert refreshed.hard_deleted_at is not None
+
+
+async def test_report_delete_does_not_cascade_to_observability_artifacts(
+    tmp_path: Path,
+) -> None:
+    """MM-463: Report deletion must not delete unrelated runtime observability."""
+
+    async with _db(tmp_path) as maker:
+        async with maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            execution = {
+                "namespace": "moonmind",
+                "workflow_id": "wf-report",
+                "run_id": "run-report",
+            }
+            report, _upload = await service.create(
+                principal="owner",
+                content_type="text/markdown",
+                link={**execution, "link_type": "report.primary"},
+                metadata_json={"title": "Final report"},
+            )
+            await service.write_complete(
+                artifact_id=report.artifact_id,
+                principal="owner",
+                payload=b"# Final report",
+                content_type="text/markdown",
+            )
+            stdout, _upload = await service.create(
+                principal="owner",
+                content_type="text/plain",
+                link=ExecutionRef(**execution, link_type="runtime.stdout"),
+                metadata_json={"artifact_kind": "runtime_stdout"},
+            )
+            await service.write_complete(
+                artifact_id=stdout.artifact_id,
+                principal="owner",
+                payload=b"stdout stays",
+                content_type="text/plain",
+            )
+
+            await service.soft_delete(
+                artifact_id=report.artifact_id,
+                principal="owner",
+            )
+
+            deleted_report = await service._repository.get_artifact(report.artifact_id)
+            retained_stdout = await service._repository.get_artifact(stdout.artifact_id)
+            assert deleted_report.status is TemporalArtifactStatus.DELETED
+            assert retained_stdout.status is TemporalArtifactStatus.COMPLETE
+            _artifact, payload = await service.read(
+                artifact_id=stdout.artifact_id,
+                principal="owner",
+            )
+            assert payload == b"stdout stays"

--- a/tests/unit/workflows/temporal/test_artifact_authorization.py
+++ b/tests/unit/workflows/temporal/test_artifact_authorization.py
@@ -126,3 +126,54 @@ async def test_restricted_raw_presign_denied_for_non_owner_in_auth_mode(
                     artifact_id=artifact.artifact_id,
                     principal="user-2",
                 )
+
+
+async def test_restricted_report_metadata_uses_preview_default_read_without_raw_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MM-463: Sensitive reports should expose preview/default-read without raw access."""
+
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled")
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            artifact, _upload = await service.create(
+                principal="owner",
+                content_type="text/markdown",
+                redaction_level=TemporalArtifactRedactionLevel.RESTRICTED,
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                },
+                metadata_json={"title": "Restricted report"},
+            )
+            await service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal="owner",
+                payload=b"# Report\ntoken=secret\nsafe summary",
+                content_type="text/markdown",
+            )
+
+            _artifact, _links, _pinned, policy = await service.get_metadata(
+                artifact_id=artifact.artifact_id,
+                principal="viewer",
+            )
+
+            assert policy.raw_access_allowed is False
+            assert policy.preview_artifact_ref is not None
+            assert (
+                policy.default_read_ref.artifact_id
+                == policy.preview_artifact_ref.artifact_id
+            )
+            assert policy.default_read_ref.artifact_id != artifact.artifact_id
+            with pytest.raises(TemporalArtifactAuthorizationError):
+                await service.presign_download(
+                    artifact_id=artifact.artifact_id,
+                    principal="viewer",
+                )

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -499,6 +499,50 @@ async def test_unpin_report_primary_restores_report_retention(tmp_path: Path) ->
             assert unpinned.retention_class is TemporalArtifactRetentionClass.LONG
 
 
+async def test_unpin_ephemeral_artifact_restores_ephemeral_retention(
+    tmp_path: Path,
+) -> None:
+    """MM-463: Unpinning trace artifacts should not upgrade retention."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            artifact, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="application/json",
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-trace",
+                    "run_id": "run-trace",
+                    "link_type": "debug.trace",
+                },
+                metadata_json={"artifact_kind": "integration_event"},
+            )
+            assert artifact.retention_class is TemporalArtifactRetentionClass.EPHEMERAL
+
+            await service.pin(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+                reason="temporary inspection",
+            )
+            pinned = await repo.get_artifact(artifact.artifact_id)
+            assert pinned.retention_class is TemporalArtifactRetentionClass.PINNED
+
+            await service.unpin(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+            )
+            unpinned = await repo.get_artifact(artifact.artifact_id)
+            assert (
+                unpinned.retention_class is TemporalArtifactRetentionClass.EPHEMERAL
+            )
+
+
 async def test_create_rejects_bad_report_link_and_metadata(tmp_path: Path) -> None:
     """MM-460: Report publication should fail before unsafe data is stored."""
 

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import (
     Base,
     TemporalArtifactRedactionLevel,
+    TemporalArtifactRetentionClass,
     TemporalArtifactStatus,
     TemporalArtifactStorageBackend,
 )
@@ -379,6 +380,123 @@ async def test_create_accepts_report_primary_with_bounded_metadata(
             links = await repo.list_links(artifact.artifact_id)
             assert artifact.metadata_json["report_type"] == "unit_test"
             assert links[0].link_type == "report.primary"
+
+
+async def test_report_primary_and_summary_default_to_long_retention(
+    tmp_path: Path,
+) -> None:
+    """MM-463: Canonical report and summary artifacts should be retained long."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            for link_type in ("report.primary", "report.summary"):
+                artifact, _upload = await service.create(
+                    principal="workflow-producer",
+                    content_type="text/markdown",
+                    link={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-report",
+                        "run_id": "run-report",
+                        "link_type": link_type,
+                    },
+                    metadata_json={"title": f"{link_type} artifact"},
+                )
+
+                assert artifact.retention_class is TemporalArtifactRetentionClass.LONG
+
+
+async def test_report_structured_and_evidence_retention_policy_defaults(
+    tmp_path: Path,
+) -> None:
+    """MM-463: Structured/evidence reports default to standard unless overridden."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            for link_type in ("report.structured", "report.evidence"):
+                artifact, _upload = await service.create(
+                    principal="workflow-producer",
+                    content_type="application/json",
+                    link={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-report",
+                        "run_id": "run-report",
+                        "link_type": link_type,
+                    },
+                    metadata_json={"title": f"{link_type} artifact"},
+                )
+                assert (
+                    artifact.retention_class is TemporalArtifactRetentionClass.STANDARD
+                )
+
+            evidence, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="application/json",
+                retention_class=TemporalArtifactRetentionClass.LONG,
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.evidence",
+                },
+                metadata_json={"title": "Long evidence"},
+            )
+            assert evidence.retention_class is TemporalArtifactRetentionClass.LONG
+
+
+async def test_unpin_report_primary_restores_report_retention(tmp_path: Path) -> None:
+    """MM-463: Unpinning a final report should restore report-derived retention."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            artifact, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="text/markdown",
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                },
+                metadata_json={
+                    "title": "Final report",
+                    "report_scope": "final",
+                    "is_final_report": True,
+                },
+            )
+            assert artifact.retention_class is TemporalArtifactRetentionClass.LONG
+
+            await service.pin(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+                reason="retain final report",
+            )
+            pinned = await repo.get_artifact(artifact.artifact_id)
+            assert pinned.retention_class is TemporalArtifactRetentionClass.PINNED
+
+            await service.unpin(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+            )
+            unpinned = await repo.get_artifact(artifact.artifact_id)
+            assert unpinned.retention_class is TemporalArtifactRetentionClass.LONG
 
 
 async def test_create_rejects_bad_report_link_and_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Jira
- Issue: MM-463

## MoonSpec
- Active feature path: `specs/231-sensitive-report-access-retention`

## Verification Verdict
- `FULLY_IMPLEMENTED` in `specs/231-sensitive-report-access-retention/verification.md`

## Tests Run
- `pytest tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py tests/integration/temporal/test_temporal_artifact_lifecycle.py -q --tb=short` (red-first before production changes, then passing)
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_artifact_authorization.py`
- `./tools/test_unit.sh`
- `rg -n "MM-463|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-022" specs/231-sensitive-report-access-retention docs/tmp/jira-orchestration-inputs/MM-463-moonspec-orchestration-input.md`

## Remaining Risks
- No remaining implementation risks identified. Secret scan found only deliberate fake credential-like strings in test fixtures, not raw credentials.