### PR TITLE
MM-464 Report workflow rollout examples

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/231-sensitive-report-access-retention"
+  "feature_directory": "specs/232-report-workflow-rollout-examples"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 3123466318,
+    "id": 3123698888,
     "disposition": "addressed",
-    "rationale": "Changed _strongest_retention_class to rank the provided values directly and added an EPHEMERAL unpin regression test."
+    "rationale": "Removed the redundant report.primary check after report-mode classification and switched the unsupported report link error to f-string formatting."
   },
   {
-    "id": 4154120748,
+    "id": 3123698898,
     "disposition": "addressed",
-    "rationale": "Duplicate summary review for the same _strongest_retention_class issue; addressed by the helper fix and regression test."
+    "rationale": "Switched the unsupported observability link error to f-string formatting."
+  },
+  {
+    "id": 3123698904,
+    "disposition": "addressed",
+    "rationale": "Removed the redundant projection key loop because validate_report_bundle_result already enforces allowed bundle keys."
+  },
+  {
+    "id": 4154383632,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the specific inline feedback from this review was addressed separately."
+  },
+  {
+    "id": 3123703552,
+    "disposition": "addressed",
+    "rationale": "Added fallback validation that rejects any non-generic link type when allow_generic_fallback=True, with unit coverage for runtime.stdout rejection."
+  },
+  {
+    "id": 4154389563,
+    "disposition": "not-applicable",
+    "rationale": "Informational Codex review body; the actionable inline comment from this review was addressed separately."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-464-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-464-moonspec-orchestration-input.md
@@ -1,0 +1,75 @@
+# MM-464 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-464
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Report Workflow Rollout and Examples
+- Labels: `moonmind-workflow-mm-ba49b1c2-6312-465a-bf68-0d46b37886cf`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-464 from MM project
+Summary: Report Workflow Rollout and Examples
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-464 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-464: Report Workflow Rollout and Examples
+
+Short Name
+report-workflow-rollout-examples
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 17. Example workflow mappings, 18. Suggested API/UI extensions, 19. Migration guidance, 20. Open questions
+- Coverage IDs: DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+
+User Story
+As a MoonMind maintainer, I can migrate report-producing workflow families incrementally to the report artifact contract with documented examples and graceful fallback for existing generic outputs.
+
+Acceptance Criteria
+- Unit-test, coverage, pentest/security, and benchmark report examples each map to `report.primary` and appropriate summary, structured, evidence, runtime, and diagnostic artifacts.
+- New report-producing workflows prefer `report.*` semantics while existing generic `output.primary` flows continue to operate.
+- The UI degrades gracefully when an execution has only generic output artifacts and no `report.primary` artifact.
+- Migration docs or examples distinguish curated reports, evidence, runtime stdout/stderr, and diagnostics for each workflow family.
+- Convenience report fields or endpoints, if introduced during rollout, remain projections over the normal artifact APIs.
+
+Requirements
+- Document and validate report mappings for unit-test, coverage, pentest/security, and benchmark workflows.
+- Support incremental rollout phases: metadata conventions, explicit `report.*` link types and UI surfacing, compact report bundle contract, and optional projections, filters, retention, and pinning.
+- Keep existing generic outputs available during migration.
+- Preserve clear separation between curated reports and observability artifacts in examples and tests.
+
+Relevant Implementation Notes
+- Use the existing artifact APIs as the baseline for the first rollout; report-aware convenience surfaces must remain projections over normal artifacts.
+- Represent report-producing workflow examples with explicit artifact families, including `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `runtime.stdout`, `runtime.stderr`, and `runtime.diagnostics` where applicable.
+- Include example mappings for unit test reports, coverage reports, pentest or security reports, and benchmark or evaluation reports.
+- Keep report metadata bounded to display and classification fields such as `artifact_type`, `producer`, `subject`, `finding_counts`, `severity_counts`, and `sensitivity` where relevant.
+- Preserve fallback behavior for executions that only have generic output artifacts and no `report.primary` artifact.
+- Treat suggested execution detail fields and any report projection endpoint as optional read models over the underlying artifact references, not as a second storage model.
+- Preserve MM-464 and coverage IDs DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, and DESIGN-REQ-022 in downstream MoonSpec artifacts and final implementation evidence.
+
+Non-Goals
+- Requiring a flag-day migration for existing report-producing workflows.
+- Replacing generic `output.primary` behavior for existing workflows during rollout.
+- Creating a second report storage model or making report convenience fields authoritative over artifact records.
+- Forcing immediate implementation of every optional API/UI extension or open question from the source document.
+- Collapsing curated reports, evidence, runtime stdout/stderr, diagnostics, and other observability artifacts into one undifferentiated output.
+
+Validation
+- Verify unit-test, coverage, pentest/security, and benchmark examples map to `report.primary` and the appropriate related report, runtime, and diagnostic artifacts.
+- Verify new report-producing workflow guidance prefers explicit `report.*` semantics while existing generic `output.primary` flows remain valid.
+- Verify UI or documentation guidance describes graceful fallback when an execution has generic outputs but no `report.primary` artifact.
+- Verify migration guidance distinguishes curated reports, evidence, runtime stdout/stderr, and diagnostics for each workflow family.
+- Verify any introduced convenience fields or report endpoint behavior is documented and implemented as a projection over normal artifact APIs.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/report_artifacts.py
+++ b/moonmind/workflows/temporal/report_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from moonmind.workflows.temporal.artifacts import TemporalArtifactValidationError
@@ -69,6 +70,30 @@ REPORT_BUNDLE_ALLOWED_KEYS = frozenset(
         "counts",
     }
 )
+GENERIC_OUTPUT_LINK_TYPES = frozenset(
+    {
+        "output.primary",
+        "output.summary",
+        "output.agent_result",
+    }
+)
+REPORT_WORKFLOW_ROLLOUT_PHASES = (
+    "metadata_conventions",
+    "report_links_and_ui_surfacing",
+    "compact_report_bundle_contract",
+    "optional_projections_filters_retention_pinning",
+)
+REPORT_PROJECTION_ALLOWED_KEYS = frozenset(
+    {
+        "has_report",
+        "latest_report_ref",
+        "latest_report_summary_ref",
+        "report_type",
+        "report_status",
+        "finding_counts",
+        "severity_counts",
+    }
+)
 _UNSAFE_REPORT_BUNDLE_KEY_PATTERN = re.compile(
     r"(?i)(body|blob|payload|raw_?download_?url|presigned|url|log|screenshot|"
     r"transcript|finding_?details|evidence_?body)"
@@ -84,6 +109,94 @@ _SECRET_VALUE_PATTERN = re.compile(
     r"(?i)(ghp_|github_pat_|AIza|ATATT|AKIA|token\s*[=:]|password\s*[=:]|"
     r"authorization\s*:|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
 )
+
+
+@dataclass(frozen=True, slots=True)
+class ReportWorkflowMapping:
+    """Executable rollout example for one report-producing workflow family."""
+
+    workflow_family: str
+    report_type: str
+    report_link_types: tuple[str, ...]
+    observability_link_types: tuple[str, ...]
+    recommended_metadata_keys: tuple[str, ...]
+
+
+REPORT_WORKFLOW_MAPPINGS: dict[str, ReportWorkflowMapping] = {
+    "unit_test": ReportWorkflowMapping(
+        workflow_family="unit_test",
+        report_type="unit_test_report",
+        report_link_types=(
+            "report.primary",
+            "report.summary",
+            "report.structured",
+            "report.evidence",
+        ),
+        observability_link_types=(
+            "runtime.stdout",
+            "runtime.stderr",
+            "runtime.diagnostics",
+        ),
+        recommended_metadata_keys=(
+            "artifact_type",
+            "producer",
+            "subject",
+            "finding_counts",
+        ),
+    ),
+    "coverage": ReportWorkflowMapping(
+        workflow_family="coverage",
+        report_type="coverage_report",
+        report_link_types=(
+            "report.primary",
+            "report.structured",
+            "report.evidence",
+        ),
+        observability_link_types=(),
+        recommended_metadata_keys=(
+            "artifact_type",
+            "subject",
+            "finding_counts",
+        ),
+    ),
+    "security_pentest": ReportWorkflowMapping(
+        workflow_family="security_pentest",
+        report_type="security_pentest_report",
+        report_link_types=(
+            "report.primary",
+            "report.summary",
+            "report.structured",
+            "report.evidence",
+        ),
+        observability_link_types=(
+            "runtime.stdout",
+            "runtime.stderr",
+            "runtime.diagnostics",
+        ),
+        recommended_metadata_keys=(
+            "artifact_type",
+            "producer",
+            "subject",
+            "severity_counts",
+            "sensitivity",
+        ),
+    ),
+    "benchmark": ReportWorkflowMapping(
+        workflow_family="benchmark",
+        report_type="benchmark_report",
+        report_link_types=(
+            "report.primary",
+            "report.structured",
+            "report.evidence",
+        ),
+        observability_link_types=(),
+        recommended_metadata_keys=(
+            "artifact_type",
+            "subject",
+            "finding_counts",
+        ),
+    ),
+}
 
 
 def is_report_artifact_link_type(link_type: str | None) -> bool:
@@ -116,6 +229,97 @@ def validate_report_artifact_contract(
         dict(metadata or {}),
         allow_internal_metadata=allow_internal_metadata,
     )
+
+
+def get_report_workflow_mapping(workflow_family: str) -> ReportWorkflowMapping:
+    """Return the executable MM-464 rollout mapping for a workflow family."""
+
+    normalized_family = str(workflow_family or "").strip().lower().replace("-", "_")
+    try:
+        return REPORT_WORKFLOW_MAPPINGS[normalized_family]
+    except KeyError as exc:
+        raise TemporalArtifactValidationError(
+            f"unsupported report workflow family '{workflow_family}'"
+        ) from exc
+
+
+def classify_report_rollout_artifacts(
+    link_types: Sequence[str],
+) -> dict[str, Any]:
+    """Classify artifact links for report rollout without local report guessing."""
+
+    normalized = tuple(str(link_type or "").strip() for link_type in link_types)
+    report_links = tuple(
+        link_type for link_type in normalized if link_type.startswith("report.")
+    )
+    generic_links = tuple(
+        link_type for link_type in normalized if link_type in GENERIC_OUTPUT_LINK_TYPES
+    )
+    has_primary_report = "report.primary" in report_links
+    if has_primary_report:
+        mode = "report"
+    elif report_links:
+        mode = "invalid"
+    elif generic_links:
+        mode = "generic_fallback"
+    else:
+        mode = "none"
+    return {
+        "mode": mode,
+        "has_canonical_report": has_primary_report,
+        "report_link_types": report_links,
+        "generic_output_link_types": generic_links,
+    }
+
+
+def validate_report_workflow_artifact_classes(
+    workflow_family: str,
+    link_types: Sequence[str],
+    *,
+    allow_generic_fallback: bool = False,
+) -> None:
+    """Validate MM-464 rollout artifact classes for a report-producing workflow."""
+
+    mapping = get_report_workflow_mapping(workflow_family)
+    classification = classify_report_rollout_artifacts(link_types)
+    if classification["mode"] == "generic_fallback":
+        if allow_generic_fallback:
+            return
+        raise TemporalArtifactValidationError(
+            "report-producing workflows must publish report.primary; "
+            "output.primary is only a generic fallback"
+        )
+    if classification["mode"] != "report":
+        raise TemporalArtifactValidationError(
+            "report-producing workflows must publish report.primary"
+        )
+
+    normalized = {str(link_type or "").strip() for link_type in link_types}
+    allowed = set(mapping.report_link_types) | set(mapping.observability_link_types)
+    unsupported_report_links = sorted(
+        link_type
+        for link_type in normalized
+        if link_type.startswith("report.") and link_type not in mapping.report_link_types
+    )
+    if unsupported_report_links:
+        raise TemporalArtifactValidationError(
+            "unsupported report workflow link type "
+            + ", ".join(unsupported_report_links)
+        )
+    if "report.primary" not in normalized:
+        raise TemporalArtifactValidationError(
+            "report-producing workflows must publish report.primary"
+        )
+    unexpected_observability = sorted(
+        link_type
+        for link_type in normalized
+        if link_type.startswith("runtime.") and link_type not in allowed
+    )
+    if unexpected_observability:
+        raise TemporalArtifactValidationError(
+            "unsupported report workflow observability link type "
+            + ", ".join(unexpected_observability)
+        )
 
 
 def build_report_bundle_result(
@@ -151,6 +355,58 @@ def build_report_bundle_result(
         result["counts"] = dict(counts)
     validate_report_bundle_result(result)
     return result
+
+
+def build_report_projection_summary(
+    bundle: Mapping[str, Any],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a report convenience projection over compact artifact refs only."""
+
+    validate_report_bundle_result(bundle)
+    for key in bundle:
+        normalized_key = str(key or "").strip()
+        if normalized_key not in REPORT_BUNDLE_ALLOWED_KEYS:
+            raise TemporalArtifactValidationError(
+                f"unsupported projection key '{normalized_key}'"
+            )
+
+    safe_metadata = dict(metadata or {})
+    for key, value in safe_metadata.items():
+        normalized_key = str(key or "").strip()
+        if normalized_key not in {"finding_counts", "severity_counts"}:
+            raise TemporalArtifactValidationError(
+                f"unsafe report projection metadata key '{normalized_key}'"
+            )
+        _validate_report_metadata_value(value, path=normalized_key, depth=0)
+
+    primary_ref = bundle.get("primary_report_ref")
+    summary_ref = bundle.get("summary_ref")
+    projection: dict[str, Any] = {"has_report": primary_ref is not None}
+    if primary_ref is not None:
+        projection["latest_report_ref"] = _compact_artifact_ref(primary_ref)
+    if summary_ref is not None:
+        projection["latest_report_summary_ref"] = _compact_artifact_ref(summary_ref)
+    if bundle.get("report_type") is not None:
+        projection["report_type"] = str(bundle["report_type"])
+    if bundle.get("report_scope") is not None:
+        projection["report_status"] = str(bundle["report_scope"])
+    for key in ("finding_counts", "severity_counts"):
+        if key in safe_metadata:
+            if not isinstance(safe_metadata[key], Mapping):
+                raise TemporalArtifactValidationError(
+                    f"unsafe report projection metadata value at '{key}'"
+                )
+            projection[key] = dict(safe_metadata[key])
+
+    for key, value in projection.items():
+        if key not in REPORT_PROJECTION_ALLOWED_KEYS:
+            raise TemporalArtifactValidationError(
+                f"unsupported projection key '{key}'"
+            )
+        _validate_report_bundle_value(value, path=key, depth=0)
+    return projection
 
 
 def validate_report_bundle_result(bundle: Mapping[str, Any]) -> None:

--- a/moonmind/workflows/temporal/report_artifacts.py
+++ b/moonmind/workflows/temporal/report_artifacts.py
@@ -282,8 +282,19 @@ def validate_report_workflow_artifact_classes(
 
     mapping = get_report_workflow_mapping(workflow_family)
     classification = classify_report_rollout_artifacts(link_types)
+    normalized = {str(link_type or "").strip() for link_type in link_types}
     if classification["mode"] == "generic_fallback":
         if allow_generic_fallback:
+            unsupported_generic_links = sorted(
+                link_type
+                for link_type in normalized
+                if link_type and link_type not in GENERIC_OUTPUT_LINK_TYPES
+            )
+            if unsupported_generic_links:
+                raise TemporalArtifactValidationError(
+                    "unsupported generic fallback link type "
+                    f"{', '.join(unsupported_generic_links)}"
+                )
             return
         raise TemporalArtifactValidationError(
             "report-producing workflows must publish report.primary; "
@@ -294,7 +305,6 @@ def validate_report_workflow_artifact_classes(
             "report-producing workflows must publish report.primary"
         )
 
-    normalized = {str(link_type or "").strip() for link_type in link_types}
     allowed = set(mapping.report_link_types) | set(mapping.observability_link_types)
     unsupported_report_links = sorted(
         link_type
@@ -303,12 +313,7 @@ def validate_report_workflow_artifact_classes(
     )
     if unsupported_report_links:
         raise TemporalArtifactValidationError(
-            "unsupported report workflow link type "
-            + ", ".join(unsupported_report_links)
-        )
-    if "report.primary" not in normalized:
-        raise TemporalArtifactValidationError(
-            "report-producing workflows must publish report.primary"
+            f"unsupported report workflow link type {', '.join(unsupported_report_links)}"
         )
     unexpected_observability = sorted(
         link_type
@@ -318,7 +323,7 @@ def validate_report_workflow_artifact_classes(
     if unexpected_observability:
         raise TemporalArtifactValidationError(
             "unsupported report workflow observability link type "
-            + ", ".join(unexpected_observability)
+            f"{', '.join(unexpected_observability)}"
         )
 
 
@@ -365,12 +370,6 @@ def build_report_projection_summary(
     """Build a report convenience projection over compact artifact refs only."""
 
     validate_report_bundle_result(bundle)
-    for key in bundle:
-        normalized_key = str(key or "").strip()
-        if normalized_key not in REPORT_BUNDLE_ALLOWED_KEYS:
-            raise TemporalArtifactValidationError(
-                f"unsupported projection key '{normalized_key}'"
-            )
 
     safe_metadata = dict(metadata or {})
     for key, value in safe_metadata.items():

--- a/specs/232-report-workflow-rollout-examples/checklists/requirements.md
+++ b/specs/232-report-workflow-rollout-examples/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Report Workflow Rollout and Examples
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-22  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The brief is classified as one runtime story and preserves MM-464 plus source design coverage IDs.

--- a/specs/232-report-workflow-rollout-examples/contracts/report-workflow-rollout.md
+++ b/specs/232-report-workflow-rollout-examples/contracts/report-workflow-rollout.md
@@ -1,0 +1,45 @@
+# Contract: Report Workflow Rollout Helpers
+
+## Supported Workflow Families
+
+The runtime exposes deterministic mappings for:
+
+- `unit_test`
+- `coverage`
+- `security_pentest`
+- `benchmark`
+
+Each mapping includes:
+
+- `workflow_family`
+- `report_type`
+- `report_link_types`
+- `observability_link_types`
+- `recommended_metadata_keys`
+
+## Validation Contract
+
+`validate_report_workflow_artifact_classes(workflow_family, link_types, allow_generic_fallback=False)`:
+
+- accepts supported report-family link sets containing `report.primary`
+- rejects unknown workflow families
+- rejects report-producing link sets missing `report.primary`
+- permits generic fallback only when explicitly requested and only for generic output classes
+- never treats `output.primary` as a canonical report
+
+## Classification Contract
+
+`classify_report_rollout_artifacts(link_types)`:
+
+- returns `mode = "report"` when `report.primary` is present
+- returns `mode = "generic_fallback"` when only generic output links are present
+- returns `mode = "invalid"` when report-like links exist without `report.primary`
+
+## Projection Contract
+
+`build_report_projection_summary(bundle, metadata=None)`:
+
+- accepts compact report bundle refs
+- emits optional `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, `finding_counts`, and `severity_counts`
+- rejects inline content, raw URLs, evidence bodies, screenshots, transcripts, logs, and unknown storage identifiers
+- does not read, write, or create artifacts

--- a/specs/232-report-workflow-rollout-examples/contracts/report-workflow-rollout.md
+++ b/specs/232-report-workflow-rollout-examples/contracts/report-workflow-rollout.md
@@ -9,6 +9,8 @@ The runtime exposes deterministic mappings for:
 - `security_pentest`
 - `benchmark`
 
+Traceability: FR-001, FR-002, SC-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019.
+
 Each mapping includes:
 
 - `workflow_family`
@@ -27,6 +29,8 @@ Each mapping includes:
 - permits generic fallback only when explicitly requested and only for generic output classes
 - never treats `output.primary` as a canonical report
 
+Traceability: FR-003, FR-004, FR-005, SC-002, DESIGN-REQ-020.
+
 ## Classification Contract
 
 `classify_report_rollout_artifacts(link_types)`:
@@ -34,6 +38,8 @@ Each mapping includes:
 - returns `mode = "report"` when `report.primary` is present
 - returns `mode = "generic_fallback"` when only generic output links are present
 - returns `mode = "invalid"` when report-like links exist without `report.primary`
+
+Traceability: FR-006, SC-003, DESIGN-REQ-020.
 
 ## Projection Contract
 
@@ -43,3 +49,22 @@ Each mapping includes:
 - emits optional `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, `finding_counts`, and `severity_counts`
 - rejects inline content, raw URLs, evidence bodies, screenshots, transcripts, logs, and unknown storage identifiers
 - does not read, write, or create artifacts
+
+Traceability: FR-008, SC-004, DESIGN-REQ-022.
+
+## Rollout Phase Contract
+
+`REPORT_WORKFLOW_ROLLOUT_PHASES` preserves the MM-464 rollout order:
+
+1. `metadata_conventions`
+2. `report_links_and_ui_surfacing`
+3. `compact_report_bundle_contract`
+4. `optional_projections_filters_retention_pinning`
+
+Traceability: FR-007, DESIGN-REQ-021.
+
+## Jira Traceability Contract
+
+The feature artifacts, runtime tests, and final verification preserve MM-464 for downstream pull request and verification evidence.
+
+Traceability: FR-009, SC-005.

--- a/specs/232-report-workflow-rollout-examples/data-model.md
+++ b/specs/232-report-workflow-rollout-examples/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: Report Workflow Rollout and Examples
+
+## ReportWorkflowMapping
+
+- `workflow_family`: stable identifier such as `unit_test`, `coverage`, `security_pentest`, or `benchmark`.
+- `report_type`: bounded report type metadata value producers can attach to report artifacts.
+- `report_link_types`: curated report classes expected for the workflow family.
+- `observability_link_types`: runtime or diagnostic artifact classes expected to remain separate from curated reports.
+- `recommended_metadata_keys`: bounded metadata keys producers should use for the workflow family.
+
+Validation rules:
+- `report.primary` is required for every supported report-producing workflow family.
+- Every `report_link_types` value must be a supported report artifact link type.
+- Observability classes must not start with `report.`.
+- Metadata keys must be allowed report metadata keys.
+
+## ReportRolloutClassification
+
+- `has_canonical_report`: true when `report.primary` is present.
+- `mode`: `report`, `generic_fallback`, or `invalid`.
+- `generic_output_link_types`: generic output links present in the artifact set.
+- `report_link_types`: report links present in the artifact set.
+
+Validation rules:
+- Generic output-only artifacts classify as `generic_fallback`.
+- Report-producing validation fails when report links exist without `report.primary` and generic fallback is not explicitly allowed.
+- `output.primary`, `output.summary`, and `output.agent_result` remain generic outputs.
+
+## ReportProjectionSummary
+
+- `has_report`: whether a canonical report ref exists.
+- `latest_report_ref`: compact primary report artifact ref when present.
+- `latest_report_summary_ref`: compact summary artifact ref when present.
+- `report_type`: bounded metadata value.
+- `report_status`: bounded report scope/status value.
+- `finding_counts` / `severity_counts`: bounded counts copied from validated metadata.
+
+Validation rules:
+- Projection summaries are derived only from compact refs and bounded scalar/count metadata.
+- Inline report bodies, evidence payloads, logs, screenshots, transcripts, raw URLs, and unknown storage identifiers are rejected.
+- Projection summaries are read models over normal artifacts and do not represent separate storage.

--- a/specs/232-report-workflow-rollout-examples/plan.md
+++ b/specs/232-report-workflow-rollout-examples/plan.md
@@ -20,6 +20,11 @@ Implement MM-464 by adding runtime helpers that encode report-producing workflow
 | FR-007 | implemented_verified | `REPORT_WORKFLOW_ROLLOUT_PHASES`; rollout phase test | complete | unit passed |
 | FR-008 | implemented_verified | `build_report_projection_summary`; projection summary tests | complete | unit passed |
 | FR-009 | implemented_verified | MM-464 traceability in spec, tasks, verification, code, and tests | complete | traceability passed |
+| SC-001 | implemented_verified | Mapping tests cover all supported workflow families and required artifact classes | complete | unit passed |
+| SC-002 | implemented_verified | Validation tests reject missing `report.primary` unless fallback is explicit | complete | unit passed |
+| SC-003 | implemented_verified | Classification tests identify generic `output.primary`-only sets as fallback | complete | unit passed |
+| SC-004 | implemented_verified | Projection tests reject inline bodies, evidence payloads, logs, screenshots, transcripts, raw URLs, and unsupported storage identifiers | complete | unit passed |
+| SC-005 | implemented_verified | Traceability check covers MM-464 across spec, plan, tasks, verification, code, and tests | complete | traceability passed |
 | DESIGN-REQ-003 | implemented_verified | Supported mappings use stable `report.*` classes | complete | unit passed |
 | DESIGN-REQ-007 | implemented_verified | Mapping fields distinguish report/evidence/observability classes | complete | unit passed |
 | DESIGN-REQ-019 | implemented_verified | Mapping metadata guidance covers finding/severity/sensitivity keys | complete | unit passed |

--- a/specs/232-report-workflow-rollout-examples/plan.md
+++ b/specs/232-report-workflow-rollout-examples/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Report Workflow Rollout and Examples
+
+**Branch**: `232-report-workflow-rollout-examples` | **Date**: 2026-04-22 | **Spec**: [spec.md](./spec.md)  
+**Input**: Single-story feature specification from `specs/232-report-workflow-rollout-examples/spec.md`
+
+## Summary
+
+Implement MM-464 by adding runtime helpers that encode report-producing workflow family examples as deterministic, validated mappings. The technical approach is to extend the existing report artifact contract module with immutable mapping data, rollout classification, and projection-summary validation while keeping storage and artifact publication unchanged. Unit tests cover mapping contents, generic fallback classification, required `report.primary` validation, and unsafe projection rejection; integration-style activity tests continue to cover the existing artifact publication boundary.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `REPORT_WORKFLOW_MAPPINGS`; `test_supported_report_workflow_mappings_separate_report_and_observability` | complete | unit passed |
+| FR-002 | implemented_verified | `ReportWorkflowMapping.recommended_metadata_keys`; mapping tests | complete | unit passed |
+| FR-003 | implemented_verified | `validate_report_workflow_artifact_classes`; validation tests | complete | unit passed |
+| FR-004 | implemented_verified | Mapping separates `report_link_types` and `observability_link_types`; mapping tests | complete | unit passed |
+| FR-005 | implemented_verified | Existing generic output artifact tests plus fallback classification test | complete | unit passed |
+| FR-006 | implemented_verified | `classify_report_rollout_artifacts`; fallback classification test | complete | unit passed |
+| FR-007 | implemented_verified | `REPORT_WORKFLOW_ROLLOUT_PHASES`; rollout phase test | complete | unit passed |
+| FR-008 | implemented_verified | `build_report_projection_summary`; projection summary tests | complete | unit passed |
+| FR-009 | implemented_verified | MM-464 traceability in spec, tasks, verification, code, and tests | complete | traceability passed |
+| DESIGN-REQ-003 | implemented_verified | Supported mappings use stable `report.*` classes | complete | unit passed |
+| DESIGN-REQ-007 | implemented_verified | Mapping fields distinguish report/evidence/observability classes | complete | unit passed |
+| DESIGN-REQ-019 | implemented_verified | Mapping metadata guidance covers finding/severity/sensitivity keys | complete | unit passed |
+| DESIGN-REQ-020 | implemented_verified | Generic fallback classification preserves generic output behavior | complete | unit passed |
+| DESIGN-REQ-021 | implemented_verified | Runtime rollout phases are ordered and tested | complete | unit passed |
+| DESIGN-REQ-022 | implemented_verified | Projection summaries validate compact refs and bounded metadata | complete | unit passed |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Existing MoonMind Temporal artifact service helpers, dataclasses, pytest  
+**Storage**: Existing artifact store only; no new persistent storage  
+**Unit Testing**: pytest through `./tools/test_unit.sh`  
+**Integration Testing**: pytest integration suite through `./tools/test_integration.sh`; targeted local validation uses existing artifact service tests  
+**Target Platform**: Linux service/runtime workers  
+**Project Type**: Python backend/runtime library  
+**Performance Goals**: Mapping/classification helpers are deterministic in-memory operations over small bounded inputs  
+**Constraints**: Preserve existing artifact APIs, no report-specific storage, no widening generic output semantics, no inline report bodies in projection summaries  
+**Scale/Scope**: One runtime story covering four workflow-family mappings, fallback classification, rollout phases, and projection summary guardrails
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS - extends runtime artifact contract helpers without introducing a new agent or report execution engine.
+- II. One-Click Agent Deployment: PASS - no new services, secrets, or deployment prerequisites.
+- III. Avoid Vendor Lock-In: PASS - workflow family mappings are provider-neutral artifact classes.
+- IV. Own Your Data: PASS - all report data remains artifact-backed in operator-controlled storage.
+- V. Skills Are First-Class and Easy to Add: PASS - no changes to skill runtime contracts.
+- VI. Design for Deletion / Thick Contracts: PASS - adds compact helper contracts rather than workflow-specific scaffolding.
+- VII. Powerful Runtime Configurability: PASS - no hardcoded external endpoints or credentials.
+- VIII. Modular and Extensible Architecture: PASS - scoped to `report_artifacts.py`.
+- IX. Resilient by Default: PASS - no workflow payload shape changes; helpers fail fast on invalid rollout payloads.
+- X. Facilitate Continuous Improvement: PASS - final verification and traceability preserve MM-464 evidence.
+- XI. Spec-Driven Development: PASS - spec, plan, tasks, implementation, and verification are created before completion.
+- XII. Canonical Documentation Separation: PASS - migration notes remain in spec/tmp artifacts; canonical docs are not rewritten as a construction diary.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliases or hidden semantic transforms are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/232-report-workflow-rollout-examples/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── report-workflow-rollout.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+└── report_artifacts.py
+
+tests/unit/workflows/temporal/
+└── test_report_workflow_rollout.py
+```
+
+**Structure Decision**: Keep MM-464 runtime helpers beside existing report artifact contract helpers because they validate report-family semantics without changing artifact persistence or API routers.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/232-report-workflow-rollout-examples/quickstart.md
+++ b/specs/232-report-workflow-rollout-examples/quickstart.md
@@ -14,11 +14,14 @@ Run the broader related unit tests before final verification:
 
 Expected behavior:
 
-- `unit_test`, `coverage`, `security_pentest`, and `benchmark` mappings all include `report.primary`.
-- Evidence and runtime diagnostics remain separate from curated report classes.
-- Generic `output.primary`-only artifact sets classify as fallback, not canonical reports.
-- Report-producing validation rejects missing `report.primary`.
-- Projection summaries contain only compact refs and bounded metadata.
+- `unit_test`, `coverage`, `security_pentest`, and `benchmark` mappings all include `report.primary` and expected report classes. Covers FR-001, FR-002, SC-001, DESIGN-REQ-003, and DESIGN-REQ-019.
+- Evidence, runtime stdout/stderr, and runtime diagnostics remain separate from curated report classes. Covers FR-004 and DESIGN-REQ-007.
+- Generic `output.primary`, `output.summary`, and `output.agent_result` classes remain valid generic outputs during rollout. Covers FR-005 and DESIGN-REQ-020.
+- Generic `output.primary`-only artifact sets classify as fallback, not canonical reports. Covers FR-006 and SC-003.
+- Report-producing validation rejects missing `report.primary` unless legacy fallback is explicit. Covers FR-003 and SC-002.
+- Ordered rollout phases are available for metadata conventions, report links/UI surfacing, compact bundle contracts, and optional projections/filters/retention/pinning. Covers FR-007 and DESIGN-REQ-021.
+- Projection summaries contain only compact refs and bounded metadata, rejecting inline report bodies, evidence payloads, logs, screenshots, transcripts, raw URLs, and unsupported storage identifiers. Covers FR-008, SC-004, and DESIGN-REQ-022.
+- Traceability output preserves MM-464 across the spec artifacts, runtime code, and tests. Covers FR-009 and SC-005.
 
 Traceability check:
 

--- a/specs/232-report-workflow-rollout-examples/quickstart.md
+++ b/specs/232-report-workflow-rollout-examples/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Report Workflow Rollout and Examples
+
+Run targeted unit tests while implementing:
+
+```bash
+pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py -q
+```
+
+Run the broader related unit tests before final verification:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py
+```
+
+Expected behavior:
+
+- `unit_test`, `coverage`, `security_pentest`, and `benchmark` mappings all include `report.primary`.
+- Evidence and runtime diagnostics remain separate from curated report classes.
+- Generic `output.primary`-only artifact sets classify as fallback, not canonical reports.
+- Report-producing validation rejects missing `report.primary`.
+- Projection summaries contain only compact refs and bounded metadata.
+
+Traceability check:
+
+```bash
+rg -n "MM-464|DESIGN-REQ-003|DESIGN-REQ-007|DESIGN-REQ-019|DESIGN-REQ-020|DESIGN-REQ-021|DESIGN-REQ-022|report_workflow" specs/232-report-workflow-rollout-examples docs/tmp/jira-orchestration-inputs/MM-464-moonspec-orchestration-input.md moonmind/workflows/temporal tests/unit/workflows/temporal
+```

--- a/specs/232-report-workflow-rollout-examples/research.md
+++ b/specs/232-report-workflow-rollout-examples/research.md
@@ -1,0 +1,49 @@
+# Research: Report Workflow Rollout and Examples
+
+## FR-001 / DESIGN-REQ-003
+
+Decision: Missing. Add deterministic report workflow example mappings for unit-test, coverage, pentest/security, and benchmark workflow families.
+Evidence: `moonmind/workflows/temporal/report_artifacts.py` has report link type and bundle helpers but no workflow family mappings.
+Rationale: MM-464 requires runtime validation of examples, not only prose guidance.
+Alternatives considered: Leave examples in `docs/Artifacts/ReportArtifacts.md`; rejected because runtime mode requires executable validation.
+Test implications: Unit tests for each supported mapping.
+
+## FR-002 / DESIGN-REQ-019
+
+Decision: Missing. Include report link classes, observability link classes, and recommended metadata keys per workflow family.
+Evidence: Metadata key validation exists globally, but no family-specific recommendation layer exists.
+Rationale: The source examples define different metadata for unit-test, coverage, security, and benchmark reports.
+Alternatives considered: Hardcode this guidance in producer workflows; rejected because it would duplicate rollout rules.
+Test implications: Unit tests assert recommended metadata keys and artifact classes.
+
+## FR-003 / FR-004 / DESIGN-REQ-007
+
+Decision: Missing. Add validation that report-producing workflows include `report.primary`, keep evidence separate, and keep runtime stdout/stderr/diagnostics distinct from curated reports.
+Evidence: Existing report bundle validation covers compact refs and final markers, but not workflow family rollout class validation.
+Rationale: MM-464 specifically targets migration safety and examples for report-producing workflow families.
+Alternatives considered: Depend solely on `publish_report_bundle`; rejected because rollout classification also needs to handle legacy generic-output executions.
+Test implications: Unit tests for missing primary and separated artifact classes.
+
+## FR-005 / FR-006 / DESIGN-REQ-020
+
+Decision: Partial. Generic output links remain accepted by artifact service tests, but no report rollout classification helper identifies generic fallback.
+Evidence: `tests/unit/workflows/temporal/test_artifacts.py` covers generic output links; no classification helper exists.
+Rationale: Mission Control can fall back safely when runtime tells it there is no canonical report.
+Alternatives considered: Let UI infer fallback by scanning artifacts; rejected because prior specs require server/query/projection behavior instead of local heuristics.
+Test implications: Unit test classifies `output.primary`-only input as fallback.
+
+## FR-007 / DESIGN-REQ-021
+
+Decision: Missing. Add ordered rollout phase data for metadata conventions, report links/UI surfacing, compact bundle contract, and optional projections/filters/retention/pinning.
+Evidence: Phases exist in `docs/Artifacts/ReportArtifacts.md` §19 only.
+Rationale: Runtime helpers and tests can preserve migration sequencing without making docs the only source.
+Alternatives considered: No runtime exposure; rejected because MM-464 asks to support incremental rollout phases.
+Test implications: Unit test asserts ordered phase names.
+
+## FR-008 / DESIGN-REQ-022
+
+Decision: Partial. Existing compact bundle validation rejects unsafe bundle fields; add projection summary helper that only emits refs and bounded metadata.
+Evidence: `build_report_bundle_result` and `validate_report_bundle_result` exist, but there is no convenience summary helper.
+Rationale: Suggested fields/endpoints must remain read models over normal artifact refs.
+Alternatives considered: Use raw bundle dictionaries directly in every consumer; rejected because unsafe projection inputs should fail fast.
+Test implications: Unit tests for safe projection and unsafe inline body/raw URL rejection.

--- a/specs/232-report-workflow-rollout-examples/spec.md
+++ b/specs/232-report-workflow-rollout-examples/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Report Workflow Rollout and Examples
+
+**Feature Branch**: `232-report-workflow-rollout-examples`  
+**Created**: 2026-04-22  
+**Status**: Draft  
+**Input**:
+
+```text
+Use the Jira preset brief for MM-464 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-464-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-464 from MM project
+Summary: Report Workflow Rollout and Examples
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-464 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-464: Report Workflow Rollout and Examples
+
+Short Name
+report-workflow-rollout-examples
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 17. Example workflow mappings, 18. Suggested API/UI extensions, 19. Migration guidance, 20. Open questions
+- Coverage IDs: DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+
+User Story
+As a MoonMind maintainer, I can migrate report-producing workflow families incrementally to the report artifact contract with documented examples and graceful fallback for existing generic outputs.
+
+Acceptance Criteria
+- Unit-test, coverage, pentest/security, and benchmark report examples each map to `report.primary` and appropriate summary, structured, evidence, runtime, and diagnostic artifacts.
+- New report-producing workflows prefer `report.*` semantics while existing generic `output.primary` flows continue to operate.
+- The UI degrades gracefully when an execution has only generic output artifacts and no `report.primary` artifact.
+- Migration docs or examples distinguish curated reports, evidence, runtime stdout/stderr, and diagnostics for each workflow family.
+- Convenience report fields or endpoints, if introduced during rollout, remain projections over the normal artifact APIs.
+
+Requirements
+- Document and validate report mappings for unit-test, coverage, pentest/security, and benchmark workflows.
+- Support incremental rollout phases: metadata conventions, explicit `report.*` link types and UI surfacing, compact report bundle contract, and optional projections, filters, retention, and pinning.
+- Keep existing generic outputs available during migration.
+- Preserve clear separation between curated reports and observability artifacts in examples and tests.
+
+Relevant Implementation Notes
+- Use the existing artifact APIs as the baseline for the first rollout; report-aware convenience surfaces must remain projections over normal artifacts.
+- Represent report-producing workflow examples with explicit artifact families, including `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `runtime.stdout`, `runtime.stderr`, and `runtime.diagnostics` where applicable.
+- Include example mappings for unit test reports, coverage reports, pentest or security reports, and benchmark or evaluation reports.
+- Keep report metadata bounded to display and classification fields such as `artifact_type`, `producer`, `subject`, `finding_counts`, `severity_counts`, and `sensitivity` where relevant.
+- Preserve fallback behavior for executions that only have generic output artifacts and no `report.primary` artifact.
+- Treat suggested execution detail fields and any report projection endpoint as optional read models over the underlying artifact references, not as a second storage model.
+- Preserve MM-464 and coverage IDs DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, and DESIGN-REQ-022 in downstream MoonSpec artifacts and final implementation evidence.
+
+Non-Goals
+- Requiring a flag-day migration for existing report-producing workflows.
+- Replacing generic `output.primary` behavior for existing workflows during rollout.
+- Creating a second report storage model or making report convenience fields authoritative over artifact records.
+- Forcing immediate implementation of every optional API/UI extension or open question from the source document.
+- Collapsing curated reports, evidence, runtime stdout/stderr, diagnostics, and other observability artifacts into one undifferentiated output.
+
+Validation
+- Verify unit-test, coverage, pentest/security, and benchmark examples map to `report.primary` and the appropriate related report, runtime, and diagnostic artifacts.
+- Verify new report-producing workflow guidance prefers explicit `report.*` semantics while existing generic `output.primary` flows remain valid.
+- Verify UI or documentation guidance describes graceful fallback when an execution has generic outputs but no `report.primary` artifact.
+- Verify migration guidance distinguishes curated reports, evidence, runtime stdout/stderr, and diagnostics for each workflow family.
+- Verify any introduced convenience fields or report endpoint behavior is documented and implemented as a projection over normal artifact APIs.
+
+Needs Clarification
+- None
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable maintainer story and does not require processing multiple specs.
+- Selected mode: Runtime.
+- Source design: `docs/Artifacts/ReportArtifacts.md` is treated as runtime source requirements because the Jira brief points at implementation behavior, not documentation-only work.
+- Resume decision: No existing Moon Spec artifacts for MM-464 were found under `specs/`; specification is the first incomplete stage.
+
+## User Story - Validate Report Workflow Rollout Mappings
+
+**Summary**: As a MoonMind maintainer, I want report-producing workflow families to have executable rollout mappings for report, evidence, runtime, and diagnostic artifacts so migrations can prefer report semantics while generic output fallback remains safe.
+
+**Goal**: Runtime code can identify and validate the expected artifact classes for unit-test, coverage, pentest/security, and benchmark reports without conflating curated reports with observability artifacts or breaking existing generic outputs.
+
+**Independent Test**: Validate each supported workflow family mapping in isolation, then verify a new report-producing workflow must include `report.primary`, evidence/runtime/diagnostic artifacts stay distinct where expected, and an execution with only generic `output.primary` is classified as a legacy fallback rather than a canonical report.
+
+**Acceptance Scenarios**:
+
+1. **Given** a unit-test report mapping is requested, **When** the runtime returns the example mapping, **Then** it includes `report.primary`, `report.summary`, `report.structured`, optional `report.evidence`, `runtime.stdout`, `runtime.stderr`, and `runtime.diagnostics` with unit-test metadata guidance.
+2. **Given** coverage, pentest/security, and benchmark mappings are requested, **When** the runtime returns each mapping, **Then** each maps curated report artifacts separately from evidence and observability artifacts.
+3. **Given** a new report-producing workflow validates its artifact classes, **When** it omits `report.primary` without explicitly using legacy fallback, **Then** validation fails instead of silently treating `output.primary` as a report.
+4. **Given** an existing execution has generic output artifacts and no `report.primary`, **When** it is classified for report rollout presentation, **Then** it is identified as a generic fallback with no canonical report.
+5. **Given** a convenience report summary is built from a report bundle, **When** refs are present, **Then** the summary contains only projection data over artifact refs and no report body or evidence payload.
+
+### Edge Cases
+
+- An unknown workflow family name is provided.
+- A report-producing workflow publishes evidence but omits its primary report.
+- Generic `output.primary` exists alongside report evidence but no `report.primary`.
+- A convenience summary input contains inline body, raw URL, transcript, or evidence payload fields.
+- A workflow family requires no stdout/stderr artifact but still requires diagnostics.
+
+## Assumptions
+
+- Report link types and compact report bundle helpers from MM-460 and MM-461 are available.
+- Mission Control report presentation from MM-462 already handles the UI fallback once the runtime reports no canonical `report.primary`.
+- The first runtime slice should provide deterministic helper functions and tests, not force all workflow producers to migrate in one change.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-003 | `docs/Artifacts/ReportArtifacts.md` §17 | Unit-test, coverage, pentest/security, and benchmark workflow examples use stable `report.*` link types for curated report artifacts. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-007 | `docs/Artifacts/ReportArtifacts.md` §17 | Examples must distinguish curated reports and evidence from runtime stdout/stderr and diagnostics. | In scope | FR-001, FR-004 |
+| DESIGN-REQ-019 | `docs/Artifacts/ReportArtifacts.md` §17.1-§17.4 | Each workflow family has recommended metadata such as artifact type, producer, subject, finding counts, severity counts, or sensitivity. | In scope | FR-002 |
+| DESIGN-REQ-020 | `docs/Artifacts/ReportArtifacts.md` §17, §19 | Existing generic outputs continue to operate during incremental rollout and are treated as fallback when no canonical report exists. | In scope | FR-005, FR-006 |
+| DESIGN-REQ-021 | `docs/Artifacts/ReportArtifacts.md` §19 | Rollout phases progress from metadata conventions, to explicit report links and UI surfacing, to compact bundles, then optional projections/filters/retention/pinning. | In scope | FR-007 |
+| DESIGN-REQ-022 | `docs/Artifacts/ReportArtifacts.md` §18 | Convenience report fields or endpoints are projections over normal artifact APIs and refs, not separate storage or authoritative report bodies. | In scope | FR-008 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose deterministic report workflow example mappings for unit-test, coverage, pentest/security, and benchmark report-producing workflow families.
+- **FR-002**: Each workflow example mapping MUST identify expected report artifact classes, observability artifact classes, and recommended bounded metadata keys for the workflow family.
+- **FR-003**: New report-producing workflow validation MUST require `report.primary` unless the caller explicitly treats the execution as a legacy generic-output fallback.
+- **FR-004**: Workflow mapping validation MUST preserve separation between curated report artifacts, report evidence artifacts, runtime stdout/stderr, and runtime diagnostics.
+- **FR-005**: Existing generic `output.primary`, `output.summary`, and `output.agent_result` artifacts MUST remain valid generic output classes during rollout.
+- **FR-006**: Report rollout classification MUST identify executions with generic output artifacts and no `report.primary` as generic fallback rather than canonical report executions.
+- **FR-007**: The system MUST expose the ordered incremental rollout phases for report-producing workflows.
+- **FR-008**: Convenience report summaries derived during rollout MUST contain only projection data over normal artifact refs and bounded metadata, not report bodies, evidence payloads, logs, screenshots, transcripts, raw URLs, or separate storage identifiers.
+- **FR-009**: Moon Spec artifacts, verification evidence, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-464.
+
+### Key Entities
+
+- **Report Workflow Mapping**: A deterministic example contract for one report-producing workflow family, including report link types, observability link types, and recommended metadata.
+- **Report Rollout Classification**: A compact decision describing whether a set of artifact link types contains a canonical report, a generic fallback, or an invalid report-producing output.
+- **Report Projection Summary**: A convenience read model derived from compact artifact refs and bounded metadata over normal artifacts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of supported workflow family mappings include `report.primary` and the expected report/evidence/runtime/diagnostic classes from the Jira brief.
+- **SC-002**: Validation tests reject report-producing workflow outputs that omit `report.primary` unless legacy fallback is explicitly requested.
+- **SC-003**: Classification tests identify generic `output.primary`-only executions as fallback with no canonical report.
+- **SC-004**: Projection summary tests reject inline report bodies, evidence payloads, logs, screenshots, transcripts, raw URLs, and unsupported storage identifiers.
+- **SC-005**: MM-464 appears in the spec, plan, tasks, verification evidence, and publish metadata for traceability.

--- a/specs/232-report-workflow-rollout-examples/tasks.md
+++ b/specs/232-report-workflow-rollout-examples/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py`
 - Integration tests: `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py -q`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -81,7 +81,7 @@
 
 - [X] T013 Run traceability check for MM-464 and source design IDs across specs, input brief, runtime code, and tests
 - [X] T014 Create `specs/232-report-workflow-rollout-examples/verification.md` with final evidence and verdict
-- [X] T015 Run `/speckit.verify` equivalent by checking the final implementation against the original MM-464 request
+- [X] T015 Run `/moonspec-verify` equivalent by checking the final implementation against the original MM-464 request
 
 ---
 

--- a/specs/232-report-workflow-rollout-examples/tasks.md
+++ b/specs/232-report-workflow-rollout-examples/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: Report Workflow Rollout and Examples
+
+**Input**: Design documents from `/specs/232-report-workflow-rollout-examples/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around a single user story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: MM-464; FR-001 through FR-009; SC-001 through SC-005; DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py`
+- Integration tests: `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py -q`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature reuses existing report artifact runtime module and tests.
+
+- [X] T001 Create Moon Spec artifacts for MM-464 in `specs/232-report-workflow-rollout-examples/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new infrastructure is required; existing report artifact helpers are the foundation.
+
+- [X] T002 Confirm existing report artifact helpers and tests in `moonmind/workflows/temporal/report_artifacts.py` and `tests/unit/workflows/temporal/test_artifacts.py`
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Validate Report Workflow Rollout Mappings
+
+**Summary**: As a MoonMind maintainer, I want report-producing workflow families to have executable rollout mappings for report, evidence, runtime, and diagnostic artifacts so migrations can prefer report semantics while generic output fallback remains safe.
+
+**Independent Test**: Validate each supported workflow family mapping in isolation, then verify a new report-producing workflow must include `report.primary`, evidence/runtime/diagnostic artifacts stay distinct where expected, and an execution with only generic `output.primary` is classified as a legacy fallback rather than a canonical report.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+
+**Test Plan**:
+
+- Unit: mapping contents, validation failures, fallback classification, projection summary guardrails
+- Integration: existing artifact service tests continue to cover generic outputs and report bundle publication boundaries
+
+### Unit Tests (write first) ⚠️
+
+- [X] T003 [P] Add failing unit tests for workflow family mappings in `tests/unit/workflows/temporal/test_report_workflow_rollout.py` covering FR-001, FR-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-019
+- [X] T004 [P] Add failing unit tests for report-producing validation and generic fallback classification in `tests/unit/workflows/temporal/test_report_workflow_rollout.py` covering FR-003, FR-005, FR-006, DESIGN-REQ-020, SC-002, and SC-003
+- [X] T005 [P] Add failing unit tests for rollout phases and projection summary guardrails in `tests/unit/workflows/temporal/test_report_workflow_rollout.py` covering FR-007, FR-008, DESIGN-REQ-021, DESIGN-REQ-022, and SC-004
+- [X] T006 Run `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py -q` to confirm T003-T005 fail before implementation
+
+### Integration Tests (write first) ⚠️
+
+- [X] T007 Reuse existing artifact service tests in `tests/unit/workflows/temporal/test_artifacts.py` as the integration-style boundary for generic outputs and report bundle publication
+- [X] T008 Run `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py -q --tb=short` to confirm new tests fail only for missing MM-464 helpers
+
+### Implementation
+
+- [X] T009 Implement report workflow mapping data and accessors in `moonmind/workflows/temporal/report_artifacts.py` covering FR-001, FR-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-019
+- [X] T010 Implement report rollout validation and generic fallback classification in `moonmind/workflows/temporal/report_artifacts.py` covering FR-003, FR-005, FR-006, and DESIGN-REQ-020
+- [X] T011 Implement ordered rollout phases and projection summary guardrails in `moonmind/workflows/temporal/report_artifacts.py` covering FR-007, FR-008, DESIGN-REQ-021, and DESIGN-REQ-022
+- [X] T012 Run targeted unit and related artifact tests, fix failures, and verify story behavior end-to-end
+
+**Checkpoint**: The story is fully functional, covered by unit and related artifact boundary tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen traceability without adding hidden scope.
+
+- [X] T013 Run traceability check for MM-464 and source design IDs across specs, input brief, runtime code, and tests
+- [X] T014 Create `specs/232-report-workflow-rollout-examples/verification.md` with final evidence and verdict
+- [X] T015 Run `/speckit.verify` equivalent by checking the final implementation against the original MM-464 request
+
+---
+
+## Dependencies & Execution Order
+
+- Setup and foundational inspection are complete before story implementation.
+- Unit tests must fail before production code changes.
+- Targeted unit tests and related artifact tests must pass before final verification.
+
+## Implementation Strategy
+
+Implement the smallest runtime contract that satisfies MM-464: immutable mappings, explicit validation/classification, and projection guardrails. Do not alter artifact persistence, Mission Control UI, or workflow publication behavior beyond these helpers.

--- a/specs/232-report-workflow-rollout-examples/verification.md
+++ b/specs/232-report-workflow-rollout-examples/verification.md
@@ -1,0 +1,49 @@
+# Verification: Report Workflow Rollout and Examples
+
+**Feature**: `232-report-workflow-rollout-examples`  
+**Jira issue**: MM-464  
+**Verdict**: FULLY_IMPLEMENTED  
+**Verified**: 2026-04-22
+
+## Summary
+
+MM-464 is implemented in runtime mode. The implementation adds executable report workflow rollout mappings, validation/classification helpers, ordered rollout phases, and projection-summary guardrails on top of the existing report artifact contract without changing artifact storage or workflow publication behavior.
+
+## Test Evidence
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py -q` | PASS | 5 passed after expected red-first import failure before implementation. |
+| `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py -q --tb=short` | PASS | 48 passed; covers new MM-464 helpers plus existing report/generic artifact behavior. |
+| `./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py` | PASS | Python: 48 passed. UI test suite invoked by wrapper: 11 files / 367 tests passed. |
+| `rg -n "MM-464|DESIGN-REQ-003|DESIGN-REQ-007|DESIGN-REQ-019|DESIGN-REQ-020|DESIGN-REQ-021|DESIGN-REQ-022|report_workflow" specs/232-report-workflow-rollout-examples docs/tmp/jira-orchestration-inputs/MM-464-moonspec-orchestration-input.md moonmind/workflows/temporal/report_artifacts.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` | PASS | Traceability present across input, spec artifacts, runtime code, and tests. |
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `REPORT_WORKFLOW_MAPPINGS`; `test_supported_report_workflow_mappings_separate_report_and_observability` covers unit-test, coverage, security, and benchmark mappings. |
+| FR-002 | VERIFIED | `ReportWorkflowMapping.recommended_metadata_keys`; mapping tests assert finding/severity/sensitivity guidance. |
+| FR-003 | VERIFIED | `validate_report_workflow_artifact_classes`; tests reject missing `report.primary` and generic `output.primary` for new report-producing workflows. |
+| FR-004 | VERIFIED | Mappings separate `report_link_types` and `observability_link_types`; tests assert curated report/runtime separation. |
+| FR-005 | VERIFIED | Existing `test_generic_output_links_remain_accepted_with_generic_metadata` remains passing in related artifact suite. |
+| FR-006 | VERIFIED | `classify_report_rollout_artifacts`; tests classify generic outputs as `generic_fallback` and report evidence without primary as `invalid`. |
+| FR-007 | VERIFIED | `REPORT_WORKFLOW_ROLLOUT_PHASES`; tests assert ordered rollout phases. |
+| FR-008 | VERIFIED | `build_report_projection_summary`; tests verify ref-only summary and unsafe inline/raw metadata rejection. |
+| FR-009 | VERIFIED | MM-464 appears in spec, tasks, verification, runtime docstrings/tests, and traceability output. |
+
+## Source Design Coverage
+
+| Source ID | Status | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-003 | VERIFIED | Supported mappings use stable `report.*` classes for report workflow examples. |
+| DESIGN-REQ-007 | VERIFIED | Mapping fields distinguish report artifacts from runtime stdout/stderr/diagnostics. |
+| DESIGN-REQ-019 | VERIFIED | Mapping metadata includes family-specific finding, severity, sensitivity, producer, and subject keys. |
+| DESIGN-REQ-020 | VERIFIED | Generic output fallback classification preserves existing output behavior without treating it as canonical report identity. |
+| DESIGN-REQ-021 | VERIFIED | Ordered rollout phases are exposed in runtime helpers and tested. |
+| DESIGN-REQ-022 | VERIFIED | Projection summary helper validates compact refs and bounded metadata only. |
+
+## Residual Risk
+
+- The helpers provide runtime validation primitives; individual workflow producers still need to call them when they migrate.
+- Full repository unit suite was not run; focused required unit wrapper and UI tests passed for the changed slice.

--- a/tests/unit/workflows/temporal/test_report_workflow_rollout.py
+++ b/tests/unit/workflows/temporal/test_report_workflow_rollout.py
@@ -1,0 +1,174 @@
+"""MM-464 report workflow rollout mapping tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.artifacts import TemporalArtifactValidationError
+from moonmind.workflows.temporal.report_artifacts import (
+    REPORT_WORKFLOW_ROLLOUT_PHASES,
+    build_report_bundle_result,
+    build_report_projection_summary,
+    classify_report_rollout_artifacts,
+    get_report_workflow_mapping,
+    validate_report_workflow_artifact_classes,
+)
+
+
+def test_supported_report_workflow_mappings_separate_report_and_observability() -> None:
+    """MM-464: workflow examples map curated report classes separately."""
+
+    unit_test = get_report_workflow_mapping("unit_test")
+    assert unit_test.workflow_family == "unit_test"
+    assert unit_test.report_type == "unit_test_report"
+    assert unit_test.report_link_types == (
+        "report.primary",
+        "report.summary",
+        "report.structured",
+        "report.evidence",
+    )
+    assert unit_test.observability_link_types == (
+        "runtime.stdout",
+        "runtime.stderr",
+        "runtime.diagnostics",
+    )
+    assert "finding_counts" in unit_test.recommended_metadata_keys
+
+    coverage = get_report_workflow_mapping("coverage")
+    assert coverage.report_link_types == (
+        "report.primary",
+        "report.structured",
+        "report.evidence",
+    )
+    assert "runtime.stdout" not in coverage.report_link_types
+    assert "finding_counts" in coverage.recommended_metadata_keys
+
+    security = get_report_workflow_mapping("security_pentest")
+    assert security.report_link_types == (
+        "report.primary",
+        "report.summary",
+        "report.structured",
+        "report.evidence",
+    )
+    assert "severity_counts" in security.recommended_metadata_keys
+    assert "sensitivity" in security.recommended_metadata_keys
+
+    benchmark = get_report_workflow_mapping("benchmark")
+    assert benchmark.report_link_types == (
+        "report.primary",
+        "report.structured",
+        "report.evidence",
+    )
+    assert "finding_counts" in benchmark.recommended_metadata_keys
+
+
+def test_report_workflow_validation_requires_primary_report() -> None:
+    """MM-464: new report-producing workflows cannot treat output.primary as a report."""
+
+    with pytest.raises(TemporalArtifactValidationError, match="report.primary"):
+        validate_report_workflow_artifact_classes(
+            "unit_test",
+            ("output.primary", "runtime.stdout", "runtime.diagnostics"),
+        )
+
+    with pytest.raises(TemporalArtifactValidationError, match="report.primary"):
+        validate_report_workflow_artifact_classes(
+            "coverage",
+            ("report.structured", "report.evidence"),
+        )
+
+    validate_report_workflow_artifact_classes(
+        "unit_test",
+        (
+            "report.primary",
+            "report.summary",
+            "report.structured",
+            "runtime.stdout",
+            "runtime.stderr",
+            "runtime.diagnostics",
+        ),
+    )
+
+
+def test_generic_output_only_artifacts_classify_as_rollout_fallback() -> None:
+    """MM-464: generic outputs remain valid fallback, not canonical reports."""
+
+    classification = classify_report_rollout_artifacts(
+        ("output.primary", "output.summary", "runtime.diagnostics")
+    )
+
+    assert classification["mode"] == "generic_fallback"
+    assert classification["has_canonical_report"] is False
+    assert classification["generic_output_link_types"] == (
+        "output.primary",
+        "output.summary",
+    )
+    assert classification["report_link_types"] == ()
+
+    invalid = classify_report_rollout_artifacts(("report.evidence", "output.primary"))
+    assert invalid["mode"] == "invalid"
+    assert invalid["has_canonical_report"] is False
+    assert invalid["report_link_types"] == ("report.evidence",)
+
+
+def test_report_rollout_phases_are_ordered() -> None:
+    """MM-464: incremental migration phases are available to runtime helpers."""
+
+    assert REPORT_WORKFLOW_ROLLOUT_PHASES == (
+        "metadata_conventions",
+        "report_links_and_ui_surfacing",
+        "compact_report_bundle_contract",
+        "optional_projections_filters_retention_pinning",
+    )
+
+
+def test_report_projection_summary_is_ref_only() -> None:
+    """MM-464: convenience summaries are projections over artifact refs."""
+
+    bundle = build_report_bundle_result(
+        primary_report_ref={"artifact_ref_v": 1, "artifact_id": "art_primary"},
+        summary_ref={"artifact_ref_v": 1, "artifact_id": "art_summary"},
+        evidence_refs=({"artifact_ref_v": 1, "artifact_id": "art_evidence"},),
+        report_type="security_pentest_report",
+        report_scope="final",
+        counts={"high": 1},
+    )
+
+    summary = build_report_projection_summary(
+        bundle,
+        metadata={
+            "finding_counts": {"total": 3},
+            "severity_counts": {"high": 1},
+        },
+    )
+
+    assert summary == {
+        "has_report": True,
+        "latest_report_ref": {"artifact_ref_v": 1, "artifact_id": "art_primary"},
+        "latest_report_summary_ref": {
+            "artifact_ref_v": 1,
+            "artifact_id": "art_summary",
+        },
+        "report_type": "security_pentest_report",
+        "report_status": "final",
+        "finding_counts": {"total": 3},
+        "severity_counts": {"high": 1},
+    }
+
+    with pytest.raises(TemporalArtifactValidationError, match="unsafe report bundle"):
+        build_report_projection_summary(
+            {
+                "report_bundle_v": 1,
+                "primary_report_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": "art_primary",
+                },
+                "report_body": "# Inline body",
+            }
+        )
+
+    with pytest.raises(TemporalArtifactValidationError, match="unsafe report"):
+        build_report_projection_summary(
+            bundle,
+            metadata={"raw_download_url": "https://example.invalid/report"},
+        )

--- a/tests/unit/workflows/temporal/test_report_workflow_rollout.py
+++ b/tests/unit/workflows/temporal/test_report_workflow_rollout.py
@@ -111,6 +111,26 @@ def test_generic_output_only_artifacts_classify_as_rollout_fallback() -> None:
     assert invalid["report_link_types"] == ("report.evidence",)
 
 
+def test_report_workflow_generic_fallback_rejects_non_generic_links() -> None:
+    """MM-464: fallback validation only accepts generic output classes."""
+
+    validate_report_workflow_artifact_classes(
+        "unit_test",
+        ("output.primary", "output.summary"),
+        allow_generic_fallback=True,
+    )
+
+    with pytest.raises(
+        TemporalArtifactValidationError,
+        match="unsupported generic fallback link type runtime.stdout",
+    ):
+        validate_report_workflow_artifact_classes(
+            "unit_test",
+            ("output.primary", "runtime.stdout"),
+            allow_generic_fallback=True,
+        )
+
+
 def test_report_rollout_phases_are_ordered() -> None:
     """MM-464: incremental migration phases are available to runtime helpers."""
 


### PR DESCRIPTION
## Jira

- Jira issue key: MM-464

## MoonSpec

- Active feature path: `specs/232-report-workflow-rollout-examples`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run

- `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py -q` - PASS, 5 passed
- `pytest tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py -q --tb=short` - PASS, 48 passed
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/workflows/temporal/test_artifacts.py` - PASS, Python 48 passed; UI 11 files / 367 tests passed

## Remaining risks

- The helpers provide runtime validation primitives; individual workflow producers still need to call them when they migrate.
- Full repository unit suite was not run; focused required wrapper validation passed for the changed slice.