### PR TITLE
MM-456 Publish remediation lifecycle audit evidence

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/230-remediation-mutation-guards"
+  "feature_directory": "specs/232-remediation-lifecycle-audit"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,8 @@ Key diagnostics:
 - No new persistent storage; uses existing provider profile row metadata and optional command/readiness data (226-route-claude-auth-actions)
 - Python 3.12 + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK (226-canonical-remediation-submissions)
 - Existing SQLAlchemy/Alembic database with `execution_remediation_links` already present (226-canonical-remediation-submissions)
+- Python 3.12 + SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK service boundaries, existing Temporal artifact service, existing remediation context/action services (232-remediation-lifecycle-audit)
+- Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and existing execution memo/search/projection paths; no new persistent database table planned unless audit events cannot reuse an existing control-event mechanism (232-remediation-lifecycle-audit)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-463",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1684"
+  "jira_issue_key": "MM-456",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1686"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,27 @@
 [
   {
-    "id": 3123468095,
+    "id": 3123798424,
+    "disposition": "addressed",
+    "rationale": "Identifier fields now bypass path-style unsafe string checks, and unit coverage verifies hierarchical target workflow/run IDs are preserved."
+  },
+  {
+    "id": 3123798439,
+    "disposition": "addressed",
+    "rationale": "String timestamps are now parsed and normalized to UTC Zulu format, with malformed strings rejected by regression coverage."
+  },
+  {
+    "id": 4154502370,
     "disposition": "not-applicable",
-    "rationale": "This MM-455 slice explicitly preserves the plan constraint of no new persistent storage; distributed database-backed lock persistence requires a separate schema-backed feature rather than an in-place PR feedback patch."
+    "rationale": "Top-level review summary only; its two actionable findings are tracked by inline comments 3123798424 and 3123798439."
   },
   {
-    "id": 3123468103,
+    "id": 3123798641,
     "disposition": "addressed",
-    "rationale": "Made RemediationMutationGuardService.evaluate require an explicit now value so callers provide workflow/activity-safe time instead of falling back to datetime.now()."
+    "rationale": "The lifecycle payload sanitizer now allowlists authorityMode while continuing to drop secret-like keys, and publisher coverage asserts remediation.summary retains authorityMode."
   },
   {
-    "id": 3123468109,
-    "disposition": "addressed",
-    "rationale": "Added bounded cleanup and size trimming for process-local guard locks, ledger entries, lost-holder records, cooldown attempts, and target counters."
-  },
-  {
-    "id": 3123468116,
-    "disposition": "addressed",
-    "rationale": "Added created_at to active lock records and serialized lock decisions as createdAt with unit coverage."
-  },
-  {
-    "id": 3123473808,
-    "disposition": "addressed",
-    "rationale": "Changed lock acquisition to evaluate expiration before the same-holder fast path and added regression coverage for expired same-holder recovery."
-  },
-  {
-    "id": 3123473812,
-    "disposition": "addressed",
-    "rationale": "Updated target freshness evaluation to treat pinned/current state, summary, and session identity differences as material drift, with regression coverage."
+    "id": 4154502596,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper with no additional actionable feedback beyond the inline comments already addressed."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-456-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-456-moonspec-orchestration-input.md
@@ -1,0 +1,89 @@
+# MM-456 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-456
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-456 from MM project
+Summary: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-456 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-456: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 13. Runtime lifecycle
+  - 14. Artifacts, summaries, and audit
+  - 16. Failure modes and edge cases
+- Coverage IDs:
+  - DESIGN-REQ-017
+  - DESIGN-REQ-018
+  - DESIGN-REQ-019
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+
+User Story
+As an operator or reviewer, I can inspect a remediation run from evidence collection through verification because each phase, decision, action, result, and final outcome leaves durable artifacts and queryable audit evidence.
+
+Acceptance Criteria
+- remediationPhase values reflect collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, or failed as the run progresses.
+- Required remediation artifacts are published with expected artifact_type values and obey artifact preview/redaction metadata rules.
+- run_summary.json includes the remediation block with target identity, mode, authorityMode, actionsAttempted, resolution, lockConflicts, approvalCount, evidenceDegraded, and escalated fields.
+- Target-managed session or workload mutations continue to produce native continuity/control artifacts in addition to remediation audit artifacts.
+- Control-plane audit events record actor, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+- Cancellation or remediation failure does not mutate the target except for already-requested actions and attempts final summary publication and lock release.
+- Continue-As-New preserves target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+
+Requirements
+- Existing MoonMind.Run state remains the top-level state source.
+- Artifacts remain operator-facing deep evidence; audit rows remain compact queryable trail.
+- Target-side linkage summary metadata is available for downstream detail views.
+
+Relevant Implementation Notes
+- Preserve MM-456 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation runtime lifecycle phases, artifact publication, final summaries, audit events, cancellation behavior, failure handling, and Continue-As-New preservation.
+- Keep MoonMind.Run as the top-level execution state source; remediation-specific phase values should complement that state rather than replace it.
+- Publish remediation artifacts with bounded metadata and existing artifact preview/redaction rules.
+- Ensure final run summaries include the remediation block with target identity, mode, authority mode, action attempts, resolution, lock conflicts, approval count, degraded evidence, and escalation state.
+- Preserve native managed-session or workload continuity/control artifacts when remediation mutates those targets.
+- Record compact queryable audit events for remediation actions, approvals, risk tiers, actors, execution principals, target workflow/run identity, timestamps, and bounded metadata.
+- On cancellation or remediation failure, avoid new target mutation except for already-requested actions; still attempt final summary publication and lock release.
+- Preserve target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor across Continue-As-New.
+
+Non-Goals
+- Replacing MoonMind.Run as the top-level state source.
+- Treating audit rows as a replacement for operator-facing artifact evidence.
+- Dropping native target continuity or control artifacts when remediation touches managed sessions or workloads.
+- Mutating targets after cancellation or failure except for already-requested actions.
+- Losing remediation context across Continue-As-New.
+
+Validation
+- Verify remediationPhase values reflect collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, or failed as the run progresses.
+- Verify required remediation artifacts are published with expected artifact_type values and obey artifact preview/redaction metadata rules.
+- Verify run_summary.json includes the remediation block with target identity, mode, authorityMode, actionsAttempted, resolution, lockConflicts, approvalCount, evidenceDegraded, and escalated fields.
+- Verify target-managed session or workload mutations continue to produce native continuity/control artifacts in addition to remediation audit artifacts.
+- Verify control-plane audit events record actor, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+- Verify cancellation or remediation failure does not mutate the target except for already-requested actions and attempts final summary publication and lock release.
+- Verify Continue-As-New preserves target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-456 blocks MM-455, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-456 is blocked by MM-457, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -73,6 +73,7 @@ SECRET_LIKE_POLICY_KEY_PARTS = (
     "secret",
     "token",
 )
+SAFE_POLICY_KEYS = frozenset({"authorityMode"})
 
 
 class RemediationContextError(RuntimeError):
@@ -685,7 +686,7 @@ def _required_string(value: Any, field_name: str) -> str:
     normalized = _string_or_none(value)
     if not normalized:
         raise RemediationContextError(f"{field_name} is required")
-    if _is_unsafe_context_string(normalized):
+    if not _is_identifier_field(field_name) and _is_unsafe_context_string(normalized):
         raise RemediationContextError(f"{field_name} is unsafe")
     return normalized
 
@@ -704,12 +705,25 @@ def _timestamp_string(value: datetime | str) -> str:
             timestamp = timestamp.replace(tzinfo=UTC)
         return timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z")
     normalized = _required_string(value, "timestamp")
-    return normalized
+    try:
+        timestamp = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RemediationContextError("timestamp must be ISO8601") from exc
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _is_secret_like_key(key: str) -> bool:
+    if key in SAFE_POLICY_KEYS:
+        return False
     normalized = key.strip().lower().replace("-", "_")
     return any(part in normalized for part in SECRET_LIKE_POLICY_KEY_PARTS)
+
+
+def _is_identifier_field(field_name: str) -> bool:
+    normalized = field_name.strip()
+    return normalized.endswith("_id") or normalized.endswith("Id")
 
 
 def _is_unsafe_context_string(value: str) -> bool:

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -10,7 +10,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Sequence
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +23,42 @@ from moonmind.workflows.temporal.artifacts import (
 REMEDIATION_CONTEXT_LINK_TYPE = "remediation.context"
 REMEDIATION_CONTEXT_ARTIFACT_NAME = "reports/remediation_context.json"
 REMEDIATION_CONTEXT_SCHEMA_VERSION = "v1"
+REMEDIATION_ARTIFACT_TYPES = frozenset(
+    {
+        "remediation.context",
+        "remediation.plan",
+        "remediation.decision_log",
+        "remediation.action_request",
+        "remediation.action_result",
+        "remediation.verification",
+        "remediation.summary",
+    }
+)
+REMEDIATION_PHASES = frozenset(
+    {
+        "collecting_evidence",
+        "diagnosing",
+        "awaiting_approval",
+        "acting",
+        "verifying",
+        "resolved",
+        "escalated",
+        "failed",
+    }
+)
+REMEDIATION_RESOLUTIONS = frozenset(
+    {
+        "not_applicable",
+        "diagnosis_only",
+        "no_action_needed",
+        "resolved_after_action",
+        "escalated",
+        "unsafe_to_act",
+        "lock_conflict",
+        "evidence_unavailable",
+        "failed",
+    }
+)
 MAX_REMEDIATION_CONTEXT_TAIL_LINES = 2000
 MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS = 20
 SECRET_LIKE_POLICY_KEY_PARTS = (
@@ -327,6 +363,250 @@ class RemediationContextBuilder:
         return _string_or_none(value)
 
 
+class RemediationLifecyclePublisher:
+    """Publish bounded remediation lifecycle artifacts for one remediation run."""
+
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        artifact_service: TemporalArtifactService,
+    ) -> None:
+        self._session = session
+        self._artifact_service = artifact_service
+
+    async def publish_json_artifact(
+        self,
+        *,
+        remediation_workflow_id: str,
+        artifact_type: str,
+        name: str,
+        payload: Mapping[str, Any],
+        target_workflow_id: str | None = None,
+        target_run_id: str | None = None,
+        principal: str = "service:remediation-lifecycle",
+    ) -> db_models.TemporalArtifact:
+        workflow_id = _required_string(
+            remediation_workflow_id, "remediation_workflow_id"
+        )
+        artifact_type = _required_string(artifact_type, "artifact_type")
+        if artifact_type not in REMEDIATION_ARTIFACT_TYPES:
+            raise RemediationContextError(
+                f"Unsupported remediation artifact type: {artifact_type}"
+            )
+        name = _required_string(name, "name")
+        if not isinstance(payload, Mapping):
+            raise RemediationContextError("payload must be a mapping")
+
+        remediation_record = await self._session.get(
+            db_models.TemporalExecutionCanonicalRecord,
+            workflow_id,
+        )
+        if remediation_record is None:
+            raise RemediationContextError(
+                f"Remediation execution not found: {workflow_id}"
+            )
+
+        safe_payload = _safe_lifecycle_payload(payload)
+        payload_bytes = json.dumps(
+            safe_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        metadata_json = {
+            "artifact_type": artifact_type,
+            "name": name,
+            "schemaVersion": REMEDIATION_CONTEXT_SCHEMA_VERSION,
+        }
+        if target_workflow_id := _string_or_none(target_workflow_id):
+            metadata_json["targetWorkflowId"] = target_workflow_id
+        if target_run_id := _string_or_none(target_run_id):
+            metadata_json["targetRunId"] = target_run_id
+
+        artifact, _upload = await self._artifact_service.create(
+            principal=principal,
+            content_type="application/json",
+            size_bytes=len(payload_bytes),
+            link=ExecutionRef(
+                namespace=remediation_record.namespace,
+                workflow_id=remediation_record.workflow_id,
+                run_id=remediation_record.run_id,
+                link_type=artifact_type,
+                label=name,
+                created_by_activity_type="remediation.lifecycle.publish",
+            ),
+            metadata_json=metadata_json,
+            redaction_level=db_models.TemporalArtifactRedactionLevel.RESTRICTED,
+        )
+        artifact = await self._artifact_service.write_complete(
+            artifact_id=artifact.artifact_id,
+            principal=principal,
+            payload=payload_bytes,
+            content_type="application/json",
+        )
+
+        refs = list(remediation_record.artifact_refs or [])
+        if artifact.artifact_id not in refs:
+            refs.append(artifact.artifact_id)
+            remediation_record.artifact_refs = refs
+        await self._session.commit()
+        await self._session.refresh(artifact)
+        return artifact
+
+
+def normalize_remediation_phase(value: Any) -> str:
+    """Return a bounded remediation phase value."""
+
+    normalized = str(value or "").strip()
+    return normalized if normalized in REMEDIATION_PHASES else "failed"
+
+
+def normalize_remediation_resolution(value: Any) -> str:
+    """Return a bounded remediation resolution value."""
+
+    normalized = str(value or "").strip()
+    return normalized if normalized in REMEDIATION_RESOLUTIONS else "failed"
+
+
+def build_remediation_summary_block(
+    *,
+    target_workflow_id: str,
+    target_run_id: str,
+    phase: str,
+    mode: str,
+    authority_mode: str,
+    actions_attempted: Sequence[Mapping[str, Any]] = (),
+    resolution: str = "not_applicable",
+    lock_conflicts: int = 0,
+    approval_count: int = 0,
+    evidence_degraded: bool = False,
+    escalated: bool = False,
+    unavailable_evidence_classes: Sequence[Any] = (),
+    fallbacks_used: Sequence[Any] = (),
+    resulting_target_run_id: str | None = None,
+) -> dict[str, Any]:
+    """Build the compact remediation block for run summaries."""
+
+    summary = {
+        "targetWorkflowId": _required_string(target_workflow_id, "target_workflow_id"),
+        "targetRunId": _required_string(target_run_id, "target_run_id"),
+        "phase": normalize_remediation_phase(phase),
+        "mode": _required_string(mode, "mode"),
+        "authorityMode": _required_string(authority_mode, "authority_mode"),
+        "actionsAttempted": _bounded_action_summaries(actions_attempted),
+        "resolution": normalize_remediation_resolution(resolution),
+        "lockConflicts": max(_positive_int_or_none(lock_conflicts) or 0, 0),
+        "approvalCount": max(_positive_int_or_none(approval_count) or 0, 0),
+        "evidenceDegraded": bool(evidence_degraded),
+        "escalated": bool(escalated),
+        "unavailableEvidenceClasses": _safe_string_list(
+            unavailable_evidence_classes
+        ),
+        "fallbacksUsed": _safe_string_list(fallbacks_used),
+    }
+    if resulting_target_run_id := _string_or_none(resulting_target_run_id):
+        summary["resultingTargetRunId"] = resulting_target_run_id
+    return summary
+
+
+def build_remediation_audit_event(
+    *,
+    event_id: str,
+    event_type: str,
+    actor_user: str | None,
+    execution_principal: str | None,
+    remediation_workflow_id: str,
+    remediation_run_id: str,
+    target_workflow_id: str,
+    target_run_id: str,
+    action_kind: str | None,
+    risk_tier: str | None,
+    approval_decision: str | None,
+    timestamp: datetime | str,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one compact queryable remediation audit event."""
+
+    return {
+        "eventId": _required_string(event_id, "event_id"),
+        "eventType": _required_string(event_type, "event_type"),
+        "actorUser": _string_or_none(actor_user),
+        "executionPrincipal": _string_or_none(execution_principal),
+        "remediationWorkflowId": _required_string(
+            remediation_workflow_id, "remediation_workflow_id"
+        ),
+        "remediationRunId": _required_string(
+            remediation_run_id, "remediation_run_id"
+        ),
+        "targetWorkflowId": _required_string(target_workflow_id, "target_workflow_id"),
+        "targetRunId": _required_string(target_run_id, "target_run_id"),
+        "actionKind": _string_or_none(action_kind),
+        "riskTier": _string_or_none(risk_tier),
+        "approvalDecision": _string_or_none(approval_decision),
+        "timestamp": _timestamp_string(timestamp),
+        "metadata": _safe_policy_mapping(metadata) or {},
+    }
+
+
+def build_remediation_continue_as_new_state(
+    *,
+    target_workflow_id: str,
+    target_run_id: str,
+    context_artifact_ref: str | None,
+    lock_identity: str | None,
+    action_ledger_ref: str | None,
+    approval_state: str | None,
+    retry_budget_state: Mapping[str, Any] | None = None,
+    live_follow_cursor: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build compact state that is safe to carry across Continue-As-New."""
+
+    return {
+        "targetWorkflowId": _required_string(target_workflow_id, "target_workflow_id"),
+        "targetRunId": _required_string(target_run_id, "target_run_id"),
+        "contextArtifactRef": _string_or_none(context_artifact_ref),
+        "lockIdentity": _string_or_none(lock_identity),
+        "actionLedgerRef": _string_or_none(action_ledger_ref),
+        "approvalState": _string_or_none(approval_state),
+        "retryBudgetState": _safe_policy_mapping(retry_budget_state) or {},
+        "liveFollowCursor": _safe_policy_mapping(live_follow_cursor) or {},
+    }
+
+
+def build_target_remediation_linkage_summary(
+    *,
+    target_workflow_id: str,
+    active_remediation_count: int = 0,
+    latest_remediation_title: str | None = None,
+    latest_remediation_status: str | None = None,
+    latest_action_kind: str | None = None,
+    latest_outcome: str | None = None,
+    active_lock_scope: str | None = None,
+    active_lock_holder: str | None = None,
+    last_updated_at: datetime | str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build compact inbound remediation metadata for target read models."""
+
+    summary = {
+        "targetWorkflowId": _required_string(target_workflow_id, "target_workflow_id"),
+        "activeRemediationCount": max(
+            _positive_int_or_none(active_remediation_count) or 0,
+            0,
+        ),
+        "latestRemediationTitle": _safe_optional_string(latest_remediation_title),
+        "latestRemediationStatus": _safe_optional_string(latest_remediation_status),
+        "latestActionKind": _safe_optional_string(latest_action_kind),
+        "latestOutcome": _safe_optional_string(latest_outcome),
+        "activeLockScope": _safe_optional_string(active_lock_scope),
+        "activeLockHolder": _safe_optional_string(active_lock_holder),
+        "metadata": _safe_policy_mapping(metadata) or {},
+    }
+    if last_updated_at is not None:
+        summary["lastUpdatedAt"] = _timestamp_string(last_updated_at)
+    return summary
+
+
 def _artifact_ref_payload(raw_ref: Any, *, kind: str | None) -> dict[str, str] | None:
     ref = _string_or_none(raw_ref)
     if not ref or not ref.startswith("art_"):
@@ -366,6 +646,65 @@ def _safe_policy_value(value: Any) -> Any:
             return None
         return value
     return None
+
+
+def _safe_lifecycle_payload(value: Mapping[str, Any]) -> dict[str, Any]:
+    return _safe_policy_mapping(value) or {}
+
+
+def _bounded_action_summaries(
+    actions_attempted: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    summaries: list[dict[str, str]] = []
+    for item in actions_attempted[:50]:
+        if not isinstance(item, Mapping):
+            continue
+        summary: dict[str, str] = {}
+        for key in ("kind", "status"):
+            if value := _string_or_none(item.get(key)):
+                if not _is_unsafe_context_string(value):
+                    summary[key] = value
+        if summary:
+            summaries.append(summary)
+    return summaries
+
+
+def _safe_string_list(values: Sequence[Any]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values[:50]:
+        item = _string_or_none(value)
+        if not item or item in seen or _is_unsafe_context_string(item):
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _required_string(value: Any, field_name: str) -> str:
+    normalized = _string_or_none(value)
+    if not normalized:
+        raise RemediationContextError(f"{field_name} is required")
+    if _is_unsafe_context_string(normalized):
+        raise RemediationContextError(f"{field_name} is unsafe")
+    return normalized
+
+
+def _safe_optional_string(value: Any) -> str | None:
+    normalized = _string_or_none(value)
+    if not normalized or _is_unsafe_context_string(normalized):
+        return None
+    return normalized
+
+
+def _timestamp_string(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        timestamp = value
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=UTC)
+        return timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    normalized = _required_string(value, "timestamp")
+    return normalized
 
 
 def _is_secret_like_key(key: str) -> bool:

--- a/specs/232-remediation-lifecycle-audit/checklists/requirements.md
+++ b/specs/232-remediation-lifecycle-audit/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Remediation Lifecycle Audit
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The request is classified as a single-story runtime feature request.
+- The implementation document cited by the Jira brief is treated as runtime source requirements.
+- No pre-existing `specs/*` feature directory referenced MM-456, so Specify was the first incomplete stage.
+- The original Jira preset brief is preserved in `spec.md` for final verification.

--- a/specs/232-remediation-lifecycle-audit/contracts/remediation-lifecycle-audit.md
+++ b/specs/232-remediation-lifecycle-audit/contracts/remediation-lifecycle-audit.md
@@ -1,0 +1,127 @@
+# Contract: Remediation Lifecycle Audit
+
+## Remediation Artifact Types
+
+Required artifact names and types:
+
+| Artifact name | artifact_type |
+| --- | --- |
+| `reports/remediation_context.json` | `remediation.context` |
+| `reports/remediation_plan.json` | `remediation.plan` |
+| `logs/remediation_decision_log.ndjson` | `remediation.decision_log` |
+| `reports/remediation_action_request-<n>.json` | `remediation.action_request` |
+| `reports/remediation_action_result-<n>.json` | `remediation.action_result` |
+| `reports/remediation_verification-<n>.json` | `remediation.verification` |
+| `reports/remediation_summary.json` | `remediation.summary` |
+
+All remediation artifacts must use the existing artifact authorization, preview, lifecycle, and redaction boundaries.
+
+## Run Summary Block
+
+`reports/run_summary.json` for remediation executions must include a compact `remediation` object:
+
+```json
+{
+  "remediation": {
+    "targetWorkflowId": "mm:target_123",
+    "targetRunId": "run_456",
+    "resultingTargetRunId": "run_789",
+    "phase": "resolved",
+    "mode": "snapshot_then_follow",
+    "authorityMode": "admin_auto",
+    "actionsAttempted": [
+      {
+        "kind": "provider_profile.evict_stale_lease",
+        "status": "applied"
+      }
+    ],
+    "resolution": "resolved_after_action",
+    "lockConflicts": 0,
+    "approvalCount": 0,
+    "evidenceDegraded": false,
+    "escalated": false,
+    "unavailableEvidenceClasses": [],
+    "fallbacksUsed": []
+  }
+}
+```
+
+Rules:
+- `phase` and `resolution` must be bounded symbolic values.
+- `resultingTargetRunId` is present only when an action intentionally changes the target run and the new run is known.
+- `actionsAttempted` contains compact action summaries only.
+- No secrets, storage keys, presigned URLs, raw local paths, or unbounded logs are allowed.
+
+## Target-Side Linkage Summary
+
+Target detail read models must be able to expose:
+
+```json
+{
+  "remediation": {
+    "activeRemediationCount": 1,
+    "latestRemediationTitle": "Publish remediation lifecycle phases, artifacts, summaries, and audit events",
+    "latestRemediationStatus": "acting",
+    "latestActionKind": "provider_profile.evict_stale_lease",
+    "latestOutcome": "resolved_after_action",
+    "activeLockScope": "target_execution",
+    "activeLockHolder": "mm:remediation_123",
+    "lastUpdatedAt": "2026-04-22T00:00:00Z"
+  }
+}
+```
+
+Rules:
+- The summary is compact target metadata, not a replacement for remediation artifacts.
+- Missing data should be omitted or set to `null`; consumers must not fetch raw artifact bodies to render the target summary.
+
+## Control-Plane Audit Event
+
+Remediation action and approval audit events must include:
+
+```json
+{
+  "eventId": "audit_123",
+  "eventType": "remediation.action",
+  "actorUser": "user:operator",
+  "executionPrincipal": "service:admin-healer",
+  "remediationWorkflowId": "mm:remediation_123",
+  "remediationRunId": "run_remediation",
+  "targetWorkflowId": "mm:target_123",
+  "targetRunId": "run_target",
+  "actionKind": "provider_profile.evict_stale_lease",
+  "riskTier": "medium",
+  "approvalDecision": "approved",
+  "timestamp": "2026-04-22T00:00:00Z",
+  "metadata": {
+    "resolution": "resolved_after_action"
+  }
+}
+```
+
+Rules:
+- `metadata` must remain bounded and redacted.
+- Audit events provide queryable control evidence; deep decision/action detail remains artifact-backed.
+
+## Continue-As-New Payload
+
+When a remediation task continues as new, the continued payload must preserve:
+
+```json
+{
+  "targetWorkflowId": "mm:target_123",
+  "targetRunId": "run_456",
+  "contextArtifactRef": "artifact_123",
+  "lockIdentity": "lock_123",
+  "actionLedgerRef": "ledger_123",
+  "approvalState": "approved",
+  "retryBudgetState": {
+    "actionsAttempted": 1
+  },
+  "liveFollowCursor": "cursor_123"
+}
+```
+
+Rules:
+- The payload carries refs and compact state only.
+- Large evidence bodies and logs must remain artifact-backed.

--- a/specs/232-remediation-lifecycle-audit/data-model.md
+++ b/specs/232-remediation-lifecycle-audit/data-model.md
@@ -1,0 +1,116 @@
+# Data Model: Remediation Lifecycle Audit
+
+## Remediation Lifecycle Snapshot
+
+Represents the compact lifecycle state exposed for a remediation run.
+
+Fields:
+- `remediationWorkflowId`: remediation execution workflow ID.
+- `remediationRunId`: remediation execution run ID.
+- `targetWorkflowId`: target execution workflow ID.
+- `targetRunId`: pinned target run ID used as the diagnosis snapshot anchor.
+- `phase`: one of `collecting_evidence`, `diagnosing`, `awaiting_approval`, `acting`, `verifying`, `resolved`, `escalated`, or `failed`.
+- `resolution`: one of `not_applicable`, `diagnosis_only`, `no_action_needed`, `resolved_after_action`, `escalated`, `unsafe_to_act`, `lock_conflict`, `evidence_unavailable`, or `failed`.
+- `evidenceDegraded`: boolean indicating whether expected evidence was unavailable or partial.
+- `escalated`: boolean indicating whether the run requires operator or policy escalation.
+- `updatedAt`: timestamp for the latest lifecycle update.
+
+Validation:
+- `phase` must be bounded to the allowed remediation phase values.
+- Terminal phases must have a terminal `resolution`.
+- Target identity must remain stable across lifecycle updates.
+
+## Remediation Artifact Record
+
+Represents one required remediation artifact linked to the remediation execution.
+
+Fields:
+- `artifactId`: immutable artifact identifier.
+- `name`: bounded artifact path such as `reports/remediation_context.json`.
+- `artifactType`: one of `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, or `remediation.summary`.
+- `remediationWorkflowId`: producing remediation execution.
+- `targetWorkflowId`: target execution, when applicable.
+- `targetRunId`: pinned target run, when applicable.
+- `metadata`: bounded display and classification fields.
+- `redactionLevel`: artifact redaction classification.
+
+Validation:
+- Artifact metadata must not contain secrets, raw access grants, presigned URLs, storage keys, raw local paths, or unbounded log bodies.
+- Artifact refs identify content; they are not access grants.
+
+## Remediation Summary Block
+
+Represents the compact block embedded in the run summary.
+
+Fields:
+- `targetWorkflowId`
+- `targetRunId`
+- `resultingTargetRunId`
+- `mode`
+- `authorityMode`
+- `actionsAttempted[]`
+- `resolution`
+- `lockConflicts`
+- `approvalCount`
+- `evidenceDegraded`
+- `escalated`
+- `unavailableEvidenceClasses[]`
+- `fallbacksUsed[]`
+
+Validation:
+- `actionsAttempted[]` contains bounded action kind/status summaries, not raw provider payloads.
+- `unavailableEvidenceClasses[]` and `fallbacksUsed[]` use bounded symbolic values.
+
+## Target-Side Linkage Summary
+
+Represents compact inbound remediation metadata for target detail views.
+
+Fields:
+- `targetWorkflowId`
+- `activeRemediationCount`
+- `latestRemediationTitle`
+- `latestRemediationStatus`
+- `latestActionKind`
+- `latestOutcome`
+- `activeLockScope`
+- `activeLockHolder`
+- `lastUpdatedAt`
+
+Validation:
+- Summaries must be derived from durable remediation links or bounded execution projections.
+- Consumers must not parse deep remediation artifact bodies to render the target summary.
+
+## Remediation Audit Event
+
+Represents compact queryable audit evidence for remediation action and approval decisions.
+
+Fields:
+- `eventId`
+- `actorUser`
+- `executionPrincipal`
+- `remediationWorkflowId`
+- `remediationRunId`
+- `targetWorkflowId`
+- `targetRunId`
+- `actionKind`
+- `riskTier`
+- `approvalDecision`
+- `eventType`
+- `timestamp`
+- `metadata`
+
+Validation:
+- `metadata` must be bounded and redacted.
+- Audit events must not replace deep artifacts; they index important control-plane decisions.
+
+## State Transitions
+
+- A run starts without a remediation lifecycle snapshot until evidence collection begins.
+- Evidence collection creates or updates phase `collecting_evidence`.
+- Diagnosis updates phase `diagnosing`.
+- Approval-gated work updates phase `awaiting_approval`.
+- Action execution updates phase `acting`.
+- Verification updates phase `verifying`.
+- Terminal outcomes update phase to `resolved`, `escalated`, or `failed`.
+- Cancellation or remediator failure attempts final summary publication and lock release before terminal state is recorded.
+- Continue-As-New carries target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor into the continued run.

--- a/specs/232-remediation-lifecycle-audit/plan.md
+++ b/specs/232-remediation-lifecycle-audit/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Remediation Lifecycle Audit
+
+**Branch**: `232-remediation-lifecycle-audit` | **Date**: 2026-04-22 | **Spec**: `specs/232-remediation-lifecycle-audit/spec.md`
+**Input**: Single-story feature specification from `/specs/232-remediation-lifecycle-audit/spec.md`
+
+## Summary
+
+Implement MM-456 by extending the existing remediation runtime boundary so each remediation run exposes a bounded lifecycle phase, required remediation artifacts, a stable remediation summary block, target-side linkage metadata, and compact audit events. Existing code already has remediation links, a context artifact builder, action authority audit payloads, link status fields, generic run summaries, and managed-session control artifacts, but it does not yet publish the full required remediation artifact set or summary/audit contract. Unit tests will cover model/serializer/service behavior; integration or service-boundary tests will verify artifact publication and read-model visibility through the existing Temporal artifact and execution services.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | no `remediationPhase` field found | add bounded remediation phase model/read output | unit + integration |
+| FR-002 | missing | no allowed remediation phase enum found | add phase validation | unit |
+| FR-003 | missing | no phase progression projection found | expose phase progression in summary/read model | integration |
+| FR-004 | partial | `execution_remediation_links.outcome` exists but no full resolution set | normalize lifecycle outcomes and summary values | unit |
+| FR-005 | implemented_unverified | cancellation audit exists for generic executions; no remediation-specific target mutation proof | add remediation cancellation/failure assertions | unit + integration |
+| FR-006 | partial | `RemediationMutationGuardService.release_lock()` exists; no final summary publication path | add best-effort summary/lock-release result evidence | unit |
+| FR-007 | partial | mutation guard tracks lock/ledger/budget in service; no Continue-As-New preservation contract | add compact continuation payload model/validation | unit |
+| FR-008 | implemented_verified | `RemediationContextBuilder` publishes `remediation.context` | no implementation beyond final traceability | final verify |
+| FR-009 | missing | no `remediation.plan` artifact publisher found | add remediation plan artifact publication contract | unit + integration |
+| FR-010 | missing | no `remediation.decision_log` artifact publisher found | add decision log artifact publication contract | unit + integration |
+| FR-011 | implemented_unverified | action authority result includes request payload but no artifact publication | publish action request artifact | unit + integration |
+| FR-012 | implemented_unverified | action authority result includes result payload but no artifact publication | publish action result artifact | unit + integration |
+| FR-013 | missing | no `remediation.verification` artifact publisher found | add verification artifact publication contract | unit + integration |
+| FR-014 | missing | no `remediation.summary` artifact publisher found | add final remediation summary artifact | unit + integration |
+| FR-015 | partial | artifact service supports metadata/redaction; only context artifact uses remediation type | enforce safety metadata for all remediation artifacts | unit |
+| FR-016 | missing | generic `reports/run_summary.json`; no remediation block found | add stable remediation summary block | unit + integration |
+| FR-017 | implemented_unverified | managed session supervisor publishes `session.control_event`; no remediation mutation test | verify native target artifacts remain linked | integration |
+| FR-018 | partial | action authority has audit payload; no parallel remediation audit trail persistence | add remediation audit event contract/service | unit |
+| FR-019 | partial | link status fields exist for latest action/outcome; active count/latest metadata read model incomplete | extend target-side linkage summary | unit + integration |
+| FR-020 | partial | action authority audit has principal/decision fields; lacks full required audit event fields | add compact audit event model | unit |
+| FR-021 | missing | no remediation audit event query surface found | persist/query compact audit trail | integration |
+| FR-022 | implemented_unverified | existing redaction helpers sanitize action audit output | add audit metadata boundedness tests | unit |
+| FR-023 | partial | `execution_remediation_links` has compact link fields | expose downstream detail summary contract | unit + integration |
+| FR-024 | partial | link stores pinned target run; resulting run not recorded | add rerun/resulting-run summary evidence | unit |
+| FR-025 | partial | context builder/action guard have bounded errors; lifecycle cases not unified | normalize failure/degraded outcome reasons | unit |
+| FR-026 | implemented_unverified | mutation guard has precondition/freshness decisions in adjacent story | verify lifecycle summary records precondition-failed/no-op | unit |
+| FR-027 | partial | lock release exists; no failed-remediator summary flow | add failure finalization evidence | unit |
+| FR-028 | missing | no degraded evidence summary flag beyond source brief | add degraded evidence reporting | unit |
+| FR-029 | partial | context payload records target refs/task runs; missing evidence-class unavailable list | add unavailable evidence class reporting | unit |
+| FR-030 | partial | context payload sets liveFollow.supported false; no fallback summary evidence | record live-follow fallback evidence | unit |
+| FR-031 | implemented_verified | spec and Jira input preserve MM-456 | preserve traceability in tasks, tests, and verification | final verify |
+| SC-001 | missing | no phase tests found | add allowed-phase tests | unit |
+| SC-002 | partial | context artifact test exists only for `remediation.context` | add artifact type matrix tests | unit + integration |
+| SC-003 | missing | no remediation summary block tests found | add summary block tests | unit + integration |
+| SC-004 | implemented_unverified | session control artifact tests exist | add remediation-target mutation preservation test | integration |
+| SC-005 | partial | action authority audit tests exist but not full control-plane audit fields | add audit event tests | unit |
+| SC-006 | partial | generic cancel audit tests exist; no remediation finalization path | add cancellation/failure finalization tests | unit + integration |
+| SC-007 | missing | no continuation payload tests for remediation context | add Continue-As-New preservation tests | unit |
+| SC-008 | partial | context/action guard degradation exists in pieces | add unified bounded outcome tests | unit |
+| DESIGN-REQ-017 | partial | generic run state and link records exist; no phase model | implement phase and lifecycle finalization | unit + integration |
+| DESIGN-REQ-018 | partial | context artifact exists; other required artifact types missing | implement remediation artifact publisher | unit + integration |
+| DESIGN-REQ-019 | partial | link status fields and action audit payloads exist | implement target linkage and audit trail | unit + integration |
+| DESIGN-REQ-022 | partial | pinned target run exists; current/resulting run evidence incomplete | implement rerun/precondition/continuation summary evidence | unit |
+| DESIGN-REQ-023 | partial | bounded errors exist in adjacent services | consolidate failure/degraded outcome evidence | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK service boundaries, existing Temporal artifact service, existing remediation context/action services  
+**Storage**: Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and existing execution memo/search/projection paths; no new persistent database table planned unless audit events cannot reuse an existing control-event mechanism  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` plus focused schema/service tests as needed  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic integration when artifact/read-model routes are touched; targeted service-boundary tests may run through `./tools/test_unit.sh` first  
+**Target Platform**: Linux server / Docker Compose deployment  
+**Project Type**: FastAPI control plane plus Temporal workflow/service boundary  
+**Performance Goals**: Remediation lifecycle evidence publication is bounded by small JSON artifacts and compact audit/link fields; no unbounded log or artifact bodies enter workflow history  
+**Constraints**: Runtime mode; preserve MM-456 traceability; keep artifacts server-mediated; no raw credentials, presigned URLs, storage keys, local filesystem paths, or unbounded logs in durable summaries/audit metadata  
+**Scale/Scope**: One remediation run linked to one target execution/run, with multiple bounded artifact and audit records for that run
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The work makes remediation orchestration visible without replacing agent behavior.
+- II. One-Click Agent Deployment: PASS. No external service or credential is required.
+- III. Avoid Vendor Lock-In: PASS. Lifecycle evidence is provider-neutral.
+- IV. Own Your Data: PASS. Evidence remains in local artifacts, links, and audit records.
+- V. Skills Are First-Class and Easy to Add: PASS. The story does not mutate skill sources or runtime skill resolution.
+- VI. Replaceable Scaffolding / Tests Anchor: PASS. The plan uses thin contracts and explicit tests around runtime evidence.
+- VII. Runtime Configurability: PASS. No hardcoded provider behavior; lifecycle values are bounded product semantics.
+- VIII. Modular Architecture: PASS. Changes stay in remediation, artifact, summary, and read-model boundaries.
+- IX. Resilient by Default: PASS. Cancellation, failure, degraded evidence, and continuation are explicit.
+- X. Continuous Improvement: PASS. Summary and audit evidence improves post-run diagnosis.
+- XI. Spec-Driven Development: PASS. This plan follows the MM-456 one-story spec.
+- XII. Canonical Documentation Separation: PASS. Temporary Jira input remains under `docs/tmp`; canonical docs are not turned into migration notes.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility alias layer is planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/232-remediation-lifecycle-audit/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-lifecycle-audit.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/temporal/
+├── remediation_context.py
+├── remediation_actions.py
+├── remediation_tools.py
+├── artifacts.py
+└── service.py
+
+api_service/db/
+└── models.py
+
+api_service/api/routers/
+├── executions.py
+└── task_runs.py
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+
+tests/unit/api/routers/
+├── test_executions.py
+└── test_task_runs.py
+```
+
+**Structure Decision**: Keep lifecycle evidence at existing remediation service and artifact boundaries. Extend compact DB/read-model fields only where needed for target-side linkage and queryable audit evidence; store deep evidence in artifacts.
+
+## Complexity Tracking
+
+None.

--- a/specs/232-remediation-lifecycle-audit/quickstart.md
+++ b/specs/232-remediation-lifecycle-audit/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Remediation Lifecycle Audit
+
+## Scope
+
+Validate MM-456 as one runtime story: remediation runs expose lifecycle phase, required artifacts, summary block, target-side linkage, compact audit events, cancellation/failure behavior, and Continue-As-New preservation.
+
+## Test-First Flow
+
+1. Add failing unit tests for bounded remediation phase values and lifecycle summary serialization.
+2. Add failing unit tests for required remediation artifact metadata and redaction rules.
+3. Add failing unit tests for remediation summary block fields and bounded degraded/fallback outcomes.
+4. Add failing service-boundary tests for target-side linkage summary metadata.
+5. Add failing tests for compact remediation audit event fields and metadata boundedness.
+6. Add failing tests for cancellation/failure finalization and Continue-As-New preservation.
+7. Implement the minimum remediation runtime changes needed to pass those tests.
+8. Run targeted unit tests, then full unit verification.
+
+## Commands
+
+Targeted unit iteration:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Router/read-model unit tests when target-side summaries or execution serialization change:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py
+```
+
+Full unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Hermetic integration verification if artifact lifecycle or API routes change:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-To-End Validation
+
+1. Create or fixture a remediation execution linked to one target workflow/run.
+2. Move the remediation lifecycle through evidence collection, diagnosis, approval/action, verification, and terminal outcome.
+3. Verify allowed `remediationPhase` values and top-level run state separation.
+4. Verify all required `remediation.*` artifact types are linked to the remediation execution with bounded safe metadata.
+5. Verify `reports/run_summary.json` contains the compact remediation block.
+6. Verify target-side detail metadata exposes inbound remediation summary fields.
+7. Verify compact audit events identify actor, principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+8. Verify cancellation/failure and Continue-As-New cases preserve the required evidence and state refs.

--- a/specs/232-remediation-lifecycle-audit/research.md
+++ b/specs/232-remediation-lifecycle-audit/research.md
@@ -1,0 +1,65 @@
+# Research: Remediation Lifecycle Audit
+
+## Input Classification
+
+Decision: MM-456 is a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-456-moonspec-orchestration-input.md` defines one user story, one source document, one acceptance-criteria set, and one bounded runtime observability/audit behavior area.
+Rationale: The Jira preset brief selects remediation lifecycle evidence from `docs/Tasks/TaskRemediation.md` sections 13, 14, and 16; it does not ask to implement the entire remediation design.
+Alternatives considered: Treating `docs/Tasks/TaskRemediation.md` as a broad declarative design was rejected because the Jira brief already selected one independently testable story. Treating this as docs mode was rejected because the selected mode is runtime.
+Test implications: Unit and service-boundary tests should target exactly this lifecycle evidence story.
+
+## Existing Remediation Evidence Boundaries
+
+Decision: Reuse remediation context, action authority, Temporal artifact, execution link, and execution read-model boundaries.
+Evidence: `moonmind/workflows/temporal/remediation_context.py` publishes `remediation.context`; `moonmind/workflows/temporal/remediation_actions.py` produces redacted action authority request/result/audit payloads; `api_service/db/models.py` contains `execution_remediation_links` with target, status, lock, action summary, and outcome fields; generic run summaries are published by worker/runtime paths.
+Rationale: The story is about durable runtime evidence and compact queryable state, so existing artifact and link surfaces are the narrowest extension points.
+Alternatives considered: A new standalone remediation evidence store was rejected because the source design requires existing artifact presentation and compact audit/read-model evidence.
+Test implications: Add tests around existing services rather than introducing provider or raw storage tests.
+
+## DESIGN-REQ-017 - Runtime Lifecycle
+
+Decision: Partial; target/run identity exists, but bounded remediation phase progression and continuation preservation are not implemented as a complete lifecycle contract.
+Evidence: `execution_remediation_links` stores remediation workflow/run and target workflow/run; no `remediationPhase` or allowed phase enum was found by repository search.
+Rationale: Existing target linkage is enough to anchor lifecycle evidence, but operators cannot yet inspect the remediation-specific phase sequence required by MM-456.
+Alternatives considered: Reusing top-level `mm_state` alone was rejected because the source design explicitly says remediation phase is a bounded remediation-specific field inside summaries/read models.
+Test implications: Unit tests for allowed phase values; integration/service-boundary tests for summary/read-model exposure.
+
+## DESIGN-REQ-018 - Required Remediation Artifacts And Summary
+
+Decision: Partial; `remediation.context` is implemented and verified, but plan, decision log, action request/result artifacts, verification artifacts, and final summary artifacts are missing or only present as in-memory action payloads.
+Evidence: `RemediationContextBuilder` creates `reports/remediation_context.json` with artifact type `remediation.context`; searches did not find publishers for `remediation.plan`, `remediation.decision_log`, `remediation.verification`, or `remediation.summary`.
+Rationale: Deep operator evidence belongs in artifacts. The existing context builder pattern can be generalized without embedding bodies in workflow history.
+Alternatives considered: Encoding all lifecycle evidence into `reports/run_summary.json` was rejected because artifacts remain the operator-facing deep evidence and summary must stay compact.
+Test implications: Artifact publication tests should assert names, artifact types, bounded metadata, redaction level, and execution links.
+
+## DESIGN-REQ-019 - Target Linkage And Control-Plane Audit
+
+Decision: Partial; link status fields and action audit payloads exist, but target-side linkage summary and queryable remediation audit events are incomplete.
+Evidence: `execution_remediation_links` includes `active_lock_scope`, `active_lock_holder`, `latest_action_summary`, and `outcome`; `RemediationActionAuthorityResult.to_dict()` includes an `audit` mapping; generic intervention audit exists in Temporal execution memo paths.
+Rationale: Link fields and action audit payloads provide useful ingredients, but the story requires compact control-plane audit events with actor, principal, remediation/target workflow-run identity, action kind, risk, approval decision, timestamps, and bounded metadata.
+Alternatives considered: Making operators parse action artifacts for target detail summaries was rejected because the source requires compact queryable trails and downstream detail metadata.
+Test implications: Unit tests for audit event schema/boundedness and read-model tests for target-side linkage summary.
+
+## DESIGN-REQ-022 - Rerun, Precondition, Continuation, And Failure Preservation
+
+Decision: Partial; pinned target run and mutation guard freshness decisions exist in adjacent work, but lifecycle summaries do not yet record resulting run, precondition-failed/no-op outcomes, or Continue-As-New preservation.
+Evidence: `execution_remediation_links.target_run_id` stores the pinned target run; mutation guard services include target freshness decisions; no lifecycle continuation payload or resulting target run summary was found.
+Rationale: The lifecycle evidence layer needs to make target changes and continuation state visible, not only enforce action guard decisions.
+Alternatives considered: Treating target reruns as implicit target status changes was rejected because the source requires recording pinned and resulting runs.
+Test implications: Unit tests should cover continuation payload validation, target rerun summary fields, and precondition failure outcomes.
+
+## DESIGN-REQ-023 - Bounded Failure And Degraded Evidence
+
+Decision: Partial; context and action guard paths have bounded errors, but the lifecycle evidence contract does not yet unify degraded evidence, partial artifact refs, live-follow fallback, lock conflict, no-op, escalation, and failed-remediator summaries.
+Evidence: `RemediationContextBuilder` limits evidence sizes and sets `liveFollow.supported`; action guard services return bounded reason codes; no final lifecycle summary model ties these cases together.
+Rationale: Operators need one consistent remediation summary and audit trail for failure/degraded cases.
+Alternatives considered: Letting each producer use bespoke reason fields was rejected because the final summary must be stable and queryable.
+Test implications: Tests should assert explicit bounded outcomes for target not visible, partial artifacts, live-follow unavailable, lock conflict, precondition failed, stale lease, missing container, unsafe forced termination, and remediator failure where supported in this story.
+
+## Testing Strategy
+
+Decision: Use focused unit tests plus service-boundary integration where artifact and read-model paths are touched.
+Evidence: Adjacent remediation stories use `tests/unit/workflows/temporal/test_remediation_context.py`; artifact authorization and lifecycle suites already exercise `TemporalArtifactService`; API router tests cover execution and task-run read models.
+Rationale: The highest-risk behavior is local runtime evidence publication and serialization, not external providers.
+Alternatives considered: Provider verification tests were rejected because MM-456 does not require external credentials. Full Temporal time-skipping tests are unnecessary unless workflow signatures or replay-sensitive payloads change.
+Test implications: Use `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` if hermetic integration routes or artifact lifecycle behavior are changed.

--- a/specs/232-remediation-lifecycle-audit/spec.md
+++ b/specs/232-remediation-lifecycle-audit/spec.md
@@ -1,0 +1,210 @@
+# Feature Specification: Remediation Lifecycle Audit
+
+**Feature Branch**: `232-remediation-lifecycle-audit`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-456 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-456-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-456 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-456
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-456 from MM project
+Summary: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-456 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-456: Publish remediation lifecycle phases, artifacts, summaries, and audit events
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 13. Runtime lifecycle
+  - 14. Artifacts, summaries, and audit
+  - 16. Failure modes and edge cases
+- Coverage IDs:
+  - DESIGN-REQ-017
+  - DESIGN-REQ-018
+  - DESIGN-REQ-019
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+
+User Story
+As an operator or reviewer, I can inspect a remediation run from evidence collection through verification because each phase, decision, action, result, and final outcome leaves durable artifacts and queryable audit evidence.
+
+Acceptance Criteria
+- remediationPhase values reflect collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, or failed as the run progresses.
+- Required remediation artifacts are published with expected artifact_type values and obey artifact preview/redaction metadata rules.
+- run_summary.json includes the remediation block with target identity, mode, authorityMode, actionsAttempted, resolution, lockConflicts, approvalCount, evidenceDegraded, and escalated fields.
+- Target-managed session or workload mutations continue to produce native continuity/control artifacts in addition to remediation audit artifacts.
+- Control-plane audit events record actor, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+- Cancellation or remediation failure does not mutate the target except for already-requested actions and attempts final summary publication and lock release.
+- Continue-As-New preserves target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+
+Requirements
+- Existing MoonMind.Run state remains the top-level state source.
+- Artifacts remain operator-facing deep evidence; audit rows remain compact queryable trail.
+- Target-side linkage summary metadata is available for downstream detail views.
+
+Relevant Implementation Notes
+- Preserve MM-456 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation runtime lifecycle phases, artifact publication, final summaries, audit events, cancellation behavior, failure handling, and Continue-As-New preservation.
+- Keep MoonMind.Run as the top-level execution state source; remediation-specific phase values should complement that state rather than replace it.
+- Publish remediation artifacts with bounded metadata and existing artifact preview/redaction rules.
+- Ensure final run summaries include the remediation block with target identity, mode, authority mode, action attempts, resolution, lock conflicts, approval count, degraded evidence, and escalation state.
+- Preserve native managed-session or workload continuity/control artifacts when remediation mutates those targets.
+- Record compact queryable audit events for remediation actions, approvals, risk tiers, actors, execution principals, target workflow/run identity, timestamps, and bounded metadata.
+- On cancellation or remediation failure, avoid new target mutation except for already-requested actions; still attempt final summary publication and lock release.
+- Preserve target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor across Continue-As-New.
+
+Non-Goals
+- Replacing MoonMind.Run as the top-level state source.
+- Treating audit rows as a replacement for operator-facing artifact evidence.
+- Dropping native target continuity or control artifacts when remediation touches managed sessions or workloads.
+- Mutating targets after cancellation or failure except for already-requested actions.
+- Losing remediation context across Continue-As-New.
+
+Validation
+- Verify remediationPhase values reflect collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, or failed as the run progresses.
+- Verify required remediation artifacts are published with expected artifact_type values and obey artifact preview/redaction metadata rules.
+- Verify run_summary.json includes the remediation block with target identity, mode, authorityMode, actionsAttempted, resolution, lockConflicts, approvalCount, evidenceDegraded, and escalated fields.
+- Verify target-managed session or workload mutations continue to produce native continuity/control artifacts in addition to remediation audit artifacts.
+- Verify control-plane audit events record actor, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+- Verify cancellation or remediation failure does not mutate the target except for already-requested actions and attempts final summary publication and lock release.
+- Verify Continue-As-New preserves target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-456 blocks MM-455, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-456 is blocked by MM-457, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## User Story - Inspect Remediation Lifecycle Evidence
+
+**Summary**: As an operator or reviewer, I want each remediation run to expose its current lifecycle phase, durable remediation artifacts, final summary, target-side continuity evidence, and compact audit trail so that I can understand what happened from evidence collection through verification.
+
+**Goal**: A remediation run produces a coherent operator-visible record that shows phase progression, decisions, actions, results, final outcome, degraded evidence, cancellation/failure handling, and preserved context after continuation.
+
+**Independent Test**: Run a remediation execution through evidence collection, diagnosis, approval or action, verification, and terminal outcome; then inspect its run summary, remediation artifacts, target-side artifacts, and audit evidence to confirm every required phase, artifact class, summary field, and bounded audit field is present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run progresses through its lifecycle, **When** operators inspect the run, **Then** the remediation-specific phase reflects collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, or failed without replacing the top-level run state.
+2. **Given** a remediation run produces evidence, plan, decision, action, verification, and summary outputs, **When** artifacts are listed or previewed, **Then** each required remediation artifact uses the expected artifact type and obeys preview and redaction rules.
+3. **Given** a remediation run reaches a terminal outcome, **When** its run summary is inspected, **Then** the remediation block includes target identity, mode, authority mode, actions attempted, resolution, lock conflicts, approval count, degraded evidence, and escalation state.
+4. **Given** a remediation action mutates a managed session or workload target, **When** the target-side evidence is inspected, **Then** subsystem-native continuity or control artifacts are still present alongside remediation audit evidence.
+5. **Given** a remediation action, approval, or risk decision occurs, **When** the audit trail is queried, **Then** compact events identify the actor, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+6. **Given** a remediation task is canceled or fails, **When** the run terminates, **Then** it avoids new target mutation except already-requested actions and still attempts final summary publication and lock release.
+7. **Given** a remediation task continues as new, **When** the continued run is inspected, **Then** target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor are preserved.
+
+### Edge Cases
+
+- Historical targets may have only merged logs; the remediation record must show degraded evidence instead of hiding the limitation.
+- Missing or partial artifact refs may still allow safe diagnosis; unavailable evidence classes must be recorded explicitly.
+- Live follow may be unavailable; durable logs, diagnostics, summaries, and artifacts remain the fallback evidence.
+- Target reruns during remediation preserve the pinned snapshot and record any intentionally resulting run.
+- A failed remediator still publishes a bounded summary and releases locks where possible; automatic remediation of the remediator remains off by default.
+
+## Assumptions
+
+- The MM-456 brief is a single runtime feature slice focused on lifecycle observability and auditability for remediation runs, not on creating remediation tasks, defining authority modes, or adding new action kinds.
+- Existing remediation create/link, evidence/context, authority, action registry, and mutation guard stories provide surrounding behavior; this story makes the lifecycle and evidence record complete and inspectable.
+- The source implementation document `docs/Tasks/TaskRemediation.md` is treated as runtime source requirements because the selected mode is runtime.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-017** (`docs/Tasks/TaskRemediation.md` section 13): Remediation must expose bounded phase progression values while preserving existing top-level run state, recommended lifecycle flow, cancellation semantics, rerun semantics, and Continue-As-New safety. Scope: in scope, mapped to FR-001 through FR-007 and FR-024.
+- **DESIGN-REQ-018** (`docs/Tasks/TaskRemediation.md` sections 14.1 through 14.3): Remediation must publish required context, plan, decision log, action request/result, verification, and summary artifacts with bounded metadata and a stable remediation summary block. Scope: in scope, mapped to FR-008 through FR-016.
+- **DESIGN-REQ-019** (`docs/Tasks/TaskRemediation.md` sections 14.2, 14.4, and 14.5): Target-side continuity artifacts, target-side linkage metadata, and compact control-plane audit events must remain available in addition to deep remediation artifacts. Scope: in scope, mapped to FR-017 through FR-023.
+- **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` sections 13.5, 13.6, 16.2, 16.7, and 16.11): Reruns, precondition changes, continuation, and remediator failure must preserve target identity and produce explicit recorded outcomes rather than silent retargeting or silent success. Scope: in scope, mapped to FR-005 through FR-007, FR-014, FR-024, FR-026, and FR-027.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` sections 16.1 through 16.11): Missing targets, partial evidence, live-follow unavailability, lock conflicts, stale leases, gone containers, unsafe forced termination, and remediator failure must degrade, no-op, escalate, fail, or deny with bounded reasons. Scope: in scope, mapped to FR-014, FR-025, and FR-027 through FR-030.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose a remediation-specific phase for remediation runs without replacing the existing top-level run state.
+- **FR-002**: The remediation-specific phase MUST use bounded values covering collecting evidence, diagnosing, awaiting approval, acting, verifying, resolved, escalated, and failed.
+- **FR-003**: Operators MUST be able to inspect phase progression from evidence collection through terminal outcome.
+- **FR-004**: Remediation lifecycle evidence MUST distinguish resolved, escalated, unsafe-to-act, evidence-unavailable, lock-conflict, and failed outcomes.
+- **FR-005**: Canceling a remediation task MUST NOT mutate the target except for actions already requested before cancellation.
+- **FR-006**: A canceled or failed remediation task MUST attempt final remediation summary publication and lock release.
+- **FR-007**: A remediation task that continues as new MUST preserve target workflow identity, pinned target run, remediation context ref, acquired lock identity, action ledger, approval state, retry budget, and last live-follow cursor.
+- **FR-008**: The system MUST publish a remediation context artifact for each remediation run that reaches evidence collection.
+- **FR-009**: The system MUST publish a remediation plan artifact when a remediation plan is selected or proposed.
+- **FR-010**: The system MUST publish a remediation decision log that records bounded decision entries.
+- **FR-011**: The system MUST publish remediation action request artifacts for requested actions.
+- **FR-012**: The system MUST publish remediation action result artifacts for attempted actions.
+- **FR-013**: The system MUST publish remediation verification artifacts for verification attempts.
+- **FR-014**: The system MUST publish a final remediation summary artifact for resolved, escalated, failed, canceled, evidence-degraded, or no-op outcomes when publication is possible.
+- **FR-015**: Remediation artifacts MUST obey normal artifact presentation safety, including bounded metadata, artifact refs rather than access URLs, correct preview/redaction behavior, and no secrets in metadata or bodies.
+- **FR-016**: The remediation run summary MUST include target workflow ID, target run ID, mode, authority mode, attempted actions, resolution, lock conflict count, approval count, evidence degraded flag, and escalation flag.
+- **FR-017**: When remediation mutates a managed session or workload target, the target side MUST continue to produce subsystem-native continuity or control artifacts.
+- **FR-018**: Remediation evidence MUST add a parallel remediation audit trail rather than replacing subsystem-native target artifacts.
+- **FR-019**: Target execution detail views or read models MUST expose inbound remediation metadata including active remediation count, latest remediation title, latest status, latest action kind, and last updated time.
+- **FR-020**: The control-plane audit trail MUST record remediation action and approval events with actor user, execution principal, remediation workflow/run, target workflow/run, action kind, risk tier, approval decision, timestamps, and bounded metadata.
+- **FR-021**: Audit evidence MUST remain compact and queryable while deep operator-facing evidence remains artifact-backed.
+- **FR-022**: Audit event metadata MUST remain bounded and MUST NOT contain secrets, raw access grants, storage keys, or unbounded log bodies.
+- **FR-023**: Target-side linkage summary metadata MUST be available for downstream detail views without requiring consumers to parse deep artifact bodies.
+- **FR-024**: If a target changes runs while remediation is active, the system MUST preserve the pinned diagnosis snapshot and record any intentionally resulting run when known.
+- **FR-025**: Missing target visibility, partial artifact refs, unavailable live follow, lock conflicts, failed preconditions, stale leases, missing containers, unsafe forced termination, and remediator failure MUST produce explicit bounded outcomes.
+- **FR-026**: If a precondition no longer holds, the system MUST record a no-op or precondition-failed outcome rather than silent success.
+- **FR-027**: If the remediation task itself fails, the system MUST publish a final remediation summary and release locks where possible, while automatic remediation of the remediator remains disabled by default.
+- **FR-028**: Historical targets with only merged logs MUST be diagnosable when safe and MUST set degraded evidence in the remediation record.
+- **FR-029**: Missing or partial artifact refs MUST identify which evidence classes are unavailable.
+- **FR-030**: Live-follow unavailability MUST fall back to durable logs, diagnostics, summaries, and artifacts.
+- **FR-031**: Remediation lifecycle, artifact, summary, and audit evidence MUST preserve MM-456 traceability through spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Remediation Phase**: A bounded remediation-specific lifecycle marker exposed inside summaries or read models while top-level run state remains authoritative.
+- **Remediation Artifact Set**: The durable operator-facing evidence for context, plan, decisions, action requests, action results, verification, and final summary.
+- **Remediation Summary Block**: The compact run-summary section containing target identity, mode, authority, attempted actions, resolution, lock conflicts, approvals, degraded evidence, and escalation state.
+- **Target-Side Linkage Summary**: The compact metadata that lets target detail views show inbound remediation status without parsing deep artifacts.
+- **Control-Plane Audit Event**: A compact queryable record of remediation actions, approvals, risk decisions, principals, targets, timestamps, and bounded metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove remediation runs expose only the allowed remediation phase values and do not replace top-level run state.
+- **SC-002**: Tests prove required remediation artifacts are published with expected artifact type values and artifact presentation safety metadata.
+- **SC-003**: Tests prove the remediation summary block includes all required target, mode, action, resolution, lock, approval, evidence, and escalation fields.
+- **SC-004**: Tests prove target-side continuity or control artifacts remain present when remediation mutates managed sessions or workloads.
+- **SC-005**: Tests prove control-plane audit events include required actor, principal, workflow/run, action, risk, approval, timestamp, and bounded metadata fields.
+- **SC-006**: Tests prove cancellation and remediator failure avoid new target mutation except already-requested actions and still attempt final summary publication and lock release.
+- **SC-007**: Tests prove Continue-As-New preserves target identity, pinned run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+- **SC-008**: Tests prove degraded evidence, partial artifacts, live-follow unavailability, precondition failure, and target rerun cases produce explicit bounded outcomes.

--- a/specs/232-remediation-lifecycle-audit/tasks.md
+++ b/specs/232-remediation-lifecycle-audit/tasks.md
@@ -18,15 +18,15 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm active feature locator points to `specs/232-remediation-lifecycle-audit` in `.specify/feature.json`
-- [ ] T002 Review existing remediation context/action/link fixtures in `tests/unit/workflows/temporal/test_remediation_context.py`
+- [X] T001 Confirm active feature locator points to `specs/232-remediation-lifecycle-audit` in `.specify/feature.json`
+- [X] T002 Review existing remediation context/action/link fixtures in `tests/unit/workflows/temporal/test_remediation_context.py`
 - [ ] T003 [P] Review target-side execution/task-run serialization tests in `tests/unit/api/routers/test_executions.py` and `tests/unit/api/routers/test_task_runs.py`
 
 ## Phase 2: Foundational
 
-- [ ] T004 Define the lifecycle evidence extension points in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_actions.py`, and `api_service/db/models.py` (FR-001 through FR-031)
-- [ ] T005 Identify whether compact remediation audit events can reuse an existing control-event/memo path or need a bounded artifact-backed event surface in `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
-- [ ] T006 Confirm no new persistent table is required, or document the migration if a compact audit event table becomes unavoidable in `specs/232-remediation-lifecycle-audit/plan.md` (DESIGN-REQ-019)
+- [X] T004 Define the lifecycle evidence extension points in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_actions.py`, and `api_service/db/models.py` (FR-001 through FR-031)
+- [X] T005 Identify whether compact remediation audit events can reuse an existing control-event/memo path or need a bounded artifact-backed event surface in `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
+- [X] T006 Confirm no new persistent table is required, or document the migration if a compact audit event table becomes unavoidable in `specs/232-remediation-lifecycle-audit/plan.md` (DESIGN-REQ-019)
 
 ## Phase 3: Story - Inspect Remediation Lifecycle Evidence
 
@@ -42,52 +42,52 @@
 
 ### Unit Tests
 
-- [ ] T007 [P] Add failing unit tests for allowed `remediationPhase` values and lifecycle outcome normalization in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001 through FR-004, SC-001, DESIGN-REQ-017)
-- [ ] T008 [P] Add failing unit tests for required remediation artifact names, artifact types, bounded metadata, redaction, and no raw access values in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002, DESIGN-REQ-018)
-- [ ] T009 [P] Add failing unit tests for remediation run summary block fields, degraded evidence flags, unavailable evidence classes, fallback evidence, and resulting target run ID in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030, SC-003, SC-008)
-- [ ] T010 [P] Add failing unit tests for compact remediation audit event fields and bounded metadata redaction in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-018, FR-020 through FR-022, SC-005, DESIGN-REQ-019)
-- [ ] T011 [P] Add failing unit tests for cancellation/failure finalization and Continue-As-New preservation payloads in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-027, SC-006, SC-007, DESIGN-REQ-022, DESIGN-REQ-023)
-- [ ] T012 Add verification tests for already-present `remediation.context`, action request/result payloads, target control artifacts, redacted audit fields, and precondition/no-op outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008, FR-011, FR-012, FR-017, FR-022, FR-026)
+- [X] T007 [P] Add failing unit tests for allowed `remediationPhase` values and lifecycle outcome normalization in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001 through FR-004, SC-001, DESIGN-REQ-017)
+- [X] T008 [P] Add failing unit tests for required remediation artifact names, artifact types, bounded metadata, redaction, and no raw access values in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002, DESIGN-REQ-018)
+- [X] T009 [P] Add failing unit tests for remediation run summary block fields, degraded evidence flags, unavailable evidence classes, fallback evidence, and resulting target run ID in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030, SC-003, SC-008)
+- [X] T010 [P] Add failing unit tests for compact remediation audit event fields and bounded metadata redaction in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-018, FR-020 through FR-022, SC-005, DESIGN-REQ-019)
+- [X] T011 [P] Add failing unit tests for cancellation/failure finalization and Continue-As-New preservation payloads in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-027, SC-006, SC-007, DESIGN-REQ-022, DESIGN-REQ-023)
+- [X] T012 Add verification tests for already-present `remediation.context`, action request/result payloads, target control artifacts, redacted audit fields, and precondition/no-op outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008, FR-011, FR-012, FR-017, FR-022, FR-026)
 
 ### Integration Tests
 
-- [ ] T013 [P] Add service-boundary artifact publication test for the full remediation artifact set in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002)
+- [X] T013 [P] Add service-boundary artifact publication test for the full remediation artifact set in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002)
 - [ ] T014 [P] Add target-side linkage summary read-model test in `tests/unit/api/routers/test_executions.py` or `tests/unit/api/routers/test_task_runs.py` (FR-019, FR-023, SC-004, DESIGN-REQ-019)
-- [ ] T015 [P] Add compact audit trail read-model or artifact-backed event test in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-020 through FR-022, SC-005)
+- [X] T015 [P] Add compact audit trail read-model or artifact-backed event test in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-020 through FR-022, SC-005)
 - [ ] T016 Add cancellation/failure and Continue-As-New service-boundary tests in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-027, SC-006, SC-007)
 
 ### Red-First Confirmation
 
-- [ ] T017 Run targeted remediation tests and confirm T007 through T013/T015/T016 fail for the expected missing lifecycle evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [X] T017 Run targeted remediation tests and confirm T007 through T013/T015/T016 fail for the expected missing lifecycle evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
 - [ ] T018 Run router/read-model tests and confirm T014 fails for the expected missing target-side summary behavior: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
 
 ### Conditional Verification Fallbacks
 
 - [ ] T019 If T012 shows action request/result or audit payloads are not persisted as artifacts, implement artifact publication fallback in `moonmind/workflows/temporal/remediation_actions.py` or `moonmind/workflows/temporal/remediation_context.py` (FR-011, FR-012, FR-022)
 - [ ] T020 If T012 shows target control artifacts are not preserved for remediation-mutated targets, add linkage preservation in the relevant managed-session/workload publication path in `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` or `moonmind/workflows/temporal/remediation_tools.py` (FR-017)
-- [ ] T021 If T012 shows precondition/no-op outcomes are not included in lifecycle summaries, add summary mapping in `moonmind/workflows/temporal/remediation_actions.py` (FR-026)
+- [X] T021 If T012 shows precondition/no-op outcomes are not included in lifecycle summaries, add summary mapping in `moonmind/workflows/temporal/remediation_actions.py` (FR-026)
 
 ### Implementation
 
-- [ ] T022 Add remediation phase, resolution, artifact type, summary, audit event, and continuation payload models/helpers in `moonmind/workflows/temporal/remediation_context.py` (FR-001 through FR-007, FR-014, FR-016, FR-020 through FR-022, FR-024 through FR-030)
-- [ ] T023 Implement remediation artifact publication helpers for plan, decision log, action request/result, verification, and summary artifacts in `moonmind/workflows/temporal/remediation_context.py` (FR-009 through FR-015, DESIGN-REQ-018)
+- [X] T022 Add remediation phase, resolution, artifact type, summary, audit event, and continuation payload models/helpers in `moonmind/workflows/temporal/remediation_context.py` (FR-001 through FR-007, FR-014, FR-016, FR-020 through FR-022, FR-024 through FR-030)
+- [X] T023 Implement remediation artifact publication helpers for plan, decision log, action request/result, verification, and summary artifacts in `moonmind/workflows/temporal/remediation_context.py` (FR-009 through FR-015, DESIGN-REQ-018)
 - [ ] T024 Integrate action authority request/result output with remediation artifact publication or lifecycle evidence helpers in `moonmind/workflows/temporal/remediation_actions.py` (FR-011, FR-012, FR-018)
-- [ ] T025 Implement remediation summary block assembly including target identity, mode, authorityMode, actionsAttempted, resolution, lock conflicts, approval count, evidence degraded, escalated, unavailable evidence classes, and fallbacks in `moonmind/workflows/temporal/remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030)
-- [ ] T026 Implement compact remediation audit event assembly and bounded metadata validation in `moonmind/workflows/temporal/remediation_context.py` or `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
+- [X] T025 Implement remediation summary block assembly including target identity, mode, authorityMode, actionsAttempted, resolution, lock conflicts, approval count, evidence degraded, escalated, unavailable evidence classes, and fallbacks in `moonmind/workflows/temporal/remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030)
+- [X] T026 Implement compact remediation audit event assembly and bounded metadata validation in `moonmind/workflows/temporal/remediation_context.py` or `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
 - [ ] T027 Extend target-side remediation linkage summary generation using `execution_remediation_links` compact fields in `api_service/api/routers/executions.py` or `api_service/api/routers/task_runs.py` (FR-019, FR-023)
 - [ ] T028 Implement cancellation/failure finalization and Continue-As-New preservation helpers in `moonmind/workflows/temporal/remediation_context.py` or `moonmind/workflows/temporal/service.py` (FR-005 through FR-007, FR-027, DESIGN-REQ-022, DESIGN-REQ-023)
 - [ ] T029 Preserve MM-456 traceability in code comments or test names only where useful and in verification artifacts in `specs/232-remediation-lifecycle-audit/verification.md` (FR-031)
 
 ### Story Validation
 
-- [ ] T030 Run targeted remediation tests until they pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [X] T030 Run targeted remediation tests until they pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
 - [ ] T031 Run router/read-model tests until they pass if target-side summary files changed: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
-- [ ] T032 Update `specs/232-remediation-lifecycle-audit/tasks.md` checkboxes for completed implementation and validation work
+- [X] T032 Update `specs/232-remediation-lifecycle-audit/tasks.md` checkboxes for completed implementation and validation work
 
 ## Final Phase: Polish And Verification
 
-- [ ] T033 Review `specs/232-remediation-lifecycle-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-lifecycle-audit.md`, and `quickstart.md` for MM-456 and DESIGN-REQ traceability
-- [ ] T034 Run full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [X] T033 Review `specs/232-remediation-lifecycle-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-lifecycle-audit.md`, and `quickstart.md` for MM-456 and DESIGN-REQ traceability
+- [X] T034 Run full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - [ ] T035 Run hermetic integration verification if artifact lifecycle/API routes changed: `./tools/test_integration.sh`
 - [ ] T036 Run `/moonspec-verify` read-only verification for `specs/232-remediation-lifecycle-audit/spec.md`
 

--- a/specs/232-remediation-lifecycle-audit/tasks.md
+++ b/specs/232-remediation-lifecycle-audit/tasks.md
@@ -1,0 +1,110 @@
+# Tasks: Remediation Lifecycle Audit
+
+**Input**: `specs/232-remediation-lifecycle-audit/spec.md`, `specs/232-remediation-lifecycle-audit/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/remediation-lifecycle-audit.md`, `quickstart.md`
+
+## Validation Commands
+
+- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Router/read-model unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
+- Final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Integration: `./tools/test_integration.sh` if artifact lifecycle or API routes change
+
+## Source Traceability Summary
+
+- MM-456 is preserved in `spec.md`, `plan.md`, this task file, quickstart, implementation notes, verification output, commit text, and pull request metadata.
+- The input is classified as one runtime story. `docs/Tasks/TaskRemediation.md` is treated as runtime source requirements.
+- Requirement status from `plan.md`: FR-008 and FR-031 are implemented/verified by existing evidence and traceability; FR-005, FR-011, FR-012, FR-017, FR-022, and FR-026 need verification with fallback implementation; the remaining rows are missing or partial and require tests plus implementation.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm active feature locator points to `specs/232-remediation-lifecycle-audit` in `.specify/feature.json`
+- [ ] T002 Review existing remediation context/action/link fixtures in `tests/unit/workflows/temporal/test_remediation_context.py`
+- [ ] T003 [P] Review target-side execution/task-run serialization tests in `tests/unit/api/routers/test_executions.py` and `tests/unit/api/routers/test_task_runs.py`
+
+## Phase 2: Foundational
+
+- [ ] T004 Define the lifecycle evidence extension points in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_actions.py`, and `api_service/db/models.py` (FR-001 through FR-031)
+- [ ] T005 Identify whether compact remediation audit events can reuse an existing control-event/memo path or need a bounded artifact-backed event surface in `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
+- [ ] T006 Confirm no new persistent table is required, or document the migration if a compact audit event table becomes unavoidable in `specs/232-remediation-lifecycle-audit/plan.md` (DESIGN-REQ-019)
+
+## Phase 3: Story - Inspect Remediation Lifecycle Evidence
+
+**Summary**: Operators and reviewers can inspect remediation phase, artifacts, final summary, target-side linkage, compact audit events, cancellation/failure behavior, and Continue-As-New state for one remediation run.
+
+**Independent Test**: Run or fixture a remediation execution through evidence collection, diagnosis, approval/action, verification, and terminal outcome; inspect artifacts, summary, target-side metadata, and audit events to confirm every required field and bounded failure case is visible.
+
+**Traceability IDs**: FR-001 through FR-031, SC-001 through SC-008, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-022, DESIGN-REQ-023
+
+**Unit Test Plan**: Add focused tests for phase validation, artifact metadata, summary block serialization, audit event boundedness, continuation payload preservation, and degraded/fallback outcomes.
+
+**Integration Test Plan**: Add service-boundary tests proving remediation artifacts are linked to executions, target-side summaries are exposed, and read-models can surface compact remediation evidence without parsing artifact bodies.
+
+### Unit Tests
+
+- [ ] T007 [P] Add failing unit tests for allowed `remediationPhase` values and lifecycle outcome normalization in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001 through FR-004, SC-001, DESIGN-REQ-017)
+- [ ] T008 [P] Add failing unit tests for required remediation artifact names, artifact types, bounded metadata, redaction, and no raw access values in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002, DESIGN-REQ-018)
+- [ ] T009 [P] Add failing unit tests for remediation run summary block fields, degraded evidence flags, unavailable evidence classes, fallback evidence, and resulting target run ID in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030, SC-003, SC-008)
+- [ ] T010 [P] Add failing unit tests for compact remediation audit event fields and bounded metadata redaction in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-018, FR-020 through FR-022, SC-005, DESIGN-REQ-019)
+- [ ] T011 [P] Add failing unit tests for cancellation/failure finalization and Continue-As-New preservation payloads in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-027, SC-006, SC-007, DESIGN-REQ-022, DESIGN-REQ-023)
+- [ ] T012 Add verification tests for already-present `remediation.context`, action request/result payloads, target control artifacts, redacted audit fields, and precondition/no-op outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008, FR-011, FR-012, FR-017, FR-022, FR-026)
+
+### Integration Tests
+
+- [ ] T013 [P] Add service-boundary artifact publication test for the full remediation artifact set in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-008 through FR-015, SC-002)
+- [ ] T014 [P] Add target-side linkage summary read-model test in `tests/unit/api/routers/test_executions.py` or `tests/unit/api/routers/test_task_runs.py` (FR-019, FR-023, SC-004, DESIGN-REQ-019)
+- [ ] T015 [P] Add compact audit trail read-model or artifact-backed event test in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-020 through FR-022, SC-005)
+- [ ] T016 Add cancellation/failure and Continue-As-New service-boundary tests in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-027, SC-006, SC-007)
+
+### Red-First Confirmation
+
+- [ ] T017 Run targeted remediation tests and confirm T007 through T013/T015/T016 fail for the expected missing lifecycle evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [ ] T018 Run router/read-model tests and confirm T014 fails for the expected missing target-side summary behavior: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
+
+### Conditional Verification Fallbacks
+
+- [ ] T019 If T012 shows action request/result or audit payloads are not persisted as artifacts, implement artifact publication fallback in `moonmind/workflows/temporal/remediation_actions.py` or `moonmind/workflows/temporal/remediation_context.py` (FR-011, FR-012, FR-022)
+- [ ] T020 If T012 shows target control artifacts are not preserved for remediation-mutated targets, add linkage preservation in the relevant managed-session/workload publication path in `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` or `moonmind/workflows/temporal/remediation_tools.py` (FR-017)
+- [ ] T021 If T012 shows precondition/no-op outcomes are not included in lifecycle summaries, add summary mapping in `moonmind/workflows/temporal/remediation_actions.py` (FR-026)
+
+### Implementation
+
+- [ ] T022 Add remediation phase, resolution, artifact type, summary, audit event, and continuation payload models/helpers in `moonmind/workflows/temporal/remediation_context.py` (FR-001 through FR-007, FR-014, FR-016, FR-020 through FR-022, FR-024 through FR-030)
+- [ ] T023 Implement remediation artifact publication helpers for plan, decision log, action request/result, verification, and summary artifacts in `moonmind/workflows/temporal/remediation_context.py` (FR-009 through FR-015, DESIGN-REQ-018)
+- [ ] T024 Integrate action authority request/result output with remediation artifact publication or lifecycle evidence helpers in `moonmind/workflows/temporal/remediation_actions.py` (FR-011, FR-012, FR-018)
+- [ ] T025 Implement remediation summary block assembly including target identity, mode, authorityMode, actionsAttempted, resolution, lock conflicts, approval count, evidence degraded, escalated, unavailable evidence classes, and fallbacks in `moonmind/workflows/temporal/remediation_context.py` (FR-014, FR-016, FR-024, FR-028 through FR-030)
+- [ ] T026 Implement compact remediation audit event assembly and bounded metadata validation in `moonmind/workflows/temporal/remediation_context.py` or `moonmind/workflows/temporal/service.py` (FR-020 through FR-022, DESIGN-REQ-019)
+- [ ] T027 Extend target-side remediation linkage summary generation using `execution_remediation_links` compact fields in `api_service/api/routers/executions.py` or `api_service/api/routers/task_runs.py` (FR-019, FR-023)
+- [ ] T028 Implement cancellation/failure finalization and Continue-As-New preservation helpers in `moonmind/workflows/temporal/remediation_context.py` or `moonmind/workflows/temporal/service.py` (FR-005 through FR-007, FR-027, DESIGN-REQ-022, DESIGN-REQ-023)
+- [ ] T029 Preserve MM-456 traceability in code comments or test names only where useful and in verification artifacts in `specs/232-remediation-lifecycle-audit/verification.md` (FR-031)
+
+### Story Validation
+
+- [ ] T030 Run targeted remediation tests until they pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [ ] T031 Run router/read-model tests until they pass if target-side summary files changed: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
+- [ ] T032 Update `specs/232-remediation-lifecycle-audit/tasks.md` checkboxes for completed implementation and validation work
+
+## Final Phase: Polish And Verification
+
+- [ ] T033 Review `specs/232-remediation-lifecycle-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-lifecycle-audit.md`, and `quickstart.md` for MM-456 and DESIGN-REQ traceability
+- [ ] T034 Run full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [ ] T035 Run hermetic integration verification if artifact lifecycle/API routes changed: `./tools/test_integration.sh`
+- [ ] T036 Run `/moonspec-verify` equivalent read-only verification for `specs/232-remediation-lifecycle-audit/spec.md`
+
+## Dependencies And Order
+
+- T001 through T006 must complete before story tests.
+- T007 through T016 must be written before T017 and T018.
+- T017 and T018 must confirm red-first failure before T019 through T028.
+- T019 through T028 must complete before T030 and T031.
+- T030 and T031 must pass before T032 through T036.
+
+## Parallel Examples
+
+- T007, T008, T009, T010, T011, and T012 can be drafted in parallel if coordinated in the same test file.
+- T013, T014, T015, and T016 touch different verification surfaces and can be drafted in parallel.
+- T023, T026, and T027 can be implemented in parallel if write ownership is kept separate across artifact helpers, audit helpers, and API read models.
+
+## Implementation Strategy
+
+Build the story vertically from bounded models to artifact publication to read-model visibility. Keep deep evidence artifact-backed, keep queryable evidence compact, and preserve top-level run state as the authority while adding remediation-specific lifecycle fields.

--- a/specs/232-remediation-lifecycle-audit/tasks.md
+++ b/specs/232-remediation-lifecycle-audit/tasks.md
@@ -89,7 +89,7 @@
 - [ ] T033 Review `specs/232-remediation-lifecycle-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-lifecycle-audit.md`, and `quickstart.md` for MM-456 and DESIGN-REQ traceability
 - [ ] T034 Run full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - [ ] T035 Run hermetic integration verification if artifact lifecycle/API routes changed: `./tools/test_integration.sh`
-- [ ] T036 Run `/moonspec-verify` equivalent read-only verification for `specs/232-remediation-lifecycle-audit/spec.md`
+- [ ] T036 Run `/moonspec-verify` read-only verification for `specs/232-remediation-lifecycle-audit/spec.md`
 
 ## Dependencies And Order
 

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -499,6 +499,57 @@ def test_remediation_lifecycle_summary_audit_and_continuation_are_bounded():
     ]
 
 
+def test_remediation_summary_allows_hierarchical_target_identifiers():
+    summary = build_remediation_summary_block(
+        target_workflow_id="/tenant/workflows/target",
+        target_run_id="/runs/target-run",
+        phase="resolved",
+        mode="snapshot_then_follow",
+        authority_mode="admin_auto",
+        resolution="resolved_after_action",
+    )
+
+    assert summary["targetWorkflowId"] == "/tenant/workflows/target"
+    assert summary["targetRunId"] == "/runs/target-run"
+
+
+def test_remediation_audit_normalizes_string_timestamps():
+    audit = build_remediation_audit_event(
+        event_id="audit-1",
+        event_type="remediation.action",
+        actor_user="user:operator",
+        execution_principal="service:admin-healer",
+        remediation_workflow_id="remediation-workflow",
+        remediation_run_id="remediation-run",
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        action_kind="restart_worker",
+        risk_tier="medium",
+        approval_decision="approved",
+        timestamp="2026-04-22T01:02:03+02:00",
+    )
+
+    assert audit["timestamp"] == "2026-04-21T23:02:03Z"
+
+
+def test_remediation_audit_rejects_malformed_string_timestamps():
+    with pytest.raises(RemediationContextError, match="timestamp must be ISO8601"):
+        build_remediation_audit_event(
+            event_id="audit-1",
+            event_type="remediation.action",
+            actor_user="user:operator",
+            execution_principal="service:admin-healer",
+            remediation_workflow_id="remediation-workflow",
+            remediation_run_id="remediation-run",
+            target_workflow_id="target-workflow",
+            target_run_id="target-run",
+            action_kind="restart_worker",
+            risk_tier="medium",
+            approval_decision="approved",
+            timestamp="not-a-timestamp",
+        )
+
+
 def test_target_remediation_linkage_summary_is_compact():
     summary = build_target_remediation_linkage_summary(
         target_workflow_id="target-workflow",
@@ -644,7 +695,9 @@ async def test_remediation_lifecycle_publisher_creates_required_artifacts(
             artifact_id=artifacts[-1].artifact_id,
             principal="service:test",
         )
-        assert json.loads(payload_bytes)["resolution"] == "resolved_after_action"
+        published_summary = json.loads(payload_bytes)
+        assert published_summary["authorityMode"] == "admin_auto"
+        assert published_summary["resolution"] == "resolved_after_action"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -30,6 +30,13 @@ from moonmind.workflows.temporal import (
 from moonmind.workflows.temporal.remediation_context import (
     RemediationContextBuilder,
     RemediationContextError,
+    RemediationLifecyclePublisher,
+    build_remediation_audit_event,
+    build_remediation_continue_as_new_state,
+    build_remediation_summary_block,
+    build_target_remediation_linkage_summary,
+    normalize_remediation_phase,
+    normalize_remediation_resolution,
 )
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationActionAuthorityService,
@@ -371,6 +378,273 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
         assert "raw-api-key" not in serialized
         assert "password" not in serialized.lower()
         assert "token=" not in serialized.lower()
+
+
+def test_remediation_lifecycle_summary_audit_and_continuation_are_bounded():
+    assert normalize_remediation_phase("diagnosing") == "diagnosing"
+    assert normalize_remediation_phase("unknown") == "failed"
+    assert normalize_remediation_resolution("resolved_after_action") == (
+        "resolved_after_action"
+    )
+    assert normalize_remediation_resolution("mystery") == "failed"
+
+    summary = build_remediation_summary_block(
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        phase="resolved",
+        mode="snapshot_then_follow",
+        authority_mode="admin_auto",
+        actions_attempted=(
+            {
+                "kind": "provider_profile.evict_stale_lease",
+                "status": "applied",
+                "token": "raw-secret",
+            },
+        ),
+        resolution="resolved_after_action",
+        lock_conflicts=1,
+        approval_count=2,
+        evidence_degraded=True,
+        escalated=False,
+        unavailable_evidence_classes=("live_follow", "artifact_refs"),
+        fallbacks_used=("logs/merged",),
+        resulting_target_run_id="target-run-2",
+    )
+
+    assert summary == {
+        "targetWorkflowId": "target-workflow",
+        "targetRunId": "target-run",
+        "resultingTargetRunId": "target-run-2",
+        "phase": "resolved",
+        "mode": "snapshot_then_follow",
+        "authorityMode": "admin_auto",
+        "actionsAttempted": [
+            {
+                "kind": "provider_profile.evict_stale_lease",
+                "status": "applied",
+            }
+        ],
+        "resolution": "resolved_after_action",
+        "lockConflicts": 1,
+        "approvalCount": 2,
+        "evidenceDegraded": True,
+        "escalated": False,
+        "unavailableEvidenceClasses": ["live_follow", "artifact_refs"],
+        "fallbacksUsed": ["logs/merged"],
+    }
+
+    audit = build_remediation_audit_event(
+        event_id="audit-1",
+        event_type="remediation.action",
+        actor_user="user:operator",
+        execution_principal="service:admin-healer",
+        remediation_workflow_id="remediation-workflow",
+        remediation_run_id="remediation-run",
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        action_kind="provider_profile.evict_stale_lease",
+        risk_tier="medium",
+        approval_decision="approved",
+        timestamp=datetime(2026, 4, 22, tzinfo=timezone.utc),
+        metadata={
+            "resolution": "resolved_after_action",
+            "token": "raw-secret",
+            "url": "https://storage.example/object?token=raw-secret",
+        },
+    )
+    assert audit["timestamp"] == "2026-04-22T00:00:00Z"
+    assert audit["metadata"] == {"resolution": "resolved_after_action"}
+    assert "raw-secret" not in json.dumps(audit)
+
+    continuation = build_remediation_continue_as_new_state(
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        context_artifact_ref="art_context",
+        lock_identity="lock-1",
+        action_ledger_ref="ledger-1",
+        approval_state="approved",
+        retry_budget_state={"actionsAttempted": 1, "token": "raw-secret"},
+        live_follow_cursor={"sequence": 42},
+    )
+    assert continuation == {
+        "targetWorkflowId": "target-workflow",
+        "targetRunId": "target-run",
+        "contextArtifactRef": "art_context",
+        "lockIdentity": "lock-1",
+        "actionLedgerRef": "ledger-1",
+        "approvalState": "approved",
+        "retryBudgetState": {"actionsAttempted": 1},
+        "liveFollowCursor": {"sequence": 42},
+    }
+
+    failed_summary = build_remediation_summary_block(
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        phase="failed",
+        mode="snapshot_then_follow",
+        authority_mode="approval_gated",
+        resolution="failed",
+        evidence_degraded=True,
+        escalated=True,
+        unavailable_evidence_classes=("target_visibility",),
+        fallbacks_used=("final_summary_publication", "lock_release_attempt"),
+    )
+    assert failed_summary["phase"] == "failed"
+    assert failed_summary["resolution"] == "failed"
+    assert failed_summary["evidenceDegraded"] is True
+    assert failed_summary["escalated"] is True
+    assert failed_summary["fallbacksUsed"] == [
+        "final_summary_publication",
+        "lock_release_attempt",
+    ]
+
+
+def test_target_remediation_linkage_summary_is_compact():
+    summary = build_target_remediation_linkage_summary(
+        target_workflow_id="target-workflow",
+        active_remediation_count=2,
+        latest_remediation_title="Publish remediation lifecycle phases",
+        latest_remediation_status="acting",
+        latest_action_kind="restart_worker",
+        latest_outcome="resolved_after_action",
+        active_lock_scope="target_execution",
+        active_lock_holder="remediation-workflow",
+        last_updated_at=datetime(2026, 4, 22, 1, 2, 3, tzinfo=timezone.utc),
+        metadata={"token": "raw-secret", "safe": "value"},
+    )
+
+    assert summary == {
+        "targetWorkflowId": "target-workflow",
+        "activeRemediationCount": 2,
+        "latestRemediationTitle": "Publish remediation lifecycle phases",
+        "latestRemediationStatus": "acting",
+        "latestActionKind": "restart_worker",
+        "latestOutcome": "resolved_after_action",
+        "activeLockScope": "target_execution",
+        "activeLockHolder": "remediation-workflow",
+        "lastUpdatedAt": "2026-04-22T01:02:03Z",
+        "metadata": {"safe": "value"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_remediation_lifecycle_publisher_creates_required_artifacts(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        publisher = RemediationLifecyclePublisher(
+            session=session,
+            artifact_service=artifact_service,
+        )
+
+        summary = build_remediation_summary_block(
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            phase="resolved",
+            mode="snapshot_then_follow",
+            authority_mode="admin_auto",
+            actions_attempted=({"kind": "restart_worker", "status": "applied"},),
+            resolution="resolved_after_action",
+        )
+        artifacts = []
+        for artifact_type, name, payload in (
+            (
+                "remediation.plan",
+                "reports/remediation_plan.json",
+                {"steps": ["diagnose", "act"]},
+            ),
+            (
+                "remediation.decision_log",
+                "logs/remediation_decision_log.ndjson",
+                {"decision": "acting"},
+            ),
+            (
+                "remediation.action_request",
+                "reports/remediation_action_request-1.json",
+                {"actionKind": "restart_worker"},
+            ),
+            (
+                "remediation.action_result",
+                "reports/remediation_action_result-1.json",
+                {"status": "applied"},
+            ),
+            (
+                "remediation.verification",
+                "reports/remediation_verification-1.json",
+                {"targetHealthy": True},
+            ),
+            (
+                "remediation.summary",
+                "reports/remediation_summary.json",
+                summary,
+            ),
+        ):
+            artifacts.append(
+                await publisher.publish_json_artifact(
+                    remediation_workflow_id=remediation.workflow_id,
+                    artifact_type=artifact_type,
+                    name=name,
+                    payload=payload,
+                    target_workflow_id=target.workflow_id,
+                    target_run_id=target.run_id,
+                    principal="service:test",
+                )
+            )
+
+        links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == remediation.workflow_id,
+                    TemporalArtifactLink.link_type.in_(
+                        [
+                            "remediation.plan",
+                            "remediation.decision_log",
+                            "remediation.action_request",
+                            "remediation.action_result",
+                            "remediation.verification",
+                            "remediation.summary",
+                        ]
+                    ),
+                )
+            )
+        ).scalars().all()
+        assert [artifact.metadata_json["artifact_type"] for artifact in artifacts] == [
+            "remediation.plan",
+            "remediation.decision_log",
+            "remediation.action_request",
+            "remediation.action_result",
+            "remediation.verification",
+            "remediation.summary",
+        ]
+        assert {link.link_type for link in links} == {
+            "remediation.plan",
+            "remediation.decision_log",
+            "remediation.action_request",
+            "remediation.action_result",
+            "remediation.verification",
+            "remediation.summary",
+        }
+        remediation_record = await session.get(
+            TemporalExecutionCanonicalRecord, remediation.workflow_id
+        )
+        assert remediation_record is not None
+        for artifact in artifacts:
+            assert artifact.artifact_id in remediation_record.artifact_refs
+
+        _artifact, payload_bytes = await artifact_service.read(
+            artifact_id=artifacts[-1].artifact_id,
+            principal="service:test",
+        )
+        assert json.loads(payload_bytes)["resolution"] == "resolved_after_action"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Jira

- Issue: MM-456

## MoonSpec

- Active feature path: `specs/232-remediation-lifecycle-audit`
- Verification verdict: `ADDITIONAL_WORK_NEEDED`

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS
  - Python: `3774 passed, 1 xpassed, 101 warnings, 16 subtests passed`
  - Frontend: `11 passed`, `367 passed`
- `./tools/test_integration.sh` - NOT RUN / blocked
  - Docker socket `/var/run/docker.sock` is unavailable in the managed container.

## Remaining Risks

- Final MoonSpec verification found `ADDITIONAL_WORK_NEEDED`, not `FULLY_IMPLEMENTED`.
- Target-side remediation linkage/read-model work remains incomplete for FR-019/FR-023.
- Action authority request/result output is not yet integrated with remediation artifact publication for FR-011/FR-012.
- Cancellation/failure finalization and Continue-As-New behavior need service-boundary coverage for FR-005 through FR-007 and FR-027.
- Hermetic integration verification could not be executed in this environment because Docker is unavailable.
