### PR TITLE
MM-457 Show remediation in Mission Control

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -117,6 +117,9 @@ _DASHBOARD_STATUS_BY_STATE: dict[MoonMindWorkflowState, str] = {
 _MAX_TASK_TITLE_LENGTH = 150
 _MAX_TASK_SUMMARY_LENGTH = 180
 _TASK_SUMMARY_ELLIPSIS = "..."
+_PENDING_REMEDIATION_APPROVAL_STATUSES = frozenset(
+    {"awaiting_approval", "approval_required"}
+)
 _GITHUB_PULL_REQUEST_PATH_PATTERN = re.compile(
     r"^/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+$",
     re.IGNORECASE,
@@ -3499,14 +3502,18 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
     authority_mode = str(getattr(link, "authority_mode", "") or "")
     status_value = str(getattr(link, "status", "") or "")
     approval_state: RemediationApprovalStateModel | None = None
+    approval_pending = status_value in _PENDING_REMEDIATION_APPROVAL_STATUSES
     if authority_mode == "approval_gated":
         approval_state = RemediationApprovalStateModel(
-            decision=(
-                "pending"
-                if status_value in {"awaiting_approval", "approval_required"}
-                else "not_required"
+            requestId=(
+                _remediation_approval_request_id(
+                    str(getattr(link, "remediation_workflow_id", ""))
+                )
+                if approval_pending
+                else None
             ),
-            canDecide=False,
+            decision=("pending" if approval_pending else "not_required"),
+            canDecide=approval_pending,
         )
 
     return RemediationLinkSummaryModel(
@@ -3523,9 +3530,13 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         resolution=getattr(link, "outcome", None),
         contextArtifactRef=getattr(link, "context_artifact_ref", None),
         approvalState=approval_state,
-        createdAt=getattr(link, "created_at"),
-        updatedAt=getattr(link, "updated_at"),
+        createdAt=getattr(link, "created_at", None),
+        updatedAt=getattr(link, "updated_at", None),
     )
+
+
+def _remediation_approval_request_id(remediation_workflow_id: str) -> str:
+    return f"{remediation_workflow_id}:approval"
 
 
 @router.get(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 from functools import lru_cache
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import Client
@@ -121,6 +121,54 @@ _GITHUB_PULL_REQUEST_PATH_PATTERN = re.compile(
     r"^/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+$",
     re.IGNORECASE,
 )
+
+
+class RemediationApprovalStateModel(BaseModel):
+    requestId: str | None = None
+    actionKind: str | None = None
+    riskTier: str | None = None
+    preconditions: str | None = None
+    blastRadius: str | None = None
+    decision: str
+    decisionActor: str | None = None
+    decisionAt: datetime | None = None
+    canDecide: bool = False
+    auditRef: str | None = None
+
+
+class RemediationLinkSummaryModel(BaseModel):
+    remediationWorkflowId: str
+    remediationRunId: str
+    targetWorkflowId: str
+    targetRunId: str
+    mode: str
+    authorityMode: str
+    status: str
+    activeLockScope: str | None = None
+    activeLockHolder: str | None = None
+    latestActionSummary: str | None = None
+    resolution: str | None = None
+    contextArtifactRef: str | None = None
+    approvalState: RemediationApprovalStateModel | None = None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class RemediationLinksResponseModel(BaseModel):
+    direction: str
+    items: list[RemediationLinkSummaryModel]
+
+
+class RemediationApprovalDecisionRequest(BaseModel):
+    decision: str
+    comment: str | None = None
+
+
+class RemediationApprovalDecisionResponse(BaseModel):
+    accepted: bool
+    workflowId: str
+    requestId: str
+    decision: str
 _PR_URL_CANDIDATE_SOURCES = (
     ("memo", "pull_request_url"),
     ("memo", "pullRequestUrl"),
@@ -3445,6 +3493,109 @@ async def create_remediation_execution(
         user=user,
         session=session,
     )
+
+
+def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryModel:
+    authority_mode = str(getattr(link, "authority_mode", "") or "")
+    status_value = str(getattr(link, "status", "") or "")
+    approval_state: RemediationApprovalStateModel | None = None
+    if authority_mode == "approval_gated":
+        approval_state = RemediationApprovalStateModel(
+            decision=(
+                "pending"
+                if status_value in {"awaiting_approval", "approval_required"}
+                else "not_required"
+            ),
+            canDecide=False,
+        )
+
+    return RemediationLinkSummaryModel(
+        remediationWorkflowId=str(getattr(link, "remediation_workflow_id", "")),
+        remediationRunId=str(getattr(link, "remediation_run_id", "")),
+        targetWorkflowId=str(getattr(link, "target_workflow_id", "")),
+        targetRunId=str(getattr(link, "target_run_id", "")),
+        mode=str(getattr(link, "mode", "")),
+        authorityMode=authority_mode,
+        status=status_value,
+        activeLockScope=getattr(link, "active_lock_scope", None),
+        activeLockHolder=getattr(link, "active_lock_holder", None),
+        latestActionSummary=getattr(link, "latest_action_summary", None),
+        resolution=getattr(link, "outcome", None),
+        contextArtifactRef=getattr(link, "context_artifact_ref", None),
+        approvalState=approval_state,
+        createdAt=getattr(link, "created_at"),
+        updatedAt=getattr(link, "updated_at"),
+    )
+
+
+@router.get(
+    "/{workflow_id}/remediations",
+    response_model=RemediationLinksResponseModel,
+)
+async def list_execution_remediations(
+    workflow_id: str,
+    direction: str = Query("inbound"),
+    service: TemporalExecutionService = Depends(_get_service),
+    user: User = Depends(get_current_user()),
+) -> RemediationLinksResponseModel:
+    if direction not in {"inbound", "outbound"}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_remediation_direction",
+                "message": "direction must be 'inbound' or 'outbound'.",
+            },
+        )
+
+    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
+    if direction == "inbound":
+        links = await service.list_remediations_for_target(workflow_id)
+    else:
+        links = await service.list_remediation_targets(workflow_id)
+
+    return RemediationLinksResponseModel(
+        direction=direction,
+        items=[_serialize_remediation_link_summary(link) for link in links],
+    )
+
+
+@router.post(
+    "/{workflow_id}/remediation/approvals/{request_id}",
+    response_model=RemediationApprovalDecisionResponse,
+)
+async def record_remediation_approval_decision(
+    workflow_id: str,
+    request_id: str,
+    payload: RemediationApprovalDecisionRequest,
+    service: TemporalExecutionService = Depends(_get_service),
+    user: User = Depends(get_current_user()),
+) -> RemediationApprovalDecisionResponse:
+    if payload.decision not in {"approved", "rejected"}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_remediation_approval_decision",
+                "message": "decision must be 'approved' or 'rejected'.",
+            },
+        )
+    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
+    try:
+        result = await service.record_remediation_approval_decision(
+            remediation_workflow_id=workflow_id,
+            request_id=request_id,
+            decision=payload.decision,
+            comment=payload.comment,
+            actor=getattr(user, "email", None) or str(getattr(user, "id", "")),
+        )
+    except TemporalExecutionValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_remediation_approval_decision",
+                "message": str(exc),
+            },
+        ) from exc
+    return RemediationApprovalDecisionResponse.model_validate(result)
 
 
 @router.post("", response_model=ExecutionModel | ScheduleCreatedResponse, status_code=status.HTTP_201_CREATED)

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-456",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1686"
+  "jira_issue_key": "MM-457",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1687"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,37 @@
 [
   {
-    "id": 3123798424,
+    "id": 3124208088,
     "disposition": "addressed",
-    "rationale": "Identifier fields now bypass path-style unsafe string checks, and unit coverage verifies hierarchical target workflow/run IDs are preserved."
+    "rationale": "Pending approval-gated remediation link summaries now include a stable requestId and set canDecide=true so Mission Control can render approve/reject controls."
   },
   {
-    "id": 3123798439,
+    "id": 3124208095,
     "disposition": "addressed",
-    "rationale": "String timestamps are now parsed and normalized to UTC Zulu format, with malformed strings rejected by regression coverage."
+    "rationale": "Remediation relationship queries now run for every loaded execution with a workflow id, independent of status or remediation keywords."
   },
   {
-    "id": 4154502370,
+    "id": 3124208100,
+    "disposition": "addressed",
+    "rationale": "Approval decisions now validate that the workflow has a pending approval-gated remediation link and that the request id matches the pending approval request before writing audit entries."
+  },
+  {
+    "id": 4154944714,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its two actionable findings are tracked by inline comments 3123798424 and 3123798439."
+    "rationale": "Top-level automated review summary; actionable inline comments from the review are tracked separately."
   },
   {
-    "id": 3123798641,
-    "disposition": "addressed",
-    "rationale": "The lifecycle payload sanitizer now allowlists authorityMode while continuing to drop secret-like keys, and publisher coverage asserts remediation.summary retains authorityMode."
-  },
-  {
-    "id": 4154502596,
+    "id": 3124208843,
     "disposition": "not-applicable",
-    "rationale": "Automated review wrapper with no additional actionable feedback beyond the inline comments already addressed."
+    "rationale": "The current file already imports datetime from datetime alongside UTC and timedelta, so the reported NameError no longer applies."
+  },
+  {
+    "id": 3124208855,
+    "disposition": "addressed",
+    "rationale": "Remediation link serialization now supplies safe getattr defaults for created_at and updated_at."
+  },
+  {
+    "id": 4154945457,
+    "disposition": "not-applicable",
+    "rationale": "Top-level automated review summary; actionable inline comments from the review are tracked separately."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md
@@ -1,0 +1,92 @@
+# MM-457 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-457
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-457 from MM project
+Summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-457 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-457: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 15. Mission Control UX
+  - 8.5 Reverse lookup API
+  - 14.4 Target-side linkage summary
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-020
+  - DESIGN-REQ-021
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+
+User Story
+As an operator in Mission Control, I can create remediation tasks from relevant target surfaces and inspect target/remediator relationships, evidence, live observation, lock state, actions, approvals, and outcomes.
+
+Acceptance Criteria
+- Operators can start remediation from target task/problem surfaces and the submission payload matches the canonical contract.
+- Target detail shows inbound remediators and active lock/action/resolution metadata.
+- Remediation detail shows target identity, pinned run, selected steps, current state, evidence, action policy, approval, and lock information.
+- Evidence links open through artifact/log APIs and honor redaction and visibility rules.
+- Live follow UI is clearly non-authoritative, resumes sequence position where possible, and falls back to durable artifacts.
+- Approval decisions for gated/high-risk actions are captured and visible in the audit trail.
+
+Requirements
+- Mission Control makes remediation relationships visible in both directions.
+- UI cannot imply raw host/admin shell access; action surfaces are typed and policy-bound.
+- Partial evidence and live-follow unavailability must be visible without deadlocking the user flow.
+
+Relevant Implementation Notes
+- Preserve MM-457 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation task creation, reverse lookup, target-side linkage summaries, remediation detail surfaces, evidence presentation, live follow behavior, approvals, and bounded operator handoff.
+- Expose create-remediation entry points from task detail, failed task banners, attention-required surfaces, stuck task surfaces, and provider-slot or session problem surfaces where applicable.
+- Ensure the create flow lets operators choose the pinned target run, choose all or selected steps, choose troubleshooting-only or admin remediation, choose live-follow mode, choose or review the action policy, and preview attached evidence.
+- Show target-side remediation relationships through a Remediation Tasks panel with links, status, authority mode, last action, resolution, and active lock state.
+- Show remediation-side target context with target execution link, pinned target run id, selected steps, current target state, evidence bundle link, allowed actions, approval state, and lock state.
+- Provide direct access to remediation context artifacts, referenced target logs and diagnostics, remediation decision logs, action request/result artifacts, and verification artifacts through existing artifact/log APIs.
+- Clearly label live-follow data as non-authoritative live observation, preserve sequence position where possible, make managed-session epoch boundaries explicit, and fall back to durable artifacts when streaming is unavailable.
+- Capture approval-gated and high-risk action decisions with proposed action, preconditions, expected blast radius, approve/reject result, and audit-trail visibility.
+- Implement reverse lookup surfaces for inbound and outbound remediation relationships, such as `GET /api/executions/{workflowId}/remediations?direction=inbound` and `GET /api/executions/{workflowId}/remediations?direction=outbound`, or equivalent repository-local API patterns.
+- Keep host/admin shell capability out of the UI language and behavior; action surfaces must remain typed, policy-bound, and auditable.
+- Surface partial evidence and unavailable live-follow streams as degraded states instead of blocking navigation or hiding remediation context.
+
+Non-Goals
+- Granting raw host/admin shell access from Mission Control remediation surfaces.
+- Treating live-follow streams as authoritative durable evidence.
+- Hiding partial evidence or unavailable streams behind loading states that deadlock the operator flow.
+- Replacing artifact/log APIs or audit trails with remediation-specific ad hoc data paths.
+- Dropping bidirectional target/remediator visibility when only one side of the relationship is currently active.
+
+Validation
+- Verify operators can start remediation from target task/problem surfaces and the submission payload matches the canonical contract.
+- Verify target detail shows inbound remediators and active lock/action/resolution metadata.
+- Verify remediation detail shows target identity, pinned run, selected steps, current state, evidence, action policy, approval, and lock information.
+- Verify evidence links open through artifact/log APIs and honor redaction and visibility rules.
+- Verify live follow UI is clearly non-authoritative, resumes sequence position where possible, and falls back to durable artifacts.
+- Verify approval decisions for gated/high-risk actions are captured and visible in the audit trail.
+- Verify inbound and outbound remediation lookup surfaces expose target/remediator relationships without relying on raw workflow history inspection.
+- Verify partial evidence and unavailable live-follow states are visible to operators without deadlocking the user flow.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-457 blocks MM-456, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-457 is blocked by MM-458, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -4557,6 +4557,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
 
     const primarySkillId = primaryValidation.value.skillId.trim() || "auto";
+    const effectiveSubmissionSkillId = resolveEffectiveSkillId(
+      primarySkillId,
+      appliedTemplates,
+    );
+    const effectivePublishMode =
+      isResolverSkill(effectiveSubmissionSkillId) && isMergeAutomationPublishMode(publishMode)
+        ? "none"
+        : normalizedPublishMode;
     const primarySkillArgsRaw = showAdvancedStepOptions
       ? String(primaryStep?.skillArgs || "").trim()
       : "";
@@ -5004,7 +5012,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
     const mergedCapabilities = deriveRequiredCapabilities({
       runtimeMode: normalizedRuntime,
-      publishMode: normalizedPublishMode,
+      publishMode: effectivePublishMode,
       taskSkillRequiredCapabilities,
       stepSkillRequiredCapabilities,
       templateCapabilities,
@@ -5041,12 +5049,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         : cleaned;
     })();
 
-    // Determine skill: applied presets define the workflow-level primary skill.
-    const effectiveSubmissionSkillId = resolveEffectiveSkillId(
-      primarySkillId,
-      appliedTemplates,
-    );
-
     // Only include task-level agent skill selectors when we have an explicit skill or a template slug.
     const taskSkillSelectors =
       hasExplicitSkillSelection(primarySkillId) || appliedTemplates.length > 0
@@ -5063,7 +5065,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
     const shouldSubmitMergeAutomation =
       isMergeAutomationPublishMode(publishMode) &&
-      normalizedPublishMode === "pr" &&
+      effectivePublishMode === "pr" &&
       !isResolverSkill(effectiveSubmissionSkillId);
 
     const taskPayload: Record<string, unknown> = {
@@ -5086,7 +5088,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         ...(providerProfile ? { profileId: providerProfile } : {}),
       },
       publish: {
-        mode: normalizedPublishMode,
+        mode: effectivePublishMode,
       },
       ...(branch.trim()
         ? {
@@ -5114,7 +5116,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           ? { requiredCapabilities: mergedCapabilities }
           : {}),
         targetRuntime: normalizedRuntime,
-        publishMode: normalizedPublishMode,
+        publishMode: effectivePublishMode,
         ...(shouldSubmitMergeAutomation
           ? { mergeAutomation: { enabled: true } }
           : {}),

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1409,6 +1409,173 @@ describe('Task Detail Entrypoint', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/executions/test-123?source=temporal');
   });
 
+  it('renders remediation create action, relationships, evidence, and degraded states', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Failed target task',
+      summary: 'Needs remediation.',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      repository: 'MoonLadderStudios/MoonMind',
+      createdAt: '2026-04-22T00:00:00Z',
+      updatedAt: '2026-04-22T00:00:01Z',
+      actions: { canSetTitle: true },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/remediations?direction=inbound')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            direction: 'inbound',
+            items: [
+              {
+                remediationWorkflowId: 'mm:remediation-1',
+                remediationRunId: 'run-remediation-1',
+                targetWorkflowId: 'test-123',
+                targetRunId: '01-run',
+                mode: 'snapshot_then_follow',
+                authorityMode: 'approval_gated',
+                status: 'awaiting_approval',
+                activeLockScope: 'target_execution',
+                activeLockHolder: 'mm:remediation-1',
+                latestActionSummary: 'Proposed session interrupt',
+                resolution: null,
+                contextArtifactRef: 'art_context',
+                approvalState: { requestId: 'approval-1', decision: 'pending', canDecide: true },
+                createdAt: '2026-04-22T00:00:02Z',
+                updatedAt: '2026-04-22T00:00:03Z',
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/remediations?direction=outbound')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            direction: 'outbound',
+            items: [
+              {
+                remediationWorkflowId: 'test-123',
+                remediationRunId: '01-run',
+                targetWorkflowId: 'mm:target-1',
+                targetRunId: 'run-target',
+                mode: 'snapshot',
+                authorityMode: 'observe_only',
+                status: 'created',
+                contextArtifactRef: null,
+                approvalState: null,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/executions/default/test-123/01-run/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            artifacts: [
+              {
+                artifactId: 'art_context',
+                contentType: 'application/json',
+                sizeBytes: 128,
+                status: 'complete',
+                metadata: { artifact_type: 'remediation.context' },
+                links: [],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/remediation') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ workflowId: 'mm:remediation-created' }),
+        } as Response);
+      }
+      if (url.includes('/executions/mm%3Aremediation-1/remediation/approvals/approval-1') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            accepted: true,
+            workflowId: 'mm:remediation-1',
+            requestId: 'approval-1',
+            decision: 'approved',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    expect(await screen.findByRole('button', { name: 'Create remediation task' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Remediation' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Remediation Tasks' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Remediation Target' })).toBeTruthy();
+    expect(screen.getByText('mm:remediation-1')).toBeTruthy();
+    expect(screen.getByText('mm:target-1')).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Remediation Evidence' })).toBeTruthy();
+    expect(screen.getByText('Context')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open Evidence' }).getAttribute('href')).toBe(
+      '/api/artifacts/art_context/download',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create remediation task' }));
+
+    await waitFor(() => {
+      const remediationCreateCall = fetchSpy.mock.calls.find(
+        ([url, init]) => String(url) === '/api/executions/test-123/remediation' && init?.method === 'POST',
+      );
+      expect(remediationCreateCall).toBeTruthy();
+      expect(JSON.parse(String(remediationCreateCall?.[1]?.body))).toMatchObject({
+        repository: 'MoonLadderStudios/MoonMind',
+        remediation: {
+          mode: 'snapshot_then_follow',
+          authorityMode: 'approval_gated',
+          target: { runId: '01-run' },
+          evidencePolicy: {
+            includeStepLedger: true,
+            includeDiagnostics: true,
+            tailLines: 2000,
+          },
+          trigger: { type: 'manual' },
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve remediation action' }));
+
+    await waitFor(() => {
+      const approvalCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url) === '/api/executions/mm%3Aremediation-1/remediation/approvals/approval-1' &&
+          init?.method === 'POST',
+      );
+      expect(approvalCall).toBeTruthy();
+      expect(JSON.parse(String(approvalCall?.[1]?.body))).toEqual({
+        decision: 'approved',
+      });
+    });
+  });
+
   it('renders task detail as separated matte evidence and action regions', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1576,6 +1576,289 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('lets operators choose remediation mode, authority, and action policy before submission', async () => {
+    const mockExecution = {
+      taskId: 'test-remediation-create-choices',
+      workflowId: 'test-remediation-create-choices',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Failed target with choices',
+      summary: 'Needs remediation.',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      repository: 'MoonLadderStudios/MoonMind',
+      createdAt: '2026-04-22T00:00:00Z',
+      updatedAt: '2026-04-22T00:00:01Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/executions/test-remediation-create-choices/remediations?direction=')) {
+        return Promise.resolve({ ok: true, json: async () => ({ direction: 'inbound', items: [] }) } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/executions/test-remediation-create-choices/remediation') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ workflowId: 'mm:remediation-created' }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    expect(await screen.findByText('Remediation create preview')).toBeTruthy();
+    expect(screen.getByText(/Evidence preview: step ledger, diagnostics, and 2000 log lines/)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Remediation mode'), {
+      target: { value: 'snapshot' },
+    });
+    fireEvent.change(screen.getByLabelText('Remediation authority'), {
+      target: { value: 'observe_only' },
+    });
+    fireEvent.change(screen.getByLabelText('Remediation action policy'), {
+      target: { value: 'troubleshooting_only' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create remediation task' }));
+
+    await waitFor(() => {
+      const remediationCreateCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url) === '/api/executions/test-remediation-create-choices/remediation' &&
+          init?.method === 'POST',
+      );
+      expect(remediationCreateCall).toBeTruthy();
+      expect(JSON.parse(String(remediationCreateCall?.[1]?.body))).toMatchObject({
+        remediation: {
+          mode: 'snapshot',
+          authorityMode: 'observe_only',
+          actionPolicyRef: 'troubleshooting_only',
+          target: { runId: '01-run' },
+          evidencePolicy: {
+            includeStepLedger: true,
+            includeDiagnostics: true,
+            tailLines: 2000,
+          },
+        },
+      });
+    });
+  });
+
+  it('hides remediation creation for ineligible completed targets', async () => {
+    const mockExecution = {
+      taskId: 'test-complete',
+      workflowId: 'test-complete',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Completed target task',
+      summary: 'No follow-up needed.',
+      status: 'completed',
+      state: 'succeeded',
+      rawState: 'succeeded',
+      temporalStatus: 'completed',
+      createdAt: '2026-04-22T00:00:00Z',
+      updatedAt: '2026-04-22T00:00:01Z',
+      actions: { canSetTitle: true },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Completed target task')).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Create remediation task' })).toBeNull();
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction='))).toBe(false);
+  });
+
+  it('renders approval-gated remediation as read-only when the operator cannot decide', async () => {
+    const mockExecution = {
+      taskId: 'test-readonly-approval',
+      workflowId: 'test-readonly-approval',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Remediation target task',
+      summary: 'Needs remediation.',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      createdAt: '2026-04-22T00:00:00Z',
+      updatedAt: '2026-04-22T00:00:01Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-readonly-approval/remediations?direction=inbound')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            direction: 'inbound',
+            items: [
+              {
+                remediationWorkflowId: 'mm:remediation-readonly',
+                remediationRunId: 'run-remediation-readonly',
+                targetWorkflowId: 'test-readonly-approval',
+                targetRunId: '01-run',
+                mode: 'snapshot_then_follow',
+                authorityMode: 'approval_gated',
+                status: 'awaiting_approval',
+                activeLockScope: 'target_execution',
+                latestActionSummary: 'Proposed session interrupt',
+                approvalState: {
+                  requestId: 'approval-readonly',
+                  actionKind: 'session_interrupt',
+                  riskTier: 'high',
+                  preconditions: 'Target run is still active.',
+                  blastRadius: 'One managed session.',
+                  decision: 'pending',
+                  canDecide: false,
+                },
+                createdAt: '2026-04-22T00:00:02Z',
+                updatedAt: '2026-04-22T00:00:03Z',
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-readonly-approval/remediations?direction=outbound')) {
+        return Promise.resolve({ ok: true, json: async () => ({ direction: 'outbound', items: [] }) } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    expect(await screen.findByText('mm:remediation-readonly')).toBeTruthy();
+    expect(screen.getByText('session_interrupt')).toBeTruthy();
+    expect(screen.getByText('high')).toBeTruthy();
+    expect(screen.getByText('Target run is still active.')).toBeTruthy();
+    expect(screen.getByText('One managed session.')).toBeTruthy();
+    expect(screen.getByText('Approval is read-only for this operator.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Approve remediation action' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reject remediation action' })).toBeNull();
+  });
+
+  it('renders degraded remediation states for missing links, evidence, and live follow data', async () => {
+    const mockExecution = {
+      taskId: 'test-remediation-degraded',
+      workflowId: 'test-remediation-degraded',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Remediation task',
+      summary: 'Remediation work with partial evidence.',
+      status: 'running',
+      state: 'running',
+      rawState: 'running',
+      temporalStatus: 'running',
+      createdAt: '2026-04-22T00:00:00Z',
+      updatedAt: '2026-04-22T00:00:01Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-remediation-degraded/remediations?direction=inbound')) {
+        return Promise.resolve({ ok: true, json: async () => ({ direction: 'inbound', items: [] }) } as Response);
+      }
+      if (url.includes('/executions/test-remediation-degraded/remediations?direction=outbound')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            direction: 'outbound',
+            items: [
+              {
+                remediationWorkflowId: 'test-remediation-degraded',
+                remediationRunId: '01-run',
+                targetWorkflowId: 'mm:target-long-workflow-id-with-many-segments-for-mobile-containment',
+                targetRunId: 'run-target-with-a-very-long-identifier-for-mobile-containment',
+                mode: 'snapshot_then_follow',
+                authorityMode: 'approval_gated',
+                status: 'collecting_context',
+                contextArtifactRef: null,
+                approvalState: { requestId: 'approval-missing', decision: 'pending', canDecide: false },
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    expect(await screen.findByRole('heading', { name: 'Remediation' })).toBeTruthy();
+    expect(screen.getByText('No inbound remediation tasks linked yet.')).toBeTruthy();
+    expect(screen.getByText('Evidence bundle is missing.')).toBeTruthy();
+    expect(screen.getByText('Live follow is unavailable; durable remediation artifacts remain authoritative.')).toBeTruthy();
+    expect(screen.getByText('No remediation evidence artifacts linked yet.')).toBeTruthy();
+
+    const longTarget = screen.getByText('mm:target-long-workflow-id-with-many-segments-for-mobile-containment');
+    expect(longTarget.closest('code')?.className).toContain('break-all');
+  });
+
+  it('keeps remediation panels accessible and contained in Mission Control CSS', async () => {
+    const { readFileSync } = await import('node:fs');
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      'utf8',
+    );
+
+    expect(missionControlCss).toMatch(/\.td-remediation-region:focus-within\s*\{[^}]*outline:\s*2px solid/s);
+    expect(missionControlCss).toMatch(/\.td-remediation-list\s+\.card\s*\{[^}]*min-width:\s*0;[^}]*max-width:\s*100%;/s);
+    expect(missionControlCss).toMatch(/@media\s*\(max-width:\s*720px\)\s*\{[^}]*\.td-remediation-region/s);
+    expect(missionControlCss).toMatch(/\.td-remediation-list\s+code\s*\{[^}]*overflow-wrap:\s*anywhere;/s);
+  });
+
   it('renders task detail as separated matte evidence and action regions', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1355,6 +1355,9 @@ describe('Task Detail Entrypoint', () => {
 
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/executions/test-complete/remediations?direction=')) {
+        return Promise.resolve({ ok: true, json: async () => ({ direction: 'inbound', items: [] }) } as Response);
+      }
       if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
         return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
       }
@@ -1696,7 +1699,8 @@ describe('Task Detail Entrypoint', () => {
     });
 
     expect(screen.queryByRole('button', { name: 'Create remediation task' })).toBeNull();
-    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction='))).toBe(false);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction=inbound'))).toBe(true);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction=outbound'))).toBe(true);
   });
 
   it('renders approval-gated remediation as read-only when the operator cannot decide', async () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -3226,6 +3226,39 @@ function remediationArtifactLabel(type: string): string {
   return labels[type] ?? type.replace(/^remediation\./, '').replaceAll('_', ' ');
 }
 
+function RemediationApprovalSummary({
+  approval,
+}: {
+  approval: z.infer<typeof RemediationApprovalStateSchema>;
+}) {
+  const hasDetails = Boolean(
+    approval.actionKind ||
+      approval.riskTier ||
+      approval.preconditions ||
+      approval.blastRadius ||
+      approval.auditRef ||
+      approval.decision,
+  );
+
+  if (!hasDetails) return null;
+
+  return (
+    <div className="td-remediation-approval">
+      <div className="grid-2">
+        <Card label="Action">{approval.actionKind || '—'}</Card>
+        <Card label="Risk">{approval.riskTier || '—'}</Card>
+        <Card label="Decision">{approval.decision || 'not_required'}</Card>
+        <Card label="Audit">{approval.auditRef || '—'}</Card>
+        <Card label="Preconditions">{approval.preconditions || '—'}</Card>
+        <Card label="Blast Radius">{approval.blastRadius || '—'}</Card>
+      </div>
+      {approval.requestId && !approval.canDecide && approval.decision === 'pending' ? (
+        <p className="notice subtle">Approval is read-only for this operator.</p>
+      ) : null}
+    </div>
+  );
+}
+
 function RemediationRelationshipsPanel({
   inbound,
   outbound,
@@ -3233,6 +3266,7 @@ function RemediationRelationshipsPanel({
   outboundError,
   onApprovalDecision,
   approvalBusy,
+  showEmpty,
 }: {
   inbound: z.infer<typeof RemediationLinksSchema> | undefined;
   outbound: z.infer<typeof RemediationLinksSchema> | undefined;
@@ -3240,12 +3274,13 @@ function RemediationRelationshipsPanel({
   outboundError: Error | null;
   onApprovalDecision: (workflowId: string, requestId: string, decision: 'approved' | 'rejected') => void;
   approvalBusy: boolean;
+  showEmpty: boolean;
 }) {
   const inboundItems = inbound?.items ?? [];
   const outboundItems = outbound?.items ?? [];
   const hasData = inboundItems.length > 0 || outboundItems.length > 0;
 
-  if (!hasData && !inboundError && !outboundError) return null;
+  if (!hasData && !inboundError && !outboundError && !showEmpty) return null;
 
   return (
     <section className="stack td-remediation-region td-evidence-region">
@@ -3265,7 +3300,7 @@ function RemediationRelationshipsPanel({
             {inboundItems.map((item) => (
               <li key={item.remediationWorkflowId} className="card">
                 <a href={dependencyHref(item.remediationWorkflowId)}>
-                  <strong>{item.remediationWorkflowId}</strong>
+                  <code className="text-xs break-all">{item.remediationWorkflowId}</code>
                 </a>
                 <div className="grid-2">
                   <Card label="Status">{item.status || '—'}</Card>
@@ -3275,6 +3310,7 @@ function RemediationRelationshipsPanel({
                   <Card label="Lock">{item.activeLockScope || 'None'}</Card>
                   <Card label="Updated">{formatWhen(item.updatedAt)}</Card>
                 </div>
+                {item.approvalState ? <RemediationApprovalSummary approval={item.approvalState} /> : null}
                 {item.approvalState?.canDecide && item.approvalState.requestId ? (
                   <div className="actions">
                     <button
@@ -3299,6 +3335,8 @@ function RemediationRelationshipsPanel({
             ))}
           </ul>
         </div>
+      ) : showEmpty && !inboundError ? (
+        <p className="notice subtle">No inbound remediation tasks linked yet.</p>
       ) : null}
       {outboundItems.length > 0 ? (
         <div className="stack">
@@ -3307,7 +3345,7 @@ function RemediationRelationshipsPanel({
             {outboundItems.map((item) => (
               <li key={item.targetWorkflowId} className="card">
                 <a href={dependencyHref(item.targetWorkflowId)}>
-                  <strong>{item.targetWorkflowId}</strong>
+                  <code className="text-xs break-all">{item.targetWorkflowId}</code>
                 </a>
                 <div className="grid-2">
                   <Card label="Pinned Run"><code className="text-xs break-all">{item.targetRunId || '—'}</code></Card>
@@ -3317,6 +3355,15 @@ function RemediationRelationshipsPanel({
                   <Card label="Evidence Bundle">{item.contextArtifactRef || 'Missing'}</Card>
                   <Card label="Approval">{item.approvalState?.decision || 'not_required'}</Card>
                 </div>
+                {!item.contextArtifactRef ? (
+                  <p className="notice subtle">Evidence bundle is missing.</p>
+                ) : null}
+                {item.mode?.includes('follow') && !item.contextArtifactRef ? (
+                  <p className="notice subtle">
+                    Live follow is unavailable; durable remediation artifacts remain authoritative.
+                  </p>
+                ) : null}
+                {item.approvalState ? <RemediationApprovalSummary approval={item.approvalState} /> : null}
                 {item.approvalState?.canDecide && item.approvalState.requestId ? (
                   <div className="actions">
                     <button
@@ -3341,6 +3388,8 @@ function RemediationRelationshipsPanel({
             ))}
           </ul>
         </div>
+      ) : showEmpty && !outboundError ? (
+        <p className="notice subtle">No outbound remediation target linked yet.</p>
       ) : null}
     </section>
   );
@@ -3349,15 +3398,25 @@ function RemediationRelationshipsPanel({
 function RemediationEvidencePanel({
   artifacts,
   apiBase,
+  showEmpty,
 }: {
   artifacts: z.infer<typeof ArtifactSummarySchema>[];
   apiBase: string;
+  showEmpty: boolean;
 }) {
   const remediationArtifacts = artifacts
     .map((artifact) => ({ artifact, type: remediationArtifactType(artifact) }))
     .filter((item): item is { artifact: z.infer<typeof ArtifactSummarySchema>; type: string } => Boolean(item.type));
 
-  if (remediationArtifacts.length === 0) return null;
+  if (remediationArtifacts.length === 0) {
+    if (!showEmpty) return null;
+    return (
+      <section className="stack td-remediation-region td-evidence-region">
+        <h3>Remediation Evidence</h3>
+        <p className="notice subtle">No remediation evidence artifacts linked yet.</p>
+      </section>
+    );
+  }
 
   return (
     <section className="stack td-remediation-region td-evidence-region">
@@ -3426,6 +3485,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const [liveUpdates, setLiveUpdates] = useState(true);
   const [expandedSteps, setExpandedSteps] = useState<Record<string, boolean>>({});
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
+  const [remediationMode, setRemediationMode] = useState('snapshot_then_follow');
+  const [remediationAuthority, setRemediationAuthority] = useState('approval_gated');
+  const [remediationActionPolicy, setRemediationActionPolicy] = useState('admin_healer_default');
 
   const detailQuery = useQuery({
     queryKey: ['task-detail', encodedTaskId, sourceTemporal],
@@ -3685,11 +3747,12 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
           repository: execution?.repository ?? null,
           instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
           remediation: {
-            mode: 'snapshot_then_follow',
-            authorityMode: 'approval_gated',
+            mode: remediationMode,
+            authorityMode: remediationAuthority,
             target: {
               runId: latestRunId || runId || undefined,
             },
+            actionPolicyRef: remediationActionPolicy.trim() || undefined,
             evidencePolicy: {
               includeStepLedger: true,
               includeDiagnostics: true,
@@ -4238,6 +4301,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             inboundError={inboundRemediationsQuery.isError ? (inboundRemediationsQuery.error as Error) : null}
             outboundError={outboundRemediationsQuery.isError ? (outboundRemediationsQuery.error as Error) : null}
             approvalBusy={remediationApprovalMutation.isPending}
+            showEmpty={shouldFetchRemediationLinks && (inboundRemediationsQuery.isSuccess || outboundRemediationsQuery.isSuccess)}
             onApprovalDecision={(remediationWorkflowId, requestId, decision) => {
               setActionError(null);
               remediationApprovalMutation.mutate({ remediationWorkflowId, requestId, decision });
@@ -4252,17 +4316,55 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               </div>
               <div className="actions">
                 {canCreateRemediation ? (
-                  <button
-                    type="button"
-                    className="secondary"
-                    disabled={busy}
-                    onClick={() => {
-                      setActionError(null);
-                      createRemediationMutation.mutate();
-                    }}
-                  >
-                    Create remediation task
-                  </button>
+                  <div className="stack td-remediation-create-preview">
+                    <h4>Remediation create preview</h4>
+                    <div className="grid-2">
+                      <label>
+                        Remediation mode
+                        <select
+                          value={remediationMode}
+                          onChange={(event) => setRemediationMode(event.target.value)}
+                        >
+                          <option value="snapshot_then_follow">Snapshot then follow</option>
+                          <option value="snapshot">Snapshot only</option>
+                          <option value="live_follow">Live follow</option>
+                        </select>
+                      </label>
+                      <label>
+                        Remediation authority
+                        <select
+                          value={remediationAuthority}
+                          onChange={(event) => setRemediationAuthority(event.target.value)}
+                        >
+                          <option value="approval_gated">Approval-gated admin remediation</option>
+                          <option value="observe_only">Troubleshooting only</option>
+                          <option value="admin_auto">Admin remediation</option>
+                        </select>
+                      </label>
+                      <label>
+                        Remediation action policy
+                        <input
+                          value={remediationActionPolicy}
+                          onChange={(event) => setRemediationActionPolicy(event.target.value)}
+                        />
+                      </label>
+                      <Card label="Pinned Run"><code className="text-xs break-all">{latestRunId || runId || '—'}</code></Card>
+                    </div>
+                    <p className="small">
+                      Evidence preview: step ledger, diagnostics, and 2000 log lines.
+                    </p>
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={busy}
+                      onClick={() => {
+                        setActionError(null);
+                        createRemediationMutation.mutate();
+                      }}
+                    >
+                      Create remediation task
+                    </button>
+                  </div>
                 ) : null}
                 {actions.canSetTitle ? (
                   <button type="button" disabled={busy} className="secondary" onClick={onRename}>
@@ -4334,6 +4436,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
           <RemediationEvidencePanel
             artifacts={artifactsQuery.data?.artifacts || []}
             apiBase={payload.apiBase}
+            showEmpty={shouldFetchRemediationLinks && artifactsQuery.isSuccess}
           />
 
           <section className="stack td-timeline-region td-evidence-region">

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -358,6 +358,48 @@ const ExecutionDetailSchema = z
   })
   .passthrough();
 
+const RemediationApprovalStateSchema = z
+  .object({
+    requestId: z.string().nullable().optional(),
+    actionKind: z.string().nullable().optional(),
+    riskTier: z.string().nullable().optional(),
+    preconditions: z.string().nullable().optional(),
+    blastRadius: z.string().nullable().optional(),
+    decision: z.string().default('not_required'),
+    decisionActor: z.string().nullable().optional(),
+    decisionAt: z.string().nullable().optional(),
+    canDecide: z.boolean().default(false),
+    auditRef: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const RemediationLinkSchema = z
+  .object({
+    remediationWorkflowId: z.string(),
+    remediationRunId: z.string(),
+    targetWorkflowId: z.string(),
+    targetRunId: z.string(),
+    mode: z.string(),
+    authorityMode: z.string(),
+    status: z.string(),
+    activeLockScope: z.string().nullable().optional(),
+    activeLockHolder: z.string().nullable().optional(),
+    latestActionSummary: z.string().nullable().optional(),
+    resolution: z.string().nullable().optional(),
+    contextArtifactRef: z.string().nullable().optional(),
+    approvalState: RemediationApprovalStateSchema.nullable().optional(),
+    createdAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const RemediationLinksSchema = z
+  .object({
+    direction: z.string().default('inbound'),
+    items: z.array(RemediationLinkSchema).default([]),
+  })
+  .passthrough();
+
 const ArtifactSummarySchema = z
   .object({
     artifactId: z.string(),
@@ -3154,6 +3196,200 @@ function renderMissingTaskRunCopy(state: MissingTaskRunState): string {
   return 'Waiting for managed runtime launch to create live logs.';
 }
 
+function isRemediationEligibleTarget(execution: z.infer<typeof ExecutionDetailSchema>): boolean {
+  const state = (execution.rawState || execution.state || execution.status || '').toLowerCase();
+  return (
+    execution.attentionRequired === true ||
+    Boolean(execution.waitingReason) ||
+    state.includes('failed') ||
+    state.includes('stuck') ||
+    state === 'awaiting_external'
+  );
+}
+
+function remediationArtifactType(artifact: z.infer<typeof ArtifactSummarySchema>): string | null {
+  const metadataType = metadataString(artifact.metadata, 'artifact_type', 'artifactType');
+  if (metadataType.startsWith('remediation.')) return metadataType;
+  return artifact.links.find((link) => link.linkType.startsWith('remediation.'))?.linkType ?? null;
+}
+
+function remediationArtifactLabel(type: string): string {
+  const labels: Record<string, string> = {
+    'remediation.context': 'Context',
+    'remediation.plan': 'Plan',
+    'remediation.decision_log': 'Decision Log',
+    'remediation.action_request': 'Action Request',
+    'remediation.action_result': 'Action Result',
+    'remediation.verification': 'Verification',
+    'remediation.summary': 'Summary',
+  };
+  return labels[type] ?? type.replace(/^remediation\./, '').replaceAll('_', ' ');
+}
+
+function RemediationRelationshipsPanel({
+  inbound,
+  outbound,
+  inboundError,
+  outboundError,
+  onApprovalDecision,
+  approvalBusy,
+}: {
+  inbound: z.infer<typeof RemediationLinksSchema> | undefined;
+  outbound: z.infer<typeof RemediationLinksSchema> | undefined;
+  inboundError: Error | null;
+  outboundError: Error | null;
+  onApprovalDecision: (workflowId: string, requestId: string, decision: 'approved' | 'rejected') => void;
+  approvalBusy: boolean;
+}) {
+  const inboundItems = inbound?.items ?? [];
+  const outboundItems = outbound?.items ?? [];
+  const hasData = inboundItems.length > 0 || outboundItems.length > 0;
+
+  if (!hasData && !inboundError && !outboundError) return null;
+
+  return (
+    <section className="stack td-remediation-region td-evidence-region">
+      <div>
+        <h3>Remediation</h3>
+        <p className="small">Target and remediator relationships are shown from bounded remediation link metadata.</p>
+      </div>
+      {inboundError || outboundError ? (
+        <div className="notice error">
+          Remediation relationship data is degraded. Existing task detail remains available.
+        </div>
+      ) : null}
+      {inboundItems.length > 0 ? (
+        <div className="stack">
+          <h4>Remediation Tasks</h4>
+          <ul className="td-remediation-list">
+            {inboundItems.map((item) => (
+              <li key={item.remediationWorkflowId} className="card">
+                <a href={dependencyHref(item.remediationWorkflowId)}>
+                  <strong>{item.remediationWorkflowId}</strong>
+                </a>
+                <div className="grid-2">
+                  <Card label="Status">{item.status || '—'}</Card>
+                  <Card label="Authority">{item.authorityMode || '—'}</Card>
+                  <Card label="Latest Action">{item.latestActionSummary || '—'}</Card>
+                  <Card label="Resolution">{item.resolution || '—'}</Card>
+                  <Card label="Lock">{item.activeLockScope || 'None'}</Card>
+                  <Card label="Updated">{formatWhen(item.updatedAt)}</Card>
+                </div>
+                {item.approvalState?.canDecide && item.approvalState.requestId ? (
+                  <div className="actions">
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={approvalBusy}
+                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'approved')}
+                    >
+                      Approve remediation action
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={approvalBusy}
+                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'rejected')}
+                    >
+                      Reject remediation action
+                    </button>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {outboundItems.length > 0 ? (
+        <div className="stack">
+          <h4>Remediation Target</h4>
+          <ul className="td-remediation-list">
+            {outboundItems.map((item) => (
+              <li key={item.targetWorkflowId} className="card">
+                <a href={dependencyHref(item.targetWorkflowId)}>
+                  <strong>{item.targetWorkflowId}</strong>
+                </a>
+                <div className="grid-2">
+                  <Card label="Pinned Run"><code className="text-xs break-all">{item.targetRunId || '—'}</code></Card>
+                  <Card label="Mode">{item.mode || '—'}</Card>
+                  <Card label="Authority">{item.authorityMode || '—'}</Card>
+                  <Card label="Status">{item.status || '—'}</Card>
+                  <Card label="Evidence Bundle">{item.contextArtifactRef || 'Missing'}</Card>
+                  <Card label="Approval">{item.approvalState?.decision || 'not_required'}</Card>
+                </div>
+                {item.approvalState?.canDecide && item.approvalState.requestId ? (
+                  <div className="actions">
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={approvalBusy}
+                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'approved')}
+                    >
+                      Approve remediation action
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={approvalBusy}
+                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'rejected')}
+                    >
+                      Reject remediation action
+                    </button>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function RemediationEvidencePanel({
+  artifacts,
+  apiBase,
+}: {
+  artifacts: z.infer<typeof ArtifactSummarySchema>[];
+  apiBase: string;
+}) {
+  const remediationArtifacts = artifacts
+    .map((artifact) => ({ artifact, type: remediationArtifactType(artifact) }))
+    .filter((item): item is { artifact: z.infer<typeof ArtifactSummarySchema>; type: string } => Boolean(item.type));
+
+  if (remediationArtifacts.length === 0) return null;
+
+  return (
+    <section className="stack td-remediation-region td-evidence-region">
+      <h3>Remediation Evidence</h3>
+      <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
+        <table>
+          <thead>
+            <tr>
+              <th>Evidence</th>
+              <th>Artifact</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {remediationArtifacts.map(({ artifact, type }) => (
+              <tr key={artifact.artifactId}>
+                <td>{remediationArtifactLabel(type)}</td>
+                <td><code>{artifact.artifactId}</code></td>
+                <td>
+                  <a className="button secondary" href={artifactDownloadHref(apiBase, artifact)}>
+                    Open Evidence
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const cfg = readDashboardConfig(payload);
@@ -3213,6 +3449,14 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const summaryArtifactRef = execution?.summaryArtifactRef || execution?.summary_artifact_ref || '';
   const explicitTaskRunId = execution?.taskRunId || execution?.task_run_id || '';
   const resolvedTaskRunId = explicitTaskRunId;
+  const shouldFetchRemediationLinks = Boolean(
+    execution &&
+      workflowId &&
+      (isRemediationEligibleTarget(execution) ||
+        /remediation/i.test(
+          `${execution.title || ''} ${execution.summary || ''} ${execution.taskInstructions || ''}`,
+        )),
+  );
   const sessionTimelineEnabled = shouldEnableSessionTimelineViewer({
     config: cfg,
     targetRuntime: execution?.targetRuntime,
@@ -3290,6 +3534,28 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     enabled: Boolean(summaryArtifactRef),
     refetchInterval: liveUpdates && summaryArtifactRef ? detailPoll : false,
   });
+  const inboundRemediationsQuery = useQuery({
+    queryKey: ['task-detail-remediations', workflowId, 'inbound'],
+    queryFn: async () => {
+      const response = await fetch(
+        `${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/remediations?direction=inbound`,
+      );
+      if (!response.ok) throw new Error(`Remediations: ${response.statusText}`);
+      return RemediationLinksSchema.parse(await response.json());
+    },
+    enabled: shouldFetchRemediationLinks,
+  });
+  const outboundRemediationsQuery = useQuery({
+    queryKey: ['task-detail-remediations', workflowId, 'outbound'],
+    queryFn: async () => {
+      const response = await fetch(
+        `${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/remediations?direction=outbound`,
+      );
+      if (!response.ok) throw new Error(`Remediations: ${response.statusText}`);
+      return RemediationLinksSchema.parse(await response.json());
+    },
+    enabled: shouldFetchRemediationLinks,
+  });
   const runSummary = runSummaryQuery.data;
   const displayedMergeAutomation =
     execution?.mergeAutomation || runSummary?.mergeAutomation || null;
@@ -3335,6 +3601,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     void queryClient.invalidateQueries({ queryKey: ['task-detail-artifacts', namespace, workflowId, latestRunId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-latest-report', namespace, workflowId, latestRunId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-run-summary', summaryArtifactRef] });
+    void queryClient.invalidateQueries({ queryKey: ['task-detail-remediations', workflowId] });
   };
 
   const updateMutation = useMutation({
@@ -3409,6 +3676,73 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     onError: (error: Error) => setActionError(error.message),
   });
 
+  const createRemediationMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(`${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/remediation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          repository: execution?.repository ?? null,
+          instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
+          remediation: {
+            mode: 'snapshot_then_follow',
+            authorityMode: 'approval_gated',
+            target: {
+              runId: latestRunId || runId || undefined,
+            },
+            evidencePolicy: {
+              includeStepLedger: true,
+              includeDiagnostics: true,
+              tailLines: 2000,
+            },
+            trigger: { type: 'manual' },
+          },
+        }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setActionNotice('Remediation task creation submitted.');
+      invalidate();
+    },
+    onError: (error: Error) => setActionError(error.message),
+  });
+
+  const remediationApprovalMutation = useMutation({
+    mutationFn: async ({
+      remediationWorkflowId,
+      requestId,
+      decision,
+    }: {
+      remediationWorkflowId: string;
+      requestId: string;
+      decision: 'approved' | 'rejected';
+    }) => {
+      const response = await fetch(
+        `${payload.apiBase}/executions/${encodeURIComponent(remediationWorkflowId)}/remediation/approvals/${encodeURIComponent(requestId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({ decision }),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setActionNotice('Remediation approval decision recorded.');
+      invalidate();
+    },
+    onError: (error: Error) => setActionError(error.message),
+  });
+
   const onRename = () => {
     setActionError(null);
     const title = window.prompt('New task title', execution?.title || '');
@@ -3462,7 +3796,12 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   };
 
   const actions = execution?.actions;
-  const busy = updateMutation.isPending || signalMutation.isPending || cancelMutation.isPending;
+  const busy =
+    updateMutation.isPending ||
+    signalMutation.isPending ||
+    cancelMutation.isPending ||
+    createRemediationMutation.isPending ||
+    remediationApprovalMutation.isPending;
   const editHref = workflowId ? taskEditHref(workflowId) : '';
   const rerunHref = workflowId ? taskRerunHref(workflowId) : '';
   const onTaskEditingNavigation = (
@@ -3480,8 +3819,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     });
   };
   const isTerminalExecution = TERMINAL_STATES.has(execution?.rawState || execution?.state || '');
+  const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
   const hasTaskEditingActions = taskEditingOn && Boolean(actions?.canUpdateInputs || actions?.canRerun);
-  const hasTaskActions = Boolean(actions?.canSetTitle || hasTaskEditingActions);
+  const hasTaskActions = Boolean(actions?.canSetTitle || hasTaskEditingActions || canCreateRemediation);
   const taskInstructions = execution?.taskInstructions?.trim() || '';
   const hasTaskInstructions = taskInstructions.length > 0;
   const hasInterventionSection = Boolean(
@@ -3892,6 +4232,18 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             </section>
           ) : null}
 
+          <RemediationRelationshipsPanel
+            inbound={inboundRemediationsQuery.data}
+            outbound={outboundRemediationsQuery.data}
+            inboundError={inboundRemediationsQuery.isError ? (inboundRemediationsQuery.error as Error) : null}
+            outboundError={outboundRemediationsQuery.isError ? (outboundRemediationsQuery.error as Error) : null}
+            approvalBusy={remediationApprovalMutation.isPending}
+            onApprovalDecision={(remediationWorkflowId, requestId, decision) => {
+              setActionError(null);
+              remediationApprovalMutation.mutate({ remediationWorkflowId, requestId, decision });
+            }}
+          />
+
           {actionsOn && actions && hasTaskActions ? (
             <section className="stack td-actions-region">
               <div>
@@ -3899,6 +4251,19 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                 <p className="small">Workflow editing actions stay separate from intervention controls.</p>
               </div>
               <div className="actions">
+                {canCreateRemediation ? (
+                  <button
+                    type="button"
+                    className="secondary"
+                    disabled={busy}
+                    onClick={() => {
+                      setActionError(null);
+                      createRemediationMutation.mutate();
+                    }}
+                  >
+                    Create remediation task
+                  </button>
+                ) : null}
                 {actions.canSetTitle ? (
                   <button type="button" disabled={busy} className="secondary" onClick={onRename}>
                     Rename
@@ -3963,6 +4328,11 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
           <ReportPresentationSection
             primaryReport={primaryReport}
             relatedArtifacts={relatedReports}
+            apiBase={payload.apiBase}
+          />
+
+          <RemediationEvidencePanel
+            artifacts={artifactsQuery.data?.artifacts || []}
             apiBase={payload.apiBase}
           />
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -3511,14 +3511,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const summaryArtifactRef = execution?.summaryArtifactRef || execution?.summary_artifact_ref || '';
   const explicitTaskRunId = execution?.taskRunId || execution?.task_run_id || '';
   const resolvedTaskRunId = explicitTaskRunId;
-  const shouldFetchRemediationLinks = Boolean(
-    execution &&
-      workflowId &&
-      (isRemediationEligibleTarget(execution) ||
-        /remediation/i.test(
-          `${execution.title || ''} ${execution.summary || ''} ${execution.taskInstructions || ''}`,
-        )),
-  );
+  const shouldFetchRemediationLinks = Boolean(execution && workflowId);
   const sessionTimelineEnabled = shouldEnableSessionTimelineViewer({
     config: cfg,
     targetRuntime: execution?.targetRuntime,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -955,6 +955,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/{workflow_id}/remediations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Execution Remediations */
+        get: operations["list_execution_remediations_api_executions__workflow_id__remediations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/executions/{workflow_id}/remediation/approvals/{request_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record Remediation Approval Decision */
+        post: operations["record_remediation_approval_decision_api_executions__workflow_id__remediation_approvals__request_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions": {
         parameters: {
             query?: never;
@@ -5067,6 +5101,95 @@ export interface components {
              */
             updatedAt: string;
         };
+        /** RemediationApprovalDecisionRequest */
+        RemediationApprovalDecisionRequest: {
+            /** Decision */
+            decision: string;
+            /** Comment */
+            comment?: string | null;
+        };
+        /** RemediationApprovalDecisionResponse */
+        RemediationApprovalDecisionResponse: {
+            /** Accepted */
+            accepted: boolean;
+            /** Workflowid */
+            workflowId: string;
+            /** Requestid */
+            requestId: string;
+            /** Decision */
+            decision: string;
+        };
+        /** RemediationApprovalStateModel */
+        RemediationApprovalStateModel: {
+            /** Requestid */
+            requestId?: string | null;
+            /** Actionkind */
+            actionKind?: string | null;
+            /** Risktier */
+            riskTier?: string | null;
+            /** Preconditions */
+            preconditions?: string | null;
+            /** Blastradius */
+            blastRadius?: string | null;
+            /** Decision */
+            decision: string;
+            /** Decisionactor */
+            decisionActor?: string | null;
+            /** Decisionat */
+            decisionAt?: string | null;
+            /**
+             * Candecide
+             * @default false
+             */
+            canDecide: boolean;
+            /** Auditref */
+            auditRef?: string | null;
+        };
+        /** RemediationLinkSummaryModel */
+        RemediationLinkSummaryModel: {
+            /** Remediationworkflowid */
+            remediationWorkflowId: string;
+            /** Remediationrunid */
+            remediationRunId: string;
+            /** Targetworkflowid */
+            targetWorkflowId: string;
+            /** Targetrunid */
+            targetRunId: string;
+            /** Mode */
+            mode: string;
+            /** Authoritymode */
+            authorityMode: string;
+            /** Status */
+            status: string;
+            /** Activelockscope */
+            activeLockScope?: string | null;
+            /** Activelockholder */
+            activeLockHolder?: string | null;
+            /** Latestactionsummary */
+            latestActionSummary?: string | null;
+            /** Resolution */
+            resolution?: string | null;
+            /** Contextartifactref */
+            contextArtifactRef?: string | null;
+            approvalState?: components["schemas"]["RemediationApprovalStateModel"] | null;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+        };
+        /** RemediationLinksResponseModel */
+        RemediationLinksResponseModel: {
+            /** Direction */
+            direction: string;
+            /** Items */
+            items: components["schemas"]["RemediationLinkSummaryModel"][];
+        };
         /** RepositorySummarizationRequest */
         RepositorySummarizationRequest: {
             /**
@@ -8475,6 +8598,75 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionModel"] | components["schemas"]["ScheduleCreatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_execution_remediations_api_executions__workflow_id__remediations_get: {
+        parameters: {
+            query?: {
+                direction?: string;
+            };
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RemediationLinksResponseModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_remediation_approval_decision_api_executions__workflow_id__remediation_approvals__request_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+                request_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemediationApprovalDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RemediationApprovalDecisionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2938,6 +2938,46 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   padding: 0;
 }
 
+.td-remediation-region:focus-within {
+  outline: 2px solid rgb(var(--mm-accent) / 0.72);
+  outline-offset: 3px;
+}
+
+.td-remediation-list .card {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.td-remediation-list code {
+  overflow-wrap: anywhere;
+}
+
+.td-remediation-approval {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.65rem;
+}
+
+.td-remediation-create-preview {
+  width: 100%;
+  min-width: 0;
+}
+
+.td-remediation-create-preview label {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.td-remediation-create-preview select,
+.td-remediation-create-preview input {
+  width: 100%;
+  min-width: 0;
+}
+
 .td-actions-region {
   padding: 0.8rem;
   border: 1px solid rgb(var(--mm-border) / 0.62);
@@ -3138,5 +3178,15 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
   .td-group dl {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .td-remediation-region {
+    padding: 0.7rem;
+  }
+
+  .td-remediation-list {
+    gap: 0.6rem;
   }
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2924,9 +2924,18 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .td-run-summary-region,
 .td-steps-region,
 .td-artifacts-region,
+.td-remediation-region,
 .td-timeline-region,
 .td-observation-region {
   overflow-wrap: anywhere;
+}
+
+.td-remediation-list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .td-actions-region {

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -527,6 +527,42 @@ class TemporalExecutionService:
         )
         return await self._scalars_all(stmt)
 
+    async def record_remediation_approval_decision(
+        self,
+        *,
+        remediation_workflow_id: str,
+        request_id: str,
+        decision: str,
+        comment: str | None,
+        actor: str | None,
+    ) -> dict[str, Any]:
+        if decision not in {"approved", "rejected"}:
+            raise TemporalExecutionValidationError(
+                "decision must be 'approved' or 'rejected'."
+            )
+        record = await self._require_source_execution(remediation_workflow_id)
+        detail_parts = [f"requestId={request_id}"]
+        if actor:
+            detail_parts.append(f"actor={actor}")
+        if comment:
+            detail_parts.append(f"comment={comment[:500]}")
+        self._append_intervention_audit(
+            record,
+            action=f"remediation_approval_{decision}",
+            transport="api",
+            summary=f"Remediation approval {decision}.",
+            detail="; ".join(detail_parts),
+        )
+        await self._session.commit()
+        await self._session.refresh(record)
+        await self._sync_projection_best_effort(record)
+        return {
+            "accepted": True,
+            "workflowId": remediation_workflow_id,
+            "requestId": request_id,
+            "decision": decision,
+        }
+
     async def list_prerequisites(
         self, dependent_workflow_id: str
     ) -> list[TemporalExecutionDependency]:

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -74,6 +74,9 @@ ALLOWED_REMEDIATION_AUTHORITY_MODES = frozenset(
     {"observe_only", "approval_gated", "admin_auto"}
 )
 ALLOWED_REMEDIATION_ACTION_POLICY_REFS = frozenset({"admin_healer_default"})
+PENDING_REMEDIATION_APPROVAL_STATUSES = frozenset(
+    {"awaiting_approval", "approval_required"}
+)
 
 import logging
 
@@ -541,6 +544,20 @@ class TemporalExecutionService:
                 "decision must be 'approved' or 'rejected'."
             )
         record = await self._require_source_execution(remediation_workflow_id)
+        link = await self._session.get(
+            TemporalExecutionRemediationLink,
+            remediation_workflow_id,
+        )
+        expected_request_id = f"{remediation_workflow_id}:approval"
+        if (
+            link is None
+            or link.authority_mode != "approval_gated"
+            or link.status not in PENDING_REMEDIATION_APPROVAL_STATUSES
+            or request_id != expected_request_id
+        ):
+            raise TemporalExecutionValidationError(
+                "request_id must reference a pending approval-gated remediation."
+            )
         detail_parts = [f"requestId={request_id}"]
         if actor:
             detail_parts.append(f"actor={actor}")

--- a/specs/224-remediation-mission-control/checklists/requirements.md
+++ b/specs/224-remediation-mission-control/checklists/requirements.md
@@ -36,5 +36,6 @@
 
 ## Notes
 
-- The source Jira issue is MM-457 and the spec preserves MM-457 traceability from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
+- The source Jira issue is MM-457 and the spec preserves the original Jira preset brief directly in `spec.md` from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
+- Implementation-oriented wording appears only inside the preserved original preset brief source block required for verification traceability; the generated user-facing specification remains behavior-focused.
 - Runtime implementation is in scope after artifact alignment.

--- a/specs/224-remediation-mission-control/checklists/requirements.md
+++ b/specs/224-remediation-mission-control/checklists/requirements.md
@@ -36,5 +36,5 @@
 
 ## Notes
 
-- The source Jira issue is explicitly unknown in the task instruction; the spec preserves MM-437 and STORY-007 traceability without inventing a Jira issue key.
-- Implementation is intentionally not run in this breakdown/orchestration task.
+- The source Jira issue is MM-457 and the spec preserves MM-457 traceability from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
+- Runtime implementation is in scope after artifact alignment.

--- a/specs/224-remediation-mission-control/plan.md
+++ b/specs/224-remediation-mission-control/plan.md
@@ -5,41 +5,41 @@
 
 ## Summary
 
-Implement MM-457 by layering Mission Control UI and narrow API read/decision surfaces over the existing remediation create/link/context/evidence foundations. Existing backend work already accepts remediation create requests, persists remediation links, builds bounded context artifacts, and exposes typed evidence tools at service boundaries. This story adds operator-visible task-detail panels and create/approval flows: target pages show remediation creation and inbound links, remediation pages show target/evidence/approval state, evidence artifact refs use the existing artifact presentation path, and approval decisions stay permission-aware and audit-backed. Tests are frontend-first with focused backend route coverage where Mission Control needs a read or decision contract that does not already exist.
+Implement MM-457 by layering Mission Control UI and narrow API read/decision surfaces over the existing remediation create/link/context/evidence foundations. Existing backend work already accepts remediation create requests, persists remediation links, builds bounded context artifacts, and exposes typed evidence tools at service boundaries. Current implementation adds operator-visible task-detail panels and create/approval flows: target pages show remediation creation and inbound links, remediation pages show target/evidence/approval state, evidence artifact refs use the existing artifact presentation path, and approval decisions stay permission-aware and audit-backed. Verification is frontend-first with focused backend route/service coverage where Mission Control needs a read or decision contract.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | missing | Task detail has generic status and action regions, but no remediation create action | Add eligible-target create action in task detail | UI unit |
-| FR-002 | partial | `POST /api/executions/{workflow_id}/remediation` exists in `api_service/api/routers/executions.py`; no Mission Control prefill flow | Wire create action/form to canonical route with target context | UI unit + router unit |
-| FR-003 | missing | No remediation create UI policy/evidence preview found | Add troubleshooting/admin choices and evidence preview | UI unit |
-| FR-004 | partial | Service methods `list_remediations_for_target` exist; no API/UI read surface | Add/read inbound remediation link API and target panel | API unit + UI unit |
-| FR-005 | partial | Service methods `list_remediation_targets` and context builder exist; no task-detail panel | Add/read outbound target API and remediation target panel | API unit + UI unit |
-| FR-006 | partial | Remediation artifacts and context refs exist; task detail shows generic artifacts only | Add remediation evidence grouping and labels | UI unit |
-| FR-007 | implemented_unverified | Artifact authorization/preview path exists; no remediation-specific no-raw-storage test | Verify evidence links use artifact refs only | UI unit |
-| FR-008 | missing | Timeline can render approval rows; no remediation approval summary contract | Add approval-state read model and UI display | API unit + UI unit |
-| FR-009 | missing | No remediation approval decision controls found | Add permission-aware approve/reject flow or read-only fallback | API unit + UI unit |
-| FR-010 | missing | No remediation degraded/empty states | Add degraded states for missing links, context, evidence, live follow, approval | UI unit |
-| FR-011 | implemented_unverified | MM-429 accessibility/fallback CSS exists; remediation-specific panels not covered | Add remediation panel accessibility/fallback assertions | UI unit |
-| FR-012 | implemented_unverified | Existing task-detail/create/artifact tests pass in prior specs | Preserve and rerun route regression tests | UI unit |
-| FR-013 | missing | This artifact set has been realigned to the canonical MM-457 orchestration input | Preserve traceability in specs/tasks/verification | final verify |
-| DESIGN-REQ-001 | missing | Desired-state doc only for Mission Control create entrypoints | Implement create action entrypoints | UI unit |
-| DESIGN-REQ-002 | missing | Desired-state doc only for remediation create choices | Implement create form/prefill choices | UI unit |
-| DESIGN-REQ-003 | partial | Backend link table/service exists; no Mission Control panel | Implement inbound panel/API | API unit + UI unit |
-| DESIGN-REQ-004 | partial | Backend outbound link/context exists; no Mission Control panel | Implement outbound panel/API | API unit + UI unit |
-| DESIGN-REQ-005 | partial | Remediation artifacts exist as generic artifacts | Implement remediation evidence grouping | UI unit |
-| DESIGN-REQ-006 | missing | No remediation approval handoff UI/API found | Implement approval display and decision path | API unit + UI unit |
-| DESIGN-REQ-007 | missing | No remediation degraded UI states | Implement partial-evidence and missing-link states | UI unit |
-| DESIGN-REQ-008 | implemented_unverified | Mission Control design tests exist but not for new remediation surfaces | Add accessibility/fallback coverage for remediation panels | UI unit |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` adds eligible-target Create remediation task action; `frontend/src/entrypoints/task-detail.test.tsx` covers eligible submission | No new implementation; add ineligible-state coverage if expanding regression scope | UI unit |
+| FR-002 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` posts target context to `POST /api/executions/{workflow_id}/remediation`; router regression remains in `tests/unit/api/routers/test_executions.py` | No new implementation | UI unit + router unit |
+| FR-003 | partial | Current UI submits bounded default mode, authority, evidence policy, and manual trigger but does not expose a complete troubleshooting/admin choice surface | Add richer operator choices and evidence preview when this scope is resumed | UI unit |
+| FR-004 | implemented_verified | `api_service/api/routers/executions.py` exposes inbound remediation link read route; `frontend/src/entrypoints/task-detail.tsx` renders Remediation Tasks; API/UI tests cover the panel | No new implementation | API unit + UI unit |
+| FR-005 | implemented_verified | `api_service/api/routers/executions.py` exposes outbound remediation target read route; `frontend/src/entrypoints/task-detail.tsx` renders Remediation Target; API/UI tests cover the panel | No new implementation | API unit + UI unit |
+| FR-006 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` groups remediation-prefixed artifacts; UI tests cover remediation evidence links | No new implementation | UI unit |
+| FR-007 | implemented_verified | Evidence links route through existing artifact download/preview paths and tests cover rendered remediation artifact links without raw storage paths | No new implementation | UI unit |
+| FR-008 | implemented_verified | `RemediationApprovalStateModel` and task-detail approval state rendering are present; API/UI tests cover approval state and decision submission | No new implementation | API unit + UI unit |
+| FR-009 | partial | Approve/reject submission route and enabled UI path exist; unauthorized/read-only fallback still needs focused UI coverage | Add unauthorized/read-only regression test before closing | API unit + UI unit |
+| FR-010 | partial | Empty and fallback panel states exist for missing relationship/evidence data; broader degraded-state coverage for live-follow and approval metadata remains open | Add degraded-state UI tests and adjust implementation if gaps appear | UI unit |
+| FR-011 | partial | `.td-remediation-region` and `.td-remediation-list` styling exists; focused accessibility, focus, reduced-motion, and mobile containment assertions remain open | Add remediation panel accessibility/fallback assertions | UI unit |
+| FR-012 | implemented_verified | Non-remediation task detail/create tests pass in focused and full unit runs | No new implementation | UI unit |
+| FR-013 | implemented_verified | `spec.md` now preserves the original MM-457 preset brief and traceability checks find MM-457 plus source coverage IDs | No new implementation | final verify |
+| DESIGN-REQ-001 | implemented_verified | Task detail create entrypoint exists and is tested for eligible remediation targets | No new implementation | UI unit |
+| DESIGN-REQ-002 | partial | Submitted create payload includes target, mode, authority, evidence policy, and trigger; richer selected-step/policy preview controls remain open | Complete richer create choices if required for closure | UI unit |
+| DESIGN-REQ-003 | implemented_verified | Inbound API and target Remediation Tasks panel exist with compact status/action/lock fields | No new implementation | API unit + UI unit |
+| DESIGN-REQ-004 | implemented_verified | Outbound API and Remediation Target panel exist with target/evidence/approval fields | No new implementation | API unit + UI unit |
+| DESIGN-REQ-005 | implemented_verified | Remediation evidence grouping and artifact links are implemented in task detail and covered by UI tests | No new implementation | UI unit |
+| DESIGN-REQ-006 | partial | Approval display and decision route exist; unauthorized/read-only approval behavior needs focused coverage | Add read-only approval tests and implementation fixes if needed | API unit + UI unit |
+| DESIGN-REQ-007 | partial | Missing relationship/evidence states exist; partial live-follow and approval degraded states need stronger coverage | Add degraded-state tests and fixes if needed | UI unit |
+| DESIGN-REQ-008 | partial | Remediation CSS exists; accessibility/fallback-specific assertions remain open | Add accessibility/fallback coverage for remediation panels | UI unit |
 
 ## Technical Context
 
 **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route/read-model tests.  
 **Primary Dependencies**: React, TanStack Query, existing Mission Control task-detail entrypoint, generated OpenAPI types, FastAPI, SQLAlchemy async ORM, existing Temporal execution/remediation services, pytest, Vitest and Testing Library.  
 **Storage**: Existing remediation link table, artifact tables, and any existing control/audit event storage; no new persistent table planned unless approval decisions lack a current audit surface.  
-**Unit Testing**: `./tools/test_unit.sh` for Python and `./tools/test_unit.sh --dashboard-only --ui-args <paths>` for frontend-focused runs.
-**Integration Testing**: Rendered React entrypoint tests plus focused API/router tests; no compose-backed integration expected unless the approval decision path crosses an existing integration boundary.  
+**Unit Testing**: `./tools/test_unit.sh` for Python service/router tests and `./tools/test_unit.sh --dashboard-only --ui-args <paths>` for frontend-focused Vitest runs.
+**Integration Testing**: React entrypoint rendering tests exercise task-detail integration behavior across query data, user actions, and rendered panels; focused FastAPI router tests exercise route-to-service contracts. No compose-backed `integration_ci` suite is required for this bounded UI/API story unless later work moves remediation approval decisions across a workflow or external service boundary.
 **Target Platform**: Browser Mission Control UI backed by FastAPI control-plane APIs.  
 **Project Type**: Frontend runtime behavior with narrow backend API/read-model support.  
 **Performance Goals**: Task detail loads remediation metadata with bounded list payloads and artifact refs only; no unbounded log or artifact body fetches during page render.  

--- a/specs/224-remediation-mission-control/plan.md
+++ b/specs/224-remediation-mission-control/plan.md
@@ -13,25 +13,25 @@ Implement MM-457 by layering Mission Control UI and narrow API read/decision sur
 | --- | --- | --- | --- | --- |
 | FR-001 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` adds eligible-target Create remediation task action; `frontend/src/entrypoints/task-detail.test.tsx` covers eligible submission | No new implementation; add ineligible-state coverage if expanding regression scope | UI unit |
 | FR-002 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` posts target context to `POST /api/executions/{workflow_id}/remediation`; router regression remains in `tests/unit/api/routers/test_executions.py` | No new implementation | UI unit + router unit |
-| FR-003 | partial | Current UI submits bounded default mode, authority, evidence policy, and manual trigger but does not expose a complete troubleshooting/admin choice surface | Add richer operator choices and evidence preview when this scope is resumed | UI unit |
+| FR-003 | implemented_verified | Task detail shows remediation mode, authority, action policy, pinned run, and evidence preview controls; UI tests cover chosen values in the submitted payload | No new implementation | UI unit |
 | FR-004 | implemented_verified | `api_service/api/routers/executions.py` exposes inbound remediation link read route; `frontend/src/entrypoints/task-detail.tsx` renders Remediation Tasks; API/UI tests cover the panel | No new implementation | API unit + UI unit |
 | FR-005 | implemented_verified | `api_service/api/routers/executions.py` exposes outbound remediation target read route; `frontend/src/entrypoints/task-detail.tsx` renders Remediation Target; API/UI tests cover the panel | No new implementation | API unit + UI unit |
 | FR-006 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` groups remediation-prefixed artifacts; UI tests cover remediation evidence links | No new implementation | UI unit |
 | FR-007 | implemented_verified | Evidence links route through existing artifact download/preview paths and tests cover rendered remediation artifact links without raw storage paths | No new implementation | UI unit |
 | FR-008 | implemented_verified | `RemediationApprovalStateModel` and task-detail approval state rendering are present; API/UI tests cover approval state and decision submission | No new implementation | API unit + UI unit |
-| FR-009 | partial | Approve/reject submission route and enabled UI path exist; unauthorized/read-only fallback still needs focused UI coverage | Add unauthorized/read-only regression test before closing | API unit + UI unit |
-| FR-010 | partial | Empty and fallback panel states exist for missing relationship/evidence data; broader degraded-state coverage for live-follow and approval metadata remains open | Add degraded-state UI tests and adjust implementation if gaps appear | UI unit |
-| FR-011 | partial | `.td-remediation-region` and `.td-remediation-list` styling exists; focused accessibility, focus, reduced-motion, and mobile containment assertions remain open | Add remediation panel accessibility/fallback assertions | UI unit |
+| FR-009 | implemented_verified | Approve/reject submission route and enabled UI path exist; read-only unauthorized approval state is rendered and covered by UI tests | No new implementation | API unit + UI unit |
+| FR-010 | implemented_verified | Empty relationship/evidence states, missing evidence bundle, unavailable live-follow fallback, and approval read-only metadata are rendered and covered by UI tests | No new implementation | UI unit |
+| FR-011 | implemented_verified | `.td-remediation-region`, `.td-remediation-list`, and remediation create/approval styles include focus, containment, and mobile safeguards covered by CSS assertions | No new implementation | UI unit |
 | FR-012 | implemented_verified | Non-remediation task detail/create tests pass in focused and full unit runs | No new implementation | UI unit |
 | FR-013 | implemented_verified | `spec.md` now preserves the original MM-457 preset brief and traceability checks find MM-457 plus source coverage IDs | No new implementation | final verify |
 | DESIGN-REQ-001 | implemented_verified | Task detail create entrypoint exists and is tested for eligible remediation targets | No new implementation | UI unit |
-| DESIGN-REQ-002 | partial | Submitted create payload includes target, mode, authority, evidence policy, and trigger; richer selected-step/policy preview controls remain open | Complete richer create choices if required for closure | UI unit |
+| DESIGN-REQ-002 | implemented_verified | Task detail exposes remediation mode, authority, action policy, pinned run, and evidence preview controls before submission | No new implementation | UI unit |
 | DESIGN-REQ-003 | implemented_verified | Inbound API and target Remediation Tasks panel exist with compact status/action/lock fields | No new implementation | API unit + UI unit |
 | DESIGN-REQ-004 | implemented_verified | Outbound API and Remediation Target panel exist with target/evidence/approval fields | No new implementation | API unit + UI unit |
 | DESIGN-REQ-005 | implemented_verified | Remediation evidence grouping and artifact links are implemented in task detail and covered by UI tests | No new implementation | UI unit |
-| DESIGN-REQ-006 | partial | Approval display and decision route exist; unauthorized/read-only approval behavior needs focused coverage | Add read-only approval tests and implementation fixes if needed | API unit + UI unit |
-| DESIGN-REQ-007 | partial | Missing relationship/evidence states exist; partial live-follow and approval degraded states need stronger coverage | Add degraded-state tests and fixes if needed | UI unit |
-| DESIGN-REQ-008 | partial | Remediation CSS exists; accessibility/fallback-specific assertions remain open | Add accessibility/fallback coverage for remediation panels | UI unit |
+| DESIGN-REQ-006 | implemented_verified | Approval display, decision route, enabled controls, and unauthorized/read-only approval behavior are implemented and covered | No new implementation | API unit + UI unit |
+| DESIGN-REQ-007 | implemented_verified | Missing relationship/evidence states, missing evidence bundle, live-follow fallback, and approval degraded states are implemented and covered | No new implementation | UI unit |
+| DESIGN-REQ-008 | implemented_verified | Remediation CSS focus, containment, and mobile safeguards are implemented and covered by CSS assertions | No new implementation | UI unit |
 
 ## Technical Context
 

--- a/specs/224-remediation-mission-control/plan.md
+++ b/specs/224-remediation-mission-control/plan.md
@@ -1,11 +1,11 @@
 # Implementation Plan: Remediation Mission Control Surfaces
 
 **Branch**: `224-remediation-mission-control` | **Date**: 2026-04-22 | **Spec**: `specs/224-remediation-mission-control/spec.md`
-**Input**: Single-story Jira Orchestrate request for MM-437 / STORY-007.
+**Input**: Single-story Jira Orchestrate request for MM-457 from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
 
 ## Summary
 
-Implement MM-437 by layering Mission Control UI and narrow API read/decision surfaces over the existing remediation create/link/context/evidence foundations. Existing backend work already accepts remediation create requests, persists remediation links, builds bounded context artifacts, and exposes typed evidence tools at service boundaries. This story adds operator-visible task-detail panels and create/approval flows: target pages show remediation creation and inbound links, remediation pages show target/evidence/approval state, evidence artifact refs use the existing artifact presentation path, and approval decisions stay permission-aware and audit-backed. Tests are frontend-first with focused backend route coverage where Mission Control needs a read or decision contract that does not already exist.
+Implement MM-457 by layering Mission Control UI and narrow API read/decision surfaces over the existing remediation create/link/context/evidence foundations. Existing backend work already accepts remediation create requests, persists remediation links, builds bounded context artifacts, and exposes typed evidence tools at service boundaries. This story adds operator-visible task-detail panels and create/approval flows: target pages show remediation creation and inbound links, remediation pages show target/evidence/approval state, evidence artifact refs use the existing artifact presentation path, and approval decisions stay permission-aware and audit-backed. Tests are frontend-first with focused backend route coverage where Mission Control needs a read or decision contract that does not already exist.
 
 ## Requirement Status
 
@@ -23,7 +23,7 @@ Implement MM-437 by layering Mission Control UI and narrow API read/decision sur
 | FR-010 | missing | No remediation degraded/empty states | Add degraded states for missing links, context, evidence, live follow, approval | UI unit |
 | FR-011 | implemented_unverified | MM-429 accessibility/fallback CSS exists; remediation-specific panels not covered | Add remediation panel accessibility/fallback assertions | UI unit |
 | FR-012 | implemented_unverified | Existing task-detail/create/artifact tests pass in prior specs | Preserve and rerun route regression tests | UI unit |
-| FR-013 | missing | This artifact set did not exist before MM-437 | Preserve traceability in specs/tasks/verification | final verify |
+| FR-013 | missing | This artifact set has been realigned to the canonical MM-457 orchestration input | Preserve traceability in specs/tasks/verification | final verify |
 | DESIGN-REQ-001 | missing | Desired-state doc only for Mission Control create entrypoints | Implement create action entrypoints | UI unit |
 | DESIGN-REQ-002 | missing | Desired-state doc only for remediation create choices | Implement create form/prefill choices | UI unit |
 | DESIGN-REQ-003 | partial | Backend link table/service exists; no Mission Control panel | Implement inbound panel/API | API unit + UI unit |
@@ -58,7 +58,7 @@ Implement MM-437 by layering Mission Control UI and narrow API read/decision sur
 - VIII. Modular Architecture: PASS. Work stays in task-detail UI, remediation API/read-model boundaries, and tests.
 - IX. Resilient by Default: PASS. Degraded states prevent missing evidence from breaking operator visibility.
 - X. Continuous Improvement: PASS. Remediation evidence and approvals make follow-up outcomes reviewable.
-- XI. Spec-Driven Development: PASS. This plan follows one MM-437 story with traceable requirements.
+- XI. Spec-Driven Development: PASS. This plan follows one MM-457 story with traceable requirements.
 - XII. Canonical Documentation Separation: PASS. Desired-state docs remain canonical; implementation work stays under specs and source/tests.
 - XIII. Pre-release Compatibility Policy: PASS. The story uses the canonical remediation contract and does not add compatibility aliases.
 

--- a/specs/224-remediation-mission-control/quickstart.md
+++ b/specs/224-remediation-mission-control/quickstart.md
@@ -26,11 +26,11 @@ Expected result:
 ## Traceability Check
 
 ```bash
-rg -n "MM-437|STORY-007|Remediation Mission Control|DESIGN-REQ-00[1-8]" specs/224-remediation-mission-control
+rg -n "MM-457|Remediation Mission Control|DESIGN-REQ-00[1-8]|DESIGN-REQ-0(20|21|22|23)" specs/224-remediation-mission-control
 ```
 
 Expected result:
-- The orchestration target, story ID, source summary, and source design mappings are present in spec, plan, tasks, and verification artifacts.
+- The orchestration target, source summary, and source design mappings are present in spec, plan, tasks, and verification artifacts.
 
 ## Final Verification
 

--- a/specs/224-remediation-mission-control/spec.md
+++ b/specs/224-remediation-mission-control/spec.md
@@ -3,14 +3,14 @@
 **Feature Branch**: `224-remediation-mission-control`
 **Created**: 2026-04-22
 **Status**: Draft
-**Input**: Jira Orchestrate for MM-437.
+**Input**: Jira Orchestrate for MM-457 using `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
 
-Source story: STORY-007.
-Source summary: Show remediation creation, evidence, links, and approvals in Mission Control.
-Source Jira issue: unknown.
-Original brief reference: not provided.
+Source summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control.
+Source Jira issue: MM-457.
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
+Source coverage IDs: DESIGN-REQ-005, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023.
 
-Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
+Use the Jira preset brief for MM-457 as the canonical Moon Spec orchestration input. Runtime mode is selected, so implementation and verification work should proceed from this artifact set.
 
 ## User Story - Remediation Mission Control Surfaces
 
@@ -43,7 +43,7 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - This story implements Mission Control visibility and operator handoff surfaces only; it does not create a new remediation execution workflow type.
 - Existing remediation create, context artifact, and evidence-tool slices provide the canonical backend foundations where already implemented.
 - Approval decision persistence may reuse an existing audit/control-event surface if one is available; otherwise this story adds only the narrow API/UI contract needed for approval-gated remediation display and decision submission.
-- The source Jira issue key is unknown in the task instruction, so artifacts preserve MM-437 as the orchestration target while recording the issue field as unknown.
+- The source Jira issue key is MM-457; artifacts, implementation notes, verification output, commit text, and pull request metadata preserve that key.
 
 ## Source Design Requirements
 
@@ -72,7 +72,7 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **FR-010**: Missing remediation links, context artifacts, evidence refs, live-follow support, or approval audit rows MUST render explicit degraded or empty states without breaking task detail rendering.
 - **FR-011**: Remediation creation, link, evidence, and approval surfaces MUST retain Mission Control accessibility, reduced-motion, mobile containment, and fallback styling guarantees.
 - **FR-012**: Existing task-list, task-detail, artifact, timeline, live-log, and execution create behavior MUST remain unchanged for non-remediation executions.
-- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-437, STORY-007, the source summary, and the unknown Jira issue status from the orchestration input.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-457, the source summary, and source coverage IDs DESIGN-REQ-005, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023 from the orchestration input.
 
 ### Key Entities
 
@@ -93,4 +93,4 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **SC-005**: UI/API tests prove approval-gated remediation shows proposed action, preconditions, blast radius, risk tier, current decision, and permission-correct approve/reject controls.
 - **SC-006**: UI tests prove missing or degraded remediation data renders explicit empty/degraded states and does not break existing task detail rendering.
 - **SC-007**: Existing task-list, task-detail, artifact, live-log, and create-page tests continue to pass for non-remediation executions.
-- **SC-008**: Traceability verification confirms MM-437, STORY-007, source summary, and DESIGN-REQ-001 through DESIGN-REQ-008 are preserved in the MoonSpec artifacts.
+- **SC-008**: Traceability verification confirms MM-457, the source summary, source coverage IDs DESIGN-REQ-005, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023, and generated design mappings DESIGN-REQ-001 through DESIGN-REQ-008 are preserved in the MoonSpec artifacts.

--- a/specs/224-remediation-mission-control/spec.md
+++ b/specs/224-remediation-mission-control/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `224-remediation-mission-control`
 **Created**: 2026-04-22
 **Status**: Draft
-**Input**: Jira Orchestrate for MM-457 using `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
+**Input**: Jira Orchestrate for MM-457 using the Jira preset brief preserved below from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`.
 
 Source summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control.
 Source Jira issue: MM-457.
@@ -11,6 +11,103 @@ Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-or
 Source coverage IDs: DESIGN-REQ-005, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023.
 
 Use the Jira preset brief for MM-457 as the canonical Moon Spec orchestration input. Runtime mode is selected, so implementation and verification work should proceed from this artifact set.
+
+**Original Jira Preset Brief**:
+
+```markdown
+# MM-457 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-457
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-457 from MM project
+Summary: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-457 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-457: Show task remediation creation, evidence, locks, approvals, and links in Mission Control
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 15. Mission Control UX
+  - 8.5 Reverse lookup API
+  - 14.4 Target-side linkage summary
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-020
+  - DESIGN-REQ-021
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+
+User Story
+As an operator in Mission Control, I can create remediation tasks from relevant target surfaces and inspect target/remediator relationships, evidence, live observation, lock state, actions, approvals, and outcomes.
+
+Acceptance Criteria
+- Operators can start remediation from target task/problem surfaces and the submission payload matches the canonical contract.
+- Target detail shows inbound remediators and active lock/action/resolution metadata.
+- Remediation detail shows target identity, pinned run, selected steps, current state, evidence, action policy, approval, and lock information.
+- Evidence links open through artifact/log APIs and honor redaction and visibility rules.
+- Live follow UI is clearly non-authoritative, resumes sequence position where possible, and falls back to durable artifacts.
+- Approval decisions for gated/high-risk actions are captured and visible in the audit trail.
+
+Requirements
+- Mission Control makes remediation relationships visible in both directions.
+- UI cannot imply raw host/admin shell access; action surfaces are typed and policy-bound.
+- Partial evidence and live-follow unavailability must be visible without deadlocking the user flow.
+
+Relevant Implementation Notes
+- Preserve MM-457 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation task creation, reverse lookup, target-side linkage summaries, remediation detail surfaces, evidence presentation, live follow behavior, approvals, and bounded operator handoff.
+- Expose create-remediation entry points from task detail, failed task banners, attention-required surfaces, stuck task surfaces, and provider-slot or session problem surfaces where applicable.
+- Ensure the create flow lets operators choose the pinned target run, choose all or selected steps, choose troubleshooting-only or admin remediation, choose live-follow mode, choose or review the action policy, and preview attached evidence.
+- Show target-side remediation relationships through a Remediation Tasks panel with links, status, authority mode, last action, resolution, and active lock state.
+- Show remediation-side target context with target execution link, pinned target run id, selected steps, current target state, evidence bundle link, allowed actions, approval state, and lock state.
+- Provide direct access to remediation context artifacts, referenced target logs and diagnostics, remediation decision logs, action request/result artifacts, and verification artifacts through existing artifact/log APIs.
+- Clearly label live-follow data as non-authoritative live observation, preserve sequence position where possible, make managed-session epoch boundaries explicit, and fall back to durable artifacts when streaming is unavailable.
+- Capture approval-gated and high-risk action decisions with proposed action, preconditions, expected blast radius, approve/reject result, and audit-trail visibility.
+- Implement reverse lookup surfaces for inbound and outbound remediation relationships, such as `GET /api/executions/{workflowId}/remediations?direction=inbound` and `GET /api/executions/{workflowId}/remediations?direction=outbound`, or equivalent repository-local API patterns.
+- Keep host/admin shell capability out of the UI language and behavior; action surfaces must remain typed, policy-bound, and auditable.
+- Surface partial evidence and unavailable live-follow streams as degraded states instead of blocking navigation or hiding remediation context.
+
+Non-Goals
+- Granting raw host/admin shell access from Mission Control remediation surfaces.
+- Treating live-follow streams as authoritative durable evidence.
+- Hiding partial evidence or unavailable streams behind loading states that deadlock the operator flow.
+- Replacing artifact/log APIs or audit trails with remediation-specific ad hoc data paths.
+- Dropping bidirectional target/remediator visibility when only one side of the relationship is currently active.
+
+Validation
+- Verify operators can start remediation from target task/problem surfaces and the submission payload matches the canonical contract.
+- Verify target detail shows inbound remediators and active lock/action/resolution metadata.
+- Verify remediation detail shows target identity, pinned run, selected steps, current state, evidence, action policy, approval, and lock information.
+- Verify evidence links open through artifact/log APIs and honor redaction and visibility rules.
+- Verify live follow UI is clearly non-authoritative, resumes sequence position where possible, and falls back to durable artifacts.
+- Verify approval decisions for gated/high-risk actions are captured and visible in the audit trail.
+- Verify inbound and outbound remediation lookup surfaces expose target/remediator relationships without relying on raw workflow history inspection.
+- Verify partial evidence and unavailable live-follow states are visible to operators without deadlocking the user flow.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-457 blocks MM-456, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-457 is blocked by MM-458, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
 
 ## User Story - Remediation Mission Control Surfaces
 

--- a/specs/224-remediation-mission-control/speckit_analyze_report.md
+++ b/specs/224-remediation-mission-control/speckit_analyze_report.md
@@ -6,7 +6,7 @@
 
 ## Result
 
-PASS WITH OPEN TASKS. The MoonSpec artifacts are aligned for a single runtime story and now reflect the current partial implementation state. Remaining unchecked tasks are intentionally preserved for richer create choices, read-only approval coverage, degraded-state coverage, accessibility/mobile containment, and final `/moonspec-verify`.
+PASS. The MoonSpec artifacts are aligned for a single runtime story and now reflect the completed MM-457 implementation state. Final `/moonspec-verify` evidence remains recorded in `verification.md`.
 
 ## Checks
 
@@ -17,7 +17,7 @@ PASS WITH OPEN TASKS. The MoonSpec artifacts are aligned for a single runtime st
 | Source design coverage | PASS | `DESIGN-REQ-001` through `DESIGN-REQ-008` map to `FR-*` requirements and tasks. |
 | Plan/test strategy | PASS | `plan.md`, `quickstart.md`, and `tasks.md` identify separate backend unit/service tests and frontend integration-style UI tests. |
 | TDD task order | PASS | `tasks.md` keeps API/UI tests and red-first runs before implementation tasks. |
-| Current implementation state | PASS | `plan.md` and `tasks.md` distinguish implemented-verified slices from partial/open coverage instead of claiming all work is complete. |
+| Current implementation state | PASS | `plan.md` and `tasks.md` mark implementation and test coverage complete for the selected story. |
 | Final verification command | PASS | Downstream artifacts use `/moonspec-verify` consistently. |
 
 ## Key Decisions
@@ -26,13 +26,11 @@ PASS WITH OPEN TASKS. The MoonSpec artifacts are aligned for a single runtime st
 - Add a bounded remediation link read surface for Mission Control instead of inferring links from raw workflow history or artifacts.
 - Keep evidence display artifact-ref based and reuse existing artifact authorization/presentation.
 - Represent approval-gated remediation as a compact current-state panel plus permission-aware decision controls.
-- Treat richer selected-step/action-policy choices, unauthorized approval fallback coverage, degraded live-follow/approval states, and remediation-specific accessibility assertions as open tasks rather than silently marking the story complete.
+- Treat remediation create choices, unauthorized approval fallback coverage, degraded live-follow/approval states, and remediation-specific accessibility assertions as required story coverage and keep them represented in UI tests.
 
 ## Remaining Risks
 
-- FR-003 / DESIGN-REQ-002 remain partial because the current create action submits bounded default remediation choices but does not expose the full operator choice surface from the source brief.
-- FR-009 / DESIGN-REQ-006 remain partial until unauthorized/read-only approval behavior has focused coverage.
-- FR-010 / DESIGN-REQ-007 and FR-011 / DESIGN-REQ-008 remain partial until degraded live-follow/approval states and accessibility/mobile containment assertions are complete.
+- None found in MoonSpec artifacts after implementation alignment.
 
 ## Validation
 

--- a/specs/224-remediation-mission-control/speckit_analyze_report.md
+++ b/specs/224-remediation-mission-control/speckit_analyze_report.md
@@ -2,7 +2,7 @@
 
 **Feature**: `specs/224-remediation-mission-control`
 **Date**: 2026-04-22
-**Source**: Jira Orchestrate request for MM-437 / STORY-007
+**Source**: Jira Orchestrate request for MM-457
 
 ## Result
 
@@ -13,7 +13,7 @@ PASS. The generated MoonSpec artifacts are aligned for a single runtime story an
 | Check | Result | Notes |
 | --- | --- | --- |
 | Single-story scope | PASS | One user story: Remediation Mission Control Surfaces. |
-| Original input preserved | PASS | `spec.md` preserves MM-437, STORY-007, source summary, unknown Jira issue, and no-implementation-inline instruction. |
+| Original input preserved | PASS | `spec.md` preserves MM-457, source summary, source coverage IDs, and the canonical orchestration input reference. |
 | Source design coverage | PASS | `DESIGN-REQ-001` through `DESIGN-REQ-008` map to `FR-*` requirements and tasks. |
 | Plan/test strategy | PASS | `plan.md`, `quickstart.md`, and `tasks.md` identify frontend UI and backend API test commands. |
 | TDD task order | PASS | `tasks.md` requires API/UI tests and red-first runs before implementation tasks. |

--- a/specs/224-remediation-mission-control/speckit_analyze_report.md
+++ b/specs/224-remediation-mission-control/speckit_analyze_report.md
@@ -6,26 +6,36 @@
 
 ## Result
 
-PASS. The generated MoonSpec artifacts are aligned for a single runtime story and implementation is intentionally deferred.
+PASS WITH OPEN TASKS. The MoonSpec artifacts are aligned for a single runtime story and now reflect the current partial implementation state. Remaining unchecked tasks are intentionally preserved for richer create choices, read-only approval coverage, degraded-state coverage, accessibility/mobile containment, and final `/moonspec-verify`.
 
 ## Checks
 
 | Check | Result | Notes |
 | --- | --- | --- |
 | Single-story scope | PASS | One user story: Remediation Mission Control Surfaces. |
-| Original input preserved | PASS | `spec.md` preserves MM-457, source summary, source coverage IDs, and the canonical orchestration input reference. |
+| Original input preserved | PASS | `spec.md` preserves MM-457, source summary, source coverage IDs, and the full original Jira preset brief from `docs/tmp/jira-orchestration-inputs/MM-457-moonspec-orchestration-input.md`. |
 | Source design coverage | PASS | `DESIGN-REQ-001` through `DESIGN-REQ-008` map to `FR-*` requirements and tasks. |
-| Plan/test strategy | PASS | `plan.md`, `quickstart.md`, and `tasks.md` identify frontend UI and backend API test commands. |
-| TDD task order | PASS | `tasks.md` requires API/UI tests and red-first runs before implementation tasks. |
-| Implementation skipped | PASS | No production code was changed; implementation tasks remain unchecked. |
+| Plan/test strategy | PASS | `plan.md`, `quickstart.md`, and `tasks.md` identify separate backend unit/service tests and frontend integration-style UI tests. |
+| TDD task order | PASS | `tasks.md` keeps API/UI tests and red-first runs before implementation tasks. |
+| Current implementation state | PASS | `plan.md` and `tasks.md` distinguish implemented-verified slices from partial/open coverage instead of claiming all work is complete. |
+| Final verification command | PASS | Downstream artifacts use `/moonspec-verify` consistently. |
 
 ## Key Decisions
 
 - Use the existing remediation create route as the create flow target rather than inventing a second durable payload.
-- Add a bounded remediation link read surface for Mission Control if task detail cannot already consume the service data.
+- Add a bounded remediation link read surface for Mission Control instead of inferring links from raw workflow history or artifacts.
 - Keep evidence display artifact-ref based and reuse existing artifact authorization/presentation.
 - Represent approval-gated remediation as a compact current-state panel plus permission-aware decision controls.
+- Treat richer selected-step/action-policy choices, unauthorized approval fallback coverage, degraded live-follow/approval states, and remediation-specific accessibility assertions as open tasks rather than silently marking the story complete.
 
 ## Remaining Risks
 
-- The exact approval audit/control-event storage surface must be confirmed during implementation. The artifacts allow a narrow route only if no existing trusted route fits.
+- FR-003 / DESIGN-REQ-002 remain partial because the current create action submits bounded default remediation choices but does not expose the full operator choice surface from the source brief.
+- FR-009 / DESIGN-REQ-006 remain partial until unauthorized/read-only approval behavior has focused coverage.
+- FR-010 / DESIGN-REQ-007 and FR-011 / DESIGN-REQ-008 remain partial until degraded live-follow/approval states and accessibility/mobile containment assertions are complete.
+
+## Validation
+
+- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: BLOCKED by branch naming guard (`run-jira-orchestrate-for-mm-457-show-tas-4ba153ea` is not a numbered feature branch).
+- Manual artifact gate: PASS. `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md`, `quickstart.md`, and `tasks.md` are present under `specs/224-remediation-mission-control`.
+- Manual task gate: PASS. `tasks.md` has exactly one story phase, red-first unit/API tasks, integration-style UI tasks, implementation tasks, story validation, and final `/moonspec-verify` work.

--- a/specs/224-remediation-mission-control/tasks.md
+++ b/specs/224-remediation-mission-control/tasks.md
@@ -68,16 +68,16 @@
 
 > NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason when they expose a gap, then implement only enough code to make them pass.
 
-- [ ] T013 Add failing task-detail UI test for eligible target states exposing Create remediation task and ineligible states hiding or disabling it in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, SC-001, DESIGN-REQ-001)
+- [X] T013 Add failing task-detail UI test for eligible target states exposing Create remediation task and ineligible states hiding or disabling it in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, SC-001, DESIGN-REQ-001)
 - [X] T014 Add failing task-detail UI test for remediation create prefill and canonical route submission in `frontend/src/entrypoints/task-detail.test.tsx` or `frontend/src/entrypoints/task-create.test.tsx`. (FR-002, FR-003, SC-001, DESIGN-REQ-002)
 - [X] T015 Add failing task-detail UI test for inbound Remediation Tasks panel on a target execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-004, SC-002, DESIGN-REQ-003)
 - [X] T016 Add failing task-detail UI test for outbound Remediation Target panel on a remediation execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-005, SC-003, DESIGN-REQ-004)
 - [X] T017 Add failing task-detail UI test for grouped remediation evidence artifact links and absence of raw storage/path/presigned URL data in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-006, FR-007, SC-004, DESIGN-REQ-005)
-- [ ] T018 Add failing task-detail UI test for approval-gated remediation state, approve/reject controls, and read-only unauthorized state in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
-- [ ] T019 Add failing task-detail UI test for missing link, missing context artifact, missing evidence refs, unavailable live follow, and approval fetch failure degraded states in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-010, SC-006, DESIGN-REQ-007)
-- [ ] T020 Add failing CSS/accessibility assertions for remediation panel focus, contrast, mobile containment, reduced-motion/fallback posture in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/styles/mission-control.css` inspection helpers. (FR-011, DESIGN-REQ-008)
-- [ ] T021 Add or confirm non-remediation task-detail/create regression coverage in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx`. (FR-012, SC-007)
-- [ ] T022 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and capture expected red-first failures for T013-T021.
+- [X] T018 Add failing task-detail UI test for approval-gated remediation state, approve/reject controls, and read-only unauthorized state in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
+- [X] T019 Add failing task-detail UI test for missing link, missing context artifact, missing evidence refs, unavailable live follow, and approval fetch failure degraded states in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-010, SC-006, DESIGN-REQ-007)
+- [X] T020 Add failing CSS/accessibility assertions for remediation panel focus, contrast, mobile containment, reduced-motion/fallback posture in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/styles/mission-control.css` inspection helpers. (FR-011, DESIGN-REQ-008)
+- [X] T021 Add or confirm non-remediation task-detail/create regression coverage in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx`. (FR-012, SC-007)
+- [X] T022 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and capture expected red-first failures for T013-T021.
 
 ### Implementation
 
@@ -87,12 +87,12 @@
 - [X] T026 Implement outbound Remediation Target panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-005, DESIGN-REQ-004)
 - [X] T027 Implement remediation evidence grouping and safe artifact link rendering in `frontend/src/entrypoints/task-detail.tsx`. (FR-006, FR-007, DESIGN-REQ-005)
 - [X] T028 Implement approval-gated remediation display and approve/reject controls in `frontend/src/entrypoints/task-detail.tsx`, wired to the trusted backend route from T010 when required. (FR-008, FR-009, DESIGN-REQ-006)
-- [ ] T029 Implement degraded and empty states for missing remediation links, context artifacts, evidence refs, live follow, and approval metadata in `frontend/src/entrypoints/task-detail.tsx`. (FR-010, DESIGN-REQ-007)
+- [X] T029 Implement degraded and empty states for missing remediation links, context artifacts, evidence refs, live follow, and approval metadata in `frontend/src/entrypoints/task-detail.tsx`. (FR-010, DESIGN-REQ-007)
 - [X] T030 Update remediation panel styling in `frontend/src/styles/mission-control.css` using existing Mission Control evidence-region patterns. (FR-011, DESIGN-REQ-008)
 - [X] T031 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
 - [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
 
-**Checkpoint**: Backend/read-model and implemented UI slices are covered by API and integration-style UI tests. Complete remaining unchecked UI coverage and degraded-state tasks before final story verification.
+**Checkpoint**: Backend/read-model and UI story slices are covered by API and integration-style UI tests.
 
 ---
 
@@ -101,11 +101,11 @@
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
 - [X] T033 [P] Review MM-457 traceability in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `tasks.md`, and `contracts/remediation-mission-control.md`. (FR-013, SC-008)
-- [ ] T034 [P] Review rendered remediation panels for long workflow IDs, run IDs, action labels, artifact labels, and mobile containment in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-011)
+- [X] T034 [P] Review rendered remediation panels for long workflow IDs, run IDs, action labels, artifact labels, and mobile containment in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-011)
 - [X] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
 - [X] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
 - [X] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
-- [ ] T038 Run `/moonspec-verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
+- [X] T038 Run `/moonspec-verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
 
 ---
 

--- a/specs/224-remediation-mission-control/tasks.md
+++ b/specs/224-remediation-mission-control/tasks.md
@@ -5,7 +5,7 @@
 
 **Tests**: Unit tests and integration-style UI tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
 
-**Organization**: Tasks are grouped around the single MM-437 / STORY-007 user story so the work stays focused, traceable, and independently testable.
+**Organization**: Tasks are grouped around the single MM-457 user story so the work stays focused, traceable, and independently testable.
 
 **Source Traceability**: This task list maps FR-001 through FR-013, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-008 from `spec.md` to concrete test, implementation, and verification work.
 
@@ -25,10 +25,10 @@
 
 **Purpose**: Confirm existing remediation and Mission Control foundations before adding UI surfaces.
 
-- [ ] T001 Confirm active MM-437 artifacts exist in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md`, and `quickstart.md`. (FR-013, SC-008)
-- [ ] T002 Review existing remediation create/link/context/evidence behavior in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/remediation_context.py`, and `moonmind/workflows/temporal/remediation_tools.py`. (FR-002, FR-004, FR-005, FR-006)
-- [ ] T003 Review current task detail action, timeline, artifact, live-log, and evidence-region rendering in `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, FR-006, FR-011, FR-012)
-- [ ] T004 [P] Review task-create remediation route usage and generated OpenAPI paths in `frontend/src/generated/openapi.ts` and `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003)
+- [X] T001 Confirm active MM-457 artifacts exist in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md`, and `quickstart.md`. (FR-013, SC-008)
+- [X] T002 Review existing remediation create/link/context/evidence behavior in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/remediation_context.py`, and `moonmind/workflows/temporal/remediation_tools.py`. (FR-002, FR-004, FR-005, FR-006)
+- [X] T003 Review current task detail action, timeline, artifact, live-log, and evidence-region rendering in `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, FR-006, FR-011, FR-012)
+- [X] T004 [P] Review task-create remediation route usage and generated OpenAPI paths in `frontend/src/generated/openapi.ts` and `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003)
 
 ---
 
@@ -38,14 +38,14 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T005 Add failing API unit tests for inbound and outbound remediation link read responses in `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-003, DESIGN-REQ-004)
-- [ ] T006 Add failing service or router unit tests for bounded remediation link summary fields in `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005)
-- [ ] T007 Add failing API unit tests for remediation approval-state read and permission-aware decision behavior in `tests/unit/api/routers/test_executions.py`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
-- [ ] T008 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and capture expected red-first failures for T005-T007.
-- [ ] T009 Implement inbound/outbound remediation link read route or task-detail payload extension in `api_service/api/routers/executions.py`, backed by existing `TemporalExecutionService` link methods. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-004)
-- [ ] T010 Implement compact remediation approval read/decision route in `api_service/api/routers/executions.py` only if no existing control-event route can satisfy T007. (FR-008, FR-009, DESIGN-REQ-006)
-- [ ] T011 Update OpenAPI generation artifacts in `frontend/src/generated/openapi.ts` if backend route changes require generated frontend types. (FR-004, FR-005, FR-008, FR-009)
-- [ ] T012 Rerun the focused API tests from T008 and fix backend failures until the remediation read/approval contract passes.
+- [X] T005 Add failing API unit tests for inbound and outbound remediation link read responses in `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-003, DESIGN-REQ-004)
+- [X] T006 Add failing service or router unit tests for bounded remediation link summary fields in `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005)
+- [X] T007 Add failing API unit tests for remediation approval-state read and permission-aware decision behavior in `tests/unit/api/routers/test_executions.py`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
+- [X] T008 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and capture expected red-first failures for T005-T007.
+- [X] T009 Implement inbound/outbound remediation link read route or task-detail payload extension in `api_service/api/routers/executions.py`, backed by existing `TemporalExecutionService` link methods. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-004)
+- [X] T010 Implement compact remediation approval read/decision route in `api_service/api/routers/executions.py` only if no existing control-event route can satisfy T007. (FR-008, FR-009, DESIGN-REQ-006)
+- [X] T011 Update OpenAPI generation artifacts in `frontend/src/generated/openapi.ts` if backend route changes require generated frontend types. (FR-004, FR-005, FR-008, FR-009)
+- [X] T012 Rerun the focused API tests from T008 and fix backend failures until the remediation read/approval contract passes.
 
 **Checkpoint**: Backend/read-model foundation ready - story UI work can now begin.
 
@@ -69,10 +69,10 @@
 > NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason when they expose a gap, then implement only enough code to make them pass.
 
 - [ ] T013 Add failing task-detail UI test for eligible target states exposing Create remediation task and ineligible states hiding or disabling it in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, SC-001, DESIGN-REQ-001)
-- [ ] T014 Add failing task-detail UI test for remediation create prefill and canonical route submission in `frontend/src/entrypoints/task-detail.test.tsx` or `frontend/src/entrypoints/task-create.test.tsx`. (FR-002, FR-003, SC-001, DESIGN-REQ-002)
-- [ ] T015 Add failing task-detail UI test for inbound Remediation Tasks panel on a target execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-004, SC-002, DESIGN-REQ-003)
-- [ ] T016 Add failing task-detail UI test for outbound Remediation Target panel on a remediation execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-005, SC-003, DESIGN-REQ-004)
-- [ ] T017 Add failing task-detail UI test for grouped remediation evidence artifact links and absence of raw storage/path/presigned URL data in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-006, FR-007, SC-004, DESIGN-REQ-005)
+- [X] T014 Add failing task-detail UI test for remediation create prefill and canonical route submission in `frontend/src/entrypoints/task-detail.test.tsx` or `frontend/src/entrypoints/task-create.test.tsx`. (FR-002, FR-003, SC-001, DESIGN-REQ-002)
+- [X] T015 Add failing task-detail UI test for inbound Remediation Tasks panel on a target execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-004, SC-002, DESIGN-REQ-003)
+- [X] T016 Add failing task-detail UI test for outbound Remediation Target panel on a remediation execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-005, SC-003, DESIGN-REQ-004)
+- [X] T017 Add failing task-detail UI test for grouped remediation evidence artifact links and absence of raw storage/path/presigned URL data in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-006, FR-007, SC-004, DESIGN-REQ-005)
 - [ ] T018 Add failing task-detail UI test for approval-gated remediation state, approve/reject controls, and read-only unauthorized state in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
 - [ ] T019 Add failing task-detail UI test for missing link, missing context artifact, missing evidence refs, unavailable live follow, and approval fetch failure degraded states in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-010, SC-006, DESIGN-REQ-007)
 - [ ] T020 Add failing CSS/accessibility assertions for remediation panel focus, contrast, mobile containment, reduced-motion/fallback posture in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/styles/mission-control.css` inspection helpers. (FR-011, DESIGN-REQ-008)
@@ -81,16 +81,16 @@
 
 ### Implementation
 
-- [ ] T023 Implement remediation create action visibility and target-state eligibility in `frontend/src/entrypoints/task-detail.tsx`. (FR-001, DESIGN-REQ-001)
-- [ ] T024 Implement remediation create draft/prefill and canonical route submission from task detail in `frontend/src/entrypoints/task-detail.tsx` or shared create helpers in `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003, DESIGN-REQ-002)
-- [ ] T025 Implement inbound Remediation Tasks panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-004, DESIGN-REQ-003)
-- [ ] T026 Implement outbound Remediation Target panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-005, DESIGN-REQ-004)
-- [ ] T027 Implement remediation evidence grouping and safe artifact link rendering in `frontend/src/entrypoints/task-detail.tsx`. (FR-006, FR-007, DESIGN-REQ-005)
-- [ ] T028 Implement approval-gated remediation display and approve/reject controls in `frontend/src/entrypoints/task-detail.tsx`, wired to the trusted backend route from T010 when required. (FR-008, FR-009, DESIGN-REQ-006)
+- [X] T023 Implement remediation create action visibility and target-state eligibility in `frontend/src/entrypoints/task-detail.tsx`. (FR-001, DESIGN-REQ-001)
+- [X] T024 Implement remediation create draft/prefill and canonical route submission from task detail in `frontend/src/entrypoints/task-detail.tsx` or shared create helpers in `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003, DESIGN-REQ-002)
+- [X] T025 Implement inbound Remediation Tasks panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-004, DESIGN-REQ-003)
+- [X] T026 Implement outbound Remediation Target panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-005, DESIGN-REQ-004)
+- [X] T027 Implement remediation evidence grouping and safe artifact link rendering in `frontend/src/entrypoints/task-detail.tsx`. (FR-006, FR-007, DESIGN-REQ-005)
+- [X] T028 Implement approval-gated remediation display and approve/reject controls in `frontend/src/entrypoints/task-detail.tsx`, wired to the trusted backend route from T010 when required. (FR-008, FR-009, DESIGN-REQ-006)
 - [ ] T029 Implement degraded and empty states for missing remediation links, context artifacts, evidence refs, live follow, and approval metadata in `frontend/src/entrypoints/task-detail.tsx`. (FR-010, DESIGN-REQ-007)
-- [ ] T030 Update remediation panel styling in `frontend/src/styles/mission-control.css` using existing Mission Control evidence-region patterns. (FR-011, DESIGN-REQ-008)
-- [ ] T031 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
-- [ ] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
+- [X] T030 Update remediation panel styling in `frontend/src/styles/mission-control.css` using existing Mission Control evidence-region patterns. (FR-011, DESIGN-REQ-008)
+- [X] T031 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
+- [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
 
 **Checkpoint**: The story is fully functional, covered by API and integration-style UI tests, and independently testable.
 
@@ -100,11 +100,11 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T033 [P] Review MM-437 traceability in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `tasks.md`, and `contracts/remediation-mission-control.md`. (FR-013, SC-008)
+- [X] T033 [P] Review MM-457 traceability in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `tasks.md`, and `contracts/remediation-mission-control.md`. (FR-013, SC-008)
 - [ ] T034 [P] Review rendered remediation panels for long workflow IDs, run IDs, action labels, artifact labels, and mobile containment in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-011)
-- [ ] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
-- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
-- [ ] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
+- [X] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
+- [X] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
+- [X] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
 - [ ] T038 Run `/speckit.verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
 
 ---
@@ -144,6 +144,6 @@
 
 ## Notes
 
-- This task list covers one story only: MM-437 / STORY-007.
+- This task list covers one story only: MM-457.
 - Do not implement automatic self-healing, new action registry kinds, raw log embedding, or direct raw storage access.
 - Preserve the canonical `task.remediation` create contract and existing non-remediation task behavior.

--- a/specs/224-remediation-mission-control/tasks.md
+++ b/specs/224-remediation-mission-control/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py`
 - Integration tests: `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -92,7 +92,7 @@
 - [X] T031 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
 - [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
 
-**Checkpoint**: The story is fully functional, covered by API and integration-style UI tests, and independently testable.
+**Checkpoint**: Backend/read-model and implemented UI slices are covered by API and integration-style UI tests. Complete remaining unchecked UI coverage and degraded-state tasks before final story verification.
 
 ---
 
@@ -105,7 +105,7 @@
 - [X] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
 - [X] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
 - [X] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
-- [ ] T038 Run `/speckit.verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
+- [ ] T038 Run `/moonspec-verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
 
 ---
 
@@ -124,7 +124,7 @@
 - UI tests must be authored before task-detail implementation.
 - Create action and data-fetch wiring should land before panels that consume remediation data.
 - Evidence grouping and approval controls depend on remediation panel data shape.
-- Final `/speckit.verify` runs only after tests pass and tasks are marked complete.
+- Final `/moonspec-verify` runs only after tests pass and tasks are marked complete.
 
 ### Parallel Opportunities
 
@@ -140,7 +140,7 @@
 3. Add task-detail and create-page UI tests for every visible operator state.
 4. Implement the UI panels using existing Mission Control evidence-region styling.
 5. Run focused frontend and backend verification.
-6. Run `/speckit.verify` and record final evidence.
+6. Run `/moonspec-verify` and record final evidence.
 
 ## Notes
 

--- a/specs/224-remediation-mission-control/verification.md
+++ b/specs/224-remediation-mission-control/verification.md
@@ -2,11 +2,12 @@
 
 **Feature**: `specs/224-remediation-mission-control`
 **Date**: 2026-04-22
-**Verdict**: ADDITIONAL_WORK_NEEDED
+**Verdict**: FULLY_IMPLEMENTED
+**Confidence**: HIGH
 
 ## Summary
 
-Jira Orchestrate artifact generation has been realigned to the canonical MM-457 orchestration input and runtime implementation has started. Backend remediation relationship and approval-decision contracts are implemented, and Mission Control task detail now renders remediation creation, relationship, evidence, and approval controls. Additional UI edge-case coverage remains before final MoonSpec verification.
+Jira Orchestrate artifact generation is aligned to the canonical MM-457 orchestration input. Backend remediation relationship and approval-decision contracts are implemented, and Mission Control task detail renders remediation creation choices, bidirectional relationships, evidence, lock/action metadata, approval controls, read-only approval state, degraded states, and containment/focus safeguards. Final MoonSpec verification found no remaining implementation or validation gaps for the selected single story.
 
 ## Artifact Coverage
 
@@ -17,7 +18,8 @@ Jira Orchestrate artifact generation has been realigned to the canonical MM-457 
 | Source design mappings | VERIFIED | `DESIGN-REQ-001` through `DESIGN-REQ-008` in `spec.md` |
 | Plan and research | VERIFIED | `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md` |
 | TDD tasks | VERIFIED | `tasks.md` includes API/UI tests before implementation tasks |
-| Implementation | PARTIAL | `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `frontend/src/entrypoints/task-detail.tsx` |
+| Implementation | VERIFIED | `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/task-create.tsx`, `frontend/src/styles/mission-control.css` |
+| Task completion | VERIFIED | T001 through T038 are marked complete in `tasks.md` |
 
 ## Validation Commands
 
@@ -37,8 +39,19 @@ git diff --check
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
 ```
 
-Result: PASS. Full unit verification reported `3789 passed, 1 xpassed, 100 warnings, 16 subtests passed`; UI verification reported `11 passed (11)` files and `368 passed (368)` tests. The backend focused command reported existing RuntimeWarning noise from AsyncMock cleanup in `tests/unit/api/routers/test_executions.py`.
+Result: PASS. Focused frontend verification reported `2 passed (2)` files and `267 passed (267)` tests. Focused backend verification reported `196 passed, 13 warnings`. Full unit verification reported `3789 passed, 1 xpassed, 101 warnings, 16 subtests passed`; UI verification reported `11 passed (11)` files and `373 passed (373)` tests. The backend focused command reported existing RuntimeWarning noise from AsyncMock cleanup in `tests/unit/api/routers/test_executions.py`.
+
+## Requirement Coverage
+
+| Requirement Set | Status | Evidence |
+| --- | --- | --- |
+| FR-001 through FR-003 | VERIFIED | Remediation create visibility, ineligible hiding, selectable mode/authority/action policy, pinned run, evidence preview, and canonical submission are covered in `frontend/src/entrypoints/task-detail.test.tsx`. |
+| FR-004 through FR-005 | VERIFIED | Inbound/outbound remediation relationship API and UI panel coverage exists in `tests/unit/api/routers/test_executions.py` and `frontend/src/entrypoints/task-detail.test.tsx`. |
+| FR-006 through FR-007 | VERIFIED | Remediation evidence grouping and safe artifact links are covered in `frontend/src/entrypoints/task-detail.test.tsx`. |
+| FR-008 through FR-009 | VERIFIED | Approval display, approve/reject submission, and read-only unauthorized state are covered in API and UI tests. |
+| FR-010 through FR-011 | VERIFIED | Missing link/evidence/live-follow degraded states and remediation panel focus/mobile containment CSS are covered in `frontend/src/entrypoints/task-detail.test.tsx`. |
+| FR-012 through FR-013 | VERIFIED | Non-remediation regressions pass in focused and full UI suites; MM-457 traceability is preserved in MoonSpec artifacts. |
 
 ## Remaining Work
 
-Complete the remaining unchecked tasks in `specs/224-remediation-mission-control/tasks.md`, especially ineligible/read-only/degraded UI assertions and final `/moonspec-verify`.
+None for MM-457.

--- a/specs/224-remediation-mission-control/verification.md
+++ b/specs/224-remediation-mission-control/verification.md
@@ -41,4 +41,4 @@ Result: PASS. Full unit verification reported `3789 passed, 1 xpassed, 100 warni
 
 ## Remaining Work
 
-Complete the remaining unchecked tasks in `specs/224-remediation-mission-control/tasks.md`, especially ineligible/read-only/degraded UI assertions and final `/speckit.verify`.
+Complete the remaining unchecked tasks in `specs/224-remediation-mission-control/tasks.md`, especially ineligible/read-only/degraded UI assertions and final `/moonspec-verify`.

--- a/specs/224-remediation-mission-control/verification.md
+++ b/specs/224-remediation-mission-control/verification.md
@@ -2,31 +2,43 @@
 
 **Feature**: `specs/224-remediation-mission-control`
 **Date**: 2026-04-22
-**Verdict**: IMPLEMENTATION_NOT_RUN
+**Verdict**: ADDITIONAL_WORK_NEEDED
 
 ## Summary
 
-Jira Orchestrate artifact generation for MM-437 / STORY-007 is complete through specify, plan, tasks, and alignment. Production implementation was intentionally not run because the task instruction says: "Do not run implementation inline inside the breakdown task."
+Jira Orchestrate artifact generation has been realigned to the canonical MM-457 orchestration input and runtime implementation has started. Backend remediation relationship and approval-decision contracts are implemented, and Mission Control task detail now renders remediation creation, relationship, evidence, and approval controls. Additional UI edge-case coverage remains before final MoonSpec verification.
 
 ## Artifact Coverage
 
 | Item | Status | Evidence |
 | --- | --- | --- |
-| MM-437 and STORY-007 input preserved | VERIFIED | `spec.md`, `tasks.md`, and this verification file |
+| MM-457 input preserved | VERIFIED | `spec.md`, `tasks.md`, and this verification file |
 | One-story spec | VERIFIED | `spec.md` defines one user story |
 | Source design mappings | VERIFIED | `DESIGN-REQ-001` through `DESIGN-REQ-008` in `spec.md` |
 | Plan and research | VERIFIED | `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md` |
 | TDD tasks | VERIFIED | `tasks.md` includes API/UI tests before implementation tasks |
-| Implementation | NOT RUN | Deferred to the generated implementation task list |
+| Implementation | PARTIAL | `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `frontend/src/entrypoints/task-detail.tsx` |
 
 ## Validation Commands
 
 ```bash
-rg -n "MM-437|STORY-007|DESIGN-REQ-00[1-8]|FR-01[0-3]|SC-00[1-8]" specs/224-remediation-mission-control
+rg -n "MM-457|DESIGN-REQ-00[1-8]|DESIGN-REQ-0(20|21|22|23)|FR-01[0-3]|SC-00[1-8]" specs/224-remediation-mission-control
 ```
 
-Result: PASS during artifact generation.
+Result: PASS after MM-457 realignment.
+
+Additional validation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py
+./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+npm run api:types
+git diff --check
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Result: PASS. Full unit verification reported `3789 passed, 1 xpassed, 100 warnings, 16 subtests passed`; UI verification reported `11 passed (11)` files and `368 passed (368)` tests. The backend focused command reported existing RuntimeWarning noise from AsyncMock cleanup in `tests/unit/api/routers/test_executions.py`.
 
 ## Remaining Work
 
-Run the implementation tasks in `specs/224-remediation-mission-control/tasks.md`, then execute the focused frontend and backend test commands from `quickstart.md` and update this file with final implementation evidence.
+Complete the remaining unchecked tasks in `specs/224-remediation-mission-control/tasks.md`, especially ineligible/read-only/degraded UI assertions and final `/speckit.verify`.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1037,7 +1037,7 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
                 "resolution": None,
                 "contextArtifactRef": "art_context",
                 "approvalState": {
-                    "requestId": None,
+                    "requestId": "mm:remediation-1:approval",
                     "actionKind": None,
                     "riskTier": None,
                     "preconditions": None,
@@ -1045,7 +1045,7 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
                     "decision": "pending",
                     "decisionActor": None,
                     "decisionAt": None,
-                    "canDecide": False,
+                    "canDecide": True,
                     "auditRef": None,
                 },
                 "createdAt": now.isoformat().replace("+00:00", "Z"),

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -987,6 +987,203 @@ def test_create_remediation_convenience_route_rejects_malformed_remediation(
     service.create_execution.assert_not_awaited()
 
 
+def test_list_remediations_for_target_returns_compact_inbound_links(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    now = datetime.now(UTC)
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+    service.list_remediations_for_target.return_value = [
+        SimpleNamespace(
+            remediation_workflow_id="mm:remediation-1",
+            remediation_run_id="run-remediation-1",
+            target_workflow_id="mm:target-workflow",
+            target_run_id="run-target",
+            mode="snapshot_then_follow",
+            authority_mode="approval_gated",
+            status="awaiting_approval",
+            active_lock_scope="target_execution",
+            active_lock_holder="mm:remediation-1",
+            latest_action_summary="Proposed session interrupt",
+            outcome=None,
+            context_artifact_ref="art_context",
+            created_at=now,
+            updated_at=now,
+        )
+    ]
+
+    response = test_client.get(
+        "/api/executions/mm:target-workflow/remediations",
+        params={"direction": "inbound"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "direction": "inbound",
+        "items": [
+            {
+                "remediationWorkflowId": "mm:remediation-1",
+                "remediationRunId": "run-remediation-1",
+                "targetWorkflowId": "mm:target-workflow",
+                "targetRunId": "run-target",
+                "mode": "snapshot_then_follow",
+                "authorityMode": "approval_gated",
+                "status": "awaiting_approval",
+                "activeLockScope": "target_execution",
+                "activeLockHolder": "mm:remediation-1",
+                "latestActionSummary": "Proposed session interrupt",
+                "resolution": None,
+                "contextArtifactRef": "art_context",
+                "approvalState": {
+                    "requestId": None,
+                    "actionKind": None,
+                    "riskTier": None,
+                    "preconditions": None,
+                    "blastRadius": None,
+                    "decision": "pending",
+                    "decisionActor": None,
+                    "decisionAt": None,
+                    "canDecide": False,
+                    "auditRef": None,
+                },
+                "createdAt": now.isoformat().replace("+00:00", "Z"),
+                "updatedAt": now.isoformat().replace("+00:00", "Z"),
+            }
+        ],
+    }
+    service.list_remediations_for_target.assert_awaited_once_with("mm:target-workflow")
+    service.list_remediation_targets.assert_not_called()
+
+
+def test_list_remediations_for_remediation_returns_compact_outbound_links(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    now = datetime.now(UTC)
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+    service.list_remediation_targets.return_value = [
+        SimpleNamespace(
+            remediation_workflow_id="mm:remediation-1",
+            remediation_run_id="run-remediation-1",
+            target_workflow_id="mm:target-workflow",
+            target_run_id="run-target",
+            mode="snapshot",
+            authority_mode="observe_only",
+            status="created",
+            active_lock_scope=None,
+            active_lock_holder=None,
+            latest_action_summary=None,
+            outcome="resolved",
+            context_artifact_ref=None,
+            created_at=now,
+            updated_at=now,
+        )
+    ]
+
+    response = test_client.get(
+        "/api/executions/mm:remediation-1/remediations",
+        params={"direction": "outbound"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["direction"] == "outbound"
+    assert response.json()["items"][0] == {
+        "remediationWorkflowId": "mm:remediation-1",
+        "remediationRunId": "run-remediation-1",
+        "targetWorkflowId": "mm:target-workflow",
+        "targetRunId": "run-target",
+        "mode": "snapshot",
+        "authorityMode": "observe_only",
+        "status": "created",
+        "activeLockScope": None,
+        "activeLockHolder": None,
+        "latestActionSummary": None,
+        "resolution": "resolved",
+        "contextArtifactRef": None,
+        "approvalState": None,
+        "createdAt": now.isoformat().replace("+00:00", "Z"),
+        "updatedAt": now.isoformat().replace("+00:00", "Z"),
+    }
+    service.list_remediation_targets.assert_awaited_once_with("mm:remediation-1")
+    service.list_remediations_for_target.assert_not_called()
+
+
+def test_list_remediations_rejects_unknown_direction(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+
+    response = test_client.get(
+        "/api/executions/mm:target-workflow/remediations",
+        params={"direction": "sideways"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_remediation_direction"
+
+
+def test_record_remediation_approval_decision_calls_trusted_service(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+    service.record_remediation_approval_decision.return_value = {
+        "accepted": True,
+        "workflowId": "mm:remediation-1",
+        "requestId": "approval-1",
+        "decision": "approved",
+    }
+
+    response = test_client.post(
+        "/api/executions/mm:remediation-1/remediation/approvals/approval-1",
+        json={"decision": "approved", "comment": "Reviewed."},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "accepted": True,
+        "workflowId": "mm:remediation-1",
+        "requestId": "approval-1",
+        "decision": "approved",
+    }
+    service.record_remediation_approval_decision.assert_awaited_once_with(
+        remediation_workflow_id="mm:remediation-1",
+        request_id="approval-1",
+        decision="approved",
+        comment="Reviewed.",
+        actor=user.email,
+    )
+
+
+def test_record_remediation_approval_decision_rejects_unknown_decision(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+
+    response = test_client.post(
+        "/api/executions/mm:remediation-1/remediation/approvals/approval-1",
+        json={"decision": "maybe"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == (
+        "invalid_remediation_approval_decision"
+    )
+    service.record_remediation_approval_decision.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -624,6 +624,52 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
 
 
 @pytest.mark.asyncio
+async def test_record_remediation_approval_decision_appends_bounded_audit(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        mock_client_adapter.start_workflow.return_value = SimpleNamespace(
+            run_id="remediation-temporal-run"
+        )
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        remediation = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        result = await service.record_remediation_approval_decision(
+            remediation_workflow_id=remediation.workflow_id,
+            request_id="approval-1",
+            decision="approved",
+            comment="Reviewed blast radius.",
+            actor="ops@example.com",
+        )
+
+        assert result == {
+            "accepted": True,
+            "workflowId": remediation.workflow_id,
+            "requestId": "approval-1",
+            "decision": "approved",
+        }
+        record = await service.describe_execution(remediation.workflow_id)
+        audit = record.memo["intervention_audit"]
+        assert audit[-1]["action"] == "remediation_approval_approved"
+        assert audit[-1]["transport"] == "api"
+        assert audit[-1]["summary"] == "Remediation approval approved."
+        assert "approval-1" in audit[-1]["detail"]
+        assert "ops@example.com" in audit[-1]["detail"]
+
+
+@pytest.mark.asyncio
 async def test_create_execution_persists_supplied_matching_remediation_run_id(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -634,6 +634,17 @@ async def test_record_remediation_approval_decision_appends_bounded_audit(
         )
         service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
 
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
         remediation = await service.create_execution(
             workflow_type="MoonMind.Run",
             owner_id=owner_id,
@@ -642,13 +653,27 @@ async def test_record_remediation_approval_decision_appends_bounded_audit(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters={
+                "task": {
+                    "remediation": {
+                        "target": {"workflowId": target.workflow_id},
+                        "mode": "snapshot",
+                        "authorityMode": "approval_gated",
+                    },
+                },
+            },
             idempotency_key=None,
         )
+        link = await session.get(
+            TemporalExecutionRemediationLink, remediation.workflow_id
+        )
+        assert link is not None
+        link.status = "awaiting_approval"
+        await session.commit()
 
         result = await service.record_remediation_approval_decision(
             remediation_workflow_id=remediation.workflow_id,
-            request_id="approval-1",
+            request_id=f"{remediation.workflow_id}:approval",
             decision="approved",
             comment="Reviewed blast radius.",
             actor="ops@example.com",
@@ -657,7 +682,7 @@ async def test_record_remediation_approval_decision_appends_bounded_audit(
         assert result == {
             "accepted": True,
             "workflowId": remediation.workflow_id,
-            "requestId": "approval-1",
+            "requestId": f"{remediation.workflow_id}:approval",
             "decision": "approved",
         }
         record = await service.describe_execution(remediation.workflow_id)
@@ -665,8 +690,41 @@ async def test_record_remediation_approval_decision_appends_bounded_audit(
         assert audit[-1]["action"] == "remediation_approval_approved"
         assert audit[-1]["transport"] == "api"
         assert audit[-1]["summary"] == "Remediation approval approved."
-        assert "approval-1" in audit[-1]["detail"]
+        assert f"{remediation.workflow_id}:approval" in audit[-1]["detail"]
         assert "ops@example.com" in audit[-1]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_record_remediation_approval_decision_rejects_non_pending_target(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        execution = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Ordinary execution",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="pending approval-gated remediation",
+        ):
+            await service.record_remediation_approval_decision(
+                remediation_workflow_id=execution.workflow_id,
+                request_id=f"{execution.workflow_id}:approval",
+                decision="approved",
+                comment=None,
+                actor="ops@example.com",
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Jira Issue
MM-457

## Active MoonSpec Feature Path
specs/224-remediation-mission-control

## Verification Verdict
FULLY_IMPLEMENTED

## Summary
- Add Mission Control remediation create controls, relationship panels, evidence links, approval decisions, read-only approval state, and degraded states.
- Add bounded remediation relationship and approval API surfaces plus service audit handling.
- Preserve MM-457 MoonSpec artifacts and final verification evidence.

## Tests Run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
- npm run api:types
- git diff --check
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh

## Remaining Risks
None for MM-457.