### PR TITLE
MM-458 Document remediation v1 policy guardrails

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/232-remediation-lifecycle-audit"
+  "feature_directory": "specs/233-remediation-v1-policy-guardrails"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-457",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1687"
+  "jira_issue_key": "MM-458",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1688"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-458-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-458-moonspec-orchestration-input.md
@@ -1,0 +1,100 @@
+# MM-458 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-458
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document and enforce bounded v1 rollout and future self-healing policy constraints
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-458 from MM project
+Summary: Document and enforce bounded v1 rollout and future self-healing policy constraints
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-458 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-458: Document and enforce bounded v1 rollout and future self-healing policy constraints
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 4. Non-goals
+  - 7.6 Future automatic self-healing policy
+  - 16. Failure modes and edge cases
+  - 17. Recommended v1
+  - 18. Future extensions
+  - 19. Acceptance criteria
+  - Appendix C. Design rule summary
+- Coverage IDs:
+  - DESIGN-REQ-016
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a product/platform owner, I can ship a constrained manual v1 and leave future automatic self-healing behind explicit bounded policy so remediation remains safe as capabilities expand.
+
+Acceptance Criteria
+- Default v1 behavior supports manual remediation only and does not automatically spawn admin healers.
+- Unsupported raw admin capabilities are absent from APIs, tools, and UI and fail closed if requested.
+- Future self-healing policy fields, if accepted by schemas, remain inert unless explicitly enabled and bounded by policy.
+- All documented failure/edge cases have structured output expectations such as validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, or failed.
+- The implementation acceptance checklist can be traced back to each design rule without relying on future-work language for current v1 guarantees.
+
+Requirements
+- V1 must stay useful but constrained.
+- Future extensions preserve artifact-first evidence, typed actions, explicit locks, strict audit, redaction, and no raw root shell.
+- Non-goals are enforced as guardrails, not merely documentation.
+
+Relevant Implementation Notes
+- Preserve MM-458 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation non-goals, future automatic self-healing policy, failure and edge-case outputs, recommended v1 scope, future extension boundaries, acceptance criteria, and design-rule summary.
+- Keep v1 remediation manual by default: operators create remediation tasks explicitly from Mission Control or equivalent operator surfaces.
+- Do not introduce an automatic rule where every failed, stalled, timed-out, or attention-required task spawns an admin healer.
+- If future automatic remediation policy fields are accepted by schemas or payload models, keep them policy-driven, bounded, and inert unless explicitly enabled.
+- Preserve bounded self-healing controls such as triggers, create mode, template reference, authority mode, and max active remediations when future policy support is modeled.
+- Enforce non-goals as runtime, API, tool, and UI guardrails: no arbitrary raw host shell, unrestricted Docker daemon access, arbitrary SQL, direct database row editing, redaction bypass, secret reads, or silent workflow-history bulk imports.
+- Keep remediation evidence artifact-first and server-mediated; do not embed unbounded workflow history, raw local filesystem paths, presigned storage URLs, or raw storage keys into workflow payloads.
+- Keep typed admin actions behind explicit policy/profile bindings and owning control planes; do not expose raw root or generic admin console semantics.
+- Require failure and edge-case handling to produce structured, auditable outcomes rather than silent success or ambiguous fallback behavior.
+- Surface degraded evidence explicitly with `evidenceDegraded = true` when diagnosis proceeds with merged logs or partial artifacts.
+- Treat unavailable targets, stale target assumptions, lock conflicts, lost locks, already-released leases, missing containers, and unsafe forced termination as explicit validation, no_op, precondition_failed, lock_conflict, verification_failed, escalated, unsafe_to_act, or failed outcomes according to policy.
+- Ensure remediation task failure attempts final summary publication and lock release; automatic remediation of the failed remediator remains off by default.
+- Align the implementation acceptance checklist with stable design rules: remediation is not dependency waiting, `workflowId` identifies the logical target, `runId` pins evidence, live follow is non-authoritative, mutations are locked/idempotent/audited, secrets stay redacted, and loop prevention is required.
+- Preserve future extension boundaries: richer action coverage, templates, analytics, stuck-detection integration, proposal-based review, and automatic remediation policies must not weaken artifact-first evidence, typed actions, explicit locks, strict audit, or redaction.
+
+Non-Goals
+- Automatically spawning admin healers for every failed task in v1.
+- Exposing raw host shell, raw root, unrestricted Docker, arbitrary SQL, direct database row edits, decrypted secret reads, or redaction bypass actions.
+- Treating future automatic self-healing fields as active behavior without explicit bounded policy enablement.
+- Using future-work language as a substitute for current v1 safety guarantees.
+- Silently importing another task's entire workflow history into `initialParameters`.
+- Treating Live Logs as authoritative durable evidence.
+- Allowing remediation loops, automatic self-remediation, or unbounded self-healing depth by default.
+
+Validation
+- Verify default v1 remediation creation remains manual and no failed-task path automatically spawns an admin healer.
+- Verify unsupported raw admin capabilities are absent from API contracts, MCP/tool surfaces, workflow inputs, and Mission Control UI language or controls.
+- Verify raw host shell, unrestricted Docker, arbitrary SQL, direct database row editing, decrypted secret reads, and redaction bypass requests fail closed with structured errors.
+- Verify future automatic self-healing policy fields, if accepted by schemas, remain inert unless explicitly enabled and bounded by policy.
+- Verify accepted self-healing policy shape preserves bounded controls such as triggers, create mode, template reference, authority mode, and max active remediations.
+- Verify documented failure and edge cases produce structured outcomes such as validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, verification_failed, or failed as appropriate.
+- Verify partial evidence paths surface `evidenceDegraded = true` and record unavailable evidence classes.
+- Verify final acceptance checks trace to the stable design rules in `docs/Tasks/TaskRemediation.md` without relying on future extension behavior.
+- Verify future extension placeholders do not weaken artifact-first evidence, typed action registry boundaries, explicit locking, audit, redaction, or loop-prevention defaults.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-458 blocks MM-457, whose embedded status is Code Review.
+- No Jira blocker links were detected where another issue blocks MM-458.
+
+Needs Clarification
+- None

--- a/specs/233-remediation-v1-policy-guardrails/checklists/requirements.md
+++ b/specs/233-remediation-v1-policy-guardrails/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Remediation V1 Policy Guardrails
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The request is classified as a single-story runtime feature request.
+- The implementation document cited by the Jira brief is treated as runtime source requirements.
+- No pre-existing `specs/*` feature directory referenced MM-458, so Specify was the first incomplete stage.
+- The original Jira preset brief is preserved in `spec.md` for final verification.

--- a/specs/233-remediation-v1-policy-guardrails/contracts/remediation-v1-policy-guardrails.md
+++ b/specs/233-remediation-v1-policy-guardrails/contracts/remediation-v1-policy-guardrails.md
@@ -1,0 +1,48 @@
+# Contract: Remediation V1 Policy Guardrails
+
+## Task Payload Policy Contract
+
+Runtime submissions may include future-facing policy metadata under task-level policy fields, but v1 creation semantics remain manual by default.
+
+```json
+{
+  "task": {
+    "remediationPolicy": {
+      "enabled": true,
+      "triggers": ["failed", "attention_required", "stuck"],
+      "createMode": "proposal",
+      "templateRef": "admin_healer_default",
+      "authorityMode": "approval_gated",
+      "maxActiveRemediations": 1,
+      "maxSelfHealingDepth": 1
+    }
+  }
+}
+```
+
+Contract rules:
+- This payload alone must not create a remediation execution or remediation link in v1.
+- Executable remediation still requires the existing explicit `task.remediation` contract.
+- Unsupported automatic behavior must fail closed or remain inert; it must not silently spawn an admin healer.
+- Future support must validate bounded triggers, create mode, template, authority mode, active remediation limit, depth, audit, and redaction constraints before creating remediation.
+
+## Action Capability Contract
+
+Allowed action metadata returned by remediation action authority must describe typed, policy-bound actions only.
+
+Required guarantees:
+- No `raw_host_shell`, host shell, raw Docker, Docker daemon, arbitrary SQL, storage-key read, decrypted secret read, or redaction-bypass action kind is discoverable as allowed action metadata.
+- If such an action kind is requested directly, the decision is non-executable and includes a structured denial reason.
+- Action result/request metadata remains redaction-safe.
+
+## Bounded Outcome Contract
+
+Policy, precondition, and edge-case failures must produce bounded machine-readable outcomes.
+
+Required guarantees:
+- Missing target visibility fails validation or returns a bounded remediation error.
+- Partial evidence records degraded evidence instead of hiding the limitation.
+- Live-follow unavailability falls back to durable evidence.
+- Target reruns and failed preconditions record no-op, re-diagnosis, precondition_failed, or escalation.
+- Lock conflicts, stale leases, missing containers, unsafe termination, and remediator failure produce explicit bounded outcomes.
+- None of these outcomes may use raw access fallback.

--- a/specs/233-remediation-v1-policy-guardrails/data-model.md
+++ b/specs/233-remediation-v1-policy-guardrails/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Remediation V1 Policy Guardrails
+
+## Remediation Creation Policy
+
+Purpose: Represents future-facing policy metadata that may describe automatic self-healing intent without making it executable by default.
+
+Fields:
+- `enabled`: whether future automatic remediation behavior is explicitly enabled.
+- `triggers`: bounded trigger names such as failed, attention_required, or stuck.
+- `createMode`: bounded creation behavior such as proposal or immediate_task when future support exists.
+- `templateRef`: remediation template identifier.
+- `authorityMode`: bounded remediation authority mode.
+- `maxActiveRemediations`: maximum active remediations allowed by policy.
+- `maxSelfHealingDepth`: maximum nested self-healing depth.
+
+Validation rules:
+- Policy metadata alone does not create a remediation link.
+- Unsupported executable behavior fails closed until a runtime implementation explicitly supports it.
+- Future executable policy must remain bounded by trigger, create mode, template, authority, max-active count, depth, audit, and redaction constraints.
+
+## Remediation Capability Surface
+
+Purpose: Runtime-visible set of typed remediation actions and explicitly denied raw capabilities.
+
+Fields:
+- `actionKind`
+- `riskTier`
+- `targetType`
+- `inputMetadata`
+- `verificationRequired`
+- `verificationHint`
+
+Validation rules:
+- Catalog entries must represent typed actions, not raw host, Docker, SQL, storage, network, secret-read, or redaction-bypass capabilities.
+- Raw or unknown action requests return structured denial reasons.
+- Metadata must not contain secrets, raw access grants, storage keys, or unbounded log bodies.
+
+## Bounded Failure Outcome
+
+Purpose: Structured result used when remediation cannot proceed safely.
+
+Allowed examples:
+- validation failure
+- evidenceDegraded
+- no_op
+- precondition_failed
+- lock_conflict
+- escalated
+- unsafe_to_act
+- verification_failed
+- failed
+
+Validation rules:
+- Missing target visibility, partial evidence, unavailable live follow, target rerun, failed precondition, lock conflict, stale lease, missing container, unsafe termination, and remediator failure must resolve to bounded outcomes.
+- Bounded outcomes must not silently succeed or fall back to raw access.
+
+## State Transitions
+
+```text
+policy metadata present
+  -> inert metadata when explicit support is absent
+  -> bounded policy evaluation when explicit support exists
+  -> manual/proposal/remediation creation only if allowed
+  -> structured denial otherwise
+
+action capability request
+  -> typed catalog action allowed for evaluation
+  -> raw/unsupported action denied
+  -> bounded outcome recorded
+```

--- a/specs/233-remediation-v1-policy-guardrails/plan.md
+++ b/specs/233-remediation-v1-policy-guardrails/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-458 by verifying and tightening the existing remediation runtime guardrails that keep v1 manual by default, deny raw administrative capability surfaces, keep future self-healing policy inert unless bounded policy support exists, and return structured bounded outcomes for edge cases. Existing remediation action authority, mutation guard, link validation, redaction, and lifecycle helpers already satisfy much of the story; this plan adds focused verification for the remaining unverified policy-only path and preserves fallback implementation tasks if those tests expose gaps.
+Implement MM-458 by verifying and preserving the existing remediation runtime guardrails that keep v1 manual by default, deny raw administrative capability surfaces, keep future self-healing policy inert unless bounded policy support exists, and return structured bounded outcomes for edge cases. Existing remediation action authority, mutation guard, link validation, redaction, and lifecycle helpers satisfy the story with focused verification tests for the policy-only and allowed-action metadata paths.
 
 ## Requirement Status
 

--- a/specs/233-remediation-v1-policy-guardrails/plan.md
+++ b/specs/233-remediation-v1-policy-guardrails/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Remediation V1 Policy Guardrails
+
+**Branch**: `233-remediation-v1-policy-guardrails` | **Date**: 2026-04-22 | **Spec**: `specs/233-remediation-v1-policy-guardrails/spec.md`
+**Input**: Single-story feature specification from `/specs/233-remediation-v1-policy-guardrails/spec.md`
+
+## Summary
+
+Implement MM-458 by verifying and tightening the existing remediation runtime guardrails that keep v1 manual by default, deny raw administrative capability surfaces, keep future self-healing policy inert unless bounded policy support exists, and return structured bounded outcomes for edge cases. Existing remediation action authority, mutation guard, link validation, redaction, and lifecycle helpers already satisfy much of the story; this plan adds focused verification for the remaining unverified policy-only path and preserves fallback implementation tasks if those tests expose gaps.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves policy-only task metadata creates no remediation link; `TemporalExecutionService.create_execution()` only creates remediation links when `task.remediation` is present | no further implementation | final verify |
+| FR-002 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves `remediationPolicy` is preserved as inert metadata without link creation | no further implementation | final verify |
+| FR-003 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves explicitly enabled future policy metadata remains non-executable; `RemediationMutationGuardPolicy` provides bounded defaults for existing guard evaluation | no further implementation | final verify |
+| FR-004 | implemented_verified | `_RAW_ACCESS_ACTION_KINDS` denies raw requests and `test_remediation_action_authority_does_not_advertise_raw_admin_actions` proves catalog metadata excludes raw host actions | no further implementation | final verify |
+| FR-005 | implemented_verified | Raw Docker, SQL, storage, and raw action kinds are denied by guard/action authority | no further implementation | final verify |
+| FR-006 | implemented_verified | `RemediationActionAuthorityService` and `RemediationMutationGuardService` return structured denial reasons for raw access | no further implementation | final verify |
+| FR-007 | implemented_verified | `RemediationContextBuilder` and evidence tools use artifact refs/bounded target health; no full workflow-history import path found | no further implementation | final verify |
+| FR-008 | implemented_verified | Mission Control and docs distinguish Live Logs from durable evidence; remediation context artifacts are separate | no further implementation | final verify |
+| FR-009 | implemented_verified | Service rejects nested remediation targets; mutation guard denies self-target/nested remediation by default | no further implementation | final verify |
+| FR-010 | implemented_verified | Mutation guard policy defaults self-healing depth to 1 and preserves typed actions/locks/audit/redaction decisions | no further implementation | final verify |
+| FR-011 | implemented_verified | Remediation target validation rejects missing, unauthorized, non-run, and run-id targets | no further implementation | final verify |
+| FR-012 | implemented_verified | Remediation lifecycle/context tests cover degraded evidence and summary outputs | no further implementation | final verify |
+| FR-013 | implemented_verified | Remediation link validation pins target run; freshness guard handles target run changes | no further implementation | final verify |
+| FR-014 | implemented_verified | Target freshness guard maps failed preconditions to no-op, rediagnose, or escalation | no further implementation | final verify |
+| FR-015 | implemented_verified | Mutation guard tests cover lock conflicts, stale locks, and lock loss | no further implementation | final verify |
+| FR-016 | implemented_verified | Action authority and mutation guard return bounded rejected/unsafe outcomes for unsupported or high-risk actions | no further implementation | final verify |
+| FR-017 | implemented_verified | Remediation summary helpers and lifecycle tests cover failed summaries and lock conflict counters; automatic self-remediation is not present | no further implementation | final verify |
+| FR-018 | implemented_verified | `test_remediation_action_authority_does_not_advertise_raw_admin_actions` proves allowed action metadata exposes typed actions only | no further implementation | final verify |
+| FR-019 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves future-only automatic self-healing metadata is not executable v1 behavior | no further implementation | final verify |
+| FR-020 | implemented_verified | MM-458 is preserved in spec, plan, tasks, quickstart, tests, and implementation evidence | no further implementation | final verify |
+| FR-021 | implemented_verified | Spec, plan, and tests distinguish current v1 guarantees from future extension behavior | no further implementation | final verify |
+| SC-001 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` verifies policy-only metadata does not spawn remediation | no further implementation | final verify |
+| SC-002 | implemented_verified | raw action denial tests and catalog boundaries exist | add allowed catalog absence check | unit |
+| SC-003 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` verifies future policy fields remain inert | no further implementation | final verify |
+| SC-004 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves enabled self-healing policy metadata does not proceed in v1 without supported bounded runtime validation | no further implementation | final verify |
+| SC-005 | implemented_verified | existing remediation context/action tests cover bounded outcomes | no further implementation | final verify |
+| SC-006 | implemented_verified | Live Logs docs/UI tests distinguish timeline from durable evidence | no further implementation | final verify |
+| SC-007 | implemented_verified | artifact and test traceability preserve MM-458 and mapped design requirements | no further implementation | final verify |
+| DESIGN-REQ-016 | implemented_verified | policy-only metadata is inert, self-healing depth defaults to 1, and manual v1 behavior is verified | no further implementation | final verify |
+| DESIGN-REQ-022 | implemented_verified | target freshness guard covers rerun/precondition outcomes | no further implementation | final verify |
+| DESIGN-REQ-023 | implemented_verified | bounded failure outcomes exist across remediation context/action tests | no further implementation | final verify |
+| DESIGN-REQ-024 | implemented_verified | raw administrative non-goals are denied or absent from allowed action metadata | no further implementation | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: SQLAlchemy async ORM, Temporal execution service boundary, remediation action authority and mutation guard services, existing pytest fixtures  
+**Storage**: Existing `TemporalExecutionCanonicalRecord` and `execution_remediation_links`; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py`  
+**Integration Testing**: Async DB-backed service-boundary tests in the unit suite; no provider credentials or compose-backed integration required for this policy-surface slice  
+**Target Platform**: Linux server / Docker Compose deployment  
+**Project Type**: FastAPI control plane plus Temporal workflow service boundary  
+**Performance Goals**: Policy and capability checks remain bounded local validation with no external calls  
+**Constraints**: Runtime mode; preserve MM-458; no raw host, Docker daemon, arbitrary SQL, secret read, storage-key, redaction bypass, or automatic remediation loop; no new compatibility aliases  
+**Scale/Scope**: One remediation policy/capability decision at task creation or action-evaluation time
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story constrains orchestration behavior without replacing agents.
+- II. One-Click Agent Deployment: PASS. No new services or external credentials.
+- III. Avoid Vendor Lock-In: PASS. Policy guardrails are provider-neutral.
+- IV. Own Your Data: PASS. Runtime decisions remain local and artifact-backed.
+- V. Skills Are First-Class and Easy to Add: PASS. No mutation of skill bundles.
+- VI. Replaceable Scaffolding / Tests Anchor: PASS. Adds thin boundary tests around existing contracts.
+- VII. Runtime Configurability: PASS. Future automatic policy remains explicit and bounded rather than hidden.
+- VIII. Modular Architecture: PASS. Work stays in remediation service/action boundaries and tests.
+- IX. Resilient by Default: PASS. Fail-closed policy behavior and bounded outcomes improve unattended safety.
+- X. Continuous Improvement: PASS. Structured outcomes make policy denials diagnosable.
+- XI. Spec-Driven Development: PASS. This plan follows the MM-458 single-story spec.
+- XII. Canonical Documentation Separation: PASS. Canonical docs remain desired-state; Jira input remains under `docs/tmp`.
+- XIII. Pre-release Compatibility Policy: PASS. No aliases or backward-compat shims.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/233-remediation-v1-policy-guardrails/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-v1-policy-guardrails.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/temporal/
+├── remediation_actions.py
+└── service.py
+
+tests/unit/workflows/temporal/
+├── test_remediation_context.py
+└── test_temporal_service.py
+```
+
+**Structure Decision**: Use the existing Temporal execution service for task/remediation creation policy verification and the existing remediation action authority service for typed action capability verification. No new source module is planned unless verification tests expose a missing fail-closed guard.
+
+## Complexity Tracking
+
+None.

--- a/specs/233-remediation-v1-policy-guardrails/plan.md
+++ b/specs/233-remediation-v1-policy-guardrails/plan.md
@@ -33,7 +33,7 @@ Implement MM-458 by verifying and tightening the existing remediation runtime gu
 | FR-020 | implemented_verified | MM-458 is preserved in spec, plan, tasks, quickstart, tests, and implementation evidence | no further implementation | final verify |
 | FR-021 | implemented_verified | Spec, plan, and tests distinguish current v1 guarantees from future extension behavior | no further implementation | final verify |
 | SC-001 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` verifies policy-only metadata does not spawn remediation | no further implementation | final verify |
-| SC-002 | implemented_verified | raw action denial tests and catalog boundaries exist | add allowed catalog absence check | unit |
+| SC-002 | implemented_verified | raw action denial tests and `test_remediation_action_authority_does_not_advertise_raw_admin_actions` cover catalog boundaries | no further implementation | final verify |
 | SC-003 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` verifies future policy fields remain inert | no further implementation | final verify |
 | SC-004 | implemented_verified | `test_create_execution_keeps_future_remediation_policy_inert` proves enabled self-healing policy metadata does not proceed in v1 without supported bounded runtime validation | no further implementation | final verify |
 | SC-005 | implemented_verified | existing remediation context/action tests cover bounded outcomes | no further implementation | final verify |

--- a/specs/233-remediation-v1-policy-guardrails/quickstart.md
+++ b/specs/233-remediation-v1-policy-guardrails/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Remediation V1 Policy Guardrails
+
+## Scope
+
+Verify MM-458 runtime guardrails:
+- remediation v1 remains manual by default;
+- future self-healing policy metadata is inert unless explicitly supported and bounded;
+- raw administrative capabilities are absent or fail closed;
+- documented edge cases produce bounded outcomes.
+
+## Test Commands
+
+Targeted verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Final unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## End-To-End Scenario
+
+1. Create a normal MoonMind.Run target.
+2. Create another MoonMind.Run with only future `task.remediationPolicy` metadata.
+3. Confirm no `TemporalExecutionRemediationLink` is created for the policy-only run.
+4. Confirm the same metadata remains ordinary task parameters and does not automatically spawn an admin healer.
+5. Ask remediation action authority for allowed admin actions.
+6. Confirm allowed action metadata contains typed actions only and no raw host, Docker, SQL, storage, secret-read, or redaction-bypass actions.
+7. Run existing remediation action/context tests to confirm raw action requests, degraded evidence, lock conflicts, stale target checks, and redaction-safe outputs remain bounded.
+
+## Expected Result
+
+All tests pass, and final verification can trace MM-458 plus DESIGN-REQ-016, DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-024 through the spec, plan, tasks, tests, and implementation evidence.

--- a/specs/233-remediation-v1-policy-guardrails/research.md
+++ b/specs/233-remediation-v1-policy-guardrails/research.md
@@ -26,9 +26,9 @@ Test implications: Add a catalog absence assertion for raw capability names.
 
 ## DESIGN-REQ-016 - Manual V1 And Bounded Self-Healing
 
-Decision: Partially implemented and needs verification; v1 has no automatic self-healing creation path, while mutation guard policy already defaults self-healing depth to 1.
-Evidence: `RemediationMutationGuardPolicy.max_self_healing_depth` defaults to 1; `TemporalExecutionService` only creates remediation links for explicit `task.remediation`.
-Rationale: Existing absence of automatic creation should be locked down with a regression test because this is the central MM-458 risk.
+Decision: Implemented and verified; v1 has no automatic self-healing creation path, while mutation guard policy already defaults self-healing depth to 1.
+Evidence: `RemediationMutationGuardPolicy.max_self_healing_depth` defaults to 1; `TemporalExecutionService` only creates remediation links for explicit `task.remediation`; `test_create_execution_keeps_future_remediation_policy_inert` proves `task.remediationPolicy` metadata creates no remediation link.
+Rationale: Existing absence of automatic creation is locked down with a regression test because this is the central MM-458 risk.
 Alternatives considered: Adding automatic policy parsing was rejected as outside this v1 guardrail story.
 Test implications: Unit test verifies `task.remediationPolicy` remains inert and does not create `TemporalExecutionRemediationLink`.
 
@@ -50,11 +50,11 @@ Test implications: Run existing remediation context tests after adding MM-458 fo
 
 ## DESIGN-REQ-024 - Enforced Non-Goals
 
-Decision: Implemented and verified for action authority, with one additional verification test planned for catalog absence.
-Evidence: `RemediationActionAuthorityService` denies raw access action kinds; service validation rejects unsupported authority modes and incompatible policies.
+Decision: Implemented and verified for action authority and allowed-action metadata.
+Evidence: `RemediationActionAuthorityService` denies raw access action kinds; service validation rejects unsupported authority modes and incompatible policies; `test_remediation_action_authority_does_not_advertise_raw_admin_actions` proves raw admin action names are not advertised.
 Rationale: Raw capability absence must be true both for action requests and discoverable action metadata.
 Alternatives considered: UI-only checks were rejected because the runtime action catalog is the primary source.
-Test implications: Add a unit test that allowed action metadata does not expose raw host, Docker, SQL, storage-key, secret-read, or redaction-bypass actions.
+Test implications: Unit test verifies allowed action metadata does not expose raw host, Docker, SQL, storage-key, secret-read, or redaction-bypass actions.
 
 ## Testing Strategy
 

--- a/specs/233-remediation-v1-policy-guardrails/research.md
+++ b/specs/233-remediation-v1-policy-guardrails/research.md
@@ -1,0 +1,65 @@
+# Research: Remediation V1 Policy Guardrails
+
+## Input Classification
+
+Decision: MM-458 is a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-458-moonspec-orchestration-input.md` defines one user story, one acceptance-criteria set, and one bounded runtime behavior area.
+Rationale: The story focuses on manual-by-default remediation v1, future self-healing policy constraints, raw capability denial, and bounded edge-case outcomes.
+Alternatives considered: Treating `docs/Tasks/TaskRemediation.md` as a broad design was rejected because the Jira preset brief already selected one independently testable slice.
+Test implications: Unit and service-boundary tests should target the selected policy/capability surface.
+
+## Existing Remediation Creation Boundary
+
+Decision: Use `TemporalExecutionService.create_execution()` as the create-time boundary for manual remediation and inert future policy verification.
+Evidence: `moonmind/workflows/temporal/service.py` creates a remediation link only when `task.remediation` is present and validates that target. Search found no `remediationPolicy` consumer.
+Rationale: MM-458 requires default v1 behavior not to spawn admin healers. The create service is the canonical local boundary for proving that policy-only task metadata does not create remediation links.
+Alternatives considered: Full workflow failure simulation was rejected because automatic remediation is not implemented; verifying the creation boundary is the narrowest deterministic proof.
+Test implications: Add async DB-backed unit tests in `tests/unit/workflows/temporal/test_temporal_service.py`.
+
+## Existing Capability Surface
+
+Decision: Use `RemediationActionAuthorityService.list_allowed_actions()` and raw-action denial as the capability-surface boundary.
+Evidence: `_ACTION_CATALOG` in `moonmind/workflows/temporal/remediation_actions.py` lists typed actions only, and existing tests deny `raw_host_shell`.
+Rationale: Unsupported raw host, Docker, SQL, storage, and secret-reading actions must be absent or fail closed. The action authority service is the runtime source of action metadata and action decisions.
+Alternatives considered: Testing frontend strings alone was rejected because runtime capability metadata is the authoritative boundary.
+Test implications: Add a catalog absence assertion for raw capability names.
+
+## DESIGN-REQ-016 - Manual V1 And Bounded Self-Healing
+
+Decision: Partially implemented and needs verification; v1 has no automatic self-healing creation path, while mutation guard policy already defaults self-healing depth to 1.
+Evidence: `RemediationMutationGuardPolicy.max_self_healing_depth` defaults to 1; `TemporalExecutionService` only creates remediation links for explicit `task.remediation`.
+Rationale: Existing absence of automatic creation should be locked down with a regression test because this is the central MM-458 risk.
+Alternatives considered: Adding automatic policy parsing was rejected as outside this v1 guardrail story.
+Test implications: Unit test verifies `task.remediationPolicy` remains inert and does not create `TemporalExecutionRemediationLink`.
+
+## DESIGN-REQ-022 - Target Changes And Preconditions
+
+Decision: Implemented and verified by existing mutation guard tests.
+Evidence: `RemediationMutationGuardService` target freshness decisions compare pinned/current run and target state, with no-op, rediagnose, or escalate outcomes.
+Rationale: MM-458 does not need a second implementation of freshness handling; it needs traceability to the existing bounded outcome behavior.
+Alternatives considered: Adding workflow-level freshness logic was rejected to avoid duplicate semantics.
+Test implications: Existing `test_remediation_context.py` tests remain part of final targeted verification.
+
+## DESIGN-REQ-023 - Bounded Failure Outcomes
+
+Decision: Implemented and verified across remediation context/action tests.
+Evidence: `moonmind/workflows/temporal/remediation_context.py` defines bounded resolution states; `test_remediation_context.py` covers degraded evidence, summaries, action authority denials, lock conflicts, and redaction-safe outputs.
+Rationale: The story depends on these bounded outcomes but does not need new storage or workflow state for them.
+Alternatives considered: New result enum was rejected because existing remediation models already expose the required outcomes.
+Test implications: Run existing remediation context tests after adding MM-458 focused tests.
+
+## DESIGN-REQ-024 - Enforced Non-Goals
+
+Decision: Implemented and verified for action authority, with one additional verification test planned for catalog absence.
+Evidence: `RemediationActionAuthorityService` denies raw access action kinds; service validation rejects unsupported authority modes and incompatible policies.
+Rationale: Raw capability absence must be true both for action requests and discoverable action metadata.
+Alternatives considered: UI-only checks were rejected because the runtime action catalog is the primary source.
+Test implications: Add a unit test that allowed action metadata does not expose raw host, Docker, SQL, storage-key, secret-read, or redaction-bypass actions.
+
+## Testing Strategy
+
+Decision: Use targeted unit/service-boundary tests plus final full unit suite when feasible.
+Evidence: Adjacent remediation specs use `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/workflows/temporal/test_remediation_context.py` for these boundaries.
+Rationale: No external provider or compose-backed service is needed for this policy guardrail story.
+Alternatives considered: Temporal time-skipping workflow tests were rejected because no workflow signature or activity contract changes are planned.
+Test implications: Primary command is `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py`; final command is `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.

--- a/specs/233-remediation-v1-policy-guardrails/spec.md
+++ b/specs/233-remediation-v1-policy-guardrails/spec.md
@@ -1,0 +1,209 @@
+# Feature Specification: Remediation V1 Policy Guardrails
+
+**Feature Branch**: `233-remediation-v1-policy-guardrails`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-458 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-458-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-458 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-458
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document and enforce bounded v1 rollout and future self-healing policy constraints
+- Labels: `moonmind-workflow-mm-4fcd9c9b-785c-42de-a6ca-ed60359eadf6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-458 from MM project
+Summary: Document and enforce bounded v1 rollout and future self-healing policy constraints
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-458 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-458: Document and enforce bounded v1 rollout and future self-healing policy constraints
+
+Source Reference
+- Source document: `docs/Tasks/TaskRemediation.md`
+- Source title: Task Remediation
+- Source sections:
+  - 4. Non-goals
+  - 7.6 Future automatic self-healing policy
+  - 16. Failure modes and edge cases
+  - 17. Recommended v1
+  - 18. Future extensions
+  - 19. Acceptance criteria
+  - Appendix C. Design rule summary
+- Coverage IDs:
+  - DESIGN-REQ-016
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a product/platform owner, I can ship a constrained manual v1 and leave future automatic self-healing behind explicit bounded policy so remediation remains safe as capabilities expand.
+
+Acceptance Criteria
+- Default v1 behavior supports manual remediation only and does not automatically spawn admin healers.
+- Unsupported raw admin capabilities are absent from APIs, tools, and UI and fail closed if requested.
+- Future self-healing policy fields, if accepted by schemas, remain inert unless explicitly enabled and bounded by policy.
+- All documented failure/edge cases have structured output expectations such as validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, or failed.
+- The implementation acceptance checklist can be traced back to each design rule without relying on future-work language for current v1 guarantees.
+
+Requirements
+- V1 must stay useful but constrained.
+- Future extensions preserve artifact-first evidence, typed actions, explicit locks, strict audit, redaction, and no raw root shell.
+- Non-goals are enforced as guardrails, not merely documentation.
+
+Relevant Implementation Notes
+- Preserve MM-458 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation non-goals, future automatic self-healing policy, failure and edge-case outputs, recommended v1 scope, future extension boundaries, acceptance criteria, and design-rule summary.
+- Keep v1 remediation manual by default: operators create remediation tasks explicitly from Mission Control or equivalent operator surfaces.
+- Do not introduce an automatic rule where every failed, stalled, timed-out, or attention-required task spawns an admin healer.
+- If future automatic remediation policy fields are accepted by schemas or payload models, keep them policy-driven, bounded, and inert unless explicitly enabled.
+- Preserve bounded self-healing controls such as triggers, create mode, template reference, authority mode, and max active remediations when future policy support is modeled.
+- Enforce non-goals as runtime, API, tool, and UI guardrails: no arbitrary raw host shell, unrestricted Docker daemon access, arbitrary SQL, direct database row editing, redaction bypass, secret reads, or silent workflow-history bulk imports.
+- Keep remediation evidence artifact-first and server-mediated; do not embed unbounded workflow history, raw local filesystem paths, presigned storage URLs, or raw storage keys into workflow payloads.
+- Keep typed admin actions behind explicit policy/profile bindings and owning control planes; do not expose raw root or generic admin console semantics.
+- Require failure and edge-case handling to produce structured, auditable outcomes rather than silent success or ambiguous fallback behavior.
+- Surface degraded evidence explicitly with `evidenceDegraded = true` when diagnosis proceeds with merged logs or partial artifacts.
+- Treat unavailable targets, stale target assumptions, lock conflicts, lost locks, already-released leases, missing containers, and unsafe forced termination as explicit validation, no_op, precondition_failed, lock_conflict, verification_failed, escalated, unsafe_to_act, or failed outcomes according to policy.
+- Ensure remediation task failure attempts final summary publication and lock release; automatic remediation of the failed remediator remains off by default.
+- Align the implementation acceptance checklist with stable design rules: remediation is not dependency waiting, `workflowId` identifies the logical target, `runId` pins evidence, live follow is non-authoritative, mutations are locked/idempotent/audited, secrets stay redacted, and loop prevention is required.
+- Preserve future extension boundaries: richer action coverage, templates, analytics, stuck-detection integration, proposal-based review, and automatic remediation policies must not weaken artifact-first evidence, typed actions, explicit locks, strict audit, or redaction.
+
+Non-Goals
+- Automatically spawning admin healers for every failed task in v1.
+- Exposing raw host shell, raw root, unrestricted Docker, arbitrary SQL, direct database row edits, decrypted secret reads, or redaction bypass actions.
+- Treating future automatic self-healing fields as active behavior without explicit bounded policy enablement.
+- Using future-work language as a substitute for current v1 safety guarantees.
+- Silently importing another task's entire workflow history into `initialParameters`.
+- Treating Live Logs as authoritative durable evidence.
+- Allowing remediation loops, automatic self-remediation, or unbounded self-healing depth by default.
+
+Validation
+- Verify default v1 remediation creation remains manual and no failed-task path automatically spawns an admin healer.
+- Verify unsupported raw admin capabilities are absent from API contracts, MCP/tool surfaces, workflow inputs, and Mission Control UI language or controls.
+- Verify raw host shell, unrestricted Docker, arbitrary SQL, direct database row editing, decrypted secret reads, and redaction bypass requests fail closed with structured errors.
+- Verify future automatic self-healing policy fields, if accepted by schemas, remain inert unless explicitly enabled and bounded by policy.
+- Verify accepted self-healing policy shape preserves bounded controls such as triggers, create mode, template reference, authority mode, and max active remediations.
+- Verify documented failure and edge cases produce structured outcomes such as validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, verification_failed, or failed as appropriate.
+- Verify partial evidence paths surface `evidenceDegraded = true` and record unavailable evidence classes.
+- Verify final acceptance checks trace to the stable design rules in `docs/Tasks/TaskRemediation.md` without relying on future extension behavior.
+- Verify future extension placeholders do not weaken artifact-first evidence, typed action registry boundaries, explicit locking, audit, redaction, or loop-prevention defaults.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-458 blocks MM-457, whose embedded status is Code Review.
+- No Jira blocker links were detected where another issue blocks MM-458.
+
+Needs Clarification
+- None
+```
+
+## User Story - Enforce Remediation V1 Policy Guardrails
+
+**Summary**: As a product/platform owner, I want remediation v1 to remain manual, bounded, and policy-constrained so that current remediation behavior is useful without enabling unsafe automatic self-healing or raw administrative capabilities.
+
+**Goal**: The runtime accepts and exposes only constrained remediation behavior: manual creation by default, no automatic admin healer spawning, no unsupported raw admin capability, inert future self-healing policy unless explicitly enabled and bounded, and structured outcomes for documented edge cases.
+
+**Independent Test**: Exercise remediation submission, policy parsing, action/tool exposure, UI-visible capability metadata, and failure/edge-case classification; verify v1 remains manual by default, unsupported raw admin requests fail closed, future self-healing policy is inert unless explicitly enabled, and every documented edge case produces a structured bounded outcome.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task fails, stalls, times out, or requests attention, **When** no explicit operator or policy-driven remediation creation request exists, **Then** the system does not automatically spawn an admin healer.
+2. **Given** a user or runtime attempts to request raw host shell, unrestricted Docker, arbitrary SQL, direct database editing, decrypted secret reads, redaction bypass, or full workflow-history import, **When** remediation contracts, tools, APIs, or UI capability metadata are evaluated, **Then** those capabilities are absent or rejected with structured fail-closed errors.
+3. **Given** future automatic self-healing policy fields are present in accepted payloads or configuration, **When** explicit bounded enablement is absent, **Then** those fields remain inert and do not create or authorize remediation.
+4. **Given** automatic self-healing policy metadata is explicitly enabled before a supported bounded runtime implementation exists, **When** policy is evaluated, **Then** it remains non-executable; future runtime support may proceed only after validating trigger, create mode, template reference, authority mode, maximum active remediation, depth, audit, and redaction limits.
+5. **Given** target visibility, evidence, live follow, locks, leases, containers, preconditions, or remediator execution fail in documented ways, **When** remediation evaluates the condition, **Then** it emits validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, verification_failed, or failed instead of silent success or raw-access fallback.
+6. **Given** downstream verification inspects the implementation, **When** traceability is checked, **Then** MM-458 and the relevant Task Remediation design rules are preserved in artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Edge Cases
+
+- Existing historical runs may only have merged logs or partial artifacts; diagnosis can continue only when safe and must set degraded evidence.
+- Policy payloads may include future self-healing fields before automatic self-healing ships; the fields must be preserved only as inert or explicitly bounded data.
+- Multiple remediation requests may be active across a target graph; v1 must still avoid automatic loops and unbounded self-healing depth.
+- UI, API, and tool metadata may be generated from different sources; unsupported raw capabilities must be absent or rejected consistently across every boundary.
+- A failed remediator must publish bounded summary evidence and release locks where possible, but it must not automatically remediate itself by default.
+- Unknown or newly introduced failure reasons must fail closed with a bounded unsupported or unsafe outcome rather than falling back to raw access.
+
+## Assumptions
+
+- The MM-458 brief is a single runtime feature slice focused on v1 rollout and future self-healing guardrails, not a request to implement automatic self-healing.
+- Existing remediation create/link, evidence/context, authority, action registry, mutation guard, UI, and lifecycle stories provide surrounding remediation behavior; this story verifies and completes the bounded policy constraints.
+- The source implementation document `docs/Tasks/TaskRemediation.md` is treated as runtime source requirements because the selected mode is runtime.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-016** (`docs/Tasks/TaskRemediation.md` sections 7.6, 17, 18, and Appendix C): Automatic remediation must remain policy-driven and bounded, v1 starts with explicit manual creation, self-healing depth remains bounded, future extensions preserve typed actions, explicit locks, strict audit, redaction, and no raw root shell. Scope: in scope, mapped to FR-001 through FR-010 and FR-018 through FR-021.
+- **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` sections 16.2 and 16.7): Reruns, stale target assumptions, and failed preconditions must produce recorded no-op, re-diagnosis, precondition_failed, or escalation outcomes rather than silent retargeting or silent success. Scope: in scope, mapped to FR-013 through FR-016.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` sections 16.1 through 16.11): Missing targets, partial evidence, unavailable live follow, lock conflicts, stale leases, gone containers, unsafe forced termination, and remediator failure must degrade, no-op, escalate, fail, or deny with bounded reasons. Scope: in scope, mapped to FR-011 through FR-017.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskRemediation.md` section 4 and Appendix C): Non-goals are enforceable guardrails: no arbitrary host shell, unrestricted Docker, arbitrary SQL, direct database row editing, redaction bypass, decrypted secret reads, full workflow-history imports, Live Logs as source of truth, or unbounded loops. Scope: in scope, mapped to FR-004 through FR-008 and FR-017 through FR-021.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Default v1 remediation behavior MUST require explicit operator or trusted workflow submission and MUST NOT automatically spawn admin healers for failed, stalled, timed-out, or attention-required tasks.
+- **FR-002**: Future automatic self-healing policy fields MAY be accepted only as inert configuration unless explicit bounded enablement is present.
+- **FR-003**: Explicitly enabled automatic remediation policy metadata MUST remain non-executable unless the runtime can validate trigger set, create mode, template reference, authority mode, maximum active remediation count, depth, audit, and redaction constraints.
+- **FR-004**: The system MUST NOT expose arbitrary raw host shell access through remediation contracts, tools, APIs, workflow payloads, or UI capability metadata.
+- **FR-005**: The system MUST NOT expose unrestricted Docker daemon access, arbitrary SQL, direct database row editing, decrypted secret reads, redaction bypass, or arbitrary network/volume mutation as remediation capabilities.
+- **FR-006**: Unsupported raw admin capability requests MUST fail closed with structured policy or validation errors instead of being ignored, silently downgraded, or translated into raw access.
+- **FR-007**: Remediation evidence access MUST remain artifact-first and server-mediated, and MUST NOT silently import another task's entire workflow history into initial parameters.
+- **FR-008**: Live follow data MUST remain non-authoritative and MUST NOT replace durable artifact, log, diagnostic, summary, or audit evidence.
+- **FR-009**: Automatic nested remediation, self-remediation, and unbounded self-healing depth MUST be disabled by default.
+- **FR-010**: Any enabled future self-healing behavior MUST preserve typed actions, explicit locks, audit records, redaction, bounded evidence, and no raw root shell.
+- **FR-011**: Missing target visibility MUST produce a structured validation failure or early bounded remediation error.
+- **FR-012**: Historical targets with only merged logs or partial artifacts MUST surface degraded evidence when diagnosis continues.
+- **FR-013**: Target reruns after remediation starts MUST preserve the pinned snapshot and MUST NOT silently retarget without a recorded outcome.
+- **FR-014**: Failed preconditions MUST produce no_op, precondition_failed, re-diagnosis, or escalation outcomes rather than silent success.
+- **FR-015**: Lock conflicts, stale leases, and lost locks MUST produce explicit bounded outcomes before further mutation.
+- **FR-016**: Missing containers or unsafe forced termination attempts MUST produce no_op, verification_failed, approval-required, unsafe_to_act, or policy rejection outcomes as appropriate.
+- **FR-017**: A failed remediator MUST attempt final summary publication and lock release, and automatic remediation of the failed remediator MUST remain off by default.
+- **FR-018**: APIs, tools, workflow contracts, and UI surfaces MUST consistently advertise only supported typed remediation capabilities.
+- **FR-019**: Unsupported or future-only capability metadata MUST be distinguishable from currently executable v1 behavior.
+- **FR-020**: Validation and verification evidence MUST trace MM-458 and DESIGN-REQ-016, DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-024 through MoonSpec artifacts, implementation notes, commit text, and pull request metadata.
+- **FR-021**: The implementation acceptance checklist MUST be traceable to current v1 guarantees and MUST NOT rely on future-work language to satisfy present safety requirements.
+
+### Key Entities
+
+- **Remediation Creation Policy**: The bounded decision data that determines whether remediation may be created manually or automatically.
+- **Self-Healing Policy Fields**: Future-facing policy data such as triggers, create mode, template reference, authority mode, maximum active remediation count, and depth.
+- **Remediation Capability Surface**: The API, tool, workflow, and UI-visible list of currently supported typed remediation actions and explicitly unsupported raw capabilities.
+- **Bounded Failure Outcome**: A structured remediation decision such as validation failure, evidenceDegraded, no_op, precondition_failed, lock_conflict, escalated, unsafe_to_act, verification_failed, or failed.
+- **V1 Guardrail Checklist**: The traceable acceptance evidence that current behavior enforces manual-by-default remediation, no raw admin fallback, bounded policy, and structured edge-case outcomes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove failed, stalled, timed-out, and attention-required tasks do not automatically spawn admin healers in default v1 behavior.
+- **SC-002**: Tests prove unsupported raw host, Docker, SQL, database-editing, secret-reading, redaction-bypass, and workflow-history-import capabilities are absent or fail closed across API, tool, workflow, and UI-visible capability surfaces.
+- **SC-003**: Tests prove future self-healing policy fields remain inert unless explicit bounded enablement is present.
+- **SC-004**: Tests prove explicitly enabled self-healing policy metadata does not proceed in v1 without supported bounded runtime validation for trigger, create mode, template, authority, max-active, depth, audit, and redaction constraints.
+- **SC-005**: Tests prove documented target visibility, partial evidence, live-follow, stale target, lock, lease, container, unsafe termination, and remediator failure cases produce structured bounded outcomes.
+- **SC-006**: Tests prove Live Logs remains non-authoritative and durable artifacts, logs, diagnostics, summaries, or audit evidence remain the fallback evidence path.
+- **SC-007**: Traceability verification confirms MM-458 and DESIGN-REQ-016, DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-024 are preserved in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/233-remediation-v1-policy-guardrails/tasks.md
+++ b/specs/233-remediation-v1-policy-guardrails/tasks.md
@@ -12,8 +12,8 @@
 ## Source Traceability Summary
 
 - MM-458 is preserved in `spec.md`, `plan.md`, this task file, quickstart, implementation notes, verification output, commit text, and pull request metadata.
-- The plan originally classified FR-001, FR-002, FR-019, SC-001, SC-003, and DESIGN-REQ-016 as verification-first; the added tests now verify them without fallback implementation.
-- The plan classifies raw capability denial and bounded outcome behavior as already implemented, with one added catalog metadata verification test.
+- The plan classifies FR-001, FR-002, FR-019, SC-001, SC-003, and DESIGN-REQ-016 as implemented and verified by policy-only metadata tests without fallback implementation.
+- The plan classifies raw capability denial and bounded outcome behavior as implemented and verified, including catalog metadata coverage.
 
 ## Phase 1: Setup
 

--- a/specs/233-remediation-v1-policy-guardrails/tasks.md
+++ b/specs/233-remediation-v1-policy-guardrails/tasks.md
@@ -1,0 +1,68 @@
+# Tasks: Remediation V1 Policy Guardrails
+
+**Input**: `specs/233-remediation-v1-policy-guardrails/spec.md`, `specs/233-remediation-v1-policy-guardrails/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/remediation-v1-policy-guardrails.md`, `quickstart.md`
+
+## Validation Commands
+
+- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py`
+- Final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Integration: service-boundary coverage lives in the unit command above; no compose-backed provider test is required.
+
+## Source Traceability Summary
+
+- MM-458 is preserved in `spec.md`, `plan.md`, this task file, quickstart, implementation notes, verification output, commit text, and pull request metadata.
+- The plan originally classified FR-001, FR-002, FR-019, SC-001, SC-003, and DESIGN-REQ-016 as verification-first; the added tests now verify them without fallback implementation.
+- The plan classifies raw capability denial and bounded outcome behavior as already implemented, with one added catalog metadata verification test.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature locator points to `specs/233-remediation-v1-policy-guardrails` in `.specify/feature.json`
+- [X] T002 Review existing remediation create/action fixtures in `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/workflows/temporal/test_remediation_context.py`
+
+## Phase 2: Foundational
+
+- [X] T003 Identify policy-only create-time verification boundary in `moonmind/workflows/temporal/service.py` (FR-001, FR-002, SC-001, SC-003, DESIGN-REQ-016)
+- [X] T004 Identify typed action capability metadata boundary in `moonmind/workflows/temporal/remediation_actions.py` (FR-004 through FR-006, FR-018, SC-002, DESIGN-REQ-024)
+
+## Phase 3: Story - Enforce Remediation V1 Policy Guardrails
+
+**Summary**: Keep remediation v1 manual by default, keep future self-healing policy metadata inert unless explicitly bounded, deny raw admin capabilities, and preserve structured bounded outcomes.
+
+**Independent Test**: Exercise remediation submission, policy parsing, action/tool exposure, UI-visible capability metadata, and failure/edge-case classification; verify v1 remains manual by default, unsupported raw admin requests fail closed, future self-healing policy is inert unless explicitly enabled, and every documented edge case produces a structured bounded outcome.
+
+**Traceability IDs**: FR-001 through FR-021, SC-001 through SC-007, DESIGN-REQ-016, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024
+
+**Unit Test Plan**: Add focused verification tests in `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/workflows/temporal/test_remediation_context.py`.
+
+**Integration Test Plan**: Use async DB-backed service-boundary unit tests to prove runtime behavior without provider credentials or compose-backed services.
+
+- [X] T005 Add verification test that a task containing only `task.remediationPolicy` does not create a `TemporalExecutionRemediationLink` in `tests/unit/workflows/temporal/test_temporal_service.py` (FR-001, FR-002, FR-019, SC-001, SC-003, DESIGN-REQ-016)
+- [X] T006 Add verification test that allowed remediation action metadata excludes raw host, Docker, SQL, storage, secret-read, and redaction-bypass capabilities in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-004 through FR-006, FR-018, SC-002, DESIGN-REQ-024)
+- [X] T007 Run targeted tests and treat failures as red-first evidence for fallback implementation: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py`
+- [X] T008 Conditional fallback skipped because T005 passed; no `moonmind/workflows/temporal/service.py` production change required (FR-001, FR-002, FR-019)
+- [X] T009 Conditional fallback skipped because T006 passed; no `moonmind/workflows/temporal/remediation_actions.py` production change required (FR-004 through FR-006, FR-018)
+- [X] T010 Confirm existing remediation bounded-outcome coverage still passes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-011 through FR-017, SC-005, SC-006, DESIGN-REQ-022, DESIGN-REQ-023)
+- [X] T011 Update this task file to mark completed verification and skipped fallback implementation decisions (FR-020, FR-021, SC-007)
+
+## Final Phase: Polish And Verification
+
+- [X] T012 Review `specs/233-remediation-v1-policy-guardrails/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-v1-policy-guardrails.md`, and `quickstart.md` for MM-458 and DESIGN-REQ traceability
+- [X] T013 Run full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [X] T014 Run `/moonspec-verify` equivalent read-only verification for `specs/233-remediation-v1-policy-guardrails/spec.md`
+
+## Dependencies And Order
+
+- T001 through T004 must complete before story verification tests.
+- T005 and T006 must be written before T007.
+- T008 and T009 are conditional and run only if the verification tests fail.
+- T010 and T011 must complete before final verification.
+
+## Parallel Examples
+
+- T005 and T006 can be drafted independently because they touch different test modules.
+- T008 and T009 touch different production modules and can run independently if both are needed.
+
+## Implementation Strategy
+
+Use verification tests first because most MM-458 behavior appears present by absence or existing guardrails. Implement only the narrow fallback changes needed if those verification tests expose executable automatic remediation or raw capability metadata.

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -158,6 +158,42 @@ def test_remediation_action_authority_lists_policy_compatible_actions():
     assert listed_again[0]["inputMetadata"]["reason"]["required"] is False
 
 
+def test_remediation_action_authority_does_not_advertise_raw_admin_actions():
+    service = RemediationActionAuthorityService(session=object())
+
+    allowed = service.list_allowed_actions(
+        permissions=_admin_permissions(),
+        security_profile=_admin_profile(
+            allowed_action_kinds=(
+                "restart_worker",
+                "terminate_session",
+                "raw_host_shell",
+                "raw_docker",
+                "raw_sql",
+                "storage_key_read",
+                "secret_read",
+                "redaction_bypass",
+            )
+        ),
+    )
+
+    action_kinds = {item["actionKind"] for item in allowed}
+    assert action_kinds == {"restart_worker", "terminate_session"}
+    assert not action_kinds.intersection(
+        {
+            "raw_host_shell",
+            "host_shell",
+            "docker_daemon",
+            "raw_docker",
+            "sql_database",
+            "raw_sql",
+            "storage_key_read",
+            "secret_read",
+            "redaction_bypass",
+        }
+    )
+
+
 @pytest.fixture
 def mock_client_adapter():
     adapter = MagicMock()

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1044,6 +1044,54 @@ async def test_create_execution_rejects_incompatible_remediation_action_policy(
 
 
 @pytest.mark.asyncio
+async def test_create_execution_keeps_future_remediation_policy_inert(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        execution = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Policy-only task",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {
+                    "instructions": "Normal task with future policy metadata.",
+                    "remediationPolicy": {
+                        "enabled": True,
+                        "triggers": ["failed", "attention_required", "stuck"],
+                        "createMode": "proposal",
+                        "templateRef": "admin_healer_default",
+                        "authorityMode": "approval_gated",
+                        "maxActiveRemediations": 1,
+                        "maxSelfHealingDepth": 1,
+                    },
+                }
+            },
+            idempotency_key=None,
+        )
+
+        record = await session.get(
+            TemporalExecutionCanonicalRecord, execution.workflow_id
+        )
+        link = await session.get(
+            TemporalExecutionRemediationLink, execution.workflow_id
+        )
+
+        assert record is not None
+        assert record.parameters["task"]["remediationPolicy"]["enabled"] is True
+        assert link is None
+        mock_client_adapter.start_workflow.assert_awaited_once()
+        start_args = mock_client_adapter.start_workflow.await_args.kwargs["input_args"]
+        assert "remediation" not in start_args["initial_parameters"]["task"]
+
+
+@pytest.mark.asyncio
 async def test_create_execution_rejects_nested_remediation_target(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Summary
- Jira issue key: MM-458
- Active MoonSpec feature path: `specs/233-remediation-v1-policy-guardrails`
- Preserves the Jira preset brief and MM-458 traceability in MoonSpec artifacts
- Adds verification coverage for inert future remediation policy metadata and raw admin capability absence

## Verification Verdict
FULLY_IMPLEMENTED

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_remediation_context.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining Risks
- No known remaining implementation gaps.
- The local prerequisite script still rejects this runtime branch name because it is not in `001-feature-name` format; artifacts were verified directly through `.specify/feature.json` and the active feature directory.
