### PR TITLE
MM-483 Finish Task Remediation runtime slices

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/241-claude-oauth-session-backend"
+  "feature_directory": "specs/242-finish-task-remediation"
 }

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1050,6 +1050,12 @@ class TemporalExecutionRemediationLink(Base):
         Text, nullable=True
     )
     outcome: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    mutation_guard_lock_state: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True
+    )
+    mutation_guard_ledger_state: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api_service/migrations/versions/f2a3b4c5d6e7_remediation_guard_state.py
+++ b/api_service/migrations/versions/f2a3b4c5d6e7_remediation_guard_state.py
@@ -1,0 +1,49 @@
+"""add remediation mutation guard state
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
+
+
+def _json_type() -> sa.JSON:
+    return sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("mutation_guard_lock_state", _json_type(), nullable=True),
+    )
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("mutation_guard_ledger_state", _json_type(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("execution_remediation_links", "mutation_guard_ledger_state")
+    op.drop_column("execution_remediation_links", "mutation_guard_lock_state")

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-478",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1708"
+  "jira_issue_key": "MM-483",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1710"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,22 @@
 [
   {
-    "id": 3127450221,
+    "id": 4300922049,
+    "disposition": "not-applicable",
+    "rationale": "Quota warning from gemini-code-assist; no code feedback to address."
+  },
+  {
+    "id": 3127713027,
     "disposition": "addressed",
-    "rationale": "Backfilled missing CLAUDE_API_KEY into existing claude_anthropic clear_env_keys while preserving existing custom clear keys."
+    "rationale": "Persisted released mutation lock state, cleared active lock fields, and added restart regression coverage."
   },
   {
-    "id": 4158522745,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary metadata; no actionable code feedback."
+    "id": 3127713030,
+    "disposition": "addressed",
+    "rationale": "Validated authority and guard remediation workflow, target, target run, and idempotency context before action execution; added regression coverage."
   },
   {
-    "id": 4158526722,
+    "id": 4158858359,
     "disposition": "not-applicable",
-    "rationale": "Review body explicitly states there is no feedback to address."
+    "rationale": "Automated review summary container; actionable child review comments are tracked separately."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md
@@ -1,0 +1,77 @@
+# MM-483 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-483
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Finish Task Remediation desired-state implementation
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-483 from MM project
+Summary: Finish Task Remediation desired-state implementation
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-483 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-483: Finish Task Remediation desired-state implementation
+
+User Story
+As a MoonMind operator, I need the Task Remediation system described in `docs/Tasks/TaskRemediation.md` to be fully implemented end to end so remediation tasks can safely diagnose, act on, audit, and verify target executions without raw host access or unbounded loops.
+
+Context
+A code audit found that MoonMind already implements several remediation foundations: canonical `task.remediation` submission and pinned links, context artifacts, typed evidence reads, Mission Control relationship panels, authority decisions, and in-memory mutation guard decisions. The system is not complete against `docs/Tasks/TaskRemediation.md` because action execution, canonical action coverage, durable locks/ledgers, lifecycle integration, target-side summaries, and automatic policy-bounded self-healing remain missing or partial.
+
+Source Documents
+- `docs/Tasks/TaskRemediation.md`
+- `specs/232-remediation-lifecycle-audit/tasks.md`
+- `moonmind/workflows/temporal/remediation_actions.py`
+- `moonmind/workflows/temporal/remediation_context.py`
+- `moonmind/workflows/temporal/remediation_tools.py`
+- `moonmind/workflows/temporal/service.py`
+- `api_service/api/routers/executions.py`
+- `frontend/src/entrypoints/task-detail.tsx`
+
+Current Implemented Baseline
+- `task.remediation` is accepted and normalized under `initialParameters.task.remediation`.
+- Remediation target `workflowId`/`runId` links are persisted and queryable inbound/outbound.
+- `reports/remediation_context.json` can be generated and linked.
+- Evidence tools can read declared artifacts/logs and gate live follow.
+- Authority/profile decisions and mutation guard decisions exist.
+- Mission Control can show remediation relationships, evidence artifacts, and approval state.
+
+Missing Work / Acceptance Criteria
+1. Canonical action registry coverage exists for the documented action kinds: `execution.pause`, `execution.resume`, `execution.request_rerun_same_workflow`, `execution.start_fresh_rerun`, `execution.cancel`, `execution.force_terminate`, `session.interrupt_turn`, `session.clear`, `session.cancel`, `session.terminate`, `session.restart_container`, `provider_profile.evict_stale_lease`, `workload.restart_helper_container`, and `workload.reap_orphan_container`. Unsupported raw host, Docker, SQL, storage, and secret-read capabilities remain absent.
+2. Accepted remediation actions execute through MoonMind-owned control-plane services or owning subsystem adapters, not through raw shell/Docker/SQL access. Each action declares target type, inputs, risk tier, preconditions, idempotency key behavior, verification requirements, and audit payload shape.
+3. The remediation evidence/tool surface includes end-to-end `execute_action` and `verify_target` behavior. Action request, action result, before/after state refs, side effects, and verification outcomes are persisted as remediation artifacts.
+4. Exclusive mutation locks and the remediation action ledger are durable across process restarts, Temporal retries, worker restarts, and replay-sensitive paths. They are no longer only in-memory service fields.
+5. Create-time validation verifies selected `taskRunIds` belong to the target execution or selected steps. Malformed or foreign `taskRunIds` fail before workflow start with structured validation errors.
+6. Remediation lifecycle integration is complete: `collecting_evidence`, `diagnosing`, `awaiting_approval`, `acting`, `verifying`, `resolved`, `escalated`, and `failed` are reflected in summaries/read models without replacing top-level `MoonMind.Run` state.
+7. Required remediation artifacts are produced automatically by the runtime path, not only by helper calls/tests: `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, and `remediation.summary`.
+8. Target-side linkage summaries are exposed through execution/task-run read models, including active remediation count, latest remediation title/status, latest action kind, active lock holder/scope, outcome, and updated time.
+9. Cancellation, failure, and Continue-As-New behavior is implemented at the service/workflow boundary: remediation cancellation does not mutate the target except already-requested actions, final summary publication and lock release are attempted, and target workflow/run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor are preserved across continuation.
+10. Action request/result output from `RemediationActionAuthorityService` is integrated with lifecycle artifact publication and audit evidence.
+11. Target-managed session and workload mutations preserve subsystem-native continuity/control artifacts in addition to remediation audit artifacts.
+12. Automatic self-healing, if enabled, is policy-driven and bounded: no implicit spawn-on-failure, max active remediations enforced, nested remediation off by default, depth limits enforced, and proposal/immediate modes are explicit.
+13. Partial historical evidence, missing artifact refs, unavailable live follow, lock conflicts, stale leases already released, gone containers, unsafe force termination attempts, and remediator failure all produce bounded degraded/no-op/escalated/failed outcomes rather than silent success or infinite waits.
+14. Mission Control exposes the completed action/approval/verification lifecycle without raw storage paths, presigned URLs, or secret-bearing data.
+15. Tests cover workflow/activity or adapter boundaries for action execution, durable locks/ledger, `taskRunId` ownership validation, lifecycle artifacts, target-side read models, cancellation/failure, Continue-As-New, and Mission Control rendering. Run at minimum: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and `./tools/test_integration.sh` when artifact lifecycle/API routes change.
+
+Out of Scope
+- Raw admin console access.
+- Direct host shell, arbitrary SQL, arbitrary Docker daemon operations, arbitrary storage-key reads, or secret redaction bypasses.
+- Replacing `MoonMind.Run` with a new top-level remediation workflow type unless the canonical doc is intentionally updated first.
+
+Implementation Notes
+- Preserve Constitution compatibility requirements for Temporal-facing payloads. Any activity/workflow/update/signal shape change must be compatibility-safe or have an explicit cutover plan.
+- Existing partial implementation should be reused where correct, but compatibility shims for superseded internal contracts should not be added.
+- The current action authority module explicitly says it does not execute host/container/SQL/provider/storage operations; this story must add the safe execution boundary through owning services, not by weakening that guardrail.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -52,24 +52,152 @@ _RAW_ACCESS_ACTION_KINDS = frozenset(
         "raw_storage",
     }
 )
+_COMMON_REASON_INPUT = {
+    "reason": {"type": "string", "required": False},
+}
+_COMMON_AUDIT_PAYLOAD_SHAPE = {
+    "actor": "string",
+    "executionPrincipal": "string",
+    "remediationWorkflowId": "string",
+    "targetWorkflowId": "string",
+    "actionKind": "string",
+    "riskTier": "string",
+    "decision": "string",
+    "timestamp": "string",
+}
 _ACTION_CATALOG: dict[str, dict[str, Any]] = {
-    "restart_worker": {
+    "execution.pause": {
         "risk": "medium",
         "enabled": True,
-        "target_type": "workload_container",
-        "input_metadata": {
-            "reason": {"type": "string", "required": False},
-        },
-        "verification_hint": "verify helper container health and target state",
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "target_active"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify target execution enters a paused or non-progressing state",
     },
-    "terminate_session": {
+    "execution.resume": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "target_paused"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify target execution leaves paused state or reports no-op",
+    },
+    "execution.request_rerun_same_workflow": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "rerun_supported"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify target run identity changes or no-op reason is recorded",
+    },
+    "execution.start_fresh_rerun": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "fresh_rerun_allowed"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify a fresh execution is created and linked to the target",
+    },
+    "execution.cancel": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "target_cancelable"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": (
+            "verify target execution records cancellation or a no-op terminal state"
+        ),
+    },
+    "execution.force_terminate": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "force_termination_approved"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify target execution termination and high-risk audit evidence",
+    },
+    "session.interrupt_turn": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "managed_session",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "active_managed_turn"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": (
+            "verify active managed turn is interrupted and control artifact is produced"
+        ),
+    },
+    "session.clear": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "managed_session",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "session_clear_supported"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify session clear boundary and continuity artifact are produced",
+    },
+    "session.cancel": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "managed_session",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "session_cancelable"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify session cancellation state and target run status",
+    },
+    "session.terminate": {
         "risk": "high",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": {
-            "reason": {"type": "string", "required": False},
-        },
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "session_termination_approved"),
+        "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session termination state and target run status",
+    },
+    "session.restart_container": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "managed_session",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "restart_approved", "owning_session_plane"),
+        "idempotency": "same target/action/reason key returns the prior decision",
+        "verification_hint": "verify new session identity and continuity boundary artifact",
+    },
+    "provider_profile.evict_stale_lease": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "provider_profile_lease",
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "profileRef": {"type": "string", "required": False},
+        },
+        "preconditions": ("target_visible", "lease_stale_or_orphaned"),
+        "idempotency": "same target/action/profile key returns the prior decision",
+        "verification_hint": "verify lease age, owner liveness, and slot state afterward",
+    },
+    "workload.restart_helper_container": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "workload_container",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "helper_container_owned_by_moonmind"),
+        "idempotency": "same target/action/container key returns the prior decision",
+        "verification_hint": "verify helper container health and target state",
+    },
+    "workload.reap_orphan_container": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "workload_container",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "container_orphaned_by_policy"),
+        "idempotency": "same target/action/container key returns the prior decision",
+        "verification_hint": "verify orphan container is gone or no-op reason is recorded",
     },
 }
 _DEFAULT_AUTO_ALLOWED_RISK = "medium"
@@ -383,8 +511,11 @@ class RemediationActionAuthorityService:
                     "riskTier": action_info["risk"],
                     "targetType": action_info["target_type"],
                     "inputMetadata": deepcopy(action_info.get("input_metadata") or {}),
+                    "preconditions": tuple(action_info.get("preconditions") or ()),
+                    "idempotency": action_info.get("idempotency"),
                     "verificationRequired": True,
                     "verificationHint": action_info["verification_hint"],
+                    "auditPayloadShape": deepcopy(_COMMON_AUDIT_PAYLOAD_SHAPE),
                 }
             )
         return tuple(actions)

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -905,7 +905,7 @@ class RemediationMutationGuardService:
         self._last_attempt_by_shape: dict[tuple[str, str, str], datetime] = {}
         self._last_target_activity: dict[str, datetime] = {}
 
-    def release_lock(self, lock_id: str) -> None:
+    async def release_lock(self, lock_id: str) -> None:
         """Mark a lock as lost/released so the holder cannot silently continue."""
 
         lock = self._locks_by_id.get(str(lock_id or "").strip())
@@ -920,6 +920,7 @@ class RemediationMutationGuardService:
                 lock.holder_workflow_id,
             )
         ] = lock.expires_at
+        await self._persist_lock_release(lock)
 
     async def evaluate(
         self,
@@ -1453,7 +1454,17 @@ class RemediationMutationGuardService:
             )
             if lock is None or lock.target_run_id != target_run_id:
                 continue
-            if lock.released or now >= lock.expires_at:
+            if lock.released:
+                self._lost_holders[
+                    (
+                        lock.scope,
+                        lock.target_workflow_id,
+                        lock.target_run_id,
+                        lock.holder_workflow_id,
+                    )
+                ] = lock.expires_at
+                continue
+            if now >= lock.expires_at:
                 continue
             lock_key = (lock.scope, lock.target_workflow_id, lock.target_run_id)
             existing = self._locks.get(lock_key)
@@ -1502,6 +1513,18 @@ class RemediationMutationGuardService:
             return
         link.active_lock_scope = lock.scope
         link.active_lock_holder = lock.holder_workflow_id
+        link.mutation_guard_lock_state = _active_lock_payload(lock)
+        await self._session.flush()
+
+    async def _persist_lock_release(self, lock: _ActiveMutationLock) -> None:
+        link = await self._session.get(
+            db_models.TemporalExecutionRemediationLink,
+            lock.holder_workflow_id,
+        )
+        if link is None:
+            return
+        link.active_lock_scope = None
+        link.active_lock_holder = None
         link.mutation_guard_lock_state = _active_lock_payload(lock)
         await self._session.flush()
 

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
@@ -473,6 +474,7 @@ class _LedgerEntry:
     request_shape_hash: str
     recorded_at: datetime
     result: RemediationMutationGuardResult
+    durable: bool = False
 
 
 class RemediationActionAuthorityService:
@@ -938,12 +940,18 @@ class RemediationMutationGuardService:
     ) -> RemediationMutationGuardResult:
         active_policy = _normalize_guard_policy(policy)
         current_time = _normalize_datetime(now)
-        self._cleanup_state(now=current_time)
         workflow_id = str(remediation_workflow_id or "").strip()
         target_id = str(target_workflow_id or "").strip()
         pinned_run_id = str(target_run_id or "").strip()
         normalized_action = str(action_kind or "").strip()
         idem = str(idempotency_key or "").strip()
+        await self._hydrate_durable_state(
+            remediation_workflow_id=workflow_id,
+            target_workflow_id=target_id,
+            target_run_id=pinned_run_id,
+            now=current_time,
+        )
+        self._cleanup_state(now=current_time)
         redacted_parameters = _redact_payload(parameters or {})
         shape_hash = _request_shape_hash(
             action_kind=normalized_action,
@@ -1010,6 +1018,8 @@ class RemediationMutationGuardService:
         existing_ledger = self._ledger.get(ledger_key)
         if existing_ledger is not None:
             if existing_ledger.request_shape_hash == shape_hash:
+                if existing_ledger.durable:
+                    return _duplicate_guard_result(existing_ledger.result)
                 return existing_ledger.result
             return self._guard_result(
                 remediation_workflow_id=workflow_id,
@@ -1080,7 +1090,7 @@ class RemediationMutationGuardService:
                 redacted_parameters=redacted_parameters,
             )
 
-        lock_decision, lock_allows = self._acquire_lock(
+        lock_decision, lock_allows = await self._acquire_lock(
             workflow_id=workflow_id,
             remediation_run_id=remediation_run_id,
             target_workflow_id=target_id,
@@ -1109,7 +1119,7 @@ class RemediationMutationGuardService:
             )
 
         if freshness_decision.status == "unavailable":
-            return self._record_guard_result(
+            return await self._record_guard_result(
                 ledger_key=ledger_key,
                 shape_hash=shape_hash,
                 result=self._guard_result(
@@ -1135,7 +1145,7 @@ class RemediationMutationGuardService:
             decision: RemediationMutationGuardDecision = (
                 active_policy.target_change_policy
             )
-            return self._record_guard_result(
+            return await self._record_guard_result(
                 ledger_key=ledger_key,
                 shape_hash=shape_hash,
                 result=self._guard_result(
@@ -1207,7 +1217,7 @@ class RemediationMutationGuardService:
             max_attempts_per_action_kind=active_policy.max_attempts_per_action_kind,
             cooldown_seconds=active_policy.cooldown_seconds,
         )
-        return self._record_guard_result(
+        return await self._record_guard_result(
             ledger_key=ledger_key,
             shape_hash=shape_hash,
             result=self._guard_result(
@@ -1230,7 +1240,7 @@ class RemediationMutationGuardService:
             ),
         )
 
-    def _acquire_lock(
+    async def _acquire_lock(
         self,
         *,
         workflow_id: str,
@@ -1290,6 +1300,7 @@ class RemediationMutationGuardService:
         )
         self._locks[lock_key] = lock
         self._locks_by_id[lock.lock_id] = lock
+        await self._persist_lock(lock)
         return (_lock_decision(lock, status), True)
 
     def _evaluate_budget(
@@ -1389,7 +1400,7 @@ class RemediationMutationGuardService:
             redacted_parameters=redacted_parameters,
         )
 
-    def _record_guard_result(
+    async def _record_guard_result(
         self,
         *,
         ledger_key: tuple[str, str],
@@ -1402,8 +1413,126 @@ class RemediationMutationGuardService:
             or datetime.fromtimestamp(0, timezone.utc),
             result=result,
         )
+        await self._persist_ledger_entry(
+            remediation_workflow_id=result.remediation_workflow_id,
+            idempotency_key=result.idempotency_key,
+            shape_hash=shape_hash,
+            result=result,
+        )
         self._trim_state()
         return result
+
+    async def _hydrate_durable_state(
+        self,
+        *,
+        remediation_workflow_id: str,
+        target_workflow_id: str,
+        target_run_id: str,
+        now: datetime,
+    ) -> None:
+        if remediation_workflow_id:
+            link = await self._session.get(
+                db_models.TemporalExecutionRemediationLink,
+                remediation_workflow_id,
+            )
+            if link is not None:
+                self._hydrate_ledger_from_link(link)
+
+        if not target_workflow_id or not target_run_id:
+            return
+
+        result = await self._session.execute(
+            select(db_models.TemporalExecutionRemediationLink).where(
+                db_models.TemporalExecutionRemediationLink.target_workflow_id
+                == target_workflow_id
+            )
+        )
+        for link in result.scalars():
+            lock = _active_lock_from_payload(
+                getattr(link, "mutation_guard_lock_state", None),
+            )
+            if lock is None or lock.target_run_id != target_run_id:
+                continue
+            if lock.released or now >= lock.expires_at:
+                continue
+            lock_key = (lock.scope, lock.target_workflow_id, lock.target_run_id)
+            existing = self._locks.get(lock_key)
+            if existing is None or existing.expires_at < lock.expires_at:
+                self._locks[lock_key] = lock
+                self._locks_by_id[lock.lock_id] = lock
+
+    def _hydrate_ledger_from_link(
+        self, link: db_models.TemporalExecutionRemediationLink
+    ) -> None:
+        payload = getattr(link, "mutation_guard_ledger_state", None)
+        if not isinstance(payload, Mapping):
+            return
+        entries = payload.get("entries")
+        if not isinstance(entries, Mapping):
+            return
+        workflow_id = str(getattr(link, "remediation_workflow_id", "") or "")
+        for idempotency_key, entry in entries.items():
+            if not isinstance(entry, Mapping):
+                continue
+            idem = str(idempotency_key or "").strip()
+            shape_hash = str(entry.get("requestShapeHash") or "").strip()
+            result_payload = entry.get("result")
+            if not idem or not shape_hash or not isinstance(result_payload, Mapping):
+                continue
+            ledger_key = (workflow_id, idem)
+            if ledger_key in self._ledger:
+                continue
+            result = _guard_result_from_payload(result_payload)
+            if result is None:
+                continue
+            self._ledger[ledger_key] = _LedgerEntry(
+                request_shape_hash=shape_hash,
+                recorded_at=_datetime_from_json(entry.get("recordedAt"))
+                or datetime.fromtimestamp(0, timezone.utc),
+                result=result,
+                durable=True,
+            )
+
+    async def _persist_lock(self, lock: _ActiveMutationLock) -> None:
+        link = await self._session.get(
+            db_models.TemporalExecutionRemediationLink,
+            lock.holder_workflow_id,
+        )
+        if link is None:
+            return
+        link.active_lock_scope = lock.scope
+        link.active_lock_holder = lock.holder_workflow_id
+        link.mutation_guard_lock_state = _active_lock_payload(lock)
+        await self._session.flush()
+
+    async def _persist_ledger_entry(
+        self,
+        *,
+        remediation_workflow_id: str,
+        idempotency_key: str,
+        shape_hash: str,
+        result: RemediationMutationGuardResult,
+    ) -> None:
+        link = await self._session.get(
+            db_models.TemporalExecutionRemediationLink,
+            remediation_workflow_id,
+        )
+        if link is None:
+            return
+        state = dict(getattr(link, "mutation_guard_ledger_state", None) or {})
+        entries = dict(state.get("entries") or {})
+        entries[idempotency_key] = {
+            "requestShapeHash": shape_hash,
+            "recordedAt": _datetime_to_json(
+                result.lock.created_at or datetime.now(timezone.utc)
+            ),
+            "result": result.to_dict(),
+        }
+        state["entries"] = entries
+        link.mutation_guard_ledger_state = state
+        link.latest_action_summary = result.action_kind
+        link.outcome = result.decision
+        await self._session.flush()
 
     def _cleanup_state(self, *, now: datetime) -> None:
         cutoff = now - timedelta(seconds=_GUARD_STATE_RETENTION_SECONDS)
@@ -1496,6 +1625,19 @@ def _datetime_to_json(value: datetime | None) -> str | None:
     return _normalize_datetime(value).isoformat().replace("+00:00", "Z")
 
 
+def _datetime_from_json(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _normalize_datetime(parsed)
+
+
 def _request_shape_hash(
     *,
     action_kind: str,
@@ -1534,6 +1676,171 @@ def _lock_decision(
         created_at=lock.created_at,
         expires_at=lock.expires_at,
     )
+
+
+def _active_lock_payload(lock: _ActiveMutationLock) -> dict[str, Any]:
+    return {
+        "lockId": lock.lock_id,
+        "scope": lock.scope,
+        "mode": lock.mode,
+        "holderWorkflowId": lock.holder_workflow_id,
+        "holderRunId": lock.holder_run_id,
+        "targetWorkflowId": lock.target_workflow_id,
+        "targetRunId": lock.target_run_id,
+        "createdAt": _datetime_to_json(lock.created_at),
+        "expiresAt": _datetime_to_json(lock.expires_at),
+        "released": bool(lock.released),
+    }
+
+
+def _active_lock_from_payload(payload: Any) -> _ActiveMutationLock | None:
+    if not isinstance(payload, Mapping):
+        return None
+    lock_id = str(payload.get("lockId") or "").strip()
+    scope = str(payload.get("scope") or "").strip()
+    mode = str(payload.get("mode") or "").strip()
+    holder = str(payload.get("holderWorkflowId") or "").strip()
+    target = str(payload.get("targetWorkflowId") or "").strip()
+    target_run = str(payload.get("targetRunId") or "").strip()
+    created_at = _datetime_from_json(payload.get("createdAt"))
+    expires_at = _datetime_from_json(payload.get("expiresAt"))
+    required = (lock_id, scope, mode, holder, target, target_run, created_at, expires_at)
+    if not all(required):
+        return None
+    return _ActiveMutationLock(
+        lock_id=lock_id,
+        scope=scope,
+        mode=mode,
+        holder_workflow_id=holder,
+        holder_run_id=_string_or_none(payload.get("holderRunId")),
+        target_workflow_id=target,
+        target_run_id=target_run,
+        created_at=created_at,
+        expires_at=expires_at,
+        released=bool(payload.get("released")),
+    )
+
+
+def _duplicate_guard_result(
+    result: RemediationMutationGuardResult,
+) -> RemediationMutationGuardResult:
+    return RemediationMutationGuardResult(
+        remediation_workflow_id=result.remediation_workflow_id,
+        target_workflow_id=result.target_workflow_id,
+        action_kind=result.action_kind,
+        idempotency_key=result.idempotency_key,
+        decision=result.decision,
+        reason=result.reason,
+        executable=result.executable,
+        lock=result.lock,
+        ledger=RemediationActionLedgerDecision(
+            status=result.ledger.status,
+            duplicate=True,
+            unsafe_reuse=result.ledger.unsafe_reuse,
+            request_shape_hash=result.ledger.request_shape_hash,
+        ),
+        budget=result.budget,
+        nested_remediation=result.nested_remediation,
+        target_freshness=result.target_freshness,
+        redacted_parameters=result.redacted_parameters,
+    )
+
+
+def _guard_result_from_payload(
+    payload: Mapping[str, Any],
+) -> RemediationMutationGuardResult | None:
+    lock_payload = payload.get("lock")
+    ledger_payload = payload.get("ledger")
+    budget_payload = payload.get("budget")
+    nested_payload = payload.get("nestedRemediation")
+    freshness_payload = payload.get("targetFreshness")
+    if not all(
+        isinstance(item, Mapping)
+        for item in (
+            lock_payload,
+            ledger_payload,
+            budget_payload,
+            nested_payload,
+            freshness_payload,
+        )
+    ):
+        return None
+
+    lock = RemediationMutationLockDecision(
+        status=str(lock_payload.get("status") or ""),
+        lock_id=_string_or_none(lock_payload.get("lockId")),
+        scope=str(lock_payload.get("scope") or ""),
+        mode=str(lock_payload.get("mode") or ""),
+        holder_workflow_id=str(lock_payload.get("holderWorkflowId") or ""),
+        holder_run_id=_string_or_none(lock_payload.get("holderRunId")),
+        target_workflow_id=str(lock_payload.get("targetWorkflowId") or ""),
+        target_run_id=str(lock_payload.get("targetRunId") or ""),
+        created_at=_datetime_from_json(lock_payload.get("createdAt")),
+        expires_at=_datetime_from_json(lock_payload.get("expiresAt")),
+    )
+    ledger = RemediationActionLedgerDecision(
+        status=str(ledger_payload.get("status") or ""),
+        duplicate=bool(ledger_payload.get("duplicate")),
+        unsafe_reuse=bool(ledger_payload.get("unsafeReuse")),
+        request_shape_hash=_string_or_none(ledger_payload.get("requestShapeHash")),
+    )
+    budget = RemediationActionBudgetDecision(
+        status=str(budget_payload.get("status") or ""),
+        actions_used=_int_or_zero(budget_payload.get("actionsUsed")),
+        max_actions_per_target=_int_or_zero(budget_payload.get("maxActionsPerTarget")),
+        attempts_for_action_kind=_int_or_zero(
+            budget_payload.get("attemptsForActionKind")
+        ),
+        max_attempts_per_action_kind=_int_or_zero(
+            budget_payload.get("maxAttemptsPerActionKind")
+        ),
+        cooldown_seconds=_int_or_zero(budget_payload.get("cooldownSeconds")),
+    )
+    nested = RemediationNestedDecision(
+        status=str(nested_payload.get("status") or ""),
+        allow_nested_remediation=bool(nested_payload.get("allowNestedRemediation")),
+        allow_self_target=bool(nested_payload.get("allowSelfTarget")),
+        max_self_healing_depth=_int_or_zero(
+            nested_payload.get("maxSelfHealingDepth")
+        ),
+    )
+    freshness = RemediationTargetFreshnessDecision(
+        status=str(freshness_payload.get("status") or ""),
+        pinned_run_id=_string_or_none(freshness_payload.get("pinnedRunId")),
+        current_run_id=_string_or_none(freshness_payload.get("currentRunId")),
+        state=_string_or_none(freshness_payload.get("state")),
+        summary=_string_or_none(freshness_payload.get("summary")),
+        session_identity=_string_or_none(freshness_payload.get("sessionIdentity")),
+        target_run_changed=bool(freshness_payload.get("targetRunChanged")),
+    )
+    redacted = payload.get("redactedParameters")
+    return RemediationMutationGuardResult(
+        remediation_workflow_id=str(payload.get("remediationWorkflowId") or ""),
+        target_workflow_id=str(payload.get("targetWorkflowId") or ""),
+        action_kind=str(payload.get("actionKind") or ""),
+        idempotency_key=str(payload.get("idempotencyKey") or ""),
+        decision=str(payload.get("decision") or "denied"),
+        reason=str(payload.get("reason") or ""),
+        executable=bool(payload.get("executable")),
+        lock=lock,
+        ledger=ledger,
+        budget=budget,
+        nested_remediation=nested,
+        target_freshness=freshness,
+        redacted_parameters=redacted if isinstance(redacted, Mapping) else {},
+    )
+
+
+def _string_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _nested_decision(

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -18,6 +18,7 @@ from api_service.db import models as db_models
 from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 from moonmind.workflows.temporal.remediation_context import (
     REMEDIATION_CONTEXT_LINK_TYPE,
+    RemediationLifecyclePublisher,
 )
 
 RemediationLogStream = Literal["stdout", "stderr", "merged", "diagnostics"]
@@ -106,6 +107,19 @@ class RemediationLiveFollower(Protocol):
         raise NotImplementedError
 
 
+class RemediationActionExecutor(Protocol):
+    """Execute one authorized remediation action through an owning subsystem."""
+
+    async def execute_action(
+        self,
+        *,
+        action_request: Mapping[str, Any],
+        guard_result: Mapping[str, Any],
+        target_health: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+
 class _UnavailableLogReader:
     async def read_logs(
         self,
@@ -132,6 +146,19 @@ class _UnavailableLiveFollower:
         )
 
 
+class _UnavailableActionExecutor:
+    async def execute_action(
+        self,
+        *,
+        action_request: Mapping[str, Any],
+        guard_result: Mapping[str, Any],
+        target_health: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        raise RemediationEvidenceToolError(
+            "remediation.execute_action is not configured in this runtime."
+        )
+
+
 class RemediationEvidenceToolService:
     """Typed evidence access surface for one remediation execution."""
 
@@ -142,6 +169,7 @@ class RemediationEvidenceToolService:
         artifact_service: TemporalArtifactService,
         log_reader: RemediationLogReader | None = None,
         live_follower: RemediationLiveFollower | None = None,
+        action_executor: RemediationActionExecutor | None = None,
         cursor_recorder: Callable[[str, dict[str, Any] | None], Awaitable[None]]
         | None = None,
     ) -> None:
@@ -149,6 +177,11 @@ class RemediationEvidenceToolService:
         self._artifact_service = artifact_service
         self._log_reader = log_reader or _UnavailableLogReader()
         self._live_follower = live_follower or _UnavailableLiveFollower()
+        self._action_executor = action_executor or _UnavailableActionExecutor()
+        self._lifecycle_publisher = RemediationLifecyclePublisher(
+            session=session,
+            artifact_service=artifact_service,
+        )
         self._cursor_recorder = cursor_recorder
         self._context_payload_cache: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -316,6 +349,117 @@ class RemediationEvidenceToolService:
             ),
             context_target=context_target_mapping,
         )
+
+    async def execute_action(
+        self,
+        *,
+        remediation_workflow_id: str,
+        authority_result: Mapping[str, Any],
+        guard_result: Mapping[str, Any],
+        principal: str = "service:remediation-tools",
+    ) -> dict[str, Any]:
+        """Execute an authorized action and publish bounded lifecycle artifacts."""
+
+        if not isinstance(authority_result, Mapping):
+            raise RemediationEvidenceToolError("authorityResult must be an object.")
+        if not isinstance(guard_result, Mapping):
+            raise RemediationEvidenceToolError("guardResult must be an object.")
+        if authority_result.get("executable") is not True:
+            raise RemediationEvidenceToolError(
+                "authorityResult must be executable before action execution."
+            )
+        if guard_result.get("executable") is not True:
+            raise RemediationEvidenceToolError(
+                "guardResult must be executable before action execution."
+            )
+
+        action_request = authority_result.get("request")
+        if not isinstance(action_request, Mapping):
+            raise RemediationEvidenceToolError("authorityResult.request is required.")
+        action_kind = _required_string(action_request.get("actionKind"), "actionKind")
+        if action_kind != _required_string(guard_result.get("actionKind"), "actionKind"):
+            raise RemediationEvidenceToolError(
+                "authorityResult and guardResult action kinds do not match."
+            )
+
+        preparation = await self.prepare_action_request(
+            remediation_workflow_id=remediation_workflow_id,
+            action_kind=action_kind,
+            principal=principal,
+        )
+        link = await self._load_link(remediation_workflow_id)
+        request_artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.action_request",
+            name=f"reports/remediation_action_request-{action_request['actionId']}.json",
+            payload={
+                "authority": dict(authority_result),
+                "guard": dict(guard_result),
+                "request": dict(action_request),
+            },
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+
+        raw_result = await self._action_executor.execute_action(
+            action_request=action_request,
+            guard_result=guard_result,
+            target_health=preparation.target,
+        )
+        if not isinstance(raw_result, Mapping):
+            raise RemediationEvidenceToolError("action executor returned invalid result.")
+        status = _required_string(raw_result.get("status"), "status")
+        result_payload = {
+            "schemaVersion": "v1",
+            "actionKind": action_kind,
+            "actionId": action_request["actionId"],
+            "status": status,
+            "beforeStateRef": _string_or_none(raw_result.get("beforeStateRef")),
+            "afterStateRef": _string_or_none(raw_result.get("afterStateRef")),
+            "sideEffects": _safe_sequence(raw_result.get("sideEffects")),
+        }
+        result_artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.action_result",
+            name=f"reports/remediation_action_result-{action_request['actionId']}.json",
+            payload=result_payload,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+
+        verification = raw_result.get("verification")
+        verification_payload = (
+            dict(verification)
+            if isinstance(verification, Mapping)
+            else {"status": "not_verified"}
+        )
+        verification_payload.setdefault("actionKind", action_kind)
+        verification_payload.setdefault("actionId", action_request["actionId"])
+        verification_artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.verification",
+            name=f"reports/remediation_verification-{action_request['actionId']}.json",
+            payload=verification_payload,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+
+        link.latest_action_summary = action_kind
+        link.outcome = status
+        await self._session.commit()
+        return {
+            "schemaVersion": "v1",
+            "actionKind": action_kind,
+            "status": status,
+            "artifactRefs": {
+                "actionRequest": request_artifact.artifact_id,
+                "actionResult": result_artifact.artifact_id,
+                "verification": verification_artifact.artifact_id,
+            },
+        }
 
     async def _load_link(
         self, remediation_workflow_id: str
@@ -497,6 +641,12 @@ def _string_or_none(value: Any) -> str | None:
     return normalized or None
 
 
+def _safe_sequence(value: Any) -> list[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(value)
+    return []
+
+
 def _enum_value(value: Any) -> str | None:
     if value is None:
         return None
@@ -505,6 +655,7 @@ def _enum_value(value: Any) -> str | None:
 
 
 __all__ = [
+    "RemediationActionExecutor",
     "RemediationActionRequestPreparation",
     "RemediationEvidenceToolError",
     "RemediationEvidenceToolService",

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -388,6 +388,13 @@ class RemediationEvidenceToolService:
             principal=principal,
         )
         link = await self._load_link(remediation_workflow_id)
+        self._validate_execution_context(
+            link=link,
+            remediation_workflow_id=remediation_workflow_id,
+            authority_result=authority_result,
+            guard_result=guard_result,
+            action_request=action_request,
+        )
         request_artifact = await self._lifecycle_publisher.publish_json_artifact(
             remediation_workflow_id=link.remediation_workflow_id,
             artifact_type="remediation.action_request",
@@ -516,6 +523,79 @@ class RemediationEvidenceToolService:
             )
         self._context_payload_cache[cache_key] = decoded
         return decoded
+
+    def _validate_execution_context(
+        self,
+        *,
+        link: db_models.TemporalExecutionRemediationLink,
+        remediation_workflow_id: str,
+        authority_result: Mapping[str, Any],
+        guard_result: Mapping[str, Any],
+        action_request: Mapping[str, Any],
+    ) -> None:
+        expected_workflow_id = link.remediation_workflow_id
+        supplied_workflow_id = _required_string(
+            remediation_workflow_id,
+            "remediationWorkflowId",
+        )
+        if supplied_workflow_id != expected_workflow_id:
+            raise RemediationEvidenceToolError(
+                "remediationWorkflowId does not match the persisted remediation link."
+            )
+
+        for label, payload in (
+            ("authorityResult", authority_result),
+            ("guardResult", guard_result),
+        ):
+            if (
+                _required_string(
+                    payload.get("remediationWorkflowId"),
+                    f"{label}.remediationWorkflowId",
+                )
+                != expected_workflow_id
+            ):
+                raise RemediationEvidenceToolError(
+                    f"{label}.remediationWorkflowId does not match the action context."
+                )
+            if (
+                _required_string(
+                    payload.get("targetWorkflowId"),
+                    f"{label}.targetWorkflowId",
+                )
+                != link.target_workflow_id
+            ):
+                raise RemediationEvidenceToolError(
+                    f"{label}.targetWorkflowId does not match the action context."
+                )
+            if (
+                _required_string(
+                    payload.get("idempotencyKey"),
+                    f"{label}.idempotencyKey",
+                )
+                != action_request["actionId"]
+            ):
+                raise RemediationEvidenceToolError(
+                    f"{label}.idempotencyKey does not match the action request."
+                )
+
+        request_target = action_request.get("target")
+        request_target_mapping = (
+            request_target if isinstance(request_target, Mapping) else {}
+        )
+        if request_target_mapping.get("workflowId") != link.target_workflow_id:
+            raise RemediationEvidenceToolError(
+                "authorityResult.request.target.workflowId does not match the action context."
+            )
+        guard_lock = guard_result.get("lock")
+        guard_lock_mapping = guard_lock if isinstance(guard_lock, Mapping) else {}
+        if guard_lock_mapping.get("targetRunId") != link.target_run_id:
+            raise RemediationEvidenceToolError(
+                "guardResult.lock.targetRunId does not match the persisted target run."
+            )
+        if guard_lock_mapping.get("holderWorkflowId") != expected_workflow_id:
+            raise RemediationEvidenceToolError(
+                "guardResult.lock.holderWorkflowId does not match the action context."
+            )
 
 
 def _collect_context_artifact_ids(context: Mapping[str, Any]) -> set[str]:

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -446,6 +446,13 @@ class TemporalExecutionService:
                 raise TemporalExecutionValidationError(
                     "task.remediation.target.taskRunIds must be a list of strings."
                 )
+            allowed_task_run_ids = self._target_task_run_ids(target_record)
+            if allowed_task_run_ids:
+                requested_task_run_ids = {str(item).strip() for item in task_run_ids}
+                if not requested_task_run_ids.issubset(allowed_task_run_ids):
+                    raise TemporalExecutionValidationError(
+                        "task.remediation.target.taskRunIds must belong to the target execution."
+                    )
 
         trigger = remediation.get("trigger")
         trigger_type = None
@@ -484,6 +491,33 @@ class TemporalExecutionService:
             status="created",
             trigger_type=trigger_type,
         )
+
+    @classmethod
+    def _target_task_run_ids(
+        cls, record: TemporalExecutionCanonicalRecord
+    ) -> set[str]:
+        output: set[str] = set()
+        for payload in (
+            getattr(record, "parameters", None),
+            getattr(record, "memo", None),
+            getattr(record, "search_attributes", None),
+        ):
+            cls._collect_task_run_ids(payload, output)
+        return output
+
+    @classmethod
+    def _collect_task_run_ids(cls, value: Any, output: set[str]) -> None:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if key in {"taskRunId", "task_run_id"}:
+                    task_run_id = str(item or "").strip()
+                    if task_run_id:
+                        output.add(task_run_id)
+                cls._collect_task_run_ids(item, output)
+            return
+        if isinstance(value, list | tuple):
+            for item in value:
+                cls._collect_task_run_ids(item, output)
 
     async def _write_dependency_edges(
         self,

--- a/specs/242-finish-task-remediation/checklists/requirements.md
+++ b/specs/242-finish-task-remediation/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Finish Task Remediation Desired-State Implementation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request. The brief spans multiple system surfaces, but it has one operator-facing outcome, a single story, and explicit non-goals.
+- Existing MoonSpec artifacts for MM-483 were not found; the first incomplete stage was `specify`.

--- a/specs/242-finish-task-remediation/contracts/remediation-runtime.md
+++ b/specs/242-finish-task-remediation/contracts/remediation-runtime.md
@@ -1,0 +1,68 @@
+# Contract: Remediation Runtime
+
+## Canonical Action Registry
+
+The remediation action registry exposes only canonical dotted action kinds:
+
+- `execution.pause`
+- `execution.resume`
+- `execution.request_rerun_same_workflow`
+- `execution.start_fresh_rerun`
+- `execution.cancel`
+- `execution.force_terminate`
+- `session.interrupt_turn`
+- `session.clear`
+- `session.cancel`
+- `session.terminate`
+- `session.restart_container`
+- `provider_profile.evict_stale_lease`
+- `workload.restart_helper_container`
+- `workload.reap_orphan_container`
+
+Each listed action returns metadata with:
+
+- `actionKind`
+- `riskTier`
+- `targetType`
+- `inputMetadata`
+- `preconditions`
+- `idempotency`
+- `verificationRequired`
+- `verificationHint`
+- `auditPayloadShape`
+
+Unsupported raw capabilities remain denied:
+
+- host shell
+- raw Docker daemon
+- arbitrary SQL
+- arbitrary storage-key reads
+- decrypted secret reads
+
+## Action Authority Boundary
+
+Authority evaluation is side-effect-free. It can allow, require approval, dry-run, or deny a request. Side effects must be executed by an owning MoonMind control-plane service or subsystem adapter after authority, mutation guard, idempotency, and verification preconditions pass.
+
+## Runtime Evidence
+
+Accepted actions produce artifact-backed evidence:
+
+- `remediation.action_request`
+- `remediation.action_result`
+- `remediation.verification`
+- `remediation.summary`
+
+Artifacts contain refs and bounded metadata, never presigned URLs, raw storage keys, local host paths, secret values, or unbounded log bodies.
+
+## Target-Side Summary
+
+Execution and task-run read models expose compact remediation summary fields:
+
+- active remediation count
+- latest remediation title/status
+- latest action kind
+- active lock holder/scope
+- outcome
+- updated time
+
+Consumers must not parse deep artifact bodies to render this summary.

--- a/specs/242-finish-task-remediation/data-model.md
+++ b/specs/242-finish-task-remediation/data-model.md
@@ -1,0 +1,98 @@
+# Data Model: Finish Task Remediation Desired-State Implementation
+
+## Remediation Action Definition
+
+- `actionKind`: canonical dotted action kind.
+- `targetType`: target resource class such as execution, managed session, provider profile lease, or workload container.
+- `riskTier`: `low`, `medium`, or `high`.
+- `inputMetadata`: bounded field metadata for accepted inputs.
+- `preconditions`: bounded checks required before execution.
+- `idempotency`: key requirements and duplicate behavior.
+- `verification`: required post-action verification description.
+- `auditPayloadShape`: bounded audit fields emitted for the action.
+
+Validation:
+- Unknown raw access action kinds are denied.
+- New action kinds must declare all metadata above.
+- Legacy internal aliases are not accepted as compatibility shims.
+
+## Remediation Action Request
+
+- `schemaVersion`
+- `actionId`
+- `actionKind`
+- `requester`
+- `target`
+- `riskTier`
+- `dryRun`
+- `idempotencyKey`
+- `params`
+
+Validation:
+- Target identity must match the remediation link.
+- Parameters are redacted before durable output.
+- Idempotency key is required for side-effecting actions.
+
+## Remediation Action Result
+
+- `schemaVersion`
+- `actionId`
+- `status`
+- `appliedAt`
+- `beforeStateRef`
+- `afterStateRef`
+- `verificationRequired`
+- `verificationHint`
+- `sideEffects`
+
+Validation:
+- Result status is bounded.
+- State references are artifact refs, not raw paths or URLs.
+
+## Remediation Mutation Lock
+
+- `lockId`
+- `scope`
+- `mode`
+- `holderWorkflowId`
+- `holderRunId`
+- `targetWorkflowId`
+- `targetRunId`
+- `createdAt`
+- `expiresAt`
+- `releasedAt`
+
+Validation:
+- Exclusive locks prevent conflicting target mutations.
+- Expired locks can be recovered through bounded policy.
+- Released or lost locks deny stale holders.
+
+## Remediation Action Ledger
+
+- `remediationWorkflowId`
+- `targetWorkflowId`
+- `actionKind`
+- `idempotencyKey`
+- `requestShapeHash`
+- `decision`
+- `reason`
+- `recordedAt`
+
+Validation:
+- Duplicate same-shape requests return the original decision.
+- Same idempotency key with a different shape is denied.
+
+## Self-Healing Policy
+
+- `enabled`
+- `triggers`
+- `createMode`
+- `templateRef`
+- `authorityMode`
+- `maxActiveRemediations`
+- `allowNestedRemediation`
+- `maxDepth`
+
+Validation:
+- Disabled by default.
+- Immediate creation and nesting require explicit policy.

--- a/specs/242-finish-task-remediation/plan.md
+++ b/specs/242-finish-task-remediation/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Finish Task Remediation Desired-State Implementation
+
+**Branch**: `242-finish-task-remediation` | **Date**: 2026-04-23 | **Spec**: `specs/242-finish-task-remediation/spec.md`
+**Input**: Single-story feature specification from `/specs/242-finish-task-remediation/spec.md`
+
+## Summary
+
+Implement MM-483 in runtime mode by completing the remaining Task Remediation desired-state contract around canonical action coverage, safe execution boundaries, durable mutation coordination, lifecycle/read-model evidence, policy-bounded self-healing, and Mission Control presentation. Repo gap analysis shows substantial existing foundations: remediation links and pinned targets, context artifacts, evidence tools, lifecycle artifact helpers from MM-456, target-side relationship rendering, authority decisions, and mutation guard tests. The first missing runtime surface is canonical action registry coverage: `remediation_actions.py` still exposes legacy aliases instead of the documented action kinds. Tests will start there and preserve broader tasks for the remaining runtime gaps.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workflows/temporal/remediation_actions.py` exposes the documented canonical dotted action set; focused tests passed | no further registry work | final verify |
+| FR-002 | implemented_verified | raw access denial exists in `RemediationActionAuthorityService` and mutation guard; canonical registry tests exclude raw actions | no further registry work | final verify |
+| FR-003 | implemented_verified | action metadata now includes target type, inputs, risk, preconditions, idempotency, verification, and audit shape | no further registry work | final verify |
+| FR-004 | partial | authority service validates but does not execute actions; safe execution adapters not yet wired | keep execution out of authority and plan adapter boundary work | unit + integration |
+| FR-005-FR-007 | partial | action request/result payloads exist; MM-456 artifact helpers exist | integrate authority output with artifact publication in later tasks | unit + integration |
+| FR-008-FR-009 | implemented_verified | service validates `taskRunIds` shape and rejects foreign IDs when target task-run evidence is available; focused tests passed | no further create-time validation work in this slice | final verify |
+| FR-010-FR-011 | partial | mutation guard has bounded nesting; no automatic self-healing creation policy path found | add policy gate before any automatic creation path | unit |
+| FR-012-FR-015 | partial | mutation guard has in-memory lock/ledger and tests; durable DB-backed guard not complete | move lock/ledger state to durable boundary or document cutover | unit + integration |
+| FR-016-FR-020 | partial | target control artifacts and compatibility constraints exist in adjacent runtime paths | add adapter-boundary tests before wiring actions | unit + integration |
+| FR-021-FR-027 | implemented_unverified | MM-456 lifecycle helpers and read-model fields exist | verify runtime publication and target-side summary coverage | unit + integration |
+| FR-028-FR-035 | partial | cancellation/degraded outcomes exist in pieces across context/action services and UI | consolidate bounded outcomes and UI exposure | unit + UI |
+| FR-036 | missing | no MM-483-specific coverage matrix exists | add workflow/activity, adapter, API, and UI tests | unit + integration |
+| FR-037 | implemented_verified | `spec.md` and Jira input preserve MM-483 | preserve in tasks, verification, commit/PR metadata | final verify |
+| FR-038 | implemented_unverified | compatibility policy is in constitution and existing code avoids raw execution | verify no compatibility shims or raw execution bypasses are added | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control if UI behavior changes  
+**Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, FastAPI, Temporal Python SDK, existing Temporal artifact and remediation services, React/Vitest  
+**Storage**: Existing `execution_remediation_links`, Temporal execution records, artifact metadata/content store, and existing control/summary projections; no new persistent table planned unless durable lock/ledger cannot reuse existing records  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and targeted router/UI unit commands as files change  
+**Integration Testing**: `./tools/test_integration.sh` when artifact lifecycle, API routes, or compose-backed runtime behavior changes  
+**Target Platform**: Linux server / Docker Compose deployment  
+**Project Type**: FastAPI control plane plus Temporal workflow/service boundary and Mission Control UI  
+**Performance Goals**: Remediation metadata remains compact; logs, snapshots, and evidence bodies stay behind artifact refs and out of workflow history  
+**Constraints**: Runtime mode; preserve MM-483 traceability; no raw host/Docker/SQL/storage/secret access; compatibility-sensitive Temporal shapes require explicit compatibility or cutover evidence  
+**Scale/Scope**: One remediation run targets one logical execution and one pinned run snapshot, with bounded action attempts and compact read-model summaries
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Typed actions orchestrate owning subsystems instead of giving the model raw control.
+- II. One-Click Agent Deployment: PASS. No required external provider dependency is added.
+- III. Avoid Vendor Lock-In: PASS. Action kinds are MoonMind control-plane semantics, not provider-specific cognitive behavior.
+- IV. Own Your Data: PASS. Evidence stays in local artifacts/read models.
+- V. Skills Are First-Class: PASS. This story does not mutate runtime skill sources.
+- VI. Tests Are the Anchor: PASS. Workflow/activity, adapter, API, and UI boundaries require tests.
+- VII. Runtime Configurability: PASS. Policy-gated self-healing and action policies remain explicit runtime configuration.
+- VIII. Modular Architecture: PASS. Work stays at remediation service, adapter, API, and UI boundaries.
+- IX. Resilient by Default: PASS. Locking, idempotency, degraded outcomes, cancellation, and continuation are explicit.
+- XII. Canonical Docs vs Tmp: PASS. Jira input remains under `docs/tmp`; canonical docs remain desired state.
+- XIII. Pre-release Compatibility Policy: PASS. Superseded legacy action aliases must be removed rather than kept as compatibility shims.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/242-finish-task-remediation/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-runtime.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/temporal/
+├── remediation_actions.py
+├── remediation_context.py
+├── remediation_tools.py
+└── service.py
+
+api_service/api/routers/
+└── executions.py
+
+frontend/src/entrypoints/
+├── task-detail.tsx
+└── task-detail.test.tsx
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+
+tests/unit/api/routers/
+└── test_executions.py
+```
+
+**Structure Decision**: Keep deep evidence artifact-backed, keep query/read-model state compact, and keep action execution behind owning control-plane or subsystem adapter boundaries.
+
+## Complexity Tracking
+
+None.

--- a/specs/242-finish-task-remediation/plan.md
+++ b/specs/242-finish-task-remediation/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-483 in runtime mode by completing the remaining Task Remediation desired-state contract around safe action execution boundaries, durable mutation coordination, lifecycle/read-model evidence, policy-bounded self-healing, and Mission Control presentation. Repo gap analysis shows substantial existing foundations: remediation links and pinned targets, context artifacts, evidence tools, lifecycle artifact helpers from MM-456, target-side relationship rendering, authority decisions, mutation guard tests, canonical action registry coverage, and `taskRunIds` ownership validation. The next missing runtime surfaces are durable lock/ledger persistence, owning-adapter action execution, aggregate artifact/read-model verification, and Mission Control lifecycle completion.
+Implement MM-483 in runtime mode by completing the remaining Task Remediation desired-state contract around safe action execution boundaries, durable mutation coordination, lifecycle/read-model evidence, policy-bounded self-healing, and Mission Control presentation. Repo gap analysis shows substantial existing foundations: remediation links and pinned targets, context artifacts, evidence tools, lifecycle artifact helpers from MM-456, target-side relationship rendering, authority decisions, mutation guard tests, canonical action registry coverage, `taskRunIds` ownership validation, durable mutation lock/ledger state on remediation links, and an evidence-tool execution boundary that publishes action request/result/verification artifacts. The next missing runtime surfaces are concrete owning-adapter action implementations, aggregate read-model verification, and Mission Control lifecycle completion.
 
 ## Requirement Status
 
@@ -15,10 +15,10 @@ Implement MM-483 in runtime mode by completing the remaining Task Remediation de
 | FR-002 | implemented_verified | raw access denial exists in `RemediationActionAuthorityService` and mutation guard; canonical registry tests exclude raw actions | no further registry work | final verify |
 | FR-003 | implemented_verified | action metadata now includes target type, inputs, risk, preconditions, idempotency, verification, and audit shape | no further registry work | final verify |
 | FR-004 | partial | authority service validates but does not execute actions; safe execution adapters not yet wired | keep execution out of authority and plan adapter boundary work | unit + integration |
-| FR-005-FR-007 | partial | action request/result payloads exist; MM-456 artifact helpers exist | integrate authority output with artifact publication in later tasks | unit + integration |
+| FR-005-FR-007 | implemented_verified | `RemediationEvidenceToolService.execute_action` publishes action request, action result, and verification artifacts from authority/guard output; focused tests passed | final aggregate verification | final verify |
 | FR-008-FR-009 | implemented_verified | service validates `taskRunIds` shape and rejects foreign IDs when target task-run evidence is available; focused tests passed | no further create-time validation work in this slice | final verify |
 | FR-010-FR-011 | partial | mutation guard has bounded nesting; no automatic self-healing creation policy path found | add policy gate before any automatic creation path | unit |
-| FR-012-FR-015 | partial | mutation guard has in-memory lock/ledger and tests; durable DB-backed guard not complete | move lock/ledger state to durable boundary or document cutover | unit + integration |
+| FR-012-FR-015 | implemented_verified | mutation guard lock and ledger state persist on `execution_remediation_links`; focused restart-durability test passed | no further durable lock/ledger work in this slice | final verify |
 | FR-016-FR-020 | partial | target control artifacts and compatibility constraints exist in adjacent runtime paths | add adapter-boundary tests before wiring actions | unit + integration |
 | FR-021-FR-027 | implemented_unverified | MM-456 lifecycle helpers and read-model fields exist | verify runtime publication and target-side summary coverage | unit + integration |
 | FR-028-FR-035 | partial | cancellation/degraded outcomes exist in pieces across context/action services and UI | consolidate bounded outcomes and UI exposure | unit + UI |

--- a/specs/242-finish-task-remediation/plan.md
+++ b/specs/242-finish-task-remediation/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-483 in runtime mode by completing the remaining Task Remediation desired-state contract around canonical action coverage, safe execution boundaries, durable mutation coordination, lifecycle/read-model evidence, policy-bounded self-healing, and Mission Control presentation. Repo gap analysis shows substantial existing foundations: remediation links and pinned targets, context artifacts, evidence tools, lifecycle artifact helpers from MM-456, target-side relationship rendering, authority decisions, and mutation guard tests. The first missing runtime surface is canonical action registry coverage: `remediation_actions.py` still exposes legacy aliases instead of the documented action kinds. Tests will start there and preserve broader tasks for the remaining runtime gaps.
+Implement MM-483 in runtime mode by completing the remaining Task Remediation desired-state contract around safe action execution boundaries, durable mutation coordination, lifecycle/read-model evidence, policy-bounded self-healing, and Mission Control presentation. Repo gap analysis shows substantial existing foundations: remediation links and pinned targets, context artifacts, evidence tools, lifecycle artifact helpers from MM-456, target-side relationship rendering, authority decisions, mutation guard tests, canonical action registry coverage, and `taskRunIds` ownership validation. The next missing runtime surfaces are durable lock/ledger persistence, owning-adapter action execution, aggregate artifact/read-model verification, and Mission Control lifecycle completion.
 
 ## Requirement Status
 

--- a/specs/242-finish-task-remediation/quickstart.md
+++ b/specs/242-finish-task-remediation/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Finish Task Remediation Desired-State Implementation
+
+1. Confirm the MM-483 source input is preserved:
+
+   ```bash
+   rg -n "MM-483|Canonical Jira Brief|DESIGN-REQ-|FR-001" specs/242-finish-task-remediation docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md
+   ```
+
+2. Run focused remediation action tests:
+
+   ```bash
+   MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+   ```
+
+3. If API read-model behavior changes, run router tests:
+
+   ```bash
+   MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py
+   ```
+
+4. If Mission Control rendering changes, run focused UI tests:
+
+   ```bash
+   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+   ```
+
+5. Before final verification, run:
+
+   ```bash
+   MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+   ```
+
+6. Run `/moonspec-verify` and record the MM-483 verdict in `specs/242-finish-task-remediation/verification.md`.

--- a/specs/242-finish-task-remediation/research.md
+++ b/specs/242-finish-task-remediation/research.md
@@ -1,0 +1,49 @@
+# Research: Finish Task Remediation Desired-State Implementation
+
+## Input Classification
+
+Decision: MM-483 is a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md` has one user story, one operator outcome, explicit acceptance criteria, and explicit non-goals.
+Rationale: Although the story spans backend, workflow, API, and UI surfaces, all requirements support one independently testable operator outcome: complete Task Remediation runtime behavior.
+Alternatives considered: Treat as broad design requiring breakdown. Rejected because Jira has already selected the single story and the brief defines concrete acceptance criteria.
+Test implications: Unit, integration, and UI coverage are required.
+
+## Canonical Action Registry
+
+Decision: Implemented first.
+Evidence: Initial gap analysis found `moonmind/workflows/temporal/remediation_actions.py` exposed `restart_worker` and `terminate_session`; the implementation now exposes the canonical dotted action kinds required by `docs/Tasks/TaskRemediation.md` and MM-483.
+Rationale: The registry is the smallest high-value missing surface and is a prerequisite for safe action execution wiring.
+Alternatives considered: Keep legacy aliases. Rejected by Constitution XIII because this is pre-release and superseded internal contracts should be removed.
+Test implications: Unit tests must assert the full canonical action set, metadata shape, profile filtering, and raw action denial.
+
+## Action Execution Boundary
+
+Decision: Partial; plan adapter-boundary work after registry coverage.
+Evidence: `RemediationActionAuthorityService` explicitly does not execute host/container/SQL/provider/storage operations; owning runtime activities exist for managed sessions and provider profiles.
+Rationale: Authority decisions should stay side-effect-free while execution moves through owning subsystem adapters.
+Alternatives considered: Execute directly from the authority service. Rejected because it would weaken the safety boundary.
+Test implications: Adapter-boundary tests must cover real invocation shapes before production execution wiring.
+
+## Durable Lock And Ledger
+
+Decision: Partial; existing guard behavior is in-memory and tested, but MM-483 requires durability across process restarts and retries.
+Evidence: `RemediationMutationGuardService` stores `_locks`, `_ledger`, and budgets in instance dictionaries.
+Rationale: The current implementation is useful for policy semantics but not sufficient for restart durability.
+Alternatives considered: Add another ad hoc compatibility layer. Rejected; either reuse existing durable records or introduce an explicit cutover-backed persistent representation.
+Test implications: Unit/service tests must simulate new service instances and prove duplicate/idempotency state survives.
+
+## Lifecycle Artifacts And Read Models
+
+Decision: Implemented unverified for the MM-483 aggregate story.
+Evidence: `RemediationContextBuilder`, MM-456 artifacts, and execution read models already expose context, summary, approval, status, lock, action, and outcome fields.
+Rationale: Existing slices likely satisfy part of this story, but MM-483 needs a final aggregate verification matrix.
+Alternatives considered: Reimplement lifecycle artifacts. Rejected because existing MM-456 work should be reused where correct.
+Test implications: Add verification tests first; implement only gaps exposed by those tests.
+
+## Mission Control Presentation
+
+Decision: Partial.
+Evidence: `frontend/src/entrypoints/task-detail.tsx` renders remediation relationships, creation preview, approval controls, and evidence panels.
+Rationale: The UI already has remediation surfaces, but MM-483 requires completed action/approval/verification lifecycle visibility without unsafe paths or secret-bearing data.
+Alternatives considered: Skip UI. Rejected because the Jira brief explicitly requires Mission Control coverage.
+Test implications: Vitest coverage is required if task detail rendering changes.

--- a/specs/242-finish-task-remediation/research.md
+++ b/specs/242-finish-task-remediation/research.md
@@ -18,19 +18,19 @@ Test implications: Unit tests must assert the full canonical action set, metadat
 
 ## Action Execution Boundary
 
-Decision: Partial; plan adapter-boundary work after registry coverage.
-Evidence: `RemediationActionAuthorityService` explicitly does not execute host/container/SQL/provider/storage operations; owning runtime activities exist for managed sessions and provider profiles.
-Rationale: Authority decisions should stay side-effect-free while execution moves through owning subsystem adapters.
+Decision: Implemented at the evidence-tool service boundary; concrete subsystem action implementations remain open.
+Evidence: `RemediationActionAuthorityService` remains side-effect-free, while `RemediationEvidenceToolService.execute_action` validates executable authority and guard results, delegates mutation to an injected action executor, and publishes `remediation.action_request`, `remediation.action_result`, and `remediation.verification` artifacts.
+Rationale: Authority decisions stay pure and side-effecting work is forced through an owning executor boundary instead of raw shell, Docker, SQL, storage, or secret access.
 Alternatives considered: Execute directly from the authority service. Rejected because it would weaken the safety boundary.
-Test implications: Adapter-boundary tests must cover real invocation shapes before production execution wiring.
+Test implications: Focused adapter-boundary tests prove delegation and artifact publication. Concrete managed-session, provider-profile, workload, and execution action implementations still need runtime-specific tests.
 
 ## Durable Lock And Ledger
 
-Decision: Partial; existing guard behavior is in-memory and tested, but MM-483 requires durability across process restarts and retries.
-Evidence: `RemediationMutationGuardService` stores `_locks`, `_ledger`, and budgets in instance dictionaries.
-Rationale: The current implementation is useful for policy semantics but not sufficient for restart durability.
-Alternatives considered: Add another ad hoc compatibility layer. Rejected; either reuse existing durable records or introduce an explicit cutover-backed persistent representation.
-Test implications: Unit/service tests must simulate new service instances and prove duplicate/idempotency state survives.
+Decision: Implemented for mutation locks and action ledger state.
+Evidence: `RemediationMutationGuardService` persists active lock state and ledger entries on `execution_remediation_links` through `mutation_guard_lock_state` and `mutation_guard_ledger_state`; restart-durability coverage constructs a new service instance and verifies duplicate idempotency replay plus cross-remediator lock conflict detection.
+Rationale: Reusing the durable remediation link keeps guard state attached to the remediation-to-target relationship without adding a separate persistence concept for this slice.
+Alternatives considered: Keep process-local dictionaries. Rejected because MM-483 requires restart durability. Add another ad hoc compatibility layer. Rejected because the existing remediation link is the natural durable boundary.
+Test implications: Focused service-boundary tests prove restart durability for lock and ledger state; final verification still needs aggregate action execution, artifact, read-model, and UI coverage.
 
 ## Lifecycle Artifacts And Read Models
 

--- a/specs/242-finish-task-remediation/spec.md
+++ b/specs/242-finish-task-remediation/spec.md
@@ -1,0 +1,212 @@
+# Feature Specification: Finish Task Remediation Desired-State Implementation
+
+**Feature Branch**: `242-finish-task-remediation`
+**Created**: 2026-04-23
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-483 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md`
+
+## Original Preset Brief
+
+```text
+# MM-483 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-483
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Finish Task Remediation desired-state implementation
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-483 from MM project
+Summary: Finish Task Remediation desired-state implementation
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-483 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-483: Finish Task Remediation desired-state implementation
+
+User Story
+As a MoonMind operator, I need the Task Remediation system described in `docs/Tasks/TaskRemediation.md` to be fully implemented end to end so remediation tasks can safely diagnose, act on, audit, and verify target executions without raw host access or unbounded loops.
+
+Context
+A code audit found that MoonMind already implements several remediation foundations: canonical `task.remediation` submission and pinned links, context artifacts, typed evidence reads, Mission Control relationship panels, authority decisions, and in-memory mutation guard decisions. The system is not complete against `docs/Tasks/TaskRemediation.md` because action execution, canonical action coverage, durable locks/ledgers, lifecycle integration, target-side summaries, and automatic policy-bounded self-healing remain missing or partial.
+
+Source Documents
+- `docs/Tasks/TaskRemediation.md`
+- `specs/232-remediation-lifecycle-audit/tasks.md`
+- `moonmind/workflows/temporal/remediation_actions.py`
+- `moonmind/workflows/temporal/remediation_context.py`
+- `moonmind/workflows/temporal/remediation_tools.py`
+- `moonmind/workflows/temporal/service.py`
+- `api_service/api/routers/executions.py`
+- `frontend/src/entrypoints/task-detail.tsx`
+
+Current Implemented Baseline
+- `task.remediation` is accepted and normalized under `initialParameters.task.remediation`.
+- Remediation target `workflowId`/`runId` links are persisted and queryable inbound/outbound.
+- `reports/remediation_context.json` can be generated and linked.
+- Evidence tools can read declared artifacts/logs and gate live follow.
+- Authority/profile decisions and mutation guard decisions exist.
+- Mission Control can show remediation relationships, evidence artifacts, and approval state.
+
+Missing Work / Acceptance Criteria
+1. Canonical action registry coverage exists for the documented action kinds: `execution.pause`, `execution.resume`, `execution.request_rerun_same_workflow`, `execution.start_fresh_rerun`, `execution.cancel`, `execution.force_terminate`, `session.interrupt_turn`, `session.clear`, `session.cancel`, `session.terminate`, `session.restart_container`, `provider_profile.evict_stale_lease`, `workload.restart_helper_container`, and `workload.reap_orphan_container`. Unsupported raw host, Docker, SQL, storage, and secret-read capabilities remain absent.
+2. Accepted remediation actions execute through MoonMind-owned control-plane services or owning subsystem adapters, not through raw shell/Docker/SQL access. Each action declares target type, inputs, risk tier, preconditions, idempotency key behavior, verification requirements, and audit payload shape.
+3. The remediation evidence/tool surface includes end-to-end `execute_action` and `verify_target` behavior. Action request, action result, before/after state refs, side effects, and verification outcomes are persisted as remediation artifacts.
+4. Exclusive mutation locks and the remediation action ledger are durable across process restarts, Temporal retries, worker restarts, and replay-sensitive paths. They are no longer only in-memory service fields.
+5. Create-time validation verifies selected `taskRunIds` belong to the target execution or selected steps. Malformed or foreign `taskRunIds` fail before workflow start with structured validation errors.
+6. Remediation lifecycle integration is complete: `collecting_evidence`, `diagnosing`, `awaiting_approval`, `acting`, `verifying`, `resolved`, `escalated`, and `failed` are reflected in summaries/read models without replacing top-level `MoonMind.Run` state.
+7. Required remediation artifacts are produced automatically by the runtime path, not only by helper calls/tests: `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, and `remediation.summary`.
+8. Target-side linkage summaries are exposed through execution/task-run read models, including active remediation count, latest remediation title/status, latest action kind, active lock holder/scope, outcome, and updated time.
+9. Cancellation, failure, and Continue-As-New behavior is implemented at the service/workflow boundary: remediation cancellation does not mutate the target except already-requested actions, final summary publication and lock release are attempted, and target workflow/run, context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor are preserved across continuation.
+10. Action request/result output from `RemediationActionAuthorityService` is integrated with lifecycle artifact publication and audit evidence.
+11. Target-managed session and workload mutations preserve subsystem-native continuity/control artifacts in addition to remediation audit artifacts.
+12. Automatic self-healing, if enabled, is policy-driven and bounded: no implicit spawn-on-failure, max active remediations enforced, nested remediation off by default, depth limits enforced, and proposal/immediate modes are explicit.
+13. Partial historical evidence, missing artifact refs, unavailable live follow, lock conflicts, stale leases already released, gone containers, unsafe force termination attempts, and remediator failure all produce bounded degraded/no-op/escalated/failed outcomes rather than silent success or infinite waits.
+14. Mission Control exposes the completed action/approval/verification lifecycle without raw storage paths, presigned URLs, or secret-bearing data.
+15. Tests cover workflow/activity or adapter boundaries for action execution, durable locks/ledger, `taskRunId` ownership validation, lifecycle artifacts, target-side read models, cancellation/failure, Continue-As-New, and Mission Control rendering. Run at minimum: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and `./tools/test_integration.sh` when artifact lifecycle/API routes change.
+
+Out of Scope
+- Raw admin console access.
+- Direct host shell, arbitrary SQL, arbitrary Docker daemon operations, arbitrary storage-key reads, or secret redaction bypasses.
+- Replacing `MoonMind.Run` with a new top-level remediation workflow type unless the canonical doc is intentionally updated first.
+
+Implementation Notes
+- Preserve Constitution compatibility requirements for Temporal-facing payloads. Any activity/workflow/update/signal shape change must be compatibility-safe or have an explicit cutover plan.
+- Existing partial implementation should be reused where correct, but compatibility shims for superseded internal contracts should not be added.
+- The current action authority module explicitly says it does not execute host/container/SQL/provider/storage operations; this story must add the safe execution boundary through owning services, not by weakening that guardrail.
+
+Needs Clarification
+- None
+```
+
+## User Story - Complete Task Remediation Runtime
+
+**Summary**: As a MoonMind operator, I want remediation tasks to diagnose, act on, audit, and verify target executions through bounded MoonMind control-plane capabilities so that failed or stuck tasks can be repaired without raw host access or unbounded self-healing loops.
+
+**Goal**: Task Remediation reaches the desired runtime contract for action coverage, safe action execution, durable mutation coordination, lifecycle artifacts, target-side summaries, bounded self-healing policy, Mission Control visibility, and verification evidence.
+
+**Independent Test**: Create or simulate remediation runs for target executions that cover action execution, evidence collection, approval/action/verification lifecycle, durable locks and ledgers, target-side read models, cancellation/failure, continuation, degraded evidence, and Mission Control rendering; then verify every required artifact, summary field, audit record, and bounded outcome is present without exposing raw host/storage/secret access.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run requests a documented action kind, **When** the action is accepted, **Then** it is validated against the canonical action registry and executed only through a MoonMind-owned control-plane service or owning subsystem adapter.
+2. **Given** a remediation action is requested or attempted, **When** operators inspect remediation evidence, **Then** action request, action result, before/after state refs, side effects, verification outcome, and audit metadata are persisted as remediation artifacts.
+3. **Given** a remediation task acts on a shared target, **When** Temporal retries, worker restarts, or process restarts occur, **Then** exclusive mutation locks and the action ledger remain durable and prevent conflicting duplicate mutations.
+4. **Given** a remediation request includes selected task run bindings, **When** the task is created, **Then** the platform rejects malformed or foreign `taskRunIds` before workflow start with structured validation errors.
+5. **Given** a remediation run progresses from evidence collection through action and verification, **When** summaries and read models are inspected, **Then** lifecycle phases, required remediation artifacts, target-side linkage summaries, and Mission Control state are complete without replacing top-level `MoonMind.Run` state.
+6. **Given** a remediation task is canceled, fails, or continues as new, **When** the workflow boundary is inspected, **Then** it avoids new target mutation except already-requested actions, attempts final summary publication and lock release, and preserves target identity, context, lock, ledger, approval, retry, and live-follow cursor state.
+7. **Given** automatic self-healing is enabled by policy, **When** a target fails, stalls, or requests attention, **Then** remediation creation remains bounded by explicit trigger mode, active-count limits, nested-remediation defaults, depth limits, and proposal/immediate behavior.
+8. **Given** evidence or target state is partial, stale, unsafe, or unavailable, **When** remediation proceeds, **Then** the system produces bounded degraded, no-op, escalated, failed, or denied outcomes rather than silent success or infinite waits.
+
+### Edge Cases
+
+- Unsupported raw host, Docker, SQL, storage, or secret-read action requests are rejected rather than routed through generic agent execution.
+- Stale leases, gone containers, unsafe force termination attempts, missing artifact refs, unavailable live follow, lock conflicts, and failed preconditions produce explicit bounded results.
+- Managed-session and workload mutations preserve subsystem-native continuity or control artifacts in addition to remediation audit artifacts.
+- Historical targets with only partial evidence remain diagnosable when safe and mark unavailable evidence classes explicitly.
+- Automatic remediation of remediation tasks remains off by default unless policy explicitly allows bounded nesting.
+
+## Assumptions
+
+- The MM-483 brief is a single runtime feature request because it has one operator-facing outcome and explicit non-goals, even though it spans backend, workflow, and Mission Control surfaces.
+- Existing MM-451, MM-454, MM-456, MM-457, and MM-482 remediation foundations provide partial behavior; this story completes the remaining desired-state runtime contract rather than reworking those completed slices.
+- The source implementation document `docs/Tasks/TaskRemediation.md` is treated as runtime source requirements because the selected mode is runtime.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Tasks/TaskRemediation.md` sections 5 through 7): Remediation remains a normal `MoonMind.Run` with nested `task.remediation`, a non-dependency target relationship, server-mediated evidence access, and typed allowlisted administrative actions. Scope: in scope, mapped to FR-001, FR-002, FR-006, FR-007, FR-022, and FR-034.
+- **DESIGN-REQ-002** (`docs/Tasks/TaskRemediation.md` sections 7.3 through 7.6): Create-time validation requires target identity, pinned run resolution, task-run ownership validation, authority/action policy validation, bounded nesting checks, and optional automatic self-healing policy. Scope: in scope, mapped to FR-008 through FR-011 and FR-028 through FR-031.
+- **DESIGN-REQ-003** (`docs/Tasks/TaskRemediation.md` sections 8 through 9): Remediation links, context artifacts, evidence refs, live-follow state, and target-side read models must remain durable and inspectable in both directions. Scope: in scope, mapped to FR-012, FR-013, FR-021 through FR-024, and FR-032.
+- **DESIGN-REQ-004** (`docs/Tasks/TaskRemediation.md` sections 10 through 12): Remediation actions must use a canonical registry, bounded action kinds, authority decisions, explicit approvals, safe execution boundaries, idempotency keys, verification requirements, and durable exclusive locks. Scope: in scope, mapped to FR-001 through FR-007, FR-014 through FR-020, and FR-033.
+- **DESIGN-REQ-005** (`docs/Tasks/TaskRemediation.md` sections 13 through 14): Runtime lifecycle phases, required remediation artifacts, final summaries, target-side continuity artifacts, and control-plane audit events must be produced automatically and remain queryable. Scope: in scope, mapped to FR-021 through FR-027 and FR-035.
+- **DESIGN-REQ-006** (`docs/Tasks/TaskRemediation.md` sections 15 through 17): Security boundaries, degradation behavior, loop prevention, cancellation/failure semantics, continuation preservation, and Mission Control presentation must fail closed and avoid secret/raw access exposure. Scope: in scope, mapped to FR-028 through FR-038.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose canonical registry coverage for `execution.pause`, `execution.resume`, `execution.request_rerun_same_workflow`, `execution.start_fresh_rerun`, `execution.cancel`, `execution.force_terminate`, `session.interrupt_turn`, `session.clear`, `session.cancel`, `session.terminate`, `session.restart_container`, `provider_profile.evict_stale_lease`, `workload.restart_helper_container`, and `workload.reap_orphan_container`.
+- **FR-002**: The remediation action registry MUST reject unsupported raw host, Docker, SQL, arbitrary storage, and secret-read capabilities.
+- **FR-003**: Every accepted remediation action kind MUST declare target type, inputs, risk tier, preconditions, idempotency key behavior, verification requirements, and audit payload shape.
+- **FR-004**: Accepted remediation actions MUST execute through MoonMind-owned control-plane services or owning subsystem adapters rather than raw shell, Docker daemon, SQL, storage-key, or secret access.
+- **FR-005**: The remediation evidence/tool surface MUST support end-to-end `execute_action` and `verify_target` behavior.
+- **FR-006**: Action request, action result, before/after state refs, side effects, and verification outcomes MUST be persisted as remediation artifacts.
+- **FR-007**: Action request/result output from `RemediationActionAuthorityService` MUST be integrated with lifecycle artifact publication and audit evidence.
+- **FR-008**: Create-time validation MUST verify selected `taskRunIds` belong to the target execution or selected steps.
+- **FR-009**: Malformed or foreign `taskRunIds` MUST fail before workflow start with structured validation errors.
+- **FR-010**: Automatic self-healing, when enabled, MUST be policy-driven and bounded by explicit trigger mode, active remediation limits, nested remediation defaults, depth limits, and proposal/immediate behavior.
+- **FR-011**: The system MUST NOT implicitly spawn remediation tasks on failure unless enabled by explicit policy.
+- **FR-012**: Exclusive mutation locks for remediation acting MUST be durable across process restarts, Temporal retries, worker restarts, and replay-sensitive paths.
+- **FR-013**: The remediation action ledger MUST be durable across process restarts, Temporal retries, worker restarts, and replay-sensitive paths.
+- **FR-014**: Duplicate action attempts under retry or replay MUST be idempotent or safely keyed to avoid duplicate destructive effects.
+- **FR-015**: Lock conflicts MUST produce explicit bounded outcomes and MUST NOT silently allow conflicting mutations.
+- **FR-016**: Target-managed session and workload mutations MUST preserve subsystem-native continuity/control artifacts in addition to remediation audit artifacts.
+- **FR-017**: Stale leases that are already released MUST produce a no-op or degraded outcome rather than silent success.
+- **FR-018**: Missing or gone workload containers MUST produce a bounded no-op, escalated, or failed outcome.
+- **FR-019**: Unsafe force termination attempts MUST be denied or escalated with a bounded reason.
+- **FR-020**: The system MUST preserve Constitution compatibility requirements for Temporal-facing payloads through compatible workflow/activity/update/signal shapes or an explicit cutover plan.
+- **FR-021**: Remediation lifecycle integration MUST expose collecting_evidence, diagnosing, awaiting_approval, acting, verifying, resolved, escalated, and failed in summaries/read models without replacing top-level `MoonMind.Run` state.
+- **FR-022**: Required remediation artifacts MUST be produced automatically by the runtime path for context, plan, decision log, action request, action result, verification, and summary.
+- **FR-023**: Required remediation artifacts MUST not rely only on helper calls or tests to appear in normal runtime paths.
+- **FR-024**: Target-side linkage summaries MUST expose active remediation count, latest remediation title/status, latest action kind, active lock holder/scope, outcome, and updated time through execution/task-run read models.
+- **FR-025**: Mission Control MUST expose completed action, approval, verification, artifact, and target-linkage lifecycle state without raw storage paths, presigned URLs, or secret-bearing data.
+- **FR-026**: Control-plane audit evidence MUST identify action kind, risk tier, actor or execution principal, target workflow/run identity, remediation workflow/run identity, approval decision when relevant, timestamps, and bounded metadata.
+- **FR-027**: Target-side read models MUST allow operators to inspect remediation relationships without parsing deep artifact bodies.
+- **FR-028**: Cancellation MUST NOT mutate the target except for actions already requested before cancellation.
+- **FR-029**: Cancellation, failure, and terminal completion MUST attempt final summary publication and lock release when possible.
+- **FR-030**: Continue-As-New behavior MUST preserve target workflow/run identity, remediation context ref, lock identity, action ledger, approval state, retry budget, and live-follow cursor.
+- **FR-031**: Remediator failure MUST produce a bounded failed or escalated outcome rather than silent success or infinite waits.
+- **FR-032**: Partial historical evidence, missing artifact refs, unavailable live follow, and unavailable evidence classes MUST be recorded as degraded evidence.
+- **FR-033**: Precondition failures MUST produce explicit no-op, degraded, escalated, or failed outcomes rather than silent success.
+- **FR-034**: Remediation tasks MUST never receive presigned URLs, raw storage keys, raw local filesystem paths, raw secrets, or unredacted secret-bearing data as durable context.
+- **FR-035**: Mission Control and API presentation MUST show remediation lifecycle state while preserving artifact preview/redaction rules.
+- **FR-036**: Tests MUST cover workflow/activity or adapter boundaries for action execution, durable locks/ledger, `taskRunId` ownership validation, lifecycle artifacts, target-side read models, cancellation/failure, Continue-As-New, and Mission Control rendering.
+- **FR-037**: The implementation MUST preserve the Jira issue key MM-483 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- **FR-038**: Existing partial implementation SHOULD be reused where correct, but compatibility shims for superseded internal contracts MUST NOT be added.
+
+### Key Entities
+
+- **Remediation Action Definition**: A typed action registry entry describing kind, target type, inputs, risk tier, preconditions, idempotency behavior, verification requirements, and audit shape.
+- **Remediation Action Request**: The validated request to execute a typed remediation action against a target through an owning subsystem.
+- **Remediation Action Result**: The durable outcome of an attempted action including side effects, before/after refs, verification status, and bounded failure or no-op reason.
+- **Remediation Mutation Lock**: A durable exclusive lock that prevents conflicting remediation mutations against a shared target.
+- **Remediation Action Ledger**: A durable record of requested, attempted, skipped, no-op, denied, failed, or verified remediation actions.
+- **Remediation Runtime Artifact Set**: The automatically produced context, plan, decision log, action request, action result, verification, and summary artifacts.
+- **Target-Side Remediation Summary**: Compact execution/task-run read-model metadata for inbound remediations, lock state, latest action, outcome, and update time.
+- **Self-Healing Policy**: Bounded policy controlling if, when, and how remediation tasks are automatically proposed or created.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove every documented remediation action kind is registered with required metadata and unsupported raw capabilities are rejected.
+- **SC-002**: Tests prove accepted actions execute through owning control-plane or subsystem boundaries and persist action request/result/verification artifacts.
+- **SC-003**: Tests prove mutation locks and action ledgers remain durable and idempotent across retry or restart simulations.
+- **SC-004**: Tests prove malformed or foreign `taskRunIds` fail at create time with structured validation errors.
+- **SC-005**: Tests prove runtime paths automatically publish required remediation artifacts and lifecycle summaries without relying only on helper calls.
+- **SC-006**: Tests prove target-side read models expose remediation counts, latest status/action, lock scope, outcome, and updated time.
+- **SC-007**: Tests prove cancellation, remediator failure, and Continue-As-New preserve or publish the required state and avoid new target mutation after cancellation except already-requested actions.
+- **SC-008**: Tests prove self-healing is disabled unless explicit policy enables bounded proposal or immediate behavior.
+- **SC-009**: Tests prove partial evidence, missing artifacts, unavailable live follow, stale leases, gone containers, unsafe force termination, lock conflicts, and failed preconditions produce bounded degraded/no-op/escalated/failed outcomes.
+- **SC-010**: Mission Control tests prove operators can inspect action, approval, verification, artifact, and target-linkage lifecycle state without raw paths, presigned URLs, or secret-bearing data.

--- a/specs/242-finish-task-remediation/tasks.md
+++ b/specs/242-finish-task-remediation/tasks.md
@@ -16,7 +16,7 @@
 - MM-483 is preserved in the Jira orchestration input, spec, plan, tasks, and final verification path.
 - Input classification: single-story runtime feature request.
 - Completed first implementation focus from `plan.md`: canonical action registry coverage, metadata shape, and `taskRunIds` ownership validation.
-- Remaining status from `plan.md`: durable lock/ledger persistence, owning-adapter action execution, aggregate artifact/read-model verification, Mission Control lifecycle completion, and full final verification remain open.
+- Remaining status from `plan.md`: concrete owning-adapter action implementations, aggregate read-model verification, Mission Control lifecycle completion, and full final verification remain open.
 
 ## Phase 1: Setup
 
@@ -41,14 +41,14 @@
 - [X] T005 Add failing unit coverage for the complete canonical action registry in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001, FR-003, SC-001, DESIGN-REQ-004)
 - [X] T006 Add failing unit coverage proving legacy action aliases are not accepted as compatibility shims in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-038, DESIGN-REQ-004)
 - [X] T007 Add failing unit coverage for `taskRunIds` ownership validation in `moonmind/workflows/temporal/service.py` through `tests/unit/workflows/temporal/test_temporal_service.py` (FR-008, FR-009)
-- [ ] T008 Add failing restart-durability coverage for mutation locks and action ledgers in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-012 through FR-015)
-- [ ] T009 Add verification coverage for automatic runtime publication of remediation action and verification artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-021 through FR-023)
+- [X] T008 Add failing restart-durability coverage for mutation locks and action ledgers in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-012 through FR-015)
+- [X] T009 Add verification coverage for automatic runtime publication of remediation action and verification artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-021 through FR-023)
 - [ ] T010 Add verification coverage for bounded cancellation/failure/Continue-As-New outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-028 through FR-033)
 
 ### Integration Tests
 
-- [ ] T011 Add service-boundary or hermetic integration coverage for durable lock/ledger behavior across a restarted service instance in `tests/integration` or `tests/unit/workflows/temporal/test_remediation_context.py` using persistent fixtures (FR-012 through FR-015, SC-003, DESIGN-REQ-004)
-- [ ] T012 Add adapter-boundary coverage proving remediation actions dispatch through owning control-plane or subsystem adapters without raw host/Docker/SQL/storage access in `tests/unit/workflows/temporal/test_remediation_context.py` or workflow boundary tests (FR-004 through FR-007, SC-002, DESIGN-REQ-004)
+- [X] T011 Add service-boundary or hermetic integration coverage for durable lock/ledger behavior across a restarted service instance in `tests/integration` or `tests/unit/workflows/temporal/test_remediation_context.py` using persistent fixtures (FR-012 through FR-015, SC-003, DESIGN-REQ-004)
+- [X] T012 Add adapter-boundary coverage proving remediation actions dispatch through owning control-plane or subsystem adapters without raw host/Docker/SQL/storage access in `tests/unit/workflows/temporal/test_remediation_context.py` or workflow boundary tests (FR-004 through FR-007, SC-002, DESIGN-REQ-004)
 - [ ] T013 Add API/read-model coverage proving target-side remediation summaries expose active count, latest status/action, lock scope, outcome, and updated time in `tests/unit/api/routers/test_executions.py` or `tests/unit/api/routers/test_task_runs.py` (FR-024, FR-027, SC-006, DESIGN-REQ-003)
 - [ ] T014 Add Mission Control rendering coverage for action, approval, verification, artifact, and target-linkage lifecycle state in `frontend/src/entrypoints/task-detail.test.tsx` (FR-025, FR-035, SC-010, DESIGN-REQ-006)
 
@@ -61,7 +61,7 @@
 - [X] T016 Replace legacy remediation action catalog entries with canonical dotted action kinds and full metadata in `moonmind/workflows/temporal/remediation_actions.py` (FR-001 through FR-003)
 - [X] T017 Update authority/listing behavior to expose canonical metadata without raw execution or legacy compatibility aliases in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-004, FR-038)
 - [X] T018 Implement `taskRunIds` ownership validation against target step/task-run evidence in `moonmind/workflows/temporal/service.py` (FR-008, FR-009)
-- [ ] T019 Move mutation lock/ledger state to durable records or an explicitly persisted existing boundary in `moonmind/workflows/temporal/remediation_actions.py` and `api_service/db/models.py` (FR-012 through FR-015)
+- [X] T019 Move mutation lock/ledger state to durable records or an explicitly persisted existing boundary in `moonmind/workflows/temporal/remediation_actions.py` and `api_service/db/models.py` (FR-012 through FR-015)
 - [ ] T020 Wire action execution through owning control-plane or subsystem adapters in `moonmind/workflows/temporal/remediation_tools.py` or adjacent runtime service boundaries (FR-004 through FR-007)
 - [ ] T021 Complete aggregate verification for lifecycle artifacts, target-side summaries, self-healing policy, Mission Control rendering, and bounded degraded outcomes (FR-010 through FR-036)
 

--- a/specs/242-finish-task-remediation/tasks.md
+++ b/specs/242-finish-task-remediation/tasks.md
@@ -15,7 +15,8 @@
 
 - MM-483 is preserved in the Jira orchestration input, spec, plan, tasks, and final verification path.
 - Input classification: single-story runtime feature request.
-- First implementation focus from `plan.md`: canonical action registry coverage and metadata shape.
+- Completed first implementation focus from `plan.md`: canonical action registry coverage, metadata shape, and `taskRunIds` ownership validation.
+- Remaining status from `plan.md`: durable lock/ledger persistence, owning-adapter action execution, aggregate artifact/read-model verification, Mission Control lifecycle completion, and full final verification remain open.
 
 ## Phase 1: Setup
 
@@ -44,26 +45,39 @@
 - [ ] T009 Add verification coverage for automatic runtime publication of remediation action and verification artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-021 through FR-023)
 - [ ] T010 Add verification coverage for bounded cancellation/failure/Continue-As-New outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-028 through FR-033)
 
+### Integration Tests
+
+- [ ] T011 Add service-boundary or hermetic integration coverage for durable lock/ledger behavior across a restarted service instance in `tests/integration` or `tests/unit/workflows/temporal/test_remediation_context.py` using persistent fixtures (FR-012 through FR-015, SC-003, DESIGN-REQ-004)
+- [ ] T012 Add adapter-boundary coverage proving remediation actions dispatch through owning control-plane or subsystem adapters without raw host/Docker/SQL/storage access in `tests/unit/workflows/temporal/test_remediation_context.py` or workflow boundary tests (FR-004 through FR-007, SC-002, DESIGN-REQ-004)
+- [ ] T013 Add API/read-model coverage proving target-side remediation summaries expose active count, latest status/action, lock scope, outcome, and updated time in `tests/unit/api/routers/test_executions.py` or `tests/unit/api/routers/test_task_runs.py` (FR-024, FR-027, SC-006, DESIGN-REQ-003)
+- [ ] T014 Add Mission Control rendering coverage for action, approval, verification, artifact, and target-linkage lifecycle state in `frontend/src/entrypoints/task-detail.test.tsx` (FR-025, FR-035, SC-010, DESIGN-REQ-006)
+
+### Red-First Confirmation
+
+- [ ] T015 Run targeted unit and integration-boundary tests after adding T008 through T014 and confirm the new coverage fails for the expected missing durable lock/ledger, action execution, read-model, or UI behavior before implementation.
+
 ### Implementation
 
-- [X] T011 Replace legacy remediation action catalog entries with canonical dotted action kinds and full metadata in `moonmind/workflows/temporal/remediation_actions.py` (FR-001 through FR-003)
-- [X] T012 Update authority/listing behavior to expose canonical metadata without raw execution or legacy compatibility aliases in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-004, FR-038)
-- [X] T013 Implement `taskRunIds` ownership validation against target step/task-run evidence in `moonmind/workflows/temporal/service.py` (FR-008, FR-009)
-- [ ] T014 Move mutation lock/ledger state to durable records or an explicitly persisted existing boundary in `moonmind/workflows/temporal/remediation_actions.py` and `api_service/db/models.py` (FR-012 through FR-015)
-- [ ] T015 Wire action execution through owning control-plane or subsystem adapters in `moonmind/workflows/temporal/remediation_tools.py` or adjacent runtime service boundaries (FR-004 through FR-007)
-- [ ] T016 Complete aggregate verification for lifecycle artifacts, target-side summaries, self-healing policy, Mission Control rendering, and bounded degraded outcomes (FR-010 through FR-036)
+- [X] T016 Replace legacy remediation action catalog entries with canonical dotted action kinds and full metadata in `moonmind/workflows/temporal/remediation_actions.py` (FR-001 through FR-003)
+- [X] T017 Update authority/listing behavior to expose canonical metadata without raw execution or legacy compatibility aliases in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-004, FR-038)
+- [X] T018 Implement `taskRunIds` ownership validation against target step/task-run evidence in `moonmind/workflows/temporal/service.py` (FR-008, FR-009)
+- [ ] T019 Move mutation lock/ledger state to durable records or an explicitly persisted existing boundary in `moonmind/workflows/temporal/remediation_actions.py` and `api_service/db/models.py` (FR-012 through FR-015)
+- [ ] T020 Wire action execution through owning control-plane or subsystem adapters in `moonmind/workflows/temporal/remediation_tools.py` or adjacent runtime service boundaries (FR-004 through FR-007)
+- [ ] T021 Complete aggregate verification for lifecycle artifacts, target-side summaries, self-healing policy, Mission Control rendering, and bounded degraded outcomes (FR-010 through FR-036)
 
 ### Story Validation
 
-- [X] T017 Run focused remediation tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
-- [ ] T018 Run final unit suite after all implementation tasks complete: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
-- [ ] T019 Run `/moonspec-verify` and record the verdict in `specs/242-finish-task-remediation/verification.md`
+- [X] T022 Run focused remediation tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [ ] T023 Run final unit suite after all implementation tasks complete: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [ ] T024 Run `/moonspec-verify` and record the verdict in `specs/242-finish-task-remediation/verification.md`
 
 ## Dependencies And Order
 
-- T005 and T006 must be written before T011 and T012.
-- T011 and T012 are the first implementation slice and unblock canonical action semantics.
-- T013 through T016 require additional service/API/UI boundary work after registry coverage lands.
+- T005 and T006 must be written before T016 and T017.
+- T008 through T014 must be written before T015 red-first confirmation.
+- T016 and T017 are the first completed implementation slice and unblock canonical action semantics.
+- T018 through T021 require service/API/UI boundary work after registry coverage lands.
+- T023 and T024 run only after remaining implementation work completes.
 
 ## Implementation Strategy
 

--- a/specs/242-finish-task-remediation/tasks.md
+++ b/specs/242-finish-task-remediation/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Finish Task Remediation Desired-State Implementation
+
+**Input**: `specs/242-finish-task-remediation/spec.md`, `specs/242-finish-task-remediation/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/remediation-runtime.md`, `quickstart.md`
+
+## Validation Commands
+
+- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Router unit when API read models change: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`
+- UI when Mission Control changes: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- Final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Integration: `./tools/test_integration.sh` if artifact lifecycle/API routes change
+
+## Source Traceability Summary
+
+- MM-483 is preserved in the Jira orchestration input, spec, plan, tasks, and final verification path.
+- Input classification: single-story runtime feature request.
+- First implementation focus from `plan.md`: canonical action registry coverage and metadata shape.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature locator points to `specs/242-finish-task-remediation` in `.specify/feature.json`
+- [X] T002 Confirm no existing MM-483 MoonSpec feature directory was present before creating `specs/242-finish-task-remediation`
+
+## Phase 2: Foundational
+
+- [X] T003 Review `moonmind/workflows/temporal/remediation_actions.py` for canonical registry gaps (FR-001 through FR-003)
+- [X] T004 Review `tests/unit/workflows/temporal/test_remediation_context.py` for existing authority and mutation guard coverage (FR-001 through FR-015)
+
+## Phase 3: Story - Complete Task Remediation Runtime
+
+**Summary**: Operators can use Task Remediation through canonical typed actions, safe control-plane boundaries, durable coordination, lifecycle evidence, target summaries, and bounded self-healing policy.
+
+**Independent Test**: Exercise remediation action metadata, authority decisions, mutation guards, lifecycle artifacts, target summaries, cancellation/continuation behavior, and Mission Control rendering without raw host/storage/secret access.
+
+**Traceability IDs**: FR-001 through FR-038, SC-001 through SC-010, DESIGN-REQ-001 through DESIGN-REQ-006
+
+### Unit Tests
+
+- [X] T005 Add failing unit coverage for the complete canonical action registry in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001, FR-003, SC-001, DESIGN-REQ-004)
+- [X] T006 Add failing unit coverage proving legacy action aliases are not accepted as compatibility shims in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-038, DESIGN-REQ-004)
+- [X] T007 Add failing unit coverage for `taskRunIds` ownership validation in `moonmind/workflows/temporal/service.py` through `tests/unit/workflows/temporal/test_service.py` or adjacent tests (FR-008, FR-009)
+- [ ] T008 Add failing restart-durability coverage for mutation locks and action ledgers in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-012 through FR-015)
+- [ ] T009 Add verification coverage for automatic runtime publication of remediation action and verification artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-021 through FR-023)
+- [ ] T010 Add verification coverage for bounded cancellation/failure/Continue-As-New outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-028 through FR-033)
+
+### Implementation
+
+- [X] T011 Replace legacy remediation action catalog entries with canonical dotted action kinds and full metadata in `moonmind/workflows/temporal/remediation_actions.py` (FR-001 through FR-003)
+- [X] T012 Update authority/listing behavior to expose canonical metadata without raw execution or legacy compatibility aliases in `moonmind/workflows/temporal/remediation_actions.py` (FR-002, FR-004, FR-038)
+- [X] T013 Implement `taskRunIds` ownership validation against target step/task-run evidence in `moonmind/workflows/temporal/service.py` (FR-008, FR-009)
+- [ ] T014 Move mutation lock/ledger state to durable records or an explicitly persisted existing boundary in `moonmind/workflows/temporal/remediation_actions.py` and `api_service/db/models.py` (FR-012 through FR-015)
+- [ ] T015 Wire action execution through owning control-plane or subsystem adapters in `moonmind/workflows/temporal/remediation_tools.py` or adjacent runtime service boundaries (FR-004 through FR-007)
+- [ ] T016 Complete aggregate verification for lifecycle artifacts, target-side summaries, self-healing policy, Mission Control rendering, and bounded degraded outcomes (FR-010 through FR-036)
+
+### Story Validation
+
+- [X] T017 Run focused remediation tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [ ] T018 Run final unit suite after all implementation tasks complete: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [ ] T019 Run `/moonspec-verify` and record the verdict in `specs/242-finish-task-remediation/verification.md`
+
+## Dependencies And Order
+
+- T005 and T006 must be written before T011 and T012.
+- T011 and T012 are the first implementation slice and unblock canonical action semantics.
+- T013 through T016 require additional service/API/UI boundary work after registry coverage lands.
+
+## Implementation Strategy
+
+Complete the story in vertical runtime slices. Start with canonical action registry semantics because every later action execution, audit, lock, and Mission Control surface depends on stable action kinds and metadata.

--- a/specs/242-finish-task-remediation/tasks.md
+++ b/specs/242-finish-task-remediation/tasks.md
@@ -5,7 +5,7 @@
 
 ## Validation Commands
 
-- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py`
 - Router unit when API read models change: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`
 - UI when Mission Control changes: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
 - Final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
@@ -40,7 +40,7 @@
 
 - [X] T005 Add failing unit coverage for the complete canonical action registry in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-001, FR-003, SC-001, DESIGN-REQ-004)
 - [X] T006 Add failing unit coverage proving legacy action aliases are not accepted as compatibility shims in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-038, DESIGN-REQ-004)
-- [X] T007 Add failing unit coverage for `taskRunIds` ownership validation in `moonmind/workflows/temporal/service.py` through `tests/unit/workflows/temporal/test_service.py` or adjacent tests (FR-008, FR-009)
+- [X] T007 Add failing unit coverage for `taskRunIds` ownership validation in `moonmind/workflows/temporal/service.py` through `tests/unit/workflows/temporal/test_temporal_service.py` (FR-008, FR-009)
 - [ ] T008 Add failing restart-durability coverage for mutation locks and action ledgers in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-012 through FR-015)
 - [ ] T009 Add verification coverage for automatic runtime publication of remediation action and verification artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-005 through FR-007, FR-021 through FR-023)
 - [ ] T010 Add verification coverage for bounded cancellation/failure/Continue-As-New outcomes in `tests/unit/workflows/temporal/test_remediation_context.py` (FR-028 through FR-033)
@@ -67,7 +67,7 @@
 
 ### Story Validation
 
-- [X] T022 Run focused remediation tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- [X] T022 Run focused remediation tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py`
 - [ ] T023 Run final unit suite after all implementation tasks complete: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - [ ] T024 Run `/moonspec-verify` and record the verdict in `specs/242-finish-task-remediation/verification.md`
 

--- a/specs/242-finish-task-remediation/verification.md
+++ b/specs/242-finish-task-remediation/verification.md
@@ -1,0 +1,45 @@
+# Verification: Finish Task Remediation Desired-State Implementation
+
+**Date**: 2026-04-23
+**Original Request Source**: `spec.md` Input and `docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md`
+**Verdict**: ADDITIONAL_WORK_NEEDED
+
+## Completed Coverage
+
+- MM-483 canonical Jira preset brief is preserved in `docs/tmp/jira-orchestration-inputs/MM-483-moonspec-orchestration-input.md` and `specs/242-finish-task-remediation/spec.md`.
+- Input classified as one runtime story and MoonSpec artifacts were created for specify, plan, research, data model, contracts, quickstart, tasks, and verification.
+- Canonical remediation action registry now exposes the documented dotted action kinds:
+  - `execution.pause`
+  - `execution.resume`
+  - `execution.request_rerun_same_workflow`
+  - `execution.start_fresh_rerun`
+  - `execution.cancel`
+  - `execution.force_terminate`
+  - `session.interrupt_turn`
+  - `session.clear`
+  - `session.cancel`
+  - `session.terminate`
+  - `session.restart_container`
+  - `provider_profile.evict_stale_lease`
+  - `workload.restart_helper_container`
+  - `workload.reap_orphan_container`
+- Legacy internal aliases `restart_worker` and `terminate_session` are not advertised as compatibility shims.
+- Action registry metadata now includes preconditions, idempotency description, verification hint, and audit payload shape.
+- Create-time remediation validation now rejects selected `taskRunIds` that do not belong to the target execution when target task-run evidence is available.
+
+## Test Evidence
+
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`: PASS
+  - Python subset: 29 passed
+  - Frontend suite invoked by wrapper: 12 files / 396 tests passed
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py`: PASS
+  - Python subset: 115 passed
+  - Frontend suite invoked by wrapper: 12 files / 396 tests passed
+
+## Remaining Work
+
+- Durable mutation locks and action ledger remain incomplete for process restart/Temporal retry durability.
+- Safe action execution still needs wiring through owning control-plane or subsystem adapters.
+- Automatic runtime publication of action request/result/verification artifacts still needs aggregate verification and any missing implementation.
+- Mission Control lifecycle presentation and aggregate target-side read-model verification still need MM-483-specific completion checks.
+- Full unit suite, hermetic integration suite, and final `/moonspec-verify` should run after the remaining implementation tasks complete.

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -753,7 +753,7 @@ def _approved_pentest_scope() -> dict[str, object]:
         "title": "Lab validation",
         "owner_user_id": "user-security",
         "created_at": "2026-04-22T00:00:00Z",
-        "expires_at": "2026-04-23T00:00:00Z",
+        "expires_at": "2099-04-23T00:00:00Z",
         "target_class": "lab",
         "targets": [{"kind": "url", "value": "https://lab.example.test"}],
         "allowed_actions": [

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -1373,6 +1373,95 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
 
 
 @pytest.mark.asyncio
+async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_context(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        builder = RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        await builder.build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "restart helper"},
+            dry_run=False,
+            idempotency_key="execute-action-context",
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(
+                allowed_action_kinds=(action_kind,),
+            ),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key="execute-action-context",
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+        executor = RecordingActionExecutor()
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=executor,
+        )
+
+        stale_authority = authority.to_dict()
+        stale_authority["remediationWorkflowId"] = "mm:other-remediation"
+        with pytest.raises(RemediationEvidenceToolError, match="authorityResult"):
+            await tools.execute_action(
+                remediation_workflow_id=remediation.workflow_id,
+                authority_result=stale_authority,
+                guard_result=guard.to_dict(),
+                principal="service:test",
+            )
+
+        stale_guard = guard.to_dict()
+        stale_guard["targetWorkflowId"] = "mm:other-target"
+        with pytest.raises(RemediationEvidenceToolError, match="guardResult"):
+            await tools.execute_action(
+                remediation_workflow_id=remediation.workflow_id,
+                authority_result=authority.to_dict(),
+                guard_result=stale_guard,
+                principal="service:test",
+            )
+
+        stale_run_guard = guard.to_dict()
+        stale_run_guard["lock"] = {
+            **stale_run_guard["lock"],
+            "targetRunId": "other-run",
+        }
+        with pytest.raises(RemediationEvidenceToolError, match="target run"):
+            await tools.execute_action(
+                remediation_workflow_id=remediation.workflow_id,
+                authority_result=authority.to_dict(),
+                guard_result=stale_run_guard,
+                principal="service:test",
+            )
+
+        assert executor.calls == []
+
+
+@pytest.mark.asyncio
 async def test_remediation_context_builder_rejects_missing_target_record(
     tmp_path, mock_client_adapter
 ):
@@ -1906,7 +1995,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             ),
             now=now + timedelta(seconds=122),
         )
-        service.release_lock(first.lock.lock_id)
+        await service.release_lock(first.lock.lock_id)
         lost = await service.evaluate(
             remediation_workflow_id=remediation.workflow_id,
             remediation_run_id=remediation.run_id,
@@ -2119,6 +2208,76 @@ async def test_remediation_mutation_guard_persists_locks_and_ledger_across_servi
         assert conflict.decision == "denied"
         assert conflict.reason == "mutation_lock_conflict"
         assert conflict.lock.lock_id == first.lock.lock_id
+
+
+@pytest.mark.asyncio
+async def test_remediation_mutation_guard_persists_released_lock_across_service_restart(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        now = datetime(2026, 4, 22, tzinfo=timezone.utc)
+        policy = RemediationMutationGuardPolicy(
+            lock_ttl_seconds=60,
+            cooldown_seconds=0,
+            max_attempts_per_action_kind=5,
+        )
+
+        first_service = RemediationMutationGuardService(session=session)
+        first = await first_service.evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="release-durable-1",
+            parameters={},
+            policy=policy,
+            now=now,
+        )
+        await first_service.release_lock(first.lock.lock_id)
+        await session.commit()
+
+        link = await session.get(
+            TemporalExecutionRemediationLink,
+            remediation.workflow_id,
+        )
+        restarted_service = RemediationMutationGuardService(session=session)
+        lost = await restarted_service.evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="release-durable-holder",
+            parameters={},
+            policy=policy,
+            now=now + timedelta(seconds=1),
+        )
+        other = await restarted_service.evaluate(
+            remediation_workflow_id="mm:other-remediator",
+            remediation_run_id="other-run",
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="release-durable-other",
+            parameters={},
+            policy=policy,
+            now=now + timedelta(seconds=2),
+        )
+
+        assert link is not None
+        assert link.active_lock_scope is None
+        assert link.active_lock_holder is None
+        assert link.mutation_guard_lock_state["released"] is True
+        assert lost.decision == "denied"
+        assert lost.reason == "mutation_lock_lost"
+        assert other.decision == "allowed"
+        assert other.lock.status == "acquired"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -895,6 +895,30 @@ class RecordingLiveFollower:
         )
 
 
+class RecordingActionExecutor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def execute_action(self, *, action_request, guard_result, target_health):
+        self.calls.append(
+            {
+                "action_request": action_request,
+                "guard_result": guard_result,
+                "target_health": target_health,
+            }
+        )
+        return {
+            "status": "applied",
+            "beforeStateRef": "artifact://before-state",
+            "afterStateRef": "artifact://after-state",
+            "sideEffects": [{"kind": "subsystem_call", "status": "accepted"}],
+            "verification": {
+                "status": "verified",
+                "targetWorkflowId": target_health.workflow_id,
+            },
+        }
+
+
 @pytest.mark.asyncio
 async def test_remediation_evidence_tools_read_only_context_declared_evidence(
     tmp_path, mock_client_adapter
@@ -1250,6 +1274,102 @@ async def test_remediation_evidence_tools_prepare_action_request_rereads_target_
                 remediation_workflow_id=remediation.workflow_id,
                 action_kind=" ",
             )
+
+
+@pytest.mark.asyncio
+async def test_remediation_execute_action_delegates_and_publishes_lifecycle_artifacts(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        builder = RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        )
+        await builder.build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "restart helper"},
+            dry_run=False,
+            idempotency_key="execute-action-1",
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(
+                allowed_action_kinds=(action_kind,),
+            ),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key="execute-action-1",
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+
+        executor = RecordingActionExecutor()
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=executor,
+        )
+
+        result = await tools.execute_action(
+            remediation_workflow_id=remediation.workflow_id,
+            authority_result=authority.to_dict(),
+            guard_result=guard.to_dict(),
+            principal="service:test",
+        )
+
+        artifact_links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == remediation.workflow_id,
+                    TemporalArtifactLink.link_type.in_(
+                        [
+                            "remediation.action_request",
+                            "remediation.action_result",
+                            "remediation.verification",
+                        ]
+                    ),
+                )
+            )
+        ).scalars().all()
+        link = await session.get(
+            TemporalExecutionRemediationLink,
+            remediation.workflow_id,
+        )
+
+        assert executor.calls[0]["action_request"]["actionKind"] == action_kind
+        assert executor.calls[0]["target_health"].workflow_id == target.workflow_id
+        assert result["status"] == "applied"
+        assert result["artifactRefs"]["actionRequest"]
+        assert result["artifactRefs"]["actionResult"]
+        assert result["artifactRefs"]["verification"]
+        assert {artifact.link_type for artifact in artifact_links} == {
+            "remediation.action_request",
+            "remediation.action_result",
+            "remediation.verification",
+        }
+        assert link is not None
+        assert link.latest_action_summary == action_kind
+        assert link.outcome == "applied"
 
 
 @pytest.mark.asyncio
@@ -1912,6 +2032,93 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
         assert second.decision == "allowed"
         assert exhausted.decision == "escalate"
         assert exhausted.reason == "action_budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_remediation_mutation_guard_persists_locks_and_ledger_across_service_restart(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        mock_client_adapter.start_workflow.side_effect = [
+            SimpleNamespace(run_id="other-run")
+        ]
+        other = await TemporalExecutionService(
+            session, client_adapter=mock_client_adapter
+        ).create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=target.owner_id,
+            title="Second remediator",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {
+                    "remediation": {
+                        "target": {"workflowId": target.workflow_id},
+                        "authorityMode": "admin_auto",
+                    }
+                }
+            },
+            idempotency_key=None,
+        )
+        now = datetime(2026, 4, 22, tzinfo=timezone.utc)
+        policy = RemediationMutationGuardPolicy(
+            lock_ttl_seconds=60,
+            cooldown_seconds=0,
+            max_attempts_per_action_kind=5,
+        )
+
+        first_service = RemediationMutationGuardService(session=session)
+        first = await first_service.evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="durable-ledger-1",
+            parameters={"reason": "restart durable"},
+            policy=policy,
+            now=now,
+        )
+
+        restarted_service = RemediationMutationGuardService(session=session)
+        replay = await restarted_service.evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="durable-ledger-1",
+            parameters={"reason": "restart durable"},
+            policy=policy,
+            now=now + timedelta(seconds=1),
+        )
+        conflict = await restarted_service.evaluate(
+            remediation_workflow_id=other.workflow_id,
+            remediation_run_id=other.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind="workload.restart_helper_container",
+            idempotency_key="durable-lock-conflict",
+            parameters={},
+            policy=policy,
+            now=now + timedelta(seconds=2),
+        )
+
+        assert first.decision == "allowed"
+        assert first.lock.status == "acquired"
+        assert replay.decision == "allowed"
+        assert replay.ledger.duplicate is True
+        assert replay.lock.lock_id == first.lock.lock_id
+        assert conflict.decision == "denied"
+        assert conflict.reason == "mutation_lock_conflict"
+        assert conflict.lock.lock_id == first.lock.lock_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -124,11 +124,72 @@ def _admin_profile(**overrides):
     data = {
         "profile_ref": "admin_healer",
         "execution_principal": "service:admin-healer",
-        "allowed_action_kinds": ("restart_worker", "terminate_session"),
+        "allowed_action_kinds": ("workload.restart_helper_container", "session.terminate"),
         "enabled": True,
     }
     data.update(overrides)
     return RemediationSecurityProfile(**data)
+
+
+CANONICAL_REMEDIATION_ACTIONS = {
+    "execution.pause",
+    "execution.resume",
+    "execution.request_rerun_same_workflow",
+    "execution.start_fresh_rerun",
+    "execution.cancel",
+    "execution.force_terminate",
+    "session.interrupt_turn",
+    "session.clear",
+    "session.cancel",
+    "session.terminate",
+    "session.restart_container",
+    "provider_profile.evict_stale_lease",
+    "workload.restart_helper_container",
+    "workload.reap_orphan_container",
+}
+
+
+def test_remediation_action_authority_lists_canonical_mm483_action_registry():
+    service = RemediationActionAuthorityService(session=object())
+
+    allowed = service.list_allowed_actions(
+        permissions=_admin_permissions(),
+        security_profile=_admin_profile(
+            allowed_action_kinds=tuple(sorted(CANONICAL_REMEDIATION_ACTIONS))
+        ),
+    )
+
+    assert {item["actionKind"] for item in allowed} == CANONICAL_REMEDIATION_ACTIONS
+    for item in allowed:
+        assert item["riskTier"] in {"low", "medium", "high"}
+        assert item["targetType"]
+        assert isinstance(item["inputMetadata"], dict)
+        assert item["preconditions"]
+        assert item["idempotency"]
+        assert item["verificationRequired"] is True
+        assert item["verificationHint"]
+        assert item["auditPayloadShape"]
+
+
+def test_remediation_action_authority_rejects_legacy_action_aliases():
+    service = RemediationActionAuthorityService(session=object())
+
+    allowed = service.list_allowed_actions(
+        permissions=_admin_permissions(),
+        security_profile=_admin_profile(
+            allowed_action_kinds=(
+                "restart_worker",
+                "terminate_session",
+                "workload.restart_helper_container",
+                "session.terminate",
+            )
+        ),
+    )
+
+    assert {item["actionKind"] for item in allowed} == {
+        "workload.restart_helper_container",
+        "session.terminate",
+    }
 
 
 def test_remediation_action_authority_lists_policy_compatible_actions():
@@ -142,10 +203,12 @@ def test_remediation_action_authority_lists_policy_compatible_actions():
 
     allowed = service.list_allowed_actions(
         permissions=_admin_permissions(),
-        security_profile=_admin_profile(allowed_action_kinds=("restart_worker",)),
+        security_profile=_admin_profile(
+            allowed_action_kinds=("workload.restart_helper_container",)
+        ),
     )
 
-    assert [item["actionKind"] for item in allowed] == ["restart_worker"]
+    assert [item["actionKind"] for item in allowed] == ["workload.restart_helper_container"]
     assert allowed[0]["riskTier"] == "medium"
     assert allowed[0]["targetType"] == "workload_container"
     assert allowed[0]["inputMetadata"]["reason"]["required"] is False
@@ -153,7 +216,9 @@ def test_remediation_action_authority_lists_policy_compatible_actions():
     allowed[0]["inputMetadata"]["reason"]["required"] = True
     listed_again = service.list_allowed_actions(
         permissions=_admin_permissions(),
-        security_profile=_admin_profile(allowed_action_kinds=("restart_worker",)),
+        security_profile=_admin_profile(
+            allowed_action_kinds=("workload.restart_helper_container",)
+        ),
     )
     assert listed_again[0]["inputMetadata"]["reason"]["required"] is False
 
@@ -165,8 +230,8 @@ def test_remediation_action_authority_does_not_advertise_raw_admin_actions():
         permissions=_admin_permissions(),
         security_profile=_admin_profile(
             allowed_action_kinds=(
-                "restart_worker",
-                "terminate_session",
+                "workload.restart_helper_container",
+                "session.terminate",
                 "raw_host_shell",
                 "raw_docker",
                 "raw_sql",
@@ -178,7 +243,7 @@ def test_remediation_action_authority_does_not_advertise_raw_admin_actions():
     )
 
     action_kinds = {item["actionKind"] for item in allowed}
-    assert action_kinds == {"restart_worker", "terminate_session"}
+    assert action_kinds == {"workload.restart_helper_container", "session.terminate"}
     assert not action_kinds.intersection(
         {
             "raw_host_shell",
@@ -559,7 +624,7 @@ def test_remediation_audit_normalizes_string_timestamps():
         remediation_run_id="remediation-run",
         target_workflow_id="target-workflow",
         target_run_id="target-run",
-        action_kind="restart_worker",
+        action_kind="workload.restart_helper_container",
         risk_tier="medium",
         approval_decision="approved",
         timestamp="2026-04-22T01:02:03+02:00",
@@ -579,7 +644,7 @@ def test_remediation_audit_rejects_malformed_string_timestamps():
             remediation_run_id="remediation-run",
             target_workflow_id="target-workflow",
             target_run_id="target-run",
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             risk_tier="medium",
             approval_decision="approved",
             timestamp="not-a-timestamp",
@@ -592,7 +657,7 @@ def test_target_remediation_linkage_summary_is_compact():
         active_remediation_count=2,
         latest_remediation_title="Publish remediation lifecycle phases",
         latest_remediation_status="acting",
-        latest_action_kind="restart_worker",
+        latest_action_kind="workload.restart_helper_container",
         latest_outcome="resolved_after_action",
         active_lock_scope="target_execution",
         active_lock_holder="remediation-workflow",
@@ -605,7 +670,7 @@ def test_target_remediation_linkage_summary_is_compact():
         "activeRemediationCount": 2,
         "latestRemediationTitle": "Publish remediation lifecycle phases",
         "latestRemediationStatus": "acting",
-        "latestActionKind": "restart_worker",
+        "latestActionKind": "workload.restart_helper_container",
         "latestOutcome": "resolved_after_action",
         "activeLockScope": "target_execution",
         "activeLockHolder": "remediation-workflow",
@@ -639,7 +704,7 @@ async def test_remediation_lifecycle_publisher_creates_required_artifacts(
             phase="resolved",
             mode="snapshot_then_follow",
             authority_mode="admin_auto",
-            actions_attempted=({"kind": "restart_worker", "status": "applied"},),
+            actions_attempted=({"kind": "workload.restart_helper_container", "status": "applied"},),
             resolution="resolved_after_action",
         )
         artifacts = []
@@ -657,7 +722,7 @@ async def test_remediation_lifecycle_publisher_creates_required_artifacts(
             (
                 "remediation.action_request",
                 "reports/remediation_action_request-1.json",
-                {"actionKind": "restart_worker"},
+                {"actionKind": "workload.restart_helper_container"},
             ),
             (
                 "remediation.action_result",
@@ -1167,11 +1232,11 @@ async def test_remediation_evidence_tools_prepare_action_request_rereads_target_
         )
         preparation = await tools.prepare_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="terminate_session",
+            action_kind="session.terminate",
         )
 
         assert preparation.remediation_workflow_id == remediation.workflow_id
-        assert preparation.action_kind == "terminate_session"
+        assert preparation.action_kind == "session.terminate"
         assert preparation.context_target["runId"] == "target-run"
         assert preparation.target.workflow_id == target.workflow_id
         assert preparation.target.pinned_run_id == "target-run"
@@ -1248,7 +1313,7 @@ async def test_remediation_action_authority_enforces_authority_modes(
 
         dry_run = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={"reason": "diagnose only"},
             dry_run=True,
             idempotency_key="observe-dry-run",
@@ -1266,7 +1331,7 @@ async def test_remediation_action_authority_enforces_authority_modes(
 
         denied = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={"reason": "side effect"},
             dry_run=False,
             idempotency_key="observe-execute",
@@ -1293,7 +1358,7 @@ async def test_remediation_action_authority_requires_approval_for_gated_mode(
 
         pending = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="gated-pending",
@@ -1307,7 +1372,7 @@ async def test_remediation_action_authority_requires_approval_for_gated_mode(
 
         approved = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="gated-approved",
@@ -1336,7 +1401,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         view_only = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="view-only",
@@ -1349,7 +1414,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         disabled_profile = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="disabled-profile",
@@ -1362,7 +1427,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="medium-allowed",
@@ -1375,7 +1440,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
         assert allowed.executable is True
         payload = allowed.to_dict()
         assert payload["schemaVersion"] == "v1"
-        assert payload["request"]["actionKind"] == "restart_worker"
+        assert payload["request"]["actionKind"] == "workload.restart_helper_container"
         assert payload["request"]["riskTier"] == "medium"
         assert payload["request"]["dryRun"] is False
         assert payload["result"]["status"] == "applied"
@@ -1386,7 +1451,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         high_risk = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="terminate_session",
+            action_kind="session.terminate",
             parameters={},
             dry_run=False,
             idempotency_key="high-risk",
@@ -1420,7 +1485,7 @@ async def test_remediation_action_authority_rejects_unsupported_authority_mode(
         service = RemediationActionAuthorityService(session=session)
         result = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="unsupported-authority",
@@ -1448,7 +1513,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
 
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="same-idempotency-key",
@@ -1458,7 +1523,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         )
         high_risk = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="terminate_session",
+            action_kind="session.terminate",
             parameters={},
             dry_run=False,
             idempotency_key="same-idempotency-key",
@@ -1468,7 +1533,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         )
         dry_run = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=True,
             idempotency_key="same-idempotency-key",
@@ -1503,7 +1568,7 @@ async def test_remediation_action_authority_redacts_audits_and_deduplicates(
 
         result = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={
                 "token": "raw-secret-token",
                 "path": "/work/agent_jobs/mm:secret/repo/.env",
@@ -1517,7 +1582,7 @@ async def test_remediation_action_authority_redacts_audits_and_deduplicates(
         )
         duplicate = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={"token": "different-secret"},
             dry_run=False,
             idempotency_key="dedupe-redact",
@@ -1575,7 +1640,7 @@ async def test_remediation_action_authority_denies_raw_access_and_unknown_target
 
         missing = await service.evaluate_action_request(
             remediation_workflow_id="mm:missing-remediation",
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             parameters={},
             dry_run=False,
             idempotency_key="missing-target",
@@ -1613,7 +1678,7 @@ async def test_remediation_action_authority_uses_prepared_action_context(
         )
         preparation = await tools.prepare_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
         )
 
         service = RemediationActionAuthorityService(session=session)
@@ -1651,7 +1716,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-1",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1666,7 +1731,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-1",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1681,7 +1746,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-expired-holder",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1696,7 +1761,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id="other-run",
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-2",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1711,7 +1776,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id="other-run",
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-3",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1727,7 +1792,7 @@ async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="lock-4",
             parameters={},
             policy=RemediationMutationGuardPolicy(
@@ -1776,7 +1841,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="ledger-1",
             parameters={"reason": "first"},
             policy=policy,
@@ -1787,7 +1852,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="ledger-1",
             parameters={"reason": "first"},
             policy=policy,
@@ -1798,7 +1863,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="ledger-1",
             parameters={"reason": "changed"},
             policy=policy,
@@ -1809,7 +1874,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="ledger-2",
             parameters={"reason": "first"},
             policy=policy,
@@ -1820,7 +1885,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="terminate_session",
+            action_kind="session.terminate",
             idempotency_key="ledger-3",
             parameters={"reason": "second"},
             policy=policy,
@@ -1831,7 +1896,7 @@ async def test_remediation_mutation_guard_enforces_ledger_budgets_and_cooldowns(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="terminate_session",
+            action_kind="session.terminate",
             idempotency_key="ledger-4",
             parameters={"reason": "third"},
             policy=policy,
@@ -1867,7 +1932,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id=remediation.workflow_id,
             target_run_id=remediation.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="nested-1",
             parameters={},
             policy=RemediationMutationGuardPolicy(),
@@ -1879,7 +1944,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id="mm:other-remediation",
             target_run_id="other-run",
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="nested-2",
             parameters={},
             policy=RemediationMutationGuardPolicy(),
@@ -1891,7 +1956,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id="mm:other-remediation",
             target_run_id="other-run",
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="nested-3",
             parameters={},
             policy=RemediationMutationGuardPolicy(allow_nested_remediation=True),
@@ -1903,7 +1968,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="fresh-1",
             parameters={},
             policy=RemediationMutationGuardPolicy(target_change_policy="rediagnose"),
@@ -1922,7 +1987,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="fresh-state-drift",
             parameters={},
             policy=RemediationMutationGuardPolicy(target_change_policy="escalate"),
@@ -1944,7 +2009,7 @@ async def test_remediation_mutation_guard_rejects_nested_and_changed_targets(
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="fresh-2",
             parameters={},
             policy=RemediationMutationGuardPolicy(),
@@ -1982,7 +2047,7 @@ async def test_remediation_mutation_guard_serialization_redacts_sensitive_values
             remediation_run_id=remediation.run_id,
             target_workflow_id=target.workflow_id,
             target_run_id=target.run_id,
-            action_kind="restart_worker",
+            action_kind="workload.restart_helper_container",
             idempotency_key="redact-guard",
             parameters={
                 "token": "secret-token-value",

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1192,6 +1192,116 @@ async def test_create_execution_rejects_malformed_remediation_task_run_ids(
 
 
 @pytest.mark.asyncio
+async def test_create_execution_rejects_foreign_remediation_task_run_ids(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "run-tests",
+                            "refs": {"taskRunId": "target-task-run"},
+                        }
+                    ]
+                }
+            },
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="task.remediation.target.taskRunIds must belong to the target execution",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                title="Remediate target",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "task": {
+                        "remediation": {
+                            "target": {
+                                "workflowId": target.workflow_id,
+                                "taskRunIds": ["foreign-task-run"],
+                            }
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_accepts_owned_remediation_task_run_ids(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "run-tests",
+                            "refs": {"taskRunId": "target-task-run"},
+                        }
+                    ]
+                }
+            },
+            idempotency_key=None,
+        )
+
+        remediation = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {
+                    "remediation": {
+                        "target": {
+                            "workflowId": target.workflow_id,
+                            "taskRunIds": ["target-task-run"],
+                        }
+                    }
+                }
+            },
+            idempotency_key=None,
+        )
+
+        link = await session.get(
+            TemporalExecutionRemediationLink, remediation.workflow_id
+        )
+        assert link is not None
+        assert link.target_workflow_id == target.workflow_id
+
+
+@pytest.mark.asyncio
 async def test_create_execution_normalizes_depends_on_before_limit_and_persistence(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Jira

- Jira issue key: MM-483

## MoonSpec

- Active feature path: `specs/242-finish-task-remediation`
- Verification verdict: `ADDITIONAL_WORK_NEEDED`

## Summary

- Added canonical Task Remediation action registry coverage and metadata.
- Added `taskRunIds` ownership validation for remediation create-time checks.
- Persisted remediation mutation guard lock and ledger state on remediation links.
- Added a remediation action execution boundary that delegates to an injected owning executor and publishes action request, result, and verification artifacts.
- Preserved MM-483 Jira orchestration input and MoonSpec artifacts.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py` - PASS (`117 passed`; wrapper also ran frontend Vitest `12 files / 396 tests passed`).
- `python -m compileall -q moonmind/workflows/temporal/remediation_actions.py moonmind/workflows/temporal/remediation_tools.py api_service/db/models.py tests/unit/workflows/temporal/test_remediation_context.py api_service/migrations/versions/f2a3b4c5d6e7_remediation_guard_state.py` - PASS.
- `./tools/test_integration.sh` - NOT RUN successfully because Docker socket `/var/run/docker.sock` is unavailable in this managed workspace.

## Remaining risks

- Verification verdict is `ADDITIONAL_WORK_NEEDED`, not `FULLY_IMPLEMENTED`.
- Concrete owning subsystem action implementations remain incomplete.
- API/read-model aggregate coverage for target-side remediation summaries remains open.
- Mission Control action/approval/verification lifecycle rendering coverage remains open.
- Cancellation, remediator failure, Continue-As-New, degraded outcome, and full integration verification remain open.
