### PR TITLE
MM-480 Claude OAuth verification profile registration

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/242-claude-browser-terminal-signin"
+  "feature_directory": "specs/243-claude-oauth-verification"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-479",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1709"
+  "jira_issue_key": "MM-480",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1712"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,17 @@
 [
   {
-    "id": 4300922049,
+    "id": 4302196849,
     "disposition": "not-applicable",
-    "rationale": "Quota warning from gemini-code-assist; no code feedback to address."
+    "rationale": "Gemini quota notice is informational and contains no actionable PR feedback."
   },
   {
-    "id": 3127713027,
+    "id": 3128784683,
     "disposition": "addressed",
-    "rationale": "Persisted released mutation lock state, cleared active lock fields, and added restart regression coverage."
+    "rationale": "Claude settings qualification now requires affirmative values and tests cover false and empty values."
   },
   {
-    "id": 3127713030,
-    "disposition": "addressed",
-    "rationale": "Validated authority and guard remediation workflow, target, target run, and idempotency context before action execution; added regression coverage."
-  },
-  {
-    "id": 4158858359,
+    "id": 4160181365,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container; actionable child review comments are tracked separately."
+    "rationale": "Top-level automated review wrapper; actionable inline finding is tracked separately."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-480-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-480-moonspec-orchestration-input.md
@@ -1,0 +1,73 @@
+# MM-480 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-480
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Claude OAuth Verification and Profile Registration
+- Labels: `moonmind-workflow-mm-8f0966f3-d711-4289-9669-3a8e435353fb`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-480 from MM project
+Summary: Claude OAuth Verification and Profile Registration
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-480 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-480: Claude OAuth Verification and Profile Registration
+
+Source Reference
+- Source Document: docs/ManagedAgents/ClaudeAnthropicOAuth.md
+- Source Title: Claude Anthropic OAuth in Settings
+- Source Sections:
+  - 5. Verification
+  - 6. Profile Registration
+  - 9. Security Requirements
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-016
+  - DESIGN-REQ-018
+
+User Story
+As an operator, I can finalize a Claude OAuth session and have MoonMind verify the auth volume, register or update the OAuth-backed provider profile, and expose only secret-free verification metadata.
+
+Acceptance Criteria
+- Given finalization runs after Claude login, then MoonMind verifies account-auth material under the mounted Claude home before profile registration.
+- Given known artifacts such as credentials.json or qualifying settings.json are present, then verification can return verified status using only metadata.
+- Given verification output is returned or persisted, then it includes only secret-free fields such as verified, status, reason, artifact counts, and timestamps.
+- Given verification succeeds, then claude_anthropic is registered or updated with credential_source oauth_volume, runtime_materialization_mode oauth_home, volume_ref claude_auth_volume, and volume_mount_path /home/app/.claude.
+- Given profile registration succeeds, then Provider Profile Manager is synced for runtime_id claude_code.
+- Given an unauthorized operator attempts finalize or repair, then the operation is rejected.
+
+Requirements
+- Verify Claude account-auth material before registering or updating the provider profile.
+- Accept only explicitly documented Claude credential artifacts as proof of account setup.
+- Return and persist secret-free verification metadata only.
+- Register or update the OAuth-backed claude_anthropic provider profile after successful verification.
+- Sync Provider Profile Manager for claude_code after successful registration.
+
+Relevant Implementation Notes
+- Preserve MM-480 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the source design reference for Claude OAuth verification, profile registration, and security requirements.
+- Verification must inspect account-auth material under the mounted Claude home before profile registration and must not expose raw credential contents.
+- Treat `credentials.json` and qualifying `settings.json` data as proof only through secret-free metadata such as verified state, status, reason, artifact counts, and timestamps.
+- On successful verification, register or update `claude_anthropic` with `credential_source` `oauth_volume`, `runtime_materialization_mode` `oauth_home`, `volume_ref` `claude_auth_volume`, and `volume_mount_path` `/home/app/.claude`.
+- Sync Provider Profile Manager for `runtime_id` `claude_code` after profile registration succeeds.
+- Reject unauthorized finalize or repair attempts.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-480 blocks MM-479, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-480 is blocked by MM-481, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+++ b/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
@@ -92,8 +92,11 @@ def _build_credential_check_command(
         credentials_path = shlex.quote(f"{mount_path}/credentials.json")
         settings_path = shlex.quote(f"{mount_path}/settings.json")
         settings_evidence_pattern = (
-            r'"(hasCompletedOnboarding|userID|userEmail|account|oauth|'
-            r'primaryApiKeyHelper|customApiKeyResponses)"[[:space:]]*:'
+            r'"hasCompletedOnboarding"[[:space:]]*:[[:space:]]*true|'
+            r'"(userID|userEmail)"[[:space:]]*:[[:space:]]*"[^"]+"|'
+            r'"(account|oauth|primaryApiKeyHelper|customApiKeyResponses)"'
+            r'[[:space:]]*:[[:space:]]*(true|"[^"]+"|\{[^{}]*[^[:space:]{}][^{}]*\}|'
+            r'\[[^][]*[^[:space:]\[\]][^][]*\])'
         )
         return " && ".join(
             (
@@ -104,7 +107,8 @@ def _build_credential_check_command(
                 ),
                 (
                     f"( test -s {settings_path} "
-                    f"&& grep -Eiq {shlex.quote(settings_evidence_pattern)} {settings_path} "
+                    f"&& tr '\\n' ' ' < {settings_path} "
+                    f"| grep -Eiq {shlex.quote(settings_evidence_pattern)} "
                     '&& echo "QUALIFIED:settings.json" ) '
                     f"|| ( test -s {settings_path} "
                     '&& echo "UNQUALIFIED:settings.json" ) '

--- a/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+++ b/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
@@ -34,8 +34,8 @@ _CODEX_CREDENTIAL_PATHS = (
 )
 
 _CLAUDE_CREDENTIAL_PATHS = (
-    ".claude/credentials.json",
-    ".claude.json",
+    "credentials.json",
+    "settings.json",
 )
 
 PROVIDER_CREDENTIAL_PATHS: dict[str, tuple[str, ...]] = {
@@ -84,6 +84,31 @@ def _build_credential_check_command(
                 (
                     f"( test -s {config_path} && echo \"FOUND:config.toml\" ) "
                     '|| echo "MISSING:config.toml"'
+                ),
+            )
+        )
+
+    if runtime_id == "claude_code":
+        credentials_path = shlex.quote(f"{mount_path}/credentials.json")
+        settings_path = shlex.quote(f"{mount_path}/settings.json")
+        settings_evidence_pattern = (
+            r'"(hasCompletedOnboarding|userID|userEmail|account|oauth|'
+            r'primaryApiKeyHelper|customApiKeyResponses)"[[:space:]]*:'
+        )
+        return " && ".join(
+            (
+                (
+                    f"( test -s {credentials_path} "
+                    '&& echo "FOUND:credentials.json" ) '
+                    '|| echo "MISSING:credentials.json"'
+                ),
+                (
+                    f"( test -s {settings_path} "
+                    f"&& grep -Eiq {shlex.quote(settings_evidence_pattern)} {settings_path} "
+                    '&& echo "QUALIFIED:settings.json" ) '
+                    f"|| ( test -s {settings_path} "
+                    '&& echo "UNQUALIFIED:settings.json" ) '
+                    '|| echo "MISSING:settings.json"'
                 ),
             )
         )
@@ -223,8 +248,12 @@ async def verify_volume_credentials(
         if line.startswith("VALID:"):
             valid.append(line[6:])
             found.append(line[6:])
+        elif line.startswith("QUALIFIED:"):
+            found.append(line[10:])
         elif line.startswith("INVALID:"):
             invalid.append(line[8:])
+        elif line.startswith("UNQUALIFIED:"):
+            missing.append(line[12:])
         elif line.startswith("FOUND:"):
             found.append(line[6:])
         elif line.startswith("MISSING:"):

--- a/specs/243-claude-oauth-verification/checklists/requirements.md
+++ b/specs/243-claude-oauth-verification/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Claude OAuth Verification and Profile Registration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request.
+- Source design requirements from `docs/ManagedAgents/ClaudeAnthropicOAuth.md` sections 5, 6, and 9 map to FR-001 through FR-010.

--- a/specs/243-claude-oauth-verification/contracts/claude-oauth-verification.md
+++ b/specs/243-claude-oauth-verification/contracts/claude-oauth-verification.md
@@ -1,0 +1,72 @@
+# Contract: Claude OAuth Verification and Profile Registration
+
+## Finalize Claude OAuth Session
+
+Endpoint: `POST /api/v1/oauth-sessions/{session_id}/finalize`
+
+Preconditions:
+
+- The session belongs to the authenticated operator.
+- The session status is `awaiting_user` or `verifying`.
+- The session runtime is `claude_code`.
+- The session has an auth volume ref and Claude home mount path.
+
+Success response:
+
+```json
+{
+  "status": "succeeded"
+}
+```
+
+Success side effects:
+
+- Verifies the mounted Claude home before provider profile mutation.
+- Registers or updates `claude_anthropic`.
+- Stores `credential_source = "oauth_volume"`.
+- Stores `runtime_materialization_mode = "oauth_home"`.
+- Stores `volume_ref = "claude_auth_volume"`.
+- Stores `volume_mount_path = "/home/app/.claude"`.
+- Syncs Provider Profile Manager for `runtime_id = "claude_code"`.
+- Marks the OAuth session `succeeded`.
+
+Failure behavior:
+
+- Failed verification returns a 400 response and marks the session `failed`.
+- Unavailable verification returns a 503 response and marks the session `failed`.
+- Unauthorized access returns without verification or profile mutation.
+- Invalid session state returns without verification or profile mutation.
+
+Secret-safety requirements:
+
+- Responses, profile rows, logs, artifacts, and workflow payloads must not contain credential file contents, token values, environment dumps, raw directory listings, or raw auth-volume entries.
+
+## Verifier Result
+
+Verifier: `verify_volume_credentials(runtime_id="claude_code", volume_ref, volume_mount_path="/home/app/.claude")`
+
+Accepted proof:
+
+- `credentials.json` present under the mounted Claude home.
+- `settings.json` present under the mounted Claude home with qualifying account-auth evidence documented by the Claude runtime adapter.
+
+Result shape:
+
+```json
+{
+  "verified": true,
+  "status": "verified",
+  "runtime_id": "claude_code",
+  "reason": "ok",
+  "credentials_found_count": 1,
+  "credentials_missing_count": 1
+}
+```
+
+Forbidden result fields:
+
+- Raw file contents.
+- Token values.
+- Environment variable values.
+- Raw directory listings.
+- Full credential file paths.

--- a/specs/243-claude-oauth-verification/data-model.md
+++ b/specs/243-claude-oauth-verification/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Claude OAuth Verification and Profile Registration
+
+## Claude OAuth Session
+
+- `session_id`: identifies the OAuth finalization target.
+- `runtime_id`: must be `claude_code` for this story.
+- `profile_id`: expected profile target, normally `claude_anthropic`.
+- `volume_ref`: auth volume reference, normally `claude_auth_volume`.
+- `volume_mount_path`: mounted Claude home path, normally `/home/app/.claude`.
+- `status`: finalization accepts `awaiting_user` or `verifying`; success moves to `succeeded`; failed verification moves to `failed`.
+- `requested_by_user_id`: owner used for finalize authorization.
+- `metadata_json`: provider metadata and rate-limit defaults used during profile registration.
+
+Validation rules:
+
+- Finalization must reject sessions not owned by the current operator.
+- Finalization must reject sessions outside allowed finalization states.
+- Failed verification must not mutate provider profiles.
+
+## Claude Auth Verification Result
+
+- `verified`: boolean.
+- `status`: `verified` or `failed`.
+- `runtime_id`: `claude_code`.
+- `reason`: compact reason such as `ok`, `no_credentials_found`, `settings_not_qualified`, `docker_not_available`, or `verification_error`.
+- `credentials_found_count`: count of accepted credential artifacts.
+- `credentials_missing_count`: count of expected missing artifacts.
+
+Validation rules:
+
+- Results must not contain credential contents, token values, raw settings values, raw directory listings, or environment dumps.
+- `credentials.json` counts as accepted account-auth material when present.
+- `settings.json` counts only when it contains documented evidence that Claude account setup completed.
+
+## OAuth-backed Provider Profile
+
+- `profile_id`: `claude_anthropic`.
+- `runtime_id`: `claude_code`.
+- `provider_id`: `anthropic`.
+- `provider_label`: `Anthropic`.
+- `credential_source`: `oauth_volume`.
+- `runtime_materialization_mode`: `oauth_home`.
+- `volume_ref`: `claude_auth_volume`.
+- `volume_mount_path`: `/home/app/.claude`.
+- `enabled`: true after successful finalization.
+
+Validation rules:
+
+- Profile registration or update happens only after verified auth volume metadata.
+- Provider profile rows store refs and metadata only, never credential file contents.
+- Provider Profile Manager sync runs for `claude_code` after registration or update succeeds.
+
+## State Transitions
+
+```text
+awaiting_user/verifying
+  -> verify auth volume
+  -> failed when verification fails
+  -> register/update claude_anthropic when verification succeeds
+  -> sync Provider Profile Manager for claude_code
+  -> succeeded
+```

--- a/specs/243-claude-oauth-verification/plan.md
+++ b/specs/243-claude-oauth-verification/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Claude OAuth Verification and Profile Registration
+
+**Branch**: `243-claude-oauth-verification` | **Date**: 2026-04-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/243-claude-oauth-verification/spec.md`
+
+## Summary
+
+Implement MM-480 by completing the Claude OAuth finalization boundary. The existing OAuth finalize route already verifies the auth volume before profile mutation, skips mutation on failed verification, writes OAuth-home provider profile fields, syncs Provider Profile Manager, and scopes finalization to the owning user. Repo gap analysis found the Claude verifier itself is incomplete: `claude_code` currently checks paths that do not match the mounted Claude home contract and does not validate qualifying `settings.json` evidence. The implementation will add failing unit tests for Claude credential artifact detection and focused route tests for successful Claude finalization, then update the verifier and any required finalization metadata handling.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| -- | -- | -- | -- | -- |
+| FR-001 | implemented_verified | `api_service/api/routers/oauth_sessions.py`; `test_finalize_oauth_session_registers_claude_oauth_profile` proves verification happens before profile registration | completed | route unit |
+| FR-002 | implemented_verified | `volume_verifiers.py`; `test_claude_verification_checks_credentials_at_mounted_home` verifies mounted-home path | completed | unit |
+| FR-003 | implemented_verified | `volume_verifiers.py`; Claude verifier tests cover `credentials.json`, qualifying `settings.json`, and non-qualifying settings | completed | unit |
+| FR-004 | implemented_verified | `_verification_result`; Claude verifier no-leak assertions prove compact metadata | completed | unit |
+| FR-005 | implemented_verified | verifier and route tests assert no raw artifact paths/values or profile credential contents are exposed | completed | unit + route unit |
+| FR-006 | implemented_verified | `test_finalize_oauth_session_rejects_failed_volume_verification` covers failed verification path | no new implementation | existing route unit |
+| FR-007 | implemented_verified | `test_finalize_oauth_session_registers_claude_oauth_profile` asserts required OAuth-volume profile fields | completed | route unit |
+| FR-008 | implemented_verified | `test_finalize_oauth_session_registers_claude_oauth_profile` asserts manager sync for `claude_code` | completed | route unit |
+| FR-009 | implemented_verified | `test_finalize_oauth_session_rejects_other_users_claude_session_before_verify` proves unauthorized finalize stops before verification or mutation | completed | route unit |
+| FR-010 | implemented_verified | Claude finalization route test asserts profile stores refs/metadata only | completed | route unit |
+| FR-011 | implemented_verified | MoonSpec artifacts and final verification preserve MM-480 traceability | completed | verification |
+| SC-001 | implemented_verified | Claude verifier tests cover documented artifacts and rejection of non-qualifying settings | completed | unit |
+| SC-002 | implemented_verified | Claude verifier tests prove compact secret-free metadata | completed | unit |
+| SC-003 | implemented_verified | route test proves verify-before-registration and failed verification test preserves no-mutation behavior | completed | route unit |
+| SC-004 | implemented_verified | route test proves `claude_anthropic` registration/update fields and `claude_code` sync | completed | route unit |
+| SC-005 | implemented_verified | unauthorized route test proves reject-before-verify behavior | completed | route unit |
+| SC-006 | implemented_verified | focused and full unit suites passed | completed | unit |
+| DESIGN-REQ-003 | implemented_verified | finalization route plus Claude route test verify before mutation | completed | route unit |
+| DESIGN-REQ-004 | implemented_verified | verifier implementation and tests cover documented Claude artifacts | completed | unit |
+| DESIGN-REQ-013 | implemented_verified | verifier implementation and tests prove secret-free metadata | completed | unit |
+| DESIGN-REQ-014 | implemented_verified | Claude route test proves OAuth-backed profile fields | completed | route unit |
+| DESIGN-REQ-016 | implemented_verified | Claude route test proves Provider Profile Manager sync | completed | route unit |
+| DESIGN-REQ-018 | implemented_verified | unauthorized route test and ref-only assertions cover auth/ref requirements | completed | route unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest  
+**Storage**: Existing OAuth session and managed provider profile tables; no new persistent tables  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh <pytest targets>`  
+**Integration Testing**: Route-level async pytest fixtures; hermetic integration through `./tools/test_integration.sh` if API or artifact lifecycle behavior changes  
+**Target Platform**: Linux API and worker containers  
+**Project Type**: FastAPI control plane plus Temporal-backed runtime services  
+**Performance Goals**: Verification remains a bounded Docker volume check with a 30 second timeout; finalization remains a single route-level transaction path plus manager sync  
+**Constraints**: No raw credential contents, tokens, environment dumps, raw auth-volume listings, or secret-bearing paths in browser-visible responses, artifacts, logs, workflow payloads, or provider profile rows; preserve existing Codex/Gemini OAuth verification behavior  
+**Scale/Scope**: One runtime (`claude_code`), one provider profile (`claude_anthropic`), one OAuth finalization path
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Extends the existing OAuth session finalization and verifier boundary.
+- II. One-Click Agent Deployment: PASS. Uses existing local Docker volume verification; no new external dependency.
+- III. Avoid Vendor Lock-In: PASS. Claude-specific artifact checks stay in provider/runtime verifier configuration.
+- IV. Own Your Data: PASS. Credential material stays in the operator-managed auth volume; only metadata leaves the verifier.
+- V. Skills Are First-Class: PASS. MoonSpec artifacts preserve MM-480 traceability.
+- VI. Bittersweet Lesson: PASS. Keeps the verifier and finalization contract thin and replaceable.
+- VII. Runtime Configurability: PASS. Uses existing runtime registry defaults and session volume refs.
+- VIII. Modular Architecture: PASS. Work stays in OAuth session route tests and provider volume verifier code.
+- IX. Resilient by Default: PASS. Failed verification fails closed and skips profile mutation.
+- X. Continuous Improvement: PASS. Verification evidence will be captured in tests and final report.
+- XI. Spec-Driven Development: PASS. This plan follows a single-story spec.
+- XII. Canonical Docs vs Tmp: PASS. Canonical docs are source requirements; Jira brief remains under `docs/tmp`.
+- XIII. Pre-Release Velocity: PASS. No compatibility aliases or hidden fallback semantics are introduced.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/243-claude-oauth-verification/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── claude-oauth-verification.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/oauth_sessions.py
+moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+tests/unit/auth/test_volume_verifiers.py
+tests/unit/api_service/api/routers/test_oauth_sessions.py
+```
+
+**Structure Decision**: Add focused verifier and route-boundary tests first. Production changes are expected in `volume_verifiers.py`; route code changes are contingency only if the Claude finalization test exposes a finalize/profile-registration gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/243-claude-oauth-verification/plan.md
+++ b/specs/243-claude-oauth-verification/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-480 by completing the Claude OAuth finalization boundary. The existing OAuth finalize route already verifies the auth volume before profile mutation, skips mutation on failed verification, writes OAuth-home provider profile fields, syncs Provider Profile Manager, and scopes finalization to the owning user. Repo gap analysis found the Claude verifier itself is incomplete: `claude_code` currently checks paths that do not match the mounted Claude home contract and does not validate qualifying `settings.json` evidence. The implementation will add failing unit tests for Claude credential artifact detection and focused route tests for successful Claude finalization, then update the verifier and any required finalization metadata handling.
+Implement MM-480 by completing the Claude OAuth finalization boundary. The existing OAuth finalize route already verifies the auth volume before profile mutation, skips mutation on failed verification, writes OAuth-home provider profile fields, syncs Provider Profile Manager, and scopes finalization to the owning user. Initial repo gap analysis found the Claude verifier itself was incomplete: `claude_code` checked paths that did not match the mounted Claude home contract and did not validate qualifying `settings.json` evidence. The completed implementation added failing unit tests for Claude credential artifact detection and focused route tests for successful Claude finalization, then updated the verifier while leaving route behavior unchanged because the route-boundary tests passed.
 
 ## Requirement Status
 

--- a/specs/243-claude-oauth-verification/quickstart.md
+++ b/specs/243-claude-oauth-verification/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: Claude OAuth Verification and Profile Registration
+
+## Focused TDD Flow
+
+1. Add failing verifier tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py
+```
+
+Expected red cases before implementation:
+
+- `claude_code` checks `credentials.json` directly under the mounted Claude home.
+- `claude_code` accepts qualifying `settings.json`.
+- `claude_code` rejects non-qualifying `settings.json`.
+- Verification results do not expose raw settings values, file contents, or full artifact paths.
+
+2. Add failing route-boundary tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py
+```
+
+Expected red cases before implementation if route coverage is missing:
+
+- Successful Claude finalization verifies before registering or updating `claude_anthropic`.
+- Finalization stores OAuth-volume profile refs only.
+- Provider Profile Manager sync is called for `claude_code`.
+- Unauthorized finalize attempts do not verify or mutate profiles.
+
+3. Implement the smallest production changes needed:
+
+- Update Claude credential artifact detection in `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py`.
+- Update finalization route only if the Claude route-boundary tests expose a behavior gap.
+
+4. Run focused validation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh \
+  tests/unit/auth/test_volume_verifiers.py \
+  tests/unit/api_service/api/routers/test_oauth_sessions.py
+```
+
+5. Run final unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Hermetic integration command if API/artifact lifecycle behavior changes:
+
+```bash
+./tools/test_integration.sh
+```

--- a/specs/243-claude-oauth-verification/research.md
+++ b/specs/243-claude-oauth-verification/research.md
@@ -1,0 +1,65 @@
+# Research: Claude OAuth Verification and Profile Registration
+
+## FR-001 / DESIGN-REQ-003
+
+Decision: implemented_unverified; add Claude route-boundary coverage.
+Evidence: `api_service/api/routers/oauth_sessions.py` calls `verify_volume_credentials` before building or mutating `ManagedAgentProviderProfile`.
+Rationale: The ordering is visible in code, but existing successful registration coverage is Codex-specific.
+Alternatives considered: Treat generic Codex route test as sufficient. Rejected because MM-480 requires Claude profile fields and runtime sync evidence.
+Test implications: Route unit test.
+
+## FR-002 / FR-003 / DESIGN-REQ-004
+
+Decision: partial; update Claude credential artifact detection.
+Evidence: `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py` currently defines Claude paths as `.claude/credentials.json` and `.claude.json`, while MM-480 requires verification under mounted Claude home using `credentials.json` and qualifying `settings.json`.
+Rationale: The auth volume is mounted at `/home/app/.claude`, so checks should evaluate artifacts relative to that mounted home, not a nested `.claude` path.
+Alternatives considered: Accept current `.claude/credentials.json` as a compatible extra path. Rejected for this story because internal pre-release policy favors the superseded pattern being replaced rather than hidden compatibility aliases.
+Test implications: Unit tests for `credentials.json`, qualifying `settings.json`, and non-qualifying `settings.json`.
+
+## FR-004 / FR-005 / DESIGN-REQ-013
+
+Decision: implemented_unverified; add Claude-specific no-leak tests.
+Evidence: `_verification_result` returns only verified state, status, runtime ID, reason, and counts. Existing tests assert `found` and `missing` are not returned for generic providers and Codex.
+Rationale: The result shape is already compact, but settings qualification adds a new parsing path that must not leak values.
+Alternatives considered: Rely on existing generic no-leak tests. Rejected because the new Claude settings check is the highest-risk path for accidentally exposing auth material.
+Test implications: Unit tests assert no raw setting values, artifact paths, or token-like content appear in verifier results.
+
+## FR-006
+
+Decision: implemented_verified; no new implementation planned.
+Evidence: `tests/unit/api_service/api/routers/test_oauth_sessions.py::test_finalize_oauth_session_rejects_failed_volume_verification` verifies failed volume verification marks the session failed, stops the auth runner, signals workflow failure, and does not register a profile.
+Rationale: The failure behavior is runtime-neutral and already covered at the route boundary.
+Alternatives considered: Duplicate the failure test for Claude. Deferred unless implementation changes route behavior.
+Test implications: Existing route unit plus final focused suite.
+
+## FR-007 / FR-008 / DESIGN-REQ-014 / DESIGN-REQ-016
+
+Decision: implemented_unverified; add Claude successful finalization route test.
+Evidence: Finalize route writes `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, session volume refs, and calls `sync_provider_profile_manager(runtime_id=session_obj.runtime_id)`. Existing successful test covers Codex only.
+Rationale: Claude profile defaults and sync target must be proven for `claude_code` and `claude_anthropic`.
+Alternatives considered: Trust the generic route. Rejected because MM-480 explicitly names Claude profile shape and manager sync.
+Test implications: Route unit test with mocked verifier and manager sync.
+
+## FR-009 / DESIGN-REQ-018
+
+Decision: implemented_unverified; add focused authorization or owner-scope assertion.
+Evidence: Finalize route fetches sessions by `session_id` and `requested_by_user_id`; provider update checks owner before mutation.
+Rationale: Existing route scope suggests unauthorized attempts fail, but MM-480 requires explicit finalize or repair rejection evidence.
+Alternatives considered: Use provider profile auth tests only. Rejected because finalization is the requested boundary.
+Test implications: Route unit test for another user's session or unauthorized profile update.
+
+## FR-010
+
+Decision: implemented_unverified; assert ref-only profile persistence in Claude route test.
+Evidence: Provider profile model stores refs and metadata, not file contents. Finalize route response is `{"status": "succeeded"}`.
+Rationale: Claude-specific test should confirm stored OAuth profile fields are refs only.
+Alternatives considered: Rely on schema shape. Rejected to keep MM-480 evidence concrete.
+Test implications: Route unit test.
+
+## FR-011
+
+Decision: missing; preserve traceability through remaining artifacts and final report.
+Evidence: `spec.md` preserves MM-480 and original Jira input.
+Rationale: Tasks, verification, commit/PR metadata, and final report still need to carry the issue key.
+Alternatives considered: Limit traceability to spec. Rejected because the Jira brief explicitly requires downstream references.
+Test implications: Final verification.

--- a/specs/243-claude-oauth-verification/research.md
+++ b/specs/243-claude-oauth-verification/research.md
@@ -2,25 +2,25 @@
 
 ## FR-001 / DESIGN-REQ-003
 
-Decision: implemented_unverified; add Claude route-boundary coverage.
-Evidence: `api_service/api/routers/oauth_sessions.py` calls `verify_volume_credentials` before building or mutating `ManagedAgentProviderProfile`.
+Decision: implemented_verified after adding Claude route-boundary coverage.
+Evidence: `api_service/api/routers/oauth_sessions.py` calls `verify_volume_credentials` before building or mutating `ManagedAgentProviderProfile`; `tests/unit/api_service/api/routers/test_oauth_sessions.py::test_finalize_oauth_session_registers_claude_oauth_profile` proves this order for Claude.
 Rationale: The ordering is visible in code, but existing successful registration coverage is Codex-specific.
 Alternatives considered: Treat generic Codex route test as sufficient. Rejected because MM-480 requires Claude profile fields and runtime sync evidence.
-Test implications: Route unit test.
+Test implications: Route unit test completed.
 
 ## FR-002 / FR-003 / DESIGN-REQ-004
 
-Decision: partial; update Claude credential artifact detection.
-Evidence: `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py` currently defines Claude paths as `.claude/credentials.json` and `.claude.json`, while MM-480 requires verification under mounted Claude home using `credentials.json` and qualifying `settings.json`.
-Rationale: The auth volume is mounted at `/home/app/.claude`, so checks should evaluate artifacts relative to that mounted home, not a nested `.claude` path.
+Decision: implemented_verified after updating Claude credential artifact detection.
+Evidence: `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py` defines Claude paths as `credentials.json` and `settings.json`, and tests verify the mounted-home path plus qualifying and non-qualifying settings behavior.
+Rationale: The auth volume is mounted at `/home/app/.claude`, so checks evaluate artifacts relative to that mounted home, not a nested `.claude` path.
 Alternatives considered: Accept current `.claude/credentials.json` as a compatible extra path. Rejected for this story because internal pre-release policy favors the superseded pattern being replaced rather than hidden compatibility aliases.
-Test implications: Unit tests for `credentials.json`, qualifying `settings.json`, and non-qualifying `settings.json`.
+Test implications: Unit tests for `credentials.json`, qualifying `settings.json`, and non-qualifying `settings.json` completed.
 
 ## FR-004 / FR-005 / DESIGN-REQ-013
 
-Decision: implemented_unverified; add Claude-specific no-leak tests.
-Evidence: `_verification_result` returns only verified state, status, runtime ID, reason, and counts. Existing tests assert `found` and `missing` are not returned for generic providers and Codex.
-Rationale: The result shape is already compact, but settings qualification adds a new parsing path that must not leak values.
+Decision: implemented_verified after adding Claude-specific no-leak tests.
+Evidence: `_verification_result` returns only verified state, status, runtime ID, reason, and counts. Claude tests assert raw paths and token-like settings values are absent from verifier output.
+Rationale: The result shape is compact, and the new settings qualification path is covered so it does not leak values.
 Alternatives considered: Rely on existing generic no-leak tests. Rejected because the new Claude settings check is the highest-risk path for accidentally exposing auth material.
 Test implications: Unit tests assert no raw setting values, artifact paths, or token-like content appear in verifier results.
 
@@ -34,32 +34,32 @@ Test implications: Existing route unit plus final focused suite.
 
 ## FR-007 / FR-008 / DESIGN-REQ-014 / DESIGN-REQ-016
 
-Decision: implemented_unverified; add Claude successful finalization route test.
-Evidence: Finalize route writes `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, session volume refs, and calls `sync_provider_profile_manager(runtime_id=session_obj.runtime_id)`. Existing successful test covers Codex only.
+Decision: implemented_verified after adding Claude successful finalization route test.
+Evidence: Finalize route writes `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, session volume refs, and calls `sync_provider_profile_manager(runtime_id=session_obj.runtime_id)`. Claude route test verifies `claude_anthropic` fields and `claude_code` sync.
 Rationale: Claude profile defaults and sync target must be proven for `claude_code` and `claude_anthropic`.
 Alternatives considered: Trust the generic route. Rejected because MM-480 explicitly names Claude profile shape and manager sync.
-Test implications: Route unit test with mocked verifier and manager sync.
+Test implications: Route unit test with mocked verifier and manager sync completed.
 
 ## FR-009 / DESIGN-REQ-018
 
-Decision: implemented_unverified; add focused authorization or owner-scope assertion.
-Evidence: Finalize route fetches sessions by `session_id` and `requested_by_user_id`; provider update checks owner before mutation.
+Decision: implemented_verified after adding focused owner-scope assertion.
+Evidence: Finalize route fetches sessions by `session_id` and `requested_by_user_id`; provider update checks owner before mutation. Claude unauthorized finalize test proves another user's session is not verified or mutated.
 Rationale: Existing route scope suggests unauthorized attempts fail, but MM-480 requires explicit finalize or repair rejection evidence.
 Alternatives considered: Use provider profile auth tests only. Rejected because finalization is the requested boundary.
-Test implications: Route unit test for another user's session or unauthorized profile update.
+Test implications: Route unit test for another user's session completed.
 
 ## FR-010
 
-Decision: implemented_unverified; assert ref-only profile persistence in Claude route test.
-Evidence: Provider profile model stores refs and metadata, not file contents. Finalize route response is `{"status": "succeeded"}`.
+Decision: implemented_verified after asserting ref-only profile persistence in Claude route test.
+Evidence: Provider profile model stores refs and metadata, not file contents. Finalize route response is `{"status": "succeeded"}` and Claude route test asserts OAuth-volume refs only.
 Rationale: Claude-specific test should confirm stored OAuth profile fields are refs only.
 Alternatives considered: Rely on schema shape. Rejected to keep MM-480 evidence concrete.
-Test implications: Route unit test.
+Test implications: Route unit test completed.
 
 ## FR-011
 
-Decision: missing; preserve traceability through remaining artifacts and final report.
-Evidence: `spec.md` preserves MM-480 and original Jira input.
+Decision: implemented_verified; preserve traceability through artifacts and final report.
+Evidence: `spec.md`, `plan.md`, `tasks.md`, and final orchestration reporting preserve MM-480 and the original Jira input.
 Rationale: Tasks, verification, commit/PR metadata, and final report still need to carry the issue key.
 Alternatives considered: Limit traceability to spec. Rejected because the Jira brief explicitly requires downstream references.
-Test implications: Final verification.
+Test implications: Final verification completed through MoonSpec orchestration report.

--- a/specs/243-claude-oauth-verification/spec.md
+++ b/specs/243-claude-oauth-verification/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Claude OAuth Verification and Profile Registration
+
+**Feature Branch**: `243-claude-oauth-verification`
+**Created**: 2026-04-23
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-480 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-480-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+
+## Original Preset Brief
+
+```text
+# MM-480 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-480
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Claude OAuth Verification and Profile Registration
+- Labels: `moonmind-workflow-mm-8f0966f3-d711-4289-9669-3a8e435353fb`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-480 from MM project
+Summary: Claude OAuth Verification and Profile Registration
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-480 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-480: Claude OAuth Verification and Profile Registration
+
+Source Reference
+- Source Document: docs/ManagedAgents/ClaudeAnthropicOAuth.md
+- Source Title: Claude Anthropic OAuth in Settings
+- Source Sections:
+  - 5. Verification
+  - 6. Profile Registration
+  - 9. Security Requirements
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-016
+  - DESIGN-REQ-018
+
+User Story
+As an operator, I can finalize a Claude OAuth session and have MoonMind verify the auth volume, register or update the OAuth-backed provider profile, and expose only secret-free verification metadata.
+
+Acceptance Criteria
+- Given finalization runs after Claude login, then MoonMind verifies account-auth material under the mounted Claude home before profile registration.
+- Given known artifacts such as credentials.json or qualifying settings.json are present, then verification can return verified status using only metadata.
+- Given verification output is returned or persisted, then it includes only secret-free fields such as verified, status, reason, artifact counts, and timestamps.
+- Given verification succeeds, then claude_anthropic is registered or updated with credential_source oauth_volume, runtime_materialization_mode oauth_home, volume_ref claude_auth_volume, and volume_mount_path /home/app/.claude.
+- Given profile registration succeeds, then Provider Profile Manager is synced for runtime_id claude_code.
+- Given an unauthorized operator attempts finalize or repair, then the operation is rejected.
+
+Requirements
+- Verify Claude account-auth material before registering or updating the provider profile.
+- Accept only explicitly documented Claude credential artifacts as proof of account setup.
+- Return and persist secret-free verification metadata only.
+- Register or update the OAuth-backed claude_anthropic provider profile after successful verification.
+- Sync Provider Profile Manager for claude_code after successful registration.
+
+Relevant Implementation Notes
+- Preserve MM-480 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the source design reference for Claude OAuth verification, profile registration, and security requirements.
+- Verification must inspect account-auth material under the mounted Claude home before profile registration and must not expose raw credential contents.
+- Treat `credentials.json` and qualifying `settings.json` data as proof only through secret-free metadata such as verified state, status, reason, artifact counts, and timestamps.
+- On successful verification, register or update `claude_anthropic` with `credential_source` `oauth_volume`, `runtime_materialization_mode` `oauth_home`, `volume_ref` `claude_auth_volume`, and `volume_mount_path` `/home/app/.claude`.
+- Sync Provider Profile Manager for `runtime_id` `claude_code` after profile registration succeeds.
+- Reject unauthorized finalize or repair attempts.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-480 blocks MM-479, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-480 is blocked by MM-481, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## User Story - Claude OAuth Verification and Profile Registration
+
+**Summary**: As an operator, I can finalize a Claude OAuth session and have MoonMind verify the auth volume, register or update the OAuth-backed provider profile, and expose only secret-free verification metadata.
+
+**Goal**: Claude OAuth finalization proves account-auth material exists without exposing secrets, then registers or updates the `claude_anthropic` provider profile so later Claude runs can select the OAuth-backed profile safely.
+
+**Independent Test**: Complete or simulate finalization for a Claude OAuth session with known account-auth artifacts under the mounted Claude home, verify that only secret-free metadata is returned or persisted, confirm `claude_anthropic` is registered or updated with OAuth-volume fields, and verify unauthorized finalize or repair attempts are rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Claude OAuth session has completed login and mounted the Claude home, **When** finalization runs, **Then** MoonMind verifies Claude account-auth material under the mounted home before registering or updating any provider profile.
+2. **Given** known Claude account-auth artifacts such as `credentials.json` or qualifying `settings.json` are present, **When** verification evaluates the mounted home, **Then** it can return a verified result using only secret-free metadata.
+3. **Given** verification output is returned, persisted, logged, or shown in Mission Control, **When** the result is inspected, **Then** it contains only fields such as verified state, status, reason, artifact counts, and timestamps, and never credential contents, tokens, environment dumps, or raw directory listings.
+4. **Given** verification succeeds, **When** finalization completes, **Then** MoonMind registers or updates `claude_anthropic` with OAuth-volume credential metadata using `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, `volume_ref = claude_auth_volume`, and `volume_mount_path = /home/app/.claude`.
+5. **Given** provider profile registration succeeds, **When** finalization completes, **Then** Provider Profile Manager is synced for `runtime_id = claude_code` so new runs can select the updated profile.
+6. **Given** an operator lacks provider-profile management permission, **When** they attempt to finalize or repair a Claude OAuth session, **Then** MoonMind rejects the operation before verification, profile registration, or profile mutation occurs.
+
+### Edge Cases
+
+- The mounted Claude home contains no accepted account-auth artifacts.
+- `settings.json` exists but does not contain qualifying evidence that Claude account setup completed.
+- Verification succeeds but provider profile registration fails.
+- Provider Profile Manager sync fails after profile registration succeeds.
+- Verification encounters token-like or secret-like content while producing metadata.
+- A stale, cancelled, expired, or already-finalized OAuth session is finalized again.
+- A repair attempt targets an OAuth auth volume owned by another profile or unauthorized operator.
+
+## Assumptions
+
+- MM-478 covers Claude provider registry defaults and auth-runner volume mounting; MM-479 covers the browser terminal sign-in ceremony. MM-480 starts from the post-login finalization boundary.
+- `credentials.json` and qualifying `settings.json` are the currently documented Claude account-auth artifacts. Additional artifacts are out of scope unless explicitly documented by the runtime adapter.
+- Runtime launch behavior after profile selection is covered by separate Claude launch materialization work; this story validates finalization-time verification and provider profile registration.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-003** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 5): Finalization must verify the Claude auth volume before registering or updating the provider profile. Scope: in scope, mapped to FR-001 and FR-006.
+- **DESIGN-REQ-004** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 5): Verification may accept only known Claude account-auth artifacts such as `credentials.json`, qualifying `settings.json`, or other explicitly documented adapter artifacts. Scope: in scope, mapped to FR-002 and FR-003.
+- **DESIGN-REQ-013** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 5): Verification metadata must be secret-free and must not return credential file contents, tokens, environment dumps, or raw directory listings. Scope: in scope, mapped to FR-004 and FR-005.
+- **DESIGN-REQ-014** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 6): After successful verification, MoonMind must register or update the OAuth-backed provider profile with `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, `volume_ref = claude_auth_volume`, and `volume_mount_path = /home/app/.claude`. Scope: in scope, mapped to FR-006 and FR-007.
+- **DESIGN-REQ-016** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 6): Provider Profile Manager must be synced for `runtime_id = claude_code` after registration succeeds. Scope: in scope, mapped to FR-008.
+- **DESIGN-REQ-018** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 9): Only authorized operators can finalize or repair Claude OAuth sessions, and provider profile rows store refs and metadata only, never credential contents. Scope: in scope, mapped to FR-005, FR-009, and FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST perform Claude OAuth verification before registering or updating the `claude_anthropic` provider profile.
+- **FR-002**: System MUST verify account-auth material under the mounted Claude home associated with the OAuth session.
+- **FR-003**: System MUST treat only `credentials.json`, qualifying `settings.json`, or runtime-adapter-documented account-auth artifacts as proof of Claude account setup.
+- **FR-004**: System MUST return and persist verification metadata containing only secret-free fields such as verified state, status, reason, artifact counts, and timestamps.
+- **FR-005**: System MUST prevent credential file contents, token values, environment dumps, and raw auth-volume directory listings from appearing in API responses, workflow payloads, logs, artifacts, browser-visible data, and provider profile rows.
+- **FR-006**: System MUST skip provider profile mutation when Claude OAuth verification fails.
+- **FR-007**: System MUST register or update `claude_anthropic` after successful verification with `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, `volume_ref = claude_auth_volume`, and `volume_mount_path = /home/app/.claude`.
+- **FR-008**: System MUST sync Provider Profile Manager for `runtime_id = claude_code` after successful profile registration or update.
+- **FR-009**: System MUST reject unauthorized Claude OAuth finalize or repair attempts before verification, profile registration, or profile mutation occurs.
+- **FR-010**: System MUST ensure provider profile rows store only credential refs and metadata for OAuth-backed Claude auth, never credential file contents.
+- **FR-011**: System MUST preserve MM-480 in implementation notes, verification output, commit text, and pull request metadata for traceability.
+
+### Key Entities
+
+- **Claude OAuth Session**: Operator-owned enrollment or repair session that reaches finalization after Claude login and references the mounted Claude home.
+- **Claude Auth Verification Result**: Secret-free metadata indicating verified state, status, reason, accepted artifact counts, and timestamps.
+- **OAuth-backed Provider Profile**: `claude_anthropic` profile row that stores OAuth-volume refs and materialization metadata for Claude runtime selection.
+- **Provider Profile Manager Sync**: Runtime profile refresh action that makes the updated `claude_code` profile available to new runs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests prove Claude OAuth verification accepts documented account-auth artifacts and rejects missing or non-qualifying artifacts without exposing raw file contents.
+- **SC-002**: Unit or API tests prove verification responses and persisted artifacts include only secret-free metadata fields.
+- **SC-003**: Workflow or activity-boundary tests prove finalization verifies the auth volume before profile registration and skips profile mutation when verification fails.
+- **SC-004**: API or service tests prove successful finalization registers or updates `claude_anthropic` with the required OAuth-volume profile fields and syncs `runtime_id = claude_code`.
+- **SC-005**: Authorization tests prove unauthorized finalize or repair attempts are rejected before verification or provider profile mutation.
+- **SC-006**: Focused validation passes for the Claude OAuth finalization, provider profile registration, and authorization paths touched by this story.

--- a/specs/243-claude-oauth-verification/tasks.md
+++ b/specs/243-claude-oauth-verification/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py tests/unit/api_service/api/routers/test_oauth_sessions.py`
 - Integration tests: route-boundary async pytest coverage through `tests/unit/api_service/api/routers/test_oauth_sessions.py`; run `./tools/test_integration.sh` only if API/artifact lifecycle behavior changes
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -90,7 +90,7 @@
 - [X] T017 [P] Review `specs/243-claude-oauth-verification/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-verification.md`, `quickstart.md`, and `tasks.md` for MM-480 traceability covering FR-011
 - [X] T018 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - [X] T019 Run `./tools/test_integration.sh` only if route/API/artifact lifecycle behavior changed; otherwise document why it was not required. Not run because MM-480 changed verifier logic and unit-tested route behavior only, with no compose/API artifact lifecycle change.
-- [X] T020 Run `/speckit.verify` equivalent by checking implementation, tests, and artifacts against the original MM-480 request and produce the final verification report
+- [X] T020 Run `/moonspec-verify` equivalent by checking implementation, tests, and artifacts against the original MM-480 request and produce the final verification report
 
 ---
 

--- a/specs/243-claude-oauth-verification/tasks.md
+++ b/specs/243-claude-oauth-verification/tasks.md
@@ -1,0 +1,128 @@
+# Tasks: Claude OAuth Verification and Profile Registration
+
+**Input**: Design documents from `specs/243-claude-oauth-verification/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/claude-oauth-verification.md, quickstart.md
+
+**Tests**: Unit tests and route-boundary tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Organization**: Tasks are grouped around the single MM-480 story: Claude OAuth finalization verifies account-auth material, registers or updates `claude_anthropic`, syncs Provider Profile Manager, and exposes only secret-free metadata.
+
+**Source Traceability**: FR-001 through FR-011, acceptance scenarios 1-6, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-016, DESIGN-REQ-018.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- Integration tests: route-boundary async pytest coverage through `tests/unit/api_service/api/routers/test_oauth_sessions.py`; run `./tools/test_integration.sh` only if API/artifact lifecycle behavior changes
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the existing project structure and validation targets for this story.
+
+- [X] T001 Confirm `specs/243-claude-oauth-verification/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/claude-oauth-verification.md`
+- [X] T002 Confirm focused test targets exist in `tests/unit/auth/test_volume_verifiers.py` and `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Validate no new schema, migration, dependency, or fixture foundation is needed before story work.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T003 Confirm no database migration is required because MM-480 uses existing OAuth session and provider profile tables in `api_service/db/models.py`
+- [X] T004 Confirm no new dependency is required because MM-480 uses existing FastAPI, SQLAlchemy, Docker-volume verifier, and pytest infrastructure
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Claude OAuth Verification and Profile Registration
+
+**Summary**: As an operator, I can finalize a Claude OAuth session and have MoonMind verify the auth volume, register or update the OAuth-backed provider profile, and expose only secret-free verification metadata.
+
+**Independent Test**: Complete or simulate finalization for a Claude OAuth session with known account-auth artifacts under the mounted Claude home, verify secret-free metadata, confirm `claude_anthropic` OAuth-volume registration and `claude_code` manager sync, and verify unauthorized attempts are rejected.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-016, DESIGN-REQ-018
+
+**Test Plan**:
+
+- Unit: Claude verifier path selection, qualifying `settings.json`, rejection of non-qualifying settings, compact secret-free metadata, and no raw path/value leakage.
+- Route-boundary: Claude finalization order, profile fields, manager sync, failed verification no-mutation behavior, and unauthorized finalize no verification or mutation.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T005 [P] Add failing Claude verifier test for mounted-home `credentials.json` covering FR-002, FR-003, SC-001, DESIGN-REQ-004 in `tests/unit/auth/test_volume_verifiers.py`
+- [X] T006 [P] Add failing Claude verifier test for qualifying `settings.json` account-auth evidence covering FR-003, SC-001, DESIGN-REQ-004 in `tests/unit/auth/test_volume_verifiers.py`
+- [X] T007 [P] Add failing Claude verifier test rejecting non-qualifying `settings.json` covering FR-003 and edge case coverage in `tests/unit/auth/test_volume_verifiers.py`
+- [X] T008 [P] Add failing Claude verifier no-leak assertions covering FR-004, FR-005, SC-002, DESIGN-REQ-013 in `tests/unit/auth/test_volume_verifiers.py`
+
+### Route-Boundary Tests (write first)
+
+- [X] T009 [P] Add failing successful Claude finalization route test covering FR-001, FR-007, FR-008, FR-010, SC-003, SC-004, DESIGN-REQ-003, DESIGN-REQ-014, DESIGN-REQ-016 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [X] T010 [P] Add failing unauthorized Claude finalize route test covering FR-009, SC-005, DESIGN-REQ-018 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [X] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py tests/unit/api_service/api/routers/test_oauth_sessions.py` and confirm T005-T010 fail for the expected reason before production changes
+
+### Implementation
+
+- [X] T012 Update Claude credential artifact definitions and command generation for mounted-home `credentials.json` and qualifying `settings.json` in `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py` covering FR-002, FR-003, SC-001, DESIGN-REQ-004
+- [X] T013 Update verifier output parsing for Claude `settings.json` qualification without leaking values in `moonmind/workflows/temporal/runtime/providers/volume_verifiers.py` covering FR-004, FR-005, SC-002, DESIGN-REQ-013
+- [X] T014 If T009 fails after verifier fixes, update Claude finalization behavior in `api_service/api/routers/oauth_sessions.py` so verification precedes profile mutation, `claude_anthropic` stores OAuth-volume fields only, and manager sync targets `claude_code` covering FR-001, FR-007, FR-008, FR-010, DESIGN-REQ-003, DESIGN-REQ-014, DESIGN-REQ-016. Skipped because T009 passed after verifier fixes.
+- [X] T015 If T010 fails, update authorization/finalize guard behavior in `api_service/api/routers/oauth_sessions.py` so unauthorized finalize attempts do not verify, register, or mutate profiles covering FR-009, DESIGN-REQ-018. Skipped because T010 passed after verifier fixes.
+- [X] T016 Run the focused unit command until all MM-480 tests pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py tests/unit/api_service/api/routers/test_oauth_sessions.py`
+
+**Checkpoint**: The MM-480 story is functionally complete, covered by verifier and route-boundary tests, and independently testable.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [X] T017 [P] Review `specs/243-claude-oauth-verification/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-verification.md`, `quickstart.md`, and `tasks.md` for MM-480 traceability covering FR-011
+- [X] T018 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [X] T019 Run `./tools/test_integration.sh` only if route/API/artifact lifecycle behavior changed; otherwise document why it was not required. Not run because MM-480 changed verifier logic and unit-tested route behavior only, with no compose/API artifact lifecycle change.
+- [X] T020 Run `/speckit.verify` equivalent by checking implementation, tests, and artifacts against the original MM-480 request and produce the final verification report
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion.
+- Story (Phase 3): depends on Foundational completion.
+- Polish (Phase 4): depends on focused story tests passing.
+
+### Within The Story
+
+- T005-T010 must be written before production changes.
+- T011 must confirm red-first behavior before T012-T015.
+- T012-T013 are required for partial verifier requirements.
+- T014-T015 are conditional fallback tasks if route-boundary tests expose gaps.
+- T016 validates story completion before polish.
+
+### Parallel Opportunities
+
+- T005-T008 can be authored together within `tests/unit/auth/test_volume_verifiers.py` only if coordinated as one file edit.
+- T009-T010 can be authored together within `tests/unit/api_service/api/routers/test_oauth_sessions.py` only if coordinated as one file edit.
+- T017 can run after implementation while final validation commands are prepared.
+
+## Implementation Strategy
+
+1. Confirm existing artifacts and no new infrastructure needs.
+2. Add verifier and route-boundary tests first.
+3. Run focused tests and preserve the red-first output.
+4. Complete the Claude verifier behavior.
+5. Apply route fallback changes only if route-boundary tests fail after verifier work.
+6. Run focused validation, then full unit validation.
+7. Write final verification with MM-480 traceability.

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -1016,3 +1016,150 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         "container_name": "moonmind_auth_oas_registercodex1",
     }
     assert completed_signal == {"session_id": session_id}
+
+
+@pytest.mark.asyncio
+async def test_finalize_oauth_session_registers_claude_oauth_profile(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_registerclaude1"
+    profile_id = "claude_anthropic"
+    verify_seen_existing_profile = None
+    synced_runtimes: list[str] = []
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id=profile_id,
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="None",
+                account_label="Claude Anthropic OAuth",
+                metadata_json={
+                    "provider_id": "anthropic",
+                    "provider_label": "Anthropic",
+                    "max_parallel_runs": 1,
+                    "cooldown_after_429_seconds": 900,
+                    "rate_limit_policy": "backoff",
+                },
+            )
+        )
+        await session.commit()
+
+    async def _successful_verify(**kwargs):
+        nonlocal verify_seen_existing_profile
+        assert kwargs["runtime_id"] == "claude_code"
+        assert kwargs["volume_ref"] == "claude_auth_volume"
+        assert kwargs["volume_mount_path"] == "/home/app/.claude"
+        async with db_base.async_session_maker() as session:
+            verify_seen_existing_profile = await session.get(
+                ManagedAgentProviderProfile, profile_id
+            )
+        return {
+            "verified": True,
+            "status": "verified",
+            "reason": "ok",
+            "credentials_found_count": 1,
+            "credentials_missing_count": 1,
+        }
+
+    async def _capture_sync(*, session: AsyncSession, runtime_id: str):
+        synced_runtimes.append(runtime_id)
+
+    async def _noop_stop(_session_obj):
+        return None
+
+    async def _noop_complete(_session_id):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _successful_verify,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions.sync_provider_profile_manager",
+        _capture_sync,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _noop_stop,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._complete_oauth_session_workflow",
+        _noop_complete,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "succeeded"}
+    assert verify_seen_existing_profile is None
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert row is not None
+        assert row.status == OAuthSessionStatus.SUCCEEDED
+        assert profile is not None
+        assert profile.runtime_id == "claude_code"
+        assert profile.provider_id == "anthropic"
+        assert profile.provider_label == "Anthropic"
+        assert profile.credential_source == ProviderCredentialSource.OAUTH_VOLUME
+        assert (
+            profile.runtime_materialization_mode
+            == RuntimeMaterializationMode.OAUTH_HOME
+        )
+        assert profile.volume_ref == "claude_auth_volume"
+        assert profile.volume_mount_path == "/home/app/.claude"
+        assert "credentials" not in repr(profile.__dict__)
+        assert "token" not in repr(profile.__dict__).lower()
+    assert synced_runtimes == ["claude_code"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_oauth_session_rejects_other_users_claude_session_before_verify(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_claudeotheruser1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id="claude_anthropic_other_user",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="different-user",
+                account_label="Claude Anthropic OAuth",
+            )
+        )
+        await session.commit()
+
+    async def _unexpected_verify(**_kwargs):
+        raise AssertionError("unauthorized finalize must not verify volume")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _unexpected_verify,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Session not found"
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        assert row.status == OAuthSessionStatus.AWAITING_USER
+        profile = await session.get(
+            ManagedAgentProviderProfile, "claude_anthropic_other_user"
+        )
+        assert profile is None

--- a/tests/unit/auth/test_volume_verifiers.py
+++ b/tests/unit/auth/test_volume_verifiers.py
@@ -30,9 +30,10 @@ class TestProviderCredentialPaths:
 
     def test_claude_paths_defined(self) -> None:
         assert "claude_code" in PROVIDER_CREDENTIAL_PATHS
-        paths = PROVIDER_CREDENTIAL_PATHS["claude_code"]
-        assert len(paths) >= 1
-        assert any("claude" in p for p in paths)
+        assert PROVIDER_CREDENTIAL_PATHS["claude_code"] == (
+            "credentials.json",
+            "settings.json",
+        )
 
 
 class TestCredentialCheckCommand:
@@ -220,6 +221,106 @@ class TestVerifyVolumeCredentials:
         assert result["verified"] is False
         assert result["reason"] == "codex_auth_invalid"
         assert "sensitive-placeholder" not in repr(result)
+
+    @pytest.mark.asyncio
+    async def test_claude_verification_checks_credentials_at_mounted_home(
+        self,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate = MagicMock(return_value="dummy")
+        mock_process.returncode = 0
+
+        with patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ) as exec_mock, patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.wait_for",
+            new_callable=AsyncMock,
+            return_value=(
+                b"FOUND:credentials.json\nMISSING:settings.json\n",
+                b"",
+            ),
+        ):
+            result = await verify_volume_credentials(
+                runtime_id="claude_code",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+            )
+
+        assert result["verified"] is True
+        assert result["status"] == "verified"
+        assert result["credentials_found_count"] == 1
+        assert result["credentials_missing_count"] == 1
+        assert "credentials.json" not in repr(result)
+        docker_args = exec_mock.call_args.args
+        assert "claude_auth_volume:/home/app/.claude:ro" in docker_args
+        command = docker_args[-1]
+        assert "/home/app/.claude/credentials.json" in command
+        assert "/home/app/.claude/.claude/credentials.json" not in command
+
+    @pytest.mark.asyncio
+    async def test_claude_verification_accepts_qualifying_settings_json(
+        self,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate = MagicMock(return_value="dummy")
+        mock_process.returncode = 0
+
+        with patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ), patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.wait_for",
+            new_callable=AsyncMock,
+            return_value=(
+                b"MISSING:credentials.json\nQUALIFIED:settings.json\n",
+                b"",
+            ),
+        ):
+            result = await verify_volume_credentials(
+                runtime_id="claude_code",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+            )
+
+        assert result["verified"] is True
+        assert result["status"] == "verified"
+        assert result["reason"] == "ok"
+        assert result["credentials_found_count"] == 1
+        assert result["credentials_missing_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_claude_verification_rejects_non_qualifying_settings_json(
+        self,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.communicate = MagicMock(return_value="dummy")
+        mock_process.returncode = 0
+
+        with patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ), patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio.wait_for",
+            new_callable=AsyncMock,
+            return_value=(
+                b"MISSING:credentials.json\nUNQUALIFIED:settings.json token-like-secret\n",
+                b"",
+            ),
+        ):
+            result = await verify_volume_credentials(
+                runtime_id="claude_code",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+            )
+
+        assert result["verified"] is False
+        assert result["status"] == "failed"
+        assert result["reason"] == "no_credentials_found"
+        assert result["credentials_found_count"] == 0
+        assert result["credentials_missing_count"] == 2
+        assert "token-like-secret" not in repr(result)
+        assert "settings.json" not in repr(result)
 
     @pytest.mark.asyncio
     async def test_no_credentials_found(self) -> None:

--- a/tests/unit/auth/test_volume_verifiers.py
+++ b/tests/unit/auth/test_volume_verifiers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -69,6 +70,86 @@ class TestCredentialCheckCommand:
             "\"/.config/gemini/credentials.json'"
             in command
         )
+
+    def test_claude_settings_false_does_not_qualify(
+        self, tmp_path
+    ) -> None:
+        (tmp_path / "settings.json").write_text(
+            '{"hasCompletedOnboarding": false}', encoding="utf-8"
+        )
+
+        command = _build_credential_check_command(
+            runtime_id="claude_code",
+            mount_path=str(tmp_path),
+            credential_paths=PROVIDER_CREDENTIAL_PATHS["claude_code"],
+        )
+
+        output = subprocess.check_output(["sh", "-c", command], text=True)
+
+        lines = output.splitlines()
+
+        assert "MISSING:credentials.json" in lines
+        assert "UNQUALIFIED:settings.json" in lines
+        assert "QUALIFIED:settings.json" not in lines
+
+    def test_claude_settings_true_qualifies(self, tmp_path) -> None:
+        (tmp_path / "settings.json").write_text(
+            '{"hasCompletedOnboarding": true}', encoding="utf-8"
+        )
+
+        command = _build_credential_check_command(
+            runtime_id="claude_code",
+            mount_path=str(tmp_path),
+            credential_paths=PROVIDER_CREDENTIAL_PATHS["claude_code"],
+        )
+
+        output = subprocess.check_output(["sh", "-c", command], text=True)
+
+        lines = output.splitlines()
+
+        assert "MISSING:credentials.json" in lines
+        assert "QUALIFIED:settings.json" in lines
+        assert "UNQUALIFIED:settings.json" not in lines
+
+    def test_claude_empty_identity_setting_does_not_qualify(
+        self, tmp_path
+    ) -> None:
+        (tmp_path / "settings.json").write_text(
+            '{"userEmail": ""}', encoding="utf-8"
+        )
+
+        command = _build_credential_check_command(
+            runtime_id="claude_code",
+            mount_path=str(tmp_path),
+            credential_paths=PROVIDER_CREDENTIAL_PATHS["claude_code"],
+        )
+
+        output = subprocess.check_output(["sh", "-c", command], text=True)
+
+        lines = output.splitlines()
+
+        assert "UNQUALIFIED:settings.json" in lines
+        assert "QUALIFIED:settings.json" not in lines
+
+    def test_claude_non_empty_identity_setting_qualifies(
+        self, tmp_path
+    ) -> None:
+        (tmp_path / "settings.json").write_text(
+            '{"userEmail": "operator@example.test"}', encoding="utf-8"
+        )
+
+        command = _build_credential_check_command(
+            runtime_id="claude_code",
+            mount_path=str(tmp_path),
+            credential_paths=PROVIDER_CREDENTIAL_PATHS["claude_code"],
+        )
+
+        output = subprocess.check_output(["sh", "-c", command], text=True)
+
+        lines = output.splitlines()
+
+        assert "QUALIFIED:settings.json" in lines
+        assert "UNQUALIFIED:settings.json" not in lines
 
 
 class TestVerifyVolumeCredentials:


### PR DESCRIPTION
Jira issue key: MM-480

Active MoonSpec feature path: specs/243-claude-oauth-verification

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_volume_verifiers.py tests/unit/api_service/api/routers/test_oauth_sessions.py
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
- git diff --check

Remaining risks:
- Hermetic integration tests were not run because this change is limited to credential-volume verification logic, OAuth finalization ordering, and unit-covered profile registration behavior; no compose-backed service boundary changed.
- Live Claude OAuth/provider verification was not run because it requires external credentials and an operator sign-in flow.
