### PR TITLE
[codex] Persist direct run input snapshots

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2757,7 +2757,7 @@ async def _persist_original_task_input_snapshot(
 async def _persist_original_task_input_snapshot_from_parameters(
     *,
     session: AsyncSession,
-    record,
+    record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
     user: User,
     parameters: Mapping[str, Any],
     attachment_refs: list[dict[str, Any]] | None = None,
@@ -3719,12 +3719,11 @@ async def create_execution(
         session=session,
         record=record,
         user=user,
-        parameters=dict(request.initial_parameters),
+        parameters=dict(getattr(record, "parameters", None) or {}),
         source_kind="create",
     )
     if snapshot_ref:
         await session.commit()
-    if isinstance(record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)):
         await session.refresh(record)
 
     return _serialize_execution(record, user=user)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2754,6 +2754,38 @@ async def _persist_original_task_input_snapshot(
     return completed.artifact_id
 
 
+async def _persist_original_task_input_snapshot_from_parameters(
+    *,
+    session: AsyncSession,
+    record,
+    user: User,
+    parameters: Mapping[str, Any],
+    attachment_refs: list[dict[str, Any]] | None = None,
+    source_kind: str,
+    source_workflow_id: str | None = None,
+    source_run_id: str | None = None,
+) -> str:
+    workflow_type_value = _enum_value(getattr(record, "workflow_type", None))
+    if workflow_type_value != "MoonMind.Run":
+        return ""
+    snapshot_payload, snapshot_task = _snapshot_source_payload_from_parameters(
+        parameters
+    )
+    if not snapshot_task:
+        return ""
+    return await _persist_original_task_input_snapshot(
+        session=session,
+        record=record,
+        user=user,
+        payload=snapshot_payload,
+        task_payload=snapshot_task,
+        attachment_refs=attachment_refs,
+        source_kind=source_kind,
+        source_workflow_id=source_workflow_id,
+        source_run_id=source_run_id,
+    )
+
+
 async def _attach_input_attachment_artifacts_to_execution(
     *,
     session: AsyncSession | None,
@@ -3683,6 +3715,18 @@ async def create_execution(
             },
         ) from exc
 
+    snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
+        session=session,
+        record=record,
+        user=user,
+        parameters=dict(request.initial_parameters),
+        source_kind="create",
+    )
+    if snapshot_ref:
+        await session.commit()
+    if isinstance(record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)):
+        await session.refresh(record)
+
     return _serialize_execution(record, user=user)
 
 
@@ -4136,22 +4180,17 @@ async def update_execution(
     refreshed_record = await service.describe_execution(response_workflow_id)
     snapshot_ref = ""
     if is_task_editing_update:
-        snapshot_payload, snapshot_task = _snapshot_source_payload_from_parameters(
-            dict(getattr(refreshed_record, "parameters", None) or {})
+        snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
+            session=session,
+            record=refreshed_record,
+            user=user,
+            parameters=dict(getattr(refreshed_record, "parameters", None) or {}),
+            source_kind=(
+                "rerun" if payload.update_name == "RequestRerun" else "edit"
+            ),
+            source_workflow_id=record.workflow_id,
+            source_run_id=getattr(record, "run_id", None),
         )
-        if snapshot_task:
-            snapshot_ref = await _persist_original_task_input_snapshot(
-                session=session,
-                record=refreshed_record,
-                user=user,
-                payload=snapshot_payload,
-                task_payload=snapshot_task,
-                source_kind=(
-                    "rerun" if payload.update_name == "RequestRerun" else "edit"
-                ),
-                source_workflow_id=record.workflow_id,
-                source_run_id=getattr(record, "run_id", None),
-            )
     if is_task_editing_update:
         accepted = bool(update_result.get("accepted", True))
         applied = str(update_result.get("applied") or "").strip() or None
@@ -4531,21 +4570,15 @@ async def rerun_execution(
             },
         ) from exc
 
-    snapshot_payload, snapshot_task = _snapshot_source_payload_from_parameters(
-        dict(initial_params)
+    snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
+        session=session,
+        record=record,
+        user=user,
+        parameters=dict(initial_params),
+        source_kind="rerun",
+        source_workflow_id=canonical.workflow_id,
+        source_run_id=canonical.run_id,
     )
-    snapshot_ref = ""
-    if snapshot_task:
-        snapshot_ref = await _persist_original_task_input_snapshot(
-            session=session,
-            record=record,
-            user=user,
-            payload=snapshot_payload,
-            task_payload=snapshot_task,
-            source_kind="rerun",
-            source_workflow_id=canonical.workflow_id,
-            source_run_id=canonical.run_id,
-        )
 
     canonical_workflow_id, alias_used = _canonicalize_execution_identifier(workflow_id)
     if alias_used:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,42 +1,27 @@
 [
   {
-    "id": 4157517883,
+    "id": 3133634364,
     "disposition": "addressed",
-    "rationale": "The minimal reduced-motion layer reset is satisfied by the current CSS selectors for __layer, __glow, and __companion, and the focused component contract test verifies all three are hidden."
+    "rationale": "Added an explicit TemporalExecutionRecord | TemporalExecutionCanonicalRecord type hint to the snapshot helper record parameter."
   },
   {
-    "id": 3126534193,
+    "id": 3133634368,
     "disposition": "addressed",
-    "rationale": "The current minimal reduced-motion CSS hides the beam layer, glow, and companion with animation disabled, opacity 0, and visibility hidden; verified by MaskedConicBorderBeam.test.tsx."
+    "rationale": "Moved session.refresh(record) inside the snapshot_ref block so it only runs after a persisted snapshot commit."
   },
   {
-    "id": 3126536200,
-    "disposition": "addressed",
-    "rationale": "Scoped the brighter minimal-mode border token to data-active=true and added a CSS contract assertion so inactive minimal beams retain the default border state."
-  },
-  {
-    "id": 4157520350,
+    "id": 4165735428,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary wrapper with no separate actionable feedback beyond discussion_r3126536200."
+    "rationale": "Review summary only; its actionable child comments were handled individually."
   },
   {
-    "id": 3128925097,
+    "id": 3133637367,
     "disposition": "addressed",
-    "rationale": "Inherited execution profiles now fall back to auto-selection when the parent runtime does not match the child runtime."
+    "rationale": "Changed direct-run snapshot creation to use parameters from the returned persisted record instead of the incoming request payload, preserving idempotency replay semantics."
   },
   {
-    "id": 4160334281,
+    "id": 4165738806,
     "disposition": "not-applicable",
-    "rationale": "Review summary comment only; the actionable runtime-compatibility feedback was handled in the code change."
-  },
-  {
-    "id": 3128933234,
-    "disposition": "addressed",
-    "rationale": "Inherited execution profiles are now validated against synced profile snapshots before being passed to child workflows."
-  },
-  {
-    "id": 4160343819,
-    "disposition": "not-applicable",
-    "rationale": "Review summary comment only; the actionable profile-validation feedback was handled in the code change."
+    "rationale": "Informational Codex review wrapper with no distinct actionable feedback beyond the child comment."
   }
 ]

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2102,6 +2102,77 @@ def test_create_execution_routes_directly_to_temporal(
     service.create_execution.assert_awaited_once()
 
 
+def test_create_execution_persists_task_input_snapshot_for_direct_run_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    record = _build_execution_record(has_task_input_snapshot=False)
+    record.parameters = {
+        "repository": "Moon/Mind",
+        "targetRuntime": "codex_cli",
+        "task": {
+            "title": "Direct run",
+            "instructions": "Implement the direct run.",
+        },
+    }
+    service.create_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=False)
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard, "temporal_task_editing_enabled", True
+    )
+
+    async def _persist_snapshot(**kwargs) -> str:
+        assert kwargs["payload"] == {
+            "repository": "Moon/Mind",
+            "targetRuntime": "codex_cli",
+            "requiredCapabilities": [],
+        }
+        assert kwargs["task_payload"] == {
+            "title": "Direct run",
+            "instructions": "Implement the direct run.",
+        }
+        assert kwargs["source_kind"] == "create"
+        target_record = kwargs["record"]
+        target_record.memo = {
+            **dict(target_record.memo or {}),
+            "task_input_snapshot_ref": "art_snapshot_direct",
+            "task_input_snapshot_version": 1,
+            "task_input_snapshot_source_kind": "create",
+        }
+        return "art_snapshot_direct"
+
+    persist_mock = AsyncMock(side_effect=_persist_snapshot)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._persist_original_task_input_snapshot",
+        persist_mock,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "workflowType": "MoonMind.Run",
+                "title": "Direct run",
+                "initialParameters": record.parameters,
+            },
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["taskInputSnapshot"]["available"] is True
+    assert body["taskInputSnapshot"]["artifactRef"] == "art_snapshot_direct"
+    assert body["actions"]["canUpdateInputs"] is True
+    persist_mock.assert_awaited_once()
+    session.commit.assert_awaited_once()
+
+
 def test_create_execution_enforces_idempotency(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2114,7 +2114,7 @@ def test_create_execution_persists_task_input_snapshot_for_direct_run_submission
         "targetRuntime": "codex_cli",
         "task": {
             "title": "Direct run",
-            "instructions": "Implement the direct run.",
+            "instructions": "Implement the persisted direct run.",
         },
     }
     service.create_execution.return_value = record
@@ -2136,7 +2136,7 @@ def test_create_execution_persists_task_input_snapshot_for_direct_run_submission
         }
         assert kwargs["task_payload"] == {
             "title": "Direct run",
-            "instructions": "Implement the direct run.",
+            "instructions": "Implement the persisted direct run.",
         }
         assert kwargs["source_kind"] == "create"
         target_record = kwargs["record"]
@@ -2160,7 +2160,14 @@ def test_create_execution_persists_task_input_snapshot_for_direct_run_submission
             json={
                 "workflowType": "MoonMind.Run",
                 "title": "Direct run",
-                "initialParameters": record.parameters,
+                "initialParameters": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex_cli",
+                    "task": {
+                        "title": "Conflicting retry",
+                        "instructions": "Do not snapshot the replay payload.",
+                    },
+                },
             },
         )
 
@@ -2171,6 +2178,7 @@ def test_create_execution_persists_task_input_snapshot_for_direct_run_submission
     assert body["actions"]["canUpdateInputs"] is True
     persist_mock.assert_awaited_once()
     session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(record)
 
 
 def test_create_execution_enforces_idempotency(

--- a/tests/unit/docs/test_dood_phase0_contract.py
+++ b/tests/unit/docs/test_dood_phase0_contract.py
@@ -54,10 +54,11 @@ def test_dood_glossary_and_scope_terms_remain_present() -> None:
         "workload container",
         "runner profile",
         "session-assisted workload",
-        "one-shot workload containers",
-        "bounded helper containers remain a later phase",
+        "one-shot workload tool",
+        "profile-backed helper containers remain explicitly owned",
         '`tool.type = "skill"`',
-        '`tool.type = "agent_runtime"`',
+        "`agent_runtime.*`",
+        "`moonmind.agentrun`",
     ):
         assert term in lowered
 

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -153,7 +153,7 @@ def test_pentest_scope_validation_accepts_authorized_scope() -> None:
         ({"approved_scope": None}, {}, "INVALID_SCOPE", "missing_approved_scope"),
         (
             {},
-            {"expires_at": datetime.now(UTC) - timedelta(days=1)},
+            {"expires_at": datetime(2026, 4, 22, 11, tzinfo=UTC)},
             "INVALID_SCOPE",
             "scope_expired",
         ),


### PR DESCRIPTION
## Summary

Fixes missing original task input snapshots for direct `MoonMind.Run` submissions created through the generic Temporal execution endpoint.

## Root Cause

The task-shaped create path persisted `task_input_snapshot_ref`, but the generic `CreateExecutionRequest` path created runs with `initialParameters.task` and returned without writing the original task input snapshot. Those runs later failed the backend Edit/Rerun capability gate with `original_task_input_snapshot_missing`.

## Changes

- Add a shared helper that persists original task input snapshots from execution parameters for `MoonMind.Run` records.
- Persist snapshots on the generic `POST /api/executions` create path.
- Reuse the helper for existing edit/rerun snapshot refresh paths.
- Add regression coverage for direct run submissions exposing an available task input snapshot and edit capability.

## Validation

- `.venv/bin/pytest tests/unit/api/routers/test_executions.py -q`
- `.venv/bin/pytest tests/contract/test_temporal_execution_api.py::test_task_shaped_create_returns_temporal_identity_and_redirect tests/contract/test_temporal_execution_api.py::test_task_shaped_create_preserves_image_input_attachments -q`
- `.venv/bin/python -m py_compile api_service/api/routers/executions.py tests/unit/api/routers/test_executions.py`
- `git diff --check -- api_service/api/routers/executions.py tests/unit/api/routers/test_executions.py`

Note: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` passed the Python execution-router suite but the wrapper also ran frontend Vitest and hit an unrelated timeout in `entrypoints/task-detail.test.tsx`.