### PR TITLE
There is wasted space to the right of the github repo in the floating bar on desktop. This space should be used to allow GitHub Repo, Branch, and publ

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,27 @@
 [
   {
-    "id": 3133634364,
-    "disposition": "addressed",
-    "rationale": "Added an explicit TemporalExecutionRecord | TemporalExecutionCanonicalRecord type hint to the snapshot helper record parameter."
-  },
-  {
-    "id": 3133634368,
-    "disposition": "addressed",
-    "rationale": "Moved session.refresh(record) inside the snapshot_ref block so it only runs after a persisted snapshot commit."
-  },
-  {
-    "id": 4165735428,
+    "id": 4166160843,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable child comments were handled individually."
+    "rationale": "Top-level Gemini summary review duplicated the actionable inline width feedback that is addressed below."
   },
   {
-    "id": 3133637367,
+    "id": 3133984746,
     "disposition": "addressed",
-    "rationale": "Changed direct-run snapshot creation to use parameters from the returned persisted record instead of the incoming request payload, preserving idempotency replay semantics."
+    "rationale": "Reduced desktop floating-bar grid minimums from 18/15/12rem to 12/10/8rem so the widened bar stays fluid on mid-width viewports."
   },
   {
-    "id": 4165738806,
+    "id": 3133984751,
+    "disposition": "addressed",
+    "rationale": "Updated the Create page CSS expectation test to match the relaxed 12/10/8rem floating-bar grid minimums."
+  },
+  {
+    "id": 3133987413,
+    "disposition": "addressed",
+    "rationale": "Restored shrinkable mid-width behavior by reducing the desktop column minimums rather than keeping overflow-prone fixed widths."
+  },
+  {
+    "id": 4166164127,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper with no distinct actionable feedback beyond the child comment."
+    "rationale": "Top-level Codex review wrapper contained no additional actionable feedback beyond the inline comment already addressed."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5781,10 +5781,10 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)[^}]*justify-content:\s*stretch/s,
+      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*84rem\)[^}]*justify-content:\s*stretch/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
+      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(18rem,\s*1\.65fr\)\s*minmax\(15rem,\s*1\.45fr\)\s*minmax\(12rem,\s*1fr\)\s*auto/s,
     );
     expect(missionControlCss).toMatch(
       /@media \(max-width:\s*640px\)\s*\{[^}]*\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5784,7 +5784,7 @@ describe("Task Create Entrypoint", () => {
       /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*84rem\)[^}]*justify-content:\s*stretch/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(18rem,\s*1\.65fr\)\s*minmax\(15rem,\s*1\.45fr\)\s*minmax\(12rem,\s*1fr\)\s*auto/s,
+      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(12rem,\s*1\.65fr\)\s*minmax\(10rem,\s*1\.45fr\)\s*minmax\(8rem,\s*1fr\)\s*auto/s,
     );
     expect(missionControlCss).toMatch(
       /@media \(max-width:\s*640px\)\s*\{[^}]*\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2483,7 +2483,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   bottom: 1.1rem;
   transform: translateX(-50%);
   z-index: 40;
-  width: min(100% - 1.5rem, 72rem);
+  width: min(100% - 1.5rem, 84rem);
   padding: 0.55rem 0.7rem;
   border-radius: 1.5rem;
   background: var(--mm-glass-fill);
@@ -2514,9 +2514,9 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .queue-floating-bar-row {
   display: grid;
   grid-template-columns:
-    minmax(0, 1.35fr)
-    minmax(0, 1.35fr)
-    minmax(9.5rem, 0.8fr)
+    minmax(18rem, 1.65fr)
+    minmax(15rem, 1.45fr)
+    minmax(12rem, 1fr)
     auto;
   gap: 0.5rem;
   align-items: center;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2514,9 +2514,9 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .queue-floating-bar-row {
   display: grid;
   grid-template-columns:
-    minmax(18rem, 1.65fr)
-    minmax(15rem, 1.45fr)
-    minmax(12rem, 1fr)
+    minmax(12rem, 1.65fr)
+    minmax(10rem, 1.45fr)
+    minmax(8rem, 1fr)
     auto;
   gap: 0.5rem;
   align-items: center;


### PR DESCRIPTION
There is wasted space to the right of the github repo in the floating bar on desktop. This space should be used to allow GitHub Repo, Branch, and publish mode dropdowns to be wider when the screen is wide.