### PR TITLE
[codex] Add provider terminal paste support

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,27 @@
 [
   {
-    "id": 3133634364,
+    "id": 3134339420,
     "disposition": "addressed",
-    "rationale": "Added an explicit TemporalExecutionRecord | TemporalExecutionCanonicalRecord type hint to the snapshot helper record parameter."
+    "rationale": "Removed the Ctrl/Cmd+V keydown interception so unsupported clipboard reads no longer block native paste delivery."
   },
   {
-    "id": 3133634368,
-    "disposition": "addressed",
-    "rationale": "Moved session.refresh(record) inside the snapshot_ref block so it only runs after a persisted snapshot commit."
-  },
-  {
-    "id": 4165735428,
+    "id": 4166572410,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable child comments were handled individually."
+    "rationale": "Top-level automated review wrapper only; the actionable inline feedback is tracked and handled separately."
   },
   {
-    "id": 3133637367,
+    "id": 3134340059,
     "disposition": "addressed",
-    "rationale": "Changed direct-run snapshot creation to use parameters from the returned persisted record instead of the incoming request payload, preserving idempotency replay semantics."
+    "rationale": "Keyboard paste now relies on the browser paste event, keeping clipboard-read permissions only for the explicit toolbar action."
   },
   {
-    "id": 4165738806,
+    "id": 3134340064,
+    "disposition": "addressed",
+    "rationale": "Replaced the obsolete Ctrl+V test with a regression asserting the shortcut is left unhandled for the native paste event path."
+  },
+  {
+    "id": 4166573078,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper with no distinct actionable feedback beyond the child comment."
+    "rationale": "Summary review comment with no separate actionable request beyond the inline feedback already addressed."
   }
 ]

--- a/frontend/src/entrypoints/oauth-terminal.test.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.test.tsx
@@ -169,23 +169,20 @@ describe('OAuthTerminalPage clipboard behavior', () => {
     );
   });
 
-  it('pastes clipboard text with Ctrl+V', async () => {
+  it('leaves Ctrl+V available for the browser paste event', async () => {
     renderPage();
-    const socket = await waitForSocket();
-    vi.stubGlobal('navigator', {
-      clipboard: {
-        readText: vi.fn(async () => 'clipboard-token'),
-      },
+    await waitForSocket();
+    const event = new KeyboardEvent('keydown', {
+      key: 'v',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
     });
     const terminalSurface = document.querySelector('.oauth-terminal-xterm') as HTMLElement;
 
-    fireEvent.keyDown(terminalSurface, { key: 'v', ctrlKey: true });
+    terminalSurface.dispatchEvent(event);
 
-    await waitFor(() =>
-      expect(socket.send).toHaveBeenCalledWith(
-        JSON.stringify({ type: 'input', data: 'clipboard-token' }),
-      ),
-    );
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it('copies selected terminal text with Ctrl+C instead of sending interrupt', async () => {

--- a/frontend/src/entrypoints/oauth-terminal.test.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.test.tsx
@@ -1,0 +1,247 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OAuthTerminalPage } from './oauth-terminal';
+import type { BootPayload } from '../boot/parseBootPayload';
+
+type TerminalDataHandler = (data: string) => void;
+
+const webSocketInstances: MockWebSocket[] = [];
+
+type MockTerminal = {
+  cols: number;
+  rows: number;
+  disposed: boolean;
+  dataHandler: TerminalDataHandler | null;
+  selection: string;
+  loadAddon: ReturnType<typeof vi.fn>;
+  open: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  writeln: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  getSelection: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+};
+
+const { terminalInstances } = vi.hoisted(() => ({
+  terminalInstances: [] as MockTerminal[],
+}));
+
+class MockWebSocket {
+  static OPEN = 1;
+
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+
+  constructor(public url: string) {
+    webSocketInstances.push(this);
+  }
+}
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    disposed = false;
+    dataHandler: TerminalDataHandler | null = null;
+    selection = '';
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn();
+    writeln = vi.fn();
+    dispose = vi.fn(() => {
+      this.disposed = true;
+    });
+    getSelection = vi.fn(() => this.selection);
+    onData = vi.fn((handler: TerminalDataHandler) => {
+      this.dataHandler = handler;
+      return { dispose: vi.fn() };
+    });
+
+    constructor() {
+      terminalInstances.push(this);
+    }
+  },
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+
+function renderPage() {
+  const payload: BootPayload = {
+    page: 'oauth-terminal',
+    apiBase: '/api',
+    initialData: { sessionId: 'session-1' },
+  };
+  render(<OAuthTerminalPage payload={payload} />);
+}
+
+function mockAttachFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL) => {
+      const href = String(url);
+      if (href.endsWith('/terminal/attach')) {
+        return new Response(
+          JSON.stringify({
+            session_id: 'session-1',
+            terminal_session_id: 'terminal-1',
+            terminal_bridge_id: 'bridge-1',
+            websocket_url: '/ws/oauth/terminal',
+            attach_token: 'attach-token',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          session_id: 'session-1',
+          status: 'bridge_ready',
+          terminal_session_id: 'terminal-1',
+          terminal_bridge_id: 'bridge-1',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }),
+  );
+}
+
+async function waitForSocket() {
+  await waitFor(() => expect(webSocketInstances).toHaveLength(1));
+  const socket = webSocketInstances[0];
+  if (!socket) {
+    throw new Error('Expected OAuth terminal WebSocket');
+  }
+  socket.onopen?.();
+  return socket;
+}
+
+function currentTerminal(): MockTerminal {
+  const terminal = terminalInstances[0];
+  if (!terminal) {
+    throw new Error('Expected OAuth terminal instance');
+  }
+  return terminal;
+}
+
+beforeEach(() => {
+  terminalInstances.length = 0;
+  webSocketInstances.length = 0;
+  mockAttachFetch();
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { origin: 'http://localhost', search: '' },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('OAuthTerminalPage clipboard behavior', () => {
+  it('forwards browser paste events to the terminal bridge', async () => {
+    renderPage();
+    const socket = await waitForSocket();
+    const terminalSurface = document.querySelector('.oauth-terminal-xterm') as HTMLElement;
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: vi.fn(() => 'oauth-code-123'),
+      },
+    });
+
+    terminalSurface.dispatchEvent(pasteEvent);
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'input', data: 'oauth-code-123' }),
+    );
+  });
+
+  it('pastes clipboard text with Ctrl+V', async () => {
+    renderPage();
+    const socket = await waitForSocket();
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        readText: vi.fn(async () => 'clipboard-token'),
+      },
+    });
+    const terminalSurface = document.querySelector('.oauth-terminal-xterm') as HTMLElement;
+
+    fireEvent.keyDown(terminalSurface, { key: 'v', ctrlKey: true });
+
+    await waitFor(() =>
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'input', data: 'clipboard-token' }),
+      ),
+    );
+  });
+
+  it('copies selected terminal text with Ctrl+C instead of sending interrupt', async () => {
+    renderPage();
+    const socket = await waitForSocket();
+    const terminal = currentTerminal();
+    terminal.selection = 'selected text';
+    const writeText = vi.fn(async () => undefined);
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText,
+      },
+    });
+    const terminalSurface = document.querySelector('.oauth-terminal-xterm') as HTMLElement;
+
+    fireEvent.keyDown(terminalSurface, { key: 'c', ctrlKey: true });
+
+    expect(writeText).toHaveBeenCalledWith('selected text');
+    expect(socket.send).not.toHaveBeenCalledWith(
+      JSON.stringify({ type: 'input', data: '\u0003' }),
+    );
+  });
+
+  it('leaves Ctrl+C available for terminal input when no text is selected', async () => {
+    renderPage();
+    await waitForSocket();
+    const terminal = currentTerminal();
+    const event = new KeyboardEvent('keydown', {
+      key: 'c',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const terminalSurface = document.querySelector('.oauth-terminal-xterm') as HTMLElement;
+
+    terminalSurface.dispatchEvent(event);
+    terminal.dataHandler?.('\u0003');
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('pastes clipboard text from the toolbar button', async () => {
+    renderPage();
+    const socket = await waitForSocket();
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        readText: vi.fn(async () => 'button-paste'),
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Paste from clipboard' }));
+
+    await waitFor(() =>
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'input', data: 'button-paste' }),
+      ),
+    );
+  });
+});

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -280,10 +280,6 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
         copyTextToClipboard(selectedText);
         return;
       }
-      if (key === 'v') {
-        event.preventDefault();
-        void pasteClipboardToTerminal();
-      }
     };
     terminalElement.addEventListener('keydown', keydownListener);
     const contextMenuListener = (event: MouseEvent) => {

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -97,6 +97,22 @@ function copyTextToClipboard(text: string): void {
   }
 }
 
+async function readTextFromClipboard(): Promise<string> {
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.clipboard ||
+    typeof navigator.clipboard.readText !== 'function'
+  ) {
+    return '';
+  }
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    // Browser clipboard permissions vary; native paste events remain the fallback path.
+    return '';
+  }
+}
+
 function readSessionId(payload: BootPayload): string {
   const initialData = payload.initialData as OAuthTerminalInitialData | undefined;
   if (initialData?.sessionId) {
@@ -160,11 +176,26 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
   const fitAddonRef = useRef<FitAddon | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
 
+  const sendTerminalInput = (data: string) => {
+    if (!data) {
+      return;
+    }
+    const socket = socketRef.current;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'input', data }));
+    }
+  };
+
   const copyTerminalSelection = () => {
     const selectedText = terminalRef.current?.getSelection() ?? '';
     if (selectedText) {
       copyTextToClipboard(selectedText);
     }
+  };
+
+  const pasteClipboardToTerminal = async () => {
+    const text = await readTextFromClipboard();
+    sendTerminalInput(text);
   };
 
   useEffect(() => {
@@ -225,6 +256,36 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       event.clipboardData.setData('text/plain', selectedText);
     };
     terminalElement.addEventListener('copy', copySelectionListener);
+    const pasteListener = (event: ClipboardEvent) => {
+      const pastedText = event.clipboardData?.getData('text/plain') ?? '';
+      if (!pastedText) {
+        return;
+      }
+      event.preventDefault();
+      sendTerminalInput(pastedText);
+    };
+    terminalElement.addEventListener('paste', pasteListener);
+    const keydownListener = (event: KeyboardEvent) => {
+      const usesShortcutModifier = event.metaKey || event.ctrlKey;
+      if (!usesShortcutModifier) {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key === 'c') {
+        const selectedText = terminal.getSelection();
+        if (!selectedText) {
+          return;
+        }
+        event.preventDefault();
+        copyTextToClipboard(selectedText);
+        return;
+      }
+      if (key === 'v') {
+        event.preventDefault();
+        void pasteClipboardToTerminal();
+      }
+    };
+    terminalElement.addEventListener('keydown', keydownListener);
     const contextMenuListener = (event: MouseEvent) => {
       const selectedText = terminal.getSelection();
       if (!selectedText) {
@@ -261,6 +322,8 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       return () => {
         window.removeEventListener('resize', resizeListener);
         terminalElement.removeEventListener('copy', copySelectionListener);
+        terminalElement.removeEventListener('paste', pasteListener);
+        terminalElement.removeEventListener('keydown', keydownListener);
         terminalElement.removeEventListener('contextmenu', contextMenuListener);
         terminal.dispose();
         terminalRef.current = null;
@@ -270,10 +333,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
 
     let closed = false;
     const inputDisposable = terminal.onData((data) => {
-      const socket = socketRef.current;
-      if (socket?.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({ type: 'input', data }));
-      }
+      sendTerminalInput(data);
     });
 
     const writeSocketMessage = (message: MessageEvent) => {
@@ -368,6 +428,8 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       closed = true;
       window.removeEventListener('resize', resizeListener);
       terminalElement.removeEventListener('copy', copySelectionListener);
+      terminalElement.removeEventListener('paste', pasteListener);
+      terminalElement.removeEventListener('keydown', keydownListener);
       terminalElement.removeEventListener('contextmenu', contextMenuListener);
       inputDisposable.dispose();
       socketRef.current?.close();
@@ -388,6 +450,9 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
         <div className="oauth-terminal-actions">
           <button type="button" className="secondary" onClick={copyTerminalSelection}>
             Copy selection
+          </button>
+          <button type="button" className="secondary" onClick={pasteClipboardToTerminal}>
+            Paste from clipboard
           </button>
           <span className="oauth-terminal-status">{status}</span>
         </div>


### PR DESCRIPTION
## Summary

- Adds paste support to the provider OAuth login terminal via browser paste events, Ctrl/Cmd+V, and a toolbar button.
- Keeps Ctrl/Cmd+C available for copy when terminal text is selected while preserving terminal interrupt behavior when no text is selected.
- Adds focused Vitest coverage for copy/paste bridge behavior.

## Validation

- npm run ui:test -- entrypoints/oauth-terminal.test.tsx
- npm run ui:typecheck
- npm run ui:lint -- frontend/src/entrypoints/oauth-terminal.tsx frontend/src/entrypoints/oauth-terminal.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
