### PR TITLE
MM-494 Align MoonSpec artifacts for report presentation

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/245-publish-report-bundles"
+  "feature_directory": "specs/230-mission-control-report-presentation"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-488",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1718"
+  "jira_issue_key": "MM-494",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1723"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,47 @@
 [
   {
-    "id": 3134202207,
+    "id": 4166704069,
     "disposition": "addressed",
-    "rationale": "Converted _apply_oauth_home_runtime_env to a static method because it does not use instance state."
+    "rationale": "Aligned the resumed MM-494 feature artifacts so the branch metadata and source coverage IDs now match the current Jira brief across plan, tasks, quickstart, research, spec, and verification."
   },
   {
-    "id": 4166409108,
+    "id": 3134446176,
+    "disposition": "addressed",
+    "rationale": "Updated plan branch metadata to the current MM-494 PR head branch in specs/230-mission-control-report-presentation/plan.md."
+  },
+  {
+    "id": 3134446179,
+    "disposition": "addressed",
+    "rationale": "Replaced the stale plan requirement-status DESIGN-REQ rows with the MM-494 coverage IDs DESIGN-REQ-005/014/015/016."
+  },
+  {
+    "id": 3134446182,
+    "disposition": "addressed",
+    "rationale": "Updated the quickstart traceability command to check the MM-494 coverage IDs DESIGN-REQ-005/014/015/016."
+  },
+  {
+    "id": 3134446197,
+    "disposition": "addressed",
+    "rationale": "Updated the research section headers to use the MM-494 coverage IDs instead of the prior MM-462-era ID set."
+  },
+  {
+    "id": 3134446201,
+    "disposition": "addressed",
+    "rationale": "Updated the tasks source-traceability summary and requirement-status summary to the MM-494 coverage IDs."
+  },
+  {
+    "id": 3134446204,
+    "disposition": "addressed",
+    "rationale": "Updated the T019 traceability gate command in tasks.md to check the MM-494 coverage IDs."
+  },
+  {
+    "id": 4166705870,
     "disposition": "not-applicable",
-    "rationale": "Summary review only; the only actionable feedback in the review was the inline static-method refactor, which is addressed separately."
+    "rationale": "This top-level Codex review body is generic wrapper text; the actionable inline traceability comment was addressed separately in comment 3134447700."
+  },
+  {
+    "id": 3134447700,
+    "disposition": "addressed",
+    "rationale": "Aligned the traceability gate with the canonical MM-494 coverage IDs in tasks.md and quickstart.md and verified it with rg."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md
@@ -1,0 +1,82 @@
+# MM-494 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-494
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Surface canonical reports in Mission Control
+- Labels:
+  - `moonmind-workflow-mm-1f7a8be1-a624-482c-bcb5-4a86e5ab4b1b`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-494 from MM project
+Summary: Surface canonical reports in Mission Control
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-494 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-494: Surface canonical reports in Mission Control
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections:
+  - 12 Presentation rules
+  - 13 Relationship to observability and diagnostics
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-016
+
+User Story
+As a Mission Control user, I want executions with canonical reports to show a report-first surface with related evidence so I can inspect the deliverable without hunting through raw artifacts or logs.
+
+Acceptance Criteria
+- Executions with a canonical `report.primary` show a Report panel or top-level report card before the generic artifact list.
+- The report surface shows summary metadata and an open action for the default read target.
+- Linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content.
+- Artifacts, stdout, stderr, diagnostics, and other observability surfaces remain accessible outside the report panel.
+- Viewer choice uses `default_read_ref`, `render_hint`, `content_type`, and `metadata.name` or `metadata.title`.
+- Markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts follow the documented renderer behavior.
+- Evidence artifacts remain individually addressable and viewable rather than being collapsed into the primary report by default.
+- When no `report.primary` exists, Mission Control falls back to the existing artifact list behavior.
+
+Requirements
+- Add report-first execution detail presentation.
+- Use existing artifact presentation contracts for default reads and viewer selection.
+- Present related evidence separately from operational logs and diagnostics.
+
+Relevant Implementation Notes
+- Preserve MM-494 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Artifacts/ReportArtifacts.md` as the design reference for report presentation rules and the relationship between reports, observability, and diagnostics.
+- Prioritize a report-first execution detail surface when canonical report artifacts are present.
+- Keep the generic artifact list and observability surfaces accessible outside the report panel rather than replacing them.
+- Use existing artifact presentation contracts to choose the default read target and renderer behavior.
+- Show related `report.summary`, `report.structured`, and `report.evidence` artifacts as associated report content without collapsing evidence into the primary report by default.
+- Support documented renderer behavior across markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts.
+- Fall back cleanly to the existing artifact-list behavior when no canonical `report.primary` artifact exists.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-494 is blocked by MM-495, whose embedded status is Backlog.
+- Trusted Jira link metadata at fetch time shows MM-494 is related to MM-493 via a Blocks link where MM-494 blocks MM-493; MM-493 is not a blocker for this story.
+
+Validation
+- Verify executions with canonical `report.primary` artifacts surface a report panel or top-level report card before the generic artifact list.
+- Verify the report surface shows summary metadata and an open action for the default read target.
+- Verify linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content.
+- Verify artifacts, stdout, stderr, diagnostics, and other observability surfaces remain accessible outside the report panel.
+- Verify viewer choice follows `default_read_ref`, `render_hint`, `content_type`, and `metadata.name` or `metadata.title`.
+- Verify markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts follow the documented renderer behavior.
+- Verify evidence artifacts remain individually addressable and are not collapsed into the primary report by default.
+- Verify execution detail falls back to the existing artifact list behavior when no canonical `report.primary` exists.
+
+Needs Clarification
+- None

--- a/specs/230-mission-control-report-presentation/checklists/requirements.md
+++ b/specs/230-mission-control-report-presentation/checklists/requirements.md
@@ -36,4 +36,4 @@
 
 ## Notes
 
-- Specification preserves MM-462 traceability and maps all in-scope DESIGN-REQ IDs from the Jira preset brief.
+- Specification preserves MM-494 traceability while reusing the existing single-story report-presentation artifacts for the same runtime behavior.

--- a/specs/230-mission-control-report-presentation/checklists/requirements.md
+++ b/specs/230-mission-control-report-presentation/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Mission Control Report Presentation
+# Specification Quality Checklist: Surface Canonical Reports in Mission Control
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-04-22

--- a/specs/230-mission-control-report-presentation/contracts/mission-control-report-presentation.md
+++ b/specs/230-mission-control-report-presentation/contracts/mission-control-report-presentation.md
@@ -1,4 +1,4 @@
-# Contract: Mission Control Report Presentation
+# Contract: Surface Canonical Reports in Mission Control
 
 ## Latest Primary Report Query
 

--- a/specs/230-mission-control-report-presentation/data-model.md
+++ b/specs/230-mission-control-report-presentation/data-model.md
@@ -1,4 +1,4 @@
-# Data Model: Mission Control Report Presentation
+# Data Model: Surface Canonical Reports in Mission Control
 
 ## Report Presentation
 

--- a/specs/230-mission-control-report-presentation/plan.md
+++ b/specs/230-mission-control-report-presentation/plan.md
@@ -11,20 +11,20 @@ The existing Mission Control report-presentation implementation already satisfie
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | implemented_unverified | `api_service/api/routers/temporal_artifacts.py` accepts `link_type` and `latest_only`; `TemporalArtifactService.list_for_execution` uses `latest_for_execution_link`. | Use this query from Mission Control and add contract/UI coverage. | unit + contract |
-| FR-002 | missing | `frontend/src/entrypoints/task-detail.tsx` shows Summary, Steps, Timeline, then Artifacts; no report-first panel exists. | Add report-first panel before Timeline/Artifacts. | frontend unit |
-| FR-003 | partial | Artifact list payload includes links/metadata, but frontend schema discards links/default read refs and does not group report content. | Parse links/default read refs and render related report content. | frontend unit |
-| FR-004 | implemented_unverified | Existing sections preserve Artifacts, Timeline, stdout/stderr/diagnostics, run summary, and session panels. | Ensure report panel is additive and tests assert generic artifacts remain visible. | frontend unit |
-| FR-005 | partial | `artifactDownloadHref` uses download URL or artifact ID only; no report viewer target helper reads `default_read_ref`, `render_hint`, or content metadata. | Add viewer target/label helper based on artifact presentation fields. | frontend unit |
-| FR-006 | implemented_unverified | Artifact list endpoint serializes metadata and links from normal artifact rows; no separate report store exists. | Keep report UI as read model over existing artifact responses. | contract + frontend unit |
-| FR-007 | missing | UI currently fetches all artifacts and would need local filtering for report identity. | Query `link_type=report.primary&latest_only=true`; do not infer canonical report from arbitrary artifacts. | frontend unit |
-| FR-008 | implemented_unverified | MM-494 preserved in `spec.md` and orchestration input. | Preserve through plan, tasks, verification, and code/test names where practical. | traceability check |
-| DESIGN-REQ-011 | implemented_unverified | Server latest-report query exists for execution/link type. | Consume latest query from UI and test query URL. | frontend unit |
-| DESIGN-REQ-012 | partial | Generic surfaces exist; report panel and related evidence section do not. | Add report panel and related content. | frontend unit |
-| DESIGN-REQ-013 | partial | API serializes `default_read_ref`; UI does not parse/use it. | Parse presentation fields and choose open target/label. | frontend unit |
-| DESIGN-REQ-014 | missing | No report-first UX in task detail. | Render report before generic artifacts. | frontend unit |
-| DESIGN-REQ-020 | partial | Generic observability surfaces exist; evidence is not report-related. | Keep evidence individually openable while preserving observability sections. | frontend unit |
-| DESIGN-REQ-022 | implemented_unverified | Existing endpoint is a read model over artifacts; optional projection not needed for this slice. | Use existing endpoint only. | contract |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/task-detail.tsx` queries `link_type=report.primary&latest_only=true`; `tests/contract/test_temporal_artifact_api.py` verifies the existing artifact endpoint contract. | No additional plan work; preserve existing verified behavior. | unit + contract |
+| FR-002 | implemented_verified | `ReportPresentationSection` renders before Timeline and Artifacts; `frontend/src/entrypoints/task-detail.test.tsx` asserts Report appears before Artifacts. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| FR-003 | implemented_verified | Frontend artifact normalization preserves links and renders related report content with open actions. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| FR-004 | implemented_verified | Generic Artifacts and observability surfaces remain rendered; fallback tests verify generic artifacts still show without report fabrication. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| FR-005 | implemented_verified | `reportOpenHref` and `reportViewerLabel` honor `default_read_ref`, `download_url`, `render_hint`, `content_type`, and metadata title/name. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| FR-006 | implemented_verified | Implementation consumes the existing artifact endpoint/read model only; no new storage or mutation route was added. | No additional plan work; preserve existing verified behavior. | unit + contract |
+| FR-007 | implemented_verified | Report section renders only when latest report response contains an actual `report.primary` link. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| FR-008 | implemented_verified | MM-494 is preserved in `spec.md`, `plan.md`, `tasks.md`, `quickstart.md`, `verification.md`, and the orchestration input. | No additional plan work; preserve traceability across resumed artifacts. | traceability check |
+| DESIGN-REQ-011 | implemented_verified | Latest report query remains server-side through `link_type=report.primary&latest_only=true`. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-012 | implemented_verified | Report section includes canonical report and related report content while preserving generic artifacts and observability. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-013 | implemented_verified | Viewer/open helpers honor artifact presentation fields. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-014 | implemented_verified | Report-first UI appears before generic artifact inspection. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-020 | implemented_verified | Related evidence remains individually openable and generic observability remains separate. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-022 | implemented_verified | Existing artifact endpoint remains a read model over artifacts; no report-specific storage plane was introduced. | No additional plan work; preserve existing verified behavior. | contract |
 
 ## Technical Context
 

--- a/specs/230-mission-control-report-presentation/plan.md
+++ b/specs/230-mission-control-report-presentation/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Surface Canonical Reports in Mission Control
 
-**Branch**: `run-jira-orchestrate-for-mm-462-mission-67b1d4e7` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)
+**Branch**: `mm-494-1c104bae` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)
 **Input**: Single-story feature specification from `specs/230-mission-control-report-presentation/spec.md`
 
 ## Summary
@@ -19,12 +19,10 @@ The existing Mission Control report-presentation implementation already satisfie
 | FR-006 | implemented_verified | Implementation consumes the existing artifact endpoint/read model only; no new storage or mutation route was added. | No additional plan work; preserve existing verified behavior. | unit + contract |
 | FR-007 | implemented_verified | Report section renders only when latest report response contains an actual `report.primary` link. | No additional plan work; preserve existing verified behavior. | frontend unit |
 | FR-008 | implemented_verified | MM-494 is preserved in `spec.md`, `plan.md`, `tasks.md`, `quickstart.md`, `verification.md`, and the orchestration input. | No additional plan work; preserve traceability across resumed artifacts. | traceability check |
-| DESIGN-REQ-011 | implemented_verified | Latest report query remains server-side through `link_type=report.primary&latest_only=true`. | No additional plan work; preserve existing verified behavior. | frontend unit |
-| DESIGN-REQ-012 | implemented_verified | Report section includes canonical report and related report content while preserving generic artifacts and observability. | No additional plan work; preserve existing verified behavior. | frontend unit |
-| DESIGN-REQ-013 | implemented_verified | Viewer/open helpers honor artifact presentation fields. | No additional plan work; preserve existing verified behavior. | frontend unit |
-| DESIGN-REQ-014 | implemented_verified | Report-first UI appears before generic artifact inspection. | No additional plan work; preserve existing verified behavior. | frontend unit |
-| DESIGN-REQ-020 | implemented_verified | Related evidence remains individually openable and generic observability remains separate. | No additional plan work; preserve existing verified behavior. | frontend unit |
-| DESIGN-REQ-022 | implemented_verified | Existing artifact endpoint remains a read model over artifacts; no report-specific storage plane was introduced. | No additional plan work; preserve existing verified behavior. | contract |
+| DESIGN-REQ-005 | implemented_verified | Latest report query and report-first presentation use the existing `report.primary` artifact path instead of browser-side inference. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-014 | implemented_verified | Report section includes canonical report and related report content before generic artifact inspection. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-015 | implemented_verified | Viewer/open helpers honor `default_read_ref`, `render_hint`, `content_type`, and metadata title/name. | No additional plan work; preserve existing verified behavior. | frontend unit |
+| DESIGN-REQ-016 | implemented_verified | Evidence remains individually openable, observability stays separate, and the existing artifact endpoint remains the read-model boundary. | No additional plan work; preserve existing verified behavior. | frontend unit + contract |
 
 ## Technical Context
 

--- a/specs/230-mission-control-report-presentation/plan.md
+++ b/specs/230-mission-control-report-presentation/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-462 by extending Mission Control's task detail surface to query the server for the latest `report.primary` artifact, present that canonical report before the generic artifact list, show related report summary/structured/evidence artifacts as report content, and choose open/download targets from artifact presentation metadata. Backend artifact APIs already expose execution-scoped filtering with `link_type` and `latest_only`; the primary implementation work is frontend parsing, report presentation, and focused UI tests with an API contract regression.
+The existing Mission Control report-presentation implementation already satisfies the MM-494 runtime story. This resumed plan preserves MM-494 as the canonical Jira source brief, reuses the verified implementation in `frontend/src/entrypoints/task-detail.tsx` and its tests, and limits current work to source-traceability alignment rather than reopening implementation.
 
 ## Requirement Status
 
@@ -18,7 +18,7 @@ Implement MM-462 by extending Mission Control's task detail surface to query the
 | FR-005 | partial | `artifactDownloadHref` uses download URL or artifact ID only; no report viewer target helper reads `default_read_ref`, `render_hint`, or content metadata. | Add viewer target/label helper based on artifact presentation fields. | frontend unit |
 | FR-006 | implemented_unverified | Artifact list endpoint serializes metadata and links from normal artifact rows; no separate report store exists. | Keep report UI as read model over existing artifact responses. | contract + frontend unit |
 | FR-007 | missing | UI currently fetches all artifacts and would need local filtering for report identity. | Query `link_type=report.primary&latest_only=true`; do not infer canonical report from arbitrary artifacts. | frontend unit |
-| FR-008 | implemented_unverified | MM-462 preserved in `spec.md` and orchestration input. | Preserve through plan, tasks, verification, and code/test names where practical. | traceability check |
+| FR-008 | implemented_unverified | MM-494 preserved in `spec.md` and orchestration input. | Preserve through plan, tasks, verification, and code/test names where practical. | traceability check |
 | DESIGN-REQ-011 | implemented_unverified | Server latest-report query exists for execution/link type. | Consume latest query from UI and test query URL. | frontend unit |
 | DESIGN-REQ-012 | partial | Generic surfaces exist; report panel and related evidence section do not. | Add report panel and related content. | frontend unit |
 | DESIGN-REQ-013 | partial | API serializes `default_read_ref`; UI does not parse/use it. | Parse presentation fields and choose open target/label. | frontend unit |
@@ -52,7 +52,7 @@ Implement MM-462 by extending Mission Control's task detail surface to query the
 - VII. Runtime Configurability: PASS. Uses existing configured API endpoints.
 - VIII. Modular and Extensible Architecture: PASS. Changes stay in task detail UI and artifact API contract.
 - IX. Resilient by Default: PASS. Report identity comes from durable artifact links, not browser heuristics.
-- X. Facilitate Continuous Improvement: PASS. Verification will produce traceable MM-462 evidence.
+- X. Facilitate Continuous Improvement: PASS. Verification preserves traceable MM-494 evidence for the resumed feature artifacts.
 - XI. Spec-Driven Development: PASS. Spec, plan, tasks, and verification drive work.
 - XII. Canonical Documentation Separation: PASS. Orchestration input remains under `docs/tmp`.
 - XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or internal semantic transforms are introduced.

--- a/specs/230-mission-control-report-presentation/plan.md
+++ b/specs/230-mission-control-report-presentation/plan.md
@@ -1,4 +1,4 @@
-# Implementation Plan: Mission Control Report Presentation
+# Implementation Plan: Surface Canonical Reports in Mission Control
 
 **Branch**: `run-jira-orchestrate-for-mm-462-mission-67b1d4e7` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)
 **Input**: Single-story feature specification from `specs/230-mission-control-report-presentation/spec.md`

--- a/specs/230-mission-control-report-presentation/quickstart.md
+++ b/specs/230-mission-control-report-presentation/quickstart.md
@@ -42,5 +42,5 @@ Run only if backend artifact behavior changes beyond the existing read-only quer
 ## Traceability Check
 
 ```bash
-rg -n "MM-494|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md
+rg -n "MM-494|DESIGN-REQ-005|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-016" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md
 ```

--- a/specs/230-mission-control-report-presentation/quickstart.md
+++ b/specs/230-mission-control-report-presentation/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart: Mission Control Report Presentation
+# Quickstart: Surface Canonical Reports in Mission Control
 
 ## Focused Frontend Validation
 

--- a/specs/230-mission-control-report-presentation/quickstart.md
+++ b/specs/230-mission-control-report-presentation/quickstart.md
@@ -42,5 +42,5 @@ Run only if backend artifact behavior changes beyond the existing read-only quer
 ## Traceability Check
 
 ```bash
-rg -n "MM-462|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-462-moonspec-orchestration-input.md
+rg -n "MM-494|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md
 ```

--- a/specs/230-mission-control-report-presentation/research.md
+++ b/specs/230-mission-control-report-presentation/research.md
@@ -1,6 +1,6 @@
 # Research: Surface Canonical Reports in Mission Control
 
-## FR-001 / DESIGN-REQ-011 - Server-Driven Latest Report
+## FR-001 / DESIGN-REQ-005 - Server-Driven Latest Report
 
 Decision: Use the existing execution artifact endpoint with `link_type=report.primary&latest_only=true` to identify the canonical final report.
 Evidence: `api_service/api/routers/temporal_artifacts.py` exposes `link_type` and `latest_only`; `moonmind/workflows/temporal/artifacts.py` routes latest lookup through `latest_for_execution_link`.
@@ -16,7 +16,7 @@ Rationale: A dedicated report region makes the canonical report visible before g
 Alternatives considered: Highlight report rows inside the existing artifact table. Rejected because the story requires report-first presentation before generic artifact inspection.
 Test implications: Frontend unit test asserting Report appears before Artifacts.
 
-## FR-003 / DESIGN-REQ-012 / DESIGN-REQ-020 - Related Report Content
+## FR-003 / DESIGN-REQ-014 / DESIGN-REQ-016 - Related Report Content
 
 Decision: Parse artifact links and metadata in the frontend schema, then derive related report content from existing artifact list rows with `report.summary`, `report.structured`, or `report.evidence` links.
 Evidence: `ArtifactMetadataModel` includes `links`, `metadata`, `default_read_ref`, and `download_url`; current frontend schema only normalizes basic artifact fields.
@@ -32,7 +32,7 @@ Rationale: Curated reports must complement observability, not replace it.
 Alternatives considered: Move artifacts into the report panel. Rejected because generic artifacts must remain accessible for non-report deliverables and diagnostics.
 Test implications: Existing task detail tests plus a report test that still finds the Artifacts section.
 
-## FR-005 / DESIGN-REQ-013 - Viewer Target Selection
+## FR-005 / DESIGN-REQ-015 - Viewer Target Selection
 
 Decision: Add frontend helpers that choose report open targets from `default_read_ref` first, then explicit download URL, then artifact ID; label the viewer from `render_hint`, `content_type`, `metadata.name`, and `metadata.title`.
 Evidence: API metadata includes `default_read_ref`; existing `artifactDownloadHref` uses only download URL or artifact ID.
@@ -40,7 +40,7 @@ Rationale: The UI can honor preview/raw read policy while keeping the first impl
 Alternatives considered: Build full inline renderers for every content type. Rejected because the source allows binary/download behavior and this story focuses on presentation and openability.
 Test implications: Frontend unit tests for default-read-ref target and content-type labels.
 
-## FR-006 / DESIGN-REQ-022 - Read Model Boundary
+## FR-006 / DESIGN-REQ-016 - Read Model Boundary
 
 Decision: Treat report presentation as a read model over normal artifact metadata; do not add storage, mutation routes, or report-specific tables.
 Evidence: `ArtifactMetadataModel` and execution artifact listing already provide the needed data.

--- a/specs/230-mission-control-report-presentation/research.md
+++ b/specs/230-mission-control-report-presentation/research.md
@@ -56,10 +56,10 @@ Rationale: The source forbids local report identity heuristics.
 Alternatives considered: Guess from `metadata.report_type`, filenames, or content type. Rejected as explicitly forbidden.
 Test implications: Frontend fallback test with generic artifacts and empty latest report response.
 
-## FR-008 - MM-462 Traceability
+## FR-008 - MM-494 Traceability
 
-Decision: Preserve MM-462 in MoonSpec artifacts and verification evidence.
-Evidence: `spec.md` and this plan include MM-462.
-Rationale: Jira traceability is required by the orchestration input.
-Alternatives considered: None.
+Decision: Preserve MM-494 in the resumed MoonSpec artifacts and verification evidence while keeping the already-completed runtime story and implementation evidence under `specs/230-mission-control-report-presentation`.
+Evidence: `spec.md`, `plan.md`, `tasks.md`, `verification.md`, and `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` include MM-494.
+Rationale: The current Jira orchestration input requires MM-494 traceability, and the existing feature directory already covers the same independently testable runtime behavior.
+Alternatives considered: Open a duplicate feature directory for MM-494. Rejected because the story was already fully specified, implemented, and verified under the existing feature directory.
 Test implications: Traceability grep in quickstart/final verification.

--- a/specs/230-mission-control-report-presentation/research.md
+++ b/specs/230-mission-control-report-presentation/research.md
@@ -1,4 +1,4 @@
-# Research: Mission Control Report Presentation
+# Research: Surface Canonical Reports in Mission Control
 
 ## FR-001 / DESIGN-REQ-011 - Server-Driven Latest Report
 

--- a/specs/230-mission-control-report-presentation/spec.md
+++ b/specs/230-mission-control-report-presentation/spec.md
@@ -1,141 +1,120 @@
-# Feature Specification: Mission Control Report Presentation
+# Feature Specification: Surface Canonical Reports in Mission Control
 
 **Feature Branch**: `230-mission-control-report-presentation`
 **Created**: 2026-04-22
 **Status**: Draft
-**Input**:
+**Input**: User description: "Use the Jira preset brief for MM-494 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: existing feature directory `specs/230-mission-control-report-presentation` already matched the MM-494 story scope, so this run resumed from the completed artifact set and aligned source traceability instead of regenerating later-stage artifacts.
+
+## Original Preset Brief
 
 ```text
-Jira issue: MM-462 from MM project
-Summary: Mission Control Report Presentation
+# MM-494 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-494
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Surface canonical reports in Mission Control
+- Labels:
+  - `moonmind-workflow-mm-1f7a8be1-a624-482c-bcb5-4a86e5ab4b1b`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-494 from MM project
+Summary: Surface canonical reports in Mission Control
 Issue type: Story
 Current Jira status: In Progress
 Jira project key: MM
 
-Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-462 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-494 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
 
-MM-462: Mission Control Report Presentation
-
-Short Name
-mission-control-report-presentation
+MM-494: Surface canonical reports in Mission Control
 
 Source Reference
 - Source document: `docs/Artifacts/ReportArtifacts.md`
 - Source title: Report Artifacts
-- Source sections: 11.4 Latest report semantics, 12. Presentation rules, 12.1 Primary UI surfaces, 12.2 Default read behavior, 12.3 Recommended renderer behavior, 12.4 Report-first UX rule, 12.5 Evidence presentation, 18. Suggested API/UI extensions
-- Coverage IDs: DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, DESIGN-REQ-022
+- Source sections:
+  - 12 Presentation rules
+  - 13 Relationship to observability and diagnostics
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-016
 
 User Story
-As an operator, I can open an execution with a final report and see the canonical report, related evidence, and normal observability surfaces without guessing which generic artifact matters.
+As a Mission Control user, I want executions with canonical reports to show a report-first surface with related evidence so I can inspect the deliverable without hunting through raw artifacts or logs.
 
 Acceptance Criteria
-- Given an execution has a canonical `report.primary` artifact, then Mission Control shows a report panel or top-level report card before requiring inspection of the generic artifact list.
-- Given linked `report.summary`, `report.structured`, or `report.evidence` artifacts exist, then they are shown as related report content and remain individually openable where access permits.
-- Given no `report.primary` artifact exists, then the UI falls back to the normal artifact list without fabricating report status from local heuristics.
-- Viewer selection uses `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title`, including appropriate markdown, JSON, text, diff, image, PDF, and binary handling.
-- Latest report selection comes from server query behavior or a projection field, not browser-side sorting of arbitrary artifacts.
+- Executions with a canonical `report.primary` show a Report panel or top-level report card before the generic artifact list.
+- The report surface shows summary metadata and an open action for the default read target.
+- Linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content.
+- Artifacts, stdout, stderr, diagnostics, and other observability surfaces remain accessible outside the report panel.
+- Viewer choice uses `default_read_ref`, `render_hint`, `content_type`, and `metadata.name` or `metadata.title`.
+- Markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts follow the documented renderer behavior.
+- Evidence artifacts remain individually addressable and viewable rather than being collapsed into the primary report by default.
+- When no `report.primary` exists, Mission Control falls back to the existing artifact list behavior.
 
 Requirements
-- Expose report-first presentation for canonical final reports in execution detail surfaces.
-- Display related report summary, structured, and evidence artifacts separately from generic artifacts and observability surfaces.
-- Use artifact presentation contract fields for read target and renderer selection.
-- Treat optional execution convenience fields and any report projection endpoint as read models over normal artifacts.
+- Add report-first execution detail presentation.
+- Use existing artifact presentation contracts for default reads and viewer selection.
+- Present related evidence separately from operational logs and diagnostics.
 
 Relevant Implementation Notes
-- Keep report presentation layered on the existing artifact presentation contract and execution detail surfaces.
-- Prioritize canonical final reports linked as `report.primary` before generic artifact list inspection.
-- Present `report.summary`, `report.structured`, and `report.evidence` artifacts as related report content while preserving individual artifact access controls and open/read behavior.
-- Preserve the normal artifact list and observability surfaces; report presentation must not hide logs, diagnostics, provider snapshots, or other non-report artifacts.
-- Use server-provided latest report query behavior or projection fields for latest report selection instead of browser-side sorting over arbitrary artifacts.
-- Choose viewers from artifact presentation fields, including `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title`.
+- Preserve MM-494 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Artifacts/ReportArtifacts.md` as the design reference for report presentation rules and the relationship between reports, observability, and diagnostics.
+- Prioritize a report-first execution detail surface when canonical report artifacts are present.
+- Keep the generic artifact list and observability surfaces accessible outside the report panel rather than replacing them.
+- Use existing artifact presentation contracts to choose the default read target and renderer behavior.
+- Show related `report.summary`, `report.structured`, and `report.evidence` artifacts as associated report content without collapsing evidence into the primary report by default.
+- Support documented renderer behavior across markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts.
+- Fall back cleanly to the existing artifact-list behavior when no canonical `report.primary` artifact exists.
 
-Non-Goals
-- Creating report status from local UI heuristics when no `report.primary` artifact exists.
-- Replacing generic artifact list behavior for executions without canonical reports.
-- Reworking artifact storage, authorization, lifecycle, or preview contracts.
-- Treating observability outputs such as stdout, stderr, diagnostics, provider snapshots, or session continuity artifacts as canonical report content.
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-494 is blocked by MM-495, whose embedded status is Backlog.
+- Trusted Jira link metadata at fetch time shows MM-494 is related to MM-493 via a Blocks link where MM-494 blocks MM-493; MM-493 is not a blocker for this story.
 
 Validation
-- Verify an execution with a canonical `report.primary` artifact shows report-first presentation in Mission Control before generic artifact list inspection.
-- Verify linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content and remain individually openable where access permits.
-- Verify executions without `report.primary` fall back to the normal artifact list without fabricated report status.
-- Verify viewer selection honors `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title` for markdown, JSON, text, diff, image, PDF, and binary artifacts.
-- Verify latest report selection uses server query behavior or a projection field, not browser-side sorting over arbitrary artifacts.
+- Verify executions with canonical `report.primary` artifacts surface a report panel or top-level report card before the generic artifact list.
+- Verify the report surface shows summary metadata and an open action for the default read target.
+- Verify linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content.
+- Verify artifacts, stdout, stderr, diagnostics, and other observability surfaces remain accessible outside the report panel.
+- Verify viewer choice follows `default_read_ref`, `render_hint`, `content_type`, and `metadata.name` or `metadata.title`.
+- Verify markdown, JSON, plain text, diff, image, PDF, and unknown binary report artifacts follow the documented renderer behavior.
+- Verify evidence artifacts remain individually addressable and are not collapsed into the primary report by default.
+- Verify execution detail falls back to the existing artifact list behavior when no canonical `report.primary` exists.
 
 Needs Clarification
 - None
 ```
 
-**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-462-moonspec-orchestration-input.md`
-
-## Original Jira Preset Brief
-
-Jira issue: MM-462 from MM project
-Summary: Mission Control Report Presentation
-Issue type: Story
-Current Jira status: In Progress
-Jira project key: MM
-
-Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-462 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
-
-MM-462: Mission Control Report Presentation
-
-Short Name
-mission-control-report-presentation
-
-Source Reference
-- Source document: `docs/Artifacts/ReportArtifacts.md`
-- Source title: Report Artifacts
-- Source sections: 11.4 Latest report semantics, 12. Presentation rules, 12.1 Primary UI surfaces, 12.2 Default read behavior, 12.3 Recommended renderer behavior, 12.4 Report-first UX rule, 12.5 Evidence presentation, 18. Suggested API/UI extensions
-- Coverage IDs: DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, DESIGN-REQ-022
-
-User Story
-As an operator, I can open an execution with a final report and see the canonical report, related evidence, and normal observability surfaces without guessing which generic artifact matters.
-
-Acceptance Criteria
-- Given an execution has a canonical `report.primary` artifact, then Mission Control shows a report panel or top-level report card before requiring inspection of the generic artifact list.
-- Given linked `report.summary`, `report.structured`, or `report.evidence` artifacts exist, then they are shown as related report content and remain individually openable where access permits.
-- Given no `report.primary` artifact exists, then the UI falls back to the normal artifact list without fabricating report status from local heuristics.
-- Viewer selection uses `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title`, including appropriate markdown, JSON, text, diff, image, PDF, and binary handling.
-- Latest report selection comes from server query behavior or a projection field, not browser-side sorting of arbitrary artifacts.
-
-Requirements
-- Expose report-first presentation for canonical final reports in execution detail surfaces.
-- Display related report summary, structured, and evidence artifacts separately from generic artifacts and observability surfaces.
-- Use artifact presentation contract fields for read target and renderer selection.
-- Treat optional execution convenience fields and any report projection endpoint as read models over normal artifacts.
-
-Relevant Implementation Notes
-- Keep report presentation layered on the existing artifact presentation contract and execution detail surfaces.
-- Prioritize canonical final reports linked as `report.primary` before generic artifact list inspection.
-- Present `report.summary`, `report.structured`, and `report.evidence` artifacts as related report content while preserving individual artifact access controls and open/read behavior.
-- Preserve the normal artifact list and observability surfaces; report presentation must not hide logs, diagnostics, provider snapshots, or other non-report artifacts.
-- Use server-provided latest report query behavior or projection fields for latest report selection instead of browser-side sorting over arbitrary artifacts.
-- Choose viewers from artifact presentation fields, including `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title`.
-
-Non-Goals
-- Creating report status from local UI heuristics when no `report.primary` artifact exists.
-- Replacing generic artifact list behavior for executions without canonical reports.
-- Reworking artifact storage, authorization, lifecycle, or preview contracts.
-- Treating observability outputs such as stdout, stderr, diagnostics, provider snapshots, or session continuity artifacts as canonical report content.
-
-Validation
-- Verify an execution with a canonical `report.primary` artifact shows report-first presentation in Mission Control before generic artifact list inspection.
-- Verify linked `report.summary`, `report.structured`, and `report.evidence` artifacts appear as related report content and remain individually openable where access permits.
-- Verify executions without `report.primary` fall back to the normal artifact list without fabricated report status.
-- Verify viewer selection honors `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title` for markdown, JSON, text, diff, image, PDF, and binary artifacts.
-- Verify latest report selection uses server query behavior or a projection field, not browser-side sorting over arbitrary artifacts.
-
-Needs Clarification
-- None
-
 ## Classification
 
 - Input type: Single-story feature request.
-- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable operator story and does not require processing multiple specs.
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-494 Jira preset brief defines one independently testable Mission Control runtime story.
 - Selected mode: Runtime.
 - Source design: `docs/Artifacts/ReportArtifacts.md` is treated as runtime source requirements because the Jira brief points at implementation behavior, not documentation-only work.
-- Resume decision: No existing Moon Spec artifacts for MM-462 were found under `specs/`; specification is the first incomplete stage.
+- Resume decision: Existing Moon Spec artifacts in `specs/230-mission-control-report-presentation` already cover this report-presentation story, and the implementation plus verification evidence were already complete.
+- Alignment decision: This run updated the preserved source brief, Jira traceability, and active feature pointer to MM-494 while reusing the existing completed runtime story artifacts.
 
 ## User Story - Present Canonical Reports In Mission Control
 
@@ -163,7 +142,7 @@ Needs Clarification
 
 ## Assumptions
 
-- The report artifact contract from MM-460 and report bundle publication behavior from MM-461 provide canonical `report.*` links and bounded presentation metadata for this UI story.
+- The narrower MM-494 Jira brief targets the same already-implemented runtime story already captured by this feature directory, so the existing report-presentation implementation and tests remain the concrete execution evidence for this aligned spec.
 - Mission Control already has an execution detail surface with generic artifact and observability sections that can be extended without replacing those surfaces.
 - Server-side latest-report query behavior or an execution/report projection is the source of truth for report identity.
 
@@ -189,7 +168,7 @@ Needs Clarification
 - **FR-005**: Mission Control MUST select report viewers from artifact presentation fields including `default_read_ref`, `render_hint`, `content_type`, `metadata.name`, and `metadata.title`.
 - **FR-006**: Mission Control MUST treat optional execution summary fields and any report projection endpoint as read models over normal artifacts rather than as a separate report storage or mutation surface.
 - **FR-007**: Mission Control MUST NOT fabricate report status or canonical report identity through browser-side sorting or local heuristics when no `report.primary` artifact is available.
-- **FR-008**: Moon Spec artifacts, verification evidence, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-462.
+- **FR-008**: Moon Spec artifacts, verification evidence, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-494.
 
 ### Key Entities
 
@@ -207,4 +186,4 @@ Needs Clarification
 - **SC-003**: Fallback tests verify executions without `report.primary` show the normal artifact list and no fabricated report status.
 - **SC-004**: Viewer selection tests cover markdown, JSON, text, diff, image, PDF or unknown binary behavior using artifact presentation fields.
 - **SC-005**: Latest report selection tests verify Mission Control consumes server query/projection data and does not sort arbitrary artifacts in the browser to infer a canonical report.
-- **SC-006**: MM-462 appears in the spec, plan, tasks, verification evidence, and publish metadata for traceability.
+- **SC-006**: MM-494 appears in the spec, plan, tasks, verification evidence, and publish metadata for traceability.

--- a/specs/230-mission-control-report-presentation/spec.md
+++ b/specs/230-mission-control-report-presentation/spec.md
@@ -150,12 +150,10 @@ Needs Clarification
 
 | ID | Source | Requirement | Scope | Mapped Requirements |
 | --- | --- | --- | --- | --- |
-| DESIGN-REQ-011 | `docs/Artifacts/ReportArtifacts.md` §11.4 | Latest-report selection is server query behavior or an explicit projection; clients must not infer the canonical report by sorting arbitrary artifacts in the browser. | In scope | FR-001, FR-007 |
-| DESIGN-REQ-012 | `docs/Artifacts/ReportArtifacts.md` §12.1 | Report-producing executions expose a Report panel or top-level report card, a Related Evidence section, and continued access to artifacts and observability surfaces. | In scope | FR-002, FR-003, FR-004 |
-| DESIGN-REQ-013 | `docs/Artifacts/ReportArtifacts.md` §12.2-§12.3 | Primary report rendering uses `default_read_ref`, `render_hint`, `content_type`, and metadata name/title to choose an appropriate viewer and raw access behavior. | In scope | FR-005 |
-| DESIGN-REQ-014 | `docs/Artifacts/ReportArtifacts.md` §12.4 | If an execution has a canonical `report.primary`, Mission Control presents that artifact before generic artifact list inspection and shows related report content. | In scope | FR-002, FR-003 |
-| DESIGN-REQ-020 | `docs/Artifacts/ReportArtifacts.md` §12.5, §13 | Evidence artifacts remain individually addressable and viewable, and curated reports remain separate from stdout, stderr, diagnostics, provider snapshots, and other observability outputs. | In scope | FR-003, FR-004 |
-| DESIGN-REQ-022 | `docs/Artifacts/ReportArtifacts.md` §18 | Optional execution summary fields and report projection endpoints are read models over normal artifacts, not a separate report storage or mutation path. | In scope | FR-001, FR-006 |
+| DESIGN-REQ-005 | `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` | Canonical report presentation MUST remain server-driven through existing `report.primary` artifact selection and must not rely on browser-side inference. | In scope | FR-001, FR-007 |
+| DESIGN-REQ-014 | `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` | Executions with a canonical report MUST surface a report-first panel with related report content before generic artifact inspection. | In scope | FR-002, FR-003 |
+| DESIGN-REQ-015 | `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` | Viewer selection MUST honor `default_read_ref`, `render_hint`, `content_type`, and `metadata.name` or `metadata.title` for the report surface. | In scope | FR-005 |
+| DESIGN-REQ-016 | `docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` | Related evidence MUST remain individually addressable, observability surfaces MUST remain accessible outside the report panel, and the implementation MUST stay on the existing artifact read model. | In scope | FR-003, FR-004, FR-006 |
 
 ## Requirements *(mandatory)*
 

--- a/specs/230-mission-control-report-presentation/tasks.md
+++ b/specs/230-mission-control-report-presentation/tasks.md
@@ -9,7 +9,7 @@
 
 ## Source Traceability
 
-- Jira: MM-462
+- Jira: MM-494
 - Story: Present canonical reports in Mission Control task detail surfaces.
 - Story count: exactly one independently testable story from `spec.md`.
 - Independent test: load an execution detail surface with report artifacts, verify report-first presentation, related content openability, presentation-field viewer selection, and no fabricated report panel when `report.primary` is absent.
@@ -19,7 +19,7 @@
 
 ## Phase 1: Setup
 
-- [X] T001 Confirm active feature context points to `specs/230-mission-control-report-presentation` in `.specify/feature.json` (MM-462).
+- [X] T001 Confirm active feature context points to `specs/230-mission-control-report-presentation` in `.specify/feature.json` (MM-494).
 - [X] T002 Inspect existing artifact list parsing and rendering in `frontend/src/entrypoints/task-detail.tsx` before editing (FR-001 through FR-007).
 - [X] T003 Inspect existing task detail and artifact API tests in `frontend/src/entrypoints/task-detail.test.tsx` and `tests/contract/test_temporal_artifact_api.py` before adding failures (FR-001 through FR-007).
 
@@ -49,7 +49,7 @@ Integration/contract test plan: API contract coverage verifies the execution art
 
 - [X] T017 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx` and fix failures (FR-001 through FR-007).
 - [X] T018 Run `./tools/test_unit.sh tests/contract/test_temporal_artifact_api.py` and fix failures (FR-001, FR-006).
-- [X] T019 Run traceability check `rg -n "MM-462|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-462-moonspec-orchestration-input.md` (FR-008, SC-006).
+- [X] T019 Run traceability check `rg -n "MM-494|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` (FR-008, SC-006).
 - [X] T020 Run final `./tools/test_unit.sh` unless blocked by environment constraints.
 
 ## Phase 5: Verify

--- a/specs/230-mission-control-report-presentation/tasks.md
+++ b/specs/230-mission-control-report-presentation/tasks.md
@@ -15,7 +15,7 @@
 - Independent test: load an execution detail surface with report artifacts, verify report-first presentation, related content openability, presentation-field viewer selection, and no fabricated report panel when `report.primary` is absent.
 - Requirements: FR-001 through FR-008; SC-001 through SC-006.
 - Source design coverage: DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, DESIGN-REQ-022.
-- Requirement statuses from plan: FR-002, FR-007, DESIGN-REQ-014 are missing; FR-003, FR-005, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-020 are partial; FR-001, FR-004, FR-006, FR-008, DESIGN-REQ-011, DESIGN-REQ-022 are implemented_unverified.
+- Requirement statuses from plan: FR-001 through FR-008 and DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, and DESIGN-REQ-022 are implemented_verified in the resumed MM-494 artifact set.
 
 ## Phase 1: Setup
 

--- a/specs/230-mission-control-report-presentation/tasks.md
+++ b/specs/230-mission-control-report-presentation/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: Mission Control Report Presentation
+# Tasks: Surface Canonical Reports in Mission Control
 
 **Input**: `specs/230-mission-control-report-presentation/spec.md`
 **Plan**: `specs/230-mission-control-report-presentation/plan.md`

--- a/specs/230-mission-control-report-presentation/tasks.md
+++ b/specs/230-mission-control-report-presentation/tasks.md
@@ -14,8 +14,8 @@
 - Story count: exactly one independently testable story from `spec.md`.
 - Independent test: load an execution detail surface with report artifacts, verify report-first presentation, related content openability, presentation-field viewer selection, and no fabricated report panel when `report.primary` is absent.
 - Requirements: FR-001 through FR-008; SC-001 through SC-006.
-- Source design coverage: DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, DESIGN-REQ-022.
-- Requirement statuses from plan: FR-001 through FR-008 and DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-020, and DESIGN-REQ-022 are implemented_verified in the resumed MM-494 artifact set.
+- Source design coverage: DESIGN-REQ-005, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016.
+- Requirement statuses from plan: FR-001 through FR-008 and DESIGN-REQ-005, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-016 are implemented_verified in the resumed MM-494 artifact set.
 
 ## Phase 1: Setup
 
@@ -28,28 +28,28 @@
 Unit test plan: frontend unit tests cover report-first UI, related report content, fallback behavior, and viewer/open-target selection.
 Integration/contract test plan: API contract coverage verifies the execution artifact boundary accepts `link_type=report.primary&latest_only=true` and preserves links/default read refs; `./tools/test_integration.sh` is reserved for backend behavior changes beyond this existing read-only contract.
 
-- [X] T004 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting the UI queries `/artifacts?link_type=report.primary&latest_only=true` and renders a Report section before Artifacts when a primary report exists (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-011, DESIGN-REQ-014).
-- [X] T005 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting related `report.summary`, `report.structured`, and `report.evidence` artifacts are displayed as related report content and individually openable (FR-003, SC-002, DESIGN-REQ-012, DESIGN-REQ-020).
+- [X] T004 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting the UI queries `/artifacts?link_type=report.primary&latest_only=true` and renders a Report section before Artifacts when a primary report exists (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-005, DESIGN-REQ-014).
+- [X] T005 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting related `report.summary`, `report.structured`, and `report.evidence` artifacts are displayed as related report content and individually openable (FR-003, SC-002, DESIGN-REQ-014, DESIGN-REQ-016).
 - [X] T006 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting no report panel/status is fabricated when latest `report.primary` returns empty but generic artifacts exist (FR-004, FR-007, SC-003).
-- [X] T007 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting report open targets use `default_read_ref` and viewer labels reflect `render_hint` or `content_type` for markdown, JSON, text, diff, image, and binary/PDF cases (FR-005, SC-004, DESIGN-REQ-013).
-- [X] T008 [P] Add failing API contract regression in `tests/contract/test_temporal_artifact_api.py` asserting the execution artifact list can be called with `link_type=report.primary&latest_only=true` and returns links/default read refs needed by Mission Control (FR-001, FR-006, DESIGN-REQ-011, DESIGN-REQ-022).
+- [X] T007 [P] Add failing frontend unit test in `frontend/src/entrypoints/task-detail.test.tsx` asserting report open targets use `default_read_ref` and viewer labels reflect `render_hint` or `content_type` for markdown, JSON, text, diff, image, and binary/PDF cases (FR-005, SC-004, DESIGN-REQ-015).
+- [X] T008 [P] Add failing API contract regression in `tests/contract/test_temporal_artifact_api.py` asserting the execution artifact list can be called with `link_type=report.primary&latest_only=true` and returns links/default read refs needed by Mission Control (FR-001, FR-006, DESIGN-REQ-005, DESIGN-REQ-016).
 - [X] T009 Run focused failing tests for T004-T008 and capture red-first evidence in `specs/230-mission-control-report-presentation/tasks.md` or verification notes.
 
 ## Phase 3: Implementation
 
 - [X] T010 Extend `ArtifactSummarySchema` and artifact normalization in `frontend/src/entrypoints/task-detail.tsx` to preserve `links`, `metadata`, `default_read_ref`, `download_url`, `content_type`, and raw access fields needed for report presentation (FR-003, FR-005).
-- [X] T011 Add report link classification, report open-target, and viewer-label helpers in `frontend/src/entrypoints/task-detail.tsx` (FR-003, FR-005, FR-007, DESIGN-REQ-013).
-- [X] T012 Add latest primary report query in `frontend/src/entrypoints/task-detail.tsx` using `link_type=report.primary&latest_only=true` and include it in invalidation/live polling (FR-001, FR-007, DESIGN-REQ-011).
+- [X] T011 Add report link classification, report open-target, and viewer-label helpers in `frontend/src/entrypoints/task-detail.tsx` (FR-003, FR-005, FR-007, DESIGN-REQ-015).
+- [X] T012 Add latest primary report query in `frontend/src/entrypoints/task-detail.tsx` using `link_type=report.primary&latest_only=true` and include it in invalidation/live polling (FR-001, FR-007, DESIGN-REQ-005).
 - [X] T013 Render a report-first section in `frontend/src/entrypoints/task-detail.tsx` before Timeline and Artifacts when a latest primary report exists (FR-002, SC-001, DESIGN-REQ-014).
-- [X] T014 Render related report summary, structured, and evidence artifacts in the report section while preserving individual open links and leaving the generic Artifacts table unchanged (FR-003, FR-004, SC-002, DESIGN-REQ-012, DESIGN-REQ-020).
+- [X] T014 Render related report summary, structured, and evidence artifacts in the report section while preserving individual open links and leaving the generic Artifacts table unchanged (FR-003, FR-004, SC-002, DESIGN-REQ-014, DESIGN-REQ-016).
 - [X] T015 Preserve fallback behavior in `frontend/src/entrypoints/task-detail.tsx` so empty latest report data shows no report status and generic artifacts still render normally (FR-004, FR-007, SC-003).
-- [X] T016 Update `tests/contract/test_temporal_artifact_api.py` test doubles only as needed to verify existing latest-report query serialization without introducing a new backend storage path (FR-001, FR-006, DESIGN-REQ-022).
+- [X] T016 Update `tests/contract/test_temporal_artifact_api.py` test doubles only as needed to verify existing latest-report query serialization without introducing a new backend storage path (FR-001, FR-006, DESIGN-REQ-016).
 
 ## Phase 4: Validation
 
 - [X] T017 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx` and fix failures (FR-001 through FR-007).
 - [X] T018 Run `./tools/test_unit.sh tests/contract/test_temporal_artifact_api.py` and fix failures (FR-001, FR-006).
-- [X] T019 Run traceability check `rg -n "MM-494|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` (FR-008, SC-006).
+- [X] T019 Run traceability check `rg -n "MM-494|DESIGN-REQ-005|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-016" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md` (FR-008, SC-006).
 - [X] T020 Run final `./tools/test_unit.sh` unless blocked by environment constraints.
 
 ## Phase 5: Verify

--- a/specs/230-mission-control-report-presentation/verification.md
+++ b/specs/230-mission-control-report-presentation/verification.md
@@ -25,12 +25,10 @@ Mission Control task detail already uses server-selected report linkage to rende
 
 | ID | Status | Evidence |
 | --- | --- | --- |
-| DESIGN-REQ-011 | VERIFIED | Latest report query is server-side through `link_type=report.primary&latest_only=true`. |
-| DESIGN-REQ-012 | VERIFIED | Report section includes canonical report and related report content while preserving Artifacts and observability. |
-| DESIGN-REQ-013 | VERIFIED | Viewer/open helpers honor artifact presentation fields. |
-| DESIGN-REQ-014 | VERIFIED | Report-first UI appears before generic artifact inspection. |
-| DESIGN-REQ-020 | VERIFIED | Related evidence remains individually openable and generic observability remains separate. |
-| DESIGN-REQ-022 | VERIFIED | Existing artifact read model is used; no report-specific storage plane introduced. |
+| DESIGN-REQ-005 | VERIFIED | Latest report query stays server-side through `link_type=report.primary&latest_only=true` and avoids browser-side inference. |
+| DESIGN-REQ-014 | VERIFIED | Report-first UI appears before generic artifact inspection and includes related report content. |
+| DESIGN-REQ-015 | VERIFIED | Viewer/open helpers honor artifact presentation fields. |
+| DESIGN-REQ-016 | VERIFIED | Related evidence remains individually openable, generic observability remains separate, and the existing artifact read model is preserved. |
 
 ## Test Evidence
 

--- a/specs/230-mission-control-report-presentation/verification.md
+++ b/specs/230-mission-control-report-presentation/verification.md
@@ -2,11 +2,11 @@
 
 **Verdict**: FULLY_IMPLEMENTED  
 **Date**: 2026-04-22  
-**Jira**: MM-462
+**Jira**: MM-494
 
 ## Summary
 
-Mission Control task detail now uses server-selected report linkage to render a canonical Report section for executions with `report.primary`, displays related `report.summary`, `report.structured`, and `report.evidence` artifacts as report content, preserves the generic Artifacts and observability surfaces, and avoids fabricating report state when the latest primary report query returns no report artifact.
+Mission Control task detail already uses server-selected report linkage to render a canonical Report section for executions with `report.primary`, displays related `report.summary`, `report.structured`, and `report.evidence` artifacts as report content, preserves the generic Artifacts and observability surfaces, and avoids fabricating report state when the latest primary report query returns no report artifact. This alignment run preserves MM-494 as the canonical Jira source without reopening the completed implementation.
 
 ## Requirement Coverage
 
@@ -19,7 +19,7 @@ Mission Control task detail now uses server-selected report linkage to render a 
 | FR-005 | VERIFIED | `reportOpenHref` and `reportViewerLabel` use `default_read_ref`, `download_url`, `render_hint`, `content_type`, and metadata title/name. |
 | FR-006 | VERIFIED | Implementation consumes existing artifact endpoint/read model only; no new storage or mutation route added. |
 | FR-007 | VERIFIED | Report section renders only when latest report response contains an actual `report.primary` link. |
-| FR-008 | VERIFIED | MM-462 appears in spec, plan, tasks, quickstart, and verification. |
+| FR-008 | VERIFIED | MM-494 appears in spec, plan, tasks, quickstart, and verification. |
 
 ## Source Design Coverage
 

--- a/specs/230-mission-control-report-presentation/verification.md
+++ b/specs/230-mission-control-report-presentation/verification.md
@@ -1,4 +1,4 @@
-# Verification: Mission Control Report Presentation
+# Verification: Surface Canonical Reports in Mission Control
 
 **Verdict**: FULLY_IMPLEMENTED  
 **Date**: 2026-04-22  


### PR DESCRIPTION
Jira issue key: MM-494
Active MoonSpec feature path: `specs/230-mission-control-report-presentation`
Verification verdict: `FULLY_IMPLEMENTED`

Tests run:
- `rg -n "MM-494|DESIGN-REQ-011|DESIGN-REQ-012|DESIGN-REQ-013|DESIGN-REQ-014|DESIGN-REQ-020|DESIGN-REQ-022" specs/230-mission-control-report-presentation docs/tmp/jira-orchestration-inputs/MM-494-moonspec-orchestration-input.md`
- `rg -n "MM-462" specs/230-mission-control-report-presentation .specify/feature.json`
- plan gate artifact existence and explicit unit/integration strategy checks
- tasks gate single-story, red-first, validation, and final `moonspec-verify` coverage checks
- existing verification evidence in `specs/230-mission-control-report-presentation/verification.md`:
  - `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx`
  - `./tools/test_unit.sh tests/contract/test_temporal_artifact_api.py`
  - `./tools/test_unit.sh`
  - `node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
  - `node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/entrypoints/task-detail.tsx frontend/src/entrypoints/task-detail.test.tsx`

Remaining risks:
- The preserved MM-494 Jira brief still records blocker `MM-495` in `Backlog`.
- This branch aligns MoonSpec artifacts and traceability to MM-494; it does not introduce new production code beyond the already-verified implementation referenced by the existing verification report.
