### PR TITLE
MM-482 Claude OAuth authorization and redaction guardrails

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/244-shimmer-sweep-status-pill"
+  "feature_directory": "/work/agent_jobs/mm:8fd107aa-8e1a-4ccd-9047-ae6bd2d21037/repo/specs/245-claude-oauth-guardrails"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "/work/agent_jobs/mm:8fd107aa-8e1a-4ccd-9047-ae6bd2d21037/repo/specs/245-claude-oauth-guardrails"
+  "feature_directory": "specs/245-claude-oauth-guardrails"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,8 @@ Key diagnostics:
 - Python 3.12 + SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK service boundaries, existing Temporal artifact service, existing remediation context/action services (232-remediation-lifecycle-audit)
 - Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and existing execution memo/search/projection paths; no new persistent database table planned unless audit events cannot reuse an existing control-event mechanism (232-remediation-lifecycle-audit)
 - TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected in this story + React, Vitest, Testing Library, existing Mission Control stylesheet, existing entrypoint render tests (244-shimmer-sweep-status-pill)
+- Python 3.12 + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest, existing OAuth session/terminal bridge/runtime-launch services (245-claude-oauth-guardrails)
+- Existing OAuth session rows, provider-profile rows, managed-session diagnostics, artifact metadata, and workflow history; no new persistent tables planned (245-claude-oauth-guardrails)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -202,6 +202,8 @@ Key diagnostics:
 - Python 3.12 + SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK service boundaries, existing Temporal artifact service, existing remediation context/action services (232-remediation-lifecycle-audit)
 - Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and existing execution memo/search/projection paths; no new persistent database table planned unless audit events cannot reuse an existing control-event mechanism (232-remediation-lifecycle-audit)
 - TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected in this story + React, Vitest, Testing Library, existing Mission Control stylesheet, existing entrypoint render tests (244-shimmer-sweep-status-pill)
+- Python 3.12 + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest, existing OAuth session/terminal bridge/runtime-launch services (245-claude-oauth-guardrails)
+- Existing OAuth session rows, provider-profile rows, managed-session diagnostics, artifact metadata, and workflow history; no new persistent tables planned (245-claude-oauth-guardrails)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -501,7 +501,7 @@ async def validate_claude_oauth_profile(
         ) from exc
 
     if not verification.get("verified", False):
-        reason = str(verification.get("reason") or "unknown")
+        reason = redact_sensitive_payload(str(verification.get("reason") or "unknown"))
         _update_claude_auth_behavior(
             profile,
             auth_state="validation_failed",

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-488",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1718"
+  "jira_issue_key": "MM-482",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1724"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3134202207,
+    "id": 3134534895,
     "disposition": "addressed",
-    "rationale": "Converted _apply_oauth_home_runtime_env to a static method because it does not use instance state."
+    "rationale": "Replaced the managed-agent absolute feature path in .specify/feature.json with the repo-relative specs/245-claude-oauth-guardrails path."
   },
   {
-    "id": 4166409108,
+    "id": 4166796428,
     "disposition": "not-applicable",
-    "rationale": "Summary review only; the only actionable feedback in the review was the inline static-method refactor, which is addressed separately."
+    "rationale": "Top-level Codex review wrapper comment; the actionable feedback was the linked review comment and has been addressed."
+  },
+  {
+    "id": 3134537750,
+    "disposition": "addressed",
+    "rationale": "Updated .specify/feature.json to use the suggested repo-relative feature_directory value for portability across environments."
+  },
+  {
+    "id": 4166799430,
+    "disposition": "not-applicable",
+    "rationale": "Top-level Gemini summary review; the only actionable item duplicated the .specify/feature.json path issue and is now fixed."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-482-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-482-moonspec-orchestration-input.md
@@ -1,0 +1,73 @@
+# MM-482 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-482
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Claude OAuth Authorization and Redaction Guardrails
+- Labels: `moonmind-workflow-mm-8f0966f3-d711-4289-9669-3a8e435353fb`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-482 from MM project
+Summary: Claude OAuth Authorization and Redaction Guardrails
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-482 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-482: Claude OAuth Authorization and Redaction Guardrails
+
+Source Reference
+- Source Document: `docs/ManagedAgents/ClaudeAnthropicOAuth.md`
+- Source Title: Claude Anthropic OAuth in Settings
+
+Source Sections
+- 2. OAuth Profile Shape
+- 3.4 Claude Sign-In Ceremony
+- 5. Verification
+- 7. Runtime Launch Behavior
+- 9. Security Requirements
+
+Coverage IDs
+- DESIGN-REQ-004
+- DESIGN-REQ-009
+- DESIGN-REQ-013
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+
+User Story
+As an operator and platform maintainer, I can rely on Claude OAuth lifecycle operations, terminal output, errors, logs, artifacts, and profile rows to enforce authorization and redact secret-like values across the full flow.
+
+Acceptance Criteria
+- Given an unauthenticated or unauthorized operator attempts to start, attach to, cancel, finalize, or repair a Claude OAuth session, then MoonMind denies the operation.
+- Given a browser terminal attach token is reused or expired, then attach fails.
+- Given terminal output, failure reasons, logs, or artifacts contain secret-like values, then externally visible output is redacted.
+- Given provider profile rows are read, then they contain refs and metadata only, never credential file contents.
+- Given OAuth auth volume metadata is surfaced, then the volume is described as a credential store and not exposed as a task workspace or audit artifact.
+- Given guardrail tests run, then they cover the real API/workflow/activity or adapter boundary rather than only isolated helpers.
+
+Requirements
+- Enforce authorization across Claude OAuth start, attach, cancel, finalize, and repair operations.
+- Make browser terminal attach tokens short-lived and single-use.
+- Redact secret-like values from terminal output, failure reasons, logs, and artifacts.
+- Keep provider profile rows limited to refs and metadata.
+- Treat OAuth auth volumes strictly as credential stores.
+
+Implementation Notes
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the governing design source for profile shape, sign-in ceremony, verification, runtime launch behavior, and security requirements.
+- Keep authorization enforcement consistent across Claude OAuth start, attach, cancel, finalize, and repair operations.
+- Ensure attach tokens are both short-lived and single-use.
+- Redact secret-like values from terminal output, failure reasons, logs, and artifacts before they become externally visible.
+- Preserve provider profile rows as refs-and-metadata only; never expose credential file contents.
+- Surface OAuth auth volumes strictly as credential stores, not as task workspaces or audit artifacts.
+- Add or update guardrail tests at the real API, workflow, activity, or adapter boundary rather than only isolated helper coverage.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -10,6 +10,8 @@ import re
 import shlex
 from typing import Any, AsyncIterator, Awaitable, Callable, Protocol
 
+from moonmind.utils.logging import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 _MAX_RECORDED_TERMINAL_EVENTS = 256
 _MAX_STARTUP_ERROR_OUTPUT_CHARS = 600
@@ -87,6 +89,7 @@ def _redact_startup_output(output: bytes) -> str:
     if not text:
         return ""
     redacted = _SECRET_ASSIGNMENT_PATTERN.sub("[REDACTED]", text)
+    redacted = redact_sensitive_text(redacted)
     return redacted[-_MAX_STARTUP_ERROR_OUTPUT_CHARS:]
 
 

--- a/specs/245-claude-oauth-guardrails/checklists/requirements.md
+++ b/specs/245-claude-oauth-guardrails/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Claude OAuth Authorization and Redaction Guardrails
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated against `specs/245-claude-oauth-guardrails/spec.md` on 2026-04-23.
+- Runtime intent is explicit, the original MM-482 Jira preset brief is preserved verbatim, and every in-scope `DESIGN-REQ-*` maps to one or more functional requirements.

--- a/specs/245-claude-oauth-guardrails/contracts/claude-oauth-guardrails.md
+++ b/specs/245-claude-oauth-guardrails/contracts/claude-oauth-guardrails.md
@@ -1,0 +1,80 @@
+# Contract: Claude OAuth Authorization and Redaction Guardrails
+
+## Covered Surfaces
+
+Boundary surfaces in scope for MM-482:
+- `POST /api/v1/oauth-sessions`
+- `POST /api/v1/oauth-sessions/{session_id}/cancel`
+- `POST /api/v1/oauth-sessions/{session_id}/terminal/attach`
+- `GET /api/v1/oauth-sessions/{session_id}`
+- `POST /api/v1/oauth-sessions/{session_id}/finalize`
+- `POST /api/v1/oauth-sessions/{session_id}/reconnect`
+- `POST /api/v1/provider-profiles/{profile_id}/oauth/validate`
+- `POST /api/v1/provider-profiles/{profile_id}/oauth/disconnect`
+- OAuth terminal WebSocket attach and frame handling
+- Claude runtime launch/session diagnostics for OAuth-home profiles
+
+## Authorization Contract
+
+Required behavior:
+- Only the owning authorized operator may create or use a Claude OAuth session tied to a non-shared profile.
+- Unauthorized operators cannot attach, cancel, finalize, or reconnect a Claude OAuth session.
+- Unauthorized access must fail before verification, provider-profile mutation, or terminal bridging occurs.
+
+Minimum proof points:
+- Owner mismatch on finalize does not call the verifier or create/update a profile.
+- Owner mismatch on reconnect does not create a successor session.
+- Owner mismatch on terminal attach does not issue an attach token.
+
+## Attach Token Contract
+
+Required behavior:
+- Attach response returns a one-time plaintext token only to the authorized caller.
+- Session metadata stores only `terminal_attach_token_sha256`, issuance timestamp, and usage state.
+- WebSocket attach accepts only a non-expired matching token whose `used` marker is still false.
+- Successful WebSocket attach flips `terminal_attach_token_used` to true.
+- Replay of the same token is denied.
+
+Forbidden behavior:
+- Persisting plaintext token values.
+- Returning the stored hash to the caller.
+- Reusing the same token across multiple WebSocket attachments.
+
+## Redaction Contract
+
+Allowed operator-visible data:
+- compact session state
+- compact provider profile summary
+- non-secret diagnostics such as `profileRef`, `runtimeId`, `volumeRef`, and `authMountTarget`
+- bounded terminal metadata counts from `safe_metadata()`
+
+Forbidden operator-visible data:
+- raw token or authorization-code values
+- raw credential file contents
+- bearer token strings
+- raw auth-volume file paths below the mount root
+- raw auth-volume directory listings
+- durable storage of pasted terminal credentials
+
+## Credential-Store Boundary Contract
+
+Required behavior:
+- `claude_auth_volume` / `/home/app/.claude` is treated as credential storage only.
+- Launch, validation, and diagnostics may reference the mount target safely, but not as workspace or artifact content roots.
+- Workspace cwd and artifact publication roots remain distinct from `MANAGED_AUTH_VOLUME_PATH`.
+
+## Unit-Test Contract
+
+Focused MM-482 unit coverage must prove:
+- owner-scoped authorization for Claude OAuth routes, including reconnect-as-repair
+- one-time hashed attach-token issuance and replay denial
+- secret-free OAuth session failure reasons and provider-profile payloads
+- secret-free Claude verification / profile / diagnostic payloads
+- auth-volume separation from workspace and artifact-backed paths
+
+## Integration-Test Contingency
+
+Run hermetic integration tests only if implementation changes:
+- artifact publication behavior,
+- worker topology or WebSocket/session wiring,
+- or another compose-backed seam that unit tests cannot fully prove.

--- a/specs/245-claude-oauth-guardrails/data-model.md
+++ b/specs/245-claude-oauth-guardrails/data-model.md
@@ -1,0 +1,95 @@
+# Data Model: Claude OAuth Authorization and Redaction Guardrails
+
+## Entities
+
+### Claude OAuth Session Authorization Boundary
+
+Represents the access-control envelope around a Claude OAuth session.
+
+Fields and state already present in repo models:
+- `session_id`: durable OAuth session identifier.
+- `runtime_id`: expected to be `claude_code` for this story.
+- `profile_id`: usually `claude_anthropic` or another Claude OAuth profile row.
+- `requested_by_user_id`: owner identity used to gate create, attach, cancel, finalize, and reconnect.
+- `status`: lifecycle state such as `pending`, `starting`, `bridge_ready`, `awaiting_user`, `verifying`, `registering_profile`, `succeeded`, `failed`, `cancelled`, or `expired`.
+- `expires_at`: lifetime bound used to deny expired terminal attachment.
+- `metadata_json`: compact attach-token and terminal metadata.
+
+Guardrail rules:
+- Owner mismatch must fail closed before verification, profile mutation, or terminal access.
+- Non-terminal reconnect/repair is only valid from expired, failed, or cancelled predecessor states.
+- Operator-visible session responses may expose compact status but not raw secrets or auth-volume contents.
+
+### OAuth Terminal Attach Token
+
+Short-lived, single-use browser terminal credential derived from the owning session.
+
+Stored shape:
+- `terminal_attach_token_sha256`: persisted digest only.
+- `terminal_attach_token_used`: boolean single-use marker.
+- `terminal_attach_issued_at`: issuance timestamp.
+- Query token: transient plaintext token returned once to the authorized caller.
+
+Guardrail rules:
+- Persist only the hash, never the plaintext token.
+- Reject expired, missing, mismatched, or already-used tokens.
+- Mark consumed on successful WebSocket attach.
+- Keep token values out of API responses beyond the one-time attach response, out of metadata, and out of logs/artifacts.
+
+### Secret-Free Observable Output
+
+Any operator-visible data emitted by the Claude OAuth lifecycle.
+
+Representative surfaces:
+- OAuth session REST responses.
+- Provider-profile REST responses and manager payloads.
+- Verification results.
+- Terminal bridge safe metadata.
+- Launcher/activity/runtime failure summaries.
+- Artifact or diagnostic metadata derived from these boundaries.
+
+Guardrail rules:
+- Redact token-like assignments, bearer strings, private keys, and auth-volume paths below the mount root.
+- Preserve compact refs and non-secret runtime metadata.
+- Never emit raw credential file contents, raw terminal paste input, or raw directory listings.
+
+### Claude OAuth Credential Store Surface
+
+The auth-volume-backed Claude home and its related metadata.
+
+Representative fields:
+- `volume_ref = claude_auth_volume`
+- `volume_mount_path = /home/app/.claude`
+- `MANAGED_AUTH_VOLUME_PATH`
+- `CLAUDE_HOME`
+- `CLAUDE_VOLUME_PATH`
+- safe diagnostics such as `volumeRef` and `authMountTarget`
+
+Guardrail rules:
+- Treat the volume as credential storage only.
+- Keep it separate from repo workspace roots and artifact publication roots.
+- Allow non-secret mount-target references when needed for diagnostics.
+- Do not expose raw auth file paths, file contents, or directory listings.
+
+## State Transitions
+
+### OAuth Session Lifecycle
+
+- `pending` -> `starting` -> `bridge_ready` -> `awaiting_user`
+- `awaiting_user` -> `verifying` -> `registering_profile` -> `succeeded`
+- Any active state -> `cancelled`, `failed`, or `expired`
+- `failed` / `cancelled` / `expired` -> reconnect/repair successor session via `POST /oauth-sessions/{id}/reconnect`
+
+### Attach Token Lifecycle
+
+- issued: hash stored, `used=false`
+- consumed: WebSocket attach succeeds, `used=true`
+- expired: session expiry denies further use
+- invalid: digest mismatch or missing token state denies attach
+
+## Validation Implications
+
+- Route tests should assert owner mismatch returns 404/403 before side effects.
+- WebSocket or bridge tests should assert single-use token consumption and replay denial.
+- Provider-profile and verification tests should assert ref-only secret-free payloads.
+- Launch and diagnostics tests should assert auth-volume separation from workspace/artifact roots.

--- a/specs/245-claude-oauth-guardrails/plan.md
+++ b/specs/245-claude-oauth-guardrails/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: Claude OAuth Authorization and Redaction Guardrails
+
+**Branch**: `245-claude-oauth-guardrails` | **Date**: 2026-04-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/245-claude-oauth-guardrails/spec.md`
+
+## Summary
+
+Implement MM-482 by hardening the cross-cutting Claude OAuth guardrails after the session-backend, browser-sign-in, verification, and runtime-launch stories. Repo inspection shows significant coverage already exists: owner-scoped create/cancel/finalize/reconnect routes, one-time hashed attach tokens, redacted OAuth failure reasons, provider-profile response redaction, Claude verification/profile registration, Claude launch-home materialization, and no-leak diagnostics around auth paths. The remaining delivery risk is boundary completeness rather than greenfield functionality: Claude-specific proof is missing for reconnect-as-repair authorization, terminal WebSocket rejection after single-use token consumption, auth-volume treatment as credential-store-only across operator-visible surfaces, and end-to-end redaction/authorization evidence that spans the full Claude OAuth lifecycle. The plan is therefore test-first around the real API, WebSocket, provider-profile, workflow/activity, and launch boundaries, with production changes only where those tests expose a gap.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| -- | -- | -- | -- | -- |
+| FR-001 | partial | `api_service/api/routers/oauth_sessions.py` scopes create/cancel/finalize/reconnect to `requested_by_user_id`; `tests/unit/api_service/api/routers/test_oauth_sessions.py::test_finalize_oauth_session_rejects_other_users_claude_session_before_verify` proves finalize ownership only | add Claude-focused authorization tests covering create/attach/cancel/reconnect-as-repair; implement missing owner or fail-closed checks only if tests expose a gap | unit + integration contingency |
+| FR-002 | implemented_unverified | attach/finalize/reconnect routes all filter by `requested_by_user_id`; WebSocket bridge binds `owner_user_id` from session metadata | add direct boundary proof that Claude terminal attachment is owner-scoped end to end and not bypassable through the WebSocket attach path | unit |
+| FR-003 | partial | `attach_oauth_terminal` hashes tokens and marks `terminal_attach_token_used=False`; `oauth_terminal_websocket` rejects missing/used/expired token; tests cover hash-only token issuance and expired-session rejection, but not successful consume-then-reuse denial for Claude | add WebSocket or route-boundary tests for single-use consumption and replay rejection; implement only if the consumed-token path leaks | unit |
+| FR-004 | implemented_unverified | `moonmind/utils/logging.py`, `api_service/api/routers/oauth_sessions.py`, `api_service/api/routers/provider_profiles.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `moonmind/workflows/temporal/runtime/launcher.py` already redact secret-like text and auth paths | add Claude-focused no-leak tests spanning failure reasons, terminal metadata, provider-profile payloads, verification output, and launch errors; patch any unredacted operator-visible surface | unit + integration contingency |
+| FR-005 | implemented_unverified | `tests/unit/api_service/api/routers/test_provider_profiles.py::test_provider_profile_response_redacts_secret_like_runtime_fields`; Claude finalize test proves ref-only profile persistence | add Claude-specific profile and verification-surface assertions so MM-482 proves refs/metadata-only behavior for Claude OAuth surfaces rather than relying on generic profile redaction alone | unit |
+| FR-006 | partial | `MANAGED_AUTH_VOLUME_PATH`, `CLAUDE_HOME`, and `CLAUDE_VOLUME_PATH` separation exists in launcher/materializer code; `tests/unit/services/temporal/runtime/test_launcher.py` and `test_agent_runtime_activities.py` prove mount-path separation for launch; no direct Claude OAuth proof spans verification, validation, audit, and artifact-adjacent surfaces | add tests proving auth volume is treated as credential storage only across launch diagnostics, provider validation, and terminal/session metadata; implement explicit exclusion if any surface treats it as workspace/artifact content | unit + integration contingency |
+| FR-007 | partial | existing tests cover route boundaries, terminal frame filtering, provider-profile redaction, Claude verification, and Claude launch materialization, but not yet as one MM-482 guardrail matrix | create the MM-482 guardrail test plan covering API route, WebSocket/terminal bridge, provider-profile, verification, and runtime-launch boundaries; add production fixes only where those tests fail | unit + integration contingency |
+| FR-008 | implemented_verified | `specs/245-claude-oauth-guardrails/spec.md` preserves MM-482 and the original Jira preset brief | preserve MM-482 through tasks, verification, and any implementation notes | none beyond final verify |
+| SC-001 | implemented_unverified | Claude finalize ownership test exists; create/cancel/reconnect/attach authorization coverage is incomplete for Claude | add focused route/WebSocket tests before code changes | unit |
+| SC-002 | partial | attach route and WebSocket logic support single-use tokens; tests do not yet prove post-consumption replay rejection for Claude | add token-consumption and replay tests; fix only if replay succeeds unexpectedly | unit |
+| SC-003 | implemented_unverified | generic and Claude-specific redaction tests exist across several surfaces but not yet as a guardrail set for Claude OAuth lifecycle outputs | add focused redaction tests for Claude terminal, route, verification, and launch outputs | unit |
+| SC-004 | implemented_unverified | generic provider-profile redaction and Claude finalize/profile registration tests exist | add Claude verification/profile payload assertions that prove refs-and-metadata-only behavior | unit |
+| SC-005 | partial | Claude launch tests prove auth mount separation at launch time; auth-volume treatment across validation/audit/operator metadata is not yet fully proven | add cross-surface credential-store tests and implement exclusion guards if needed | unit + integration contingency |
+| SC-006 | partial | coverage exists at several real boundaries but not yet organized to prove every MM-482 guardrail at a real boundary | write MM-482 tasks that keep tests at routes, WebSocket bridge, provider-profile, workflow/activity, and launcher boundaries | unit + integration contingency |
+| DESIGN-REQ-004 | implemented_unverified | provider-profile rows, redaction helpers, and Claude finalize behavior already avoid credential-bearing profile payloads | add Claude-specific verification/profile surface proof | unit |
+| DESIGN-REQ-009 | partial | OAuth session workflow enters `awaiting_user`; attach route supports `AWAITING_USER`; token hashing exists; replay-proof evidence is incomplete | add attach-token lifecycle tests at route/WebSocket boundary | unit |
+| DESIGN-REQ-013 | implemented_unverified | verifier, launch, and API surfaces use secret redaction helpers | add MM-482-specific no-leak tests for all Claude operator-visible outputs in scope | unit |
+| DESIGN-REQ-016 | partial | owner checks exist for create/cancel/finalize/reconnect and profile management; Claude coverage is incomplete across all lifecycle actions | add Claude-focused auth tests for the remaining lifecycle actions and repair-like reconnect path | unit |
+| DESIGN-REQ-017 | partial | token hashing and consume-on-connect logic exist; no direct test yet proves replay is denied after first successful connect | add WebSocket replay-denial test and implement only if current logic fails | unit |
+| DESIGN-REQ-018 | partial | Claude launch and provider-profile surfaces already keep auth paths sanitized and separate from workspaces, but cross-surface credential-store-only proof remains incomplete | add tests for auth-volume treatment across validation, launch diagnostics, and operator-visible metadata; implement explicit guards if any surface leaks workspace/artifact semantics | unit + integration contingency |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest, existing OAuth session/terminal bridge/runtime-launch services  
+**Storage**: Existing OAuth session rows, provider-profile rows, managed-session diagnostics, artifact metadata, and workflow history; no new persistent tables planned  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` with focused targets under `tests/unit/api_service/api/routers/`, `tests/unit/services/temporal/runtime/`, and `tests/unit/workflows/temporal/`  
+**Integration Testing**: `./tools/test_integration.sh` only if changes affect hermetic API/artifact/worker seams beyond current in-process boundary tests  
+**Target Platform**: Linux API and worker containers in MoonMind-managed runtime environments  
+**Project Type**: FastAPI control plane plus Temporal-backed OAuth/session/runtime orchestration  
+**Performance Goals**: Guardrail enforcement remains bounded to existing route, WebSocket, verification, and launch surfaces without introducing new persistent storage or extra provider round-trips  
+**Constraints**: No raw credential contents, raw auth-volume paths below the mount root, token values, environment dumps, or durable terminal-input storage in operator-visible surfaces; preserve existing MM-478 through MM-481 behavior while strengthening guardrails; no compatibility aliases or hidden fallback semantics  
+**Scale/Scope**: One runtime (`claude_code`), one OAuth-backed profile (`claude_anthropic`), one OAuth session/terminal flow, one verification boundary, one runtime launch path, one cross-cutting guardrail story  
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The plan strengthens existing OAuth session, terminal, provider-profile, and launch boundaries rather than introducing a parallel auth system.
+- II. One-Click Agent Deployment: PASS. No new deployment dependencies or operator-managed services are introduced.
+- III. Avoid Vendor Lock-In: PASS. Claude-specific rules remain inside runtime/provider boundaries and shared redaction utilities.
+- IV. Own Your Data: PASS. Credential material remains in operator-controlled auth volumes; only redacted metadata crosses boundaries.
+- V. Skills Are First-Class: PASS. MoonSpec artifacts preserve MM-482 traceability for downstream automation.
+- VI. Bittersweet Lesson: PASS. The work is test-first around stable contracts and keeps scaffolding thin.
+- VII. Runtime Configurability: PASS. Existing profile/env-driven control surfaces remain the source of truth.
+- VIII. Modular Architecture: PASS. Planned work stays inside routes, terminal bridge, redaction helpers, provider-profile serialization, and launch/session activities.
+- IX. Resilient by Default: PASS. The plan emphasizes fail-closed authorization, one-time token use, and sanitized operator-visible failures.
+- X. Continuous Improvement: PASS. The requirement-status table and quickstart commands preserve verification evidence.
+- XI. Spec-Driven Development: PASS. This plan follows one independently testable MM-482 story.
+- XII. Canonical Docs vs Tmp: PASS. `docs/ManagedAgents/ClaudeAnthropicOAuth.md` remains the source design and the Jira brief stays under `docs/tmp`.
+- XIII. Pre-Release Velocity: PASS. No compatibility wrappers or partial migrations are proposed.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/245-claude-oauth-guardrails/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── claude-oauth-guardrails.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/oauth_sessions.py
+api_service/api/routers/provider_profiles.py
+api_service/services/provider_profile_service.py
+moonmind/utils/logging.py
+moonmind/workflows/temporal/workflows/oauth_session.py
+moonmind/workflows/temporal/runtime/terminal_bridge.py
+moonmind/workflows/temporal/activity_runtime.py
+moonmind/workflows/adapters/materializer.py
+moonmind/workflows/adapters/managed_agent_adapter.py
+moonmind/workflows/temporal/runtime/launcher.py
+
+ tests/unit/api_service/api/routers/test_oauth_sessions.py
+ tests/unit/api_service/api/routers/test_provider_profiles.py
+ tests/unit/services/temporal/runtime/test_terminal_bridge.py
+ tests/unit/workflows/temporal/test_agent_runtime_activities.py
+ tests/unit/services/temporal/runtime/test_launcher.py
+```
+
+**Structure Decision**: Add failing MM-482 guardrail tests first in the existing route, provider-profile, terminal-bridge, launch, and activity suites, then make the smallest production changes in shared authorization/redaction/materialization boundaries only where those tests expose a gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/245-claude-oauth-guardrails/quickstart.md
+++ b/specs/245-claude-oauth-guardrails/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Claude OAuth Authorization and Redaction Guardrails
+
+## Focused TDD Flow
+
+1. Add failing MM-482 guardrail tests first:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh \
+  tests/unit/api_service/api/routers/test_oauth_sessions.py \
+  tests/unit/api_service/api/routers/test_provider_profiles.py \
+  tests/unit/services/temporal/runtime/test_terminal_bridge.py \
+  tests/unit/workflows/temporal/test_agent_runtime_activities.py \
+  tests/unit/services/temporal/runtime/test_launcher.py
+```
+
+Expected red cases before implementation:
+- Claude reconnect-as-repair rejects unauthorized access before starting a successor session.
+- Claude attach-token replay is denied after the first successful WebSocket attach.
+- Claude OAuth session, provider-profile, verification, and launch-visible failures remain secret-free even when token-like data is present.
+- Claude auth-volume metadata is treated as credential-store-only and not as a workspace or artifact root.
+
+2. Implement the smallest production changes needed in existing boundaries:
+- `api_service/api/routers/oauth_sessions.py`
+- `api_service/api/routers/provider_profiles.py`
+- `moonmind/utils/logging.py`
+- `moonmind/workflows/temporal/runtime/terminal_bridge.py`
+- `moonmind/workflows/temporal/activity_runtime.py`
+- `moonmind/workflows/temporal/runtime/launcher.py`
+- other shared helpers only if the new tests expose a real guardrail gap
+
+3. Re-run focused validation until all MM-482 guardrail tests pass:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh \
+  tests/unit/api_service/api/routers/test_oauth_sessions.py \
+  tests/unit/api_service/api/routers/test_provider_profiles.py \
+  tests/unit/services/temporal/runtime/test_terminal_bridge.py \
+  tests/unit/workflows/temporal/test_agent_runtime_activities.py \
+  tests/unit/services/temporal/runtime/test_launcher.py
+```
+
+4. Run the full unit suite before closing implementation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Integration Strategy
+
+Run hermetic integration coverage only if the implementation changes compose-backed API, artifact, or worker-topology seams that the focused unit tests cannot prove safely:
+
+```bash
+./tools/test_integration.sh
+```
+
+Potential integration targets if MM-482 crosses compose-backed seams:
+- OAuth session route + WebSocket lifecycle integration
+- artifact/diagnostic publication around OAuth failures
+- managed runtime launch paths that surface auth diagnostics
+
+## End-to-End Verification Goal
+
+The story is ready for `/moonspec.verify` when the focused and full validation evidence proves:
+- unauthorized Claude OAuth lifecycle actions fail closed,
+- attach tokens are short-lived and single-use,
+- operator-visible surfaces remain secret-free,
+- and Claude auth volumes are treated only as credential stores.

--- a/specs/245-claude-oauth-guardrails/research.md
+++ b/specs/245-claude-oauth-guardrails/research.md
@@ -1,0 +1,65 @@
+# Research: Claude OAuth Authorization and Redaction Guardrails
+
+## FR-001 / DESIGN-REQ-016
+
+Decision: partial because the repo already enforces owner-scoped access for create, cancel, finalize, and reconnect, but Claude-specific proof is incomplete across the full lifecycle and there is no separate named repair test.
+Evidence: `api_service/api/routers/oauth_sessions.py` filters create/profile ownership, cancel/finalize/reconnect by `requested_by_user_id`; `tests/unit/api_service/api/routers/test_oauth_sessions.py::test_finalize_oauth_session_rejects_other_users_claude_session_before_verify` proves unauthorized Claude finalize is rejected before verification or mutation.
+Rationale: The core ownership checks exist and likely cover most of the story already. The remaining gap is proof that the repair-like reconnect flow and the other lifecycle actions satisfy the same Claude guardrail standard.
+Alternatives considered: Mark missing because repair is not a distinct route. Rejected because `POST /oauth-sessions/{id}/reconnect` clearly acts as the current repair/re-enrollment path.
+Test implications: Unit tests for Claude reconnect ownership and any missing create/cancel/attach owner-scope proof; no integration needed unless route behavior changes materially.
+
+## FR-002 / FR-003 / DESIGN-REQ-009 / DESIGN-REQ-017
+
+Decision: partial because hashed one-time attach tokens and consume-on-connect logic already exist, but the repo lacks direct Claude-focused proof that a successfully consumed token cannot be replayed.
+Evidence: `attach_oauth_terminal` stores `terminal_attach_token_sha256` and `terminal_attach_token_used=False`; `oauth_terminal_websocket` rejects missing, expired, used, or mismatched tokens and flips `terminal_attach_token_used=True` on connect; tests cover hash-only token issuance for Claude and expired-session rejection, but not successful consume-then-reuse denial.
+Rationale: The implementation looks correct, so the likely need is verification rather than redesign. MM-482 still needs explicit replay-denial evidence at the real route/WebSocket boundary.
+Alternatives considered: Mark implemented_verified from code inspection alone. Rejected because token-replay behavior is exactly the kind of boundary condition that should be proven by test.
+Test implications: Unit tests that attach once, mark the token used, and verify a second connect or attach attempt is rejected.
+
+## FR-004 / DESIGN-REQ-013
+
+Decision: implemented_unverified because secret-redaction helpers are already used throughout OAuth session responses, provider-profile serialization, launch activities, and launcher errors, but MM-482 needs Claude guardrail evidence that ties those surfaces together.
+Evidence: `moonmind/utils/logging.py` redacts bearer tokens, token assignments, auth-like paths, and nested payloads; `api_service/api/routers/oauth_sessions.py` redacts `failure_reason`; `api_service/api/routers/provider_profiles.py` and `provider_profile_service.py` redact secret-like runtime fields; `moonmind/workflows/temporal/activity_runtime.py` and `runtime/launcher.py` redact session and launch failures.
+Rationale: The infrastructure is present and already exercised in generic or adjacent Claude tests. The remaining work is to prove the MM-482 operator-visible surfaces stay secret-free when Claude-specific outputs contain token-like content.
+Alternatives considered: Mark partial and assume code changes are likely. Rejected because the current redaction implementation is already broad and the first step should be targeted proof.
+Test implications: Unit tests covering Claude failure reasons, provider-profile payloads, verification results, terminal bridge metadata, and launcher failures with token/path-shaped content.
+
+## FR-005 / DESIGN-REQ-004
+
+Decision: implemented_unverified because provider-profile response redaction and Claude finalize/profile registration already ensure ref-only persistence, but the story still lacks a Claude-specific proof matrix for profile and verification surfaces.
+Evidence: `tests/unit/api_service/api/routers/test_provider_profiles.py::test_provider_profile_response_redacts_secret_like_runtime_fields`; `test_provider_profile_manager_payload_redacts_secret_like_runtime_fields`; `tests/unit/api_service/api/routers/test_oauth_sessions.py::test_finalize_oauth_session_registers_claude_oauth_profile` asserts the Claude profile stores OAuth-home refs only and does not surface token-like values in its persisted shape.
+Rationale: The code paths likely satisfy the requirement already. MM-482 needs direct traceability showing those protections apply to the Claude OAuth lifecycle rather than only generic profile serialization.
+Alternatives considered: Mark implemented_verified now. Rejected because the existing generic redaction test is not Claude-specific and the story demands explicit guardrail evidence.
+Test implications: Unit tests that read Claude profile or verification payloads after lifecycle actions and assert ref-only / metadata-only output.
+
+## FR-006 / DESIGN-REQ-018
+
+Decision: partial because auth-volume separation already exists in launch/materialization and provider validation flows, but the repo does not yet prove the auth volume is treated as credential-store-only across all operator-visible surfaces in scope.
+Evidence: `moonmind/workflows/adapters/materializer.py`, `managed_agent_adapter.py`, `activity_runtime.py`, and `test_agent_runtime_activities.py::test_launch_session_materializes_claude_oauth_home_environment` keep `MANAGED_AUTH_VOLUME_PATH` and auth diagnostics separate from the workspace; `tests/unit/services/temporal/runtime/test_launcher.py` verifies the launcher cwd is distinct from the auth mount; `provider_profiles.py::validate_claude_oauth_profile` uses the mounted auth volume for verification.
+Rationale: Launch-time separation is already strong. The remaining risk is that validation, diagnostics, or audit-adjacent surfaces could still imply that the auth volume is a workspace or artifact root.
+Alternatives considered: Mark implemented_verified from launch tests alone. Rejected because MM-482 explicitly spans verification, launch, logs, artifacts, and profile rows.
+Test implications: Unit tests for validation/diagnostic payloads and launch metadata; integration only if artifact publication or compose-backed seams change.
+
+## FR-007 / SC-006 / DESIGN-REQ-018
+
+Decision: partial because multiple real-boundary tests already exist, but the story still needs a consolidated MM-482 proof set mapped to every protection in scope.
+Evidence: OAuth routes, provider-profile routes, terminal bridge, launch activities, and launcher tests all exist; current Claude-focused tests are distributed across MM-479, MM-480, and MM-481 boundary suites.
+Rationale: The implementation is not greenfield. The planning need is to formalize the guardrail matrix so implementation only changes code if distributed boundary tests reveal a genuine gap.
+Alternatives considered: Treat adjacent-story tests as final proof. Rejected because MM-482 is specifically the cross-cutting guardrail story and needs its own explicit traceability.
+Test implications: Unit-first test plan touching routes, WebSocket bridge, provider-profile serialization, verification, and launch boundaries.
+
+## FR-008
+
+Decision: implemented_verified.
+Evidence: `specs/245-claude-oauth-guardrails/spec.md` preserves MM-482 and the original Jira preset brief verbatim.
+Rationale: Traceability is already satisfied at the specification stage and must be carried forward.
+Alternatives considered: None.
+Test implications: None beyond final verify.
+
+## Test Strategy
+
+Decision: Use focused unit tests as the primary TDD harness, with hermetic integration tests only when guardrail changes affect compose-backed API/artifact/worker seams that unit tests cannot prove safely.
+Evidence: Existing MM-482-relevant coverage lives in route, WebSocket, provider-profile, launch-activity, and launcher unit suites. Repo guidance requires `./tools/test_unit.sh` for final unit validation and reserves `./tools/test_integration.sh` for hermetic integration seams.
+Rationale: The missing evidence is overwhelmingly in Python boundary behavior rather than external-provider behavior. Unit tests provide the fastest red/green loop and align with the story’s need for precise boundary proof.
+Alternatives considered: Start with integration tests. Rejected because the current gaps are best isolated and diagnosed at the unit boundary first.
+Test implications: Focused `./tools/test_unit.sh` targets first, then full `./tools/test_unit.sh`; run `./tools/test_integration.sh` only if implementation changes artifact publication, worker topology, or other compose-backed seams.

--- a/specs/245-claude-oauth-guardrails/spec.md
+++ b/specs/245-claude-oauth-guardrails/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Claude OAuth Authorization and Redaction Guardrails
+
+**Feature Branch**: `245-claude-oauth-guardrails`
+**Created**: 2026-04-23
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-482 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-482-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+
+## Original Preset Brief
+
+```text
+# MM-482 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-482
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Claude OAuth Authorization and Redaction Guardrails
+- Labels: `moonmind-workflow-mm-8f0966f3-d711-4289-9669-3a8e435353fb`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-482 from MM project
+Summary: Claude OAuth Authorization and Redaction Guardrails
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-482 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-482: Claude OAuth Authorization and Redaction Guardrails
+
+Source Reference
+- Source Document: `docs/ManagedAgents/ClaudeAnthropicOAuth.md`
+- Source Title: Claude Anthropic OAuth in Settings
+
+Source Sections
+- 2. OAuth Profile Shape
+- 3.4 Claude Sign-In Ceremony
+- 5. Verification
+- 7. Runtime Launch Behavior
+- 9. Security Requirements
+
+Coverage IDs
+- DESIGN-REQ-004
+- DESIGN-REQ-009
+- DESIGN-REQ-013
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+
+User Story
+As an operator and platform maintainer, I can rely on Claude OAuth lifecycle operations, terminal output, errors, logs, artifacts, and profile rows to enforce authorization and redact secret-like values across the full flow.
+
+Acceptance Criteria
+- Given an unauthenticated or unauthorized operator attempts to start, attach to, cancel, finalize, or repair a Claude OAuth session, then MoonMind denies the operation.
+- Given a browser terminal attach token is reused or expired, then attach fails.
+- Given terminal output, failure reasons, logs, or artifacts contain secret-like values, then externally visible output is redacted.
+- Given provider profile rows are read, then they contain refs and metadata only, never credential file contents.
+- Given OAuth auth volume metadata is surfaced, then the volume is described as a credential store and not exposed as a task workspace or audit artifact.
+- Given guardrail tests run, then they cover the real API/workflow/activity or adapter boundary rather than only isolated helpers.
+
+Requirements
+- Enforce authorization across Claude OAuth start, attach, cancel, finalize, and repair operations.
+- Make browser terminal attach tokens short-lived and single-use.
+- Redact secret-like values from terminal output, failure reasons, logs, and artifacts.
+- Keep provider profile rows limited to refs and metadata.
+- Treat OAuth auth volumes strictly as credential stores.
+
+Implementation Notes
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the governing design source for profile shape, sign-in ceremony, verification, runtime launch behavior, and security requirements.
+- Keep authorization enforcement consistent across Claude OAuth start, attach, cancel, finalize, and repair operations.
+- Ensure attach tokens are both short-lived and single-use.
+- Redact secret-like values from terminal output, failure reasons, logs, and artifacts before they become externally visible.
+- Preserve provider profile rows as refs-and-metadata only; never expose credential file contents.
+- Surface OAuth auth volumes strictly as credential stores, not as task workspaces or audit artifacts.
+- Add or update guardrail tests at the real API, workflow, activity, or adapter boundary rather than only isolated helper coverage.
+
+Needs Clarification
+- None
+```
+
+## User Story - Claude OAuth Authorization and Redaction Guardrails
+
+**Summary**: As an operator and platform maintainer, I want Claude OAuth lifecycle operations and observable outputs to enforce authorization and redact secret-like values so credential enrollment and runtime use remain secure across the full flow.
+
+**Goal**: Claude OAuth start, attach, cancel, finalize, repair, runtime launch, logs, artifacts, and provider-profile surfaces consistently reject unauthorized access, treat auth volumes as credential stores, and expose only secret-free metadata.
+
+**Independent Test**: Exercise or simulate authorized and unauthorized Claude OAuth lifecycle operations, terminal attach-token reuse, terminal/log/artifact output containing secret-like values, and provider-profile read paths, then verify unauthorized actions fail closed, attach tokens are single-use and short-lived, auth volumes are not exposed as workspaces or artifacts, and all externally visible outputs remain secret-free.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator lacks permission for a Claude OAuth session, **When** they attempt to start, attach to, cancel, finalize, or repair it, **Then** the system rejects the operation before terminal access, verification, profile mutation, or other side effects occur.
+2. **Given** a browser terminal attach token is expired, reused, or presented by the wrong operator, **When** terminal attachment is attempted, **Then** the attachment is denied and the token cannot be used to access the Claude OAuth terminal.
+3. **Given** terminal output, failure summaries, diagnostics, logs, or artifacts include secret-like values, **When** the system records or exposes those surfaces, **Then** only redacted or secret-free output is visible to operators and downstream systems.
+4. **Given** a provider profile row or OAuth verification result is returned, **When** it is inspected through API or UI surfaces, **Then** it contains refs and metadata only and never credential file contents, raw tokens, or other secret-bearing payloads.
+5. **Given** the Claude OAuth auth volume or mounted Claude home is referenced during verification, launch, or auditing, **When** external metadata is produced, **Then** the volume is described only as a credential store and is not treated as a task workspace or artifact-backed path.
+6. **Given** guardrail validation runs for Claude OAuth, **When** implementation evidence is collected, **Then** coverage includes the real API, workflow, activity, terminal-bridge, or adapter boundary rather than only isolated helper tests.
+
+### Edge Cases
+
+- An operator owns one Claude OAuth session but attempts to attach to or repair another operator's session.
+- A terminal attach token is still within session lifetime but has already been consumed once.
+- Redaction logic encounters secret-like data in structured JSON, multiline terminal text, or nested error payloads.
+- Existing successful OAuth verification or runtime-launch behavior must remain intact while authorization and redaction controls are strengthened.
+- Debug or diagnostic output attempts to include raw auth-volume paths, credential filenames, or provider-profile payloads.
+
+## Assumptions
+
+- MM-478, MM-479, MM-480, and MM-481 cover Claude OAuth session creation, browser sign-in, verification/profile registration, and runtime launch behavior respectively; MM-482 is the cross-cutting guardrail story spanning those lifecycle surfaces.
+- `docs/ManagedAgents/ClaudeAnthropicOAuth.md` is the authoritative source design for Claude OAuth profile shape, sign-in ceremony, verification, runtime launch behavior, and security requirements.
+- Runtime intent is required; documentation updates alone are not sufficient for this story.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-004** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 2): OAuth-backed Claude profile and related metadata surfaces must preserve the documented credential-store boundaries and must not degrade into exposing credential-bearing content. Scope: in scope, mapped to FR-004 and FR-005.
+- **DESIGN-REQ-009** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 3.4): Claude OAuth terminal interaction must remain gated by operator-waiting and attach-token controls so only authorized attachment succeeds. Scope: in scope, mapped to FR-002 and FR-003.
+- **DESIGN-REQ-013** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 5): OAuth verification and related observable outputs must expose only secret-free metadata and never raw credential contents. Scope: in scope, mapped to FR-004 and FR-006.
+- **DESIGN-REQ-016** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 9): Only authorized operators may start, attach to, cancel, finalize, or repair Claude OAuth sessions. Scope: in scope, mapped to FR-001 and FR-002.
+- **DESIGN-REQ-017** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 9): Browser terminal attach tokens must be short-lived and single-use. Scope: in scope, mapped to FR-002 and FR-003.
+- **DESIGN-REQ-018** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` sections 7 and 9): Claude OAuth runtime launch and surrounding surfaces must keep auth-volume material treated as credential storage, avoid raw credential contents in workflow history/logs/artifacts, and maintain secure runtime boundaries. Scope: in scope, mapped to FR-005, FR-006, and FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST enforce authorization checks across Claude OAuth start, attach, cancel, finalize, and repair operations before any side effects occur.
+- **FR-002**: System MUST restrict browser terminal attachment for Claude OAuth sessions to the owning authorized operator.
+- **FR-003**: System MUST require Claude OAuth browser terminal attach tokens to be short-lived, single-use, and rejected after expiration or prior consumption.
+- **FR-004**: System MUST redact or exclude secret-like values from terminal output, failure summaries, logs, diagnostics, artifacts, API responses, and other externally visible Claude OAuth surfaces.
+- **FR-005**: System MUST ensure provider-profile rows and related OAuth metadata surfaces expose refs and metadata only and never credential file contents or raw token values.
+- **FR-006**: System MUST treat Claude OAuth auth volumes and mounted Claude-home paths strictly as credential stores rather than task workspaces, artifact-backed paths, or audit artifact content.
+- **FR-007**: System MUST provide guardrail validation at the real API, workflow, activity, terminal-bridge, or adapter boundary for the authorization, token, redaction, and credential-store protections in this story.
+- **FR-008**: System MUST preserve MM-482 in implementation notes, verification output, commit text, and pull request metadata for traceability.
+
+### Key Entities
+
+- **Claude OAuth Session Authorization Boundary**: The access-control decision surface governing who may start, attach to, cancel, finalize, or repair a Claude OAuth session.
+- **OAuth Terminal Attach Token**: A short-lived, single-use session attachment credential scoped to the owning operator and Claude OAuth terminal bridge.
+- **Secret-Free Observable Output**: Any operator-visible terminal output, failure summary, diagnostic record, artifact, API response, or provider-profile payload with secret-like values removed or excluded.
+- **Claude OAuth Credential Store Surface**: The auth volume, mounted Claude-home path, and related metadata that must remain credential-storage only rather than becoming a workspace or artifact content source.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Boundary tests prove unauthorized Claude OAuth start, attach, cancel, finalize, and repair attempts are rejected before side effects occur.
+- **SC-002**: Terminal attach tests prove expired or reused Claude OAuth attach tokens are rejected and cannot access the terminal bridge.
+- **SC-003**: Redaction tests prove secret-like values are absent from terminal output, failure summaries, logs, diagnostics, artifacts, and API-visible metadata after Claude OAuth flows run.
+- **SC-004**: Provider-profile or verification-surface tests prove only refs and metadata are returned and no credential file contents or raw token values are exposed.
+- **SC-005**: Runtime-launch or audit-surface tests prove Claude OAuth auth volumes are not treated as task workspaces or artifact-backed content paths.
+- **SC-006**: Verification evidence covers the real API, workflow, activity, terminal-bridge, or adapter boundary for each protection in scope rather than only isolated helper functions.

--- a/specs/245-claude-oauth-guardrails/tasks.md
+++ b/specs/245-claude-oauth-guardrails/tasks.md
@@ -25,8 +25,8 @@
 
 **Purpose**: Confirm the active MM-482 artifact set and validation targets before any test or code work begins.
 
-- [ ] T001 Confirm `specs/245-claude-oauth-guardrails/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/claude-oauth-guardrails.md`
-- [ ] T002 Confirm focused validation targets exist in `tests/unit/api_service/api/routers/test_oauth_sessions.py`, `tests/unit/api_service/api/routers/test_provider_profiles.py`, `tests/unit/services/temporal/runtime/test_terminal_bridge.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, and `tests/unit/services/temporal/runtime/test_launcher.py`
+- [X] T001 Confirm `specs/245-claude-oauth-guardrails/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/claude-oauth-guardrails.md`
+- [X] T002 Confirm focused validation targets exist in `tests/unit/api_service/api/routers/test_oauth_sessions.py`, `tests/unit/api_service/api/routers/test_provider_profiles.py`, `tests/unit/services/temporal/runtime/test_terminal_bridge.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, and `tests/unit/services/temporal/runtime/test_launcher.py`
 
 ---
 
@@ -36,9 +36,9 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T003 Confirm no database migration is required because MM-482 uses existing OAuth session rows, provider-profile rows, metadata payloads, and artifact/diagnostic redaction infrastructure in `api_service/db/models.py`
-- [ ] T004 Confirm no new package dependency is required because MM-482 uses existing FastAPI, SQLAlchemy async ORM, Temporal runtime, terminal bridge, launcher, and pytest infrastructure in `api_service/api/routers/`, `moonmind/workflows/temporal/`, and `moonmind/utils/logging.py`
-- [ ] T005 Confirm integration remains contingency-only unless the MM-482 fixes change compose-backed API/artifact/worker seams, based on `specs/245-claude-oauth-guardrails/plan.md`, `research.md`, and `quickstart.md`
+- [X] T003 Confirm no database migration is required because MM-482 uses existing OAuth session rows, provider-profile rows, metadata payloads, and artifact/diagnostic redaction infrastructure in `api_service/db/models.py`
+- [X] T004 Confirm no new package dependency is required because MM-482 uses existing FastAPI, SQLAlchemy async ORM, Temporal runtime, terminal bridge, launcher, and pytest infrastructure in `api_service/api/routers/`, `moonmind/workflows/temporal/`, and `moonmind/utils/logging.py`
+- [X] T005 Confirm integration remains contingency-only unless the MM-482 fixes change compose-backed API/artifact/worker seams, based on `specs/245-claude-oauth-guardrails/plan.md`, `research.md`, and `quickstart.md`
 
 **Checkpoint**: Foundation ready. Story verification and implementation work can now begin.
 
@@ -68,49 +68,49 @@
 
 > Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
 
-- [ ] T006 [P] Add failing Claude OAuth authorization route tests for create, cancel, and reconnect-as-repair ownership boundaries covering FR-001, SC-001, and DESIGN-REQ-016 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
-- [ ] T007 [P] Add failing Claude OAuth attach-token replay and single-use tests covering FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
-- [ ] T008 [P] Add failing Claude OAuth provider-profile and verification-surface no-leak tests covering FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013 in `tests/unit/api_service/api/routers/test_provider_profiles.py`
-- [ ] T009 [P] Add failing Claude OAuth terminal-bridge safe-metadata and replay-adjacent tests covering FR-003, FR-004, SC-002, SC-003, DESIGN-REQ-009, and DESIGN-REQ-013 in `tests/unit/services/temporal/runtime/test_terminal_bridge.py`
-- [ ] T010 [P] Add failing Claude auth-diagnostics sanitization tests covering FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-013, and DESIGN-REQ-018 in `tests/unit/workflows/temporal/test_agent_runtime_activities.py`
-- [ ] T011 [P] Add failing Claude auth-volume credential-store boundary tests for launch metadata and workspace separation covering FR-006, SC-005, and DESIGN-REQ-018 in `tests/unit/services/temporal/runtime/test_launcher.py`
+- [X] T006 [P] Add failing Claude OAuth authorization route tests for create, cancel, and reconnect-as-repair ownership boundaries covering FR-001, SC-001, and DESIGN-REQ-016 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [X] T007 [P] Add failing Claude OAuth attach-token replay and single-use tests covering FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [X] T008 [P] Add failing Claude OAuth provider-profile and verification-surface no-leak tests covering FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013 in `tests/unit/api_service/api/routers/test_provider_profiles.py`
+- [X] T009 [P] Add failing Claude OAuth terminal-bridge safe-metadata and replay-adjacent tests covering FR-003, FR-004, SC-002, SC-003, DESIGN-REQ-009, and DESIGN-REQ-013 in `tests/unit/services/temporal/runtime/test_terminal_bridge.py`
+- [X] T010 [P] Add failing Claude auth-diagnostics sanitization tests covering FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-013, and DESIGN-REQ-018 in `tests/unit/workflows/temporal/test_agent_runtime_activities.py`
+- [X] T011 [P] Add failing Claude auth-volume credential-store boundary tests for launch metadata and workspace separation covering FR-006, SC-005, and DESIGN-REQ-018 in `tests/unit/services/temporal/runtime/test_launcher.py`
 
 ### Integration Tests (write before implementation when required)
 
-- [ ] T012 Add contingent hermetic integration coverage for MM-482 in `tests/integration/temporal/test_claude_oauth_guardrails.py` only if T006-T011 expose behavior that cannot be proven safely by unit tests, covering FR-007, SC-006, and DESIGN-REQ-018
+- [X] T012 Add contingent hermetic integration coverage for MM-482 in `tests/integration/temporal/test_claude_oauth_guardrails.py` only if T006-T011 expose behavior that cannot be proven safely by unit tests, covering FR-007, SC-006, and DESIGN-REQ-018. Not required because the MM-482 gaps were proven and fixed inside existing route, provider-profile, terminal-bridge, activity, and launcher unit boundaries.
 
 ### Red-First Confirmation
 
-- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py` and confirm T006-T011 fail for the expected MM-482 reasons before production changes
-- [ ] T014 If T012 was required, run `./tools/test_integration.sh` and confirm the new MM-482 integration coverage fails for the expected reason before production changes
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py` and confirm T006-T011 fail for the expected MM-482 reasons before production changes
+- [X] T014 If T012 was required, run `./tools/test_integration.sh` and confirm the new MM-482 integration coverage fails for the expected reason before production changes. Not required because T012 was not needed.
 
 ### Conditional Fallback Implementation Tasks for `implemented_unverified` Rows
 
-- [ ] T015 If T007 or T009 fails because attach-token replay or single-use enforcement is incomplete, update `api_service/api/routers/oauth_sessions.py` and `moonmind/workflows/temporal/runtime/terminal_bridge.py` for FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017
-- [ ] T016 If T008, T010, or T011 fails because operator-visible Claude OAuth surfaces leak secret-like values or raw auth-path details, update `moonmind/utils/logging.py`, `api_service/api/routers/provider_profiles.py`, `api_service/services/provider_profile_service.py`, and `moonmind/workflows/temporal/activity_runtime.py` for FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013
+- [X] T015 If T007 or T009 fails because attach-token replay or single-use enforcement is incomplete, update `api_service/api/routers/oauth_sessions.py` and `moonmind/workflows/temporal/runtime/terminal_bridge.py` for FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017. Skipped because the replay and single-use enforcement already passed once the new boundary tests were in place.
+- [X] T016 If T008, T010, or T011 fails because operator-visible Claude OAuth surfaces leak secret-like values or raw auth-path details, update `moonmind/utils/logging.py`, `api_service/api/routers/provider_profiles.py`, `api_service/services/provider_profile_service.py`, and `moonmind/workflows/temporal/activity_runtime.py` for FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013
 
 ### Models / Entities / Validation
 
-- [ ] T017 If T006 or T008 fails because session/profile ownership or Claude OAuth metadata validation is incomplete, update `api_service/api/routers/oauth_sessions.py`, `api_service/api/routers/provider_profiles.py`, and any related validation helpers for FR-001, FR-005, SC-001, and DESIGN-REQ-016
+- [X] T017 If T006 or T008 fails because session/profile ownership or Claude OAuth metadata validation is incomplete, update `api_service/api/routers/oauth_sessions.py`, `api_service/api/routers/provider_profiles.py`, and any related validation helpers for FR-001, FR-005, SC-001, and DESIGN-REQ-016. Skipped because the new ownership and metadata-validation tests passed without router contract changes.
 
 ### Services / Domain Logic
 
-- [ ] T018 If T010 or T011 fails because auth-volume metadata is treated as workspace or artifact state, update `moonmind/workflows/adapters/materializer.py`, `moonmind/workflows/adapters/managed_agent_adapter.py`, and `moonmind/workflows/temporal/runtime/launcher.py` for FR-006, SC-005, and DESIGN-REQ-018
-- [ ] T019 If T008 fails because ref-only/profile-summary behavior is inconsistent between API and manager payloads, update `api_service/services/provider_profile_service.py` and `api_service/api/routers/provider_profiles.py` for FR-005, SC-004, and DESIGN-REQ-004
+- [X] T018 If T010 or T011 fails because auth-volume metadata is treated as workspace or artifact state, update `moonmind/workflows/adapters/materializer.py`, `moonmind/workflows/adapters/managed_agent_adapter.py`, and `moonmind/workflows/temporal/runtime/launcher.py` for FR-006, SC-005, and DESIGN-REQ-018. Skipped because the added auth-volume boundary tests passed without runtime-materialization changes.
+- [X] T019 If T008 fails because ref-only/profile-summary behavior is inconsistent between API and manager payloads, update `api_service/services/provider_profile_service.py` and `api_service/api/routers/provider_profiles.py` for FR-005, SC-004, and DESIGN-REQ-004. Skipped because the new Claude profile-summary assertions passed once validation-failure redaction was fixed.
 
 ### Endpoints / Public Contracts / Runtime Boundaries
 
-- [ ] T020 If T006 or T007 fails because lifecycle authorization or reconnect-as-repair behavior is incomplete for Claude OAuth, update `api_service/api/routers/oauth_sessions.py` for FR-001, FR-002, FR-003, SC-001, SC-002, and DESIGN-REQ-016
-- [ ] T021 If T010 or T011 fails because launch/activity boundaries still surface raw auth-volume details, update `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/runtime/launcher.py` for FR-004, FR-006, FR-007, SC-003, SC-005, and DESIGN-REQ-018
+- [X] T020 If T006 or T007 fails because lifecycle authorization or reconnect-as-repair behavior is incomplete for Claude OAuth, update `api_service/api/routers/oauth_sessions.py` for FR-001, FR-002, FR-003, SC-001, SC-002, and DESIGN-REQ-016. Skipped because the new lifecycle authorization and replay tests passed without changing the OAuth session router.
+- [X] T021 If T010 or T011 fails because launch/activity boundaries still surface raw auth-volume details, update `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/runtime/launcher.py` for FR-004, FR-006, FR-007, SC-003, SC-005, and DESIGN-REQ-018. Skipped because the added launch/activity boundary checks passed without further code changes.
 
 ### Integration Wiring
 
-- [ ] T022 If T012 becomes necessary, wire the minimum integration fixtures and assertions in `tests/integration/temporal/test_claude_oauth_guardrails.py` and document the seam-specific rationale in `specs/245-claude-oauth-guardrails/tasks.md`
+- [X] T022 If T012 becomes necessary, wire the minimum integration fixtures and assertions in `tests/integration/temporal/test_claude_oauth_guardrails.py` and document the seam-specific rationale in `specs/245-claude-oauth-guardrails/tasks.md`. Not required because T012 was not needed.
 
 ### Story Validation
 
-- [ ] T023 Run the focused MM-482 unit validation command until all new Claude guardrail tests pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py`
-- [ ] T024 Run `./tools/test_integration.sh` only if T012/T014/T022 were required by changed compose-backed seams; otherwise record the explicit no-integration rationale for MM-482 in `specs/245-claude-oauth-guardrails/tasks.md`
+- [X] T023 Run the focused MM-482 unit validation command until all new Claude guardrail tests pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py`
+- [X] T024 Run `./tools/test_integration.sh` only if T012/T014/T022 were required by changed compose-backed seams; otherwise record the explicit no-integration rationale for MM-482 in `specs/245-claude-oauth-guardrails/tasks.md`. Not run because MM-482 was completed entirely inside existing unit-testable boundaries and did not change any compose-backed seam.
 
 **Checkpoint**: The MM-482 story is functionally complete, independently testable, and validated against the Claude OAuth guardrail contract.
 
@@ -120,10 +120,10 @@
 
 **Purpose**: Strengthen the completed story without expanding scope.
 
-- [ ] T025 [P] Review `specs/245-claude-oauth-guardrails/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-guardrails.md`, `quickstart.md`, and `tasks.md` for MM-482 traceability covering FR-008
-- [ ] T026 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
-- [ ] T027 If compose-backed seams changed, run final hermetic integration verification with `./tools/test_integration.sh`; otherwise preserve the documented no-integration rationale covering FR-007 and SC-006
-- [ ] T028 Run `/moonspec-verify` after implementation and tests pass, using `specs/245-claude-oauth-guardrails/spec.md` and the preserved MM-482 Jira preset brief as the final alignment source
+- [X] T025 [P] Review `specs/245-claude-oauth-guardrails/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-guardrails.md`, `quickstart.md`, and `tasks.md` for MM-482 traceability covering FR-008
+- [X] T026 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [X] T027 If compose-backed seams changed, run final hermetic integration verification with `./tools/test_integration.sh`; otherwise preserve the documented no-integration rationale covering FR-007 and SC-006. Not run because MM-482 did not require any compose-backed integration seam change.
+- [X] T028 Run `/moonspec-verify` after implementation and tests pass, using `specs/245-claude-oauth-guardrails/spec.md` and the preserved MM-482 Jira preset brief as the final alignment source
 
 ---
 

--- a/specs/245-claude-oauth-guardrails/tasks.md
+++ b/specs/245-claude-oauth-guardrails/tasks.md
@@ -1,0 +1,164 @@
+# Tasks: Claude OAuth Authorization and Redaction Guardrails
+
+**Input**: Design documents from `specs/245-claude-oauth-guardrails/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-guardrails.md`, `quickstart.md`
+
+**Tests**: Unit tests are REQUIRED and must be written or confirmed first. Integration tests are REQUIRED by the story only when changes reach compose-backed API, artifact, worker-topology, or WebSocket seams that unit tests cannot safely prove. Confirm red-first behavior before production changes.
+
+**Organization**: Tasks are grouped around the single MM-482 story: Claude OAuth lifecycle operations, attach tokens, operator-visible outputs, provider-profile payloads, and auth-volume boundaries must enforce authorization, remain secret-free, and treat the Claude auth volume strictly as a credential store.
+
+**Source Traceability**: FR-001 through FR-008, acceptance scenarios 1-6, SC-001 through SC-006, and DESIGN-REQ-004, DESIGN-REQ-009, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-018.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py`
+- Integration tests: `./tools/test_integration.sh` only if implementation changes compose-backed API/artifact/worker seams beyond the current in-process guardrail boundaries
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when tasks touch different files and do not depend on incomplete work.
+- Include exact file paths in descriptions.
+- Include requirement, scenario, or source IDs when the task implements or validates behavior.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active MM-482 artifact set and validation targets before any test or code work begins.
+
+- [ ] T001 Confirm `specs/245-claude-oauth-guardrails/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/claude-oauth-guardrails.md`
+- [ ] T002 Confirm focused validation targets exist in `tests/unit/api_service/api/routers/test_oauth_sessions.py`, `tests/unit/api_service/api/routers/test_provider_profiles.py`, `tests/unit/services/temporal/runtime/test_terminal_bridge.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, and `tests/unit/services/temporal/runtime/test_launcher.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Validate that no additional schema, migration, dependency, or test-harness foundation is needed before story work begins.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T003 Confirm no database migration is required because MM-482 uses existing OAuth session rows, provider-profile rows, metadata payloads, and artifact/diagnostic redaction infrastructure in `api_service/db/models.py`
+- [ ] T004 Confirm no new package dependency is required because MM-482 uses existing FastAPI, SQLAlchemy async ORM, Temporal runtime, terminal bridge, launcher, and pytest infrastructure in `api_service/api/routers/`, `moonmind/workflows/temporal/`, and `moonmind/utils/logging.py`
+- [ ] T005 Confirm integration remains contingency-only unless the MM-482 fixes change compose-backed API/artifact/worker seams, based on `specs/245-claude-oauth-guardrails/plan.md`, `research.md`, and `quickstart.md`
+
+**Checkpoint**: Foundation ready. Story verification and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Claude OAuth Authorization and Redaction Guardrails
+
+**Summary**: As an operator and platform maintainer, Claude OAuth lifecycle operations and observable outputs must enforce authorization, reject attach-token replay, redact secret-like values, and keep the Claude auth volume treated as a credential store across the full flow.
+
+**Independent Test**: Exercise or simulate authorized and unauthorized Claude OAuth lifecycle actions, attach-token issuance and replay, secret-like terminal/log/artifact output, provider-profile and verification payloads, and auth-volume-related launch/validation metadata. Verify unauthorized actions fail closed, replay is denied, all operator-visible surfaces remain secret-free, and the auth volume is never treated as a workspace or artifact root.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-004, DESIGN-REQ-009, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-018
+
+**Unit Test Plan**:
+
+- Route tests prove owner-scoped authorization for create/attach/cancel/finalize/reconnect and prove attach-token replay denial at the real OAuth session boundary.
+- Provider-profile tests prove Claude OAuth profile and verification-adjacent payloads expose refs and metadata only.
+- Terminal-bridge tests prove safe metadata stays secret-free and token-like input is not leaked while replay or unsupported-frame cases are denied.
+- Activity and launcher tests prove Claude auth diagnostics and auth-volume metadata stay sanitized and separate from workspace/artifact roots.
+
+**Integration Test Plan**:
+
+- If implementation changes compose-backed OAuth session, WebSocket wiring, artifact publication, or managed-runtime launch seams, add or update hermetic integration coverage and run `./tools/test_integration.sh`.
+- If implementation remains inside the current route, bridge, provider-profile, activity, and launcher unit boundaries, document why integration did not need to run.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [ ] T006 [P] Add failing Claude OAuth authorization route tests for create, cancel, and reconnect-as-repair ownership boundaries covering FR-001, SC-001, and DESIGN-REQ-016 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [ ] T007 [P] Add failing Claude OAuth attach-token replay and single-use tests covering FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017 in `tests/unit/api_service/api/routers/test_oauth_sessions.py`
+- [ ] T008 [P] Add failing Claude OAuth provider-profile and verification-surface no-leak tests covering FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013 in `tests/unit/api_service/api/routers/test_provider_profiles.py`
+- [ ] T009 [P] Add failing Claude OAuth terminal-bridge safe-metadata and replay-adjacent tests covering FR-003, FR-004, SC-002, SC-003, DESIGN-REQ-009, and DESIGN-REQ-013 in `tests/unit/services/temporal/runtime/test_terminal_bridge.py`
+- [ ] T010 [P] Add failing Claude auth-diagnostics sanitization tests covering FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-013, and DESIGN-REQ-018 in `tests/unit/workflows/temporal/test_agent_runtime_activities.py`
+- [ ] T011 [P] Add failing Claude auth-volume credential-store boundary tests for launch metadata and workspace separation covering FR-006, SC-005, and DESIGN-REQ-018 in `tests/unit/services/temporal/runtime/test_launcher.py`
+
+### Integration Tests (write before implementation when required)
+
+- [ ] T012 Add contingent hermetic integration coverage for MM-482 in `tests/integration/temporal/test_claude_oauth_guardrails.py` only if T006-T011 expose behavior that cannot be proven safely by unit tests, covering FR-007, SC-006, and DESIGN-REQ-018
+
+### Red-First Confirmation
+
+- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py` and confirm T006-T011 fail for the expected MM-482 reasons before production changes
+- [ ] T014 If T012 was required, run `./tools/test_integration.sh` and confirm the new MM-482 integration coverage fails for the expected reason before production changes
+
+### Conditional Fallback Implementation Tasks for `implemented_unverified` Rows
+
+- [ ] T015 If T007 or T009 fails because attach-token replay or single-use enforcement is incomplete, update `api_service/api/routers/oauth_sessions.py` and `moonmind/workflows/temporal/runtime/terminal_bridge.py` for FR-002, FR-003, SC-002, DESIGN-REQ-009, and DESIGN-REQ-017
+- [ ] T016 If T008, T010, or T011 fails because operator-visible Claude OAuth surfaces leak secret-like values or raw auth-path details, update `moonmind/utils/logging.py`, `api_service/api/routers/provider_profiles.py`, `api_service/services/provider_profile_service.py`, and `moonmind/workflows/temporal/activity_runtime.py` for FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-004, and DESIGN-REQ-013
+
+### Models / Entities / Validation
+
+- [ ] T017 If T006 or T008 fails because session/profile ownership or Claude OAuth metadata validation is incomplete, update `api_service/api/routers/oauth_sessions.py`, `api_service/api/routers/provider_profiles.py`, and any related validation helpers for FR-001, FR-005, SC-001, and DESIGN-REQ-016
+
+### Services / Domain Logic
+
+- [ ] T018 If T010 or T011 fails because auth-volume metadata is treated as workspace or artifact state, update `moonmind/workflows/adapters/materializer.py`, `moonmind/workflows/adapters/managed_agent_adapter.py`, and `moonmind/workflows/temporal/runtime/launcher.py` for FR-006, SC-005, and DESIGN-REQ-018
+- [ ] T019 If T008 fails because ref-only/profile-summary behavior is inconsistent between API and manager payloads, update `api_service/services/provider_profile_service.py` and `api_service/api/routers/provider_profiles.py` for FR-005, SC-004, and DESIGN-REQ-004
+
+### Endpoints / Public Contracts / Runtime Boundaries
+
+- [ ] T020 If T006 or T007 fails because lifecycle authorization or reconnect-as-repair behavior is incomplete for Claude OAuth, update `api_service/api/routers/oauth_sessions.py` for FR-001, FR-002, FR-003, SC-001, SC-002, and DESIGN-REQ-016
+- [ ] T021 If T010 or T011 fails because launch/activity boundaries still surface raw auth-volume details, update `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/runtime/launcher.py` for FR-004, FR-006, FR-007, SC-003, SC-005, and DESIGN-REQ-018
+
+### Integration Wiring
+
+- [ ] T022 If T012 becomes necessary, wire the minimum integration fixtures and assertions in `tests/integration/temporal/test_claude_oauth_guardrails.py` and document the seam-specific rationale in `specs/245-claude-oauth-guardrails/tasks.md`
+
+### Story Validation
+
+- [ ] T023 Run the focused MM-482 unit validation command until all new Claude guardrail tests pass: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py`
+- [ ] T024 Run `./tools/test_integration.sh` only if T012/T014/T022 were required by changed compose-backed seams; otherwise record the explicit no-integration rationale for MM-482 in `specs/245-claude-oauth-guardrails/tasks.md`
+
+**Checkpoint**: The MM-482 story is functionally complete, independently testable, and validated against the Claude OAuth guardrail contract.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [ ] T025 [P] Review `specs/245-claude-oauth-guardrails/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/claude-oauth-guardrails.md`, `quickstart.md`, and `tasks.md` for MM-482 traceability covering FR-008
+- [ ] T026 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [ ] T027 If compose-backed seams changed, run final hermetic integration verification with `./tools/test_integration.sh`; otherwise preserve the documented no-integration rationale covering FR-007 and SC-006
+- [ ] T028 Run `/moonspec-verify` after implementation and tests pass, using `specs/245-claude-oauth-guardrails/spec.md` and the preserved MM-482 Jira preset brief as the final alignment source
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion.
+- Story (Phase 3): depends on Foundational completion.
+- Polish (Phase 4): depends on story validation passing.
+
+### Within The Story
+
+- T006-T011 must be written before any production code changes.
+- T012 is contingent and only applies when unit tests expose a compose-backed seam that requires hermetic proof.
+- T013 and T014 must confirm red-first behavior before T015-T022.
+- T015-T022 are conditional fallback implementation tasks and should be executed only when the corresponding verification tests expose a real gap.
+- T023 must pass before T024 and any polish work.
+
+### Parallel Opportunities
+
+- T006-T007 can be authored together in `tests/unit/api_service/api/routers/test_oauth_sessions.py` if coordinated as one file edit.
+- T008 can run in parallel because it targets `tests/unit/api_service/api/routers/test_provider_profiles.py`.
+- T009 can run in parallel because it targets `tests/unit/services/temporal/runtime/test_terminal_bridge.py`.
+- T010 can run in parallel because it targets `tests/unit/workflows/temporal/test_agent_runtime_activities.py`.
+- T011 can run in parallel because it targets `tests/unit/services/temporal/runtime/test_launcher.py`.
+- T025 can run in parallel with final verification command preparation after T023 completes.
+
+## Implementation Strategy
+
+1. Confirm the active MM-482 artifacts and validation targets.
+2. Add failing Claude guardrail tests first across routes, provider-profile serialization, terminal bridge, activities, and launcher boundaries.
+3. Run the focused red-first validation and preserve the failure evidence.
+4. Apply only the conditional production changes exposed by the failing tests.
+5. Re-run focused validation until the MM-482 story passes.
+6. Run full unit verification and hermetic integration verification only when required by the changed seam.
+7. Finish with `/moonspec-verify` using the preserved MM-482 preset brief as the final alignment source.

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -25,6 +25,7 @@ from api_service.main import app
 from api_service.api.routers.oauth_sessions import (
     _handle_oauth_terminal_ws_message,
     _make_terminal_output_sender,
+    oauth_terminal_websocket,
 )
 from moonmind.workflows.temporal.runtime.terminal_bridge import (
     InMemoryPtyAdapter,
@@ -1163,3 +1164,212 @@ async def test_finalize_oauth_session_rejects_other_users_claude_session_before_
             ManagedAgentProviderProfile, "claude_anthropic_other_user"
         )
         assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_create_claude_oauth_session_rejects_other_users_profile_id(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "claude_anthropic_owned_elsewhere"
+    owner_id = uuid.uuid4()
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="claude_code",
+                provider_id="anthropic",
+                provider_label="Anthropic",
+                owner_user_id=owner_id,
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                enabled=True,
+            )
+        )
+        await session.commit()
+
+    async def _unexpected_start(_session_model):
+        raise AssertionError("unauthorized create must not start workflow")
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _unexpected_start,
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions",
+            json={
+                "runtime_id": "claude_code",
+                "profile_id": profile_id,
+                "account_label": "Claude Anthropic OAuth",
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized to use this profile ID."
+
+    async with db_base.async_session_maker() as session:
+        query = await session.execute(
+            select(ManagedAgentOAuthSession).where(
+                ManagedAgentOAuthSession.profile_id == profile_id
+            )
+        )
+        assert query.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_oauth_session_rejects_other_users_claude_session(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_claudecancelother1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id="claude_anthropic_cancel_other_user",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="different-user",
+                account_label="Claude Anthropic OAuth",
+            )
+        )
+        await session.commit()
+
+    async def _unexpected_cancel(_session_id: str) -> None:
+        raise AssertionError("unauthorized cancel must not signal workflow")
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.cancel_oauth_session_workflow",
+        _unexpected_cancel,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/cancel")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Session not found"
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        assert row.status == OAuthSessionStatus.AWAITING_USER
+
+
+@pytest.mark.asyncio
+async def test_reconnect_oauth_session_rejects_other_users_claude_session(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_claudereconnectother1"
+    profile_id = "claude_anthropic_reconnect_other_user"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id=profile_id,
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                status=OAuthSessionStatus.FAILED,
+                requested_by_user_id="different-user",
+                account_label="Claude Anthropic OAuth",
+                metadata_json={"provider_id": "anthropic", "provider_label": "Anthropic"},
+            )
+        )
+        await session.commit()
+
+    async def _unexpected_start(_session_model) -> None:
+        raise AssertionError("unauthorized reconnect must not start workflow")
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _unexpected_start,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/reconnect")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Session not found"
+
+    async with db_base.async_session_maker() as session:
+        query = await session.execute(
+            select(ManagedAgentOAuthSession).where(
+                ManagedAgentOAuthSession.profile_id == profile_id
+            )
+        )
+        rows = query.scalars().all()
+        assert len(rows) == 1
+        assert rows[0].session_id == session_id
+
+
+@pytest.mark.asyncio
+async def test_claude_oauth_terminal_websocket_rejects_replayed_attach_token(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_claudewsreplay1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id="claude_anthropic_ws_replay",
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="None",
+                terminal_session_id="term_oas_claudewsreplay1",
+                terminal_bridge_id="br_oas_claudewsreplay1",
+                container_name="moonmind_auth_oas_claudewsreplay1",
+                expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            )
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._oauth_terminal_pty_adapter_factory",
+        lambda **_kwargs: InMemoryPtyAdapter(),
+    )
+
+    async with client_app as client:
+        attach_response = await client.post(
+            f"/api/v1/oauth-sessions/{session_id}/terminal/attach"
+        )
+
+    assert attach_response.status_code == 200
+    token = attach_response.json()["attach_token"]
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        assert row.metadata_json is not None
+        row.metadata_json = {
+            **row.metadata_json,
+            "terminal_attach_token_used": True,
+        }
+        await session.commit()
+
+    class _CloseOnlyWebSocket:
+        def __init__(self) -> None:
+            self.closed: list[int] = []
+            self.accepted = False
+
+        async def close(self, code: int) -> None:
+            self.closed.append(code)
+
+        async def accept(self) -> None:
+            self.accepted = True
+            raise AssertionError("replayed tokens must fail before websocket accept")
+
+    websocket = _CloseOnlyWebSocket()
+    await oauth_terminal_websocket(websocket, session_id, token)
+
+    assert websocket.closed == [4403]
+    assert websocket.accepted is False

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -974,3 +974,81 @@ async def test_claude_manual_auth_commit_rejects_unsupported_profile_without_per
             )
         )
         assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_claude_oauth_validate_failure_redacts_secret_like_reason(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_id = "claude-anthropic-oauth-validation-redaction"
+    raw_secret = "sk-ant-test-validation-secret"
+    raw_path = "/home/app/.claude/credentials.json"
+
+    async def _fake_verify(
+        *,
+        runtime_id: str,
+        volume_ref: str,
+        volume_mount_path: str | None,
+    ) -> dict[str, object]:
+        assert runtime_id == "claude_code"
+        assert volume_ref == "claude_auth_volume"
+        assert volume_mount_path == "/home/app/.claude"
+        return {
+            "verified": False,
+            "reason": f"token={raw_secret} in {raw_path}",
+        }
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _fake_verify,
+    )
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="claude_code",
+                    provider_id="anthropic",
+                    provider_label="Anthropic",
+                    credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                    runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                    volume_ref="claude_auth_volume",
+                    volume_mount_path="/home/app/.claude",
+                    enabled=True,
+                    command_behavior={
+                        "auth_strategy": "claude_credential_methods",
+                        "auth_actions": [
+                            "connect_oauth",
+                            "use_api_key",
+                            "validate_oauth",
+                            "disconnect_oauth",
+                        ],
+                    },
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/validate"
+        )
+
+    assert response.status_code == 400
+    assert raw_secret not in response.text
+    assert raw_path not in response.text
+    detail = response.json()["detail"]
+    assert "Claude OAuth validation failed:" in detail
+    assert "[REDACTED]" in detail
+    assert "[REDACTED_AUTH_PATH]" in detail
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        readiness = (profile.command_behavior or {}).get("auth_readiness", {})
+        assert raw_secret not in str(readiness)
+        assert raw_path not in str(readiness)
+        assert readiness["failure_reason"] == "token=[REDACTED] in [REDACTED_AUTH_PATH]"

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1947,3 +1947,61 @@ async def test_launch_materializes_claude_anthropic_oauth_home_profile(
     assert "OPENAI_API_KEY" not in captured_env
     assert captured_cwd["value"] == str(workspace.resolve())
     assert captured_cwd["value"] != captured_env["MANAGED_AUTH_VOLUME_PATH"]
+
+
+@pytest.mark.asyncio
+async def test_launch_materializes_claude_oauth_home_profile_without_auth_volume_cleanup_paths(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace-cleanup"
+    workspace.mkdir()
+    profile = _make_profile(
+        profile_id="claude_anthropic",
+        runtime_id="claude_code",
+        provider_id="anthropic",
+        credential_source="oauth_volume",
+        runtime_materialization_mode="oauth_home",
+        command_template=["claude", "-p", "hello"],
+        clear_env_keys=["ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "OPENAI_API_KEY"],
+        volume_ref="claude_auth_volume",
+        volume_mount_path="/home/app/.claude",
+        passthrough_env_keys=[],
+    )
+    request = _make_request(execution_profile_ref="claude_anthropic")
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 1006) -> None:
+            self.pid = pid
+            self.returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
+    )
+
+    _record, process, cleanup_paths, _deferred_cleanup = await launcher.launch(
+        run_id="run-claude-oauth-home-cleanup-1",
+        request=request,
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    assert all("/home/app/.claude" not in str(path) for path in cleanup_paths)

--- a/tests/unit/services/temporal/runtime/test_terminal_bridge.py
+++ b/tests/unit/services/temporal/runtime/test_terminal_bridge.py
@@ -331,3 +331,36 @@ async def test_start_terminal_bridge_container_uses_configured_runner_user(
 
     assert "--user" in observed
     assert "2001:2001" in observed
+
+
+@pytest.mark.asyncio
+async def test_start_terminal_bridge_container_redacts_claude_auth_paths_in_startup_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess(
+            returncode=1,
+            stderr=b"/home/app/.claude/credentials.json token=super-secret failed",
+        )
+
+    monkeypatch.setattr(
+        terminal_bridge.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await start_terminal_bridge_container(
+            session_id="oas_terminal_runner_claude_failed",
+            runtime_id="claude_code",
+            volume_ref="claude_auth_volume",
+            volume_mount_path="/home/app/.claude",
+            session_ttl=1800,
+            bootstrap_command=("claude", "login"),
+        )
+
+    message = str(exc_info.value)
+    assert "super-secret" not in message
+    assert "/home/app/.claude/credentials.json" not in message
+    assert "[REDACTED]" in message
+    assert "[REDACTED_AUTH_PATH]" in message

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2676,3 +2676,55 @@ async def test_launch_session_failure_redacts_claude_auth_paths(
     assert "/home/app/.claude/credentials.json" not in message
     assert "[REDACTED]" in message
     assert "[REDACTED_AUTH_PATH]" in message
+
+
+async def test_launch_session_claude_auth_diagnostics_do_not_alias_workspace_or_artifacts(
+    tmp_path: Path,
+) -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-claude-2",
+                "sessionEpoch": 1,
+                "containerId": "ctr-claude-2",
+                "threadId": "thread-claude-2",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+            metadata={},
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+    workspace_path = str(tmp_path / "task-2" / "repo")
+    artifact_spool_path = str(tmp_path / "task-2" / "artifacts")
+
+    result = await activities.agent_runtime_launch_session(
+        {
+            "request": {
+                "taskRunId": "task-2",
+                "sessionId": "sess-claude-2",
+                "threadId": "thread-claude-2",
+                "workspacePath": workspace_path,
+                "sessionWorkspacePath": str(tmp_path / "task-2" / "session"),
+                "artifactSpoolPath": artifact_spool_path,
+                "codexHomePath": str(tmp_path / "task-2" / ".moonmind" / "codex-home"),
+                "imageRef": "moonmind:latest",
+            },
+            "profile": {
+                "runtimeId": "claude_code",
+                "profileId": "claude_anthropic",
+                "providerId": "anthropic",
+                "credentialSource": "oauth_volume",
+                "runtimeMaterializationMode": "oauth_home",
+                "volumeRef": "claude_auth_volume",
+                "volumeMountPath": "/home/app/.claude",
+            },
+        }
+    )
+
+    diagnostics = result.metadata["authDiagnostics"]
+    assert diagnostics["authMountTarget"] == "/home/app/.claude"
+    assert diagnostics["authMountTarget"] != workspace_path
+    assert diagnostics["authMountTarget"] != artifact_spool_path
+    assert diagnostics["volumeRef"] == "claude_auth_volume"


### PR DESCRIPTION
## Summary
- Jira issue: MM-482
- Active MoonSpec feature path: `specs/245-claude-oauth-guardrails`
- Verification verdict: `FULLY_IMPLEMENTED`
- Adds Claude OAuth authorization boundary coverage for create, cancel, reconnect, and attach-token replay denial
- Redacts secret-like verifier failures and Claude auth-path startup failures at the real provider-profile and terminal-bridge boundaries
- Preserves MM-482 traceability through the MoonSpec artifacts and completed task checklist

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_terminal_bridge.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_launcher.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `./tools/test_integration.sh` not run because MM-482 stayed within existing unit-testable route, provider-profile, terminal-bridge, activity, and launcher seams without changing a compose-backed boundary

## Remaining Risks
- Hermetic integration coverage was not rerun in this branch because the implemented guardrails did not change an `integration_ci` seam
- Provider verification coverage was not run; only local unit verification was required for this story
