### PR TITLE
Run Jira Orchestrate for MM-499: Enforce Docker workflow modes and registry gating

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/246-animate-shimmer-motion"
+  "feature_directory": "specs/248-enforce-docker-workflow-modes-and-registry-gating"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,97 +1,42 @@
 [
   {
-    "id": 3134339420,
-    "disposition": "addressed",
-    "rationale": "Removed the Ctrl/Cmd+V keydown interception so unsupported clipboard reads no longer block native paste delivery."
-  },
-  {
-    "id": 4166572410,
+    "id": 4167329002,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper only; the actionable inline feedback is tracked and handled separately."
+    "rationale": "Top-level review summary only; the actionable line comments below were evaluated and resolved individually."
   },
   {
-    "id": 3134340059,
+    "id": 3134994540,
     "disposition": "addressed",
-    "rationale": "Keyboard paste now relies on the browser paste event, keeping clipboard-read permissions only for the explicit toolbar action."
+    "rationale": "Unrestricted Docker CLI execution now replaces the leading docker token with the configured runtime binary so commands no longer become 'docker docker ...'."
   },
   {
-    "id": 3134340064,
+    "id": 3134994545,
     "disposition": "addressed",
-    "rationale": "Replaced the obsolete Ctrl+V test with a regression asserting the shortcut is left unhandled for the native paste event path."
+    "rationale": "The helper-side unrestricted Docker path now reuses the same normalized command builder and handles unrestricted requests before profile-only validation."
   },
   {
-    "id": 4166573078,
-    "disposition": "not-applicable",
-    "rationale": "Summary review comment with no separate actionable request beyond the inline feedback already addressed."
-  },
-  {
-    "id": 3134586258,
+    "id": 3134994548,
     "disposition": "addressed",
-    "rationale": "Removed the superseded --mm-executing-sweep-duration and --mm-executing-sweep-delay variables so the stylesheet keeps only the active cycle-duration contract."
+    "rationale": "The unrestricted fallback runner profile is now a module-level constant instead of being revalidated from a hardcoded dict on every invocation."
   },
   {
-    "id": 3134586265,
+    "id": 3134994551,
     "disposition": "addressed",
-    "rationale": "Dropped the obsolete CSS test expectations for the removed duration and delay tokens so the suite reflects the active shimmer contract only."
+    "rationale": "The helper path now shares the module-level unrestricted runner profile and unrestricted arg builder instead of repeating inline model validation."
   },
   {
-    "id": 3134586268,
+    "id": 3134994554,
     "disposition": "addressed",
-    "rationale": "Simplified the single-quoted selector string literal to remove unnecessary escaped double quotes."
+    "rationale": "Default timeout and kill-grace values are now centralized as module-level constants and reused across labels, diagnostics, and timeout handling."
   },
   {
-    "id": 4166856735,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its actionable items were handled through the inline review comments above."
-  },
-  {
-    "id": 3134718993,
+    "id": 3134994556,
     "disposition": "addressed",
-    "rationale": "Handled the no-WebGL DOM fallback path as a successful initialization so the hook no longer retries after liquidGL returns fallback elements without calling on.init."
+    "rationale": "Workflow Docker mode normalization is now centralized in a shared module used by both settings and the tool bridge, removing the duplicated implementation."
   },
   {
-    "id": 3134719011,
+    "id": 3134997019,
     "disposition": "addressed",
-    "rationale": "HTMLElement targets are now translated into a temporary selector before calling the vendor library, preserving hook support without passing an invalid target type into liquidGL."
-  },
-  {
-    "id": 4167005196,
-    "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary only; the actionable inline comments from this review were addressed separately."
-  },
-  {
-    "id": 3134722327,
-    "disposition": "addressed",
-    "rationale": "The hook now marks DOM fallback returns as initialized immediately, which stops false stall teardown and retry loops for fallback clients."
-  },
-  {
-    "id": 3134722330,
-    "disposition": "addressed",
-    "rationale": "The hook no longer forwards HTMLElement targets directly to the vendor API and now verifies that adapter path with a focused test."
-  },
-  {
-    "id": 4167008311,
-    "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary only; the actionable inline comments from this review were addressed separately."
-  },
-  {
-    "id": 3134781723,
-    "disposition": "addressed",
-    "rationale": "Split the long pseudo-selector assertion into a named predicate and standalone expectation in mission-control.test.tsx."
-  },
-  {
-    "id": 3134781727,
-    "disposition": "addressed",
-    "rationale": "Reworked the awaiting_external check to assert directly against rendered status-pill hosts instead of a conditional closest() lookup that could skip coverage."
-  },
-  {
-    "id": 3134781729,
-    "disposition": "addressed",
-    "rationale": "Applied the same direct rendered-host assertion strategy to finalizing pills so the regression guard cannot silently pass."
-  },
-  {
-    "id": 4167072074,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; the actionable items are tracked and addressed by the three inline review comments above."
+    "rationale": "Removed the unused CONTAINER_RUN_CONTAINER_TOOL import from the Temporal worker runtime unit test."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -38,5 +38,10 @@
     "id": 3134997019,
     "disposition": "addressed",
     "rationale": "Removed the unused CONTAINER_RUN_CONTAINER_TOOL import from the Temporal worker runtime unit test."
+  },
+  {
+    "id": 3135008658,
+    "disposition": "addressed",
+    "rationale": "Unrestricted workload requests no longer dereference profile-only concurrency metadata; the launcher now skips per-profile concurrency caps when profile=None and covers the path with a regression test."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md
@@ -1,0 +1,74 @@
+# MM-499 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-499
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Enforce Docker workflow modes and registry gating
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-499 from MM project
+Summary: Enforce Docker workflow modes and registry gating
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-499 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-499: Enforce Docker workflow modes and registry gating
+
+Source Reference
+- Source Document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source Title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source Sections:
+  - 1. Purpose
+  - 2. Core decisions
+  - 6. Docker workflow permission modes
+  - 19. Stable design rules
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-003
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+
+User Story
+As a deployment operator, I can set Docker workflow access to disabled, profiles, or unrestricted so MoonMind exposes and enforces only the workload tools allowed for that environment.
+
+Acceptance Criteria
+- Given `MOONMIND_WORKFLOW_DOCKER_MODE` is omitted, when settings load, then the effective mode is `profiles`.
+- Given `MOONMIND_WORKFLOW_DOCKER_MODE` is an unsupported value, when the service starts, then startup fails with a deterministic configuration error.
+- Given mode is `disabled`, when the registry snapshot is built or a DooD tool is invoked directly, then all Docker-backed tools are omitted or denied at runtime.
+- Given mode is `profiles`, when the registry snapshot is built, then profile-backed and curated DooD tools are available while unrestricted tools are omitted and denied.
+- Given mode is `unrestricted`, when the registry snapshot is built, then profile-backed and unrestricted DooD tools are available while session-side Docker authority remains unchanged.
+
+Requirements
+- Normalize the deployment-owned Docker mode from `MOONMIND_WORKFLOW_DOCKER_MODE` at settings load time.
+- Keep `disabled`, `profiles`, and `unrestricted` as the only supported modes.
+- Make registry exposure mode-aware without relying on registration alone for enforcement.
+- Return deterministic denial behavior for mode-forbidden tool invocations.
+
+Relevant Implementation Notes
+- Preserve MM-499 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for purpose, core decisions, Docker workflow permission modes, and stable design rules.
+- Treat `MOONMIND_WORKFLOW_DOCKER_MODE` as deployment-owned configuration normalized at settings-load time.
+- Support only the `disabled`, `profiles`, and `unrestricted` workflow Docker modes.
+- Ensure registry exposure is mode-aware, but also enforce denials at runtime so registration alone is not the only guardrail.
+- In `disabled` mode, omit Docker-backed tools from the registry snapshot and deny direct invocation attempts deterministically.
+- In `profiles` mode, expose only curated and profile-backed Docker workload tools while omitting and denying unrestricted tools.
+- In `unrestricted` mode, expose profile-backed and unrestricted Docker workload tools without broadening session-side Docker authority.
+- Keep startup validation fail-fast and deterministic for unsupported mode values.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-499 is blocked by MM-500, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -16,6 +16,7 @@ from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
 from moonmind.jules.runtime import (
     build_runtime_gate_state as build_jules_runtime_gate_state,
 )
+from moonmind.workflow_docker_mode import normalize_workflow_docker_mode
 
 _ALLOWED_TARGET_DEFAULTS = ("project", "moonmind", "both")
 _ALLOWED_PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
@@ -975,14 +976,7 @@ class WorkflowSettings(BaseSettings):
     @field_validator("workflow_docker_mode", mode="before")
     @classmethod
     def _normalize_workflow_docker_mode(cls, value: object) -> str:
-        text = str(value or "").strip().lower()
-        if not text:
-            return "profiles"
-        if text not in {"disabled", "profiles", "unrestricted"}:
-            raise ValueError(
-                "workflow_docker_mode must be one of: disabled, profiles, unrestricted"
-            )
-        return text
+        return normalize_workflow_docker_mode(value)
 
     @field_validator("moonmind_ci_repository", mode="before")
     @classmethod

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -893,12 +893,12 @@ class WorkflowSettings(BaseSettings):
         description="Hard timeout for non-container worker stage commands.",
         ge=1,
     )
-    workflow_docker_enabled: bool = Field(
-        True,
-        validation_alias=AliasChoices("MOONMIND_WORKFLOW_DOCKER_ENABLED"),
+    workflow_docker_mode: Literal["disabled", "profiles", "unrestricted"] = Field(
+        "profiles",
+        validation_alias=AliasChoices("MOONMIND_WORKFLOW_DOCKER_MODE"),
         description=(
-            "Allow workflow-requested Docker-backed workload tools to route "
-            "through the DooD worker/tool boundary."
+            "Deployment-owned workflow Docker access mode for Docker-backed "
+            "workload tools (disabled|profiles|unrestricted)."
         ),
     )
 
@@ -969,6 +969,18 @@ class WorkflowSettings(BaseSettings):
             allowed = ", ".join(_ALLOWED_PROPOSAL_SEVERITIES)
             raise ValueError(
                 f"workflow.proposal_moonmind_severity_floor must be one of: {allowed}"
+            )
+        return text
+
+    @field_validator("workflow_docker_mode", mode="before")
+    @classmethod
+    def _normalize_workflow_docker_mode(cls, value: object) -> str:
+        text = str(value or "").strip().lower()
+        if not text:
+            return "profiles"
+        if text not in {"disabled", "profiles", "unrestricted"}:
+            raise ValueError(
+                "workflow_docker_mode must be one of: disabled, profiles, unrestricted"
             )
         return text
 

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -54,6 +54,8 @@ WorkloadStatus = Literal[
 WorkloadKind = Literal["one_shot", "bounded_service"]
 WorkloadOwnershipKind = Literal["workload", "bounded_service"]
 WorkloadNetworkPolicy = Literal["none", "bridge"]
+WorkflowDockerMode = Literal["disabled", "profiles", "unrestricted"]
+WorkloadAccessKind = Literal["profile", "unrestricted_container", "unrestricted_docker_cli"]
 WorkloadDeviceMode = Literal["none"]
 WorkloadReadinessProbeType = Literal["exec"]
 
@@ -222,6 +224,24 @@ class WorkloadCredentialMount(BaseModel):
             )
         if not _is_safe_absolute_profile_path(self.target):
             raise ValueError("credential mount target must be an absolute safe path")
+        return self
+
+
+class UnrestrictedCacheMount(BaseModel):
+    """Deployment-approved named-cache mount for unrestricted containers."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    source: NonBlankStr = Field(..., alias="source")
+    target: NonBlankStr = Field(..., alias="target")
+    read_only: bool = Field(False, alias="readOnly")
+
+    @model_validator(mode="after")
+    def _validate_mount(self) -> "UnrestrictedCacheMount":
+        if _VOLUME_NAME_PATTERN.match(self.source) is None:
+            raise ValueError("cacheMounts source must be a Docker named volume")
+        if not _is_safe_absolute_profile_path(self.target):
+            raise ValueError("cacheMounts target must be an absolute safe path")
         return self
 
 
@@ -440,6 +460,7 @@ class WorkloadOwnershipMetadata(BaseModel):
     workload_profile: NonBlankStr = Field(..., alias="workloadProfile")
     session_id: NonBlankStr | None = Field(None, alias="sessionId")
     session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    workload_access: WorkloadAccessKind = Field("profile", alias="workloadAccess")
 
     @property
     def labels(self) -> dict[str, str]:
@@ -455,6 +476,7 @@ class WorkloadOwnershipMetadata(BaseModel):
             labels["moonmind.session_id"] = self.session_id
         if self.session_epoch is not None:
             labels["moonmind.session_epoch"] = str(self.session_epoch)
+        labels["moonmind.workload_access"] = self.workload_access
         return labels
 
 
@@ -484,6 +506,7 @@ class WorkloadRequest(BaseModel):
     )
     session_id: NonBlankStr | None = Field(None, alias="sessionId")
     session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    workload_access: WorkloadAccessKind = Field("profile", alias="workloadAccess")
     source_turn_id: NonBlankStr | None = Field(None, alias="sourceTurnId")
 
     @model_validator(mode="after")
@@ -521,6 +544,7 @@ class WorkloadRequest(BaseModel):
             workloadProfile=self.profile_id,
             sessionId=self.session_id,
             sessionEpoch=self.session_epoch,
+            workloadAccess="profile",
         )
 
     @property
@@ -532,13 +556,150 @@ class WorkloadRequest(BaseModel):
         )
 
 
+class UnrestrictedContainerRequest(BaseModel):
+    """Canonical unrestricted runtime-container request."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    step_id: NonBlankStr = Field(..., alias="stepId")
+    attempt: int = Field(..., alias="attempt", ge=1)
+    tool_name: Literal["container.run_container"] = Field(..., alias="toolName")
+    repo_dir: NonBlankStr = Field(..., alias="repoDir")
+    artifacts_dir: NonBlankStr = Field(..., alias="artifactsDir")
+    scratch_dir: NonBlankStr = Field(..., alias="scratchDir")
+    image: NonBlankStr = Field(..., alias="image")
+    entrypoint: tuple[NonBlankStr, ...] = Field(default_factory=tuple, alias="entrypoint")
+    command: tuple[NonBlankStr, ...] = Field(..., alias="command", min_length=1)
+    workdir: NonBlankStr | None = Field(None, alias="workdir")
+    env_overrides: dict[str, str] = Field(default_factory=dict, alias="envOverrides")
+    cache_mounts: tuple[UnrestrictedCacheMount, ...] = Field(default_factory=tuple, alias="cacheMounts")
+    network_mode: WorkloadNetworkPolicy = Field("none", alias="networkMode")
+    timeout_seconds: int | None = Field(None, alias="timeoutSeconds", ge=1)
+    resources: WorkloadResourceOverrides = Field(default_factory=WorkloadResourceOverrides, alias="resources")
+    declared_outputs: dict[str, str] = Field(default_factory=dict, alias="declaredOutputs")
+    session_id: NonBlankStr | None = Field(None, alias="sessionId")
+    session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    source_turn_id: NonBlankStr | None = Field(None, alias="sourceTurnId")
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "UnrestrictedContainerRequest":
+        if not _image_has_tag_or_digest(self.image):
+            raise ValueError("image must include an explicit tag or digest")
+        if self.image.rsplit("/", 1)[-1].endswith(":latest"):
+            raise ValueError("image must not use the latest tag")
+        self.command = tuple(require_non_blank(item, field_name="command[]") for item in self.command)
+        self.entrypoint = tuple(require_non_blank(item, field_name="entrypoint[]") for item in self.entrypoint)
+        normalized_env: dict[str, str] = {}
+        for raw_key, raw_value in self.env_overrides.items():
+            key = _normalize_env_name(str(raw_key), field_name="envOverrides key")
+            normalized_env[key] = str(raw_value)
+        self.env_overrides = normalized_env
+        self.declared_outputs = {
+            _validate_declared_output_key(key): _validate_relative_artifact_path(str(value), field_name="declaredOutputs value")
+            for key, value in self.declared_outputs.items()
+        }
+        if self.workdir is not None:
+            self.workdir = require_non_blank(self.workdir, field_name="workdir")
+        if self.session_id is None and (self.session_epoch is not None or self.source_turn_id is not None):
+            raise ValueError("sessionEpoch/sourceTurnId require sessionId association metadata")
+        return self
+
+    def ownership_metadata(self) -> WorkloadOwnershipMetadata:
+        return WorkloadOwnershipMetadata(
+            taskRunId=self.task_run_id,
+            stepId=self.step_id,
+            attempt=self.attempt,
+            toolName=self.tool_name,
+            workloadProfile="unrestricted",
+            sessionId=self.session_id,
+            sessionEpoch=self.session_epoch,
+            workloadAccess="unrestricted_container",
+        )
+
+    @property
+    def container_name(self) -> str:
+        return workload_container_name(task_run_id=self.task_run_id, step_id=self.step_id, attempt=self.attempt)
+
+
+class UnrestrictedDockerRequest(BaseModel):
+    """Canonical unrestricted Docker CLI request."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    step_id: NonBlankStr = Field(..., alias="stepId")
+    attempt: int = Field(..., alias="attempt", ge=1)
+    tool_name: Literal["container.run_docker"] = Field(..., alias="toolName")
+    repo_dir: NonBlankStr = Field(..., alias="repoDir")
+    artifacts_dir: NonBlankStr = Field(..., alias="artifactsDir")
+    command: tuple[NonBlankStr, ...] = Field(..., alias="command", min_length=1)
+    env_overrides: dict[str, str] = Field(default_factory=dict, alias="envOverrides")
+    timeout_seconds: int | None = Field(None, alias="timeoutSeconds", ge=1)
+    resources: WorkloadResourceOverrides = Field(default_factory=WorkloadResourceOverrides, alias="resources")
+    declared_outputs: dict[str, str] = Field(default_factory=dict, alias="declaredOutputs")
+    session_id: NonBlankStr | None = Field(None, alias="sessionId")
+    session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    source_turn_id: NonBlankStr | None = Field(None, alias="sourceTurnId")
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "UnrestrictedDockerRequest":
+        self.command = tuple(require_non_blank(item, field_name="command[]") for item in self.command)
+        if not self.command or self.command[0] != "docker":
+            raise ValueError("container.run_docker command[0] must be docker")
+        normalized_env: dict[str, str] = {}
+        for raw_key, raw_value in self.env_overrides.items():
+            key = _normalize_env_name(str(raw_key), field_name="envOverrides key")
+            normalized_env[key] = str(raw_value)
+        self.env_overrides = normalized_env
+        self.declared_outputs = {
+            _validate_declared_output_key(key): _validate_relative_artifact_path(str(value), field_name="declaredOutputs value")
+            for key, value in self.declared_outputs.items()
+        }
+        if self.session_id is None and (self.session_epoch is not None or self.source_turn_id is not None):
+            raise ValueError("sessionEpoch/sourceTurnId require sessionId association metadata")
+        return self
+
+    def ownership_metadata(self) -> WorkloadOwnershipMetadata:
+        return WorkloadOwnershipMetadata(
+            taskRunId=self.task_run_id,
+            stepId=self.step_id,
+            attempt=self.attempt,
+            toolName=self.tool_name,
+            workloadProfile="unrestricted",
+            sessionId=self.session_id,
+            sessionEpoch=self.session_epoch,
+            workloadAccess="unrestricted_docker_cli",
+        )
+
+    @property
+    def container_name(self) -> str:
+        return workload_container_name(task_run_id=self.task_run_id, step_id=self.step_id, attempt=self.attempt)
+
+
+AnyWorkloadRequest = WorkloadRequest | UnrestrictedContainerRequest | UnrestrictedDockerRequest
+
+
+def parse_workload_request(value: Any) -> AnyWorkloadRequest:
+    if isinstance(value, (WorkloadRequest, UnrestrictedContainerRequest, UnrestrictedDockerRequest)):
+        return value
+    if not isinstance(value, dict):
+        raise TypeError("workload request must be an object")
+    tool_name = str(value.get("toolName") or "").strip()
+    if tool_name == "container.run_container":
+        return UnrestrictedContainerRequest.model_validate(value)
+    if tool_name == "container.run_docker":
+        return UnrestrictedDockerRequest.model_validate(value)
+    return WorkloadRequest.model_validate(value)
+
+
 class ValidatedWorkloadRequest(BaseModel):
     """Profile-aware validated workload request."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    request: WorkloadRequest = Field(..., alias="request")
-    profile: RunnerProfile = Field(..., alias="profile")
+    request: AnyWorkloadRequest = Field(..., alias="request")
+    profile: RunnerProfile | None = Field(None, alias="profile")
     ownership: WorkloadOwnershipMetadata = Field(..., alias="ownership")
     container_name: NonBlankStr = Field(..., alias="containerName")
 

--- a/moonmind/workflow_docker_mode.py
+++ b/moonmind/workflow_docker_mode.py
@@ -1,0 +1,26 @@
+"""Shared workflow Docker mode normalization and policy constants."""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+
+WorkflowDockerMode = Literal["disabled", "profiles", "unrestricted"]
+WORKFLOW_DOCKER_MODE_VALUES: Final[tuple[WorkflowDockerMode, ...]] = (
+    "disabled",
+    "profiles",
+    "unrestricted",
+)
+DEFAULT_WORKFLOW_DOCKER_MODE: Final[WorkflowDockerMode] = "profiles"
+
+
+def normalize_workflow_docker_mode(value: object) -> WorkflowDockerMode:
+    """Return the canonical deployment-owned workflow Docker mode."""
+
+    normalized = str(value or DEFAULT_WORKFLOW_DOCKER_MODE).strip().lower()
+    if not normalized:
+        return DEFAULT_WORKFLOW_DOCKER_MODE
+    if normalized not in WORKFLOW_DOCKER_MODE_VALUES:
+        allowed = ", ".join(WORKFLOW_DOCKER_MODE_VALUES)
+        raise ValueError(f"workflow_docker_mode must be one of: {allowed}")
+    return normalized  # type: ignore[return-value]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -68,12 +68,14 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
     ManagedRuntimeProfile,
 )
-from moonmind.schemas.workload_models import WorkloadRequest, WorkloadResult
+from moonmind.schemas.workload_models import WorkloadResult, parse_workload_request
 from moonmind.workloads.tool_bridge import (
     CONTAINER_START_HELPER_TOOL,
     CONTAINER_STOP_HELPER_TOOL,
     build_dood_tool_definition_payload,
     is_dood_tool,
+    normalize_workflow_docker_mode,
+    tool_allowed_for_workflow_docker_mode,
 )
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -319,6 +321,14 @@ def _docker_workflows_disabled_failure() -> temporal_exceptions.ApplicationError
     return temporal_exceptions.ApplicationError(
         "policy_denied: docker_workflows_disabled",
         type="docker_workflows_disabled",
+        non_retryable=True,
+    )
+
+
+def _docker_workflow_mode_forbidden_failure(*, workflow_docker_mode: str, tool_name: str) -> temporal_exceptions.ApplicationError:
+    return temporal_exceptions.ApplicationError(
+        f"policy_denied: docker_workflow_mode_forbidden ({tool_name} requires unrestricted; current mode={workflow_docker_mode})",
+        type="docker_workflow_mode_forbidden",
         non_retryable=True,
     )
 
@@ -2849,7 +2859,7 @@ class TemporalAgentRuntimeActivities:
         session_controller: ManagedSessionController | None = None,
         workload_launcher: Any | None = None,
         workload_registry: Any | None = None,
-        workflow_docker_enabled: bool = True,
+        workflow_docker_mode: str = "profiles",
         client_adapter: Any = None,
     ) -> None:
         self._artifact_service = artifact_service
@@ -2859,7 +2869,7 @@ class TemporalAgentRuntimeActivities:
         self._session_controller = session_controller
         self._workload_launcher = workload_launcher
         self._workload_registry = workload_registry
-        self._workflow_docker_enabled = workflow_docker_enabled
+        self._workflow_docker_mode = normalize_workflow_docker_mode(workflow_docker_mode)
         if client_adapter is None:
             from moonmind.workflows.temporal import client as temporal_client_module
 
@@ -3187,7 +3197,8 @@ class TemporalAgentRuntimeActivities:
     ) -> dict[str, Any]:
         """Run one validated Docker workload on the agent_runtime fleet."""
 
-        if not self._workflow_docker_enabled:
+        workflow_mode = self._workflow_docker_mode
+        if workflow_mode == "disabled":
             raise _docker_workflows_disabled_failure()
         if self._workload_registry is None or self._workload_launcher is None:
             raise TemporalActivityRuntimeError(
@@ -3197,7 +3208,15 @@ class TemporalAgentRuntimeActivities:
         reason = str(request_payload.pop("reason", "") or "bounded_window_complete")
         if request_payload.get("toolName") == CONTAINER_STOP_HELPER_TOOL:
             request_payload.setdefault("command", ["stop"])
-        request = WorkloadRequest.model_validate(request_payload)
+        request = parse_workload_request(request_payload)
+        if not tool_allowed_for_workflow_docker_mode(
+            tool_name=request.tool_name,
+            workflow_docker_mode=workflow_mode,
+        ):
+            raise _docker_workflow_mode_forbidden_failure(
+                workflow_docker_mode=workflow_mode,
+                tool_name=request.tool_name,
+            )
         validated = self._workload_registry.validate_request(request)
         if request.tool_name == CONTAINER_START_HELPER_TOOL:
             result = await self._workload_launcher.start_helper(validated)
@@ -3225,7 +3244,7 @@ class TemporalAgentRuntimeActivities:
         silently falling back to the generic tool executor.
         """
 
-        if not self._workflow_docker_enabled:
+        if self._workflow_docker_mode == "disabled":
             raise _docker_workflows_disabled_failure()
         raw_payload = dict(payload)
         nested_request = raw_payload.get("request")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1246,13 +1246,13 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 session_controller=session_controller,
                 workload_registry=workload_registry,
                 workload_launcher=workload_launcher,
-                workflow_docker_enabled=settings.workflow.workflow_docker_enabled,
+                workflow_docker_mode=settings.workflow.workflow_docker_mode,
             )
             register_workload_tool_handlers(
                 dispatcher,
                 registry=workload_registry,
                 launcher=workload_launcher,
-                workflow_docker_enabled=settings.workflow.workflow_docker_enabled,
+                workflow_docker_mode=settings.workflow.workflow_docker_mode,
             )
 
         bindings = build_worker_activity_bindings(

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -92,9 +92,12 @@ class DockerWorkloadConcurrencyLimiter:
         request: ValidatedWorkloadRequest,
     ) -> _ConcurrencyLease:
         profile_id = request.profile.id if request.profile is not None else request.request.tool_name
+        max_concurrency = (
+            request.profile.max_concurrency if request.profile is not None else None
+        )
         async with self._lock:
             active_for_profile = self._active_by_profile.get(profile_id, 0)
-            if active_for_profile >= request.profile.max_concurrency:
+            if max_concurrency is not None and active_for_profile >= max_concurrency:
                 raise DockerWorkloadLauncherError(
                     "workload concurrency limit exceeded for profile "
                     f"{profile_id}"

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -25,6 +25,27 @@ from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_te
 
 _MAX_CAPTURED_STREAM_CHARS = 64_000
 _MAX_CAPTURED_STREAM_BYTES = 64_000
+_DEFAULT_TIMEOUT_SECONDS = 300
+_DEFAULT_KILL_GRACE_SECONDS = 30
+_UNRESTRICTED_RUNNER_PROFILE = RunnerProfile.model_validate(
+    {
+        "id": "unrestricted",
+        "kind": "one_shot",
+        "image": "busybox:1.0",
+        "workdirTemplate": "/tmp",
+        "requiredMounts": [
+            {
+                "type": "volume",
+                "source": "tmp",
+                "target": "/tmp",
+            }
+        ],
+        "envAllowlist": [],
+        "networkPolicy": "none",
+        "resources": {},
+        "timeoutSeconds": _DEFAULT_TIMEOUT_SECONDS,
+    }
+)
 
 
 class DockerWorkloadLauncherError(RuntimeError):
@@ -246,8 +267,8 @@ def _operational_labels(request: ValidatedWorkloadRequest) -> dict[str, str]:
             "moonmind.expires_at": _isoformat(expires_at) or "",
             "moonmind.helper_ttl_seconds": str(ttl_seconds),
         }
-    timeout_seconds = request.request.timeout_seconds or (request.profile.timeout_seconds if request.profile is not None else 300)
-    kill_grace_seconds = request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30
+    timeout_seconds = _request_timeout_seconds(request)
+    kill_grace_seconds = _request_kill_grace_seconds(request)
     expires_at = datetime.now(UTC) + timedelta(seconds=timeout_seconds + kill_grace_seconds)
     return {
         **request.ownership.labels,
@@ -414,6 +435,71 @@ def _publish_workload_artifacts(
     return stdout_ref, stderr_ref, diagnostics_ref, output_refs, publication
 
 
+def _request_timeout_seconds(request: ValidatedWorkloadRequest) -> int | float:
+    return request.request.timeout_seconds or (
+        request.profile.timeout_seconds
+        if request.profile is not None
+        else _DEFAULT_TIMEOUT_SECONDS
+    )
+
+
+def _request_kill_grace_seconds(request: ValidatedWorkloadRequest) -> int:
+    return (
+        request.profile.cleanup.kill_grace_seconds
+        if request.profile is not None
+        else _DEFAULT_KILL_GRACE_SECONDS
+    )
+
+
+def _build_unrestricted_run_args(
+    *,
+    docker_binary: str,
+    request: ValidatedWorkloadRequest,
+) -> list[str]:
+    workload = request.request
+    if isinstance(workload, UnrestrictedDockerRequest):
+        return [docker_binary, *workload.command[1:]]
+    if not isinstance(workload, UnrestrictedContainerRequest):
+        raise DockerWorkloadLauncherError("unsupported unrestricted workload request")
+    args = [
+        docker_binary,
+        "run",
+        "--name",
+        request.container_name,
+        "--workdir",
+        workload.workdir or workload.repo_dir,
+        "--network",
+        workload.network_mode,
+        "--privileged=false",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+    ]
+    for key, value in _operational_labels(request).items():
+        args.extend(["--label", f"{key}={value}"])
+    args.extend(["--mount", f"type=bind,source={workload.repo_dir},target={workload.repo_dir}"])
+    args.extend(["--mount", f"type=bind,source={workload.artifacts_dir},target={workload.artifacts_dir}"])
+    args.extend(["--mount", f"type=bind,source={workload.scratch_dir},target={workload.scratch_dir}"])
+    for mount in workload.cache_mounts:
+        suffix = ",readonly" if mount.read_only else ""
+        args.extend(["--mount", f"type=volume,source={mount.source},target={mount.target}{suffix}"])
+    for key, value in workload.env_overrides.items():
+        args.extend(["--env", f"{key}={value}"])
+    for flag, value in _effective_resources(
+        profile=_UNRESTRICTED_RUNNER_PROFILE,
+        overrides=workload.resources,
+    ).items():
+        args.extend([flag, value])
+    if workload.entrypoint:
+        args.extend(["--entrypoint", workload.entrypoint[0]])
+    args.append(workload.image)
+    if workload.entrypoint[1:]:
+        args.extend(workload.entrypoint[1:])
+    args.extend(workload.command)
+    return args
+
+
 def _ensure_paths_are_mounted(request: ValidatedWorkloadRequest) -> None:
     if request.profile is None:
         return
@@ -559,44 +645,10 @@ class DockerWorkloadLauncher:
         profile = request.profile
         workload = request.request
         if profile is None:
-            if isinstance(workload, UnrestrictedDockerRequest):
-                return [self._docker_binary, *workload.command]
-            if not isinstance(workload, UnrestrictedContainerRequest):
-                raise DockerWorkloadLauncherError("unsupported unrestricted workload request")
-            args = [
-                self._docker_binary,
-                "run",
-                "--name",
-                request.container_name,
-                "--workdir",
-                workload.workdir or workload.repo_dir,
-                "--network",
-                workload.network_mode,
-                "--privileged=false",
-                "--cap-drop",
-                "ALL",
-                "--security-opt",
-                "no-new-privileges",
-            ]
-            for key, value in _operational_labels(request).items():
-                args.extend(["--label", f"{key}={value}"])
-            args.extend(["--mount", f"type=bind,source={workload.repo_dir},target={workload.repo_dir}"])
-            args.extend(["--mount", f"type=bind,source={workload.artifacts_dir},target={workload.artifacts_dir}"])
-            args.extend(["--mount", f"type=bind,source={workload.scratch_dir},target={workload.scratch_dir}"])
-            for mount in workload.cache_mounts:
-                suffix = ",readonly" if mount.read_only else ""
-                args.extend(["--mount", f"type=volume,source={mount.source},target={mount.target}{suffix}"])
-            for key, value in workload.env_overrides.items():
-                args.extend(["--env", f"{key}={value}"])
-            for flag, value in _effective_resources(profile=RunnerProfile.model_validate({"id":"unrestricted","kind":"one_shot","image":"busybox:1.0","workdirTemplate":"/tmp","requiredMounts":[{"type":"volume","source":"tmp","target":"/tmp"}],"envAllowlist":[],"networkPolicy":"none","resources":{},"timeoutSeconds":300}), overrides=workload.resources).items():
-                args.extend([flag, value])
-            if workload.entrypoint:
-                args.extend(["--entrypoint", workload.entrypoint[0]])
-            args.append(workload.image)
-            if workload.entrypoint[1:]:
-                args.extend(workload.entrypoint[1:])
-            args.extend(workload.command)
-            return args
+            return _build_unrestricted_run_args(
+                docker_binary=self._docker_binary,
+                request=request,
+            )
         args = [
             self._docker_binary,
             "run",
@@ -642,52 +694,18 @@ class DockerWorkloadLauncher:
         return args
 
     def build_helper_run_args(self, request: ValidatedWorkloadRequest) -> list[str]:
-        if request.profile.kind != "bounded_service":
+        profile = request.profile
+        workload = request.request
+        if profile is None:
+            return _build_unrestricted_run_args(
+                docker_binary=self._docker_binary,
+                request=request,
+            )
+        if profile.kind != "bounded_service":
             raise DockerWorkloadLauncherError(
                 "start_helper requires a bounded_service runner profile"
             )
         _ensure_paths_are_mounted(request)
-        profile = request.profile
-        workload = request.request
-        if profile is None:
-            if isinstance(workload, UnrestrictedDockerRequest):
-                return [self._docker_binary, *workload.command]
-            if not isinstance(workload, UnrestrictedContainerRequest):
-                raise DockerWorkloadLauncherError("unsupported unrestricted workload request")
-            args = [
-                self._docker_binary,
-                "run",
-                "--name",
-                request.container_name,
-                "--workdir",
-                workload.workdir or workload.repo_dir,
-                "--network",
-                workload.network_mode,
-                "--privileged=false",
-                "--cap-drop",
-                "ALL",
-                "--security-opt",
-                "no-new-privileges",
-            ]
-            for key, value in _operational_labels(request).items():
-                args.extend(["--label", f"{key}={value}"])
-            args.extend(["--mount", f"type=bind,source={workload.repo_dir},target={workload.repo_dir}"])
-            args.extend(["--mount", f"type=bind,source={workload.artifacts_dir},target={workload.artifacts_dir}"])
-            args.extend(["--mount", f"type=bind,source={workload.scratch_dir},target={workload.scratch_dir}"])
-            for mount in workload.cache_mounts:
-                suffix = ",readonly" if mount.read_only else ""
-                args.extend(["--mount", f"type=volume,source={mount.source},target={mount.target}{suffix}"])
-            for key, value in workload.env_overrides.items():
-                args.extend(["--env", f"{key}={value}"])
-            for flag, value in _effective_resources(profile=RunnerProfile.model_validate({"id":"unrestricted","kind":"one_shot","image":"busybox:1.0","workdirTemplate":"/tmp","requiredMounts":[{"type":"volume","source":"tmp","target":"/tmp"}],"envAllowlist":[],"networkPolicy":"none","resources":{},"timeoutSeconds":300}), overrides=workload.resources).items():
-                args.extend([flag, value])
-            if workload.entrypoint:
-                args.extend(["--entrypoint", workload.entrypoint[0]])
-            args.append(workload.image)
-            if workload.entrypoint[1:]:
-                args.extend(workload.entrypoint[1:])
-            args.extend(workload.command)
-            return args
         args = [
             self._docker_binary,
             "run",
@@ -745,7 +763,7 @@ class DockerWorkloadLauncher:
         configured_timeout = (
             timeout_seconds
             if timeout_seconds is not None
-            else request.request.timeout_seconds or (request.profile.timeout_seconds if request.profile is not None else 300)
+            else _request_timeout_seconds(request)
         )
         lease = await self._concurrency_limiter.acquire(request)
 
@@ -777,7 +795,7 @@ class DockerWorkloadLauncher:
                             stdout_buffer=stdout_buffer,
                             stderr_buffer=stderr_buffer,
                         ),
-                        timeout=max(1, request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30),
+                        timeout=max(1, _request_kill_grace_seconds(request)),
                     )
                 except asyncio.TimeoutError:
                     process.kill()
@@ -798,7 +816,7 @@ class DockerWorkloadLauncher:
                                 stdout_buffer=stdout_buffer,
                                 stderr_buffer=stderr_buffer,
                             ),
-                            timeout=max(1, request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30),
+                            timeout=max(1, _request_kill_grace_seconds(request)),
                         )
                     except asyncio.TimeoutError:
                         process.kill()
@@ -837,7 +855,7 @@ class DockerWorkloadLauncher:
                 by_alias=True,
                 exclude_none=True,
             ),
-            "cleanup": (request.profile.cleanup.model_dump(mode="json", by_alias=True) if request.profile is not None else {"removeContainerOnExit": False, "killGraceSeconds": 30}),
+            "cleanup": (request.profile.cleanup.model_dump(mode="json", by_alias=True) if request.profile is not None else {"removeContainerOnExit": False, "killGraceSeconds": _DEFAULT_KILL_GRACE_SECONDS}),
         }
         declared_refs, missing_declared_outputs = _declared_output_refs(request)
         diagnostics["declaredOutputRefs"] = dict(declared_refs)

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -13,6 +13,8 @@ from typing import Mapping, Protocol, Sequence
 
 from moonmind.schemas.workload_models import (
     RunnerProfile,
+    UnrestrictedContainerRequest,
+    UnrestrictedDockerRequest,
     ValidatedWorkloadRequest,
     WorkloadMount,
     WorkloadResourceOverrides,
@@ -68,7 +70,7 @@ class DockerWorkloadConcurrencyLimiter:
         self,
         request: ValidatedWorkloadRequest,
     ) -> _ConcurrencyLease:
-        profile_id = request.profile.id
+        profile_id = request.profile.id if request.profile is not None else request.request.tool_name
         async with self._lock:
             active_for_profile = self._active_by_profile.get(profile_id, 0)
             if active_for_profile >= request.profile.max_concurrency:
@@ -232,7 +234,7 @@ def _session_context(request: ValidatedWorkloadRequest) -> dict[str, object] | N
 
 
 def _operational_labels(request: ValidatedWorkloadRequest) -> dict[str, str]:
-    if request.profile.kind == "bounded_service":
+    if request.profile is not None and request.profile.kind == "bounded_service":
         ttl_seconds = (
             request.request.ttl_seconds
             or request.profile.helper_ttl_seconds
@@ -244,10 +246,9 @@ def _operational_labels(request: ValidatedWorkloadRequest) -> dict[str, str]:
             "moonmind.expires_at": _isoformat(expires_at) or "",
             "moonmind.helper_ttl_seconds": str(ttl_seconds),
         }
-    timeout_seconds = request.request.timeout_seconds or request.profile.timeout_seconds
-    expires_at = datetime.now(UTC) + timedelta(
-        seconds=timeout_seconds + request.profile.cleanup.kill_grace_seconds
-    )
+    timeout_seconds = request.request.timeout_seconds or (request.profile.timeout_seconds if request.profile is not None else 300)
+    kill_grace_seconds = request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30
+    expires_at = datetime.now(UTC) + timedelta(seconds=timeout_seconds + kill_grace_seconds)
     return {
         **request.ownership.labels,
         "moonmind.expires_at": _isoformat(expires_at) or "",
@@ -264,13 +265,15 @@ def _workload_metadata(
     duration_seconds: float,
     timeout_reason: str | None,
 ) -> dict[str, object]:
+    image_ref = request.profile.image if request.profile is not None else getattr(request.request, "image", None)
+    profile_id = request.profile.id if request.profile is not None else None
     return {
         "taskRunId": request.request.task_run_id,
         "stepId": request.request.step_id,
         "attempt": request.request.attempt,
         "toolName": request.request.tool_name,
-        "profileId": request.profile.id,
-        "imageRef": request.profile.image,
+        "profileId": profile_id,
+        "imageRef": image_ref,
         "containerName": request.container_name,
         "identityKind": request.ownership.kind,
         "status": status,
@@ -412,6 +415,8 @@ def _publish_workload_artifacts(
 
 
 def _ensure_paths_are_mounted(request: ValidatedWorkloadRequest) -> None:
+    if request.profile is None:
+        return
     mounts = (*request.profile.required_mounts, *request.profile.optional_mounts)
     workload = request.request
     if not _path_is_under_mount(workload.repo_dir, mounts):
@@ -553,6 +558,45 @@ class DockerWorkloadLauncher:
         _ensure_paths_are_mounted(request)
         profile = request.profile
         workload = request.request
+        if profile is None:
+            if isinstance(workload, UnrestrictedDockerRequest):
+                return [self._docker_binary, *workload.command]
+            if not isinstance(workload, UnrestrictedContainerRequest):
+                raise DockerWorkloadLauncherError("unsupported unrestricted workload request")
+            args = [
+                self._docker_binary,
+                "run",
+                "--name",
+                request.container_name,
+                "--workdir",
+                workload.workdir or workload.repo_dir,
+                "--network",
+                workload.network_mode,
+                "--privileged=false",
+                "--cap-drop",
+                "ALL",
+                "--security-opt",
+                "no-new-privileges",
+            ]
+            for key, value in _operational_labels(request).items():
+                args.extend(["--label", f"{key}={value}"])
+            args.extend(["--mount", f"type=bind,source={workload.repo_dir},target={workload.repo_dir}"])
+            args.extend(["--mount", f"type=bind,source={workload.artifacts_dir},target={workload.artifacts_dir}"])
+            args.extend(["--mount", f"type=bind,source={workload.scratch_dir},target={workload.scratch_dir}"])
+            for mount in workload.cache_mounts:
+                suffix = ",readonly" if mount.read_only else ""
+                args.extend(["--mount", f"type=volume,source={mount.source},target={mount.target}{suffix}"])
+            for key, value in workload.env_overrides.items():
+                args.extend(["--env", f"{key}={value}"])
+            for flag, value in _effective_resources(profile=RunnerProfile.model_validate({"id":"unrestricted","kind":"one_shot","image":"busybox:1.0","workdirTemplate":"/tmp","requiredMounts":[{"type":"volume","source":"tmp","target":"/tmp"}],"envAllowlist":[],"networkPolicy":"none","resources":{},"timeoutSeconds":300}), overrides=workload.resources).items():
+                args.extend([flag, value])
+            if workload.entrypoint:
+                args.extend(["--entrypoint", workload.entrypoint[0]])
+            args.append(workload.image)
+            if workload.entrypoint[1:]:
+                args.extend(workload.entrypoint[1:])
+            args.extend(workload.command)
+            return args
         args = [
             self._docker_binary,
             "run",
@@ -605,6 +649,45 @@ class DockerWorkloadLauncher:
         _ensure_paths_are_mounted(request)
         profile = request.profile
         workload = request.request
+        if profile is None:
+            if isinstance(workload, UnrestrictedDockerRequest):
+                return [self._docker_binary, *workload.command]
+            if not isinstance(workload, UnrestrictedContainerRequest):
+                raise DockerWorkloadLauncherError("unsupported unrestricted workload request")
+            args = [
+                self._docker_binary,
+                "run",
+                "--name",
+                request.container_name,
+                "--workdir",
+                workload.workdir or workload.repo_dir,
+                "--network",
+                workload.network_mode,
+                "--privileged=false",
+                "--cap-drop",
+                "ALL",
+                "--security-opt",
+                "no-new-privileges",
+            ]
+            for key, value in _operational_labels(request).items():
+                args.extend(["--label", f"{key}={value}"])
+            args.extend(["--mount", f"type=bind,source={workload.repo_dir},target={workload.repo_dir}"])
+            args.extend(["--mount", f"type=bind,source={workload.artifacts_dir},target={workload.artifacts_dir}"])
+            args.extend(["--mount", f"type=bind,source={workload.scratch_dir},target={workload.scratch_dir}"])
+            for mount in workload.cache_mounts:
+                suffix = ",readonly" if mount.read_only else ""
+                args.extend(["--mount", f"type=volume,source={mount.source},target={mount.target}{suffix}"])
+            for key, value in workload.env_overrides.items():
+                args.extend(["--env", f"{key}={value}"])
+            for flag, value in _effective_resources(profile=RunnerProfile.model_validate({"id":"unrestricted","kind":"one_shot","image":"busybox:1.0","workdirTemplate":"/tmp","requiredMounts":[{"type":"volume","source":"tmp","target":"/tmp"}],"envAllowlist":[],"networkPolicy":"none","resources":{},"timeoutSeconds":300}), overrides=workload.resources).items():
+                args.extend([flag, value])
+            if workload.entrypoint:
+                args.extend(["--entrypoint", workload.entrypoint[0]])
+            args.append(workload.image)
+            if workload.entrypoint[1:]:
+                args.extend(workload.entrypoint[1:])
+            args.extend(workload.command)
+            return args
         args = [
             self._docker_binary,
             "run",
@@ -662,7 +745,7 @@ class DockerWorkloadLauncher:
         configured_timeout = (
             timeout_seconds
             if timeout_seconds is not None
-            else request.request.timeout_seconds or request.profile.timeout_seconds
+            else request.request.timeout_seconds or (request.profile.timeout_seconds if request.profile is not None else 300)
         )
         lease = await self._concurrency_limiter.acquire(request)
 
@@ -694,7 +777,7 @@ class DockerWorkloadLauncher:
                             stdout_buffer=stdout_buffer,
                             stderr_buffer=stderr_buffer,
                         ),
-                        timeout=max(1, request.profile.cleanup.kill_grace_seconds),
+                        timeout=max(1, request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30),
                     )
                 except asyncio.TimeoutError:
                     process.kill()
@@ -715,7 +798,7 @@ class DockerWorkloadLauncher:
                                 stdout_buffer=stdout_buffer,
                                 stderr_buffer=stderr_buffer,
                             ),
-                            timeout=max(1, request.profile.cleanup.kill_grace_seconds),
+                            timeout=max(1, request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30),
                         )
                     except asyncio.TimeoutError:
                         process.kill()
@@ -726,7 +809,7 @@ class DockerWorkloadLauncher:
                         )
                 raise
             finally:
-                if request.profile.cleanup.remove_container_on_exit:
+                if request.profile is not None and request.profile.cleanup.remove_container_on_exit:
                     await self._janitor.remove(request.container_name)
         finally:
             await lease.release()
@@ -754,10 +837,7 @@ class DockerWorkloadLauncher:
                 by_alias=True,
                 exclude_none=True,
             ),
-            "cleanup": request.profile.cleanup.model_dump(
-                mode="json",
-                by_alias=True,
-            ),
+            "cleanup": (request.profile.cleanup.model_dump(mode="json", by_alias=True) if request.profile is not None else {"removeContainerOnExit": False, "killGraceSeconds": 30}),
         }
         declared_refs, missing_declared_outputs = _declared_output_refs(request)
         diagnostics["declaredOutputRefs"] = dict(declared_refs)
@@ -774,8 +854,8 @@ class DockerWorkloadLauncher:
         workload_metadata["artifactPublication"] = artifact_publication
         metadata = redact_sensitive_payload({
             "containerName": request.container_name,
-            "image": request.profile.image,
-            "imageRef": request.profile.image,
+            "image": request.profile.image if request.profile is not None else getattr(request.request, "image", None),
+            "imageRef": request.profile.image if request.profile is not None else getattr(request.request, "image", None),
             "dockerHost": self._docker_host or os.environ.get("DOCKER_HOST", ""),
             "artifactsDir": request.request.artifacts_dir,
             "stdout": stdout,
@@ -785,7 +865,7 @@ class DockerWorkloadLauncher:
         })
         return WorkloadResult(
             requestId=request.container_name,
-            profileId=request.profile.id,
+            profileId=request.profile.id if request.profile is not None else request.request.tool_name,
             status=status,
             labels=request.ownership.labels,
             exitCode=exit_code,
@@ -973,10 +1053,7 @@ class DockerWorkloadLauncher:
                 by_alias=True,
                 exclude_none=True,
             ),
-            "cleanup": request.profile.cleanup.model_dump(
-                mode="json",
-                by_alias=True,
-            ),
+            "cleanup": (request.profile.cleanup.model_dump(mode="json", by_alias=True) if request.profile is not None else {"removeContainerOnExit": False, "killGraceSeconds": 30}),
         }
         declared_refs, missing_declared_outputs = _declared_output_refs(request)
         diagnostics["declaredOutputRefs"] = dict(declared_refs)
@@ -993,8 +1070,8 @@ class DockerWorkloadLauncher:
         helper_metadata["artifactPublication"] = artifact_publication
         metadata = {
             "containerName": request.container_name,
-            "image": request.profile.image,
-            "imageRef": request.profile.image,
+            "image": request.profile.image if request.profile is not None else getattr(request.request, "image", None),
+            "imageRef": request.profile.image if request.profile is not None else getattr(request.request, "image", None),
             "dockerHost": self._docker_host or os.environ.get("DOCKER_HOST", ""),
             "artifactsDir": request.request.artifacts_dir,
             "stdout": stdout,
@@ -1004,7 +1081,7 @@ class DockerWorkloadLauncher:
         }
         return WorkloadResult(
             requestId=request.container_name,
-            profileId=request.profile.id,
+            profileId=request.profile.id if request.profile is not None else request.request.tool_name,
             status=status,
             labels=request.ownership.labels,
             exitCode=None,
@@ -1039,6 +1116,6 @@ class DockerWorkloadLauncher:
     async def _terminate_container(self, request: ValidatedWorkloadRequest) -> None:
         await self._janitor.stop(
             request.container_name,
-            grace_seconds=request.profile.cleanup.kill_grace_seconds,
+            grace_seconds=request.profile.cleanup.kill_grace_seconds if request.profile is not None else 30,
         )
         await self._janitor.kill(request.container_name)

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -11,12 +11,15 @@ from pydantic import ValidationError
 
 from moonmind.schemas.workload_models import (
     RunnerProfile,
+    UnrestrictedContainerRequest,
+    UnrestrictedDockerRequest,
     ValidatedWorkloadRequest,
     WorkloadRequest,
     WorkloadOwnershipMetadata,
     helper_container_name,
     parse_cpu_units,
     parse_size_bytes,
+    parse_workload_request,
 )
 
 
@@ -124,54 +127,64 @@ class RunnerProfileRegistry:
 
     def validate_request(
         self,
-        request: WorkloadRequest | Mapping[str, Any],
+        request: WorkloadRequest | UnrestrictedContainerRequest | UnrestrictedDockerRequest | Mapping[str, Any],
     ) -> ValidatedWorkloadRequest:
-        parsed_request = (
-            request
-            if isinstance(request, WorkloadRequest)
-            else WorkloadRequest.model_validate(request)
-        )
-        profile = self._profiles.get(parsed_request.profile_id)
-        if profile is None:
-            raise WorkloadPolicyError(
-                f"unknown runner profile: {parsed_request.profile_id}",
-                reason="unknown_profile",
-                details={"profileId": parsed_request.profile_id},
+        parsed_request = parse_workload_request(request) if isinstance(request, Mapping) else request
+
+        if isinstance(parsed_request, WorkloadRequest):
+            profile = self._profiles.get(parsed_request.profile_id)
+            if profile is None:
+                raise WorkloadPolicyError(
+                    f"unknown runner profile: {parsed_request.profile_id}",
+                    reason="unknown_profile",
+                    details={"profileId": parsed_request.profile_id},
+                )
+
+            self._validate_workspace_path(parsed_request.repo_dir, field_name="repoDir")
+            self._validate_workspace_path(
+                parsed_request.artifacts_dir,
+                field_name="artifactsDir",
+            )
+            self._validate_env_overrides(parsed_request, profile)
+            self._validate_timeout(parsed_request, profile)
+            self._validate_helper_ttl(parsed_request, profile)
+            self._validate_resources(parsed_request, profile)
+            container_name = parsed_request.container_name
+            ownership = parsed_request.ownership_metadata()
+            if profile.kind == "bounded_service":
+                container_name = helper_container_name(
+                    task_run_id=parsed_request.task_run_id,
+                    step_id=parsed_request.step_id,
+                    attempt=parsed_request.attempt,
+                )
+                ownership = WorkloadOwnershipMetadata(
+                    kind="bounded_service",
+                    taskRunId=parsed_request.task_run_id,
+                    stepId=parsed_request.step_id,
+                    attempt=parsed_request.attempt,
+                    toolName=parsed_request.tool_name,
+                    workloadProfile=parsed_request.profile_id,
+                    sessionId=parsed_request.session_id,
+                    sessionEpoch=parsed_request.session_epoch,
+                    workloadAccess="profile",
+                )
+
+            return ValidatedWorkloadRequest(
+                request=parsed_request,
+                profile=profile,
+                ownership=ownership,
+                containerName=container_name,
             )
 
         self._validate_workspace_path(parsed_request.repo_dir, field_name="repoDir")
-        self._validate_workspace_path(
-            parsed_request.artifacts_dir,
-            field_name="artifactsDir",
-        )
-        self._validate_env_overrides(parsed_request, profile)
-        self._validate_timeout(parsed_request, profile)
-        self._validate_helper_ttl(parsed_request, profile)
-        self._validate_resources(parsed_request, profile)
-        container_name = parsed_request.container_name
-        ownership = parsed_request.ownership_metadata()
-        if profile.kind == "bounded_service":
-            container_name = helper_container_name(
-                task_run_id=parsed_request.task_run_id,
-                step_id=parsed_request.step_id,
-                attempt=parsed_request.attempt,
-            )
-            ownership = WorkloadOwnershipMetadata(
-                kind="bounded_service",
-                taskRunId=parsed_request.task_run_id,
-                stepId=parsed_request.step_id,
-                attempt=parsed_request.attempt,
-                toolName=parsed_request.tool_name,
-                workloadProfile=parsed_request.profile_id,
-                sessionId=parsed_request.session_id,
-                sessionEpoch=parsed_request.session_epoch,
-            )
-
+        self._validate_workspace_path(parsed_request.artifacts_dir, field_name="artifactsDir")
+        if isinstance(parsed_request, UnrestrictedContainerRequest):
+            self._validate_workspace_path(parsed_request.scratch_dir, field_name="scratchDir")
         return ValidatedWorkloadRequest(
             request=parsed_request,
-            profile=profile,
-            ownership=ownership,
-            containerName=container_name,
+            profile=None,
+            ownership=parsed_request.ownership_metadata(),
+            containerName=parsed_request.container_name,
         )
 
     def _validate_workspace_path(self, value: str, *, field_name: str) -> None:

--- a/moonmind/workloads/tool_bridge.py
+++ b/moonmind/workloads/tool_bridge.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Mapping
 
 from pydantic import ValidationError
 
-from moonmind.schemas.workload_models import WorkloadRequest, WorkloadResult
+from moonmind.schemas.workload_models import WorkloadResult, parse_workload_request
 from moonmind.workflows.skills.skill_plan_contracts import (
     SkillFailure as ToolFailure,
     SkillResult,
@@ -23,11 +23,13 @@ WorkloadToolHandler = Callable[
 CONTAINER_RUN_WORKLOAD_TOOL = "container.run_workload"
 CONTAINER_START_HELPER_TOOL = "container.start_helper"
 CONTAINER_STOP_HELPER_TOOL = "container.stop_helper"
+CONTAINER_RUN_CONTAINER_TOOL = "container.run_container"
+CONTAINER_RUN_DOCKER_TOOL = "container.run_docker"
 INTEGRATION_CI_TOOL = "moonmind.integration_ci"
 INTEGRATION_CI_PROFILE_ID = "moonmind-integration-ci"
 UNREAL_RUN_TESTS_TOOL = "unreal.run_tests"
 DEFAULT_UNREAL_PROFILE_ID = "unreal-5_3-linux"
-DOOD_TOOL_NAMES = frozenset(
+CURATED_DOOD_TOOL_NAMES = frozenset(
     {
         CONTAINER_RUN_WORKLOAD_TOOL,
         CONTAINER_START_HELPER_TOOL,
@@ -36,6 +38,32 @@ DOOD_TOOL_NAMES = frozenset(
         UNREAL_RUN_TESTS_TOOL,
     }
 )
+UNRESTRICTED_DOOD_TOOL_NAMES = frozenset(
+    {
+        CONTAINER_RUN_CONTAINER_TOOL,
+        CONTAINER_RUN_DOCKER_TOOL,
+    }
+)
+DOOD_TOOL_NAMES = frozenset({*CURATED_DOOD_TOOL_NAMES, *UNRESTRICTED_DOOD_TOOL_NAMES})
+
+
+def normalize_workflow_docker_mode(value: str | None) -> str:
+    normalized = str(value or "profiles").strip().lower() or "profiles"
+    if normalized not in {"disabled", "profiles", "unrestricted"}:
+        raise ValueError(
+            "workflow_docker_mode must be one of: disabled, profiles, unrestricted"
+        )
+    return normalized
+
+
+def tool_allowed_for_workflow_docker_mode(*, tool_name: str, workflow_docker_mode: str) -> bool:
+    normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
+    normalized_tool = str(tool_name or "").strip()
+    if normalized_mode == "disabled":
+        return False
+    if normalized_mode == "profiles":
+        return normalized_tool in CURATED_DOOD_TOOL_NAMES
+    return normalized_tool in DOOD_TOOL_NAMES
 
 
 def is_dood_tool(name: str) -> bool:
@@ -170,6 +198,68 @@ def build_dood_tool_definition_payload(*, name: str, version: str) -> dict[str, 
             "additionalProperties": False,
         }
         description = "Stop one policy-gated bounded helper container."
+    elif normalized == CONTAINER_RUN_CONTAINER_TOOL:
+        input_schema = {
+            "type": "object",
+            "required": ["image", "repoDir", "artifactsDir", "scratchDir", "command"],
+            "properties": {
+                "taskRunId": {"type": "string", "minLength": 1},
+                "stepId": {"type": "string", "minLength": 1},
+                "attempt": {"type": "integer", "minimum": 1},
+                "repoDir": {"type": "string", "minLength": 1},
+                "artifactsDir": {"type": "string", "minLength": 1},
+                "scratchDir": {"type": "string", "minLength": 1},
+                "image": {"type": "string", "minLength": 1},
+                "entrypoint": {"type": "array", "items": {"type": "string", "minLength": 1}},
+                "command": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+                "workdir": {"type": "string", "minLength": 1},
+                "envOverrides": {"type": "object", "additionalProperties": {"type": "string"}},
+                "cacheMounts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["source", "target"],
+                        "properties": {
+                            "source": {"type": "string", "minLength": 1},
+                            "target": {"type": "string", "minLength": 1},
+                            "readOnly": {"type": "boolean"},
+                        },
+                        "additionalProperties": False,
+                    },
+                },
+                "networkMode": {"type": "string", "enum": ["none", "bridge"]},
+                "timeoutSeconds": {"type": "integer", "minimum": 1},
+                "resources": _resources_schema(),
+                "declaredOutputs": _declared_outputs_schema(),
+                "sessionId": {"type": "string", "minLength": 1},
+                "sessionEpoch": {"type": "integer", "minimum": 1},
+                "sourceTurnId": {"type": "string", "minLength": 1},
+            },
+            "additionalProperties": False,
+        }
+        description = "Run one unrestricted runtime-selected container through MoonMind."
+    elif normalized == CONTAINER_RUN_DOCKER_TOOL:
+        input_schema = {
+            "type": "object",
+            "required": ["repoDir", "artifactsDir", "command"],
+            "properties": {
+                "taskRunId": {"type": "string", "minLength": 1},
+                "stepId": {"type": "string", "minLength": 1},
+                "attempt": {"type": "integer", "minimum": 1},
+                "repoDir": {"type": "string", "minLength": 1},
+                "artifactsDir": {"type": "string", "minLength": 1},
+                "command": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+                "envOverrides": {"type": "object", "additionalProperties": {"type": "string"}},
+                "timeoutSeconds": {"type": "integer", "minimum": 1},
+                "resources": _resources_schema(),
+                "declaredOutputs": _declared_outputs_schema(),
+                "sessionId": {"type": "string", "minLength": 1},
+                "sessionEpoch": {"type": "integer", "minimum": 1},
+                "sourceTurnId": {"type": "string", "minLength": 1},
+            },
+            "additionalProperties": False,
+        }
+        description = "Run one unrestricted Docker CLI command through MoonMind."
     elif normalized == UNREAL_RUN_TESTS_TOOL:
         input_schema = {
             "type": "object",
@@ -278,14 +368,20 @@ def register_workload_tool_handlers(
     *,
     registry: RunnerProfileRegistry,
     launcher: Any,
-    workflow_docker_enabled: bool = True,
+    workflow_docker_mode: str = "profiles",
 ) -> None:
+    normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
     for tool_name in sorted(DOOD_TOOL_NAMES):
+        if not tool_allowed_for_workflow_docker_mode(
+            tool_name=tool_name,
+            workflow_docker_mode=normalized_mode,
+        ):
+            continue
         handler = build_workload_tool_handler(
             tool_name=tool_name,
             registry=registry,
             launcher=launcher,
-            workflow_docker_enabled=workflow_docker_enabled,
+            workflow_docker_mode=normalized_mode,
         )
         for version in ("1.0", "1.0.0"):
             dispatcher.register_skill(
@@ -300,9 +396,10 @@ def build_workload_tool_handler(
     tool_name: str,
     registry: RunnerProfileRegistry,
     launcher: Any,
-    workflow_docker_enabled: bool = True,
+    workflow_docker_mode: str = "profiles",
 ) -> WorkloadToolHandler:
     normalized = str(tool_name or "").strip()
+    normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
     if not is_dood_tool(normalized):
         raise ValueError(f"unknown Docker workload tool: {tool_name}")
 
@@ -310,16 +407,34 @@ def build_workload_tool_handler(
         inputs: Mapping[str, Any],
         context: Mapping[str, Any] | None,
     ) -> SkillResult:
-        if not workflow_docker_enabled:
+        if not tool_allowed_for_workflow_docker_mode(
+            tool_name=normalized,
+            workflow_docker_mode=normalized_mode,
+        ):
+            if normalized_mode == "disabled":
+                raise ToolFailure(
+                    error_code="PERMISSION_DENIED",
+                    message=(
+                        "Docker-backed workflow tools are disabled by "
+                        "MOONMIND_WORKFLOW_DOCKER_MODE=disabled "
+                        "(docker_workflows_disabled)"
+                    ),
+                    retryable=False,
+                    details={"reason": "docker_workflows_disabled"},
+                )
             raise ToolFailure(
                 error_code="PERMISSION_DENIED",
                 message=(
-                    "Docker-backed workflow tools are disabled by "
-                    "MOONMIND_WORKFLOW_DOCKER_ENABLED=false "
-                    "(docker_workflows_disabled)"
+                    f"Docker-backed workflow tool {normalized} is not allowed when "
+                    f"MOONMIND_WORKFLOW_DOCKER_MODE={normalized_mode} "
+                    "(docker_workflow_mode_forbidden)"
                 ),
                 retryable=False,
-                details={"reason": "docker_workflows_disabled"},
+                details={
+                    "reason": "docker_workflow_mode_forbidden",
+                    "workflowDockerMode": normalized_mode,
+                    "toolName": normalized,
+                },
             )
         try:
             request = _build_workload_request(
@@ -365,7 +480,7 @@ def _build_workload_request(
     tool_name: str,
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
-) -> WorkloadRequest:
+) -> Any:
     if not isinstance(inputs, Mapping):
         raise ValueError("workload tool inputs must be an object")
     request_payload = dict(inputs)
@@ -417,7 +532,7 @@ def _build_workload_request(
         request_payload["profileId"] = INTEGRATION_CI_PROFILE_ID
         request_payload["command"] = ("./tools/test_integration.sh",)
 
-    return WorkloadRequest.model_validate(request_payload)
+    return parse_workload_request(request_payload)
 
 
 def _request_payload_reason(inputs: Mapping[str, Any]) -> str | None:
@@ -580,15 +695,20 @@ def _to_skill_result(result: WorkloadResult) -> SkillResult:
 
 __all__ = [
     "CONTAINER_RUN_WORKLOAD_TOOL",
+    "CONTAINER_RUN_CONTAINER_TOOL",
+    "CONTAINER_RUN_DOCKER_TOOL",
     "CONTAINER_START_HELPER_TOOL",
     "CONTAINER_STOP_HELPER_TOOL",
     "DEFAULT_UNREAL_PROFILE_ID",
     "DOOD_TOOL_NAMES",
+    "CURATED_DOOD_TOOL_NAMES",
     "INTEGRATION_CI_PROFILE_ID",
     "INTEGRATION_CI_TOOL",
     "UNREAL_RUN_TESTS_TOOL",
     "build_dood_tool_definition_payload",
     "build_workload_tool_handler",
     "is_dood_tool",
+    "normalize_workflow_docker_mode",
     "register_workload_tool_handlers",
+    "tool_allowed_for_workflow_docker_mode",
 ]

--- a/moonmind/workloads/tool_bridge.py
+++ b/moonmind/workloads/tool_bridge.py
@@ -8,6 +8,7 @@ from typing import Any, Awaitable, Callable, Mapping
 from pydantic import ValidationError
 
 from moonmind.schemas.workload_models import WorkloadResult, parse_workload_request
+from moonmind.workflow_docker_mode import normalize_workflow_docker_mode
 from moonmind.workflows.skills.skill_plan_contracts import (
     SkillFailure as ToolFailure,
     SkillResult,
@@ -45,15 +46,6 @@ UNRESTRICTED_DOOD_TOOL_NAMES = frozenset(
     }
 )
 DOOD_TOOL_NAMES = frozenset({*CURATED_DOOD_TOOL_NAMES, *UNRESTRICTED_DOOD_TOOL_NAMES})
-
-
-def normalize_workflow_docker_mode(value: str | None) -> str:
-    normalized = str(value or "profiles").strip().lower() or "profiles"
-    if normalized not in {"disabled", "profiles", "unrestricted"}:
-        raise ValueError(
-            "workflow_docker_mode must be one of: disabled, profiles, unrestricted"
-        )
-    return normalized
 
 
 def tool_allowed_for_workflow_docker_mode(*, tool_name: str, workflow_docker_mode: str) -> bool:

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/checklists/requirements.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Enforce Docker Workflow Modes and Registry Gating
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent selected from the task instructions.
+- Input classified as a single-story runtime feature request.
+- `docs/ManagedAgents/DockerOutOfDocker.md` is treated as runtime source requirements because the Jira brief describes product behavior rather than documentation-only output.
+- No existing Moon Spec artifacts for MM-499 were found under `specs/`, so `Specify` is the first incomplete stage.
+- The canonical Jira preset brief is preserved in `spec.md`, including the MM-499 traceability requirement.
+- In-scope source design requirements from `docs/ManagedAgents/DockerOutOfDocker.md` sections 1, 2, 6, and 19 map to FR-001 through FR-007.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/contracts/workflow-docker-mode-contract.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/contracts/workflow-docker-mode-contract.md
@@ -1,0 +1,71 @@
+# Contract: Workflow Docker Mode
+
+## Purpose
+
+Define the runtime contract for deployment-owned workflow Docker access under MM-499.
+
+## Configuration Surface
+
+- Canonical environment variable: `MOONMIND_WORKFLOW_DOCKER_MODE`
+- Allowed values:
+  - `disabled`
+  - `profiles`
+  - `unrestricted`
+- Default when omitted: `profiles`
+- Unsupported values: startup error at settings-load time
+- Task prompts, plans, and runtime tool inputs cannot override the selected mode
+
+## Mode Behavior Matrix
+
+| Mode | Curated/profile-backed Docker workload tools | Unrestricted Docker workload tools | Direct invocation of forbidden Docker tools |
+| --- | --- | --- | --- |
+| `disabled` | not exposed | not exposed | deterministic non-retryable denial |
+| `profiles` | exposed | not exposed | deterministic non-retryable denial |
+| `unrestricted` | exposed | exposed | allowed when request passes validation |
+
+## Curated/Profile-Backed Tool Set
+
+The existing profile-backed workflow Docker path remains the normal execution path and includes curated tools such as:
+
+- `container.run_workload`
+- `container.start_helper`
+- `container.stop_helper`
+- `moonmind.integration_ci`
+- `unreal.run_tests`
+
+These tools validate requests through deployment-owned runner profiles.
+
+## Unrestricted Tool Contract
+
+Unrestricted-mode-only tools expose deployment-gated arbitrary runtime container or Docker CLI behavior through MoonMind-owned tool contracts.
+
+Rules:
+- they must not appear in `disabled` or `profiles` mode
+- they must route through the same workload policy boundary rather than widening session-container Docker authority
+- enabling unrestricted workflow mode must not grant raw Docker authority to the managed session container itself
+
+## Registration And Runtime Alignment
+
+The same normalized workflow Docker mode must drive both:
+
+1. registry/tool exposure during worker setup
+2. runtime denial or allow behavior inside tool handlers and Temporal activity helpers
+
+Discovery and execution must not disagree about whether a tool is allowed for the selected mode.
+
+## Validation And Errors
+
+- Invalid `MOONMIND_WORKFLOW_DOCKER_MODE` values fail fast during settings load.
+- Mode-forbidden direct invocation returns a deterministic non-retryable permission denial.
+- Disabled-mode denial reasons remain machine-readable so tests and operators can distinguish policy failures from generic launcher failures.
+
+## Testing Requirements
+
+Unit coverage must verify:
+- default `profiles` mode normalization
+- invalid-mode rejection
+- mode-aware registration matrix
+- mode-aware tool-handler denial behavior
+- Temporal activity/runtime denial behavior
+
+Hermetic integration coverage must verify at least one dispatcher/runtime boundary where mode-aware registration and execution stay aligned.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Enforce Docker Workflow Modes and Registry Gating
+
+**Branch**: `248-enforce-docker-workflow-modes-and-registry-gating` | **Date**: 2026-04-24 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/248-enforce-docker-workflow-modes-and-registry-gating/spec.md`
+
+## Summary
+
+Plan MM-499 as a runtime implementation story that replaces the current boolean workflow Docker gate with an explicit tri-mode deployment contract. The repository already contains Docker workload tooling, curated runner-profile validation, and disabled-mode denial paths in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `moonmind/workflows/temporal/worker_runtime.py`, but those paths are wired through `MOONMIND_WORKFLOW_DOCKER_ENABLED` and do not provide the required `disabled` / `profiles` / `unrestricted` configuration model or mode-aware registry exposure. The implementation plan is therefore to add the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` setting, propagate normalized mode-aware policy into registration and runtime enforcement, preserve curated profile-backed tools as the normal path, and add explicit unit plus hermetic integration coverage for mode-specific discovery and denial behavior.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `workflow_docker_enabled` in `moonmind/config/settings.py`; handler/runtime gating in `moonmind/workloads/tool_bridge.py` and `moonmind/workflows/temporal/activity_runtime.py` | replace boolean gate with canonical tri-mode workflow Docker policy and propagate through worker/runtime setup | unit + integration |
+| FR-002 | missing | current default is boolean `True` via `workflow_docker_enabled`; no `profiles` mode setting exists | add normalized `MOONMIND_WORKFLOW_DOCKER_MODE` with default `profiles` and update configuration tests | unit |
+| FR-003 | missing | no mode parser or unsupported-value validation exists; only boolean env parsing in `tests/unit/config/test_settings.py` | add fail-fast mode normalization and invalid-value tests | unit |
+| FR-004 | partial | disabled-mode denial exists in `build_workload_tool_handler`, `TemporalAgentRuntimeActivities.workload_run`, and tests; handlers are still registered so discovery omission is missing | make disabled mode omit Docker-backed tools from registry exposure and keep non-retryable runtime denial for direct invocation | unit + integration |
+| FR-005 | missing | curated profile-backed tools exist, but there is no profiles-mode distinction in settings or registration | introduce profiles-mode registration and enforcement so curated/profile-backed tools remain exposed while unrestricted tools stay hidden | unit + integration |
+| FR-006 | missing | unrestricted container/Docker CLI contract is documented but not implemented on the workflow Docker mode path; no unrestricted tool exposure control exists | add unrestricted-mode exposure/enforcement contract without broadening session-side Docker authority | unit + integration |
+| FR-007 | partial | runtime denial exists only for the global disabled boolean gate; discovery and execution can diverge by mode | centralize mode-aware policy so discovery and runtime execution share one decision path | unit + integration |
+| FR-008 | partial | `spec.md` preserves MM-499 and the Jira brief; downstream plan, tasks, and verification artifacts do not yet all exist | preserve MM-499 through plan, tasks, verification, and delivery metadata | traceability review |
+| DESIGN-REQ-001 | partial | deployment-owned boolean gate exists, but not the required explicit mode model | implement deployment-owned tri-mode policy surface | unit + integration |
+| DESIGN-REQ-003 | missing | no canonical mode enum or normalized mode type exists | add canonical disabled/profiles/unrestricted mode model and update consumers | unit |
+| DESIGN-REQ-007 | missing | omitted mode does not resolve to `profiles`; current omission resolves to boolean enabled | change default behavior to `profiles` and verify in settings + registration tests | unit |
+| DESIGN-REQ-008 | missing | unsupported values are not validated against a mode enum | add fail-fast invalid-mode validation at settings load | unit |
+| DESIGN-REQ-009 | partial | disabled mode denies execution, but registry exposure still includes Docker-backed tools | omit Docker-backed tools from discovery in disabled mode and preserve runtime denial | unit + integration |
+| DESIGN-REQ-010 | missing | no profiles-mode allowlist of curated/profile-backed vs unrestricted tools exists | define profiles-mode exposure matrix and test tool registration/dispatch against it | unit + integration |
+| DESIGN-REQ-011 | missing | no unrestricted-mode behavior or protection against session-authority widening is enforced via workflow mode | add unrestricted-mode contract and coverage that session-side Docker authority remains unchanged | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing Docker workload launcher/registry stack, pytest  
+**Storage**: No new persistent storage; deployment config plus existing workload registry/runtime wiring only  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` with focused config, workload-tool, and Temporal runtime suites  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage of mode-aware tool registration/dispatch behavior  
+**Target Platform**: MoonMind worker runtime and Docker-backed workload tool path  
+**Project Type**: Backend runtime/configuration story with worker/tool contract changes  
+**Performance Goals**: Preserve bounded tool registration and validation overhead; mode checks remain cheap and deterministic at settings load, registry exposure, and runtime dispatch  
+**Constraints**: Use the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` surface; keep the mode deployment-owned; do not add compatibility aliases or hidden fallback behavior; preserve curated profile-backed tools as the normal path; keep session-side Docker authority unchanged in unrestricted mode  
+**Scale/Scope**: One story covering workflow Docker mode normalization, registry exposure, runtime enforcement, and traceability for MM-499
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - extends the existing Docker workload tool/runtime boundary instead of introducing a new execution path.
+- II. One-Click Agent Deployment: PASS - adds configuration normalization and tests only; no new service or external dependency is required.
+- III. Avoid Vendor Lock-In: PASS - the story modifies MoonMind-owned workload policy, not vendor-specific behavior.
+- IV. Own Your Data: PASS - no new data leaves operator-controlled systems.
+- V. Skills Are First-Class and Easy to Add: PASS - preserves tool-driven workload routing and does not fork the skill/tool system.
+- VI. Replaceable AI Scaffolding: PASS - work is centered on durable runtime configuration and testable policy boundaries.
+- VII. Runtime Configurability: PASS - promotes the documented deployment-owned mode into a validated runtime configuration surface.
+- VIII. Modular and Extensible Architecture: PASS - confines changes to settings, worker/runtime policy wiring, and workload tool registration.
+- IX. Resilient by Default: PASS - explicit mode validation and deterministic denial behavior improve fail-fast safety.
+- X. Facilitate Continuous Improvement: PASS - downstream verification can report concrete mode-coverage evidence and any remaining drift.
+- XI. Spec-Driven Development: PASS - MM-499 spec and Jira brief remain the source of truth for the implementation plan.
+- XII. Canonical Documentation Separation: PASS - desired-state source requirements remain in `docs/ManagedAgents/DockerOutOfDocker.md`; implementation planning stays feature-local.
+- XIII. Pre-release Compatibility Policy: PASS - the plan assumes the legacy boolean workflow Docker setting is removed in favor of the canonical mode contract rather than preserved via aliasing.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/248-enforce-docker-workflow-modes-and-registry-gating/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+├── contracts/
+│   └── workflow-docker-mode-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/config/
+└── settings.py
+
+moonmind/workloads/
+├── tool_bridge.py
+└── registry.py
+
+moonmind/workflows/temporal/
+├── activity_runtime.py
+└── worker_runtime.py
+
+tests/unit/config/
+└── test_settings.py
+
+tests/unit/workloads/
+└── test_workload_tool_bridge.py
+
+tests/unit/workflows/temporal/
+├── test_activity_runtime.py
+├── test_temporal_worker_runtime.py
+└── test_workload_run_activity.py
+
+tests/integration/temporal/
+└── test_integration_ci_tool_contract.py
+```
+
+**Structure Decision**: Keep MM-499 scoped to workflow configuration normalization, mode-aware workload tool registration, and runtime denial wiring across the existing Docker workload path. No new storage or separate subsystem is needed; the main gap is replacing the boolean gate with one shared tri-mode policy model and proving discovery and execution stay aligned.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md
@@ -79,7 +79,11 @@ specs/248-enforce-docker-workflow-modes-and-registry-gating/
 moonmind/config/
 └── settings.py
 
+moonmind/schemas/
+└── workload_models.py
+
 moonmind/workloads/
+├── docker_launcher.py
 ├── tool_bridge.py
 └── registry.py
 
@@ -91,6 +95,7 @@ tests/unit/config/
 └── test_settings.py
 
 tests/unit/workloads/
+├── test_workload_contract.py
 └── test_workload_tool_bridge.py
 
 tests/unit/workflows/temporal/
@@ -102,7 +107,7 @@ tests/integration/temporal/
 └── test_integration_ci_tool_contract.py
 ```
 
-**Structure Decision**: Keep MM-499 scoped to workflow configuration normalization, mode-aware workload tool registration, and runtime denial wiring across the existing Docker workload path. No new storage or separate subsystem is needed; the main gap is replacing the boolean gate with one shared tri-mode policy model and proving discovery and execution stay aligned.
+**Structure Decision**: Keep MM-499 scoped to workflow configuration normalization, mode-aware workload tool registration, unrestricted request schema/policy support, and runtime denial wiring across the existing Docker workload path. No new storage or separate subsystem is needed; the main gap is replacing the boolean gate with one shared tri-mode policy model and proving discovery and execution stay aligned.
 
 ## Complexity Tracking
 

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md
@@ -9,12 +9,13 @@ Implement and verify the MM-499 workflow Docker mode contract before generating 
 Run the focused settings and workload policy suites first:
 
 ```bash
-MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py
 ```
 
 What this proves:
 - the canonical workflow Docker mode setting normalizes correctly
 - invalid mode values fail fast
+- unrestricted request schemas and registry policy validation align with the selected mode
 - worker/runtime registration uses the selected mode
 - disabled-, profiles-, and unrestricted-mode execution behavior is covered at the tool handler and activity boundaries
 

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: Enforce Docker Workflow Modes and Registry Gating
+
+## Goal
+
+Implement and verify the MM-499 workflow Docker mode contract before generating tasks or claiming runtime completion.
+
+## Focused Unit Verification
+
+Run the focused settings and workload policy suites first:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py
+```
+
+What this proves:
+- the canonical workflow Docker mode setting normalizes correctly
+- invalid mode values fail fast
+- worker/runtime registration uses the selected mode
+- disabled-, profiles-, and unrestricted-mode execution behavior is covered at the tool handler and activity boundaries
+
+## Hermetic Integration Verification
+
+Run the required hermetic integration suite when the mode-aware registration/dispatch boundary changes:
+
+```bash
+./tools/test_integration.sh
+```
+
+Focused integration coverage target:
+- `tests/integration/temporal/test_integration_ci_tool_contract.py`
+- add or update one `integration_ci` boundary test that proves registry exposure and dispatch behavior stay aligned for the selected workflow Docker mode
+
+What this proves:
+- the worker-facing dispatcher exposes the expected Docker-backed tools for the selected mode
+- forbidden Docker-backed tools remain unavailable or denied through the real integration boundary
+- curated integration-ci routing still works in the allowed modes
+
+## Full Unit Verification
+
+Before claiming MM-499 is complete, rerun the required unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## End-to-End Story Validation
+
+1. Confirm `spec.md`, `plan.md`, and downstream artifacts preserve MM-499 and the original Jira preset brief.
+2. Add unit tests for mode normalization and mode-aware registration/denial behavior before changing production code.
+3. Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` contract and remove the superseded boolean workflow Docker setting.
+4. Rerun the focused unit verification command.
+5. Rerun hermetic integration verification if worker/runtime registration or dispatcher behavior changed.
+6. Run the full unit suite.
+7. Preserve MM-499 and DESIGN-REQ-001/003/007/008/009/010/011 in tasks and final verification output.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/research.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/research.md
@@ -1,0 +1,81 @@
+# Research: Enforce Docker Workflow Modes and Registry Gating
+
+## Story Classification
+
+Decision: Treat MM-499 as a single-story runtime implementation request, not a breakdown candidate.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`; `specs/248-enforce-docker-workflow-modes-and-registry-gating/spec.md`.
+Rationale: The Jira preset brief defines one independently testable runtime outcome: one deployment-owned workflow Docker mode governs tool exposure and runtime denial behavior.
+Alternatives considered: Broad design breakdown was rejected because the Jira brief already selects one story and does not require processing multiple specs.
+Test implications: Unit tests plus at least one hermetic integration boundary are required because the story changes worker/runtime policy wiring.
+
+## FR-001 / DESIGN-REQ-001 Deployment-Owned Workflow Docker Policy
+
+Decision: partial.
+Evidence: `moonmind/config/settings.py` defines `workflow_docker_enabled`; `moonmind/workflows/temporal/worker_runtime.py` passes the boolean into tool registration and activity runtime; `moonmind/workloads/tool_bridge.py` and `moonmind/workflows/temporal/activity_runtime.py` deny execution when the boolean is false.
+Rationale: Deployment-owned gating exists, but it is only a boolean on/off switch and does not satisfy the required tri-mode policy model.
+Alternatives considered: Treat the existing boolean gate as sufficient. Rejected because MM-499 explicitly requires `disabled`, `profiles`, and `unrestricted` modes with different discovery and execution semantics.
+Test implications: Unit tests for settings normalization plus worker/runtime policy wiring; integration test to confirm the selected mode reaches actual tool dispatch behavior.
+
+## FR-002 / FR-003 / DESIGN-REQ-003 / DESIGN-REQ-007 / DESIGN-REQ-008 Canonical Mode Configuration
+
+Decision: missing.
+Evidence: `moonmind/config/settings.py` exposes only `workflow_docker_enabled: bool`; `tests/unit/config/test_settings.py` covers default `True` and `false` override only; no `MOONMIND_WORKFLOW_DOCKER_MODE` parsing or invalid-value rejection exists.
+Rationale: The canonical mode surface from `docs/ManagedAgents/DockerOutOfDocker.md` is absent from runtime settings, so default-to-`profiles` and fail-fast invalid values are both unimplemented.
+Alternatives considered: Add a compatibility layer that preserves the legacy boolean flag. Rejected because the repo compatibility policy requires replacing superseded internal contracts rather than adding aliases.
+Test implications: Add focused unit coverage for default `profiles`, allowed mode parsing, and invalid-mode startup failure.
+
+## FR-004 / DESIGN-REQ-009 Disabled Mode Discovery And Runtime Enforcement
+
+Decision: partial.
+Evidence: `build_workload_tool_handler(... workflow_docker_enabled=False)` raises `SkillFailure` in `moonmind/workloads/tool_bridge.py`; `TemporalAgentRuntimeActivities.workload_run` and `security_pentest_execute` raise `docker_workflows_disabled` in `moonmind/workflows/temporal/activity_runtime.py`; tests exist in `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, and `tests/unit/workflows/temporal/test_activity_runtime.py`.
+Rationale: Runtime denial for disabled mode already exists, but `register_workload_tool_handlers()` still registers Docker-backed tools even when disabled, so registry exposure does not yet match the story.
+Alternatives considered: Keep tool discovery unchanged and rely only on runtime denial. Rejected because MM-499 requires disabled mode to omit Docker-backed tools from the registry snapshot as well as deny direct invocation.
+Test implications: Update unit tests for registration/discovery omission and preserve direct-denial tests; add an integration_ci boundary test that verifies the disabled-mode dispatcher surface is absent or denied consistently.
+
+## FR-005 / DESIGN-REQ-010 Profiles Mode Exposure
+
+Decision: missing.
+Evidence: `moonmind/workloads/tool_bridge.py` defines only curated/profile-backed tools (`container.run_workload`, `container.start_helper`, `container.stop_helper`, `moonmind.integration_ci`, `unreal.run_tests`), but no mode-aware selection differentiates profiles mode from unrestricted mode; `worker_runtime.py` always registers the same set whenever the boolean gate is enabled.
+Rationale: The repo already has curated/profile-backed tools, but it lacks the policy layer that makes them the default exposed set in `profiles` mode while keeping unrestricted tools unavailable.
+Alternatives considered: Treat the current enabled state as equivalent to profiles mode. Rejected because there is no separate unrestricted surface to exclude, so the policy distinction is not actually encoded or testable.
+Test implications: Add unit tests for mode-aware registration matrix and integration coverage that the curated/profile-backed tool set is exposed in `profiles` mode.
+
+## FR-006 / DESIGN-REQ-011 Unrestricted Mode Exposure Without Session-Authority Drift
+
+Decision: missing.
+Evidence: `docs/ManagedAgents/DockerOutOfDocker.md` defines unrestricted behavior conceptually, but `moonmind/workloads/tool_bridge.py` has no `container.run_container` or `container.run_docker` registration, and `worker_runtime.py`/`activity_runtime.py` have no unrestricted-mode selection logic.
+Rationale: The unrestricted-mode contract is not yet represented in runtime code, so neither exposure nor the “session-side Docker authority remains unchanged” invariant can be verified.
+Alternatives considered: Defer unrestricted mode entirely and implement only disabled/profiles. Rejected because MM-499 explicitly includes unrestricted mode in scope.
+Test implications: Add unit tests for unrestricted-mode tool registration and denial matrix plus integration coverage that unrestricted tools are only reachable in unrestricted mode while session-side behavior remains unchanged.
+
+## FR-007 Discovery/Execution Alignment
+
+Decision: partial.
+Evidence: Runtime denial is implemented in both tool handlers and Temporal activity helpers, but registration is unconditional once the boolean gate is true; `tests/integration/temporal/test_integration_ci_tool_contract.py` shows current dispatcher execution for a curated tool without mode differentiation.
+Rationale: Discovery and execution share some plumbing, but they do not yet share one mode-aware policy decision, which creates a gap between visible tools and allowed behavior.
+Alternatives considered: Add more denial-only tests without changing registration. Rejected because alignment is a product requirement, not just a test concern.
+Test implications: Add unit tests around registration + handler wiring, and an integration boundary that validates mode-specific registry/dispatch behavior end to end.
+
+## FR-008 Traceability
+
+Decision: partial.
+Evidence: `spec.md` and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md` preserve MM-499 and the original Jira brief.
+Rationale: Planning artifacts now need to preserve MM-499, and downstream tasks/verification still need the same traceability.
+Alternatives considered: Treat spec-only preservation as sufficient. Rejected because the story explicitly requires downstream traceability for final verification.
+Test implications: Final traceability review only.
+
+## Design Artifact Decision
+
+Decision: create a feature-local contract artifact and skip `data-model.md`.
+Evidence: MM-499 changes configuration normalization, registry exposure, and runtime policy boundaries, but it does not introduce new persisted entities or stateful domain records.
+Rationale: A contract document is needed because the story changes the external configuration surface and the behavior matrix for workload tool exposure. A data model artifact would add noise because the story has no new durable entities.
+Alternatives considered: Create `data-model.md` to describe the mode enum. Rejected because the enum belongs in the configuration/contract boundary rather than a persistent data model.
+Test implications: Contract review plus traceable unit/integration coverage are sufficient.
+
+## Repo Gap Analysis Outcome
+
+Decision: MM-499 requires production code changes plus tests.
+Evidence: The current runtime already has curated Docker workload tooling and disabled-mode denial coverage, but it does not expose the tri-mode configuration contract or mode-aware registration matrix required by the source design.
+Rationale: This is not a verification-only story. The repository must replace the boolean `workflow_docker_enabled` contract with one shared mode model and update settings, worker/runtime wiring, and tests accordingly.
+Alternatives considered: Treat the story as verification-first because DooD tooling already exists. Rejected because the missing mode contract is central to the requested behavior.
+Test implications: Start with focused unit tests for settings and policy wiring, then add/update hermetic integration coverage for mode-aware dispatcher behavior before final full-unit verification.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/spec.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: Enforce Docker Workflow Modes and Registry Gating
+
+**Feature Branch**: `248-enforce-docker-workflow-modes-and-registry-gating`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-499 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched MM-499 under `specs/`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-499 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-499
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Enforce Docker workflow modes and registry gating
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-499 from MM project
+Summary: Enforce Docker workflow modes and registry gating
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-499 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-499: Enforce Docker workflow modes and registry gating
+
+Source Reference
+- Source Document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source Title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source Sections:
+  - 1. Purpose
+  - 2. Core decisions
+  - 6. Docker workflow permission modes
+  - 19. Stable design rules
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-003
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+
+User Story
+As a deployment operator, I can set Docker workflow access to disabled, profiles, or unrestricted so MoonMind exposes and enforces only the workload tools allowed for that environment.
+
+Acceptance Criteria
+- Given `MOONMIND_WORKFLOW_DOCKER_MODE` is omitted, when settings load, then the effective mode is `profiles`.
+- Given `MOONMIND_WORKFLOW_DOCKER_MODE` is an unsupported value, when the service starts, then startup fails with a deterministic configuration error.
+- Given mode is `disabled`, when the registry snapshot is built or a DooD tool is invoked directly, then all Docker-backed tools are omitted or denied at runtime.
+- Given mode is `profiles`, when the registry snapshot is built, then profile-backed and curated DooD tools are available while unrestricted tools are omitted and denied.
+- Given mode is `unrestricted`, when the registry snapshot is built, then profile-backed and unrestricted DooD tools are available while session-side Docker authority remains unchanged.
+
+Requirements
+- Normalize the deployment-owned Docker mode from `MOONMIND_WORKFLOW_DOCKER_MODE` at settings load time.
+- Keep `disabled`, `profiles`, and `unrestricted` as the only supported modes.
+- Make registry exposure mode-aware without relying on registration alone for enforcement.
+- Return deterministic denial behavior for mode-forbidden tool invocations.
+
+Relevant Implementation Notes
+- Preserve MM-499 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for purpose, core decisions, Docker workflow permission modes, and stable design rules.
+- Treat `MOONMIND_WORKFLOW_DOCKER_MODE` as deployment-owned configuration normalized at settings-load time.
+- Support only the `disabled`, `profiles`, and `unrestricted` workflow Docker modes.
+- Ensure registry exposure is mode-aware, but also enforce denials at runtime so registration alone is not the only guardrail.
+- In `disabled` mode, omit Docker-backed tools from the registry snapshot and deny direct invocation attempts deterministically.
+- In `profiles` mode, expose only curated and profile-backed Docker workload tools while omitting and denying unrestricted tools.
+- In `unrestricted` mode, expose profile-backed and unrestricted Docker workload tools without broadening session-side Docker authority.
+- Keep startup validation fail-fast and deterministic for unsupported mode values.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-499 is blocked by MM-500, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief already defines one independently testable runtime story.
+- Selected mode: Runtime.
+- Source design: `docs/ManagedAgents/DockerOutOfDocker.md` is treated as runtime source requirements because the brief describes system behavior, not documentation-only work.
+- Resume decision: No existing Moon Spec artifacts for MM-499 were found under `specs/`; specification is the first incomplete stage.
+
+## User Story - Govern Workflow Docker Access
+
+**Summary**: As a deployment operator, I want workflow Docker access to follow one explicit deployment mode so MoonMind exposes and enforces only the workload tools allowed for that environment.
+
+**Goal**: Operators can control whether workflow Docker-backed tools are unavailable, profile-limited, or unrestricted through one deployment-owned mode, and the system applies that mode consistently during startup, tool discovery, and runtime enforcement.
+
+**Independent Test**: Start the system in each supported workflow Docker mode plus one unsupported value, then verify the effective mode defaults correctly, invalid mode values fail deterministically at startup, registry discovery reflects the selected mode, runtime invocation denies mode-forbidden tools, and MM-499 traceability is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** workflow Docker mode is not explicitly configured, **When** the system loads deployment configuration, **Then** the effective workflow Docker mode is `profiles`.
+2. **Given** workflow Docker mode is set to an unsupported value, **When** the system starts, **Then** startup fails with a deterministic configuration error instead of silently choosing another mode.
+3. **Given** workflow Docker mode is `disabled`, **When** workflow tool discovery or direct invocation occurs, **Then** Docker-backed workload tools are unavailable and denied.
+4. **Given** workflow Docker mode is `profiles`, **When** workflow tool discovery occurs, **Then** only curated and profile-backed Docker workload tools are available while unrestricted Docker workload tools remain unavailable.
+5. **Given** workflow Docker mode is `unrestricted`, **When** workflow tool discovery occurs, **Then** profile-backed and unrestricted Docker workload tools are available without altering session-side Docker authority.
+6. **Given** a caller attempts to invoke a Docker-backed workflow tool that the selected mode does not allow, **When** the invocation reaches the runtime boundary, **Then** the system returns a deterministic denial outcome.
+
+### Edge Cases
+
+- Startup receives an empty, misspelled, or unexpected workflow Docker mode value.
+- Registry discovery and direct invocation disagree about whether a tool is allowed for the selected mode.
+- Curated or profile-backed Docker tools are accidentally hidden in `profiles` mode.
+- Unrestricted Docker tools leak into `profiles` mode through fallback registration behavior.
+- Session-side Docker authority changes as a side effect of enabling unrestricted workflow mode.
+
+## Assumptions
+
+- MM-499 is limited to deployment-owned workflow Docker mode selection and enforcement, not broader redesign of managed-session Docker authority.
+- Curated, profile-backed, and unrestricted Docker-backed workload tools are already distinguishable by the system's existing tool metadata.
+- The MM-500 blocker relationship is tracked operationally outside this specification and does not change the single-story scope definition for MM-499.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/ManagedAgents/DockerOutOfDocker.md` §1 | Workflow Docker access must be governed by deployment-owned policy rather than implicit runtime behavior. | In scope | FR-001, FR-002 |
+| DESIGN-REQ-003 | `docs/ManagedAgents/DockerOutOfDocker.md` §2 | The supported workflow Docker modes are limited to disabled, profiles, and unrestricted. | In scope | FR-001, FR-003 |
+| DESIGN-REQ-007 | `docs/ManagedAgents/DockerOutOfDocker.md` §6 | Omitted workflow Docker mode configuration resolves deterministically to profiles. | In scope | FR-002 |
+| DESIGN-REQ-008 | `docs/ManagedAgents/DockerOutOfDocker.md` §6 | Unsupported workflow Docker mode values fail deterministically during startup. | In scope | FR-003 |
+| DESIGN-REQ-009 | `docs/ManagedAgents/DockerOutOfDocker.md` §6 | Disabled mode omits and denies Docker-backed workflow tools. | In scope | FR-004, FR-007 |
+| DESIGN-REQ-010 | `docs/ManagedAgents/DockerOutOfDocker.md` §6 | Profiles mode exposes only curated and profile-backed Docker workflow tools while keeping unrestricted tools unavailable. | In scope | FR-005, FR-007 |
+| DESIGN-REQ-011 | `docs/ManagedAgents/DockerOutOfDocker.md` §19 | Unrestricted workflow mode exposes additional workload tools without changing session-side Docker authority. | In scope | FR-006 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST govern workflow Docker-backed tool availability through one deployment-owned workflow Docker mode.
+- **FR-002**: The system MUST default the effective workflow Docker mode to `profiles` when no explicit mode is configured.
+- **FR-003**: The system MUST reject unsupported workflow Docker mode values with a deterministic startup error.
+- **FR-004**: The system MUST omit Docker-backed workflow tools from discovery and deny their invocation when workflow Docker mode is `disabled`.
+- **FR-005**: The system MUST expose only curated and profile-backed Docker-backed workflow tools when workflow Docker mode is `profiles`.
+- **FR-006**: The system MUST expose both profile-backed and unrestricted Docker-backed workflow tools when workflow Docker mode is `unrestricted` without changing session-side Docker authority.
+- **FR-007**: The system MUST enforce the selected workflow Docker mode at runtime invocation boundaries rather than relying on discovery or registration behavior alone.
+- **FR-008**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-499.
+
+### Key Entities
+
+- **Workflow Docker Mode**: The deployment-owned mode that determines whether Docker-backed workflow tools are disabled, profile-limited, or unrestricted.
+- **Docker-Backed Workflow Tool**: A workload tool whose availability depends on workflow Docker access policy.
+- **Registry Discovery View**: The workflow-facing tool listing that reflects which Docker-backed tools are available for the selected mode.
+- **Deterministic Denial Outcome**: A predictable runtime response returned when a caller invokes a mode-forbidden Docker-backed workflow tool.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Validation confirms omitted workflow Docker mode configuration resolves to `profiles` every time.
+- **SC-002**: Validation confirms unsupported workflow Docker mode values fail startup with one deterministic configuration error path.
+- **SC-003**: Validation confirms `disabled` mode removes Docker-backed workflow tools from discovery and denies direct invocation.
+- **SC-004**: Validation confirms `profiles` mode exposes curated and profile-backed Docker-backed workflow tools while excluding unrestricted ones.
+- **SC-005**: Validation confirms `unrestricted` mode exposes profile-backed and unrestricted Docker-backed workflow tools without broadening session-side Docker authority.
+- **SC-006**: Validation confirms runtime invocation enforcement matches discovery behavior for every supported workflow Docker mode.
+- **SC-007**: Traceability review confirms MM-499 and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 remain preserved in MoonSpec artifacts and downstream implementation evidence.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Enforce Docker Workflow Modes and Registry Gating
+
+**Input**: Design documents from `specs/248-enforce-docker-workflow-modes-and-registry-gating/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and hermetic integration verification are REQUIRED. For MM-499, write or update failing unit and integration coverage before production code changes, confirm the new coverage fails for the current boolean gate, then implement the canonical tri-mode workflow Docker contract.
+
+**Organization**: Tasks are grouped around the single MM-499 story: replace the legacy boolean workflow Docker gate with the deployment-owned `disabled` / `profiles` / `unrestricted` mode contract, keep curated/profile-backed tools as the normal path, align registry exposure with runtime denial behavior, and preserve MM-499 traceability.
+
+**Source Traceability**: MM-499; FR-001 through FR-008; acceptance scenarios 1-6; SC-001 through SC-007; DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011.
+
+**Requirement Status Summary**: missing/partial only. Code-and-test work is required for FR-001 through FR-007 and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011. Traceability-preservation work is required for FR-008 and SC-007. No rows are `implemented_verified` or `implemented_unverified`, so there are no verification-only or conditional-fallback-only tasks in this story.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py`
+- Hermetic integration tests: `./tools/test_integration.sh`
+- Final full unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the single-story MM-499 artifact set and the exact repo surfaces that must move from a boolean Docker gate to a tri-mode policy contract.
+
+- [ ] T001 Confirm `specs/248-enforce-docker-workflow-modes-and-registry-gating/` contains `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, and `quickstart.md` for MM-499
+- [ ] T002 Confirm the current MM-499 touchpoints and traceability targets in `moonmind/config/settings.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Lock the shared prerequisites for the story before changing runtime behavior.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T003 Confirm no `data-model.md`, database migration, or new persistent storage is required for MM-499 because the story changes runtime configuration and tool policy only, using `specs/248-enforce-docker-workflow-modes-and-registry-gating/research.md` as the source of truth
+- [ ] T004 Confirm the unit and hermetic integration harnesses named in `specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md` are the correct boundaries for FR-001 through FR-007 before adding new coverage
+
+**Checkpoint**: Foundation ready - red-first story work can now begin.
+
+---
+
+## Phase 3: Story - Govern Workflow Docker Access
+
+**Summary**: As a deployment operator, I want workflow Docker access to follow one explicit deployment mode so MoonMind exposes and enforces only the workload tools allowed for that environment.
+
+**Independent Test**: Start the system in each supported workflow Docker mode plus one unsupported value, then verify the effective mode defaults correctly, invalid mode values fail deterministically at startup, registry discovery reflects the selected mode, runtime invocation denies mode-forbidden tools, and MM-499 traceability is preserved.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011
+
+**Unit Test Plan**:
+
+- Verify settings normalization and fail-fast invalid values in `tests/unit/config/test_settings.py`.
+- Verify mode-aware tool definition exposure, handler denial, and unrestricted-tool gating in `tests/unit/workloads/test_workload_tool_bridge.py`.
+- Verify Temporal activity/runtime denial and worker registration alignment in `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, and `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`.
+
+**Integration Test Plan**:
+
+- Add or update one `integration_ci` dispatcher boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py` so the selected workflow Docker mode governs tool exposure and execution together.
+- Escalate through `./tools/test_integration.sh` after the new integration coverage is in place and again after implementation changes land.
+
+### Unit Tests (write first)
+
+- [ ] T005 [P] Add failing unit tests for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008 in `tests/unit/config/test_settings.py` covering default `profiles`, accepted `disabled` / `profiles` / `unrestricted` values, and invalid `MOONMIND_WORKFLOW_DOCKER_MODE` rejection
+- [ ] T006 [P] Add failing unit tests for FR-001, FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_tool_bridge.py` covering mode-aware registration matrices, disabled-mode omission, profiles-mode curated exposure, unrestricted-mode unrestricted tool exposure, and deterministic denial of forbidden direct invocation
+- [ ] T007 [P] Add failing unit tests for FR-004, FR-006, FR-007, SC-003, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_activity_runtime.py` and `tests/unit/workflows/temporal/test_workload_run_activity.py` covering mode-aware activity denial and allowed execution paths for Docker-backed tools
+- [ ] T008 [P] Add failing unit tests for FR-001, FR-005, FR-006, FR-007, SC-004, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering worker/runtime wiring of the normalized workflow Docker mode into registration and execution surfaces
+
+### Integration Tests (write first)
+
+- [ ] T009 [P] Add a failing `integration_ci` boundary test for acceptance scenarios 3-6, SC-003 through SC-006, and DESIGN-REQ-009 through DESIGN-REQ-011 in `tests/integration/temporal/test_integration_ci_tool_contract.py` proving registry exposure and dispatcher execution stay aligned for `disabled`, `profiles`, and `unrestricted` modes
+
+### Red-First Confirmation
+
+- [ ] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py` and confirm the new MM-499-focused unit coverage fails against the current boolean workflow Docker gate
+- [ ] T011 Run `./tools/test_integration.sh` and confirm the new MM-499 hermetic integration boundary fails until mode-aware registration and execution are aligned
+
+### Implementation
+
+- [ ] T012 Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` configuration surface and remove the superseded boolean workflow Docker setting in `moonmind/config/settings.py` for FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008
+- [ ] T013 Implement normalized workflow Docker mode policy helpers and mode-aware tool registration in `moonmind/workloads/tool_bridge.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011
+- [ ] T014 Implement unrestricted request and validation support for `container.run_container` and `container.run_docker` in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, and `moonmind/workloads/docker_launcher.py` for FR-006, SC-005, and DESIGN-REQ-011
+- [ ] T015 Implement mode-aware worker/runtime wiring in `moonmind/workflows/temporal/worker_runtime.py` and `moonmind/workflows/temporal/activity_runtime.py` so discovery and execution share the same policy decision for FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, and SC-006
+
+### Story Validation
+
+- [ ] T016 Rerun the focused unit command from T010 until FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011 pass in `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/workflows/temporal/test_workload_run_activity.py`
+- [ ] T017 Rerun `./tools/test_integration.sh` until the updated `tests/integration/temporal/test_integration_ci_tool_contract.py` boundary confirms disabled/profiles/unrestricted registry and execution alignment for acceptance scenarios 3-6 and SC-003 through SC-006
+- [ ] T018 Review `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`, changed code, and tests to confirm FR-008 and SC-007 preserve MM-499 and the original Jira preset brief across downstream artifacts and implementation evidence
+
+**Checkpoint**: The MM-499 story is complete when the canonical mode setting replaces the boolean gate, discovery and execution align across all three modes, and the focused unit plus hermetic integration coverage passes.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Complete final validation and preserve story-level evidence without adding hidden scope.
+
+- [ ] T019 [P] Update `specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md`, `research.md`, and `quickstart.md` if implementation details or test commands changed while preserving MM-499 traceability
+- [ ] T020 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` to confirm the full required unit suite still passes after the MM-499 runtime and test changes
+- [ ] T021 Run `/moonspec-verify` for `specs/248-enforce-docker-workflow-modes-and-registry-gating/` and produce `verification.md` covering MM-499, FR-001 through FR-008, SC-001 through SC-007, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion.
+- Story (Phase 3): depends on Foundational completion.
+- Polish (Phase 4): depends on story validation completing.
+
+### Within The Story
+
+- T005-T009 must be written before any production implementation task.
+- T010-T011 must confirm the red state before T012-T015 begin.
+- T012 establishes the canonical configuration surface before mode-aware tool/runtime wiring is finalized.
+- T013 and T014 define the mode-aware tool contract and unrestricted runtime surface before T015 integrates the policy into worker/activity execution.
+- T016-T018 validate story completion before Polish begins.
+
+### Parallel Opportunities
+
+- T005-T008 can run in parallel because they modify different unit test files.
+- T009 can run in parallel with T005-T008 because it modifies a different integration file.
+- T019 can run in parallel with verification preparation once T018 confirms traceability.
+
+## Implementation Strategy
+
+1. Confirm the MM-499 planning artifacts and repo touchpoints.
+2. Add failing unit and hermetic integration coverage for the tri-mode workflow Docker contract.
+3. Replace the legacy boolean workflow Docker setting with the canonical mode surface.
+4. Implement mode-aware tool registration, unrestricted tool support, and unified worker/runtime policy wiring.
+5. Rerun focused unit and hermetic integration verification until the story passes.
+6. Preserve MM-499 traceability in all downstream artifacts and finish with `/moonspec-verify`.

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
@@ -28,8 +28,8 @@
 
 **Purpose**: Confirm the single-story MM-499 artifact set and the exact repo surfaces that must move from a boolean Docker gate to a tri-mode policy contract.
 
-- [ ] T001 Confirm `specs/248-enforce-docker-workflow-modes-and-registry-gating/` contains `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, and `quickstart.md` for MM-499
-- [ ] T002 Confirm the current MM-499 touchpoints and traceability targets in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`
+- [X] T001 Confirm `specs/248-enforce-docker-workflow-modes-and-registry-gating/` contains `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, and `quickstart.md` for MM-499
+- [X] T002 Confirm the current MM-499 touchpoints and traceability targets in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`
 
 ---
 
@@ -39,8 +39,8 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T003 Confirm no `data-model.md`, database migration, or new persistent storage is required for MM-499 because the story changes runtime configuration and tool policy only, using `specs/248-enforce-docker-workflow-modes-and-registry-gating/research.md` as the source of truth
-- [ ] T004 Confirm the unit and hermetic integration harnesses named in `specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md` are the correct boundaries for FR-001 through FR-007 before adding new coverage
+- [X] T003 Confirm no `data-model.md`, database migration, or new persistent storage is required for MM-499 because the story changes runtime configuration and tool policy only, using `specs/248-enforce-docker-workflow-modes-and-registry-gating/research.md` as the source of truth
+- [X] T004 Confirm the unit and hermetic integration harnesses named in `specs/248-enforce-docker-workflow-modes-and-registry-gating/quickstart.md` are the correct boundaries for FR-001 through FR-007 before adding new coverage
 
 **Checkpoint**: Foundation ready - red-first story work can now begin.
 
@@ -68,33 +68,33 @@
 
 ### Unit Tests (write first)
 
-- [ ] T005 [P] Add failing unit tests for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008 in `tests/unit/config/test_settings.py` covering default `profiles`, accepted `disabled` / `profiles` / `unrestricted` values, and invalid `MOONMIND_WORKFLOW_DOCKER_MODE` rejection
-- [ ] T006 [P] Add failing unit tests for FR-006, SC-005, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_contract.py` covering unrestricted request schemas, validation rules, and policy boundaries for `container.run_container` and `container.run_docker`
-- [ ] T007 [P] Add failing unit tests for FR-001, FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_tool_bridge.py` covering mode-aware registration matrices, disabled-mode omission, profiles-mode curated exposure, unrestricted-mode unrestricted tool exposure, and deterministic denial of forbidden direct invocation
-- [ ] T008 [P] Add failing unit tests for FR-004, FR-006, FR-007, SC-003, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_activity_runtime.py` and `tests/unit/workflows/temporal/test_workload_run_activity.py` covering mode-aware activity denial and allowed execution paths for Docker-backed tools
-- [ ] T009 [P] Add failing unit tests for FR-001, FR-005, FR-006, FR-007, SC-004, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering worker/runtime wiring of the normalized workflow Docker mode into registration and execution surfaces
+- [X] T005 [P] Add failing unit tests for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008 in `tests/unit/config/test_settings.py` covering default `profiles`, accepted `disabled` / `profiles` / `unrestricted` values, and invalid `MOONMIND_WORKFLOW_DOCKER_MODE` rejection
+- [X] T006 [P] Add failing unit tests for FR-006, SC-005, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_contract.py` covering unrestricted request schemas, validation rules, and policy boundaries for `container.run_container` and `container.run_docker`
+- [X] T007 [P] Add failing unit tests for FR-001, FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_tool_bridge.py` covering mode-aware registration matrices, disabled-mode omission, profiles-mode curated exposure, unrestricted-mode unrestricted tool exposure, and deterministic denial of forbidden direct invocation
+- [X] T008 [P] Add failing unit tests for FR-004, FR-006, FR-007, SC-003, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_activity_runtime.py` and `tests/unit/workflows/temporal/test_workload_run_activity.py` covering mode-aware activity denial and allowed execution paths for Docker-backed tools
+- [X] T009 [P] Add failing unit tests for FR-001, FR-005, FR-006, FR-007, SC-004, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering worker/runtime wiring of the normalized workflow Docker mode into registration and execution surfaces
 
 ### Integration Tests (write first)
 
-- [ ] T010 [P] Add a failing `integration_ci` boundary test for acceptance scenarios 3-6, SC-003 through SC-006, and DESIGN-REQ-009 through DESIGN-REQ-011 in `tests/integration/temporal/test_integration_ci_tool_contract.py` proving registry exposure and dispatcher execution stay aligned for `disabled`, `profiles`, and `unrestricted` modes
+- [X] T010 [P] Add a failing `integration_ci` boundary test for acceptance scenarios 3-6, SC-003 through SC-006, and DESIGN-REQ-009 through DESIGN-REQ-011 in `tests/integration/temporal/test_integration_ci_tool_contract.py` proving registry exposure and dispatcher execution stay aligned for `disabled`, `profiles`, and `unrestricted` modes
 
 ### Red-First Confirmation
 
-- [ ] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py` and confirm the new MM-499-focused unit coverage fails against the current boolean workflow Docker gate
+- [X] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py` and confirm the new MM-499-focused unit coverage fails against the current boolean workflow Docker gate
 - [ ] T012 Run `./tools/test_integration.sh` and confirm the new MM-499 hermetic integration boundary fails until mode-aware registration and execution are aligned
 
 ### Implementation
 
-- [ ] T013 Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` configuration surface and remove the superseded boolean workflow Docker setting in `moonmind/config/settings.py` for FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008
-- [ ] T014 Implement unrestricted request models and validation support for `container.run_container` and `container.run_docker` in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, and `moonmind/workloads/docker_launcher.py` for FR-006, SC-005, and DESIGN-REQ-011
-- [ ] T015 Implement normalized workflow Docker mode policy helpers and mode-aware tool registration in `moonmind/workloads/tool_bridge.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011
-- [ ] T016 Implement mode-aware worker/runtime wiring in `moonmind/workflows/temporal/worker_runtime.py` and `moonmind/workflows/temporal/activity_runtime.py` so discovery and execution share the same policy decision for FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, and SC-006
+- [X] T013 Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` configuration surface and remove the superseded boolean workflow Docker setting in `moonmind/config/settings.py` for FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008
+- [X] T014 Implement unrestricted request models and validation support for `container.run_container` and `container.run_docker` in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, and `moonmind/workloads/docker_launcher.py` for FR-006, SC-005, and DESIGN-REQ-011
+- [X] T015 Implement normalized workflow Docker mode policy helpers and mode-aware tool registration in `moonmind/workloads/tool_bridge.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011
+- [X] T016 Implement mode-aware worker/runtime wiring in `moonmind/workflows/temporal/worker_runtime.py` and `moonmind/workflows/temporal/activity_runtime.py` so discovery and execution share the same policy decision for FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, and SC-006
 
 ### Story Validation
 
-- [ ] T017 Rerun the focused unit command from T011 until FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011 pass in `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/workflows/temporal/test_workload_run_activity.py`
+- [X] T017 Rerun the focused unit command from T011 until FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011 pass in `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/workflows/temporal/test_workload_run_activity.py`
 - [ ] T018 Rerun `./tools/test_integration.sh` until the updated `tests/integration/temporal/test_integration_ci_tool_contract.py` boundary confirms disabled/profiles/unrestricted registry and execution alignment for acceptance scenarios 3-6 and SC-003 through SC-006
-- [ ] T019 Review `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`, changed code, and tests to confirm FR-008 and SC-007 preserve MM-499 and the original Jira preset brief across downstream artifacts and implementation evidence
+- [X] T019 Review `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`, changed code, and tests to confirm FR-008 and SC-007 preserve MM-499 and the original Jira preset brief across downstream artifacts and implementation evidence
 
 **Checkpoint**: The MM-499 story is complete when the canonical mode setting replaces the boolean gate, discovery and execution align across all three modes, and the focused unit plus hermetic integration coverage passes.
 
@@ -104,8 +104,8 @@
 
 **Purpose**: Complete final validation and preserve story-level evidence without adding hidden scope.
 
-- [ ] T020 [P] Update `specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md`, `research.md`, and `quickstart.md` if implementation details or test commands changed while preserving MM-499 traceability
-- [ ] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` to confirm the full required unit suite still passes after the MM-499 runtime and test changes
+- [X] T020 [P] Update `specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md`, `research.md`, and `quickstart.md` if implementation details or test commands changed while preserving MM-499 traceability
+- [X] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` to confirm the full required unit suite still passes after the MM-499 runtime and test changes
 - [ ] T022 Run `/moonspec-verify` for `specs/248-enforce-docker-workflow-modes-and-registry-gating/` and produce `verification.md` covering MM-499, FR-001 through FR-008, SC-001 through SC-007, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011
 
 ---

--- a/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
+++ b/specs/248-enforce-docker-workflow-modes-and-registry-gating/tasks.md
@@ -13,7 +13,7 @@
 
 **Test Commands**:
 
-- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py`
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py`
 - Hermetic integration tests: `./tools/test_integration.sh`
 - Final full unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - Final verification: `/moonspec-verify`
@@ -29,7 +29,7 @@
 **Purpose**: Confirm the single-story MM-499 artifact set and the exact repo surfaces that must move from a boolean Docker gate to a tri-mode policy contract.
 
 - [ ] T001 Confirm `specs/248-enforce-docker-workflow-modes-and-registry-gating/` contains `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, and `quickstart.md` for MM-499
-- [ ] T002 Confirm the current MM-499 touchpoints and traceability targets in `moonmind/config/settings.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`
+- [ ] T002 Confirm the current MM-499 touchpoints and traceability targets in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `docs/tmp/jira-orchestration-inputs/MM-499-moonspec-orchestration-input.md`
 
 ---
 
@@ -57,6 +57,7 @@
 **Unit Test Plan**:
 
 - Verify settings normalization and fail-fast invalid values in `tests/unit/config/test_settings.py`.
+- Verify unrestricted request schemas and registry validation behavior in `tests/unit/workloads/test_workload_contract.py`.
 - Verify mode-aware tool definition exposure, handler denial, and unrestricted-tool gating in `tests/unit/workloads/test_workload_tool_bridge.py`.
 - Verify Temporal activity/runtime denial and worker registration alignment in `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, and `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`.
 
@@ -68,31 +69,32 @@
 ### Unit Tests (write first)
 
 - [ ] T005 [P] Add failing unit tests for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008 in `tests/unit/config/test_settings.py` covering default `profiles`, accepted `disabled` / `profiles` / `unrestricted` values, and invalid `MOONMIND_WORKFLOW_DOCKER_MODE` rejection
-- [ ] T006 [P] Add failing unit tests for FR-001, FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_tool_bridge.py` covering mode-aware registration matrices, disabled-mode omission, profiles-mode curated exposure, unrestricted-mode unrestricted tool exposure, and deterministic denial of forbidden direct invocation
-- [ ] T007 [P] Add failing unit tests for FR-004, FR-006, FR-007, SC-003, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_activity_runtime.py` and `tests/unit/workflows/temporal/test_workload_run_activity.py` covering mode-aware activity denial and allowed execution paths for Docker-backed tools
-- [ ] T008 [P] Add failing unit tests for FR-001, FR-005, FR-006, FR-007, SC-004, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering worker/runtime wiring of the normalized workflow Docker mode into registration and execution surfaces
+- [ ] T006 [P] Add failing unit tests for FR-006, SC-005, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_contract.py` covering unrestricted request schemas, validation rules, and policy boundaries for `container.run_container` and `container.run_docker`
+- [ ] T007 [P] Add failing unit tests for FR-001, FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011 in `tests/unit/workloads/test_workload_tool_bridge.py` covering mode-aware registration matrices, disabled-mode omission, profiles-mode curated exposure, unrestricted-mode unrestricted tool exposure, and deterministic denial of forbidden direct invocation
+- [ ] T008 [P] Add failing unit tests for FR-004, FR-006, FR-007, SC-003, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_activity_runtime.py` and `tests/unit/workflows/temporal/test_workload_run_activity.py` covering mode-aware activity denial and allowed execution paths for Docker-backed tools
+- [ ] T009 [P] Add failing unit tests for FR-001, FR-005, FR-006, FR-007, SC-004, SC-005, and SC-006 in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering worker/runtime wiring of the normalized workflow Docker mode into registration and execution surfaces
 
 ### Integration Tests (write first)
 
-- [ ] T009 [P] Add a failing `integration_ci` boundary test for acceptance scenarios 3-6, SC-003 through SC-006, and DESIGN-REQ-009 through DESIGN-REQ-011 in `tests/integration/temporal/test_integration_ci_tool_contract.py` proving registry exposure and dispatcher execution stay aligned for `disabled`, `profiles`, and `unrestricted` modes
+- [ ] T010 [P] Add a failing `integration_ci` boundary test for acceptance scenarios 3-6, SC-003 through SC-006, and DESIGN-REQ-009 through DESIGN-REQ-011 in `tests/integration/temporal/test_integration_ci_tool_contract.py` proving registry exposure and dispatcher execution stay aligned for `disabled`, `profiles`, and `unrestricted` modes
 
 ### Red-First Confirmation
 
-- [ ] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py` and confirm the new MM-499-focused unit coverage fails against the current boolean workflow Docker gate
-- [ ] T011 Run `./tools/test_integration.sh` and confirm the new MM-499 hermetic integration boundary fails until mode-aware registration and execution are aligned
+- [ ] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_workload_run_activity.py` and confirm the new MM-499-focused unit coverage fails against the current boolean workflow Docker gate
+- [ ] T012 Run `./tools/test_integration.sh` and confirm the new MM-499 hermetic integration boundary fails until mode-aware registration and execution are aligned
 
 ### Implementation
 
-- [ ] T012 Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` configuration surface and remove the superseded boolean workflow Docker setting in `moonmind/config/settings.py` for FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008
-- [ ] T013 Implement normalized workflow Docker mode policy helpers and mode-aware tool registration in `moonmind/workloads/tool_bridge.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011
-- [ ] T014 Implement unrestricted request and validation support for `container.run_container` and `container.run_docker` in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, and `moonmind/workloads/docker_launcher.py` for FR-006, SC-005, and DESIGN-REQ-011
-- [ ] T015 Implement mode-aware worker/runtime wiring in `moonmind/workflows/temporal/worker_runtime.py` and `moonmind/workflows/temporal/activity_runtime.py` so discovery and execution share the same policy decision for FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, and SC-006
+- [ ] T013 Implement the canonical `MOONMIND_WORKFLOW_DOCKER_MODE` configuration surface and remove the superseded boolean workflow Docker setting in `moonmind/config/settings.py` for FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, and DESIGN-REQ-008
+- [ ] T014 Implement unrestricted request models and validation support for `container.run_container` and `container.run_docker` in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, and `moonmind/workloads/docker_launcher.py` for FR-006, SC-005, and DESIGN-REQ-011
+- [ ] T015 Implement normalized workflow Docker mode policy helpers and mode-aware tool registration in `moonmind/workloads/tool_bridge.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-011
+- [ ] T016 Implement mode-aware worker/runtime wiring in `moonmind/workflows/temporal/worker_runtime.py` and `moonmind/workflows/temporal/activity_runtime.py` so discovery and execution share the same policy decision for FR-004, FR-005, FR-006, FR-007, SC-003, SC-004, SC-005, and SC-006
 
 ### Story Validation
 
-- [ ] T016 Rerun the focused unit command from T010 until FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011 pass in `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/workflows/temporal/test_workload_run_activity.py`
-- [ ] T017 Rerun `./tools/test_integration.sh` until the updated `tests/integration/temporal/test_integration_ci_tool_contract.py` boundary confirms disabled/profiles/unrestricted registry and execution alignment for acceptance scenarios 3-6 and SC-003 through SC-006
-- [ ] T018 Review `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`, changed code, and tests to confirm FR-008 and SC-007 preserve MM-499 and the original Jira preset brief across downstream artifacts and implementation evidence
+- [ ] T017 Rerun the focused unit command from T011 until FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011 pass in `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/workflows/temporal/test_workload_run_activity.py`
+- [ ] T018 Rerun `./tools/test_integration.sh` until the updated `tests/integration/temporal/test_integration_ci_tool_contract.py` boundary confirms disabled/profiles/unrestricted registry and execution alignment for acceptance scenarios 3-6 and SC-003 through SC-006
+- [ ] T019 Review `spec.md`, `plan.md`, `research.md`, `contracts/workflow-docker-mode-contract.md`, `quickstart.md`, changed code, and tests to confirm FR-008 and SC-007 preserve MM-499 and the original Jira preset brief across downstream artifacts and implementation evidence
 
 **Checkpoint**: The MM-499 story is complete when the canonical mode setting replaces the boolean gate, discovery and execution align across all three modes, and the focused unit plus hermetic integration coverage passes.
 
@@ -102,9 +104,9 @@
 
 **Purpose**: Complete final validation and preserve story-level evidence without adding hidden scope.
 
-- [ ] T019 [P] Update `specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md`, `research.md`, and `quickstart.md` if implementation details or test commands changed while preserving MM-499 traceability
-- [ ] T020 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` to confirm the full required unit suite still passes after the MM-499 runtime and test changes
-- [ ] T021 Run `/moonspec-verify` for `specs/248-enforce-docker-workflow-modes-and-registry-gating/` and produce `verification.md` covering MM-499, FR-001 through FR-008, SC-001 through SC-007, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011
+- [ ] T020 [P] Update `specs/248-enforce-docker-workflow-modes-and-registry-gating/plan.md`, `research.md`, and `quickstart.md` if implementation details or test commands changed while preserving MM-499 traceability
+- [ ] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` to confirm the full required unit suite still passes after the MM-499 runtime and test changes
+- [ ] T022 Run `/moonspec-verify` for `specs/248-enforce-docker-workflow-modes-and-registry-gating/` and produce `verification.md` covering MM-499, FR-001 through FR-008, SC-001 through SC-007, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011
 
 ---
 
@@ -119,23 +121,24 @@
 
 ### Within The Story
 
-- T005-T009 must be written before any production implementation task.
-- T010-T011 must confirm the red state before T012-T015 begin.
-- T012 establishes the canonical configuration surface before mode-aware tool/runtime wiring is finalized.
-- T013 and T014 define the mode-aware tool contract and unrestricted runtime surface before T015 integrates the policy into worker/activity execution.
-- T016-T018 validate story completion before Polish begins.
+- T005-T010 must be written before any production implementation task.
+- T011-T012 must confirm the red state before T013-T016 begin.
+- T013 establishes the canonical configuration surface before mode-aware tool/runtime wiring is finalized.
+- T014 defines unrestricted request validation and launcher support before T015 and T016 integrate the policy into registration and execution.
+- T015 and T016 finalize the shared mode-aware policy across tool registration and Temporal runtime behavior.
+- T017-T019 validate story completion before Polish begins.
 
 ### Parallel Opportunities
 
-- T005-T008 can run in parallel because they modify different unit test files.
-- T009 can run in parallel with T005-T008 because it modifies a different integration file.
-- T019 can run in parallel with verification preparation once T018 confirms traceability.
+- T005-T009 can run in parallel because they modify different unit test files.
+- T010 can run in parallel with T005-T009 because it modifies a different integration file.
+- T020 can run in parallel with verification preparation once T019 confirms traceability.
 
 ## Implementation Strategy
 
 1. Confirm the MM-499 planning artifacts and repo touchpoints.
-2. Add failing unit and hermetic integration coverage for the tri-mode workflow Docker contract.
+2. Add failing unit and hermetic integration coverage for the tri-mode workflow Docker contract, including unrestricted request schema/policy tests.
 3. Replace the legacy boolean workflow Docker setting with the canonical mode surface.
-4. Implement mode-aware tool registration, unrestricted tool support, and unified worker/runtime policy wiring.
+4. Implement unrestricted request support, mode-aware tool registration, and unified worker/runtime policy wiring.
 5. Rerun focused unit and hermetic integration verification until the story passes.
 6. Preserve MM-499 traceability in all downstream artifacts and finish with `/moonspec-verify`.

--- a/tests/integration/temporal/test_integration_ci_tool_contract.py
+++ b/tests/integration/temporal/test_integration_ci_tool_contract.py
@@ -15,10 +15,12 @@ from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
 from moonmind.workflows.skills.tool_registry import create_registry_snapshot
 from moonmind.workloads.registry import RunnerProfileRegistry
 from moonmind.workloads.tool_bridge import (
+    CONTAINER_RUN_CONTAINER_TOOL,
     INTEGRATION_CI_PROFILE_ID,
     INTEGRATION_CI_TOOL,
     build_dood_tool_definition_payload,
     build_workload_tool_handler,
+    register_workload_tool_handlers,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
@@ -57,7 +59,7 @@ class _FakeLauncher:
         self.validated = validated
         return WorkloadResult(
             requestId=validated.container_name,
-            profileId=validated.profile.id,
+            profileId=(validated.profile.id if validated.profile is not None else validated.request.tool_name),
             status="succeeded",
             labels=validated.ownership.labels,
             exitCode=0,
@@ -68,7 +70,7 @@ class _FakeLauncher:
             metadata={
                 "workload": {
                     "toolName": validated.request.tool_name,
-                    "profileId": validated.profile.id,
+                    "profileId": (validated.profile.id if validated.profile is not None else validated.request.tool_name),
                     "command": list(validated.request.command),
                 },
                 "artifactPublication": {"status": "complete"},
@@ -131,3 +133,107 @@ async def test_moonmind_integration_ci_routes_through_curated_workload_tool() ->
     assert result.outputs["stdoutRef"] == "art:sha256:stdout"
     assert result.outputs["stderrRef"] == "art:sha256:stderr"
     assert result.outputs["diagnosticsRef"] == "art:sha256:diagnostics"
+
+
+async def test_workflow_docker_mode_keeps_registry_and_dispatch_aligned() -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_integration_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+
+    disabled_dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        disabled_dispatcher,
+        registry=registry,
+        launcher=_FakeLauncher(),
+        workflow_docker_mode="disabled",
+    )
+    assert disabled_dispatcher._skill_handlers == {}
+
+    profiles_snapshot = create_registry_snapshot(
+        skills=(
+            parse_tool_definition(
+                build_dood_tool_definition_payload(
+                    name=CONTAINER_RUN_CONTAINER_TOOL,
+                    version="1.0",
+                )
+            ),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+    profiles_dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        profiles_dispatcher,
+        registry=registry,
+        launcher=_FakeLauncher(),
+        workflow_docker_mode="profiles",
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await execute_tool_activity(
+            invocation_payload={
+                "id": "step-run-container",
+                "tool": {
+                    "type": "skill",
+                    "name": CONTAINER_RUN_CONTAINER_TOOL,
+                    "version": "1.0",
+                },
+                "inputs": {
+                    "repoDir": "/work/agent_jobs/wf-1/repo",
+                    "artifactsDir": "/work/agent_jobs/wf-1/artifacts/integration-ci",
+                    "scratchDir": "/work/agent_jobs/wf-1/scratch",
+                    "image": "ghcr.io/example/runtime:1.2.3",
+                    "command": ["pytest", "-q"],
+                },
+            },
+            registry_snapshot=profiles_snapshot,
+            dispatcher=profiles_dispatcher,
+            context={"workflow_id": "wf-1", "node_id": "step-run-container"},
+        )
+    message = getattr(exc_info.value, "message", str(exc_info.value))
+    assert "No mm.tool.execute handler registered" in message or "PERMISSION_DENIED" in message
+
+    unrestricted_dispatcher = ToolActivityDispatcher()
+    launcher = _FakeLauncher()
+    register_workload_tool_handlers(
+        unrestricted_dispatcher,
+        registry=registry,
+        launcher=launcher,
+        workflow_docker_mode="unrestricted",
+    )
+    unrestricted_snapshot = create_registry_snapshot(
+        skills=(
+            parse_tool_definition(
+                build_dood_tool_definition_payload(
+                    name=CONTAINER_RUN_CONTAINER_TOOL,
+                    version="1.0",
+                )
+            ),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+    result = await execute_tool_activity(
+        invocation_payload={
+            "id": "step-run-container",
+            "tool": {
+                "type": "skill",
+                "name": CONTAINER_RUN_CONTAINER_TOOL,
+                "version": "1.0",
+            },
+            "inputs": {
+                "repoDir": "/work/agent_jobs/wf-1/repo",
+                "artifactsDir": "/work/agent_jobs/wf-1/artifacts/integration-ci",
+                "scratchDir": "/work/agent_jobs/wf-1/scratch",
+                "image": "ghcr.io/example/runtime:1.2.3",
+                "command": ["pytest", "-q"],
+            },
+        },
+        registry_snapshot=unrestricted_snapshot,
+        dispatcher=unrestricted_dispatcher,
+        context={"workflow_id": "wf-1", "node_id": "step-run-container"},
+    )
+
+    assert launcher.validated is not None
+    assert launcher.validated.profile is None
+    assert result.status == "COMPLETED"

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -772,25 +772,39 @@ class TestWorkflowSettings:
 
         monkeypatch.delenv("MOONMIND_LOG_STREAMING_ENABLED", raising=False)
 
-    def test_workflow_docker_enabled_defaults_to_true(self, monkeypatch):
-        """Workflow Docker access should be enabled unless explicitly disabled."""
+    def test_workflow_docker_mode_defaults_to_profiles(self, monkeypatch):
+        """Workflow Docker mode should default to profiles when omitted."""
 
-        monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_ENABLED", raising=False)
-
-        settings = WorkflowSettings(_env_file=None)
-
-        assert settings.workflow_docker_enabled is True
-
-    def test_workflow_docker_enabled_env_override(self, monkeypatch):
-        """Workflow Docker access should honor MOONMIND_WORKFLOW_DOCKER_ENABLED."""
-
-        monkeypatch.setenv("MOONMIND_WORKFLOW_DOCKER_ENABLED", "false")
+        monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
 
         settings = WorkflowSettings(_env_file=None)
 
-        assert settings.workflow_docker_enabled is False
+        assert settings.workflow_docker_mode == "profiles"
 
-        monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_ENABLED", raising=False)
+    @pytest.mark.parametrize(
+        "mode",
+        ["disabled", "profiles", "unrestricted"],
+    )
+    def test_workflow_docker_mode_env_override(self, monkeypatch, mode):
+        """Workflow Docker mode should honor MOONMIND_WORKFLOW_DOCKER_MODE."""
+
+        monkeypatch.setenv("MOONMIND_WORKFLOW_DOCKER_MODE", mode)
+
+        settings = WorkflowSettings(_env_file=None)
+
+        assert settings.workflow_docker_mode == mode
+
+        monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
+
+    def test_workflow_docker_mode_rejects_invalid_values(self, monkeypatch):
+        """Workflow Docker mode should fail fast for unsupported values."""
+
+        monkeypatch.setenv("MOONMIND_WORKFLOW_DOCKER_MODE", "anything-goes")
+
+        with pytest.raises(ValidationError, match="workflow_docker_mode"):
+            WorkflowSettings(_env_file=None)
+
+        monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
 
     def test_app_settings_accepts_task_proposals_env(
         self, app_settings_defaults, monkeypatch

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -809,7 +809,7 @@ async def test_security_pentest_execute_fails_closed_before_runner_without_scope
 
 
 async def test_security_pentest_execute_denies_without_retry_when_workflow_docker_disabled():
-    activities = TemporalAgentRuntimeActivities(workflow_docker_enabled=False)
+    activities = TemporalAgentRuntimeActivities(workflow_docker_mode="disabled")
 
     with pytest.raises(temporal_exceptions.ApplicationError) as exc_info:
         await activities.security_pentest_execute(_pentest_activity_payload())

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base
-from moonmind.workloads.tool_bridge import CONTAINER_RUN_CONTAINER_TOOL
 from moonmind.workflows.temporal.worker_runtime import (
     MoonMindAgentRun,
     MoonMindManifestIngest,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base
+from moonmind.workloads.tool_bridge import CONTAINER_RUN_CONTAINER_TOOL
 from moonmind.workflows.temporal.worker_runtime import (
     MoonMindAgentRun,
     MoonMindManifestIngest,
@@ -1556,7 +1557,7 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
         session_controller=session_controller,
         workload_registry=workload_registry,
         workload_launcher=workload_launcher,
-        workflow_docker_enabled=True,
+        workflow_docker_mode="profiles",
     )
     mock_build_bindings.assert_called_once_with(
         fleet=AGENT_RUNTIME_FLEET,
@@ -1571,4 +1572,77 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
         review_activities=ANY,
         agent_skills_activities=ANY,
     )
+    await resources.aclose()
+
+
+@pytest.mark.asyncio
+@patch("moonmind.workflows.temporal.worker_runtime.settings")
+@patch("moonmind.workflows.temporal.worker_runtime.register_workload_tool_handlers")
+@patch("moonmind.workflows.temporal.worker_runtime.build_worker_activity_bindings")
+@patch("moonmind.workflows.temporal.worker_runtime._build_agent_runtime_deps")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalAgentRuntimeActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalReviewActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalProposalActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.AgentSkillsActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalArtifactActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalPlanActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalManifestActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalSkillActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalSandboxActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalIntegrationActivities")
+async def test_build_runtime_activities_registers_unrestricted_mode(
+    mock_integration_activities_cls,
+    mock_sandbox_activities_cls,
+    mock_skill_activities_cls,
+    mock_manifest_activities_cls,
+    mock_plan_activities_cls,
+    mock_artifact_activities_cls,
+    mock_agent_skills_activities_cls,
+    mock_proposal_activities_cls,
+    mock_review_activities_cls,
+    mock_agent_runtime_activities_cls,
+    mock_build_deps,
+    mock_build_bindings,
+    mock_register_workload_tool_handlers,
+    mock_settings,
+):
+    run_store = MagicMock()
+    run_supervisor = MagicMock()
+    run_supervisor.reconcile = AsyncMock(return_value=[])
+    run_launcher = MagicMock()
+    session_controller = MagicMock()
+    session_controller.reconcile = AsyncMock(return_value=[])
+    workload_registry = MagicMock()
+    workload_launcher = MagicMock()
+    mock_build_deps.return_value = (
+        run_store,
+        run_supervisor,
+        run_launcher,
+        session_controller,
+        workload_registry,
+        workload_launcher,
+    )
+    mock_settings.workflow.workflow_docker_mode = "unrestricted"
+
+    @asynccontextmanager
+    async def _fake_session_context():
+        yield "session"
+
+    topology = MagicMock()
+    topology.fleet = AGENT_RUNTIME_FLEET
+
+    mock_binding = MagicMock()
+    mock_binding.handler = "agent_runtime_handler"
+    mock_build_bindings.return_value = [mock_binding]
+
+    with patch(
+        "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
+        side_effect=_fake_session_context,
+    ):
+        resources, _handlers = await _build_runtime_activities(topology)
+
+    mock_agent_runtime_activities_cls.assert_called_once()
+    assert mock_agent_runtime_activities_cls.call_args.kwargs["workflow_docker_mode"] == "unrestricted"
+    mock_register_workload_tool_handlers.assert_called_once()
+    assert mock_register_workload_tool_handlers.call_args.kwargs["workflow_docker_mode"] == "unrestricted"
     await resources.aclose()

--- a/tests/unit/workflows/temporal/test_workload_run_activity.py
+++ b/tests/unit/workflows/temporal/test_workload_run_activity.py
@@ -257,7 +257,7 @@ async def test_workload_run_activity_denies_when_workflow_docker_disabled() -> N
     activities = TemporalAgentRuntimeActivities(
         workload_registry=_FailingRegistry(),
         workload_launcher=_FailingLauncher(),
-        workflow_docker_enabled=False,
+        workflow_docker_mode="disabled",
     )
 
     with pytest.raises(temporal_exceptions.ApplicationError) as exc_info:
@@ -268,3 +268,30 @@ async def test_workload_run_activity_denies_when_workflow_docker_disabled() -> N
     assert "policy_denied" in message
     assert exc_info.value.type == "docker_workflows_disabled"
     assert exc_info.value.non_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_workload_run_activity_denies_unrestricted_tool_when_mode_is_profiles() -> None:
+    activities = TemporalAgentRuntimeActivities(
+        workload_registry=_FailingRegistry(),
+        workload_launcher=_FailingLauncher(),
+        workflow_docker_mode="profiles",
+    )
+
+    with pytest.raises(temporal_exceptions.ApplicationError) as exc_info:
+        await activities.workload_run(
+            {
+                "request": {
+                    "taskRunId": "task-1",
+                    "stepId": "step-test",
+                    "attempt": 1,
+                    "toolName": "container.run_docker",
+                    "repoDir": "/work/agent_jobs/task-1/repo",
+                    "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+                    "command": ["docker", "ps"],
+                }
+            }
+        )
+
+    assert exc_info.value.type == "docker_workflow_mode_forbidden"
+    assert "profiles" in str(exc_info.value)

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -940,6 +940,44 @@ async def test_launcher_captures_bounded_process_output(
 
 
 @pytest.mark.asyncio
+async def test_launcher_runs_unrestricted_requests_without_profile_concurrency_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_create_subprocess_exec(*args: str, **_kwargs: Any) -> _Process:
+        if args[1] == "ps":
+            return _Process(returncode=0, stdout=b"CONTAINER ID\n")
+        return _Process(returncode=0)
+
+    monkeypatch.setattr(
+        "moonmind.workloads.docker_launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    registry = _registry(tmp_path)
+    validated = registry.validate_request(
+        UnrestrictedDockerRequest.model_validate(
+            {
+                "toolName": "container.run_docker",
+                "taskRunId": "task-unrestricted",
+                "stepId": "docker-cli",
+                "attempt": 1,
+                "repoDir": "/work/agent_jobs/task-unrestricted/repo",
+                "artifactsDir": "/work/agent_jobs/task-unrestricted/artifacts/docker-cli",
+                "command": ["docker", "ps"],
+            }
+        )
+    )
+
+    result = await DockerWorkloadLauncher(
+        concurrency_limiter=DockerWorkloadConcurrencyLimiter(fleet_limit=2)
+    ).run(validated)
+
+    assert result.status == "succeeded"
+    assert result.exit_code == 0
+
+
+
+@pytest.mark.asyncio
 async def test_launcher_enforces_profile_concurrency_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from moonmind.schemas.workload_models import WorkloadRequest
+from moonmind.schemas.workload_models import UnrestrictedDockerRequest, WorkloadRequest
 from moonmind.workloads.docker_launcher import (
     DockerContainerJanitor,
     DockerWorkloadConcurrencyLimiter,
@@ -310,6 +310,52 @@ def test_launcher_wraps_multi_part_shell_command_as_single_arg(
     )
 
     assert run_args[-3:] == ["python:3.12-slim", "-lc", "python -V"]
+
+
+def test_unrestricted_docker_request_replaces_leading_docker_binary(
+    tmp_path: Path,
+) -> None:
+    request = UnrestrictedDockerRequest.model_validate(
+        {
+            "toolName": "container.run_docker",
+            "taskRunId": "task-1",
+            "stepId": "docker-cli",
+            "attempt": 1,
+            "repoDir": "/work/agent_jobs/task-1/repo",
+            "artifactsDir": "/work/agent_jobs/task-1/artifacts/docker-cli",
+            "command": ["docker", "ps"],
+        }
+    )
+    registry = _registry(tmp_path)
+    validated = registry.validate_request(request)
+
+    args = DockerWorkloadLauncher(docker_binary="podman").build_run_args(validated)
+
+    assert args == ["podman", "ps"]
+
+
+def test_unrestricted_helper_request_reuses_unrestricted_arg_builder(
+    tmp_path: Path,
+) -> None:
+    request = UnrestrictedDockerRequest.model_validate(
+        {
+            "toolName": "container.run_docker",
+            "taskRunId": "task-1",
+            "stepId": "docker-helper",
+            "attempt": 1,
+            "repoDir": "/work/agent_jobs/task-1/repo",
+            "artifactsDir": "/work/agent_jobs/task-1/artifacts/docker-helper",
+            "command": ["docker", "images"],
+        }
+    )
+    registry = _registry(tmp_path)
+    validated = registry.validate_request(request)
+
+    args = DockerWorkloadLauncher(docker_binary="podman").build_helper_run_args(validated)
+
+    assert args == ["podman", "images"]
+
+
 
 
 def test_unreal_profile_launch_args_include_cache_volumes_and_safe_posture() -> None:

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -7,6 +7,8 @@ import pytest
 from pydantic import ValidationError
 
 from moonmind.schemas.workload_models import (
+    UnrestrictedContainerRequest,
+    UnrestrictedDockerRequest,
     WorkloadRequest,
     WorkloadResult,
     parse_size_bytes,
@@ -111,6 +113,7 @@ def test_registry_validates_request_and_derives_required_labels(tmp_path: Path) 
         "moonmind.workload_profile": "local-python",
         "moonmind.session_id": "session-1",
         "moonmind.session_epoch": "2",
+        "moonmind.workload_access": "profile",
     }
     assert validated.container_name == "mm-workload-task-1-step-test-1"
 
@@ -754,3 +757,94 @@ def test_registry_rejects_bounded_helper_ttl_above_profile_limit(
         "resource": "ttlSeconds",
         "profileId": "redis-helper",
     }
+
+
+def test_unrestricted_container_request_accepts_runtime_container_shape() -> None:
+    request = UnrestrictedContainerRequest.model_validate(
+        {
+            "taskRunId": "task-1",
+            "stepId": "step-test",
+            "attempt": 1,
+            "toolName": "container.run_container",
+            "repoDir": "/work/agent_jobs/task-1/repo",
+            "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+            "scratchDir": "/work/agent_jobs/task-1/scratch",
+            "image": "ghcr.io/example/runtime:1.2.3",
+            "entrypoint": ["/bin/bash", "-lc"],
+            "command": ["pytest", "-q"],
+            "workdir": "/work/agent_jobs/task-1/repo",
+            "envOverrides": {"CI": "1"},
+            "cacheMounts": [
+                {
+                    "source": "build_cache",
+                    "target": "/work/cache",
+                }
+            ],
+            "networkMode": "bridge",
+            "timeoutSeconds": 300,
+            "declaredOutputs": {"output.primary": "reports/results.json"},
+        }
+    )
+
+    assert request.image == "ghcr.io/example/runtime:1.2.3"
+    assert request.tool_name == "container.run_container"
+    assert request.command == ("pytest", "-q")
+    assert request.cache_mounts[0].source == "build_cache"
+
+
+def test_unrestricted_docker_request_requires_docker_cli_prefix() -> None:
+    with pytest.raises(ValidationError, match="docker"):
+        UnrestrictedDockerRequest.model_validate(
+            {
+                "taskRunId": "task-1",
+                "stepId": "step-test",
+                "attempt": 1,
+                "toolName": "container.run_docker",
+                "repoDir": "/work/agent_jobs/task-1/repo",
+                "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+                "command": ["bash", "-lc", "docker ps"],
+            }
+        )
+
+
+def test_registry_accepts_unrestricted_requests_without_runner_profile(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    validated = registry.validate_request(
+        {
+            "taskRunId": "task-1",
+            "stepId": "step-test",
+            "attempt": 1,
+            "toolName": "container.run_container",
+            "repoDir": "/work/agent_jobs/task-1/repo",
+            "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+            "scratchDir": "/work/agent_jobs/task-1/scratch",
+            "image": "ghcr.io/example/runtime:1.2.3",
+            "command": ["pytest", "-q"],
+            "networkMode": "none",
+            "timeoutSeconds": 300,
+        }
+    )
+
+    assert validated.profile is None
+    assert validated.ownership.labels["moonmind.workload_access"] == "unrestricted_container"
+    assert validated.ownership.labels["moonmind.tool_name"] == "container.run_container"
+
+
+def test_registry_rejects_unrestricted_request_outside_workspace_root(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    with pytest.raises(WorkloadPolicyError, match="workspace root") as exc_info:
+        registry.validate_request(
+            {
+                "taskRunId": "task-1",
+                "stepId": "step-test",
+                "attempt": 1,
+                "toolName": "container.run_docker",
+                "repoDir": "/tmp/elsewhere",
+                "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+                "command": ["docker", "ps"],
+            }
+        )
+
+    assert exc_info.value.reason == "disallowed_mount"

--- a/tests/unit/workloads/test_workload_tool_bridge.py
+++ b/tests/unit/workloads/test_workload_tool_bridge.py
@@ -9,10 +9,14 @@ from moonmind.schemas.workload_models import RunnerProfile, WorkloadResult
 from moonmind.workflows.skills.skill_plan_contracts import SkillFailure, SkillResult
 from moonmind.workloads.registry import RunnerProfileRegistry
 from moonmind.workloads.tool_bridge import (
+    CONTAINER_RUN_CONTAINER_TOOL,
+    CONTAINER_RUN_DOCKER_TOOL,
+    DOOD_TOOL_NAMES,
     INTEGRATION_CI_PROFILE_ID,
     INTEGRATION_CI_TOOL,
     build_dood_tool_definition_payload,
     build_workload_tool_handler,
+    register_workload_tool_handlers,
 )
 
 
@@ -89,7 +93,7 @@ class _FakeLauncher:
         self.validated = validated
         return WorkloadResult(
             requestId=validated.container_name,
-            profileId=validated.profile.id,
+            profileId=(validated.profile.id if validated.profile is not None else validated.request.tool_name),
             status=self._status,
             labels=validated.ownership.labels,
             exitCode=0 if self._status == "succeeded" else 1,
@@ -118,7 +122,7 @@ class _FakeLauncher:
                     "stepId": validated.request.step_id,
                     "attempt": validated.request.attempt,
                     "toolName": validated.request.tool_name,
-                    "profileId": validated.profile.id,
+                    "profileId": (validated.profile.id if validated.profile is not None else validated.request.tool_name),
                     "sessionContext": (
                         {
                             "sessionId": validated.request.session_id,
@@ -137,7 +141,7 @@ class _FakeLauncher:
         self.validated = validated
         return WorkloadResult(
             requestId=validated.container_name,
-            profileId=validated.profile.id,
+            profileId=(validated.profile.id if validated.profile is not None else validated.request.tool_name),
             status="ready",
             labels=validated.ownership.labels,
             exitCode=None,
@@ -162,7 +166,7 @@ class _FakeLauncher:
         self.validated = validated
         return WorkloadResult(
             requestId=validated.container_name,
-            profileId=validated.profile.id,
+            profileId=(validated.profile.id if validated.profile is not None else validated.request.tool_name),
             status="stopped",
             labels=validated.ownership.labels,
             exitCode=None,
@@ -370,7 +374,7 @@ async def test_workload_tool_handler_denies_when_workflow_docker_disabled() -> N
         tool_name="container.run_workload",
         registry=_FailingRegistry(),
         launcher=_FailingLauncher(),
-        workflow_docker_enabled=False,
+        workflow_docker_mode="disabled",
     )
 
     with pytest.raises(SkillFailure) as exc_info:
@@ -395,7 +399,7 @@ async def test_integration_ci_tool_denies_when_workflow_docker_disabled() -> Non
         tool_name=INTEGRATION_CI_TOOL,
         registry=_FailingRegistry(),
         launcher=_FailingLauncher(),
-        workflow_docker_enabled=False,
+        workflow_docker_mode="disabled",
     )
 
     with pytest.raises(SkillFailure) as exc_info:
@@ -896,3 +900,113 @@ async def test_unreal_run_tests_handler_requires_project_path_before_launch() ->
     assert exc_info.value.error_code == "INVALID_INPUT"
     assert "projectPath" in exc_info.value.message
     assert launcher.validated is None
+
+
+class _RecordingDispatcher:
+    def __init__(self) -> None:
+        self.skills: list[tuple[str, str]] = []
+
+    def register_skill(self, *, skill_name: str, version: str, handler: Any) -> None:
+        self.skills.append((skill_name, version))
+
+
+def test_unrestricted_tool_definitions_are_registered_as_docker_workloads() -> None:
+    for tool_name in (CONTAINER_RUN_CONTAINER_TOOL, CONTAINER_RUN_DOCKER_TOOL):
+        definition = build_dood_tool_definition_payload(name=tool_name, version="1.0")
+
+        assert definition["type"] == "skill"
+        assert definition["executor"]["activity_type"] == "mm.tool.execute"
+        assert definition["requirements"]["capabilities"] == ["docker_workload"]
+
+
+def test_register_workload_tool_handlers_omits_all_dood_tools_when_disabled() -> None:
+    dispatcher = _RecordingDispatcher()
+
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="disabled",
+    )
+
+    assert dispatcher.skills == []
+
+
+def test_register_workload_tool_handlers_exposes_only_curated_tools_in_profiles_mode() -> None:
+    dispatcher = _RecordingDispatcher()
+
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="profiles",
+    )
+
+    registered = {name for name, _version in dispatcher.skills}
+    assert CONTAINER_RUN_CONTAINER_TOOL not in registered
+    assert CONTAINER_RUN_DOCKER_TOOL not in registered
+    assert INTEGRATION_CI_TOOL in registered
+
+
+def test_register_workload_tool_handlers_exposes_unrestricted_tools_only_in_unrestricted_mode() -> None:
+    dispatcher = _RecordingDispatcher()
+
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="unrestricted",
+    )
+
+    registered = {name for name, _version in dispatcher.skills}
+    assert registered == DOOD_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_profiles_mode_denies_direct_unrestricted_container_invocation() -> None:
+    handler = build_workload_tool_handler(
+        tool_name=CONTAINER_RUN_CONTAINER_TOOL,
+        registry=_FailingRegistry(),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="profiles",
+    )
+
+    with pytest.raises(SkillFailure) as exc_info:
+        await handler(
+            {
+                "image": "ghcr.io/example/runtime:1.2.3",
+                "repoDir": "/work/agent_jobs/task-1/repo",
+                "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+                "scratchDir": "/work/agent_jobs/task-1/scratch",
+                "command": ["pytest", "-q"],
+            },
+            {"workflow_id": "task-1", "node_id": "step-test"},
+        )
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert exc_info.value.details["reason"] == "docker_workflow_mode_forbidden"
+    assert exc_info.value.details["workflowDockerMode"] == "profiles"
+
+
+@pytest.mark.asyncio
+async def test_unrestricted_mode_allows_unrestricted_docker_handler() -> None:
+    launcher = _FakeLauncher()
+    handler = build_workload_tool_handler(
+        tool_name=CONTAINER_RUN_DOCKER_TOOL,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=launcher,
+        workflow_docker_mode="unrestricted",
+    )
+
+    result = await handler(
+        {
+            "repoDir": "/work/agent_jobs/task-1/repo",
+            "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+            "command": ["docker", "ps"],
+        },
+        {"workflow_id": "task-1", "node_id": "step-test"},
+    )
+
+    assert result.status == "COMPLETED"
+    assert launcher.validated.profile is None
+    assert launcher.validated.request.tool_name == CONTAINER_RUN_DOCKER_TOOL


### PR DESCRIPTION
Run Jira Orchestrate for MM-499.

Source story: STORY-001.
Source summary: Enforce Docker workflow modes and registry gating.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.