### PR TITLE
MM-496 expose report-aware execution projections

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/231-sensitive-report-access-retention"
+  "feature_directory": "specs/248-report-aware-execution-projections"
 }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -45,6 +45,7 @@ from moonmind.schemas.manifest_ingest_models import (
     ManifestNodePageModel,
     ManifestStatusSnapshotModel,
 )
+from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
 from moonmind.schemas.temporal_models import (
     CancelExecutionRequest,
     ConfigureIntegrationMonitoringRequest,
@@ -58,6 +59,7 @@ from moonmind.schemas.temporal_models import (
     ExecutionListResponse,
     ExecutionModel,
     ExecutionProgressModel,
+    ExecutionReportProjectionModel,
     ExecutionRefreshEnvelope,
     ExecutionSkillLifecycleIntentModel,
     ExecutionSkillProvenanceModel,
@@ -83,6 +85,8 @@ from moonmind.workflows.temporal import (
     TemporalExecutionValidationError,
     build_manifest_status_snapshot,
 )
+from moonmind.workflows.temporal.artifacts import build_artifact_ref
+from moonmind.workflows.temporal.report_artifacts import build_report_projection_summary
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.client import TemporalClientAdapter, query_workflow
 from moonmind.workflows.tasks.model_resolver import resolve_effective_model
@@ -1449,6 +1453,117 @@ async def _enrich_execution_merge_automation(
         )
 
     return execution.model_copy(update={"merge_automation": normalized})
+
+
+def _build_execution_artifact_ref_model(artifact: Any) -> ArtifactRefModel:
+    compact_ref = build_artifact_ref(artifact)
+    return ArtifactRefModel(
+        artifact_ref_v=compact_ref.artifact_ref_v,
+        artifact_id=compact_ref.artifact_id,
+        sha256=compact_ref.sha256,
+        size_bytes=compact_ref.size_bytes,
+        content_type=compact_ref.content_type,
+        encryption=compact_ref.encryption,
+        diagnostics=None,
+    )
+
+
+async def _hydrate_execution_report_projection(
+    execution: ExecutionModel,
+    *,
+    session: AsyncSession | None,
+    user: User,
+) -> ExecutionModel:
+    if session is None or execution.entry != "run" or not execution.run_id:
+        return execution
+
+    principal = str(getattr(user, "id", "") or "system")
+    try:
+        artifact_service = get_temporal_artifact_service(session)
+        primary_artifacts = await artifact_service.list_for_execution(
+            namespace=execution.namespace,
+            workflow_id=execution.workflow_id,
+            run_id=execution.run_id,
+            principal=principal,
+            link_type="report.primary",
+            latest_only=True,
+        )
+        primary_artifact = primary_artifacts[0] if primary_artifacts else None
+        if primary_artifact is None:
+            return execution.model_copy(
+                update={
+                    "report_projection": ExecutionReportProjectionModel(
+                        hasReport=False
+                    )
+                }
+            )
+
+        summary_artifacts = await artifact_service.list_for_execution(
+            namespace=execution.namespace,
+            workflow_id=execution.workflow_id,
+            run_id=execution.run_id,
+            principal=principal,
+            link_type="report.summary",
+            latest_only=True,
+        )
+        summary_artifact = summary_artifacts[0] if summary_artifacts else None
+
+        primary_ref_model = _build_execution_artifact_ref_model(primary_artifact)
+        summary_ref_model = (
+            _build_execution_artifact_ref_model(summary_artifact)
+            if summary_artifact is not None
+            else None
+        )
+        metadata_json = (
+            primary_artifact.metadata_json
+            if isinstance(getattr(primary_artifact, "metadata_json", None), Mapping)
+            else {}
+        )
+        projection_bundle: dict[str, Any] = {
+            "report_bundle_v": 1,
+            "evidence_refs": [],
+            "primary_report_ref": primary_ref_model.model_dump(
+                by_alias=True, exclude_none=False
+            ),
+        }
+        if summary_ref_model is not None:
+            projection_bundle["summary_ref"] = summary_ref_model.model_dump(
+                by_alias=True, exclude_none=False
+            )
+        report_type = metadata_json.get("report_type")
+        if report_type is not None:
+            projection_bundle["report_type"] = report_type
+        report_scope = metadata_json.get("report_scope")
+        if report_scope is not None:
+            projection_bundle["report_scope"] = report_scope
+
+        projection_metadata: dict[str, dict[str, int]] = {}
+        for key in ("finding_counts", "severity_counts"):
+            value = metadata_json.get(key)
+            if isinstance(value, Mapping):
+                projection_metadata[key] = dict(value)
+
+        projection_payload = build_report_projection_summary(
+            projection_bundle,
+            metadata=projection_metadata or None,
+        )
+        projection_payload["latest_report_ref"] = primary_ref_model.model_dump(
+            by_alias=True, exclude_none=False
+        )
+        if summary_ref_model is not None:
+            projection_payload[
+                "latest_report_summary_ref"
+            ] = summary_ref_model.model_dump(by_alias=True, exclude_none=False)
+        projection = ExecutionReportProjectionModel.model_validate(projection_payload)
+        return execution.model_copy(update={"report_projection": projection})
+    except Exception as exc:
+        logger.warning(
+            "Failed to hydrate report projection for execution %s: %s",
+            execution.workflow_id,
+            exc,
+            exc_info=True,
+        )
+        return execution
 
 
 async def _hydrate_provider_profile_metadata(
@@ -4146,6 +4261,11 @@ async def describe_execution(
             execution,
             temporal_client=temporal_client,
         )
+    execution = await _hydrate_execution_report_projection(
+        execution,
+        session=session,
+        user=user,
+    )
     if not execution.task_run_id:
         task_run_ids = await asyncio.to_thread(
             _resolve_task_run_ids_from_managed_store,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1468,6 +1468,13 @@ def _build_execution_artifact_ref_model(artifact: Any) -> ArtifactRefModel:
     )
 
 
+def _select_complete_execution_artifact(artifacts: list[Any]) -> Any | None:
+    for artifact in artifacts:
+        if getattr(artifact, "status", None) is TemporalArtifactStatus.COMPLETE:
+            return artifact
+    return None
+
+
 async def _hydrate_execution_report_projection(
     execution: ExecutionModel,
     *,
@@ -1498,7 +1505,7 @@ async def _hydrate_execution_report_projection(
                 latest_only=True,
             ),
         )
-        primary_artifact = primary_artifacts[0] if primary_artifacts else None
+        primary_artifact = _select_complete_execution_artifact(primary_artifacts)
         if primary_artifact is None:
             return execution.model_copy(
                 update={
@@ -1508,7 +1515,7 @@ async def _hydrate_execution_report_projection(
                 }
             )
 
-        summary_artifact = summary_artifacts[0] if summary_artifacts else None
+        summary_artifact = _select_complete_execution_artifact(summary_artifacts)
 
         primary_ref_model = _build_execution_artifact_ref_model(primary_artifact)
         summary_ref_model = (

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1480,13 +1480,23 @@ async def _hydrate_execution_report_projection(
     principal = str(getattr(user, "id", "") or "system")
     try:
         artifact_service = get_temporal_artifact_service(session)
-        primary_artifacts = await artifact_service.list_for_execution(
-            namespace=execution.namespace,
-            workflow_id=execution.workflow_id,
-            run_id=execution.run_id,
-            principal=principal,
-            link_type="report.primary",
-            latest_only=True,
+        primary_artifacts, summary_artifacts = await asyncio.gather(
+            artifact_service.list_for_execution(
+                namespace=execution.namespace,
+                workflow_id=execution.workflow_id,
+                run_id=execution.run_id,
+                principal=principal,
+                link_type="report.primary",
+                latest_only=True,
+            ),
+            artifact_service.list_for_execution(
+                namespace=execution.namespace,
+                workflow_id=execution.workflow_id,
+                run_id=execution.run_id,
+                principal=principal,
+                link_type="report.summary",
+                latest_only=True,
+            ),
         )
         primary_artifact = primary_artifacts[0] if primary_artifacts else None
         if primary_artifact is None:
@@ -1498,14 +1508,6 @@ async def _hydrate_execution_report_projection(
                 }
             )
 
-        summary_artifacts = await artifact_service.list_for_execution(
-            namespace=execution.namespace,
-            workflow_id=execution.workflow_id,
-            run_id=execution.run_id,
-            principal=principal,
-            link_type="report.summary",
-            latest_only=True,
-        )
         summary_artifact = summary_artifacts[0] if summary_artifacts else None
 
         primary_ref_model = _build_execution_artifact_ref_model(primary_artifact)
@@ -1547,13 +1549,6 @@ async def _hydrate_execution_report_projection(
             projection_bundle,
             metadata=projection_metadata or None,
         )
-        projection_payload["latest_report_ref"] = primary_ref_model.model_dump(
-            by_alias=True, exclude_none=False
-        )
-        if summary_ref_model is not None:
-            projection_payload[
-                "latest_report_summary_ref"
-            ] = summary_ref_model.model_dump(by_alias=True, exclude_none=False)
         projection = ExecutionReportProjectionModel.model_validate(projection_payload)
         return execution.model_copy(update={"report_projection": projection})
     except Exception as exc:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -23,5 +23,30 @@
     "id": 4167425940,
     "disposition": "not-applicable",
     "rationale": "Top-level Codex review wrapper contained no standalone actionable feedback beyond the inline comment already addressed."
+  },
+  {
+    "id": 3135097062,
+    "disposition": "addressed",
+    "rationale": "Removed the unused user binding from _client_with_service while preserving dependency override side effects."
+  },
+  {
+    "id": 3135097068,
+    "disposition": "addressed",
+    "rationale": "Removed the unused admin test user binding in test_list_executions_passes_temporal_filters_for_admin."
+  },
+  {
+    "id": 3135097076,
+    "disposition": "addressed",
+    "rationale": "Removed an unused user binding in the send-message signal test setup."
+  },
+  {
+    "id": 3135097078,
+    "disposition": "addressed",
+    "rationale": "Removed an unused user binding in the skip-dependency signal test setup."
+  },
+  {
+    "id": 3135097081,
+    "disposition": "addressed",
+    "rationale": "Dropped the unused ArtifactRefModel import after switching execution report projections to CompactArtifactRefModel."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -12,6 +12,16 @@
   {
     "id": 4167397793,
     "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary only restated the two inline comments and required no separate change."
+    "rationale": "Top-level Gemini review summary only restated the inline comments and required no separate change."
+  },
+  {
+    "id": 3135074437,
+    "disposition": "addressed",
+    "rationale": "Report hydration now ignores incomplete report.primary and report.summary artifacts and only projects COMPLETE artifacts."
+  },
+  {
+    "id": 4167425940,
+    "disposition": "not-applicable",
+    "rationale": "Top-level Codex review wrapper contained no standalone actionable feedback beyond the inline comment already addressed."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,17 @@
 [
   {
-    "id": 4167224734,
+    "id": 3135051899,
+    "disposition": "addressed",
+    "rationale": "Hydration now fetches primary and summary report artifacts concurrently with asyncio.gather."
+  },
+  {
+    "id": 3135051901,
+    "disposition": "addressed",
+    "rationale": "Execution report projections now preserve compact artifact refs end to end instead of re-injecting full artifact metadata."
+  },
+  {
+    "id": 4167397793,
     "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary only; the actionable retention-mapping items were addressed in the referenced files."
-  },
-  {
-    "id": 3134907874,
-    "disposition": "addressed",
-    "rationale": "Updated FR-005 and related spec language to include report.appendix, report.findings_index, and report.export as long-retention link types."
-  },
-  {
-    "id": 3134907881,
-    "disposition": "addressed",
-    "rationale": "Expanded the plan evidence summary for FR-005 to list every report link type that defaults to long retention."
-  },
-  {
-    "id": 3134907887,
-    "disposition": "addressed",
-    "rationale": "Revised the research decision and evidence text so the retention-default analysis matches the implementation mapping."
-  },
-  {
-    "id": 3134907889,
-    "disposition": "addressed",
-    "rationale": "Updated verification coverage to record all report link types that derive long retention by default."
+    "rationale": "Top-level bot review summary only restated the two inline comments and required no separate change."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md
@@ -1,0 +1,77 @@
+# MM-496 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-496
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Expose report-aware execution projections
+- Labels:
+  - `moonmind-workflow-mm-1f7a8be1-a624-482c-bcb5-4a86e5ab4b1b`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-496 from MM project
+Summary: Expose report-aware execution projections
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-496 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-496: Expose report-aware execution projections
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections:
+  - 11.4 Latest report semantics
+  - 18 Suggested API/UI extensions
+  - 20 Open questions
+- Coverage IDs:
+  - DESIGN-REQ-013
+  - DESIGN-REQ-022
+  - DESIGN-REQ-024
+
+User Story
+As an API consumer, I want execution detail responses and an optional report projection to expose the latest report refs and bounded counts so clients can build report-first views without duplicating artifact-selection heuristics.
+
+Acceptance Criteria
+- Execution detail data can expose `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, and bounded finding/severity counts.
+- A report projection endpoint, if implemented in this story, returns `execution_ref`, `primary_report_ref`, `summary_ref`, `structured_ref`, `evidence_refs`, `report_type`, and bounded counts over standard artifacts.
+- Projection output never becomes a second report storage model; underlying artifacts remain individually addressable.
+- Latest report selection is resolved server-side using execution identity and report link types.
+- Restricted artifacts still obey artifact authorization and preview/default-read behavior.
+- The story records whether the projection endpoint is implemented immediately or deferred in favor of execution-detail summary fields.
+
+Requirements
+- Provide report-aware server selection for clients.
+- Keep projection data as a convenience read model over artifacts.
+- Make unresolved projection timing explicit.
+
+Relevant Implementation Notes
+- Preserve MM-496 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Artifacts/ReportArtifacts.md` as the source design reference for latest-report semantics, projection-friendly API/UI extensions, and the open question around when projection behavior should ship.
+- Add report-aware execution detail fields that expose the latest canonical report refs and bounded counts without requiring clients to re-run artifact selection heuristics.
+- If a projection endpoint is implemented in this story, keep it as a convenience read model over standard artifacts rather than a second report storage model.
+- Resolve latest report selection server-side from execution identity and report link types.
+- Keep restricted-artifact authorization and preview/default-read behavior intact for any report projection or execution-detail exposure.
+- Make the implementation decision explicit if the projection endpoint is deferred in favor of execution-detail summary fields.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-496 is blocked by MM-497, whose embedded status is Selected for Development.
+- Trusted Jira link metadata at fetch time shows MM-496 is related to MM-495 via a Blocks link where MM-496 blocks MM-495; MM-495 is not a blocker for this story.
+
+Validation
+- Verify execution detail responses expose `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, and bounded finding/severity counts when canonical reports exist.
+- Verify any projection endpoint added by this story returns `execution_ref`, `primary_report_ref`, `summary_ref`, `structured_ref`, `evidence_refs`, `report_type`, and bounded counts over standard artifacts.
+- Verify projection output remains a convenience read model and does not become a second report storage model.
+- Verify latest report selection is resolved server-side from execution identity and report link types.
+- Verify restricted artifacts continue to obey artifact authorization and preview/default-read behavior.
+- Verify the implementation records whether projection behavior ships now or is deferred in favor of execution-detail summary fields.
+
+Needs Clarification
+- None

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3059,6 +3059,19 @@ export interface components {
          */
         CodexWorkerShardStatus: "active" | "draining" | "offline";
         /**
+         * CompactArtifactRefModel
+         * @description Bounded artifact reference for execution-level convenience projections.
+         */
+        CompactArtifactRefModel: {
+            /**
+             * Artifact Ref V
+             * @default 1
+             */
+            artifact_ref_v: number;
+            /** Artifact Id */
+            artifact_id: string;
+        };
+        /**
          * CompleteArtifactPartModel
          * @description Multipart completion part descriptor (reserved for compatibility).
          */
@@ -3756,6 +3769,7 @@ export interface components {
             skillRuntime?: components["schemas"]["ExecutionSkillRuntimeModel"] | null;
             /** Artifactrefs */
             artifactRefs?: string[];
+            reportProjection?: components["schemas"]["ExecutionReportProjectionModel"] | null;
             actions?: components["schemas"]["ExecutionActionCapabilityModel"];
             debugFields?: components["schemas"]["ExecutionDebugFieldsModel"] | null;
             /** Redirectpath */
@@ -3954,6 +3968,28 @@ export interface components {
              * Format: date-time
              */
             refreshedAt: string;
+        };
+        /**
+         * ExecutionReportProjectionModel
+         * @description Bounded report summary surfaced on execution detail responses.
+         */
+        ExecutionReportProjectionModel: {
+            /** Hasreport */
+            hasReport: boolean;
+            latestReportRef?: components["schemas"]["CompactArtifactRefModel"] | null;
+            latestReportSummaryRef?: components["schemas"]["CompactArtifactRefModel"] | null;
+            /** Reporttype */
+            reportType?: string | null;
+            /** Reportstatus */
+            reportStatus?: string | null;
+            /** Findingcounts */
+            findingCounts?: {
+                [key: string]: number;
+            } | null;
+            /** Severitycounts */
+            severityCounts?: {
+                [key: string]: number;
+            } | null;
         };
         /**
          * ExecutionSkillLifecycleIntentModel

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -33,6 +33,15 @@ class ArtifactRefModel(BaseModel):
     diagnostics: Optional[dict[str, Any]] = None
 
 
+class CompactArtifactRefModel(BaseModel):
+    """Bounded artifact reference for execution-level convenience projections."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    artifact_ref_v: int = Field(1, alias="artifact_ref_v")
+    artifact_id: str = Field(..., alias="artifact_id")
+
+
 class ArtifactExecutionLinkModel(BaseModel):
     """Execution linkage metadata associated with an artifact."""
 

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -14,7 +14,10 @@ from pydantic import (
     model_validator,
 )
 
-from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
+from moonmind.schemas.temporal_artifact_models import (
+    ArtifactRefModel,
+    CompactArtifactRefModel,
+)
 from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 SUPPORTED_WORKFLOW_TYPES = (
@@ -1024,8 +1027,10 @@ class ExecutionReportProjectionModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     has_report: bool = Field(..., alias="hasReport")
-    latest_report_ref: ArtifactRefModel | None = Field(None, alias="latestReportRef")
-    latest_report_summary_ref: ArtifactRefModel | None = Field(
+    latest_report_ref: CompactArtifactRefModel | None = Field(
+        None, alias="latestReportRef"
+    )
+    latest_report_summary_ref: CompactArtifactRefModel | None = Field(
         None, alias="latestReportSummaryRef"
     )
     report_type: str | None = Field(None, alias="reportType")

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
+from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
 from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 SUPPORTED_WORKFLOW_TYPES = (
@@ -1010,6 +1018,27 @@ class StepLedgerSnapshotModel(BaseModel):
     steps: list[StepLedgerRowModel] = Field(default_factory=list, alias="steps")
 
 
+class ExecutionReportProjectionModel(BaseModel):
+    """Bounded report summary surfaced on execution detail responses."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    has_report: bool = Field(..., alias="hasReport")
+    latest_report_ref: ArtifactRefModel | None = Field(None, alias="latestReportRef")
+    latest_report_summary_ref: ArtifactRefModel | None = Field(
+        None, alias="latestReportSummaryRef"
+    )
+    report_type: str | None = Field(None, alias="reportType")
+    report_status: str | None = Field(None, alias="reportStatus")
+    finding_counts: dict[str, int] | None = Field(None, alias="findingCounts")
+    severity_counts: dict[str, int] | None = Field(None, alias="severityCounts")
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_nulls(self, handler):
+        payload = handler(self)
+        return {key: value for key, value in payload.items() if value is not None}
+
+
 class ExecutionModel(BaseModel):
     """Materialized execution view returned by lifecycle APIs."""
 
@@ -1102,6 +1131,9 @@ class ExecutionModel(BaseModel):
         None, alias="skillRuntime"
     )
     artifact_refs: list[str] = Field(default_factory=list, alias="artifactRefs")
+    report_projection: ExecutionReportProjectionModel | None = Field(
+        None, alias="reportProjection"
+    )
     actions: ExecutionActionCapabilityModel = Field(
         default_factory=ExecutionActionCapabilityModel, alias="actions"
     )

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -14,10 +14,7 @@ from pydantic import (
     model_validator,
 )
 
-from moonmind.schemas.temporal_artifact_models import (
-    ArtifactRefModel,
-    CompactArtifactRefModel,
-)
+from moonmind.schemas.temporal_artifact_models import CompactArtifactRefModel
 from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 SUPPORTED_WORKFLOW_TYPES = (

--- a/specs/248-report-aware-execution-projections/contracts/execution-report-projection-contract.md
+++ b/specs/248-report-aware-execution-projections/contracts/execution-report-projection-contract.md
@@ -1,0 +1,59 @@
+# Contract: Execution Report Projection
+
+## Purpose
+
+Define the bounded MM-496 execution-detail report projection contract so `/api/executions/{workflowId}` can expose canonical report summary data without introducing a dedicated report storage model or bypassing artifact authorization.
+
+## Response Shape
+
+`ExecutionModel` exposes an optional report projection object with the following fields:
+
+```json
+{
+  "reportProjection": {
+    "hasReport": true,
+    "latestReportRef": {"artifact_ref_v": 1, "artifact_id": "art_primary"},
+    "latestReportSummaryRef": {"artifact_ref_v": 1, "artifact_id": "art_summary"},
+    "reportType": "security_pentest_report",
+    "reportStatus": "final",
+    "findingCounts": {"total": 8},
+    "severityCounts": {"critical": 1, "high": 2}
+  }
+}
+```
+
+Rules:
+- `reportProjection` is optional and may be absent or null when no canonical report exists.
+- `hasReport` is required when `reportProjection` is present.
+- `latestReportRef` and `latestReportSummaryRef` are compact artifact refs only.
+- `findingCounts` and `severityCounts` are optional bounded maps only.
+
+## Derivation Rules
+
+- The projection is derived server-side from canonical report artifact semantics for the execution.
+- Latest report resolution is link-driven and server-defined.
+- Projection shaping reuses the validated report projection helper rather than duplicating logic in the API layer.
+
+## Safety Rules
+
+- No raw report bodies, report markdown, screenshots, logs, transcripts, unrestricted URLs, or presigned downloads appear in `reportProjection`.
+- Unsupported projection metadata keys are rejected or omitted before surfacing through execution detail.
+- Artifact authorization and preview/default-read behavior remain owned by the artifact APIs.
+- `reportProjection` is a convenience read model, not a second storage system.
+
+## Deferred Scope
+
+The dedicated `/report` endpoint is explicitly deferred in MM-496.
+
+Rules:
+- This story adds execution-detail summary exposure only.
+- Any future `/report` endpoint must be delivered by a separate story with its own contract and tests.
+
+## Verification Targets
+
+This contract is satisfied when tests prove:
+- execution detail surfaces bounded report projection data when canonical report artifacts exist
+- execution detail omits fabricated refs when no canonical report exists
+- latest report resolution remains server-defined
+- only compact artifact refs and bounded counts are exposed
+- the dedicated `/report` endpoint remains deferred and unimplemented in this story

--- a/specs/248-report-aware-execution-projections/data-model.md
+++ b/specs/248-report-aware-execution-projections/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: Report-Aware Execution Projections
+
+## Entities
+
+### Execution Detail Report Projection
+
+Represents the bounded report-aware read model exposed on one execution detail response.
+
+Fields:
+- `hasReport`
+- optional `latestReportRef`
+- optional `latestReportSummaryRef`
+- optional `reportType`
+- optional `reportStatus`
+- optional `findingCounts`
+- optional `severityCounts`
+
+Rules:
+- All fields are derived server-side from canonical report artifacts and bounded report metadata.
+- The projection contains compact artifact refs and bounded counts only.
+- The projection is omitted or empty when no canonical report exists.
+- The projection does not carry report bodies, raw artifact payloads, unrestricted URLs, or unbounded metadata.
+
+### Canonical Latest Report Selection
+
+Represents the server-side resolution of the current report for one execution.
+
+Fields:
+- execution identity: `namespace`, `workflowId`, `runId`
+- canonical latest report linkage from report artifact semantics
+- optional summary artifact linkage
+- optional bounded count metadata
+
+Rules:
+- Latest selection is link-driven and server-defined.
+- Clients must not infer recency from artifact ordering, filenames, or local heuristics.
+- Selection reuses canonical report bundle/report artifact semantics already defined by the report contract stories.
+
+### Bounded Count Summary
+
+Represents the optional count maps included in the execution-detail projection.
+
+Fields:
+- `findingCounts`
+- `severityCounts`
+
+Rules:
+- Only bounded mapping shapes are allowed.
+- Unsupported keys or oversized nested values are rejected before surfacing through execution detail.
+- Counts remain convenience summaries over artifact-backed report data rather than a second source of truth.
+
+### Deferred Report Endpoint Decision
+
+Represents the explicit feature-local choice to defer the dedicated report endpoint.
+
+Fields:
+- `implemented_now` = false
+- `reason` = execution-detail summary fields are the bounded first slice
+- traceability to MM-496 and source design open question
+
+Rules:
+- The decision must be recorded in plan/tasks/verification artifacts.
+- Deferral does not block future introduction of a dedicated endpoint in a separate story.
+- The execution-detail projection remains valid even while the endpoint is deferred.
+
+## Relationships
+
+- One `Canonical Latest Report Selection` may populate one `Execution Detail Report Projection` for a given execution.
+- One `Execution Detail Report Projection` may include zero or one bounded `Bounded Count Summary` maps for findings and severities.
+- The `Deferred Report Endpoint Decision` constrains this feature to execution detail exposure and prevents scope creep into a second API route.
+
+## Validation Notes
+
+- Artifact refs surfaced through execution detail remain individually addressable only through the existing artifact APIs.
+- Execution detail never becomes the durable storage location for report content.
+- The projection must degrade safely when a canonical report is absent or when bounded count metadata is not available.

--- a/specs/248-report-aware-execution-projections/plan.md
+++ b/specs/248-report-aware-execution-projections/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Report-Aware Execution Projections
+
+**Branch**: `248-report-aware-execution-projections` | **Date**: 2026-04-24 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/248-report-aware-execution-projections/spec.md`
+
+## Summary
+
+Plan MM-496 as a real runtime implementation story with a bounded first slice: add report-aware summary projection data to `/api/executions/{workflowId}` and explicitly defer the dedicated report endpoint. The repository already contains the compact report projection helper in `moonmind/workflows/temporal/report_artifacts.py`, but the execution detail API model and materialization path do not yet surface those fields. The implementation plan is therefore to reuse the existing projection helper, extend execution detail schemas and router materialization, add focused router/contract tests, and preserve explicit MM-496 traceability while keeping report refs artifact-backed and authorization-safe.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `build_report_projection_summary` in `moonmind/workflows/temporal/report_artifacts.py` already defines the bounded projection shape, but `ExecutionModel` in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` do not yet surface it. | Extend execution detail schema and materialization to expose the bounded projection. | unit + contract |
+| FR-002 | partial | Helper logic already derives latest refs from the compact report bundle, but no execution detail path currently invokes it. | Thread server-side latest report projection into execution detail materialization. | unit + contract |
+| FR-003 | implemented_partial | The helper already limits projection output to compact refs and bounded counts only. | Reuse the helper directly in execution detail materialization; add boundary tests proving no second storage/read model is introduced. | unit + contract |
+| FR-004 | partial | Existing artifact APIs already enforce authorization and preview/default-read behavior, but execution detail does not yet surface report refs. | Ensure execution detail carries only artifact refs and does not bypass artifact-read controls; verify no raw artifact payloads are exposed. | unit + contract |
+| FR-005 | planned | `docs/Artifacts/ReportArtifacts.md` treats the endpoint as optional future work, but no MM-496 feature-local artifact records the decision yet. | Preserve the explicit defer-now decision in plan, tasks, and later verification artifacts. | traceability review |
+| FR-006 | partial | `build_report_projection_summary` supports `has_report = false`, but execution detail does not yet carry the projection. | Add safe no-report behavior tests at the execution detail boundary. | unit + contract |
+| FR-007 | implemented_partial | The helper already rejects unsupported projection metadata keys and unsafe values. | Verify execution detail only passes bounded metadata through the helper and does not widen the allowed shape. | unit |
+| FR-008 | partial | MM-496 is preserved in the Jira brief and spec only. | Preserve MM-496 throughout plan, tasks, and verification artifacts. | traceability review |
+| DESIGN-REQ-013 | partial | Execution detail projection helper exists, but API wiring is missing. | Reuse helper and wire it into execution detail materialization. | unit + contract |
+| DESIGN-REQ-022 | planned | Source doc recommends execution detail conveniences first and treats the endpoint as optional future work. | Implement the summary-field slice and explicitly defer the endpoint. | traceability review |
+| DESIGN-REQ-024 | implemented_partial | Helper keeps projection compact and artifact-backed; execution detail does not yet expose it. | Preserve compact refs only and verify no second storage model or auth bypass is introduced. | unit + contract |
+
+## Technical Context
+
+**Language/Version**: Python 3.12 backend/runtime; existing TypeScript/React consumers remain downstream but are not the primary implementation surface for this slice  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, existing Temporal artifact service/helpers  
+**Storage**: Existing temporal artifact metadata tables and configured artifact store; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py`  
+**Integration Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` for the execution-detail API boundary; `./tools/test_integration.sh` only if implementation crosses into compose-backed persistence or serialization behavior beyond the existing contract test surface  
+**Target Platform**: MoonMind API service execution detail route backed by Temporal execution records and artifact linkage  
+**Project Type**: Backend runtime/API story with contract verification  
+**Performance Goals**: Reuse bounded report projection helpers and keep execution detail reads compact; avoid unbounded artifact hydration or extra storage indirection  
+**Constraints**: No second report storage model, no raw artifact payloads in execution detail, preserve artifact authorization behavior, keep endpoint defer decision explicit, preserve MM-496 traceability  
+**Scale/Scope**: One story covering report-aware execution detail exposure for canonical reports
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - reuses existing report artifact helpers and execution-detail boundaries instead of inventing a parallel report service.
+- II. One-Click Agent Deployment: PASS - no new service, secret, or operator setup is introduced.
+- III. Avoid Vendor Lock-In: PASS - the projection is an artifact/read-model contract, not provider-specific behavior.
+- IV. Own Your Data: PASS - reports remain in MoonMind-managed artifact storage and execution detail carries refs only.
+- V. Skills Are First-Class and Easy to Add: PASS - no skill runtime changes are required.
+- VI. Replaceable AI Scaffolding: PASS - the work centers on durable API/runtime contracts and bounded helper reuse.
+- VII. Powerful Runtime Configurability: PASS - existing execution/artifact configuration remains unchanged.
+- VIII. Modular and Extensible Architecture: PASS - changes stay within execution schema/materialization and existing report helper boundaries.
+- IX. Resilient by Default: PASS - projection data remains bounded, deterministic, and artifact-backed.
+- X. Facilitate Continuous Improvement: PASS - later verification will capture the explicit endpoint defer decision and any remaining drift.
+- XI. Spec-Driven Development: PASS - MM-496 is preserved through spec, plan, and later tasks/verification.
+- XII. Canonical Documentation Separation: PASS - Jira/orchestration input remains under `docs/tmp`, while this feature directory captures the selected runtime slice.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliasing or hidden semantic transforms are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/248-report-aware-execution-projections/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── execution-report-projection-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/temporal_models.py
+└── workflows/temporal/report_artifacts.py
+
+api_service/api/routers/
+└── executions.py
+
+tests/unit/api/routers/
+└── test_executions.py
+
+tests/unit/workflows/temporal/
+└── test_report_workflow_rollout.py
+
+tests/contract/
+└── test_temporal_execution_api.py
+```
+
+**Structure Decision**: Keep MM-496 scoped to the existing report projection helper, execution detail schema/materialization, and execution API contract tests. The dedicated `/report` endpoint is explicitly deferred; this story's first runtime slice is bounded execution-detail projection exposure.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/248-report-aware-execution-projections/quickstart.md
+++ b/specs/248-report-aware-execution-projections/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Report-Aware Execution Projections
+
+## Goal
+
+Implement and verify MM-496 by exposing a bounded report projection on execution detail responses while explicitly deferring the dedicated report endpoint.
+
+## Focused Unit Verification
+
+Run the focused report helper and execution router tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/api/routers/test_executions.py
+```
+
+What this proves:
+- bounded report projection helper behavior remains valid
+- execution detail materialization exposes the projection shape correctly
+- no-report behavior degrades safely
+- unsupported projection metadata is not widened by the API layer
+
+## Execution API Contract Verification
+
+Run the execution-detail contract regression:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py
+```
+
+What this proves:
+- `/api/executions/{workflowId}` returns the new report projection contract
+- projection data stays bounded to compact refs and counts only
+- execution detail remains the only new surface in this story
+
+## Full Unit Verification
+
+Before claiming MM-496 is complete, rerun the full required unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Integration Strategy
+
+Use the hermetic integration suite only if implementation changes execution persistence, artifact-link query wiring, or API serialization behavior beyond the existing unit and contract boundary coverage:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-to-End Story Validation
+
+1. Confirm `spec.md` preserves MM-496 and the original Jira preset brief.
+2. Run the focused unit verification command.
+3. Run the execution API contract verification command.
+4. If verification exposes drift, implement the smallest contract-preserving fix in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` while reusing `moonmind/workflows/temporal/report_artifacts.py`.
+5. Rerun focused verification.
+6. Run the full unit suite.
+7. Preserve MM-496 and DESIGN-REQ-013/022/024 in downstream tasks and verification artifacts.

--- a/specs/248-report-aware-execution-projections/research.md
+++ b/specs/248-report-aware-execution-projections/research.md
@@ -6,6 +6,7 @@ Decision: Treat MM-496 as a single-story runtime feature request.
 Evidence: `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md`; `specs/248-report-aware-execution-projections/spec.md`.
 Rationale: The brief defines one independently testable runtime outcome: expose bounded report-aware summary data on execution detail without introducing a second report storage model.
 Alternatives considered: Broad design breakdown was rejected because the Jira brief already selects one story and does not require processing multiple specs.
+Breakdown decision: `moonspec-breakdown` was not run because the MM-496 Jira preset brief already defines one independently testable runtime story and does not require processing multiple specs.
 Test implications: Unit and execution-API contract tests are both required.
 
 ## Execution Detail Summary Fields First, Endpoint Deferred

--- a/specs/248-report-aware-execution-projections/research.md
+++ b/specs/248-report-aware-execution-projections/research.md
@@ -1,0 +1,49 @@
+# Research: Report-Aware Execution Projections
+
+## Story Classification
+
+Decision: Treat MM-496 as a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md`; `specs/248-report-aware-execution-projections/spec.md`.
+Rationale: The brief defines one independently testable runtime outcome: expose bounded report-aware summary data on execution detail without introducing a second report storage model.
+Alternatives considered: Broad design breakdown was rejected because the Jira brief already selects one story and does not require processing multiple specs.
+Test implications: Unit and execution-API contract tests are both required.
+
+## Execution Detail Summary Fields First, Endpoint Deferred
+
+Decision: Implement report-aware summary fields on `/api/executions/{workflowId}` now and explicitly defer the dedicated report endpoint.
+Evidence: `docs/Artifacts/ReportArtifacts.md` §18.1 recommends execution detail convenience fields first, while §18.2 labels the dedicated report endpoint as optional future work.
+Rationale: The issue brief asks for execution detail exposure and only treats the endpoint as optional. Choosing the summary-field slice keeps the first implementation bounded and avoids widening the story into a new route contract.
+Alternatives considered: Add the dedicated `/report` endpoint immediately. Rejected because it is optional in the source design and would expand the implementation surface beyond the minimal first slice.
+Test implications: Contract tests should cover execution detail serialization; no new route-level contract is required in this story.
+
+## Reuse Existing Projection Helper
+
+Decision: Reuse `build_report_projection_summary` from `moonmind/workflows/temporal/report_artifacts.py` rather than inventing a second projection builder inside the API layer.
+Evidence: The helper already validates bounded projection keys, compact refs, `has_report`, latest report refs, `report_type`, `report_status`, and bounded `finding_counts` / `severity_counts`.
+Rationale: Reusing the helper keeps the API aligned with the canonical report contract and reduces drift between workflow/runtime bundle semantics and execution detail presentation.
+Alternatives considered: Reimplement projection shaping in `api_service/api/routers/executions.py`. Rejected because it would duplicate validation and risk diverging semantics.
+Test implications: Existing helper tests remain valuable; execution router tests should prove the helper output is surfaced correctly through execution detail.
+
+## ExecutionModel Requires Extension
+
+Decision: Extend the execution detail response contract to carry a bounded report projection object.
+Evidence: `ExecutionModel` in `moonmind/schemas/temporal_models.py` currently does not expose report-aware fields, and `api_service/api/routers/executions.py` does not materialize them.
+Rationale: The projection must be part of the canonical execution-detail response to satisfy the story for API consumers.
+Alternatives considered: Keep the projection only in internal helpers until a future endpoint exists. Rejected because the MM-496 story is specifically about execution detail exposure.
+Test implications: Router unit tests and execution API contract tests need explicit coverage for the new response field.
+
+## No New Storage Or Authorization Model
+
+Decision: Keep report-aware execution detail as a convenience read model over existing artifacts only.
+Evidence: `docs/Artifacts/ReportArtifacts.md` §18.2 and §21 require projection output to remain a read model over standard artifacts, and existing artifact APIs already own authorization and preview/default-read behavior.
+Rationale: Execution detail should surface refs and bounded counts only, leaving artifact content access and restrictions to the existing artifact endpoints and policies.
+Alternatives considered: Store a separate execution-level report projection row or inline artifact metadata beyond bounded counts. Rejected because both would violate the artifact-first design.
+Test implications: Contract tests should verify only refs and bounded count fields are returned; execution detail must not surface raw artifact payloads.
+
+## Blocker Note
+
+Decision: Preserve MM-497 as an implementation sequencing blocker in feature-local artifacts, but do not let it prevent spec/plan/tasks generation for MM-496.
+Evidence: Trusted Jira link metadata in `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md` records MM-496 as blocked by MM-497.
+Rationale: The user requested MoonSpec artifact generation from the Jira preset brief. Planning can proceed while still recording that implementation sequencing remains externally blocked.
+Alternatives considered: Stop before creating planning artifacts. Rejected because the brief itself remains the canonical source for this MoonSpec workflow.
+Test implications: Traceability should preserve the blocker note; implementation execution can be deferred until the dependency is resolved.

--- a/specs/248-report-aware-execution-projections/spec.md
+++ b/specs/248-report-aware-execution-projections/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Report-Aware Execution Projections
+
+**Feature Branch**: `248-report-aware-execution-projections`
+**Created**: 2026-04-24
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-496 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: existing report-related feature directories in `specs/` map to different Jira stories (`MM-492`, `MM-493`, `MM-494`), so no active Moon Spec feature directory matched MM-496 and `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-496 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-496
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Expose report-aware execution projections
+- Labels:
+  - `moonmind-workflow-mm-1f7a8be1-a624-482c-bcb5-4a86e5ab4b1b`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-496 from MM project
+Summary: Expose report-aware execution projections
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-496 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-496: Expose report-aware execution projections
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections:
+  - 11.4 Latest report semantics
+  - 18 Suggested API/UI extensions
+  - 20 Open questions
+- Coverage IDs:
+  - DESIGN-REQ-013
+  - DESIGN-REQ-022
+  - DESIGN-REQ-024
+
+User Story
+As an API consumer, I want execution detail responses and an optional report projection to expose the latest report refs and bounded counts so clients can build report-first views without duplicating artifact-selection heuristics.
+
+Acceptance Criteria
+- Execution detail data can expose `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, and bounded finding/severity counts.
+- A report projection endpoint, if implemented in this story, returns `execution_ref`, `primary_report_ref`, `summary_ref`, `structured_ref`, `evidence_refs`, `report_type`, and bounded counts over standard artifacts.
+- Projection output never becomes a second report storage model; underlying artifacts remain individually addressable.
+- Latest report selection is resolved server-side using execution identity and report link types.
+- Restricted artifacts still obey artifact authorization and preview/default-read behavior.
+- The story records whether the projection endpoint is implemented immediately or deferred in favor of execution-detail summary fields.
+
+Requirements
+- Provide report-aware server selection for clients.
+- Keep projection data as a convenience read model over artifacts.
+- Make unresolved projection timing explicit.
+
+Relevant Implementation Notes
+- Preserve MM-496 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Artifacts/ReportArtifacts.md` as the source design reference for latest-report semantics, projection-friendly API/UI extensions, and the open question around when projection behavior should ship.
+- Add report-aware execution detail fields that expose the latest canonical report refs and bounded counts without requiring clients to re-run artifact selection heuristics.
+- If a projection endpoint is implemented in this story, keep it as a convenience read model over standard artifacts rather than a second report storage model.
+- Resolve latest report selection server-side from execution identity and report link types.
+- Keep restricted-artifact authorization and preview/default-read behavior intact for any report projection or execution-detail exposure.
+- Make the implementation decision explicit if the projection endpoint is deferred in favor of execution-detail summary fields.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-496 is blocked by MM-497, whose embedded status is Selected for Development.
+- Trusted Jira link metadata at fetch time shows MM-496 is related to MM-495 via a Blocks link where MM-496 blocks MM-495; MM-495 is not a blocker for this story.
+
+Validation
+- Verify execution detail responses expose `has_report`, `latest_report_ref`, `latest_report_summary_ref`, `report_type`, `report_status`, and bounded finding/severity counts when canonical reports exist.
+- Verify any projection endpoint added by this story returns `execution_ref`, `primary_report_ref`, `summary_ref`, `structured_ref`, `evidence_refs`, `report_type`, and bounded counts over standard artifacts.
+- Verify projection output remains a convenience read model and does not become a second report storage model.
+- Verify latest report selection is resolved server-side from execution identity and report link types.
+- Verify restricted artifacts continue to obey artifact authorization and preview/default-read behavior.
+- Verify the implementation records whether projection behavior ships now or is deferred in favor of execution-detail summary fields.
+
+Needs Clarification
+- None
+```
+
+## User Story - Expose Report-Aware Execution Detail Fields
+
+**Summary**: As an API consumer, I want execution detail responses to expose canonical report refs and bounded report summary counts so clients can build report-first behavior without artifact-guessing heuristics.
+
+**Goal**: The `/api/executions/{workflowId}` response surfaces a bounded report projection derived server-side from canonical report artifacts, while the dedicated report endpoint remains explicitly deferred unless implementation work demonstrates it is needed now.
+
+**Independent Test**: Request execution detail for a run with canonical report artifacts and verify the response includes a report-aware projection with canonical refs and bounded counts, resolves latest report selection on the server, preserves authorization-safe artifact refs only, and continues to degrade cleanly when no report exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** an execution has a canonical latest report bundle, **When** a client fetches `/api/executions/{workflowId}`, **Then** the execution detail response includes report-aware summary data for `hasReport`, `latestReportRef`, `latestReportSummaryRef`, `reportType`, `reportStatus`, and bounded count fields.
+2. **Given** the latest canonical report is derived from report link semantics, **When** execution detail is materialized, **Then** latest report selection is resolved server-side from execution identity and report link types rather than browser-side artifact sorting.
+3. **Given** a report projection is exposed through execution detail, **When** it references report content, **Then** it contains compact artifact refs and bounded counts only and does not become a second report storage model.
+4. **Given** the latest canonical report or summary artifact is restricted, **When** execution detail is returned, **Then** projection data continues to honor artifact authorization and preview/default-read behavior rather than bypassing access rules.
+5. **Given** an execution has no canonical report bundle, **When** execution detail is requested, **Then** the report-aware projection degrades safely without fabricated refs or counts.
+6. **Given** the story leaves the dedicated report endpoint deferred, **When** planning and verification artifacts are reviewed, **Then** they make that defer-now decision explicit rather than leaving the projection shape ambiguous.
+
+### Edge Cases
+
+- An execution publishes a canonical primary report but no summary artifact.
+- The latest report bundle includes finding counts but no severity counts, or severity counts but no finding counts.
+- An execution has report artifacts, but no canonical `report.primary` for the relevant scope.
+- Projection metadata includes unsupported keys or oversized values that would violate bounded report metadata rules.
+- Clients attempt to infer report recency from artifact ordering instead of the server projection.
+
+## Assumptions
+
+- MM-492 established the canonical report artifact contract and MM-493 established immutable report bundle publication, so MM-496 can reuse existing helper logic rather than inventing a new projection model.
+- MM-494 already covers Mission Control report-first presentation; MM-496 focuses on the execution detail API read model that can support similar consumers.
+- The dedicated report projection endpoint remains optional future work; this story's bounded first slice is execution-detail summary exposure unless implementation evidence proves the endpoint is required immediately.
+- MM-497 remains an upstream Jira blocker for implementation sequencing, but it does not prevent preserving MM-496 as a complete MoonSpec artifact set.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-013 | `docs/Artifacts/ReportArtifacts.md` §11.4, §18.1 | Latest report selection and execution detail summary fields must be resolved server-side from canonical report semantics and bounded artifact-backed refs. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-022 | `docs/Artifacts/ReportArtifacts.md` §18.1-§18.2 | Execution detail summary fields are the first recommended convenience surface; any dedicated report endpoint is optional and its status must be explicit. | In scope | FR-001, FR-005 |
+| DESIGN-REQ-024 | `docs/Artifacts/ReportArtifacts.md` §18.2, §21 | Projection output remains a convenience read model over standard artifacts and must not become a second report storage system or bypass artifact authorization behavior. | In scope | FR-003, FR-004 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose an execution-detail report projection for `/api/executions/{workflowId}` containing `hasReport`, `latestReportRef`, `latestReportSummaryRef`, `reportType`, `reportStatus`, and bounded `findingCounts` / `severityCounts` when canonical report data exists.
+- **FR-002**: The system MUST derive the execution-detail report projection server-side from execution identity and canonical report link semantics rather than client-side artifact ordering or filename heuristics.
+- **FR-003**: The system MUST keep the execution-detail report projection bounded to compact artifact refs and bounded counts, and MUST NOT introduce a second report storage model.
+- **FR-004**: The system MUST preserve artifact authorization and preview/default-read behavior for any report refs surfaced through execution detail.
+- **FR-005**: The system MUST explicitly record whether the dedicated report projection endpoint is implemented now or deferred in favor of execution-detail summary fields; silent ambiguity is not allowed.
+- **FR-006**: The system MUST degrade safely when no canonical report exists by returning no fabricated latest-report refs or bounded counts.
+- **FR-007**: The system MUST reject or omit unsupported report projection metadata keys or unsafe oversized values instead of surfacing them through execution detail.
+- **FR-008**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this story MUST preserve Jira issue key MM-496.
+
+### Key Entities
+
+- **Execution Detail Report Projection**: The bounded report-aware read model exposed on execution detail responses for one execution.
+- **Canonical Latest Report Selection**: The server-defined resolution of the current canonical report for an execution using report link semantics.
+- **Bounded Count Summary**: The optional `findingCounts` and `severityCounts` maps derived from validated report metadata.
+- **Deferred Report Endpoint Decision**: The explicit feature-local decision that the dedicated report endpoint is either implemented in this story or deferred in favor of execution-detail summary fields.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests prove execution detail responses surface the bounded report projection when canonical report data exists and omit fabricated refs when it does not.
+- **SC-002**: Tests prove latest report selection is resolved server-side from canonical report link semantics rather than browser-side sorting heuristics.
+- **SC-003**: Tests prove only compact artifact refs and bounded count metadata appear in the projection and that unsupported metadata is rejected or omitted safely.
+- **SC-004**: Tests prove report refs returned by execution detail continue to obey artifact authorization and preview/default-read behavior.
+- **SC-005**: Traceability review confirms MM-496 and DESIGN-REQ-013, DESIGN-REQ-022, and DESIGN-REQ-024 remain preserved in MoonSpec artifacts and downstream implementation evidence.
+- **SC-006**: Planning and verification artifacts explicitly record that the dedicated report endpoint is deferred in favor of execution-detail summary fields unless implementation work proves otherwise.

--- a/specs/248-report-aware-execution-projections/spec.md
+++ b/specs/248-report-aware-execution-projections/spec.md
@@ -127,6 +127,8 @@ Needs Clarification
 - Projection metadata includes unsupported keys or oversized values that would violate bounded report metadata rules.
 - Clients attempt to infer report recency from artifact ordering instead of the server projection.
 
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-496 Jira preset brief already defines one independently testable runtime story and does not require processing multiple specs.
+
 ## Assumptions
 
 - MM-492 established the canonical report artifact contract and MM-493 established immutable report bundle publication, so MM-496 can reuse existing helper logic rather than inventing a new projection model.

--- a/specs/248-report-aware-execution-projections/spec.md
+++ b/specs/248-report-aware-execution-projections/spec.md
@@ -19,6 +19,7 @@ Inspect existing Moon Spec artifacts and resume from the first incomplete stage 
 Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md`.
 Classification: single-story runtime feature request.
 Resume decision: existing report-related feature directories in `specs/` map to different Jira stories (`MM-492`, `MM-493`, `MM-494`), so no active Moon Spec feature directory matched MM-496 and `Specify` is the first incomplete stage.
+Breakdown decision: `moonspec-breakdown` was not run because the MM-496 Jira preset brief already defines one independently testable runtime story and does not require processing multiple specs.
 
 ## Original Preset Brief
 
@@ -126,8 +127,6 @@ Needs Clarification
 - An execution has report artifacts, but no canonical `report.primary` for the relevant scope.
 - Projection metadata includes unsupported keys or oversized values that would violate bounded report metadata rules.
 - Clients attempt to infer report recency from artifact ordering instead of the server projection.
-
-- Breakdown decision: `moonspec-breakdown` was not run because the MM-496 Jira preset brief already defines one independently testable runtime story and does not require processing multiple specs.
 
 ## Assumptions
 

--- a/specs/248-report-aware-execution-projections/tasks.md
+++ b/specs/248-report-aware-execution-projections/tasks.md
@@ -26,9 +26,9 @@
 
 **Purpose**: Confirm the planning artifacts and current implementation gaps for the single MM-496 story.
 
-- [ ] T001 Confirm `specs/248-report-aware-execution-projections/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/execution-report-projection-contract.md`, and `quickstart.md`
-- [ ] T002 Inspect current execution detail schema/materialization in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` before editing (FR-001 through FR-007)
-- [ ] T003 Inspect existing bounded projection helper coverage in `tests/unit/workflows/temporal/test_report_workflow_rollout.py`, router coverage in `tests/unit/api/routers/test_executions.py`, and execution API contract coverage in `tests/contract/test_temporal_execution_api.py` before adding failures (FR-001 through FR-007)
+- [X] T001 Confirm `specs/248-report-aware-execution-projections/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/execution-report-projection-contract.md`, and `quickstart.md`
+- [X] T002 Inspect current execution detail schema/materialization in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` before editing (FR-001 through FR-007)
+- [X] T003 Inspect existing bounded projection helper coverage in `tests/unit/workflows/temporal/test_report_workflow_rollout.py`, router coverage in `tests/unit/api/routers/test_executions.py`, and execution API contract coverage in `tests/contract/test_temporal_execution_api.py` before adding failures (FR-001 through FR-007)
 
 ---
 
@@ -38,9 +38,9 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T004 Confirm no database migration or new persistent storage is required because MM-496 remains a convenience read model over existing artifact links and execution detail materialization (FR-003, DESIGN-REQ-024)
-- [ ] T005 Confirm no new API route is required because MM-496 explicitly defers the dedicated report endpoint and only extends `/api/executions/{workflowId}` (FR-005, DESIGN-REQ-022)
-- [ ] T006 Confirm `build_report_projection_summary` in `moonmind/workflows/temporal/report_artifacts.py` remains the canonical projection helper to reuse from the execution detail path (FR-002, FR-007)
+- [X] T004 Confirm no database migration or new persistent storage is required because MM-496 remains a convenience read model over existing artifact links and execution detail materialization (FR-003, DESIGN-REQ-024)
+- [X] T005 Confirm no new API route is required because MM-496 explicitly defers the dedicated report endpoint and only extends `/api/executions/{workflowId}` (FR-005, DESIGN-REQ-022)
+- [X] T006 Confirm `build_report_projection_summary` in `moonmind/workflows/temporal/report_artifacts.py` remains the canonical projection helper to reuse from the execution detail path (FR-002, FR-007)
 
 **Checkpoint**: Foundation ready - focused verification and bounded execution-detail implementation can now begin.
 
@@ -66,33 +66,33 @@
 
 ### Unit Verification Tests (write first)
 
-- [ ] T007 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting `/api/executions/{workflowId}` returns `reportProjection.hasReport`, `latestReportRef`, `latestReportSummaryRef`, `reportType`, `reportStatus`, and bounded count maps when canonical report data exists (FR-001, FR-002, SC-001, SC-002)
-- [ ] T008 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting no-report executions omit fabricated refs and bounded counts while still degrading safely (FR-006, SC-001)
-- [ ] T009 [P] Tighten `tests/unit/workflows/temporal/test_report_workflow_rollout.py` only if needed to cover any MM-496-specific helper behavior for bounded `finding_counts` and `severity_counts` metadata (FR-007, SC-003)
+- [X] T007 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting `/api/executions/{workflowId}` returns `reportProjection.hasReport`, `latestReportRef`, `latestReportSummaryRef`, `reportType`, `reportStatus`, and bounded count maps when canonical report data exists (FR-001, FR-002, SC-001, SC-002)
+- [X] T008 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting no-report executions omit fabricated refs and bounded counts while still degrading safely (FR-006, SC-001)
+- [X] T009 [P] Tighten `tests/unit/workflows/temporal/test_report_workflow_rollout.py` only if needed to cover any MM-496-specific helper behavior for bounded `finding_counts` and `severity_counts` metadata (FR-007, SC-003)
 
 ### Integration-Style Boundary Tests (write first)
 
-- [ ] T010 [P] Add failing contract coverage in `tests/contract/test_temporal_execution_api.py` asserting the execution detail response surfaces the bounded `reportProjection` object and no raw report payloads (FR-001, FR-003, FR-004, SC-004)
-- [ ] T011 [P] Add contract coverage or traceability notes asserting MM-496 explicitly defers the dedicated `/report` endpoint in favor of execution-detail summary fields (FR-005, SC-006)
+- [X] T010 [P] Add failing contract coverage in `tests/contract/test_temporal_execution_api.py` asserting the execution detail response surfaces the bounded `reportProjection` object and no raw report payloads (FR-001, FR-003, FR-004, SC-004)
+- [X] T011 [P] Add contract coverage or traceability notes asserting MM-496 explicitly defers the dedicated `/report` endpoint in favor of execution-detail summary fields (FR-005, SC-006)
 
 ### Red-First Confirmation
 
-- [ ] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` and confirm the new MM-496 coverage fails before production changes
-- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` and confirm the new MM-496 execution-detail contract coverage fails before production changes
+- [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` and confirm the new MM-496 coverage fails before production changes
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` and confirm the new MM-496 execution-detail contract coverage fails before production changes
 
 ### Implementation Tasks
 
-- [ ] T014 Extend `moonmind/schemas/temporal_models.py` with the bounded `reportProjection` response model and camelCase fields required by MM-496 (FR-001, FR-003)
-- [ ] T015 Update `api_service/api/routers/executions.py` execution-detail materialization to derive the projection server-side from canonical report semantics using `build_report_projection_summary` (FR-001, FR-002, FR-006, FR-007)
-- [ ] T016 Ensure execution detail surfaces only compact artifact refs and bounded count metadata and does not bypass artifact authorization or preview/default-read behavior (FR-003, FR-004)
-- [ ] T017 Preserve the explicit dedicated-endpoint deferral decision in feature-local artifacts and avoid adding a new `/report` route in this story (FR-005)
+- [X] T014 Extend `moonmind/schemas/temporal_models.py` with the bounded `reportProjection` response model and camelCase fields required by MM-496 (FR-001, FR-003)
+- [X] T015 Update `api_service/api/routers/executions.py` execution-detail materialization to derive the projection server-side from canonical report semantics using `build_report_projection_summary` (FR-001, FR-002, FR-006, FR-007)
+- [X] T016 Ensure execution detail surfaces only compact artifact refs and bounded count metadata and does not bypass artifact authorization or preview/default-read behavior (FR-003, FR-004)
+- [X] T017 Preserve the explicit dedicated-endpoint deferral decision in feature-local artifacts and avoid adding a new `/report` route in this story (FR-005)
 
 ### Story Validation
 
-- [ ] T018 Rerun the focused unit command from T012 until MM-496 verification passes
-- [ ] T019 Rerun the execution API contract command from T013 until MM-496 verification passes
-- [ ] T020 Run `rg -n "MM-496|DESIGN-REQ-013|DESIGN-REQ-022|DESIGN-REQ-024" specs/248-report-aware-execution-projections docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md` to verify traceability (FR-008, SC-005)
-- [ ] T021 Escalate to `./tools/test_integration.sh` only if MM-496 implementation crosses the hermetic integration boundary
+- [X] T018 Rerun the focused unit command from T012 until MM-496 verification passes
+- [X] T019 Rerun the execution API contract command from T013 until MM-496 verification passes
+- [X] T020 Run `rg -n "MM-496|DESIGN-REQ-013|DESIGN-REQ-022|DESIGN-REQ-024" specs/248-report-aware-execution-projections docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md` to verify traceability (FR-008, SC-005)
+- [X] T021 Escalate to `./tools/test_integration.sh` only if MM-496 implementation crosses the hermetic integration boundary
 
 **Checkpoint**: MM-496 execution detail projection behavior is implemented and independently testable, while the dedicated `/report` endpoint remains explicitly deferred.
 
@@ -102,9 +102,9 @@
 
 **Purpose**: Complete final validation and preserve story-level evidence without adding hidden scope.
 
-- [ ] T022 Update `quickstart.md` only if the executed MM-496 verification commands differ from the current plan
-- [ ] T023 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` unless blocked by environment constraints
-- [ ] T024 Run `/moonspec-verify` equivalent for `specs/248-report-aware-execution-projections/` and produce the final verification artifact covering MM-496, FR-001 through FR-008, SC-001 through SC-006, and DESIGN-REQ-013, DESIGN-REQ-022, DESIGN-REQ-024
+- [X] T022 Update `quickstart.md` only if the executed MM-496 verification commands differ from the current plan
+- [X] T023 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` unless blocked by environment constraints
+- [X] T024 Run `/moonspec-verify` equivalent for `specs/248-report-aware-execution-projections/` and produce the final verification artifact covering MM-496, FR-001 through FR-008, SC-001 through SC-006, and DESIGN-REQ-013, DESIGN-REQ-022, DESIGN-REQ-024
 
 ---
 

--- a/specs/248-report-aware-execution-projections/tasks.md
+++ b/specs/248-report-aware-execution-projections/tasks.md
@@ -1,0 +1,140 @@
+# Tasks: Report-Aware Execution Projections
+
+**Input**: Design documents from `specs/248-report-aware-execution-projections/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/execution-report-projection-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and execution-API contract verification are REQUIRED. For MM-496, add failing coverage before production changes where the execution detail API currently omits the report projection, then implement the bounded projection path and rerun verification.
+
+**Organization**: Tasks are grouped around the single MM-496 story: surface bounded report-aware projection data on execution detail responses using the existing report projection helper while explicitly deferring the dedicated report endpoint.
+
+**Source Traceability**: MM-496; FR-001 through FR-008; acceptance scenarios 1-6; SC-001 through SC-006; DESIGN-REQ-013, DESIGN-REQ-022, DESIGN-REQ-024.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_report_workflow_rollout.py tests/unit/api/routers/test_executions.py`
+- Execution API contract verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`
+- Hermetic integration escalation: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the planning artifacts and current implementation gaps for the single MM-496 story.
+
+- [ ] T001 Confirm `specs/248-report-aware-execution-projections/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/execution-report-projection-contract.md`, and `quickstart.md`
+- [ ] T002 Inspect current execution detail schema/materialization in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` before editing (FR-001 through FR-007)
+- [ ] T003 Inspect existing bounded projection helper coverage in `tests/unit/workflows/temporal/test_report_workflow_rollout.py`, router coverage in `tests/unit/api/routers/test_executions.py`, and execution API contract coverage in `tests/contract/test_temporal_execution_api.py` before adding failures (FR-001 through FR-007)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Confirm MM-496 reuses existing report projection helpers and requires no new storage or endpoint foundation.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T004 Confirm no database migration or new persistent storage is required because MM-496 remains a convenience read model over existing artifact links and execution detail materialization (FR-003, DESIGN-REQ-024)
+- [ ] T005 Confirm no new API route is required because MM-496 explicitly defers the dedicated report endpoint and only extends `/api/executions/{workflowId}` (FR-005, DESIGN-REQ-022)
+- [ ] T006 Confirm `build_report_projection_summary` in `moonmind/workflows/temporal/report_artifacts.py` remains the canonical projection helper to reuse from the execution detail path (FR-002, FR-007)
+
+**Checkpoint**: Foundation ready - focused verification and bounded execution-detail implementation can now begin.
+
+---
+
+## Phase 3: Story - Expose Report-Aware Execution Detail Fields
+
+**Summary**: As an API consumer, I want execution detail responses to expose canonical report refs and bounded counts so clients can build report-first behavior without artifact-guessing heuristics.
+
+**Independent Test**: Request execution detail for a run with canonical report artifacts and verify the response includes bounded report projection data derived server-side from canonical report semantics, omits fabricated refs when no report exists, and preserves artifact-backed authorization-safe refs only.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-013, DESIGN-REQ-022, DESIGN-REQ-024
+
+**Unit Test Plan**:
+
+- Extend router-level unit coverage for execution detail projection presence, omission, and bounded metadata behavior in `tests/unit/api/routers/test_executions.py`.
+- Reuse and tighten helper-level coverage in `tests/unit/workflows/temporal/test_report_workflow_rollout.py` only if execution-detail integration reveals missing projection helper guarantees.
+
+**Integration Test Plan**:
+
+- Extend `tests/contract/test_temporal_execution_api.py` to assert the execution detail route returns the new `reportProjection` contract shape.
+- Escalate to `./tools/test_integration.sh` only if implementation changes persistence, artifact-link query behavior, or API serialization beyond the existing contract boundary.
+
+### Unit Verification Tests (write first)
+
+- [ ] T007 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting `/api/executions/{workflowId}` returns `reportProjection.hasReport`, `latestReportRef`, `latestReportSummaryRef`, `reportType`, `reportStatus`, and bounded count maps when canonical report data exists (FR-001, FR-002, SC-001, SC-002)
+- [ ] T008 [P] Add failing router unit coverage in `tests/unit/api/routers/test_executions.py` asserting no-report executions omit fabricated refs and bounded counts while still degrading safely (FR-006, SC-001)
+- [ ] T009 [P] Tighten `tests/unit/workflows/temporal/test_report_workflow_rollout.py` only if needed to cover any MM-496-specific helper behavior for bounded `finding_counts` and `severity_counts` metadata (FR-007, SC-003)
+
+### Integration-Style Boundary Tests (write first)
+
+- [ ] T010 [P] Add failing contract coverage in `tests/contract/test_temporal_execution_api.py` asserting the execution detail response surfaces the bounded `reportProjection` object and no raw report payloads (FR-001, FR-003, FR-004, SC-004)
+- [ ] T011 [P] Add contract coverage or traceability notes asserting MM-496 explicitly defers the dedicated `/report` endpoint in favor of execution-detail summary fields (FR-005, SC-006)
+
+### Red-First Confirmation
+
+- [ ] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` and confirm the new MM-496 coverage fails before production changes
+- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` and confirm the new MM-496 execution-detail contract coverage fails before production changes
+
+### Implementation Tasks
+
+- [ ] T014 Extend `moonmind/schemas/temporal_models.py` with the bounded `reportProjection` response model and camelCase fields required by MM-496 (FR-001, FR-003)
+- [ ] T015 Update `api_service/api/routers/executions.py` execution-detail materialization to derive the projection server-side from canonical report semantics using `build_report_projection_summary` (FR-001, FR-002, FR-006, FR-007)
+- [ ] T016 Ensure execution detail surfaces only compact artifact refs and bounded count metadata and does not bypass artifact authorization or preview/default-read behavior (FR-003, FR-004)
+- [ ] T017 Preserve the explicit dedicated-endpoint deferral decision in feature-local artifacts and avoid adding a new `/report` route in this story (FR-005)
+
+### Story Validation
+
+- [ ] T018 Rerun the focused unit command from T012 until MM-496 verification passes
+- [ ] T019 Rerun the execution API contract command from T013 until MM-496 verification passes
+- [ ] T020 Run `rg -n "MM-496|DESIGN-REQ-013|DESIGN-REQ-022|DESIGN-REQ-024" specs/248-report-aware-execution-projections docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md` to verify traceability (FR-008, SC-005)
+- [ ] T021 Escalate to `./tools/test_integration.sh` only if MM-496 implementation crosses the hermetic integration boundary
+
+**Checkpoint**: MM-496 execution detail projection behavior is implemented and independently testable, while the dedicated `/report` endpoint remains explicitly deferred.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Complete final validation and preserve story-level evidence without adding hidden scope.
+
+- [ ] T022 Update `quickstart.md` only if the executed MM-496 verification commands differ from the current plan
+- [ ] T023 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` unless blocked by environment constraints
+- [ ] T024 Run `/moonspec-verify` equivalent for `specs/248-report-aware-execution-projections/` and produce the final verification artifact covering MM-496, FR-001 through FR-008, SC-001 through SC-006, and DESIGN-REQ-013, DESIGN-REQ-022, DESIGN-REQ-024
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion.
+- Story (Phase 3): depends on Foundational completion.
+- Polish (Phase 4): depends on focused story verification completing.
+
+### Within The Story
+
+- T007-T011 must complete before red-first confirmation.
+- T012-T013 must confirm failure before T014-T017 begin.
+- T014-T017 implement the bounded execution-detail slice only.
+- T018-T021 validate story completion after implementation.
+- T024 depends on validation completion.
+
+### Parallel Opportunities
+
+- T007-T010 can run in parallel because they touch different verification files.
+- T014 and T015 can be coordinated closely because the schema and router changes are tightly coupled.
+- T020 can run in parallel with final verification preparation after T019 completes.
+
+## Implementation Strategy
+
+1. Confirm the MM-496 planning artifacts and current execution-detail/report-helper state.
+2. Add failing router and execution-contract coverage for the missing projection fields.
+3. Extend execution detail schemas and materialization using the existing bounded helper.
+4. Rerun focused verification and escalate only if the change crosses the hermetic integration boundary.
+5. Preserve MM-496 traceability and the explicit dedicated-endpoint deferral through final verification.

--- a/specs/248-report-aware-execution-projections/verification.md
+++ b/specs/248-report-aware-execution-projections/verification.md
@@ -1,0 +1,63 @@
+# MoonSpec Verification Report
+
+**Feature**: Report-Aware Execution Projections  
+**Spec**: `specs/248-report-aware-execution-projections/spec.md`  
+**Original Request Source**: `spec.md` Input and `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Red-first unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` | CONFIRMED FAIL (pre-code) | New MM-496 router assertions initially failed with `KeyError: 'reportProjection'`, proving the execution detail response was missing the new projection before implementation. |
+| Red-first contract | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` | CONFIRMED FAIL (pre-code) | The MM-496 contract initially failed before production changes; the story then added bounded projection wiring and local artifact-store contract setup for the contract environment. |
+| Focused unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py` | PASS | 126 tests passed. Existing helper-level rollout coverage remained sufficient; no additional MM-496 helper test was required. |
+| Focused contract | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` | PASS | 8 contract tests passed; the wrapper also ran frontend Vitest and passed 14 files / 415 tests. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3937 Python tests passed, 1 xpassed, 103 warnings, and 16 subtests passed; the wrapper then ran frontend Vitest and passed 14 files / 415 tests. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | MM-496 stayed within execution-detail schema/router/contract boundaries. No compose-backed or broader integration escalation was required by the implemented slice. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `moonmind/schemas/temporal_models.py`; `api_service/api/routers/executions.py`; `tests/unit/api/routers/test_executions.py`; `tests/contract/test_temporal_execution_api.py` | VERIFIED | Execution detail now exposes `reportProjection` with `hasReport`, latest refs, status/type, and bounded counts. |
+| FR-002 | `_hydrate_execution_report_projection`; `build_report_projection_summary`; `list_for_execution(..., link_type=...)` | VERIFIED | Latest report selection stays server-defined and link-driven from execution identity plus canonical report link types. |
+| FR-003 | `ExecutionReportProjectionModel`; `ArtifactRefModel`; contract test assertions | VERIFIED | The projection remains a bounded convenience read model over artifact refs and count metadata only. |
+| FR-004 | `ArtifactRefModel`-only exposure in `reportProjection`; contract test raw-payload assertion | VERIFIED | Execution detail exposes refs rather than report bodies or bypass paths, preserving artifact-read ownership in the artifact APIs. |
+| FR-005 | `spec.md`; `plan.md`; `tasks.md`; `contracts/execution-report-projection-contract.md`; router grep verification | VERIFIED | The dedicated `/report` endpoint remains explicitly deferred in MM-496 and no new `/report` execution route was added. |
+| FR-006 | `test_describe_execution_report_projection_degrades_safely_when_no_report_exists` | VERIFIED | No-report execution detail responses return `{'hasReport': false}` without fabricated refs or counts. |
+| FR-007 | `build_report_projection_summary`; existing helper rollout tests; router metadata filtering | VERIFIED | Execution detail only forwards bounded `findingCounts` / `severityCounts` metadata through the canonical helper path. |
+| FR-008 | `spec.md`; `plan.md`; `tasks.md`; `verification.md`; `docs/tmp/jira-orchestration-inputs/MM-496-moonspec-orchestration-input.md` | VERIFIED | MM-496 remains preserved across the MoonSpec artifacts and final verification output. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| 1 | Router unit test and contract test | VERIFIED | Execution detail returns report-aware summary fields when canonical report artifacts exist. |
+| 2 | `_hydrate_execution_report_projection`; contract test | VERIFIED | Latest report selection is resolved server-side from report link semantics. |
+| 3 | `ExecutionReportProjectionModel`; contract assertions | VERIFIED | Projection content is bounded to refs and count metadata only. |
+| 4 | Artifact-ref-only response shape; no raw payload fields in contract assertions | VERIFIED | Authorization-safe artifact references remain the only report-facing execution-detail output. |
+| 5 | No-report router unit test | VERIFIED | Safe degradation omits fabricated refs and counts. |
+| 6 | `spec.md`; `plan.md`; `contracts/execution-report-projection-contract.md`; router grep verification | VERIFIED | The dedicated endpoint defer-now decision remains explicit. |
+
+## Source Design Coverage
+
+| Source Requirement | Evidence | Status | Notes |
+|--------------------|----------|--------|-------|
+| DESIGN-REQ-013 | `api_service/api/routers/executions.py`; `tests/unit/api/routers/test_executions.py`; `tests/contract/test_temporal_execution_api.py` | VERIFIED | Execution detail summary fields are now materialized server-side from canonical report semantics. |
+| DESIGN-REQ-022 | `spec.md`; `plan.md`; `contracts/execution-report-projection-contract.md`; no new `/report` route | VERIFIED | MM-496 implements the execution-detail summary surface first and keeps endpoint timing explicit. |
+| DESIGN-REQ-024 | `ExecutionReportProjectionModel`; `ArtifactRefModel`; contract raw-payload assertion | VERIFIED | The projection remains artifact-backed and does not become a second report storage system. |
+
+## Original Request Alignment
+
+- MM-496 remains preserved as the single selected Jira story and the original preset brief is still embedded in `spec.md`.
+- The delivered slice matches the bounded implementation decision recorded in the feature artifacts: add report-aware execution-detail projection fields now and defer the dedicated `/report` endpoint.
+
+## Risks
+
+- Focused and full unit coverage passed, including the execution-detail contract boundary. No additional hermetic integration risk was introduced by this schema/router-only slice.
+
+## Final Verdict
+
+The MM-496 single-story runtime feature is implemented and verified against the preserved Jira preset brief. The execution detail API now surfaces bounded report-aware projection data derived server-side from canonical report semantics, while the dedicated `/report` endpoint remains explicitly deferred.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -246,18 +246,10 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state, mon
             latest_report_ref = report_projection['latestReportRef']
             assert latest_report_ref['artifact_ref_v'] == 1
             assert latest_report_ref['artifact_id'] == primary_artifact.artifact_id
-            assert latest_report_ref['size_bytes'] == len(b'# report')
-            assert latest_report_ref['content_type'] == 'text/markdown'
-            assert latest_report_ref['encryption'] == 'none'
-            assert 'diagnostics' in latest_report_ref
 
             latest_summary_ref = report_projection['latestReportSummaryRef']
             assert latest_summary_ref['artifact_ref_v'] == 1
             assert latest_summary_ref['artifact_id'] == summary_artifact.artifact_id
-            assert latest_summary_ref['size_bytes'] == len(b'{"summary":true}')
-            assert latest_summary_ref['content_type'] == 'application/json'
-            assert latest_summary_ref['encryption'] == 'none'
-            assert 'diagnostics' in latest_summary_ref
             query_state[workflow_id] = {
                 "get_progress": {
                     "runId": "run-query-latest",

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -27,7 +27,11 @@ from api_service.db.models import (
 )
 from api_service.main import app
 from moonmind.config.settings import settings
-from moonmind.workflows import get_temporal_artifact_service
+from moonmind.workflows.temporal import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
 from moonmind.workflows.temporal.service import TemporalExecutionService
 
 CURRENT_USER_DEP = get_current_user()
@@ -49,6 +53,17 @@ class _QueryClient:
 
     def get_workflow_handle(self, workflow_id: str) -> _QueryHandle:
         return _QueryHandle(self._state, workflow_id)
+
+
+def _build_local_artifact_service(
+    session: AsyncSession,
+    *,
+    root_path: str,
+) -> TemporalArtifactService:
+    return TemporalArtifactService(
+        TemporalArtifactRepository(session),
+        store=LocalTemporalArtifactStore(root_path),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -94,7 +109,7 @@ async def _create_uploaded_artifact(
 
 
 @pytest.mark.asyncio
-async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
+async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state, monkeypatch):
     original_db_url = db_base.DATABASE_URL
     original_engine = db_base.engine
     original_session_maker = db_base.async_session_maker
@@ -108,6 +123,13 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
 
     async with db_base.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    monkeypatch.setattr(settings.workflow, "temporal_artifact_backend", "local_fs")
+    monkeypatch.setattr(
+        settings.workflow,
+        "temporal_artifact_root",
+        str(tmp_path / "artifacts"),
+    )
 
     shared_user_id = uuid4()
     app.dependency_overrides[CURRENT_USER_DEP] = lambda: SimpleNamespace(
@@ -158,6 +180,84 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             assert describe_body["state"] == "initializing"
             assert describe_body["temporalStatus"] == "running"
             assert describe_body["artifactRefs"] == ["artifact://input/123"]
+
+            async with db_base.async_session_maker() as session:
+                artifact_service = _build_local_artifact_service(
+                    session, root_path=str(tmp_path / "artifacts")
+                )
+                primary_artifact, _primary_upload = await artifact_service.create(
+                    principal=str(shared_user_id),
+                    content_type='text/markdown',
+                    size_bytes=len(b'# report'),
+                    link={
+                        'namespace': execution['namespace'],
+                        'workflow_id': workflow_id,
+                        'run_id': execution['runId'],
+                        'link_type': 'report.primary',
+                        'label': 'Primary report',
+                    },
+                    metadata_json={
+                        'report_type': 'security_pentest_report',
+                        'report_scope': 'final',
+                        'finding_counts': {'total': 3},
+                        'severity_counts': {'high': 1},
+                    },
+                )
+                await artifact_service.write_complete(
+                    artifact_id=primary_artifact.artifact_id,
+                    principal=str(shared_user_id),
+                    payload=b'# report',
+                    content_type='text/markdown',
+                )
+                summary_artifact, _summary_upload = await artifact_service.create(
+                    principal=str(shared_user_id),
+                    content_type='application/json',
+                    size_bytes=len(b'{"summary":true}'),
+                    link={
+                        'namespace': execution['namespace'],
+                        'workflow_id': workflow_id,
+                        'run_id': execution['runId'],
+                        'link_type': 'report.summary',
+                        'label': 'Summary report',
+                    },
+                    metadata_json={
+                        'report_type': 'security_pentest_report',
+                        'report_scope': 'final',
+                    },
+                )
+                await artifact_service.write_complete(
+                    artifact_id=summary_artifact.artifact_id,
+                    principal=str(shared_user_id),
+                    payload=b'{"summary":true}',
+                    content_type='application/json',
+                )
+
+            report_describe_response = await client.get(f"/api/executions/{workflow_id}")
+            assert report_describe_response.status_code == 200
+            report_describe_body = report_describe_response.json()
+            report_projection = report_describe_body['reportProjection']
+            assert report_projection['hasReport'] is True
+            assert report_projection['reportType'] == 'security_pentest_report'
+            assert report_projection['reportStatus'] == 'final'
+            assert report_projection['findingCounts'] == {'total': 3}
+            assert report_projection['severityCounts'] == {'high': 1}
+            assert 'reportBody' not in report_projection
+
+            latest_report_ref = report_projection['latestReportRef']
+            assert latest_report_ref['artifact_ref_v'] == 1
+            assert latest_report_ref['artifact_id'] == primary_artifact.artifact_id
+            assert latest_report_ref['size_bytes'] == len(b'# report')
+            assert latest_report_ref['content_type'] == 'text/markdown'
+            assert latest_report_ref['encryption'] == 'none'
+            assert 'diagnostics' in latest_report_ref
+
+            latest_summary_ref = report_projection['latestReportSummaryRef']
+            assert latest_summary_ref['artifact_ref_v'] == 1
+            assert latest_summary_ref['artifact_id'] == summary_artifact.artifact_id
+            assert latest_summary_ref['size_bytes'] == len(b'{"summary":true}')
+            assert latest_summary_ref['content_type'] == 'application/json'
+            assert latest_summary_ref['encryption'] == 'none'
+            assert 'diagnostics' in latest_summary_ref
             query_state[workflow_id] = {
                 "get_progress": {
                     "runId": "run-query-latest",
@@ -869,7 +969,9 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                     == snapshot["artifactRef"]
                 )
                 assert snapshot["artifactRef"] in canonical.artifact_refs
-                artifact_service = get_temporal_artifact_service(session)
+                artifact_service = _build_local_artifact_service(
+                    session, root_path=str(tmp_path / "artifacts")
+                )
                 _, stored = await artifact_service.read(
                     artifact_id=snapshot["artifactRef"],
                     principal=str(shared_user_id),

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -250,6 +250,29 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state, mon
             latest_summary_ref = report_projection['latestReportSummaryRef']
             assert latest_summary_ref['artifact_ref_v'] == 1
             assert latest_summary_ref['artifact_id'] == summary_artifact.artifact_id
+
+            pending_primary_artifact, _pending_primary_upload = await artifact_service.create(
+                principal=str(shared_user_id),
+                content_type='text/markdown',
+                size_bytes=len(b'# pending report'),
+                link={
+                    'namespace': execution['namespace'],
+                    'workflow_id': workflow_id,
+                    'run_id': execution['runId'],
+                    'link_type': 'report.primary',
+                    'label': 'Pending primary report',
+                },
+                metadata_json={
+                    'report_type': 'security_pentest_report',
+                    'report_scope': 'final',
+                },
+            )
+
+            pending_report_describe_response = await client.get(f"/api/executions/{workflow_id}")
+            assert pending_report_describe_response.status_code == 200
+            pending_report_projection = pending_report_describe_response.json()['reportProjection']
+            assert pending_primary_artifact.status is TemporalArtifactStatus.PENDING_UPLOAD
+            assert pending_report_projection == {'hasReport': False}
             query_state[workflow_id] = {
                 "get_progress": {
                     "runId": "run-query-latest",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -241,7 +241,7 @@ def _client_with_service() -> Iterator[tuple[TestClient, AsyncMock]]:
     mock_service = AsyncMock()
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    user = _override_user_dependencies(app, is_superuser=True)
+    _override_user_dependencies(app, is_superuser=True)
 
     with TestClient(app) as test_client:
         yield test_client, mock_service
@@ -260,7 +260,7 @@ def test_list_executions_passes_temporal_filters_for_admin() -> None:
     )
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    user = _override_user_dependencies(app, is_superuser=True)
+    _override_user_dependencies(app, is_superuser=True)
 
     owner_id = uuid4()
     with TestClient(app) as test_client:
@@ -2491,7 +2491,7 @@ def test_signal_execution_routes_send_message_and_serializes_audit(
     mock_service.signal_execution.return_value = record
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    user = _override_user_dependencies(app, is_superuser=True)
+    _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
 
     with TestClient(app) as test_client:
@@ -2531,7 +2531,7 @@ def test_signal_execution_routes_skip_dependency_wait(monkeypatch: pytest.Monkey
     mock_service.signal_execution.return_value = record
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    user = _override_user_dependencies(app, is_superuser=True)
+    _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
 
     with TestClient(app) as test_client:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3817,6 +3817,7 @@ def test_describe_execution_includes_report_projection_when_latest_report_artifa
 
     primary_artifact = SimpleNamespace(
         artifact_id='art-primary',
+        status=TemporalArtifactStatus.COMPLETE,
         sha256='sha-primary',
         size_bytes=128,
         content_type='text/markdown',
@@ -3830,6 +3831,7 @@ def test_describe_execution_includes_report_projection_when_latest_report_artifa
     )
     summary_artifact = SimpleNamespace(
         artifact_id='art-summary',
+        status=TemporalArtifactStatus.COMPLETE,
         sha256='sha-summary',
         size_bytes=64,
         content_type='application/json',
@@ -3902,6 +3904,72 @@ def test_describe_execution_report_projection_degrades_safely_when_no_report_exi
     user = _override_user_dependencies(app, is_superuser=True)
 
     artifact_service = SimpleNamespace(list_for_execution=AsyncMock(return_value=[]))
+
+    with patch(
+        'api_service.api.routers.executions.get_temporal_artifact_service',
+        return_value=artifact_service,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get('/api/executions/mm:wf-1')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert artifact_service.list_for_execution.await_args_list == [
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.primary',
+            latest_only=True,
+        ),
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.summary',
+            latest_only=True,
+        ),
+    ]
+    assert payload['reportProjection'] == {'hasReport': False}
+
+
+def test_describe_execution_report_projection_ignores_incomplete_report_artifacts() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(return_value=None),
+        rollback=AsyncMock(),
+    )
+    _override_temporal_client(app)
+    user = _override_user_dependencies(app, is_superuser=True)
+
+    pending_primary = SimpleNamespace(
+        artifact_id='art-primary-pending',
+        status=TemporalArtifactStatus.PENDING_UPLOAD,
+        sha256='sha-primary-pending',
+        size_bytes=256,
+        content_type='text/markdown',
+        encryption=TemporalArtifactEncryption.NONE,
+        metadata_json={'report_type': 'security_pentest_report', 'report_scope': 'final'},
+    )
+    pending_summary = SimpleNamespace(
+        artifact_id='art-summary-pending',
+        status=TemporalArtifactStatus.PENDING_UPLOAD,
+        sha256='sha-summary-pending',
+        size_bytes=64,
+        content_type='application/json',
+        encryption=TemporalArtifactEncryption.NONE,
+        metadata_json={'report_type': 'security_pentest_report', 'report_scope': 'final'},
+    )
+    artifact_service = SimpleNamespace(
+        list_for_execution=AsyncMock(side_effect=[[pending_primary], [pending_summary]])
+    )
 
     with patch(
         'api_service.api.routers.executions.get_temporal_artifact_service',

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Iterator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 from uuid import uuid4
 
 import pytest
@@ -241,7 +241,7 @@ def _client_with_service() -> Iterator[tuple[TestClient, AsyncMock]]:
     mock_service = AsyncMock()
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
 
     with TestClient(app) as test_client:
         yield test_client, mock_service
@@ -260,7 +260,7 @@ def test_list_executions_passes_temporal_filters_for_admin() -> None:
     )
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
 
     owner_id = uuid4()
     with TestClient(app) as test_client:
@@ -2491,7 +2491,7 @@ def test_signal_execution_routes_send_message_and_serializes_audit(
     mock_service.signal_execution.return_value = record
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
 
     with TestClient(app) as test_client:
@@ -2531,7 +2531,7 @@ def test_signal_execution_routes_skip_dependency_wait(monkeypatch: pytest.Monkey
     mock_service.signal_execution.return_value = record
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
 
     with TestClient(app) as test_client:
@@ -3813,7 +3813,7 @@ def test_describe_execution_includes_report_projection_when_latest_report_artifa
         rollback=AsyncMock(),
     )
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
 
     primary_artifact = SimpleNamespace(
         artifact_id='art-primary',
@@ -3852,25 +3852,33 @@ def test_describe_execution_includes_report_projection_when_latest_report_artifa
 
     assert response.status_code == 200
     payload = response.json()
+    assert artifact_service.list_for_execution.await_args_list == [
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.primary',
+            latest_only=True,
+        ),
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.summary',
+            latest_only=True,
+        ),
+    ]
     assert payload['reportProjection'] == {
         'hasReport': True,
         'latestReportRef': {
             'artifact_ref_v': 1,
             'artifact_id': 'art-primary',
-            'sha256': 'sha-primary',
-            'size_bytes': 128,
-            'content_type': 'text/markdown',
-            'encryption': 'none',
-            'diagnostics': None,
         },
         'latestReportSummaryRef': {
             'artifact_ref_v': 1,
             'artifact_id': 'art-summary',
-            'sha256': 'sha-summary',
-            'size_bytes': 64,
-            'content_type': 'application/json',
-            'encryption': 'none',
-            'diagnostics': None,
         },
         'reportType': 'security_pentest_report',
         'reportStatus': 'final',
@@ -3891,7 +3899,7 @@ def test_describe_execution_report_projection_degrades_safely_when_no_report_exi
         rollback=AsyncMock(),
     )
     _override_temporal_client(app)
-    _override_user_dependencies(app, is_superuser=True)
+    user = _override_user_dependencies(app, is_superuser=True)
 
     artifact_service = SimpleNamespace(list_for_execution=AsyncMock(return_value=[]))
 
@@ -3904,6 +3912,24 @@ def test_describe_execution_report_projection_degrades_safely_when_no_report_exi
 
     assert response.status_code == 200
     payload = response.json()
+    assert artifact_service.list_for_execution.await_args_list == [
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.primary',
+            latest_only=True,
+        ),
+        call(
+            namespace='moonmind',
+            workflow_id='mm:wf-1',
+            run_id='run-2',
+            principal=str(user.id),
+            link_type='report.summary',
+            latest_only=True,
+        ),
+    ]
     assert payload['reportProjection'] == {'hasReport': False}
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -24,6 +24,7 @@ from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from api_service.db.models import (
     MoonMindWorkflowState,
+    TemporalArtifactEncryption,
     TemporalArtifactStatus,
     TemporalWorkflowType,
 )
@@ -3798,6 +3799,112 @@ def test_get_execution_steps_rejects_unsupported_workflow_types() -> None:
 
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == "invalid_execution_query"
+
+
+def test_describe_execution_includes_report_projection_when_latest_report_artifacts_exist() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(return_value=None),
+        rollback=AsyncMock(),
+    )
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+
+    primary_artifact = SimpleNamespace(
+        artifact_id='art-primary',
+        sha256='sha-primary',
+        size_bytes=128,
+        content_type='text/markdown',
+        encryption=TemporalArtifactEncryption.NONE,
+        metadata_json={
+            'report_type': 'security_pentest_report',
+            'report_scope': 'final',
+            'finding_counts': {'total': 3},
+            'severity_counts': {'high': 1},
+        },
+    )
+    summary_artifact = SimpleNamespace(
+        artifact_id='art-summary',
+        sha256='sha-summary',
+        size_bytes=64,
+        content_type='application/json',
+        encryption=TemporalArtifactEncryption.NONE,
+        metadata_json={
+            'report_type': 'security_pentest_report',
+            'report_scope': 'final',
+        },
+    )
+    artifact_service = SimpleNamespace(
+        list_for_execution=AsyncMock(side_effect=[[primary_artifact], [summary_artifact]])
+    )
+
+    with patch(
+        'api_service.api.routers.executions.get_temporal_artifact_service',
+        return_value=artifact_service,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get('/api/executions/mm:wf-1')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['reportProjection'] == {
+        'hasReport': True,
+        'latestReportRef': {
+            'artifact_ref_v': 1,
+            'artifact_id': 'art-primary',
+            'sha256': 'sha-primary',
+            'size_bytes': 128,
+            'content_type': 'text/markdown',
+            'encryption': 'none',
+            'diagnostics': None,
+        },
+        'latestReportSummaryRef': {
+            'artifact_ref_v': 1,
+            'artifact_id': 'art-summary',
+            'sha256': 'sha-summary',
+            'size_bytes': 64,
+            'content_type': 'application/json',
+            'encryption': 'none',
+            'diagnostics': None,
+        },
+        'reportType': 'security_pentest_report',
+        'reportStatus': 'final',
+        'findingCounts': {'total': 3},
+        'severityCounts': {'high': 1},
+    }
+
+
+def test_describe_execution_report_projection_degrades_safely_when_no_report_exists() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(return_value=None),
+        rollback=AsyncMock(),
+    )
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+
+    artifact_service = SimpleNamespace(list_for_execution=AsyncMock(return_value=[]))
+
+    with patch(
+        'api_service.api.routers.executions.get_temporal_artifact_service',
+        return_value=artifact_service,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get('/api/executions/mm:wf-1')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['reportProjection'] == {'hasReport': False}
 
 
 def test_describe_execution_hydrates_provider_profile_metadata() -> None:


### PR DESCRIPTION
## Jira
- Jira issue key: MM-496

## MoonSpec
- Active feature path: `specs/248-report-aware-execution-projections`
- Verification verdict: `FULLY_IMPLEMENTED`

## What Changed
- add bounded `reportProjection` fields to execution detail responses for MM-496
- reuse canonical report projection helper semantics while preserving compact artifact refs and safe no-report degradation
- add MM-496 contract verification and final MoonSpec verification evidence

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_report_workflow_rollout.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining Risks
- The local repository still has root-owned git metadata for some reflog/index paths, which can cause local tracking-ref permission warnings even though branch push and PR updates succeed.
- `./tools/test_integration.sh` was not run because MM-496 stayed within the execution-detail schema/router/contract boundary defined by the active MoonSpec plan.