### PR TITLE
Run Jira Orchestrate for MM-500: Implement profile-backed workload and helper tool contracts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/248-enforce-docker-workflow-modes-and-registry-gating"
+  "feature_directory": "specs/249-profile-backed-workload-contracts"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,22 @@
 [
   {
-    "id": 4167329002,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; the actionable line comments below were evaluated and resolved individually."
+    "id": 3135151857,
+    "disposition": "addressed",
+    "rationale": "Switched the new test to the canonical skill wrapper imports and removed the duplicated tool-module imports."
   },
   {
-    "id": 3134994540,
+    "id": 3135151861,
     "disposition": "addressed",
-    "rationale": "Unrestricted Docker CLI execution now replaces the leading docker token with the configured runtime binary so commands no longer become 'docker docker ...'."
+    "rationale": "Added the explicit SkillRegistrySnapshot return type to _snapshot for clearer typing."
   },
   {
-    "id": 3134994545,
+    "id": 3135151866,
     "disposition": "addressed",
-    "rationale": "The helper-side unrestricted Docker path now reuses the same normalized command builder and handles unrestricted requests before profile-only validation."
+    "rationale": "Pinned both helper calls to the same explicit stepId so the stop path targets the same deterministic helper container name."
   },
   {
-    "id": 3134994548,
+    "id": 3135151868,
     "disposition": "addressed",
-    "rationale": "The unrestricted fallback runner profile is now a module-level constant instead of being revalidated from a hardcoded dict on every invocation."
-  },
-  {
-    "id": 3134994551,
-    "disposition": "addressed",
-    "rationale": "The helper path now shares the module-level unrestricted runner profile and unrestricted arg builder instead of repeating inline model validation."
-  },
-  {
-    "id": 3134994554,
-    "disposition": "addressed",
-    "rationale": "Default timeout and kill-grace values are now centralized as module-level constants and reused across labels, diagnostics, and timeout handling."
-  },
-  {
-    "id": 3134994556,
-    "disposition": "addressed",
-    "rationale": "Workflow Docker mode normalization is now centralized in a shared module used by both settings and the tool bridge, removing the duplicated implementation."
-  },
-  {
-    "id": 3134997019,
-    "disposition": "addressed",
-    "rationale": "Removed the unused CONTAINER_RUN_CONTAINER_TOOL import from the Temporal worker runtime unit test."
-  },
-  {
-    "id": 3135008658,
-    "disposition": "addressed",
-    "rationale": "Unrestricted workload requests no longer dereference profile-only concurrency metadata; the launcher now skips per-profile concurrency caps when profile=None and covers the path with a regression test."
+    "rationale": "Updated the disabled-mode test to assert the dispatcher omits handlers and fails with the missing-handler message that matches current disabled-mode behavior."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md
@@ -1,0 +1,67 @@
+# MM-500 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-500
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Implement profile-backed workload and helper tool contracts
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-500 from MM project
+Summary: Implement profile-backed workload and helper tool contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-500 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-500: Implement profile-backed workload and helper tool contracts
+
+Source Reference
+- Source document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source sections:
+  - 7. Supported container roles
+  - 11. User-facing tool surface
+  - 12. Runner profile model
+  - 18.1 Unreal test run in profiles mode
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-017
+  - DESIGN-REQ-018
+  - DESIGN-REQ-025
+
+User Story
+As a workflow author, I can run curated and profile-backed workload containers and helpers through stable MoonMind tool contracts that validate against runner profiles instead of raw container inputs.
+
+Acceptance Criteria
+- Given mode is profiles or unrestricted, when `container.run_workload` is invoked with an approved `profileId`, then MoonMind resolves the runner profile and launches the workload with profile-defined mounts, env policy, resources, timeout, and cleanup.
+- Given `container.run_workload` is invoked with raw image strings, arbitrary host-path mounts, or unrestricted privilege fields, then validation fails because the contract remains profile-backed.
+- Given `container.start_helper` and `container.stop_helper` are invoked with an approved helper profile, then MoonMind treats the helper as an explicitly owned, bounded workload lifecycle rather than an arbitrary detached service.
+- Given mode is disabled, when any profile-backed workload or helper tool is invoked, then the request is denied deterministically.
+
+Requirements
+- Keep `container.run_workload` generic but strictly profile-validated.
+- Preserve bounded helper semantics for `container.start_helper` and `container.stop_helper`.
+- Model normal execution around runner profiles rather than unrestricted image strings.
+- Keep curated domain tools such as `unreal.run_tests` aligned with the same DooD execution model.
+
+Relevant Implementation Notes
+- Preserve MM-500 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for supported container roles, the user-facing tool surface, runner profile modeling, and Unreal test execution in profiles mode.
+- Keep workload and helper execution contracts profile-backed; do not widen them to arbitrary image, mount, or privilege inputs.
+- Ensure helper lifecycle semantics remain explicitly owned and bounded rather than detached-service style.
+- Keep curated domain tools aligned with the same runner-profile and DooD execution model as the generic container tools.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-500 blocks MM-499, whose embedded status is In Progress.
+- Trusted Jira link metadata at fetch time shows MM-500 is blocked by MM-501, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/specs/249-profile-backed-workload-contracts/checklists/requirements.md
+++ b/specs/249-profile-backed-workload-contracts/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Profile-Backed Workload Contracts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-24  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated against `specs/249-profile-backed-workload-contracts/spec.md` on 2026-04-24. The spec preserves the original MM-500 Jira preset brief, one story, mapped source requirements, measurable success criteria, and bounded runtime scope.

--- a/specs/249-profile-backed-workload-contracts/contracts/profile-backed-workload-contract.md
+++ b/specs/249-profile-backed-workload-contracts/contracts/profile-backed-workload-contract.md
@@ -1,0 +1,80 @@
+# Contract: Profile-Backed Workload And Helper Tools
+
+## Purpose
+
+Define the runtime contract for MM-500: approved Docker-backed workloads and helpers stay profile-backed rather than widening into arbitrary raw container requests.
+
+## In-Scope Tool Surface
+
+Profile-backed normal-path tools:
+
+- `container.run_workload`
+- `container.start_helper`
+- `container.stop_helper`
+
+Curated tools that must remain aligned with the same runner-profile model:
+
+- `unreal.run_tests`
+- `moonmind.integration_ci`
+
+## `container.run_workload`
+
+Contract rules:
+
+- requires an approved `profileId`
+- resolves through the runner profile registry before launch
+- accepts workspace-rooted `repoDir` and `artifactsDir`
+- accepts command and bounded overrides that stay within the selected runner profile
+- must not accept raw image selection, arbitrary host-path mounts, unrestricted device requests, or unrestricted privilege fields
+
+Expected outcome:
+
+- validated profile-backed requests launch through the workload launcher with runner-profile-defined mounts, env policy, resources, timeout, and cleanup
+- invalid raw-container fields fail before launch with a deterministic invalid-input outcome
+
+## `container.start_helper` And `container.stop_helper`
+
+Contract rules:
+
+- require an approved helper profile
+- preserve bounded-service lifecycle semantics rather than detached-service semantics
+- helper start returns readiness metadata
+- helper stop returns teardown metadata and preserves the explicit stop reason when provided
+
+Expected outcome:
+
+- helper lifecycle remains explicitly owned by the workload plane
+- helper readiness and teardown metadata stay artifact/result-backed
+
+## Disabled-Mode Behavior
+
+When workflow Docker mode is `disabled`:
+
+- profile-backed workload and helper tools must not execute
+- the runtime returns a deterministic denial outcome instead of launching the request
+
+## Curated Tool Alignment
+
+Curated domain tools must stay on the same runner-profile-backed path:
+
+- `unreal.run_tests` selects a curated approved profile and command shape
+- `moonmind.integration_ci` selects a curated approved profile and command shape
+
+These tools must not drift into raw runtime-selected container behavior.
+
+## Testing Requirements
+
+Unit coverage must verify:
+
+- profile-backed request validation
+- raw-container input rejection
+- bounded helper lifecycle behavior
+- curated-tool runner-profile alignment
+- disabled-mode denial
+
+Hermetic integration coverage must verify:
+
+- dispatcher-boundary execution of an approved profile-backed workload
+- dispatcher-boundary helper lifecycle behavior
+- dispatcher-boundary rejection of raw container fields
+- dispatcher-boundary denial when disabled mode forbids the profile-backed path

--- a/specs/249-profile-backed-workload-contracts/plan.md
+++ b/specs/249-profile-backed-workload-contracts/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Profile-Backed Workload Contracts
+
+**Branch**: `249-profile-backed-workload-contracts` | **Date**: 2026-04-24 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/249-profile-backed-workload-contracts/spec.md`
+
+## Summary
+
+MM-500 is a runtime verification-first story. The repository already contains the core profile-backed workload contract in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workloads/docker_launcher.py`, and `moonmind/workflows/temporal/activity_runtime.py`, plus strong unit coverage for one-shot workloads, bounded helpers, disabled-mode denial, and curated workload tools. The remaining orchestration work is to capture MM-500 in MoonSpec artifacts, add a hermetic integration boundary that proves the existing contract at the dispatcher/runtime edge, and verify that the current code satisfies the source-design requirements without widening the profile-backed path.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/schemas/workload_models.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| FR-002 | implemented_verified | `moonmind/workloads/registry.py`, `moonmind/workloads/docker_launcher.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| FR-003 | implemented_verified | `moonmind/schemas/workload_models.py`, `moonmind/workloads/tool_bridge.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| FR-004 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workflows/temporal/activity_runtime.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| FR-005 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+| FR-006 | implemented_verified | `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workloads/tool_bridge.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| FR-007 | implemented_verified | `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md`, `specs/249-profile-backed-workload-contracts/spec.md`, `plan.md`, `research.md`, `contracts/profile-backed-workload-contract.md`, `quickstart.md`, `tasks.md` | preserve MM-500 through final verification output | traceability review |
+| DESIGN-REQ-012 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-017 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/schemas/workload_models.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-018 | implemented_verified | `moonmind/workloads/registry.py`, `moonmind/workloads/docker_launcher.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/integration/temporal/test_profile_backed_workload_contract.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-025 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing Docker workload launcher/registry stack, pytest  
+**Storage**: No new persistent storage; existing workload registry, launcher, and artifact-backed workload outputs only  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workloads/test_docker_workload_launcher.py`  
+**Integration Testing**: `./tools/test_integration.sh`  
+**Target Platform**: MoonMind worker runtime and Docker-backed workload tool path  
+**Project Type**: Backend runtime and verification story for Docker-backed workload contracts  
+**Performance Goals**: Preserve deterministic low-overhead request validation and workload dispatch with no additional runtime storage or orchestration layers  
+**Constraints**: Keep the workload and helper tool contracts profile-backed; do not widen `container.run_workload`; keep helper lifecycle explicitly bounded; preserve disabled-mode deterministic denial; keep curated tools aligned with the same runner-profile model; preserve MM-500 traceability  
+**Scale/Scope**: One story covering profile-backed one-shot workloads, bounded helpers, curated-tool alignment, disabled-mode denial, and MoonSpec traceability for MM-500
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - continues to use the existing workload tool and Temporal runtime boundaries instead of inventing a new execution path.
+- II. One-Click Agent Deployment: PASS - no new service or operator prerequisite is introduced.
+- III. Avoid Vendor Lock-In: PASS - all changes stay inside MoonMind-owned workload contracts.
+- IV. Own Your Data: PASS - workload outputs remain artifact-backed on operator-controlled infrastructure.
+- V. Skills Are First-Class and Easy to Add: PASS - the story keeps workload execution on the tool/skill path.
+- VI. Replaceable AI Scaffolding: PASS - work focuses on durable runtime policy and evidence, not agent-specific scaffolding.
+- VII. Runtime Configurability: PASS - preserves deployment-owned Docker mode behavior already normalized in runtime settings.
+- VIII. Modular and Extensible Architecture: PASS - changes stay localized to feature artifacts and an integration boundary test.
+- IX. Resilient by Default: PASS - disabled-mode denial and bounded helper ownership remain explicit and test-covered.
+- X. Facilitate Continuous Improvement: PASS - final verification will produce concrete MM-500 evidence and gaps if any remain.
+- XI. Spec-Driven Development: PASS - MM-500 Jira brief and spec remain the source of truth.
+- XII. Canonical Documentation Separation: PASS - source requirements remain in `docs/ManagedAgents/DockerOutOfDocker.md`; implementation planning stays feature-local.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliasing or fallback behavior is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/249-profile-backed-workload-contracts/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+├── contracts/
+│   └── profile-backed-workload-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/schemas/
+└── workload_models.py
+
+moonmind/workloads/
+├── docker_launcher.py
+├── registry.py
+└── tool_bridge.py
+
+moonmind/workflows/temporal/
+└── activity_runtime.py
+
+tests/unit/workloads/
+├── test_docker_workload_launcher.py
+├── test_workload_contract.py
+└── test_workload_tool_bridge.py
+
+tests/unit/workflows/temporal/
+└── test_workload_run_activity.py
+
+tests/integration/temporal/
+├── test_integration_ci_tool_contract.py
+└── test_profile_backed_workload_contract.py
+```
+
+**Structure Decision**: MM-500 stays entirely on the existing Docker-backed workload path. No new data model, API router, or workflow type is needed; the only code addition is a focused `integration_ci` dispatcher-boundary test file that proves the already-implemented profile-backed contract at the integration layer.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/249-profile-backed-workload-contracts/quickstart.md
+++ b/specs/249-profile-backed-workload-contracts/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Profile-Backed Workload Contracts
+
+## Goal
+
+Verify MM-500 using the existing profile-backed workload implementation plus the feature-local integration boundary.
+
+## Focused Unit Verification
+
+Run the workload contract and launcher-focused unit suites first:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workloads/test_docker_workload_launcher.py
+```
+
+What this proves:
+
+- approved profile-backed workload requests validate through runner profiles
+- raw image, mount, device, and privilege fields are rejected
+- bounded helper lifecycle behavior remains explicit
+- disabled-mode denial is deterministic at the runtime boundary
+
+## Hermetic Integration Verification
+
+Run the hermetic integration suite after the MM-500 integration boundary is in place:
+
+```bash
+./tools/test_integration.sh
+```
+
+Focused integration coverage target:
+
+- `tests/integration/temporal/test_profile_backed_workload_contract.py`
+- existing curated-tool evidence in `tests/integration/temporal/test_integration_ci_tool_contract.py`
+
+What this proves:
+
+- the dispatcher/runtime boundary executes approved profile-backed workloads through a runner profile
+- helper lifecycle remains bounded-service behavior at the integration layer
+- raw container fields are rejected at the dispatcher/runtime boundary
+- disabled mode denies the profile-backed tool path deterministically
+
+## End-To-End Story Validation
+
+1. Confirm `spec.md`, `plan.md`, `research.md`, `contracts/profile-backed-workload-contract.md`, `quickstart.md`, and `tasks.md` preserve MM-500 and the original Jira preset brief.
+2. Run the focused unit verification command.
+3. Run the hermetic integration verification command.
+4. Reuse the existing curated-tool evidence for `unreal.run_tests` and `moonmind.integration_ci`.
+5. Complete final MoonSpec verification against MM-500, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-012, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-025.

--- a/specs/249-profile-backed-workload-contracts/research.md
+++ b/specs/249-profile-backed-workload-contracts/research.md
@@ -1,0 +1,81 @@
+# Research: Profile-Backed Workload Contracts
+
+## Story Classification
+
+Decision: Treat MM-500 as a single-story runtime verification-first feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md`; `specs/249-profile-backed-workload-contracts/spec.md`.
+Rationale: The Jira preset brief defines one independently testable runtime outcome: profile-backed workload and helper tools stay on approved runner profiles rather than widening into arbitrary raw container inputs.
+Alternatives considered: Broad design breakdown was rejected because the Jira brief already selects one bounded story.
+Test implications: Unit tests plus at least one hermetic integration boundary are required because the story touches dispatcher/runtime execution behavior.
+
+## FR-001 / DESIGN-REQ-017 Profile-Backed `container.run_workload`
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` defines `container.run_workload` as a profile-backed tool requiring `profileId`; `moonmind/schemas/workload_models.py` validates `WorkloadRequest`; `tests/unit/workloads/test_workload_tool_bridge.py` verifies the tool definition and handler behavior; `tests/integration/temporal/test_profile_backed_workload_contract.py` verifies dispatcher execution against an approved runner profile.
+Rationale: The one-shot workload tool already routes through the existing runner-profile model and no production gap remained after adding the integration boundary.
+Alternatives considered: Classify as implemented_unverified. Rejected after the dispatcher-boundary integration test confirmed the same contract at the integration layer.
+Test implications: Maintain unit plus integration evidence.
+
+## FR-002 / DESIGN-REQ-012 / DESIGN-REQ-018 Runner Profile Resolution And Launch Policy
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/registry.py` resolves and validates profile-backed requests; `moonmind/workloads/docker_launcher.py` applies runner-profile mounts, env policy, timeout, cleanup, and helper lifecycle; `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, and `tests/integration/temporal/test_profile_backed_workload_contract.py` cover these behaviors.
+Rationale: The current repo already enforces runner-profile-defined policy at validation and launch time, and the integration boundary now proves the dispatcher reaches that validated path.
+Alternatives considered: Add production-code changes to restate existing policy. Rejected because the behavior already exists and the missing gap was proof, not implementation.
+Test implications: Preserve unit and integration coverage for registry validation and launcher behavior.
+
+## FR-003 / DESIGN-REQ-017 Raw Container Input Rejection
+
+Decision: implemented_verified.
+Evidence: `moonmind/schemas/workload_models.py` and `moonmind/workloads/tool_bridge.py` reject unsupported request fields; `tests/unit/workloads/test_workload_tool_bridge.py` covers `image`, `mounts`, `devices`, and `privileged`; `tests/integration/temporal/test_profile_backed_workload_contract.py` verifies dispatcher-boundary rejection of raw fields.
+Rationale: The profile-backed tool surface already fails closed against raw container-shape input.
+Alternatives considered: Add more request-model complexity or a separate rejection layer. Rejected because the existing contract already expresses the policy cleanly.
+Test implications: Keep both unit and integration invalid-input coverage.
+
+## FR-004 / DESIGN-REQ-012 / DESIGN-REQ-018 Bounded Helper Lifecycle
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` maps `container.start_helper` and `container.stop_helper`; `moonmind/workloads/docker_launcher.py` implements readiness and teardown behavior; `moonmind/workflows/temporal/activity_runtime.py` dispatches helper tools by `toolName`; `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, and `tests/integration/temporal/test_profile_backed_workload_contract.py` verify helper lifecycle metadata.
+Rationale: Helper lifecycle ownership is already explicitly bounded and the integration boundary now proves it through the tool dispatcher.
+Alternatives considered: Treat helpers as detached services. Rejected because the source design explicitly forbids that shape.
+Test implications: Keep unit and integration evidence for readiness and teardown behavior.
+
+## FR-005 / DESIGN-REQ-025 Curated Tool Alignment
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` keeps `unreal.run_tests` and `moonmind.integration_ci` on curated runner profiles; `tests/unit/workloads/test_workload_tool_bridge.py` verifies curated command/profile behavior; `tests/integration/temporal/test_integration_ci_tool_contract.py` verifies profile-backed integration-ci routing.
+Rationale: Curated domain tools already align with the same runner-profile-backed execution model.
+Alternatives considered: Add duplicate curated-tool tests inside MM-500. Rejected because existing verified integration evidence already covers that adjacent boundary.
+Test implications: Final verification should reuse the existing curated-tool evidence rather than add redundant runtime code.
+
+## FR-006 Disabled-Mode Denial
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` denies forbidden tools via `tool_allowed_for_workflow_docker_mode`; `moonmind/workflows/temporal/activity_runtime.py` returns deterministic application errors for disabled mode; `tests/unit/workflows/temporal/test_workload_run_activity.py` and `tests/integration/temporal/test_profile_backed_workload_contract.py` verify denial.
+Rationale: Disabled-mode denial is already implemented and now verified at the dispatcher boundary for the MM-500 tool path.
+Alternatives considered: Add separate runtime code for profile-backed denial. Rejected because current behavior already matches the story.
+Test implications: Preserve deterministic-denial integration coverage.
+
+## FR-007 Traceability
+
+Decision: implemented_verified.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md`; `specs/249-profile-backed-workload-contracts/spec.md`; `plan.md`; `research.md`; `contracts/profile-backed-workload-contract.md`; `quickstart.md`; `tasks.md`.
+Rationale: The feature-local MoonSpec artifact set now preserves MM-500 and the original Jira preset brief for downstream work and verification.
+Alternatives considered: Preserve the Jira key only in the source brief. Rejected because the story explicitly requires downstream traceability.
+Test implications: Final traceability review only.
+
+## Design Artifact Decision
+
+Decision: create a feature-local contract artifact and skip `data-model.md`.
+Evidence: MM-500 changes runtime tool-contract verification and traceability only; it does not add persisted domain entities or new stored state.
+Rationale: A contract artifact is necessary because the story is about the profile-backed workload/helper tool surface and its allowed/forbidden inputs. A data model would add noise.
+Alternatives considered: Create `data-model.md` for runner profiles. Rejected because runner profiles are already modeled in repo code and this story does not change their persisted shape.
+Test implications: Contract review plus unit/integration verification are sufficient.
+
+## Repo Gap Analysis Outcome
+
+Decision: MM-500 required no production-code changes after adding one missing hermetic integration boundary.
+Evidence: Core runtime behavior already existed in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workloads/tool_bridge.py`, and `moonmind/workflows/temporal/activity_runtime.py`; the only missing evidence was a dispatcher-boundary `integration_ci` test for the existing profile-backed contract.
+Rationale: This is primarily a verification and traceability story. The repo already implements the required behavior; the orchestration work was to document it in MoonSpec artifacts, add the missing integration proof, and validate the result.
+Alternatives considered: Treat MM-500 as code-implementation work. Rejected because the requested behavior was already present and stable in the codebase.
+Test implications: Run the focused workload unit suites plus the targeted hermetic integration boundary and use those results in final verification.

--- a/specs/249-profile-backed-workload-contracts/spec.md
+++ b/specs/249-profile-backed-workload-contracts/spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: Profile-Backed Workload Contracts
+
+**Feature Branch**: `249-profile-backed-workload-contracts`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-500 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched MM-500 under `specs/`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-500 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-500
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Implement profile-backed workload and helper tool contracts
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-500 from MM project
+Summary: Implement profile-backed workload and helper tool contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-500 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-500: Implement profile-backed workload and helper tool contracts
+
+Source Reference
+- Source document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source sections:
+  - 7. Supported container roles
+  - 11. User-facing tool surface
+  - 12. Runner profile model
+  - 18.1 Unreal test run in profiles mode
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-017
+  - DESIGN-REQ-018
+  - DESIGN-REQ-025
+
+User Story
+As a workflow author, I can run curated and profile-backed workload containers and helpers through stable MoonMind tool contracts that validate against runner profiles instead of raw container inputs.
+
+Acceptance Criteria
+- Given mode is profiles or unrestricted, when `container.run_workload` is invoked with an approved `profileId`, then MoonMind resolves the runner profile and launches the workload with profile-defined mounts, env policy, resources, timeout, and cleanup.
+- Given `container.run_workload` is invoked with raw image strings, arbitrary host-path mounts, or unrestricted privilege fields, then validation fails because the contract remains profile-backed.
+- Given `container.start_helper` and `container.stop_helper` are invoked with an approved helper profile, then MoonMind treats the helper as an explicitly owned, bounded workload lifecycle rather than an arbitrary detached service.
+- Given mode is disabled, when any profile-backed workload or helper tool is invoked, then the request is denied deterministically.
+
+Requirements
+- Keep `container.run_workload` generic but strictly profile-validated.
+- Preserve bounded helper semantics for `container.start_helper` and `container.stop_helper`.
+- Model normal execution around runner profiles rather than unrestricted image strings.
+- Keep curated domain tools such as `unreal.run_tests` aligned with the same DooD execution model.
+
+Relevant Implementation Notes
+- Preserve MM-500 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for supported container roles, the user-facing tool surface, runner profile modeling, and Unreal test execution in profiles mode.
+- Keep workload and helper execution contracts profile-backed; do not widen them to arbitrary image, mount, or privilege inputs.
+- Ensure helper lifecycle semantics remain explicitly owned and bounded rather than detached-service style.
+- Keep curated domain tools aligned with the same runner-profile and DooD execution model as the generic container tools.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-500 blocks MM-499, whose embedded status is In Progress.
+- Trusted Jira link metadata at fetch time shows MM-500 is blocked by MM-501, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief already defines one independently testable runtime story.
+- Selected mode: Runtime.
+- Source design: `docs/ManagedAgents/DockerOutOfDocker.md` is treated as runtime source requirements because the brief describes system behavior, not documentation-only work.
+- Resume decision: No existing Moon Spec artifacts for MM-500 were found under `specs/`; specification is the first incomplete stage.
+
+## User Story - Run Profile-Backed Workloads
+
+**Summary**: As a workflow author, I want Docker-backed workload and helper tools to stay profile-backed so MoonMind launches only approved container shapes instead of arbitrary raw container requests.
+
+**Goal**: Workflow authors can launch approved one-shot workloads and bounded helpers through stable MoonMind tool contracts that enforce runner-profile policy, preserve deterministic helper lifecycle ownership, and deny disabled-mode execution.
+
+**Independent Test**: Through the worker-facing tool dispatcher, invoke `container.run_workload`, `container.start_helper`, and `container.stop_helper` with approved profiles plus invalid raw-container fields and disabled-mode execution, then verify approved profile-backed requests resolve through the runner profile registry, helpers remain bounded-service lifecycles, invalid raw fields are rejected, disabled mode denies execution, curated tools remain profile-backed, and MM-500 traceability is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** workflow Docker mode is `profiles` or `unrestricted`, **When** `container.run_workload` is invoked with an approved `profileId`, **Then** MoonMind resolves that runner profile and launches the workload with profile-defined mounts, env policy, resources, timeout, and cleanup.
+2. **Given** `container.run_workload` receives raw image strings, arbitrary host-path mounts, or unrestricted privilege fields, **When** the request is validated, **Then** MoonMind rejects the request instead of widening the profile-backed contract.
+3. **Given** `container.start_helper` and `container.stop_helper` are invoked with an approved helper profile, **When** the helper lifecycle runs, **Then** MoonMind treats the helper as an explicitly owned bounded-service workload with readiness and teardown metadata rather than as an arbitrary detached service.
+4. **Given** workflow Docker mode is `disabled`, **When** a profile-backed workload or helper tool is invoked, **Then** MoonMind returns a deterministic denial outcome instead of launching the request.
+5. **Given** curated tools such as `unreal.run_tests` or `moonmind.integration_ci` use the Docker-backed workload path, **When** they are invoked, **Then** MoonMind continues to resolve them through approved runner profiles instead of raw container inputs.
+
+### Edge Cases
+
+- A workflow tries to pass raw `image`, `mounts`, `devices`, or `privileged` fields through `container.run_workload`.
+- A helper profile uses bounded-service readiness or teardown metadata that must remain distinct from one-shot workload results.
+- Disabled-mode registration and dispatcher execution disagree about whether profile-backed tools are allowed.
+- Curated tools drift away from the same runner-profile model used by `container.run_workload`.
+
+## Assumptions
+
+- MM-500 is scoped to the existing profile-backed workload and helper contract path rather than the unrestricted Docker mode introduced by adjacent stories.
+- The blocker relationship to MM-501 is tracked operationally outside this specification and does not change the one-story scope or runtime requirements captured here.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-012 | `docs/ManagedAgents/DockerOutOfDocker.md` §7 | Supported workload-container roles must stay on the Docker workload plane rather than becoming arbitrary session-owned containers. | In scope | FR-001, FR-004 |
+| DESIGN-REQ-017 | `docs/ManagedAgents/DockerOutOfDocker.md` §11 | The user-facing workload tool surface must remain profile-backed for `container.run_workload`, `container.start_helper`, and `container.stop_helper`. | In scope | FR-001, FR-003, FR-004 |
+| DESIGN-REQ-018 | `docs/ManagedAgents/DockerOutOfDocker.md` §12 | Runner profiles define approved mounts, env policy, resources, timeout, and cleanup for normal workload execution. | In scope | FR-002, FR-004 |
+| DESIGN-REQ-025 | `docs/ManagedAgents/DockerOutOfDocker.md` §18.1 | Curated domain workload tools such as Unreal test execution must stay aligned with the same profiles-mode execution model. | In scope | FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose `container.run_workload` as a profile-backed one-shot Docker workload tool that requires an approved `profileId`.
+- **FR-002**: The system MUST resolve approved profile-backed workload and helper requests through the runner profile registry and apply profile-defined mounts, env policy, resources, timeout, and cleanup semantics.
+- **FR-003**: The system MUST reject raw image strings, arbitrary host-path mounts, unrestricted device fields, and unrestricted privilege fields from the `container.run_workload` contract.
+- **FR-004**: The system MUST expose `container.start_helper` and `container.stop_helper` as approved helper-profile tools with bounded-service lifecycle, readiness, and teardown behavior.
+- **FR-005**: The system MUST keep curated workload tools such as `unreal.run_tests` and `moonmind.integration_ci` aligned with the same runner-profile-backed execution model as `container.run_workload`.
+- **FR-006**: The system MUST deterministically deny profile-backed workload and helper tool execution when workflow Docker mode is `disabled`.
+- **FR-007**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-500.
+
+### Key Entities
+
+- **Runner Profile**: The curated workload-container definition that supplies approved image, mounts, env policy, resources, timeout, cleanup, and helper lifecycle rules.
+- **Profile-Backed Workload Request**: The validated request for `container.run_workload`, `container.start_helper`, or `container.stop_helper` that must resolve through a runner profile rather than raw container input.
+- **Bounded Helper Lifecycle**: The explicitly owned helper lifecycle that produces readiness and teardown metadata instead of a detached-service contract.
+- **Deterministic Denial Outcome**: The non-retryable policy response returned when disabled mode forbids profile-backed workload execution.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Validation proves approved `container.run_workload` requests resolve through runner profiles and carry profile-backed metadata rather than raw container-shape input.
+- **SC-002**: Validation proves raw container fields on `container.run_workload` are rejected before launch.
+- **SC-003**: Validation proves helper start and stop requests preserve bounded-service readiness and teardown behavior.
+- **SC-004**: Validation proves disabled mode denies profile-backed workload execution deterministically.
+- **SC-005**: Validation proves curated workload tools remain aligned with the same runner-profile-backed model.
+- **SC-006**: Traceability review confirms MM-500 and DESIGN-REQ-012, DESIGN-REQ-017, DESIGN-REQ-018, and DESIGN-REQ-025 remain preserved in MoonSpec artifacts and downstream verification evidence.

--- a/specs/249-profile-backed-workload-contracts/tasks.md
+++ b/specs/249-profile-backed-workload-contracts/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Profile-Backed Workload Contracts
+
+**Input**: Design documents from `specs/249-profile-backed-workload-contracts/`  
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/profile-backed-workload-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and hermetic integration verification are REQUIRED. For MM-500, the repository already contained most production behavior and unit coverage, so the story work is verification-first: preserve the canonical artifacts, add the missing dispatcher-boundary integration test, and verify the existing workload contract end to end.
+
+**Organization**: Tasks are grouped around the single MM-500 story: keep `container.run_workload`, `container.start_helper`, and `container.stop_helper` profile-backed, preserve bounded helper lifecycle semantics, prove disabled-mode denial, keep curated tools aligned with the runner-profile model, and preserve MM-500 traceability.
+
+**Source Traceability**: MM-500; FR-001 through FR-007; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-012, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-025.
+
+**Requirement Status Summary**: verification-first. Runtime behavior for FR-001 through FR-006 and DESIGN-REQ-012/017/018/025 is already implemented in the repository and now has direct unit evidence; MM-500 required feature-local traceability artifacts plus one hermetic integration boundary to upgrade those rows to implemented-verified. FR-007 and SC-006 are satisfied by the new MoonSpec artifact set and final verification evidence.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workloads/test_docker_workload_launcher.py`
+- Hermetic integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the MM-500 source brief, feature scope, and repo surfaces before verification work.
+
+- [X] T001 Confirm `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md` is the canonical MM-500 source input and no existing MM-500 spec directory exists under `specs/`
+- [X] T002 Confirm the MM-500 runtime touchpoints in `moonmind/schemas/workload_models.py`, `moonmind/workloads/registry.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and the existing workload unit suites
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Lock the feature-local artifact and validation shape before story verification.
+
+- [X] T003 Confirm MM-500 needs no `data-model.md`, migration, or new persistent storage because the story is a runtime contract verification story
+- [X] T004 Confirm the focused unit suites and the hermetic integration boundary are the correct validation paths for FR-001 through FR-006 and DESIGN-REQ-012/017/018/025
+
+**Checkpoint**: Foundation ready - story verification work can begin.
+
+---
+
+## Phase 3: Story - Run Profile-Backed Workloads
+
+**Summary**: As a workflow author, I want Docker-backed workload and helper tools to stay profile-backed so MoonMind launches only approved container shapes instead of arbitrary raw container requests.
+
+**Independent Test**: Through the worker-facing tool dispatcher, invoke `container.run_workload`, `container.start_helper`, and `container.stop_helper` with approved profiles plus invalid raw-container fields and disabled-mode execution, then verify approved profile-backed requests resolve through the runner profile registry, helpers remain bounded-service lifecycles, invalid raw fields are rejected, disabled mode denies execution, curated tools remain profile-backed, and MM-500 traceability is preserved.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-012, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-025
+
+**Unit Test Plan**:
+
+- Reuse and rerun the existing workload contract, tool-bridge, activity-runtime, and launcher unit suites.
+
+**Integration Test Plan**:
+
+- Add one `integration_ci` boundary in `tests/integration/temporal/test_profile_backed_workload_contract.py` covering approved one-shot workload execution, raw-field rejection, bounded helper lifecycle behavior, and disabled-mode denial.
+- Reuse existing curated-tool integration evidence in `tests/integration/temporal/test_integration_ci_tool_contract.py`.
+
+### Verification Tests
+
+- [X] T005 [P] Add `integration_ci` coverage for FR-001, FR-002, SC-001, and DESIGN-REQ-018 in `tests/integration/temporal/test_profile_backed_workload_contract.py` verifying approved `container.run_workload` requests resolve through an approved runner profile
+- [X] T006 [P] Add `integration_ci` coverage for FR-003, SC-002, and DESIGN-REQ-017 in `tests/integration/temporal/test_profile_backed_workload_contract.py` verifying raw container fields are rejected at the dispatcher/runtime boundary
+- [X] T007 [P] Add `integration_ci` coverage for FR-004, SC-003, DESIGN-REQ-012, and DESIGN-REQ-018 in `tests/integration/temporal/test_profile_backed_workload_contract.py` verifying bounded helper lifecycle behavior for `container.start_helper` and `container.stop_helper`
+- [X] T008 [P] Add `integration_ci` coverage for FR-006 and SC-004 in `tests/integration/temporal/test_profile_backed_workload_contract.py` verifying disabled-mode denial for the profile-backed tool path
+
+### Story Validation
+
+- [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workloads/test_docker_workload_launcher.py` and confirm the MM-500-focused workload unit suites pass
+- [X] T010 Attempt `./tools/test_integration.sh`, record the managed-session Docker-socket blocker, then run `pytest tests/integration/temporal/test_profile_backed_workload_contract.py tests/integration/temporal/test_integration_ci_tool_contract.py -q --tb=short -m 'integration_ci'` as a focused fallback and confirm the MM-500 integration boundary plus existing integration-ci curated-tool evidence pass
+- [X] T011 Review `tests/integration/temporal/test_integration_ci_tool_contract.py` together with the new MM-500 integration boundary to confirm FR-005 and DESIGN-REQ-025 remain covered without widening the profile-backed path
+- [X] T012 Review `spec.md`, `plan.md`, `research.md`, `contracts/profile-backed-workload-contract.md`, `quickstart.md`, and `docs/tmp/jira-orchestration-inputs/MM-500-moonspec-orchestration-input.md` to confirm FR-007 and SC-006 preserve MM-500 across downstream artifacts
+
+**Checkpoint**: MM-500 is complete when the existing profile-backed workload/helper implementation is proven at unit and integration boundaries and the canonical artifact set preserves the Jira source brief.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Final traceability and read-only verification for the completed story.
+
+- [X] T013 [P] Align the feature-local artifacts in `specs/249-profile-backed-workload-contracts/` after the integration boundary was added so terminology, traceability, and test commands stay coherent
+- [X] T014 Run `/moonspec-verify` for `specs/249-profile-backed-workload-contracts/` and produce a final evidence-backed verification report in the task closeout covering MM-500, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-012, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-025
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies
+- Foundational (Phase 2): depends on Setup completion
+- Story (Phase 3): depends on Foundational completion
+- Polish (Phase 4): depends on story validation completing
+
+### Within The Story
+
+- T005-T008 define the missing integration boundary before story-level validation.
+- T009 and T010 provide the required unit and integration evidence.
+- T011 confirms curated-tool alignment using existing integration evidence.
+- T012 and T013 preserve MM-500 traceability before final verification.
+
+### Parallel Opportunities
+
+- T005-T008 touch the same new integration file and therefore execute sequentially in practice even though they describe distinct coverage goals.
+- T012 and T013 can run in parallel with verification preparation after tests pass.
+
+## Implementation Strategy
+
+1. Preserve MM-500 as the canonical MoonSpec source input and create the feature-local artifact set.
+2. Add one missing hermetic integration boundary for the existing profile-backed workload and helper contract.
+3. Rerun the focused workload unit suites.
+4. Rerun the hermetic integration suite.
+5. Reconcile curated-tool evidence and final traceability.
+6. Finish with MoonSpec verification against the original MM-500 brief.

--- a/tests/integration/temporal/test_profile_backed_workload_contract.py
+++ b/tests/integration/temporal/test_profile_backed_workload_contract.py
@@ -7,13 +7,18 @@ import pytest
 
 from moonmind.schemas.workload_models import RunnerProfile, WorkloadResult
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
-from moonmind.workflows.skills.tool_dispatcher import (
-    ToolActivityDispatcher,
-    execute_tool_activity,
+from moonmind.workflows.skills.skill_dispatcher import (
+    SkillActivityDispatcher as ToolActivityDispatcher,
+    execute_skill_activity as execute_tool_activity,
 )
-from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
-from moonmind.workflows.skills.tool_registry import create_registry_snapshot
-from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.skill_plan_contracts import (
+    SkillFailure as ToolFailure,
+    parse_skill_definition as parse_tool_definition,
+)
+from moonmind.workflows.skills.skill_registry import (
+    SkillRegistrySnapshot,
+    create_registry_snapshot,
+)
 from moonmind.workloads.registry import RunnerProfileRegistry
 from moonmind.workloads.tool_bridge import (
     CONTAINER_RUN_WORKLOAD_TOOL,
@@ -155,7 +160,7 @@ class _FakeLauncher:
         )
 
 
-def _snapshot(*tool_names: str):
+def _snapshot(*tool_names: str) -> SkillRegistrySnapshot:
     return create_registry_snapshot(
         skills=tuple(
             parse_tool_definition(
@@ -287,6 +292,7 @@ async def test_profile_backed_helper_lifecycle_stays_bounded() -> None:
             },
             "inputs": {
                 "profileId": "redis-helper",
+                "stepId": "helper-lifecycle",
                 "repoDir": "/work/agent_jobs/wf-1/repo",
                 "artifactsDir": "/work/agent_jobs/wf-1/artifacts/helper",
                 "command": ["--appendonly", "no"],
@@ -300,7 +306,7 @@ async def test_profile_backed_helper_lifecycle_stays_bounded() -> None:
 
     assert launcher.validated is not None
     assert launcher.validated.profile.kind == "bounded_service"
-    assert launcher.validated.container_name == "mm-helper-wf-1-step-start-helper-1"
+    assert launcher.validated.container_name == "mm-helper-wf-1-helper-lifecycle-1"
     assert start_result.status == "COMPLETED"
     assert start_result.outputs["workloadMetadata"]["helper"]["readiness"]["status"] == "ready"
 
@@ -314,6 +320,7 @@ async def test_profile_backed_helper_lifecycle_stays_bounded() -> None:
             },
             "inputs": {
                 "profileId": "redis-helper",
+                "stepId": "helper-lifecycle",
                 "repoDir": "/work/agent_jobs/wf-1/repo",
                 "artifactsDir": "/work/agent_jobs/wf-1/artifacts/helper",
                 "ttlSeconds": 300,
@@ -345,6 +352,8 @@ async def test_disabled_mode_denies_profile_backed_workload_tools() -> None:
         workflow_docker_mode="disabled",
     )
 
+    assert dispatcher._skill_handlers == {}
+
     with pytest.raises(ToolFailure) as exc_info:
         await execute_tool_activity(
             invocation_payload={
@@ -367,3 +376,4 @@ async def test_disabled_mode_denies_profile_backed_workload_tools() -> None:
         )
 
     assert exc_info.value.error_code == "INVALID_INPUT"
+    assert "No mm.tool.execute handler registered" in exc_info.value.message

--- a/tests/integration/temporal/test_profile_backed_workload_contract.py
+++ b/tests/integration/temporal/test_profile_backed_workload_contract.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.workload_models import RunnerProfile, WorkloadResult
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.tool_dispatcher import (
+    ToolActivityDispatcher,
+    execute_tool_activity,
+)
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+from moonmind.workflows.skills.tool_registry import create_registry_snapshot
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workloads.registry import RunnerProfileRegistry
+from moonmind.workloads.tool_bridge import (
+    CONTAINER_RUN_WORKLOAD_TOOL,
+    CONTAINER_START_HELPER_TOOL,
+    CONTAINER_STOP_HELPER_TOOL,
+    build_dood_tool_definition_payload,
+    register_workload_tool_handlers,
+)
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+WORKSPACE_ROOT = Path("/work/agent_jobs")
+
+
+def _profile_payload() -> dict[str, object]:
+    return {
+        "id": "local-python",
+        "kind": "one_shot",
+        "image": "python:3.12-slim",
+        "entrypoint": ["/bin/bash", "-lc"],
+        "workdirTemplate": "/work/agent_jobs/${task_run_id}/repo",
+        "requiredMounts": [
+            {
+                "type": "volume",
+                "source": "agent_workspaces",
+                "target": "/work/agent_jobs",
+            }
+        ],
+        "envAllowlist": ["CI"],
+        "networkPolicy": "none",
+        "timeoutSeconds": 300,
+        "maxTimeoutSeconds": 600,
+        "cleanup": {
+            "removeContainerOnExit": True,
+            "killGraceSeconds": 30,
+        },
+    }
+
+
+def _helper_profile_payload() -> dict[str, object]:
+    return {
+        "id": "redis-helper",
+        "kind": "bounded_service",
+        "image": "redis:7.2-alpine",
+        "workdirTemplate": "/work/agent_jobs/${task_run_id}/repo",
+        "requiredMounts": [
+            {
+                "type": "volume",
+                "source": "agent_workspaces",
+                "target": "/work/agent_jobs",
+            }
+        ],
+        "envAllowlist": ["CI"],
+        "networkPolicy": "bridge",
+        "timeoutSeconds": 60,
+        "maxTimeoutSeconds": 120,
+        "helperTtlSeconds": 300,
+        "maxHelperTtlSeconds": 900,
+        "readinessProbe": {
+            "type": "exec",
+            "command": ["redis-cli", "ping"],
+            "intervalSeconds": 0,
+            "timeoutSeconds": 1,
+            "retries": 3,
+        },
+        "cleanup": {
+            "removeContainerOnExit": True,
+            "killGraceSeconds": 3,
+        },
+    }
+
+
+class _FakeLauncher:
+    def __init__(self) -> None:
+        self.validated: Any | None = None
+        self.reason: str | None = None
+
+    async def run(self, validated: Any) -> WorkloadResult:
+        self.validated = validated
+        return WorkloadResult(
+            requestId=validated.container_name,
+            profileId=validated.profile.id,
+            status="succeeded",
+            labels=validated.ownership.labels,
+            exitCode=0,
+            stdoutRef="art:sha256:stdout",
+            stderrRef="art:sha256:stderr",
+            diagnosticsRef="art:sha256:diagnostics",
+            metadata={
+                "containerName": validated.container_name,
+                "workload": {
+                    "toolName": validated.request.tool_name,
+                    "profileId": validated.profile.id,
+                },
+                "artifactPublication": {"status": "complete"},
+            },
+        )
+
+    async def start_helper(self, validated: Any) -> WorkloadResult:
+        self.validated = validated
+        return WorkloadResult(
+            requestId=validated.container_name,
+            profileId=validated.profile.id,
+            status="ready",
+            labels=validated.ownership.labels,
+            metadata={
+                "helper": {
+                    "containerName": validated.container_name,
+                    "status": "ready",
+                    "readiness": {"status": "ready", "attempts": 1},
+                    "ttlSeconds": validated.request.ttl_seconds,
+                },
+                "artifactPublication": {"status": "complete"},
+            },
+        )
+
+    async def stop_helper(
+        self,
+        validated: Any,
+        *,
+        reason: str = "bounded_window_complete",
+    ) -> WorkloadResult:
+        self.validated = validated
+        self.reason = reason
+        return WorkloadResult(
+            requestId=validated.container_name,
+            profileId=validated.profile.id,
+            status="stopped",
+            labels=validated.ownership.labels,
+            metadata={
+                "helper": {
+                    "containerName": validated.container_name,
+                    "status": "stopped",
+                    "teardown": {"status": "complete", "reason": reason},
+                },
+                "artifactPublication": {"status": "complete"},
+            },
+        )
+
+
+def _snapshot(*tool_names: str):
+    return create_registry_snapshot(
+        skills=tuple(
+            parse_tool_definition(
+                build_dood_tool_definition_payload(name=tool_name, version="1.0")
+            )
+            for tool_name in tool_names
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+
+async def test_profile_backed_run_workload_routes_through_runner_profile() -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+    launcher = _FakeLauncher()
+    dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=registry,
+        launcher=launcher,
+        workflow_docker_mode="profiles",
+    )
+
+    result = await execute_tool_activity(
+        invocation_payload={
+            "id": "step-run-workload",
+            "tool": {
+                "type": "skill",
+                "name": CONTAINER_RUN_WORKLOAD_TOOL,
+                "version": "1.0",
+            },
+            "inputs": {
+                "profileId": "local-python",
+                "repoDir": "/work/agent_jobs/wf-1/repo",
+                "artifactsDir": "/work/agent_jobs/wf-1/artifacts/workload",
+                "command": ["pytest", "-q"],
+                "envOverrides": {"CI": "1"},
+            },
+        },
+        registry_snapshot=_snapshot(CONTAINER_RUN_WORKLOAD_TOOL),
+        dispatcher=dispatcher,
+        context={"workflow_id": "wf-1", "node_id": "step-run-workload"},
+    )
+
+    assert launcher.validated is not None
+    assert launcher.validated.profile.id == "local-python"
+    assert launcher.validated.profile.required_mounts[0].source == "agent_workspaces"
+    assert launcher.validated.profile.cleanup.remove_container_on_exit is True
+    assert launcher.validated.request.tool_name == CONTAINER_RUN_WORKLOAD_TOOL
+    assert result.status == "COMPLETED"
+    assert result.outputs["profileId"] == "local-python"
+
+
+@pytest.mark.parametrize(
+    ("raw_field", "raw_value"),
+    (
+        ("image", "ghcr.io/example/runtime:1.2.3"),
+        ("mounts", [{"source": "/tmp/host", "target": "/work/host"}]),
+        ("privileged", True),
+    ),
+)
+async def test_profile_backed_run_workload_rejects_raw_container_fields(
+    raw_field: str,
+    raw_value: object,
+) -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+    launcher = _FakeLauncher()
+    dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=registry,
+        launcher=launcher,
+        workflow_docker_mode="profiles",
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await execute_tool_activity(
+            invocation_payload={
+                "id": "step-run-workload-invalid",
+                "tool": {
+                    "type": "skill",
+                    "name": CONTAINER_RUN_WORKLOAD_TOOL,
+                    "version": "1.0",
+                },
+                "inputs": {
+                    "profileId": "local-python",
+                    "repoDir": "/work/agent_jobs/wf-1/repo",
+                    "artifactsDir": "/work/agent_jobs/wf-1/artifacts/workload",
+                    "command": ["pytest", "-q"],
+                    raw_field: raw_value,
+                },
+            },
+            registry_snapshot=_snapshot(CONTAINER_RUN_WORKLOAD_TOOL),
+            dispatcher=dispatcher,
+            context={"workflow_id": "wf-1", "node_id": "step-run-workload-invalid"},
+        )
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+    assert launcher.validated is None
+
+
+async def test_profile_backed_helper_lifecycle_stays_bounded() -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_helper_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+    launcher = _FakeLauncher()
+    dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=registry,
+        launcher=launcher,
+        workflow_docker_mode="profiles",
+    )
+    snapshot = _snapshot(CONTAINER_START_HELPER_TOOL, CONTAINER_STOP_HELPER_TOOL)
+
+    start_result = await execute_tool_activity(
+        invocation_payload={
+            "id": "step-start-helper",
+            "tool": {
+                "type": "skill",
+                "name": CONTAINER_START_HELPER_TOOL,
+                "version": "1.0",
+            },
+            "inputs": {
+                "profileId": "redis-helper",
+                "repoDir": "/work/agent_jobs/wf-1/repo",
+                "artifactsDir": "/work/agent_jobs/wf-1/artifacts/helper",
+                "command": ["--appendonly", "no"],
+                "ttlSeconds": 300,
+            },
+        },
+        registry_snapshot=snapshot,
+        dispatcher=dispatcher,
+        context={"workflow_id": "wf-1", "node_id": "step-start-helper"},
+    )
+
+    assert launcher.validated is not None
+    assert launcher.validated.profile.kind == "bounded_service"
+    assert launcher.validated.container_name == "mm-helper-wf-1-step-start-helper-1"
+    assert start_result.status == "COMPLETED"
+    assert start_result.outputs["workloadMetadata"]["helper"]["readiness"]["status"] == "ready"
+
+    stop_result = await execute_tool_activity(
+        invocation_payload={
+            "id": "step-stop-helper",
+            "tool": {
+                "type": "skill",
+                "name": CONTAINER_STOP_HELPER_TOOL,
+                "version": "1.0",
+            },
+            "inputs": {
+                "profileId": "redis-helper",
+                "repoDir": "/work/agent_jobs/wf-1/repo",
+                "artifactsDir": "/work/agent_jobs/wf-1/artifacts/helper",
+                "ttlSeconds": 300,
+                "reason": "owner_task_canceled",
+            },
+        },
+        registry_snapshot=snapshot,
+        dispatcher=dispatcher,
+        context={"workflow_id": "wf-1", "node_id": "step-stop-helper"},
+    )
+
+    assert launcher.reason == "owner_task_canceled"
+    assert stop_result.status == "COMPLETED"
+    assert stop_result.outputs["workloadMetadata"]["helper"]["teardown"]["reason"] == (
+        "owner_task_canceled"
+    )
+
+
+async def test_disabled_mode_denies_profile_backed_workload_tools() -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=registry,
+        launcher=_FakeLauncher(),
+        workflow_docker_mode="disabled",
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await execute_tool_activity(
+            invocation_payload={
+                "id": "step-run-workload-disabled",
+                "tool": {
+                    "type": "skill",
+                    "name": CONTAINER_RUN_WORKLOAD_TOOL,
+                    "version": "1.0",
+                },
+                "inputs": {
+                    "profileId": "local-python",
+                    "repoDir": "/work/agent_jobs/wf-1/repo",
+                    "artifactsDir": "/work/agent_jobs/wf-1/artifacts/workload",
+                    "command": ["pytest", "-q"],
+                },
+            },
+            registry_snapshot=_snapshot(CONTAINER_RUN_WORKLOAD_TOOL),
+            dispatcher=dispatcher,
+            context={"workflow_id": "wf-1", "node_id": "step-run-workload-disabled"},
+        )
+
+    assert exc_info.value.error_code == "INVALID_INPUT"


### PR DESCRIPTION
Run Jira Orchestrate for MM-500.

Source story: STORY-002.
Source summary: Implement profile-backed workload and helper tool contracts.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.