### PR TITLE
MM-501 unrestricted container and Docker CLI contracts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/249-profile-backed-workload-contracts"
+  "feature_directory": "specs/250-unrestricted-container-and-docker-cli-contracts"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,72 +1,12 @@
 [
   {
-    "id": 3135051899,
-    "disposition": "addressed",
-    "rationale": "Hydration now fetches primary and summary report artifacts concurrently with asyncio.gather."
-  },
-  {
-    "id": 3135051901,
-    "disposition": "addressed",
-    "rationale": "Execution report projections now preserve compact artifact refs end to end instead of re-injecting full artifact metadata."
-  },
-  {
-    "id": 4167397793,
+    "id": 4167635630,
     "disposition": "not-applicable",
-    "rationale": "Top-level Gemini review summary only restated the inline comments and required no separate change."
+    "rationale": "Top-level review summary only; no independent action required beyond the linked inline comment disposition."
   },
   {
-    "id": 3135074437,
+    "id": 3135262955,
     "disposition": "addressed",
-    "rationale": "Report hydration now ignores incomplete report.primary and report.summary artifacts and only projects COMPLETE artifacts."
-  },
-  {
-    "id": 4167425940,
-    "disposition": "not-applicable",
-    "rationale": "Top-level Codex review wrapper contained no standalone actionable feedback beyond the inline comment already addressed."
-  },
-  {
-    "id": 3135097062,
-    "disposition": "addressed",
-    "rationale": "Removed the unused user binding from _client_with_service while preserving dependency override side effects."
-  },
-  {
-    "id": 3135097068,
-    "disposition": "addressed",
-    "rationale": "Removed the unused admin test user binding in test_list_executions_passes_temporal_filters_for_admin."
-  },
-  {
-    "id": 3135097076,
-    "disposition": "addressed",
-    "rationale": "Removed an unused user binding in the send-message signal test setup."
-  },
-  {
-    "id": 3135097078,
-    "disposition": "addressed",
-    "rationale": "Removed an unused user binding in the skip-dependency signal test setup."
-  },
-  {
-    "id": 3135097081,
-    "disposition": "addressed",
-    "rationale": "Dropped the unused ArtifactRefModel import after switching execution report projections to CompactArtifactRefModel."
-  },
-  {
-    "id": 3135151857,
-    "disposition": "addressed",
-    "rationale": "Switched the new test to the canonical skill wrapper imports and removed the duplicated tool-module imports."
-  },
-  {
-    "id": 3135151861,
-    "disposition": "addressed",
-    "rationale": "Added the explicit SkillRegistrySnapshot return type to _snapshot for clearer typing."
-  },
-  {
-    "id": 3135151866,
-    "disposition": "addressed",
-    "rationale": "Pinned both helper calls to the same explicit stepId so the stop path targets the same deterministic helper container name."
-  },
-  {
-    "id": 3135151868,
-    "disposition": "addressed",
-    "rationale": "Updated the disabled-mode test to assert the dispatcher omits handlers and fails with the missing-handler message that matches current disabled-mode behavior."
+    "rationale": "Replaced the absolute workspace path in specs/250-unrestricted-container-and-docker-cli-contracts/checklists/requirements.md with the relative link ../spec.md."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md
@@ -1,0 +1,71 @@
+# MM-501 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-501
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Add unrestricted container and Docker CLI execution contracts
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-501 from MM project
+Summary: Add unrestricted container and Docker CLI execution contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-501 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-501: Add unrestricted container and Docker CLI execution contracts
+
+Source Reference
+- Source Document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source Title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source Sections:
+  - 2. Core decisions
+  - 7. Supported container roles
+  - 11.4 container.run_container
+  - 11.5 container.run_docker
+  - 18.2-18.4 Example flows
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-010
+  - DESIGN-REQ-017
+  - DESIGN-REQ-022
+  - DESIGN-REQ-025
+
+User Story
+As a trusted deployment operator, I can allow arbitrary runtime containers and explicit Docker CLI workloads through separate unrestricted MoonMind tools without weakening the normal profile-backed contract.
+
+Acceptance Criteria
+- Given mode is unrestricted, when `container.run_container` is invoked with a runtime-selected image plus workspace paths and declared outputs, then MoonMind launches the container without requiring a pre-registered runner profile.
+- Given `container.run_container` includes arbitrary host-path mounts, privileged flags, host networking, or implicit auth inheritance, then validation rejects the request because those capabilities are outside the structured unrestricted contract.
+- Given mode is unrestricted, when `container.run_docker` is invoked, then `command[0]` must equal `docker` and the command runs as a Docker CLI invocation rather than a general shell surface.
+- Given mode is `disabled` or `profiles`, when unrestricted tools are invoked, then MoonMind returns deterministic denial codes such as `unrestricted_container_disabled` or `unrestricted_docker_disabled`.
+
+Requirements
+- Expose `container.run_container` as the first-class unrestricted arbitrary-container contract.
+- Expose `container.run_docker` as the explicit Docker CLI escape hatch and not as generic shell access.
+- Keep unrestricted execution deployment-gated and auditable.
+- Preserve the meaning of `container.run_workload` as profile-backed even when unrestricted mode is enabled.
+
+Relevant Implementation Notes
+- Preserve MM-501 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for core decisions, supported container roles, unrestricted container execution, Docker CLI execution, and the documented example flows.
+- Keep unrestricted execution deployment-gated and auditable rather than widening it into unbounded shell access.
+- Treat `container.run_container` and `container.run_docker` as distinct unrestricted tool contracts with explicit validation boundaries.
+- Ensure `container.run_docker` remains a Docker CLI-specific surface where `command[0]` must be `docker`, not a general-purpose shell mechanism.
+- Preserve the profile-backed meaning of `container.run_workload` even when unrestricted mode is enabled.
+- Reject unrestricted requests that attempt arbitrary host-path mounts, privileged flags, host networking, or implicit auth inheritance outside the structured contract.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-501 blocks MM-500, whose embedded status is In Progress.
+- Trusted Jira link metadata at fetch time shows MM-501 is blocked by MM-502, whose embedded status is Backlog.
+
+Needs Clarification
+- None

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/checklists/requirements.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-04-24
-**Feature**: [spec.md](/work/agent_jobs/mm:b1ef7bdc-2515-49c4-a314-225562cce660/repo/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/checklists/requirements.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Unrestricted Container and Docker CLI Contracts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](/work/agent_jobs/mm:b1ef7bdc-2515-49c4-a314-225562cce660/repo/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist passed after initial spec drafting. The spec preserves the original MM-501 orchestration brief, keeps runtime intent explicit, and maps all in-scope `DESIGN-REQ-*` source requirements to functional requirements.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/contracts/unrestricted-docker-workload-contract.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/contracts/unrestricted-docker-workload-contract.md
@@ -1,0 +1,80 @@
+# Contract: Unrestricted Container And Docker CLI Workloads
+
+## Purpose
+
+Define the runtime contract for MM-501: unrestricted Docker-backed execution is available only through explicit MoonMind tools, remains deployment-gated, and does not weaken the normal profile-backed workload path.
+
+## In-Scope Tool Surface
+
+Unrestricted tools:
+
+- `container.run_container`
+- `container.run_docker`
+
+Related normal-path tools whose meaning must remain unchanged:
+
+- `container.run_workload`
+- `container.start_helper`
+- `container.stop_helper`
+
+## `container.run_container`
+
+Contract rules:
+
+- available only when workflow Docker mode is `unrestricted`
+- accepts a runtime-selected image with an explicit tag or digest
+- requires workspace-rooted `repoDir`, `artifactsDir`, and `scratchDir`
+- accepts command, workdir, declared outputs, bounded resource overrides, named cache mounts, and explicit network mode within the unrestricted schema
+- must not expose arbitrary host-path mounts, unrestricted privilege flags, implicit credential inheritance, or generic shell authority
+
+Expected outcome:
+
+- validated unrestricted container requests launch through the Docker workload launcher without requiring a runner profile
+- unrestricted launches remain explicitly labeled and auditable
+- forbidden unrestricted shapes fail before launch with deterministic invalid-input or policy outcomes
+
+## `container.run_docker`
+
+Contract rules:
+
+- available only when workflow Docker mode is `unrestricted`
+- command must be a Docker CLI invocation where `command[0]` equals `docker`
+- runs through the trusted Docker-capable worker plane rather than through generic shell access
+- declared outputs and bounded resource overrides remain explicit in the request
+
+Expected outcome:
+
+- MoonMind executes Docker CLI requests as Docker-specific workloads rather than widening them into arbitrary shell commands
+- unrestricted Docker CLI usage is explicit in metadata and result labeling
+
+## Mode Matrix
+
+| Workflow Docker Mode | `container.run_workload` | `container.run_container` | `container.run_docker` |
+| --- | --- | --- | --- |
+| `disabled` | denied | denied | denied |
+| `profiles` | allowed | denied | denied |
+| `unrestricted` | allowed | allowed | allowed |
+
+## Preservation Of The Profile-Backed Path
+
+When workflow Docker mode is `unrestricted`:
+
+- `container.run_workload` remains a profile-backed contract
+- unrestricted container execution does not turn `container.run_workload` into an alias for runtime-selected images
+- unrestricted execution expands the control-plane tool surface, not session-side Docker authority
+
+## Testing Requirements
+
+Unit coverage must verify:
+
+- unrestricted request schema validation
+- Docker CLI prefix enforcement
+- unrestricted tool registration only in `unrestricted` mode
+- runtime denial in `profiles` mode
+- bounded unrestricted launcher args and metadata
+
+Hermetic integration coverage must verify:
+
+- dispatcher-boundary omission or denial of unrestricted tools outside `unrestricted` mode
+- dispatcher-boundary execution of `container.run_container` in `unrestricted` mode
+- alignment between registry exposure and runtime enforcement for unrestricted tools

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/plan.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Unrestricted Container and Docker CLI Contracts
+
+**Branch**: `250-unrestricted-container-and-docker-cli-contracts` | **Date**: 2026-04-24 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`
+
+## Summary
+
+MM-501 is a runtime verification-first story. The repository already contains the unrestricted request schemas in `moonmind/schemas/workload_models.py`, unrestricted launcher behavior in `moonmind/workloads/docker_launcher.py`, mode-aware tool definitions and handler gating in `moonmind/workloads/tool_bridge.py`, runtime enforcement in `moonmind/workflows/temporal/activity_runtime.py`, normalized deployment mode settings in `moonmind/config/settings.py`, and unit plus hermetic integration coverage for unrestricted registration, validation, and dispatcher behavior. The planning work is therefore to preserve MM-501 traceability in MoonSpec artifacts, document the unrestricted contract explicitly, and carry forward focused unit and integration verification rather than plan broad production refactors.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/schemas/workload_models.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+| FR-002 | implemented_unverified | `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_docker_workload_launcher.py` | strengthen verification of structured unrestricted boundaries; implementation contingency only if verification exposes a gap | unit + integration |
+| FR-003 | implemented_verified | `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workloads/test_workload_tool_bridge.py` | none beyond final verify | unit + integration |
+| FR-004 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+| FR-005 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/workflow_docker_mode.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+| FR-006 | implemented_unverified | `docs/ManagedAgents/DockerOutOfDocker.md`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workloads/docker_launcher.py` | final verification must compare documented unrestricted example flows and contract boundaries against current runtime behavior | unit + final verify |
+| FR-007 | implemented_verified | `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, `quickstart.md` | preserve MM-501 through tasks and final verification output | traceability review |
+| DESIGN-REQ-003 | implemented_verified | `moonmind/workflow_docker_mode.py`, `moonmind/config/settings.py`, `moonmind/workloads/tool_bridge.py`, `tests/unit/config/test_settings.py`, `tests/unit/workloads/test_workload_tool_bridge.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-010 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-017 | implemented_verified | `moonmind/schemas/workload_models.py`, `moonmind/workloads/tool_bridge.py`, `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py` | none beyond final verify | unit + integration |
+| DESIGN-REQ-022 | implemented_unverified | `docs/ManagedAgents/DockerOutOfDocker.md`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `tests/unit/workloads/test_workload_contract.py` | compare the documented unrestricted example-flow request shapes against current contract and add tests only if the review finds drift | unit + final verify |
+| DESIGN-REQ-025 | implemented_verified | `moonmind/workloads/tool_bridge.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/integration/temporal/test_integration_ci_tool_contract.py` | none beyond final verify | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing Docker workload launcher/registry stack, pytest  
+**Storage**: No new persistent storage; existing workload registry, launcher, worker runtime wiring, and artifact-backed workload outputs only  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py`  
+**Integration Testing**: `./tools/test_integration.sh`  
+**Target Platform**: MoonMind worker runtime and Docker-backed workload tool path  
+**Project Type**: Backend runtime contract and verification story for unrestricted Docker-backed workload execution  
+**Performance Goals**: Preserve deterministic request validation and low-overhead mode-aware tool dispatch with no new orchestration layers or storage  
+**Constraints**: Keep unrestricted execution deployment-gated and auditable; preserve the profile-backed meaning of `container.run_workload`; do not widen unrestricted execution into generic shell or session-side Docker authority; keep `container.run_docker` Docker-specific; preserve MM-501 traceability  
+**Scale/Scope**: One story covering unrestricted runtime-container requests, unrestricted Docker CLI requests, mode-aware denial, profile-backed-path preservation, and MM-501 traceability
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - stays on the existing Docker workload tool/runtime boundary rather than inventing a new execution plane.
+- II. One-Click Agent Deployment: PASS - adds no new service or operator prerequisite.
+- III. Avoid Vendor Lock-In: PASS - the work stays within MoonMind-owned workload contracts and Docker-facing runtime behavior.
+- IV. Own Your Data: PASS - workload outputs remain artifact-backed on operator-controlled infrastructure.
+- V. Skills Are First-Class and Easy to Add: PASS - unrestricted execution remains a tool-surface contract instead of a shell-side escape mechanism.
+- VI. Replaceable AI Scaffolding: PASS - work focuses on durable policy boundaries and verifiable runtime behavior.
+- VII. Runtime Configurability: PASS - preserves deployment-owned `MOONMIND_WORKFLOW_DOCKER_MODE` behavior.
+- VIII. Modular and Extensible Architecture: PASS - changes stay localized to workload schemas, tool registration, runtime activity enforcement, and tests.
+- IX. Resilient by Default: PASS - mode-aware denial remains explicit and non-retryable when unrestricted tools are forbidden.
+- X. Facilitate Continuous Improvement: PASS - final verification can report concrete MM-501 evidence and any remaining drift between source design and runtime behavior.
+- XI. Spec-Driven Development: PASS - MM-501 spec and Jira preset brief remain the source of truth.
+- XII. Canonical Documentation Separation: PASS - desired-state source requirements remain in `docs/ManagedAgents/DockerOutOfDocker.md`; feature-local planning stays under `specs/250-unrestricted-container-and-docker-cli-contracts/`.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliasing or fallback behavior is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/250-unrestricted-container-and-docker-cli-contracts/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+└── contracts/
+    └── unrestricted-docker-workload-contract.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/config/
+└── settings.py
+
+moonmind/schemas/
+└── workload_models.py
+
+moonmind/workloads/
+├── docker_launcher.py
+├── registry.py
+└── tool_bridge.py
+
+moonmind/workflows/temporal/
+├── activity_runtime.py
+└── worker_runtime.py
+
+tests/unit/config/
+└── test_settings.py
+
+tests/unit/workloads/
+├── test_docker_workload_launcher.py
+├── test_workload_contract.py
+└── test_workload_tool_bridge.py
+
+tests/unit/workflows/temporal/
+├── test_temporal_worker_runtime.py
+└── test_workload_run_activity.py
+
+tests/integration/temporal/
+└── test_integration_ci_tool_contract.py
+```
+
+**Structure Decision**: MM-501 stays entirely on the existing workflow Docker mode, unrestricted request schema, tool bridge, and Temporal runtime path. No new subsystem or persistent data model is needed; the remaining work is to keep unrestricted behavior traceable, contract-documented, and explicitly verified against the source design.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/plan.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/plan.md
@@ -26,15 +26,15 @@ MM-501 is a runtime verification-first story. The repository already contains th
 
 ## Technical Context
 
-**Language/Version**: Python 3.12  
-**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing Docker workload launcher/registry stack, pytest  
-**Storage**: No new persistent storage; existing workload registry, launcher, worker runtime wiring, and artifact-backed workload outputs only  
-**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py`  
-**Integration Testing**: `./tools/test_integration.sh`  
-**Target Platform**: MoonMind worker runtime and Docker-backed workload tool path  
-**Project Type**: Backend runtime contract and verification story for unrestricted Docker-backed workload execution  
-**Performance Goals**: Preserve deterministic request validation and low-overhead mode-aware tool dispatch with no new orchestration layers or storage  
-**Constraints**: Keep unrestricted execution deployment-gated and auditable; preserve the profile-backed meaning of `container.run_workload`; do not widen unrestricted execution into generic shell or session-side Docker authority; keep `container.run_docker` Docker-specific; preserve MM-501 traceability  
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing Docker workload launcher/registry stack, pytest
+**Storage**: No new persistent storage; existing workload registry, launcher, worker runtime wiring, and artifact-backed workload outputs only
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py`
+**Integration Testing**: `./tools/test_integration.sh`
+**Target Platform**: MoonMind worker runtime and Docker-backed workload tool path
+**Project Type**: Backend runtime contract and verification story for unrestricted Docker-backed workload execution
+**Performance Goals**: Preserve deterministic request validation and low-overhead mode-aware tool dispatch with no new orchestration layers or storage
+**Constraints**: Keep unrestricted execution deployment-gated and auditable; preserve the profile-backed meaning of `container.run_workload`; do not widen unrestricted execution into generic shell or session-side Docker authority; keep `container.run_docker` Docker-specific; preserve MM-501 traceability
 **Scale/Scope**: One story covering unrestricted runtime-container requests, unrestricted Docker CLI requests, mode-aware denial, profile-backed-path preservation, and MM-501 traceability
 
 ## Constitution Check

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/quickstart.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Unrestricted Container and Docker CLI Contracts
+
+## Goal
+
+Verify MM-501 using the existing unrestricted execution implementation plus the feature-local contract and traceability review.
+
+## Focused Unit Verification
+
+Run the unrestricted-request and workload-policy unit suites first:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py
+```
+
+What this proves:
+
+- unrestricted container requests parse and validate through the structured contract
+- unrestricted Docker CLI requests require `command[0] == docker`
+- unrestricted tools are only exposed in `unrestricted` workflow Docker mode
+- runtime invocation denies unrestricted tools in `profiles` mode
+- unrestricted launcher behavior stays bounded and preserves Docker-specific execution
+
+## Hermetic Integration Verification
+
+Run the hermetic integration suite after the focused unit pass:
+
+```bash
+./tools/test_integration.sh
+```
+
+Focused integration coverage target:
+
+- `tests/integration/temporal/test_integration_ci_tool_contract.py`
+
+What this proves:
+
+- the dispatcher/runtime boundary omits unrestricted tools outside `unrestricted` mode
+- the dispatcher/runtime boundary executes `container.run_container` in `unrestricted` mode
+- mode-aware registration and runtime denial stay aligned for the unrestricted tool surface
+
+## End-To-End Story Validation
+
+1. Confirm `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` preserve MM-501 and the original Jira preset brief.
+2. Run the focused unit verification command.
+3. Run the hermetic integration verification command.
+4. Compare the unrestricted example flows in `docs/ManagedAgents/DockerOutOfDocker.md` sections 18.2-18.4 against the current unrestricted request schema and launcher behavior.
+5. Complete final MoonSpec verification against MM-501, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/research.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/research.md
@@ -1,0 +1,81 @@
+# Research: Unrestricted Container and Docker CLI Contracts
+
+## Story Classification
+
+Decision: Treat MM-501 as a single-story runtime verification-first feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`; `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`.
+Rationale: The Jira preset brief defines one independently testable runtime outcome: MoonMind exposes and enforces distinct unrestricted container and Docker CLI contracts without weakening the normal profile-backed path.
+Alternatives considered: Broad design breakdown was rejected because the Jira brief already selects one bounded story.
+Test implications: Unit tests plus at least one hermetic integration boundary are required because the story touches request validation, tool registration, and dispatcher/runtime execution behavior.
+
+## FR-001 / DESIGN-REQ-017 First-Class `container.run_container`
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` registers `container.run_container` as a Docker-backed workload tool in unrestricted mode; `moonmind/schemas/workload_models.py` defines `UnrestrictedContainerRequest`; `tests/unit/workloads/test_workload_tool_bridge.py` verifies unrestricted tool registration; `tests/unit/workloads/test_workload_contract.py` verifies unrestricted request parsing; `tests/integration/temporal/test_integration_ci_tool_contract.py` executes `container.run_container` through the tool activity dispatcher in unrestricted mode.
+Rationale: The unrestricted arbitrary-container contract already exists at the schema, tool-registration, and dispatcher/runtime layers.
+Alternatives considered: Classify as implemented_unverified. Rejected because there is both unit and integration evidence for the unrestricted container path.
+Test implications: Preserve unit plus integration evidence.
+
+## FR-002 Structured Unrestricted Boundary Rejection
+
+Decision: implemented_unverified.
+Evidence: `moonmind/schemas/workload_models.py` restricts unrestricted requests to explicit fields, Docker named-cache mounts, and allowed network policies; `moonmind/workloads/docker_launcher.py` hard-codes `--privileged=false`, `--cap-drop ALL`, and `no-new-privileges`; `tests/unit/workloads/test_workload_contract.py` verifies unrestricted cache-mount and workspace constraints; `tests/unit/workloads/test_docker_workload_launcher.py` verifies restricted launcher args.
+Rationale: The current code strongly suggests the structured unrestricted boundary is enforced, but the exact user-facing rejection set named by the MM-501 brief should remain under verification scrutiny until final traceability review confirms the source-design examples and current test coverage line up completely.
+Alternatives considered: Mark as implemented_verified immediately. Rejected to keep the plan conservative where the source design names several forbidden capability classes that are enforced partly by schema shape and partly by launcher defaults.
+Test implications: Re-run focused unit coverage and use final verification to decide whether any additional negative tests are needed.
+
+## FR-003 / DESIGN-REQ-017 Docker-CLI-Specific `container.run_docker`
+
+Decision: implemented_verified.
+Evidence: `moonmind/schemas/workload_models.py` defines `UnrestrictedDockerRequest` and rejects commands whose first token is not `docker`; `moonmind/workloads/docker_launcher.py` replaces only the leading Docker binary while preserving Docker CLI arguments; `tests/unit/workloads/test_workload_contract.py` verifies the `docker` prefix requirement; `tests/unit/workloads/test_docker_workload_launcher.py` verifies Docker CLI arg construction; `tests/unit/workloads/test_workload_tool_bridge.py` verifies unrestricted Docker handler execution in unrestricted mode.
+Rationale: The unrestricted Docker CLI contract is already explicitly distinguished from arbitrary-container execution.
+Alternatives considered: Treat `container.run_docker` as a generic shell wrapper. Rejected because the code and tests already enforce the Docker-specific contract.
+Test implications: Preserve unit plus integration evidence.
+
+## FR-004 / DESIGN-REQ-010 Mode-Aware Denial
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` omits unrestricted tools in `profiles` mode and denies direct unrestricted invocation when not allowed; `moonmind/workflows/temporal/activity_runtime.py` raises non-retryable `docker_workflow_mode_forbidden` errors; `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py` verify `profiles` versus `unrestricted` behavior.
+Rationale: Mode-aware unrestricted-tool denial is already enforced both at registration and at runtime invocation.
+Alternatives considered: Add a second policy layer outside the existing tool bridge and activity runtime. Rejected because the current shared decision path already exists.
+Test implications: Preserve unit plus integration evidence.
+
+## FR-005 / DESIGN-REQ-025 Preserve `container.run_workload` As Profile-Backed
+
+Decision: implemented_verified.
+Evidence: `moonmind/workloads/tool_bridge.py` keeps `container.run_workload`, `container.start_helper`, and `container.stop_helper` in the curated/profile-backed set while adding unrestricted tools separately; `moonmind/workflow_docker_mode.py` and `tool_allowed_for_workflow_docker_mode` keep the mode matrix explicit; `tests/unit/workloads/test_workload_tool_bridge.py` verifies profiles-mode exposure excludes unrestricted tools; `tests/integration/temporal/test_integration_ci_tool_contract.py` shows unrestricted registration is additive rather than a replacement for curated workload paths.
+Rationale: The current unrestricted implementation preserves the normal profile-backed path instead of widening it.
+Alternatives considered: Treat `container.run_workload` as a backward-compatible alias for unrestricted requests. Rejected because both the source design and repo code keep the paths distinct.
+Test implications: Preserve unit plus integration evidence.
+
+## FR-006 / DESIGN-REQ-022 Example-Flow Alignment
+
+Decision: implemented_unverified.
+Evidence: `docs/ManagedAgents/DockerOutOfDocker.md` defines unrestricted example flows in sections 18.2-18.4; `moonmind/schemas/workload_models.py` and `moonmind/workloads/docker_launcher.py` define the current request shape and runtime behavior; `tests/unit/workloads/test_workload_contract.py` covers example-like unrestricted request payloads.
+Rationale: The repo appears aligned with the documented unrestricted examples, but this is principally a traceability and contract-verification concern that final verification should compare directly rather than assume from adjacent coverage.
+Alternatives considered: Mark as implemented_verified solely from source/code similarity. Rejected because the story explicitly names example-flow alignment and that deserves an explicit final review.
+Test implications: Focused unit verification plus final contract review; add tests only if final verification finds drift.
+
+## FR-007 Traceability
+
+Decision: implemented_verified.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`; `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`; `plan.md`; `research.md`; `contracts/unrestricted-docker-workload-contract.md`; `quickstart.md`.
+Rationale: The feature-local MoonSpec artifacts preserve MM-501 and the original Jira preset brief for downstream tasks and verification.
+Alternatives considered: Preserve the Jira key only in the source brief. Rejected because the story explicitly requires downstream traceability.
+Test implications: Final traceability review only.
+
+## Design Artifact Decision
+
+Decision: create a feature-local contract artifact and skip `data-model.md`.
+Evidence: MM-501 is about runtime tool-contract behavior, policy boundaries, and verification evidence; it does not add new persisted entities or a changed storage shape.
+Rationale: A contract artifact is necessary because the story is about the unrestricted tool surface and its allowed and forbidden inputs. A separate data model would duplicate existing request-model code without clarifying the story.
+Alternatives considered: Create `data-model.md` for unrestricted request entities. Rejected because those shapes already exist in repo code and the story does not introduce new persistent data.
+Test implications: Contract review plus unit and integration verification are sufficient.
+
+## Planning Workflow Gap
+
+Decision: continue manual planning artifact generation and record the missing helper scripts as an environment gap.
+Evidence: `scripts/bash/setup-plan.sh` and `scripts/bash/update-agent-context.sh` are not present in this repository checkout.
+Rationale: The MoonSpec plan gate still requires `plan.md`, `research.md`, `quickstart.md`, and required contract artifacts, so planning should continue instead of stopping on missing helper automation.
+Alternatives considered: Stop planning entirely because the helper scripts are absent. Rejected because the required planning artifacts can still be produced deterministically from the active feature directory.
+Test implications: None beyond documenting the missing helper scripts in the final report.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Unrestricted Container and Docker CLI Contracts
+
+**Feature Branch**: `250-unrestricted-container-and-docker-cli-contracts`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-501 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched MM-501 under `specs/`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-501 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-501
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Add unrestricted container and Docker CLI execution contracts
+- Labels: `moonmind-workflow-mm-f5953598-583e-468e-b58f-219d2fe54fc3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-501 from MM project
+Summary: Add unrestricted container and Docker CLI execution contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-501 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-501: Add unrestricted container and Docker CLI execution contracts
+
+Source Reference
+- Source Document: `docs/ManagedAgents/DockerOutOfDocker.md`
+- Source Title: DockerOutOfDocker: Docker-backed Specialized Workload Containers for MoonMind
+- Source Sections:
+  - 2. Core decisions
+  - 7. Supported container roles
+  - 11.4 container.run_container
+  - 11.5 container.run_docker
+  - 18.2-18.4 Example flows
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-010
+  - DESIGN-REQ-017
+  - DESIGN-REQ-022
+  - DESIGN-REQ-025
+
+User Story
+As a trusted deployment operator, I can allow arbitrary runtime containers and explicit Docker CLI workloads through separate unrestricted MoonMind tools without weakening the normal profile-backed contract.
+
+Acceptance Criteria
+- Given mode is unrestricted, when `container.run_container` is invoked with a runtime-selected image plus workspace paths and declared outputs, then MoonMind launches the container without requiring a pre-registered runner profile.
+- Given `container.run_container` includes arbitrary host-path mounts, privileged flags, host networking, or implicit auth inheritance, then validation rejects the request because those capabilities are outside the structured unrestricted contract.
+- Given mode is unrestricted, when `container.run_docker` is invoked, then `command[0]` must equal `docker` and the command runs as a Docker CLI invocation rather than a general shell surface.
+- Given mode is `disabled` or `profiles`, when unrestricted tools are invoked, then MoonMind returns deterministic denial codes such as `unrestricted_container_disabled` or `unrestricted_docker_disabled`.
+
+Requirements
+- Expose `container.run_container` as the first-class unrestricted arbitrary-container contract.
+- Expose `container.run_docker` as the explicit Docker CLI escape hatch and not as generic shell access.
+- Keep unrestricted execution deployment-gated and auditable.
+- Preserve the meaning of `container.run_workload` as profile-backed even when unrestricted mode is enabled.
+
+Relevant Implementation Notes
+- Preserve MM-501 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/DockerOutOfDocker.md` as the source design reference for core decisions, supported container roles, unrestricted container execution, Docker CLI execution, and the documented example flows.
+- Keep unrestricted execution deployment-gated and auditable rather than widening it into unbounded shell access.
+- Treat `container.run_container` and `container.run_docker` as distinct unrestricted tool contracts with explicit validation boundaries.
+- Ensure `container.run_docker` remains a Docker CLI-specific surface where `command[0]` must be `docker`, not a general-purpose shell mechanism.
+- Preserve the profile-backed meaning of `container.run_workload` even when unrestricted mode is enabled.
+- Reject unrestricted requests that attempt arbitrary host-path mounts, privileged flags, host networking, or implicit auth inheritance outside the structured contract.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-501 blocks MM-500, whose embedded status is In Progress.
+- Trusted Jira link metadata at fetch time shows MM-501 is blocked by MM-502, whose embedded status is Backlog.
+
+Needs Clarification
+- None
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief already defines one independently testable runtime story.
+- Selected mode: Runtime.
+- Source design: `docs/ManagedAgents/DockerOutOfDocker.md` is treated as runtime source requirements because the brief describes system behavior, not documentation-only work.
+- Resume decision: No existing Moon Spec artifacts for MM-501 were found under `specs/`; specification is the first incomplete stage.
+
+## User Story - Run Unrestricted Containers And Docker CLI Workloads
+
+**Summary**: As a trusted deployment operator, I want separate unrestricted container and Docker CLI workflow tools so MoonMind can support operator-approved unrestricted execution without weakening the normal profile-backed workload contract.
+
+**Goal**: Deployment operators can enable a narrowly defined unrestricted execution mode where MoonMind exposes `container.run_container` and `container.run_docker`, enforces their distinct validation boundaries, keeps `container.run_workload` profile-backed, and returns deterministic denials when unrestricted execution is not allowed.
+
+**Independent Test**: In each workflow Docker mode, invoke `container.run_container`, `container.run_docker`, and `container.run_workload` with allowed and disallowed inputs, then verify unrestricted mode permits only the defined unrestricted contracts, `container.run_docker` requires a Docker CLI invocation, structured validation rejects forbidden host-path, privilege, networking, or auth inheritance inputs, non-unrestricted modes return deterministic denial outcomes, and MM-501 traceability remains preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** workflow Docker mode is `unrestricted`, **When** `container.run_container` is invoked with a runtime-selected image, workspace paths, and declared outputs that fit the unrestricted contract, **Then** MoonMind launches the container without requiring a pre-registered runner profile.
+2. **Given** `container.run_container` includes arbitrary host-path mounts, privileged flags, host networking, or implicit auth inheritance, **When** the request is validated, **Then** MoonMind rejects the request because those capabilities are outside the structured unrestricted contract.
+3. **Given** workflow Docker mode is `unrestricted`, **When** `container.run_docker` is invoked, **Then** MoonMind executes it only as a Docker CLI workload where `command[0]` is `docker` rather than as a general shell surface.
+4. **Given** workflow Docker mode is `disabled` or `profiles`, **When** unrestricted tools are invoked, **Then** MoonMind returns deterministic denial outcomes such as `unrestricted_container_disabled` or `unrestricted_docker_disabled`.
+5. **Given** unrestricted execution mode is enabled, **When** `container.run_workload` is invoked, **Then** MoonMind preserves its existing profile-backed meaning instead of treating it as an unrestricted alias.
+
+### Edge Cases
+
+- A caller attempts to pass arbitrary host-path mounts, privileged execution flags, or host networking through `container.run_container`.
+- A caller uses `container.run_docker` with a command whose first token is not `docker`.
+- Registry discovery exposes unrestricted tools in a mode that runtime invocation later denies, or vice versa.
+- Enabling unrestricted mode accidentally widens `container.run_workload` into raw image or shell-oriented execution.
+- Unrestricted example flows diverge from the contract enforced at the worker boundary.
+
+## Assumptions
+
+- MM-501 is scoped to the unrestricted workflow execution contracts and their boundaries, not to redesigning profile-backed workload semantics already covered by adjacent stories.
+- The blocker relationship to MM-502 is tracked operationally outside this specification and does not change the single-story runtime scope captured here.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-003 | `docs/ManagedAgents/DockerOutOfDocker.md` §2 | Workflow Docker execution modes must preserve explicit boundaries between profile-backed and unrestricted behavior. | In scope | FR-001, FR-004, FR-005 |
+| DESIGN-REQ-010 | `docs/ManagedAgents/DockerOutOfDocker.md` §2 | Unrestricted workflow mode exposes additional workload capabilities without weakening unrelated execution boundaries. | In scope | FR-001, FR-004, FR-005 |
+| DESIGN-REQ-017 | `docs/ManagedAgents/DockerOutOfDocker.md` §11.4-11.5 | The user-facing unrestricted tool surface must distinguish arbitrary-container execution from explicit Docker CLI execution. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-022 | `docs/ManagedAgents/DockerOutOfDocker.md` §18.2-18.4 | Example unrestricted execution flows must remain consistent with the formal unrestricted tool contracts and validation behavior. | In scope | FR-002, FR-003, FR-006 |
+| DESIGN-REQ-025 | `docs/ManagedAgents/DockerOutOfDocker.md` §7 | Profile-backed workload tools remain part of the supported container-role model and must not silently change meaning when unrestricted mode is enabled. | In scope | FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose `container.run_container` as the first-class unrestricted arbitrary-container workflow contract for runtime-selected container execution.
+- **FR-002**: The system MUST reject `container.run_container` requests that include arbitrary host-path mounts, privileged execution flags, host networking, or implicit auth inheritance outside the structured unrestricted contract.
+- **FR-003**: The system MUST expose `container.run_docker` as a distinct unrestricted Docker CLI workload contract and MUST require `command[0]` to equal `docker`.
+- **FR-004**: The system MUST deterministically deny unrestricted tool invocations when workflow Docker mode is `disabled` or `profiles`.
+- **FR-005**: The system MUST preserve the profile-backed meaning of `container.run_workload` even when unrestricted mode is enabled.
+- **FR-006**: The system MUST keep unrestricted example flows and operator-visible behavior aligned with the same validation boundaries enforced at runtime.
+- **FR-007**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-501.
+
+### Key Entities
+
+- **Unrestricted Container Request**: The structured request for `container.run_container` that permits runtime-selected container execution within bounded unrestricted validation rules.
+- **Docker CLI Workload Request**: The structured request for `container.run_docker` that allows Docker CLI execution only when the command is explicitly a Docker invocation.
+- **Profile-Backed Workload Contract**: The existing `container.run_workload` contract whose meaning remains tied to approved runner profiles even when unrestricted mode is enabled.
+- **Deterministic Denial Outcome**: The predictable non-success result returned when unrestricted execution is invoked from a non-unrestricted workflow Docker mode or with forbidden unrestricted inputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Validation proves `container.run_container` accepts only the structured unrestricted request shape and rejects forbidden mounts, privilege, networking, or auth inheritance inputs.
+- **SC-002**: Validation proves `container.run_docker` executes only Docker CLI invocations where `command[0]` is `docker`.
+- **SC-003**: Validation proves `disabled` and `profiles` modes return deterministic denials for unrestricted tool invocations.
+- **SC-004**: Validation proves `container.run_workload` remains profile-backed and does not become an unrestricted alias when unrestricted mode is enabled.
+- **SC-005**: Validation proves operator-visible unrestricted example flows and runtime validation behavior remain aligned.
+- **SC-006**: Traceability review confirms MM-501 and DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, and DESIGN-REQ-025 remain preserved in MoonSpec artifacts and downstream verification evidence.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/spec.md
@@ -1,8 +1,8 @@
 # Feature Specification: Unrestricted Container and Docker CLI Contracts
 
-**Feature Branch**: `250-unrestricted-container-and-docker-cli-contracts`  
-**Created**: 2026-04-24  
-**Status**: Draft  
+**Feature Branch**: `250-unrestricted-container-and-docker-cli-contracts`
+**Created**: 2026-04-24
+**Status**: Draft
 **Input**: User description: "Use the Jira preset brief for MM-501 as the canonical Moon Spec orchestration input.
 
 Additional constraints:

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Unrestricted Container and Docker CLI Contracts
 
-**Input**: Design documents from `specs/250-unrestricted-container-and-docker-cli-contracts/`  
+**Input**: Design documents from `specs/250-unrestricted-container-and-docker-cli-contracts/`
 **Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, `quickstart.md`
 
 **Tests**: Unit tests and hermetic integration verification are REQUIRED. For MM-501, the repository already contains most unrestricted-mode production behavior and broad test evidence, so the story work is verification-first: preserve the canonical artifacts, re-run the focused unrestricted verification suites, close the remaining `implemented_unverified` gaps with tests first, and implement code changes only if verification exposes drift.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
@@ -1,0 +1,125 @@
+# Tasks: Unrestricted Container and Docker CLI Contracts
+
+**Input**: Design documents from `specs/250-unrestricted-container-and-docker-cli-contracts/`  
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and hermetic integration verification are REQUIRED. For MM-501, the repository already contains most unrestricted-mode production behavior and broad test evidence, so the story work is verification-first: preserve the canonical artifacts, re-run the focused unrestricted verification suites, close the remaining `implemented_unverified` gaps with tests first, and implement code changes only if verification exposes drift.
+
+**Organization**: Tasks are grouped around the single MM-501 story: verify `container.run_container` and `container.run_docker` as distinct unrestricted contracts, prove mode-aware denial and profile-backed-path preservation, compare the documented unrestricted example flows to runtime behavior, and preserve MM-501 traceability.
+
+**Source Traceability**: MM-501; FR-001 through FR-007; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025.
+
+**Requirement Status Summary**: verification-first. `FR-001`, `FR-003`, `FR-004`, `FR-005`, `FR-007`, `DESIGN-REQ-003`, `DESIGN-REQ-010`, `DESIGN-REQ-017`, and `DESIGN-REQ-025` are already implemented and verified by current code plus unit/integration evidence. `FR-002`, `FR-006`, and `DESIGN-REQ-022` are `implemented_unverified` and require verification tests plus conditional fallback implementation only if verification fails.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py`
+- Hermetic integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the MM-501 source brief, planning artifacts, and unrestricted-mode repo surfaces before verification work.
+
+- [ ] T001 Confirm `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` remain the canonical MM-501 artifact set
+- [ ] T002 Confirm the MM-501 runtime touchpoints in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflow_docker_mode.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/temporal/worker_runtime.py`, and the existing unrestricted-mode test suites
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Lock the feature-local validation shape before story verification.
+
+- [ ] T003 Confirm `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` remains correct that MM-501 needs no `data-model.md`, migration, or new persistent storage because the story is a runtime contract verification story
+- [ ] T004 Confirm the focused unit suites in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/config/test_settings.py`, plus the hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py`, are the correct validation paths for MM-501
+
+**Checkpoint**: Foundation ready - story verification work can begin.
+
+---
+
+## Phase 3: Story - Run Unrestricted Containers And Docker CLI Workloads
+
+**Summary**: As a trusted deployment operator, I want separate unrestricted container and Docker CLI workflow tools so MoonMind can support operator-approved unrestricted execution without weakening the normal profile-backed workload contract.
+
+**Independent Test**: In each workflow Docker mode, invoke `container.run_container`, `container.run_docker`, and `container.run_workload` with allowed and disallowed inputs, then verify unrestricted mode permits only the defined unrestricted contracts, `container.run_docker` requires a Docker CLI invocation, structured validation rejects forbidden host-path, privilege, networking, or auth inheritance inputs, non-unrestricted modes return deterministic denial outcomes, and MM-501 traceability remains preserved.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025
+
+**Unit Test Plan**:
+
+- Re-run and, only if needed, strengthen `tests/unit/workloads/test_workload_contract.py` and `tests/unit/workloads/test_docker_workload_launcher.py` for structured unrestricted-boundary rejection, Docker CLI prefix enforcement, and example-flow request-shape alignment.
+- Re-run the unrestricted mode registration and denial coverage in `tests/unit/workloads/test_workload_tool_bridge.py`.
+- Re-run the Temporal runtime and worker wiring coverage in `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`.
+
+**Integration Test Plan**:
+
+- Re-run `tests/integration/temporal/test_integration_ci_tool_contract.py` through `./tools/test_integration.sh` to prove dispatcher/runtime omission outside `unrestricted` mode and execution of `container.run_container` in `unrestricted` mode.
+- Add targeted integration assertions in `tests/integration/temporal/test_integration_ci_tool_contract.py` only if the current boundary does not fully prove FR-002 or FR-006 after verification.
+
+### Verification Tests
+
+- [ ] T005 [P] Re-run and review unrestricted request validation coverage for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-017, and DESIGN-REQ-022 in `tests/unit/workloads/test_workload_contract.py` and `tests/unit/workloads/test_docker_workload_launcher.py`
+- [ ] T006 [P] Re-run and review unrestricted tool registration and mode-aware denial coverage for FR-001, FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-003, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/unit/workloads/test_workload_tool_bridge.py`
+- [ ] T007 [P] Re-run and review runtime wiring and mode propagation coverage for FR-004, SC-003, DESIGN-REQ-003, and DESIGN-REQ-010 in `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
+- [ ] T008 Re-run and review the hermetic dispatcher boundary for FR-001, FR-004, FR-005, SC-003, SC-004, SC-005, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/integration/temporal/test_integration_ci_tool_contract.py`
+
+### Red-First Confirmation
+
+- [ ] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py` and confirm whether the MM-501-focused unit verification already passes or exposes a gap
+- [ ] T010 Run `./tools/test_integration.sh` and confirm whether the current hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py` already passes for MM-501 or exposes a gap
+
+### Conditional Fallback Implementation
+
+- [ ] T011 If T005 or T009 exposes a structured unrestricted-boundary gap for FR-002, implement the minimum schema or launcher fix in `moonmind/schemas/workload_models.py` and `moonmind/workloads/docker_launcher.py`
+- [ ] T012 If T008 or T010 exposes a dispatcher/runtime alignment gap for FR-006 or DESIGN-REQ-022, implement the minimum tool registration, runtime enforcement, or integration assertion fix in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py`
+
+### Story Validation
+
+- [ ] T013 Re-run the focused unit command from T009 after any fallback changes and confirm MM-501 unit evidence is green in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
+- [ ] T014 Re-run `./tools/test_integration.sh` after any fallback changes and confirm `tests/integration/temporal/test_integration_ci_tool_contract.py` proves unrestricted-mode dispatcher/runtime behavior end to end
+- [ ] T015 Compare `docs/ManagedAgents/DockerOutOfDocker.md` sections 11.4, 11.5, and 18.2-18.4 against `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, and `contracts/unrestricted-docker-workload-contract.md` to confirm FR-006 and DESIGN-REQ-022 remain aligned
+- [ ] T016 Review `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` to confirm FR-007 and SC-006 preserve MM-501 and the original Jira preset brief across downstream artifacts
+
+**Checkpoint**: MM-501 is complete when the unrestricted container and Docker CLI contracts are proven at unit and integration boundaries, any exposed verification gap is remediated conservatively, the source-design examples still match runtime behavior, and the canonical artifact set preserves the Jira brief.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Final traceability and read-only verification for the completed story.
+
+- [ ] T017 [P] Update `specs/250-unrestricted-container-and-docker-cli-contracts/plan.md`, `research.md`, `quickstart.md`, and `contracts/unrestricted-docker-workload-contract.md` if the verification evidence changed any MM-501 implementation assumptions or commands
+- [ ] T018 [P] Review the missing helper-script note in `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` against the current repository state and keep it accurate without adding hidden scope
+- [ ] T019 Run `/moonspec-verify` for `specs/250-unrestricted-container-and-docker-cli-contracts/` and produce final verification evidence covering MM-501, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies
+- Foundational (Phase 2): depends on Setup completion
+- Story (Phase 3): depends on Foundational completion
+- Polish (Phase 4): depends on story validation completing
+
+### Within The Story
+
+- T005-T008 define the verification surface before any fallback implementation is considered.
+- T009-T010 confirm whether MM-501 is already green or whether the conditional fallback path is needed.
+- T011-T012 only execute if the preceding verification exposes a real gap.
+- T013-T016 provide the required post-fix or post-verification story validation before final verification.
+
+### Parallel Opportunities
+
+- T005-T007 can run in parallel because they validate different unit-test files.
+- T017 and T018 can run in parallel after story validation is complete.
+
+## Implementation Strategy
+
+1. Preserve MM-501 as the canonical MoonSpec source input and artifact set.
+2. Re-run the focused unrestricted-mode unit and integration verification suites before touching production code.
+3. Apply the smallest possible fallback fix only if verification exposes a real runtime or test gap.
+4. Re-validate unit and integration evidence after any fallback change.
+5. Confirm source-design example-flow alignment and MM-501 traceability.
+6. Finish with `/moonspec-verify`.

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
@@ -53,7 +53,7 @@
 
 **Integration Test Plan**:
 
-- Re-run `tests/integration/temporal/test_integration_ci_tool_contract.py` through `./tools/test_integration.sh` to prove dispatcher/runtime omission outside `unrestricted` mode and execution of `container.run_container` in `unrestricted` mode.
+- Re-run `tests/integration/temporal/test_integration_ci_tool_contract.py` through `./tools/test_integration.sh` to prove dispatcher/runtime omission outside `unrestricted` mode, execution of `container.run_container` in `unrestricted` mode, and whether the current boundary sufficiently exercises the structured unrestricted contract.
 - Add targeted integration assertions in `tests/integration/temporal/test_integration_ci_tool_contract.py` only if the current boundary does not fully prove FR-002 or FR-006 after verification.
 
 ### Verification Tests
@@ -61,7 +61,7 @@
 - [ ] T005 [P] Re-run and review unrestricted request validation coverage for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-017, and DESIGN-REQ-022 in `tests/unit/workloads/test_workload_contract.py` and `tests/unit/workloads/test_docker_workload_launcher.py`
 - [ ] T006 [P] Re-run and review unrestricted tool registration and mode-aware denial coverage for FR-001, FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-003, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/unit/workloads/test_workload_tool_bridge.py`
 - [ ] T007 [P] Re-run and review runtime wiring and mode propagation coverage for FR-004, SC-003, DESIGN-REQ-003, and DESIGN-REQ-010 in `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
-- [ ] T008 Re-run and review the hermetic dispatcher boundary for FR-001, FR-004, FR-005, SC-003, SC-004, SC-005, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/integration/temporal/test_integration_ci_tool_contract.py`
+- [ ] T008 Re-run and review the hermetic dispatcher boundary for FR-001, FR-002, FR-004, FR-005, SC-003, SC-004, SC-005, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/integration/temporal/test_integration_ci_tool_contract.py`
 
 ### Red-First Confirmation
 
@@ -71,7 +71,7 @@
 ### Conditional Fallback Implementation
 
 - [ ] T011 If T005 or T009 exposes a structured unrestricted-boundary gap for FR-002, implement the minimum schema or launcher fix in `moonmind/schemas/workload_models.py` and `moonmind/workloads/docker_launcher.py`
-- [ ] T012 If T008 or T010 exposes a dispatcher/runtime alignment gap for FR-006 or DESIGN-REQ-022, implement the minimum tool registration, runtime enforcement, or integration assertion fix in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py`
+- [ ] T012 If T008 or T010 exposes a dispatcher/runtime alignment gap for FR-002, FR-006, or DESIGN-REQ-022, implement the minimum tool registration, runtime enforcement, or integration assertion fix in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py`
 
 ### Story Validation
 

--- a/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
+++ b/specs/250-unrestricted-container-and-docker-cli-contracts/tasks.md
@@ -21,8 +21,8 @@
 
 **Purpose**: Confirm the MM-501 source brief, planning artifacts, and unrestricted-mode repo surfaces before verification work.
 
-- [ ] T001 Confirm `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` remain the canonical MM-501 artifact set
-- [ ] T002 Confirm the MM-501 runtime touchpoints in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflow_docker_mode.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/temporal/worker_runtime.py`, and the existing unrestricted-mode test suites
+- [X] T001 Confirm `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `specs/250-unrestricted-container-and-docker-cli-contracts/spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` remain the canonical MM-501 artifact set
+- [X] T002 Confirm the MM-501 runtime touchpoints in `moonmind/config/settings.py`, `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/workloads/tool_bridge.py`, `moonmind/workflow_docker_mode.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/temporal/worker_runtime.py`, and the existing unrestricted-mode test suites
 
 ---
 
@@ -30,8 +30,8 @@
 
 **Purpose**: Lock the feature-local validation shape before story verification.
 
-- [ ] T003 Confirm `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` remains correct that MM-501 needs no `data-model.md`, migration, or new persistent storage because the story is a runtime contract verification story
-- [ ] T004 Confirm the focused unit suites in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/config/test_settings.py`, plus the hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py`, are the correct validation paths for MM-501
+- [X] T003 Confirm `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` remains correct that MM-501 needs no `data-model.md`, migration, or new persistent storage because the story is a runtime contract verification story
+- [X] T004 Confirm the focused unit suites in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/config/test_settings.py`, plus the hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py`, are the correct validation paths for MM-501
 
 **Checkpoint**: Foundation ready - story verification work can begin.
 
@@ -58,27 +58,27 @@
 
 ### Verification Tests
 
-- [ ] T005 [P] Re-run and review unrestricted request validation coverage for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-017, and DESIGN-REQ-022 in `tests/unit/workloads/test_workload_contract.py` and `tests/unit/workloads/test_docker_workload_launcher.py`
-- [ ] T006 [P] Re-run and review unrestricted tool registration and mode-aware denial coverage for FR-001, FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-003, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/unit/workloads/test_workload_tool_bridge.py`
-- [ ] T007 [P] Re-run and review runtime wiring and mode propagation coverage for FR-004, SC-003, DESIGN-REQ-003, and DESIGN-REQ-010 in `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
-- [ ] T008 Re-run and review the hermetic dispatcher boundary for FR-001, FR-002, FR-004, FR-005, SC-003, SC-004, SC-005, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/integration/temporal/test_integration_ci_tool_contract.py`
+- [X] T005 [P] Re-run and review unrestricted request validation coverage for FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-017, and DESIGN-REQ-022 in `tests/unit/workloads/test_workload_contract.py` and `tests/unit/workloads/test_docker_workload_launcher.py`
+- [X] T006 [P] Re-run and review unrestricted tool registration and mode-aware denial coverage for FR-001, FR-004, FR-005, SC-003, SC-004, DESIGN-REQ-003, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/unit/workloads/test_workload_tool_bridge.py`
+- [X] T007 [P] Re-run and review runtime wiring and mode propagation coverage for FR-004, SC-003, DESIGN-REQ-003, and DESIGN-REQ-010 in `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
+- [X] T008 Re-run and review the hermetic dispatcher boundary for FR-001, FR-002, FR-004, FR-005, SC-003, SC-004, SC-005, DESIGN-REQ-010, and DESIGN-REQ-025 in `tests/integration/temporal/test_integration_ci_tool_contract.py`
 
 ### Red-First Confirmation
 
-- [ ] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py` and confirm whether the MM-501-focused unit verification already passes or exposes a gap
-- [ ] T010 Run `./tools/test_integration.sh` and confirm whether the current hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py` already passes for MM-501 or exposes a gap
+- [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py` and confirm whether the MM-501-focused unit verification already passes or exposes a gap
+- [X] T010 Run `./tools/test_integration.sh` and confirm whether the current hermetic integration boundary in `tests/integration/temporal/test_integration_ci_tool_contract.py` already passes for MM-501 or exposes a gap
 
 ### Conditional Fallback Implementation
 
-- [ ] T011 If T005 or T009 exposes a structured unrestricted-boundary gap for FR-002, implement the minimum schema or launcher fix in `moonmind/schemas/workload_models.py` and `moonmind/workloads/docker_launcher.py`
-- [ ] T012 If T008 or T010 exposes a dispatcher/runtime alignment gap for FR-002, FR-006, or DESIGN-REQ-022, implement the minimum tool registration, runtime enforcement, or integration assertion fix in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py`
+- [X] T011 If T005 or T009 exposes a structured unrestricted-boundary gap for FR-002, implement the minimum schema or launcher fix in `moonmind/schemas/workload_models.py` and `moonmind/workloads/docker_launcher.py`
+- [X] T012 If T008 or T010 exposes a dispatcher/runtime alignment gap for FR-002, FR-006, or DESIGN-REQ-022, implement the minimum tool registration, runtime enforcement, or integration assertion fix in `moonmind/workloads/tool_bridge.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `tests/integration/temporal/test_integration_ci_tool_contract.py`
 
 ### Story Validation
 
-- [ ] T013 Re-run the focused unit command from T009 after any fallback changes and confirm MM-501 unit evidence is green in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
-- [ ] T014 Re-run `./tools/test_integration.sh` after any fallback changes and confirm `tests/integration/temporal/test_integration_ci_tool_contract.py` proves unrestricted-mode dispatcher/runtime behavior end to end
-- [ ] T015 Compare `docs/ManagedAgents/DockerOutOfDocker.md` sections 11.4, 11.5, and 18.2-18.4 against `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, and `contracts/unrestricted-docker-workload-contract.md` to confirm FR-006 and DESIGN-REQ-022 remain aligned
-- [ ] T016 Review `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` to confirm FR-007 and SC-006 preserve MM-501 and the original Jira preset brief across downstream artifacts
+- [X] T013 Re-run the focused unit command from T009 after any fallback changes and confirm MM-501 unit evidence is green in `tests/unit/workloads/test_workload_contract.py`, `tests/unit/workloads/test_workload_tool_bridge.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/workflows/temporal/test_workload_run_activity.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, and `tests/unit/config/test_settings.py`
+- [X] T014 Re-run `./tools/test_integration.sh` after any fallback changes and confirm `tests/integration/temporal/test_integration_ci_tool_contract.py` proves unrestricted-mode dispatcher/runtime behavior end to end
+- [X] T015 Compare `docs/ManagedAgents/DockerOutOfDocker.md` sections 11.4, 11.5, and 18.2-18.4 against `moonmind/schemas/workload_models.py`, `moonmind/workloads/docker_launcher.py`, and `contracts/unrestricted-docker-workload-contract.md` to confirm FR-006 and DESIGN-REQ-022 remain aligned
+- [X] T016 Review `docs/tmp/jira-orchestration-inputs/MM-501-moonspec-orchestration-input.md`, `spec.md`, `plan.md`, `research.md`, `contracts/unrestricted-docker-workload-contract.md`, and `quickstart.md` to confirm FR-007 and SC-006 preserve MM-501 and the original Jira preset brief across downstream artifacts
 
 **Checkpoint**: MM-501 is complete when the unrestricted container and Docker CLI contracts are proven at unit and integration boundaries, any exposed verification gap is remediated conservatively, the source-design examples still match runtime behavior, and the canonical artifact set preserves the Jira brief.
 
@@ -88,9 +88,9 @@
 
 **Purpose**: Final traceability and read-only verification for the completed story.
 
-- [ ] T017 [P] Update `specs/250-unrestricted-container-and-docker-cli-contracts/plan.md`, `research.md`, `quickstart.md`, and `contracts/unrestricted-docker-workload-contract.md` if the verification evidence changed any MM-501 implementation assumptions or commands
-- [ ] T018 [P] Review the missing helper-script note in `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` against the current repository state and keep it accurate without adding hidden scope
-- [ ] T019 Run `/moonspec-verify` for `specs/250-unrestricted-container-and-docker-cli-contracts/` and produce final verification evidence covering MM-501, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025
+- [X] T017 [P] Update `specs/250-unrestricted-container-and-docker-cli-contracts/plan.md`, `research.md`, `quickstart.md`, and `contracts/unrestricted-docker-workload-contract.md` if the verification evidence changed any MM-501 implementation assumptions or commands
+- [X] T018 [P] Review the missing helper-script note in `specs/250-unrestricted-container-and-docker-cli-contracts/research.md` against the current repository state and keep it accurate without adding hidden scope
+- [X] T019 Run `/moonspec-verify` for `specs/250-unrestricted-container-and-docker-cli-contracts/` and produce final verification evidence covering MM-501, FR-001 through FR-007, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-022, DESIGN-REQ-025
 
 ---
 


### PR DESCRIPTION
Jira issue key: `MM-501`

Active MoonSpec feature path: `specs/250-unrestricted-container-and-docker-cli-contracts`

Verification verdict: `FULLY_IMPLEMENTED` (`MEDIUM` confidence)

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workloads/test_docker_workload_launcher.py tests/unit/workflows/temporal/test_workload_run_activity.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/config/test_settings.py` - PASS
- `pytest tests/integration/temporal/test_integration_ci_tool_contract.py -q --tb=short -m 'integration_ci'` - PASS
- `./tools/test_integration.sh` - environment-blocked in this managed runtime because `/var/run/docker.sock` is unavailable

Remaining risks:
- The full compose-backed hermetic integration command could not run in this runtime because Docker is unavailable.
- Verification confidence remains medium because final integration evidence relies on the story-specific `integration_ci` test rather than the full compose-backed suite.
