### PR TITLE
[codex] Make pr-resolver merge recheck more robust

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4311,15 +4311,19 @@ class TemporalAgentRuntimeActivities:
                 )
 
             # pr-resolver runs inside the session container where GitHub auth
-            # may be unavailable; transient auth errors get misclassified as
-            # pr_not_found. The activity worker has a valid token, so re-check
-            # against GitHub before surfacing execution_error. If the PR is
-            # actually merged, clear the failure so the workflow sees success.
+            # or mergeability state may lag the activity worker's view. Re-check
+            # against GitHub before surfacing a terminal resolver failure. If
+            # the PR is actually merged, clear the stale failure so the workflow
+            # sees success.
+            pr_number = self._pr_number_from_run_id(run_id)
             if (
                 pr_resolver_expected
                 and result.failure_class is not None
-                and head_branch
-                and "pr_not_found" in (result.summary or "").lower()
+                and (head_branch or pr_number is not None)
+                and (
+                    "pr-resolver" in (result.summary or "").lower()
+                    or pr_number is not None
+                )
             ):
                 merged_pr = self._reverify_pr_merged_state(
                     run_id=run_id,
@@ -5489,6 +5493,19 @@ class TemporalAgentRuntimeActivities:
         match = re.search(r"github\.com[:/]([^/]+/[^/.]+?)(?:\.git)?$", url)
         return match.group(1) if match else ""
 
+    @staticmethod
+    def _pr_number_from_run_id(run_id: str | None) -> int | None:
+        """Extract a resolver PR number from stable run ids when present."""
+        import re
+
+        match = re.search(r"(?:^|:)pr:(\d+)(?::|$)", str(run_id or ""))
+        if match is None:
+            return None
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+
     def _reverify_pr_merged_state(
         self,
         *,
@@ -5498,14 +5515,17 @@ class TemporalAgentRuntimeActivities:
     ) -> dict[str, Any] | None:
         """Return PR metadata when *head_branch*'s PR is merged on GitHub.
 
-        Used to recover from pr-resolver's pr_not_found misclassification when
-        the managed session container lacks working GitHub CLI auth.
+        Used to recover from stale pr-resolver failures after GitHub has already
+        accepted or observed the merge.
         """
         import subprocess
 
         branch = (head_branch or "").strip()
         expected_base = (base_branch or "").strip()
-        if not branch or self._run_store is None:
+        pr_number = self._pr_number_from_run_id(run_id)
+        if not branch and pr_number is None:
+            return None
+        if self._run_store is None:
             return None
         record = self._run_store.load(run_id)
         if record is None or not record.workspace_path:
@@ -5516,16 +5536,23 @@ class TemporalAgentRuntimeActivities:
             repo = self._detect_repo_from_workspace(workspace)
             if not repo:
                 return None
-            pr_list_cmd = [
-                "gh", "pr", "list",
-                "--repo", repo,
-                "--head", branch,
-                "--state", "all",
-                "--json", "number,state,mergedAt,url,baseRefName,headRefName",
-                "--limit", "20",
-            ]
-            if expected_base:
-                pr_list_cmd.extend(["--base", expected_base])
+            if pr_number is not None:
+                pr_list_cmd = [
+                    "gh", "pr", "view", str(pr_number),
+                    "--repo", repo,
+                    "--json", "number,state,mergedAt,url,baseRefName,headRefName",
+                ]
+            else:
+                pr_list_cmd = [
+                    "gh", "pr", "list",
+                    "--repo", repo,
+                    "--head", branch,
+                    "--state", "all",
+                    "--json", "number,state,mergedAt,url,baseRefName,headRefName",
+                    "--limit", "20",
+                ]
+                if expected_base:
+                    pr_list_cmd.extend(["--base", expected_base])
             pr_result = subprocess.run(
                 pr_list_cmd,
                 capture_output=True,
@@ -5538,7 +5565,7 @@ class TemporalAgentRuntimeActivities:
                 return None
             raw_stdout = pr_result.stdout.strip()
             try:
-                prs = json.loads(raw_stdout or "[]")
+                parsed = json.loads(raw_stdout or "null")
             except json.JSONDecodeError:
                 logger.debug(
                     "Failed to parse GitHub PR re-verify output for run %s; "
@@ -5557,7 +5584,8 @@ class TemporalAgentRuntimeActivities:
             )
             return None
 
-        if not isinstance(prs, list) or not prs:
+        prs = parsed if isinstance(parsed, list) else [parsed]
+        if not prs:
             return None
         for pr in prs:
             if not isinstance(pr, dict):
@@ -5587,8 +5615,7 @@ class TemporalAgentRuntimeActivities:
             override_meta["pull_request_url"] = url
         number = merged_pr.get("number")
         new_summary = (
-            f"pr-resolver reported pr_not_found; PR "
-            f"#{number} confirmed merged on GitHub"
+            f"pr-resolver result was stale; PR #{number} confirmed merged on GitHub"
         )
         return result.model_copy(
             update={

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1613,6 +1613,68 @@ async def test_fetch_result_preserves_failure_when_reverify_returns_none(
     assert result.metadata.get("prResolverReverified") is None
 
 
+async def test_fetch_result_reverifies_blocked_resolver_by_pr_number_when_merged(
+    tmp_path: Path,
+) -> None:
+    """Regression: resolver runs can omit head_branch in fetch_result input.
+
+    When the stable run id carries the PR number and GitHub confirms that PR is
+    merged, stale resolver states such as ci_running must not fail merge
+    automation.
+    """
+    from unittest.mock import patch
+
+    run_id = "resolver:pr:1727:head:623c3697e576:h:54dc00462b516f8d:1"
+    store = _make_store(tmp_path)
+    _save_record(store, run_id=run_id, status="completed")
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+        autospec=True,
+    ) as mock_adapter_cls:
+        adapter = mock_adapter_cls.return_value
+        adapter.fetch_result = AsyncMock(
+            return_value=AgentRunResult(
+                summary=(
+                    "pr-resolver reported status 'blocked'; ci_running; "
+                    "next_step=retry_finalize_after_backoff"
+                ),
+                failure_class="user_error",
+            )
+        )
+
+        with patch.object(
+            activities,
+            "_reverify_pr_merged_state",
+            return_value={
+                "number": 1727,
+                "state": "MERGED",
+                "url": "https://github.com/org/repo/pull/1727",
+                "mergedAt": "2026-04-24T00:55:48Z",
+            },
+        ) as mock_reverify:
+            result = await activities.agent_runtime_fetch_result(
+                {
+                    "run_id": run_id,
+                    "pr_resolver_expected": True,
+                }
+            )
+
+    mock_reverify.assert_called_once_with(
+        run_id=run_id,
+        head_branch=None,
+        base_branch=None,
+    )
+    assert result.failure_class is None
+    assert "#1727" in (result.summary or "")
+    assert result.metadata.get("prResolverReverified") is True
+    assert result.metadata.get("mergeAutomationDisposition") == "already_merged"
+    assert "ci_running" in (
+        result.metadata.get("prResolverStaleSummary") or ""
+    )
+
+
 async def test_fetch_result_skips_reverify_without_head_branch(
     tmp_path: Path,
 ) -> None:
@@ -1649,6 +1711,57 @@ async def test_fetch_result_skips_reverify_without_head_branch(
 
     mock_reverify.assert_not_called()
     assert result.failure_class == "execution_error"
+
+
+async def test_reverify_pr_merged_state_queries_pr_number_from_run_id(
+    tmp_path: Path,
+) -> None:
+    """The activity can recover when fetch_result omitted the head branch."""
+    import subprocess
+    from unittest.mock import patch
+
+    run_id = "resolver:pr:1727:head:623c3697e576:h:54dc00462b516f8d:1"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    store = _make_store(tmp_path)
+    _save_record(
+        store,
+        run_id=run_id,
+        status="completed",
+        workspace_path=str(workspace),
+    )
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    calls: list[list[str]] = []
+
+    def _mock_run(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        calls.append(args)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"number":1727,"state":"MERGED",'
+                '"url":"https://github.com/org/repo/pull/1727",'
+                '"mergedAt":"2026-04-24T00:55:48Z",'
+                '"baseRefName":"main","headRefName":"mm-491-d125a4e3"}'
+            ),
+            stderr="",
+        )
+
+    with (
+        patch.object(
+            activities, "_detect_repo_from_workspace", return_value="org/repo",
+        ),
+        patch("subprocess.run", side_effect=_mock_run),
+    ):
+        merged_pr = activities._reverify_pr_merged_state(
+            run_id=run_id,
+            head_branch=None,
+            base_branch=None,
+        )
+
+    assert merged_pr is not None
+    assert merged_pr["number"] == 1727
+    assert calls[0][:4] == ["gh", "pr", "view", "1727"]
 
 
 async def test_reverify_pr_merged_state_queries_head_and_base_branch(


### PR DESCRIPTION
## Summary
- Re-check GitHub before surfacing terminal pr-resolver failures from managed runtime fetch_result.
- Extract PR numbers from stable resolver run IDs so stale blocked results can be cleared even when headBranch is missing.
- Add regression coverage for stale ci_running/blocked resolver results after the PR is already merged.

## Root Cause
A resolver agent could successfully merge a PR, but MoonMind could still fail the workflow because fetch_result trusted an older structured pr-resolver status such as `blocked; ci_running`.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`