### PR TITLE
[codex] Add explicit report output contract

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2363,6 +2363,96 @@ def _normalize_publish_payload(raw_publish: Any) -> dict[str, Any]:
         normalized["prBaseBranch"] = normalized["baseBranch"]
     return normalized
 
+_REPORT_OUTPUT_STRING_KEYS = frozenset(
+    {
+        "reportType",
+        "report_type",
+        "title",
+        "description",
+        "primaryPath",
+        "primary_path",
+    }
+)
+_REPORT_OUTPUT_MAX_STRING_CHARS = 512
+
+def _normalize_report_output_payload(
+    *raw_payloads: Any,
+) -> dict[str, Any]:
+    for raw_payload in raw_payloads:
+        report_payload = _coerce_mapping(raw_payload)
+        if not report_payload:
+            continue
+        try:
+            enabled = _coerce_bool(report_payload.get("enabled"), default=False)
+            required = _coerce_bool(report_payload.get("required"), default=True)
+        except ValueError as exc:
+            raise _invalid_task_request(
+                f"reportOutput boolean value is invalid: {exc}"
+            ) from exc
+        if not enabled:
+            return {"enabled": False}
+
+        raw_report_type = (
+            report_payload.get("reportType")
+            or report_payload.get("report_type")
+            or "agent_run_report"
+        )
+        if not isinstance(raw_report_type, str):
+            raise _invalid_task_request("reportOutput.reportType must be a string.")
+        report_type = raw_report_type.strip() or "agent_run_report"
+        if len(report_type) > _REPORT_OUTPUT_MAX_STRING_CHARS:
+            raise _invalid_task_request(
+                f"reportOutput.reportType must be "
+                f"{_REPORT_OUTPUT_MAX_STRING_CHARS} characters or fewer."
+            )
+        normalized: dict[str, Any] = {
+            "enabled": True,
+            "required": required,
+            "reportType": report_type,
+        }
+        for key in _REPORT_OUTPUT_STRING_KEYS:
+            if key in {"reportType", "report_type"}:
+                continue
+            value = report_payload.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                raise _invalid_task_request(f"reportOutput.{key} must be a string.")
+            text = value.strip()
+            if not text:
+                continue
+            if len(text) > _REPORT_OUTPUT_MAX_STRING_CHARS:
+                raise _invalid_task_request(
+                    f"reportOutput.{key} must be "
+                    f"{_REPORT_OUTPUT_MAX_STRING_CHARS} characters or fewer."
+                )
+            canonical_key = {
+                "primary_path": "primaryPath",
+            }.get(key, key)
+            normalized[canonical_key] = text
+        return normalized
+    return {}
+
+def _report_output_instruction(report_output: Mapping[str, Any]) -> str:
+    if not _coerce_bool(report_output.get("enabled"), default=False):
+        return ""
+    primary_path = str(report_output.get("primaryPath") or "").strip()
+    path_sentence = (
+        f" Also write the same report to `{primary_path}` when the runtime "
+        "workspace makes that path available."
+        if primary_path
+        else ""
+    )
+    return (
+        "\n\nMoonMind report output contract:\n"
+        "- Finish with a concise final report suitable for a `report.primary` artifact.\n"
+        "- Include outcome, commands or tools run, key evidence, failures or "
+        "skipped work, and recommended next action.\n"
+        "- Do not include secrets, raw credentials, cookies, tokens, or full "
+        "environment dumps.\n"
+        f"{path_sentence}"
+    )
+
 def _task_publish_skill_id(
     task_payload: Mapping[str, Any],
     normalized_tool: Mapping[str, Any] | None,
@@ -3026,6 +3116,12 @@ async def _create_execution_from_task_request(
     story_output_payload = _normalize_story_output_payload(
         task_payload.get("storyOutput") or task_payload.get("story_output")
     )
+    report_output_payload = _normalize_report_output_payload(
+        task_payload.get("reportOutput"),
+        task_payload.get("report_output"),
+        payload.get("reportOutput"),
+        payload.get("report_output"),
+    )
     normalized_tool = _normalize_task_tool(task_payload)
     publish_payload = _resolve_task_publish_payload(
         payload=payload,
@@ -3042,10 +3138,16 @@ async def _create_execution_from_task_request(
     propose_tasks = _coerce_bool(task_payload.get("proposeTasks"), default=False)
     normalized_task_for_planner: dict[str, Any] = {}
     instructions = str(task_payload.get("instructions") or "").strip()
+    if report_output_payload.get("enabled"):
+        instructions = (
+            instructions + _report_output_instruction(report_output_payload)
+        ).strip()
     if depends_on:
         normalized_task_for_planner["dependsOn"] = depends_on
     if instructions:
         normalized_task_for_planner["instructions"] = instructions
+    if report_output_payload:
+        normalized_task_for_planner["reportOutput"] = dict(report_output_payload)
     normalized_task_for_planner["proposeTasks"] = propose_tasks
     if normalized_proposal_policy is not None:
         normalized_task_for_planner["proposalPolicy"] = normalized_proposal_policy
@@ -3199,6 +3301,8 @@ async def _create_execution_from_task_request(
     }
     if story_output_payload:
         initial_parameters["storyOutput"] = dict(story_output_payload)
+    if report_output_payload:
+        initial_parameters["reportOutput"] = dict(report_output_payload)
     if merge_automation_payload:
         initial_parameters["mergeAutomation"] = dict(merge_automation_payload)
     if instructions:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 3139932227,
-    "disposition": "addressed",
-    "rationale": "Added transition: var(--mm-control-transition) to .queue-page-size-selector and covered it with the Mission Control CSS test."
+    "id": 3141071210,
+    "disposition": "not-applicable",
+    "rationale": "The referenced activity-runtime values are already defined before use: info is read from the Temporal activity context, metadata/moonmind_metadata are extracted from result metadata, and summary_payload is built before reportOutput is read."
   },
   {
-    "id": 4172986718,
+    "id": 3141071212,
+    "disposition": "not-applicable",
+    "rationale": "TemporalActivityRuntimeError is defined in moonmind/workflows/temporal/activity_runtime.py and is already available in this module."
+  },
+  {
+    "id": 4174446344,
+    "disposition": "not-applicable",
+    "rationale": "This review summary repeats the two Gemini inline comments; both underlying concerns are not applicable to the current code."
+  },
+  {
+    "id": 3141083599,
     "disposition": "addressed",
-    "rationale": "Top-level review summary duplicated the inline transition concern, which is fixed by the page size selector CSS/test update."
+    "rationale": "Persisted lastAssistantText is now bounded to 4 KiB with truncation metadata before session-store validation, with focused controller test coverage."
+  },
+  {
+    "id": 3141083600,
+    "disposition": "addressed",
+    "rationale": "The Create page now reconstructs reportOutputEnabled for edit/rerun mode and submits reportOutput.enabled=false when the report checkbox is unchecked, with focused draft reconstruction coverage."
+  },
+  {
+    "id": 4174464058,
+    "disposition": "not-applicable",
+    "rationale": "This is the Codex review container comment and contains no actionable code finding beyond the separate inline comments."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2673,6 +2673,24 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("reconstructs enabled report output from Temporal input parameters", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:report-output",
+      workflowType: "MoonMind.Run",
+      inputParameters: {
+        reportOutput: {
+          enabled: true,
+          reportType: "agent_run_report",
+        },
+        task: {
+          instructions: "Produce a final report.",
+        },
+      },
+    });
+
+    expect(draft.reportOutputEnabled).toBe(true);
+  });
+
   it("fails draft reconstruction when instructions are missing", () => {
     expect(() =>
       buildTemporalSubmissionDraftFromExecution({

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2625,6 +2625,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           : normalizedDraftPublishMode,
       );
     }
+    setProduceReport(draft.reportOutputEnabled);
     const reconstructedSteps = createStepStateEntriesFromTemporalDraft(draft);
     setSteps(reconstructedSteps);
     setShowAdvancedStepOptions(hasAdvancedStepOptionValues(reconstructedSteps));
@@ -5091,12 +5092,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       publish: {
         mode: effectivePublishMode,
       },
-      ...(produceReport
+      ...(produceReport || pageMode.mode !== "create"
         ? {
             reportOutput: {
-              enabled: true,
-              required: true,
-              reportType: "agent_run_report",
+              enabled: produceReport,
+              ...(produceReport
+                ? {
+                    required: true,
+                    reportType: "agent_run_report",
+                  }
+                : {}),
             },
           }
         : {}),
@@ -5127,12 +5132,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           : {}),
         targetRuntime: normalizedRuntime,
         publishMode: effectivePublishMode,
-        ...(produceReport
+        ...(produceReport || pageMode.mode !== "create"
           ? {
               reportOutput: {
-                enabled: true,
-                required: true,
-                reportType: "agent_run_report",
+                enabled: produceReport,
+                ...(produceReport
+                  ? {
+                      required: true,
+                      reportType: "agent_run_report",
+                    }
+                  : {}),
               },
             }
           : {}),

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2274,6 +2274,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [publishMode, setPublishMode] = useState(
     normalizePublishModeForSubmit(defaultPublishMode),
   );
+  const [produceReport, setProduceReport] = useState(false);
   const [priority, setPriority] = useState(0);
   const [maxAttempts, setMaxAttempts] = useState(3);
   const [proposeTasks, setProposeTasks] = useState(() =>
@@ -5090,6 +5091,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       publish: {
         mode: effectivePublishMode,
       },
+      ...(produceReport
+        ? {
+            reportOutput: {
+              enabled: true,
+              required: true,
+              reportType: "agent_run_report",
+            },
+          }
+        : {}),
       ...(branch.trim()
         ? {
             git: {
@@ -5117,6 +5127,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           : {}),
         targetRuntime: normalizedRuntime,
         publishMode: effectivePublishMode,
+        ...(produceReport
+          ? {
+              reportOutput: {
+                enabled: true,
+                required: true,
+                reportType: "agent_run_report",
+              },
+            }
+          : {}),
         ...(shouldSubmitMergeAutomation
           ? { mergeAutomation: { enabled: true } }
           : {}),
@@ -6632,6 +6651,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 ) : null}
               </select>
             </div>
+            <label className="checkbox queue-inline-selector queue-inline-selector--report">
+              <input
+                type="checkbox"
+                checked={produceReport}
+                aria-label="Produce report artifact"
+                onChange={(event) => setProduceReport(event.target.checked)}
+              />
+              Report
+            </label>
             <button
               type="submit"
               className={

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -62,6 +62,7 @@ export type TemporalSubmissionDraft = {
   legacyBranchWarning: string | null;
   publishMode: string | null;
   mergeAutomationEnabled: boolean;
+  reportOutputEnabled: boolean;
   taskInstructions: string;
   primarySkill: string | null;
   inputAttachments: TemporalTaskInputAttachmentRef[];
@@ -481,6 +482,18 @@ function nullableStringValue(...values: unknown[]): string | null {
   return stringValue(...values) || null;
 }
 
+function booleanEnabledValue(...values: unknown[]): boolean {
+  return values.some((value) => {
+    if (value === true) {
+      return true;
+    }
+    if (typeof value !== 'string') {
+      return false;
+    }
+    return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase());
+  });
+}
+
 function skillSelectorNames(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.map((item) => stringValue(item)).filter(Boolean);
@@ -671,6 +684,11 @@ export function buildTemporalSubmissionDraftFromExecution(
   const artifactMergeAutomation = objectValue(artifactParams.mergeAutomation);
   const taskMergeAutomation = objectValue(task.mergeAutomation);
   const artifactTaskMergeAutomation = objectValue(artifactTask.mergeAutomation);
+  const reportOutput = objectValue(params.reportOutput);
+  const artifactReportOutput = objectValue(artifactParams.reportOutput);
+  const taskReportOutput = objectValue(task.reportOutput);
+  const artifactTaskReportOutput = objectValue(artifactTask.reportOutput);
+  const snapshotReportOutput = objectValue(snapshotDraft.reportOutput);
   const tool = objectValue(task.tool);
   const skill = objectValue(task.skill);
   const artifactTool = objectValue(artifactTask.tool);
@@ -776,6 +794,13 @@ export function buildTemporalSubmissionDraftFromExecution(
         artifactMergeAutomation.enabled ||
         taskMergeAutomation.enabled ||
         artifactTaskMergeAutomation.enabled,
+    ),
+    reportOutputEnabled: booleanEnabledValue(
+      snapshotReportOutput.enabled,
+      reportOutput.enabled,
+      artifactReportOutput.enabled,
+      taskReportOutput.enabled,
+      artifactTaskReportOutput.enabled,
     ),
     taskInstructions:
       Object.keys(snapshotDraft).length > 0

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3397,9 +3397,70 @@ class TemporalAgentRuntimeActivities:
             "provider_error_code": result_dict.get("provider_error_code") or result_dict.get("providerErrorCode"),
             "metrics": result_dict.get("metrics") or {},
         }
+        report_output = (
+            moonmind_metadata.get("reportOutput")
+            if isinstance(moonmind_metadata.get("reportOutput"), Mapping)
+            else {}
+        )
+        try:
+            report_output_enabled = _coerce_bool(
+                report_output.get("enabled"), default=False
+            )
+            report_output_required = _coerce_bool(
+                report_output.get("required"), default=True
+            )
+        except ValueError as exc:
+            logger.warning("Invalid reportOutput contract: %s", exc)
+            report_output_enabled = False
+            report_output_required = True
+
+        def _report_execution_identity() -> tuple[str, str, str]:
+            execution_ref = (
+                report_output.get("executionRef")
+                if isinstance(report_output.get("executionRef"), Mapping)
+                else {}
+            )
+            if info is not None:
+                namespace = str(execution_ref.get("namespace") or info.namespace)
+                workflow_id = str(
+                    execution_ref.get("workflow_id")
+                    or execution_ref.get("workflowId")
+                    or info.workflow_id
+                )
+                run_id = str(
+                    execution_ref.get("run_id")
+                    or execution_ref.get("runId")
+                    or info.workflow_run_id
+                )
+                return namespace, workflow_id, run_id
+            return (
+                str(execution_ref.get("namespace") or "default"),
+                str(
+                    execution_ref.get("workflow_id")
+                    or execution_ref.get("workflowId")
+                    or ""
+                ),
+                str(execution_ref.get("run_id") or execution_ref.get("runId") or ""),
+            )
+
+        def _report_body() -> str:
+            assistant_text = ""
+            for key in ("assistantText", "lastAssistantText"):
+                value = metadata.get(key)
+                if isinstance(value, str) and value.strip():
+                    assistant_text = value.strip()
+                    break
+            summary_text = str(summary_payload.get("summary") or "").strip()
+            body = assistant_text or summary_text
+            if not body:
+                body = "Agent run completed without a textual report body."
+            if body.lstrip().startswith("#"):
+                return body.rstrip() + "\n"
+            title = str(report_output.get("title") or "Final report").strip()
+            return f"# {title}\n\n{body.rstrip()}\n"
 
         try:
-            published_refs: dict[str, str] = {}
+            published_refs: dict[str, Any] = {}
             if instruction_ref:
                 published_refs["inputInstructionsRef"] = await _write_reference_artifact(
                     link_type="input.instructions",
@@ -3436,6 +3497,93 @@ class TemporalAgentRuntimeActivities:
                     **step_artifact_metadata,
                 },
             )
+            if report_output_enabled:
+                namespace, workflow_id, run_id = _report_execution_identity()
+                if not workflow_id or not run_id:
+                    raise TemporalActivityRuntimeError(
+                        "reportOutput enabled but executionRef is incomplete"
+                    )
+                report_type = str(
+                    report_output.get("reportType")
+                    or report_output.get("report_type")
+                    or "agent_run_report"
+                ).strip() or "agent_run_report"
+                report_bundle = await self._artifact_service.publish_report_bundle(
+                    principal="system:agent_runtime",
+                    namespace=namespace,
+                    workflow_id=workflow_id,
+                    run_id=run_id,
+                    report_type=report_type,
+                    report_scope="final",
+                    primary={
+                        "payload": _report_body(),
+                        "content_type": "text/markdown",
+                        "label": "Final report",
+                        "metadata": {
+                            "artifact_type": report_type,
+                            "title": str(
+                                report_output.get("title") or "Final report"
+                            ).strip()
+                            or "Final report",
+                            "description": str(
+                                report_output.get("description") or ""
+                            ).strip()
+                            or "Agent-authored final report",
+                            "producer": "activity:agent_runtime.publish_artifacts",
+                            "render_hint": "text",
+                            "name": "final-report.md",
+                            **step_artifact_metadata,
+                        },
+                    },
+                    summary={
+                        "payload": str(summary_payload.get("summary") or "").strip()
+                        or "Report generated.",
+                        "content_type": "text/plain",
+                        "label": "Report summary",
+                        "metadata": {
+                            "artifact_type": report_type,
+                            "title": "Report summary",
+                            "producer": "activity:agent_runtime.publish_artifacts",
+                            "render_hint": "text",
+                            "name": "report-summary.txt",
+                            **step_artifact_metadata,
+                        },
+                    },
+                    structured={
+                        "payload": {
+                            "summary": summary_payload.get("summary") or "",
+                            "output_refs": summary_payload.get("output_refs") or [],
+                            "diagnostics_ref": agent_result_ref.artifact_id,
+                            "failure_class": summary_payload.get("failure_class"),
+                            "provider_error_code": summary_payload.get(
+                                "provider_error_code"
+                            ),
+                        },
+                        "content_type": "application/json",
+                        "label": "Report structured output",
+                        "metadata": {
+                            "artifact_type": report_type,
+                            "title": "Structured report data",
+                            "producer": "activity:agent_runtime.publish_artifacts",
+                            "render_hint": "json",
+                            "name": "report-structured.json",
+                            **step_artifact_metadata,
+                        },
+                    },
+                    step_id=step_artifact_metadata.get("step_id"),
+                    attempt=step_artifact_metadata.get("attempt"),
+                    scope=step_artifact_metadata.get("scope") or "final",
+                )
+                published_refs["reportBundle"] = report_bundle
+                primary_report_ref = report_bundle.get("primary_report_ref")
+                if isinstance(primary_report_ref, Mapping):
+                    primary_report_id = str(
+                        primary_report_ref.get("artifact_id")
+                        or primary_report_ref.get("artifactId")
+                        or ""
+                    ).strip()
+                    if primary_report_id:
+                        published_refs["primaryReportRef"] = primary_report_id
             # Enrich result with the diagnostics ref
             if isinstance(result, Mapping):
                 enriched = dict(result)
@@ -3481,6 +3629,8 @@ class TemporalAgentRuntimeActivities:
                 "agent_runtime.publish_artifacts failed to publish managed-session artifacts",
                 exc_info=True,
             )
+            if report_output_enabled and report_output_required:
+                raise
             return result
 
     def _require_session_controller(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1742,6 +1742,10 @@ class DockerCodexManagedSessionController:
         if self._session_store is not None:
             record = self._session_store.load(request.session_id)
             if record is not None:
+                record_metadata = dict(record.metadata)
+                assistant_text = terminal_response.metadata.get("assistantText")
+                if isinstance(assistant_text, str) and assistant_text.strip():
+                    record_metadata["lastAssistantText"] = assistant_text.strip()
                 updated_record = await self._session_store.update(
                     request.session_id,
                     session_epoch=terminal_response.session_state.session_epoch,
@@ -1751,6 +1755,7 @@ class DockerCodexManagedSessionController:
                     status=self._record_status_from_turn_status(terminal_response.status),
                     updated_at=datetime.now(tz=UTC),
                     error_message=self._turn_error_message(terminal_response),
+                    metadata=record_metadata,
                 )
                 if self._session_supervisor is not None:
                     await self._emit_session_event(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -66,7 +66,25 @@ _GITHUB_TOKEN_GIT_CREDENTIAL_HELPER = (
 _SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 _CONTAINER_LOG_EXCERPT_TAIL_LINES = 40
 _CONTAINER_LOG_EXCERPT_MAX_CHARS = 2000
+_LAST_ASSISTANT_TEXT_METADATA_MAX_BYTES = 4 * 1024
 logger = logging.getLogger(__name__)
+
+def _last_assistant_text_metadata(value: str) -> dict[str, Any]:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return {}
+    encoded = normalized.encode("utf-8")
+    if len(encoded) <= _LAST_ASSISTANT_TEXT_METADATA_MAX_BYTES:
+        return {"lastAssistantText": normalized}
+    truncated = encoded[:_LAST_ASSISTANT_TEXT_METADATA_MAX_BYTES].decode(
+        "utf-8",
+        errors="ignore",
+    )
+    return {
+        "lastAssistantText": truncated,
+        "lastAssistantTextTruncated": True,
+        "lastAssistantTextOriginalChars": len(normalized),
+    }
 
 def _managed_session_docker_network(
     request_environment: Mapping[str, str] | None = None,
@@ -1745,7 +1763,7 @@ class DockerCodexManagedSessionController:
                 record_metadata = dict(record.metadata)
                 assistant_text = terminal_response.metadata.get("assistantText")
                 if isinstance(assistant_text, str) and assistant_text.strip():
-                    record_metadata["lastAssistantText"] = assistant_text.strip()
+                    record_metadata.update(_last_assistant_text_metadata(assistant_text))
                 updated_record = await self._session_store.update(
                     request.session_id,
                     session_epoch=terminal_response.session_state.session_epoch,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -489,6 +489,11 @@ class MoonMindAgentRun:
             metadata.setdefault("taskRunId", task_run_id)
 
         step_ledger_context = _request_step_ledger_context(request)
+        report_output_context = (
+            request.parameters.get("reportOutput")
+            if isinstance(request.parameters, Mapping)
+            else None
+        )
         if step_ledger_context is not None:
             moonmind_payload = (
                 metadata.get("moonmind")
@@ -496,6 +501,14 @@ class MoonMindAgentRun:
                 else {}
             )
             moonmind_payload["stepLedger"] = step_ledger_context
+            metadata["moonmind"] = moonmind_payload
+        if isinstance(report_output_context, Mapping):
+            moonmind_payload = (
+                metadata.get("moonmind")
+                if isinstance(metadata.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload["reportOutput"] = dict(report_output_context)
             metadata["moonmind"] = moonmind_payload
 
         return result.model_copy(update={"metadata": metadata})

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3819,6 +3819,45 @@ class MoonMindRunWorkflow:
             parameters["metadata"] = self._json_mapping(
                 raw_metadata, path=f"node[{node_id}].metadata"
             )
+        raw_report_output = (
+            node_inputs.get("reportOutput")
+            or node_inputs.get("report_output")
+            or (
+                workflow_parameters.get("reportOutput")
+                if isinstance(workflow_parameters, Mapping)
+                else None
+            )
+            or (
+                workflow_parameters.get("report_output")
+                if isinstance(workflow_parameters, Mapping)
+                else None
+            )
+        )
+        if isinstance(raw_report_output, Mapping):
+            report_output = self._json_mapping(
+                raw_report_output,
+                path=f"node[{node_id}].reportOutput",
+            )
+            if _coerce_bool(report_output.get("enabled"), default=False):
+                report_output["executionRef"] = {
+                    "namespace": wf_info.namespace,
+                    "workflow_id": wf_info.workflow_id,
+                    "run_id": wf_info.run_id,
+                }
+                parameters["reportOutput"] = report_output
+                metadata_payload = (
+                    parameters.get("metadata")
+                    if isinstance(parameters.get("metadata"), dict)
+                    else {}
+                )
+                moonmind_payload = (
+                    metadata_payload.get("moonmind")
+                    if isinstance(metadata_payload.get("moonmind"), dict)
+                    else {}
+                )
+                moonmind_payload["reportOutput"] = report_output
+                metadata_payload["moonmind"] = moonmind_payload
+                parameters["metadata"] = metadata_payload
         selected_skill = str(node_inputs.get("selectedSkill") or "").strip()
         if selected_skill:
             metadata_payload = (

--- a/specs/258-explicit-report-output-contract/plan.md
+++ b/specs/258-explicit-report-output-contract/plan.md
@@ -1,0 +1,21 @@
+# Implementation Plan: Explicit Report Output Contract
+
+## Approach
+
+Reuse the existing report artifact system. Add an explicit `reportOutput` payload accepted at task submission, propagate it to the run and agent-runtime request metadata, and publish a report bundle from `agent_runtime.publish_artifacts` only when the contract is enabled.
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS - report publication remains an orchestration/platform concern around existing agent runtimes.
+- III Avoid Vendor Lock-In: PASS - contract is runtime-neutral.
+- IV Own Your Data: PASS - reports are stored in MoonMind artifacts.
+- IX Resilient by Default: PASS - required reports fail visibly when publication fails.
+- XI Spec-Driven Development: PASS - this feature-local artifact records the change before implementation.
+- XII Canonical Documentation Separation: PASS - implementation notes stay under `specs/`.
+
+## Test Strategy
+
+- Add focused activity-runtime tests for report bundle publication.
+- Add workflow construction tests for propagation of `reportOutput`.
+- Add API/task submission tests if existing coverage requires normalization checks.
+- Run targeted unit tests before finalizing.

--- a/specs/258-explicit-report-output-contract/spec.md
+++ b/specs/258-explicit-report-output-contract/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Explicit Report Output Contract
+
+**Feature Branch**: `258-explicit-report-output-contract`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User request: "Implement your recommended path" for reliable report generation and artifact publication.
+
+## User Story
+
+As an operator, I want tasks to explicitly request a final report artifact so MoonMind can publish a canonical `report.primary` output reliably instead of depending on prompt wording or generic output artifacts.
+
+## Requirements
+
+- **FR-001**: Task creation MAY include `reportOutput.enabled=true` with bounded report metadata such as `reportType`, `title`, `primaryPath`, and `required`.
+- **FR-002**: Workflow and agent-runtime boundaries MUST carry report-output intent as compact metadata only.
+- **FR-003**: When report output is enabled, MoonMind MUST publish a report bundle through the existing artifact publication boundary using `report.primary` and final-report metadata.
+- **FR-004**: Existing generic `output.primary`, `output.summary`, and `output.agent_result` behavior MUST remain unchanged when report output is not enabled.
+- **FR-005**: If a required report cannot be published, the run MUST fail visibly instead of silently completing without a canonical report.
+
+## Source Design
+
+- `docs/Artifacts/ReportArtifacts.md` sections 7, 8, 9, 11, and 16.
+- Existing report bundle publication service in `moonmind/workflows/temporal/artifacts.py`.
+- Existing execution projection in `api_service/api/routers/executions.py`.
+
+## Validation
+
+- Unit tests cover explicit report-output propagation, report bundle publication, generic-output compatibility, and fail-closed behavior.
+- Targeted unit runs verify the changed Temporal activity and workflow boundaries.

--- a/specs/258-explicit-report-output-contract/tasks.md
+++ b/specs/258-explicit-report-output-contract/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Explicit Report Output Contract
+
+- [x] T001 Accept and normalize explicit `reportOutput` task payloads.
+- [x] T002 Propagate report-output intent through `MoonMind.Run` agent-runtime request metadata.
+- [x] T003 Publish report bundles from `agent_runtime.publish_artifacts` when explicitly enabled.
+- [x] T004 Preserve generic output behavior when report output is disabled.
+- [x] T005 Add fail-closed behavior for required report publication failures.
+- [x] T006 Add focused unit tests for workflow/activity boundaries.
+- [x] T007 Run targeted unit verification.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -817,6 +817,50 @@ def test_create_task_shaped_execution_applies_default_publish_mode(
     assert initial_parameters["publishMode"] == "pr"
     assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
+def test_create_task_shaped_execution_preserves_report_output_contract(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "reportOutput": {
+                    "enabled": True,
+                    "required": True,
+                    "reportType": "integration_test_report",
+                    "title": "Integration test report",
+                },
+                "task": {
+                    "instructions": "Run the integration test suite.",
+                    "runtime": {"mode": "codex"},
+                    "publish": {"mode": "none"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.call_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["reportOutput"] == {
+        "enabled": True,
+        "required": True,
+        "reportType": "integration_test_report",
+        "title": "Integration test report",
+    }
+    assert initial_parameters["task"]["reportOutput"] == initial_parameters[
+        "reportOutput"
+    ]
+    assert "MoonMind report output contract" in initial_parameters["task"][
+        "instructions"
+    ]
+
 def test_create_task_shaped_execution_prefers_task_publish_mode_alias_over_top_publish(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3522,6 +3522,76 @@ async def test_controller_send_turn_persists_failed_turn_status(tmp_path: Path) 
     assert updated.error_message == "turn execution failed"
 
 @pytest.mark.asyncio
+async def test_controller_send_turn_bounds_persisted_last_assistant_text(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="busy",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "completed",
+                "metadata": {"assistantText": "x" * 12000},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Write a long report",
+        )
+    )
+
+    updated = store.load("sess-1")
+    assert response.status == "completed"
+    assert updated is not None
+    assert updated.metadata["lastAssistantTextTruncated"] is True
+    assert updated.metadata["lastAssistantTextOriginalChars"] == 8190
+    assert len(str(updated.metadata["lastAssistantText"]).encode("utf-8")) <= 4096
+
+@pytest.mark.asyncio
 async def test_controller_interrupt_turn_preserves_failed_runtime_result(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -7,15 +7,19 @@ import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from temporalio import activity as temporal_activity
 from temporalio import exceptions as temporal_exceptions
 
 from api_service.db.models import Base
 from moonmind.config.settings import settings
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
+from moonmind.schemas.agent_runtime_models import AgentRunResult
 from moonmind.schemas.jules_models import JulesTaskResponse
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
@@ -1915,6 +1919,125 @@ async def test_build_activity_bindings_resolves_agent_runtime_fleet(
             assert "agent_skill.resolve" in bound_types
             assert "agent_skill.materialize" in bound_types
             assert "agent_skill.build_prompt_index" in bound_types
+
+async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(artifact_service=service)
+
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:node-1",
+                    workflow_run_id="child-run-1",
+                ),
+            )
+
+            result = await activities.agent_runtime_publish_artifacts(
+                AgentRunResult(
+                    summary="Completed integration tests.",
+                    metadata={
+                        "assistantText": "# Integration test report\n\nAll tests passed.",
+                        "moonmind": {
+                            "reportOutput": {
+                                "enabled": True,
+                                "required": True,
+                                "reportType": "integration_test_report",
+                                "executionRef": {
+                                    "namespace": "default",
+                                    "workflow_id": "parent-wf",
+                                    "run_id": "parent-run-1",
+                                },
+                            }
+                        },
+                    },
+                )
+            )
+
+            assert result is not None
+            assert result.metadata["primaryReportRef"].startswith("art_")
+            assert result.metadata["reportBundle"]["report_bundle_v"] == 1
+
+            reports = await service.list_for_execution(
+                namespace="default",
+                workflow_id="parent-wf",
+                run_id="parent-run-1",
+                principal="system:agent_runtime",
+                link_type="report.primary",
+                latest_only=True,
+            )
+
+            assert len(reports) == 1
+            assert reports[0].metadata_json["report_type"] == "integration_test_report"
+            assert reports[0].metadata_json["report_scope"] == "final"
+            assert reports[0].metadata_json["is_final_report"] is True
+
+async def test_agent_runtime_publish_artifacts_fails_required_report_on_publish_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingReportService:
+        def __init__(self, wrapped: TemporalArtifactService) -> None:
+            self._wrapped = wrapped
+
+        async def create(self, **kwargs: Any) -> Any:
+            return await self._wrapped.create(**kwargs)
+
+        async def write_complete(self, **kwargs: Any) -> Any:
+            return await self._wrapped.write_complete(**kwargs)
+
+        async def publish_report_bundle(self, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("report publication failed")
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=_FailingReportService(service)  # type: ignore[arg-type]
+            )
+
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:node-1",
+                    workflow_run_id="child-run-1",
+                ),
+            )
+
+            with pytest.raises(RuntimeError, match="report publication failed"):
+                await activities.agent_runtime_publish_artifacts(
+                    AgentRunResult(
+                        summary="Completed.",
+                        metadata={
+                            "moonmind": {
+                                "reportOutput": {
+                                    "enabled": True,
+                                    "required": True,
+                                    "reportType": "integration_test_report",
+                                    "executionRef": {
+                                        "namespace": "default",
+                                        "workflow_id": "parent-wf",
+                                        "run_id": "parent-run-1",
+                                    },
+                                }
+                            }
+                        },
+                    )
+                )
 
 async def test_agent_runtime_send_turn_disables_catalog_retries(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -841,6 +841,48 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         moonmind = metadata.get("moonmind") or {}
         self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")
 
+    def test_build_agent_execution_request_carries_report_output_contract(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "parent-wf-id"
+            run_id = "parent-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex",
+                },
+                node_id="node-report",
+                tool_name="codex",
+                workflow_parameters={
+                    "reportOutput": {
+                        "enabled": True,
+                        "required": True,
+                        "reportType": "integration_test_report",
+                    }
+                },
+            )
+
+        report_output = request.parameters["reportOutput"]
+        self.assertEqual(report_output["reportType"], "integration_test_report")
+        self.assertEqual(
+            report_output["executionRef"],
+            {
+                "namespace": "default",
+                "workflow_id": "parent-wf-id",
+                "run_id": "parent-run-id",
+            },
+        )
+        metadata = request.parameters.get("metadata") or {}
+        self.assertEqual(metadata["moonmind"]["reportOutput"], report_output)
+
     def test_build_agent_execution_request_preserves_retry_feedback_in_instructions_fields(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds an explicit `reportOutput` task contract that carries report intent through task creation, workflow dispatch, and agent runtime metadata.
- Publishes canonical report bundles with `report.primary`, `report.summary`, and `report.structured` artifacts when report output is enabled.
- Adds a Create page Report toggle and focused API, workflow, and activity tests.

## Why

A workflow could finish with generic output artifacts but no canonical report artifact. This change makes report generation an explicit platform contract instead of relying on prompt wording or a separate agent skill.

## Validation

- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_preserves_report_output_contract tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py::TestBuildAgentExecutionRequest::test_build_agent_execution_request_carries_report_output_contract tests/unit/workflows/temporal/test_activity_runtime.py::test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle tests/unit/workflows/temporal/test_activity_runtime.py::test_agent_runtime_publish_artifacts_fails_required_report_on_publish_error`
