### PR TITLE
Make claude-opus-4-7 the default model for the claude runtime in the code

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -662,7 +662,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "is_default": True,
             "provider_id": "anthropic",
             "provider_label": "Anthropic",
-            "default_model": None,  # inherits runtime default: Sonnet 4.6
+            "default_model": None,  # inherits runtime default: claude-opus-4-7
             "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
             "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
             "volume_ref": get_provider_default("claude_code", "volume_ref"),

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -54,7 +54,7 @@ const mockPayload: BootPayload = {
         defaultTaskModelByRuntime: {
           codex_cli: "gpt-5.4",
           gemini_cli: "gemini-2.5-pro",
-          claude_code: "claude-3.7-sonnet",
+          claude_code: "claude-opus-4-7",
         },
         defaultTaskEffortByRuntime: {
           codex_cli: "medium",

--- a/moonmind/workflows/tasks/runtime_defaults.py
+++ b/moonmind/workflows/tasks/runtime_defaults.py
@@ -17,7 +17,7 @@ DEFAULT_REPOSITORY = "MoonLadderStudios/MoonMind"
 _DEFAULT_RUNTIME_MODELS: dict[str, str] = {
     "codex_cli": "gpt-5.4",
     "gemini_cli": "gemini-3.1-pro-preview",
-    "claude_code": "Sonnet 4.6",
+    "claude_code": "claude-opus-4-7",
 }
 _DEFAULT_RUNTIME_EFFORTS: dict[str, str] = {
     "codex_cli": "high",

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -338,7 +338,7 @@ def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
 
     assert config["system"]["supportedTaskRuntimes"] == ["codex_cli", "gemini_cli", "claude_code", "codex_cloud"]
     assert config["system"]["defaultTaskRuntime"] == "claude_code"
-    assert config["system"]["defaultTaskModel"] == "Sonnet 4.6"
+    assert config["system"]["defaultTaskModel"] == "claude-opus-4-7"
 
 def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
     monkeypatch.setattr(settings.workflow, "github_repository", "Octo/Repo")
@@ -600,7 +600,7 @@ def test_build_runtime_config_uses_repo_runtime_model_defaults(monkeypatch) -> N
 
     assert config["system"]["defaultTaskModelByRuntime"]["codex_cli"] == "gpt-5.4"
     assert config["system"]["defaultTaskModelByRuntime"]["gemini_cli"] == "gemini-3.1-pro-preview"
-    assert config["system"]["defaultTaskModelByRuntime"]["claude_code"] == "Sonnet 4.6"
+    assert config["system"]["defaultTaskModelByRuntime"]["claude_code"] == "claude-opus-4-7"
 
 def test_normalize_status_maps_temporal_waits_to_awaiting_action() -> None:
     assert dashboard_view_model.normalize_status("temporal", "awaiting_external") == "awaiting_action"

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -62,7 +62,7 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert profile_ids == {"gemini_default", "codex_default", "claude_anthropic"}
     # Standard profiles are seeded with default_model=None so they inherit
     # the runtime default (codex_cli→gpt-5.4, gemini_cli→gemini-3.1-pro-preview,
-    # claude_code→Sonnet 4.6) rather than storing a duplicate value.
+    # claude_code→claude-opus-4-7) rather than storing a duplicate value.
     defaults = {p.profile_id: p.default_model for p in profiles}
     assert defaults["gemini_default"] is None
     assert defaults["codex_default"] is None

--- a/tests/unit/workflows/tasks/test_model_resolver.py
+++ b/tests/unit/workflows/tasks/test_model_resolver.py
@@ -133,7 +133,7 @@ class TestResolveEffectiveModelRuntimeDefault:
         [
             ("codex_cli", "gpt-5.4"),
             ("gemini_cli", "gemini-3.1-pro-preview"),
-            ("claude_code", "Sonnet 4.6"),
+            ("claude_code", "claude-opus-4-7"),
         ],
     )
     def test_runtime_default_for_each_canonical_id(self, runtime_id, expected_model):

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -84,7 +84,7 @@ class TestClaudeCodeBuildCommand:
         # When no profile default_model is set, the claude_code runtime default applies.
         assert cmd == [
             "claude",
-            "--model", "Sonnet 4.6",
+            "--model", "claude-opus-4-7",
             "-p", "--dangerously-skip-permissions", "Refactor this",
         ]
 
@@ -124,7 +124,7 @@ class TestClaudeCodeBuildCommand:
         request = _make_request()
         cmd = s.build_command(profile, request)
         # No instruction_ref but runtime default model still applies.
-        assert cmd == ["claude", "--model", "Sonnet 4.6", "-p", "--dangerously-skip-permissions"]
+        assert cmd == ["claude", "--model", "claude-opus-4-7", "-p", "--dangerously-skip-permissions"]
 
     def test_anthropic_model_env_suppresses_model_flag(self) -> None:
         """When ANTHROPIC_MODEL is in env_overrides (MiniMax profile), --model must be omitted."""


### PR DESCRIPTION
Make claude-opus-4-7 the default model for the claude runtime in the code