### PR TITLE
[codex] Restore executing shimmer letter brightening

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -410,6 +410,9 @@ describe('Mission Control shared entry', () => {
     expect(missionControlCss).toMatch(/--mm-executing-sweep-end-y:\s*-160%/);
     expect(missionControlCss).toMatch(/--mm-executing-sweep-layer-offset-x:\s*-12%/);
     expect(missionControlCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
+    expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-width:\s*84%/);
+    expect(missionControlCss).toContain('--mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32)');
+    expect(missionControlCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, rgb(var(--mm-panel)) 32%)');
 
     const shimmerBlock = cssRuleBlocks(
       missionControlCss,
@@ -456,11 +459,23 @@ describe('Mission Control shared entry', () => {
         rule.selector.includes('shimmer-sweep') &&
         rule.selector.includes('::after'),
     );
-    expect(shimmerAfterBlock).toContain('mix-blend-mode: overlay');
+    expect(shimmerAfterBlock).not.toContain('mix-blend-mode: overlay');
+    expect(shimmerAfterBlock).not.toContain('rgb(255 255 255');
+    expect(shimmerAfterBlock).toContain('content: "executing"');
+    expect(shimmerAfterBlock).toContain('background-clip: text');
+    expect(shimmerAfterBlock).toContain('-webkit-background-clip: text');
+    expect(shimmerAfterBlock).toContain('-webkit-text-fill-color: transparent');
+    expect(shimmerAfterBlock).toContain('var(--mm-executing-letter-halo)');
+    expect(shimmerAfterBlock).toContain('var(--mm-executing-letter-bright)');
+    expect(shimmerAfterBlock).toContain('background-size: var(--mm-executing-letter-sweep-width) var(--mm-executing-sweep-band-height)');
+    expect(shimmerAfterBlock).toContain('filter: drop-shadow(0 0 3px rgb(var(--mm-accent-2) / 0.28))');
     expect(shimmerAfterBlock).toContain('animation: mm-status-pill-shimmer-letters');
     expect(shimmerAfterBlock).toContain('var(--mm-executing-sweep-cycle-duration)');
     expect(shimmerAfterBlock).toContain('linear infinite');
-    expect(shimmerAfterBlock).toContain("content: ''");
+    expect(cssRuleBlock(
+      missionControlCss,
+      '.status-running[data-state="executing"][data-effect="shimmer-sweep"][data-shimmer-label]::after',
+    )).toContain('content: attr(data-shimmer-label)');
     expect(missionControlCss).toMatch(
       /@keyframes mm-status-pill-shimmer-letters\s*\{[\s\S]*?0%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-start-x\)\s*var\(--mm-executing-sweep-start-y\)[\s\S]*?100%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-end-x\)\s*var\(--mm-executing-sweep-end-y\)/,
     );

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -407,6 +407,7 @@ describe('Task Detail Entrypoint', () => {
     expect(toolbarStatus?.dataset.effect).toBe('shimmer-sweep');
     expect(toolbarStatus?.className).toContain('is-executing');
     expect(toolbarStatus?.className).toContain('status-running');
+    expect(toolbarStatus?.dataset.shimmerLabel).toBe('executing');
     expect(toolbarStatus?.childElementCount).toBe(0);
     expect(toolbarStatus?.textContent).toBe('executing');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-489');

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -125,6 +125,7 @@ describe('Tasks List Entrypoint', () => {
       expect(pill.dataset.state).toBe('executing');
       expect(pill.className).toContain('is-executing');
       expect(pill.className).toContain('status-running');
+      expect(pill.dataset.shimmerLabel).toBe('executing');
       expect(pill.childElementCount).toBe(0);
       expect(pill.textContent).toBe('executing');
     }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -54,6 +54,9 @@
   --mm-executing-sweep-layer-offset-y: -10%;
   --mm-executing-sweep-core-opacity: 0.34;
   --mm-executing-sweep-halo-opacity: 0.14;
+  --mm-executing-letter-sweep-width: 84%;
+  --mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32);
+  --mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, rgb(var(--mm-panel)) 32%);
   --mm-font-headline: var(--mm-font-sans);
   --mm-font-mono: "IBM Plex Mono", ui-monospace, monospace;
 }
@@ -1318,22 +1321,42 @@ tr[data-proposal-id].proposal-consuming td {
 
 .status-running[data-state="executing"][data-effect="shimmer-sweep"]::after,
 .status-running.is-executing::after {
-  content: '';
+  content: "executing";
   position: absolute;
   inset: 0;
   z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: inherit;
+  border-radius: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  white-space: inherit;
+  color: transparent;
   pointer-events: none;
-  background-image: linear-gradient(
-    var(--mm-executing-sweep-angle),
-    transparent 0 38%,
-    rgb(255 255 255 / 0.82) 50%,
-    transparent 62%
-  );
+  background-image:
+    linear-gradient(
+      var(--mm-executing-sweep-angle),
+      transparent 0 30%,
+      var(--mm-executing-letter-halo) 42%,
+      var(--mm-executing-letter-bright) 50%,
+      var(--mm-executing-letter-halo) 58%,
+      transparent 70%
+    );
+  background-clip: text;
   background-repeat: no-repeat;
-  background-size: calc(var(--mm-executing-sweep-band-width) * 4) var(--mm-executing-sweep-band-height);
+  background-size: var(--mm-executing-letter-sweep-width) var(--mm-executing-sweep-band-height);
   background-position: var(--mm-executing-sweep-start-x) var(--mm-executing-sweep-start-y);
   animation: mm-status-pill-shimmer-letters var(--mm-executing-sweep-cycle-duration) linear infinite;
-  mix-blend-mode: overlay;
+  filter: drop-shadow(0 0 3px rgb(var(--mm-accent-2) / 0.28));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.status-running[data-state="executing"][data-effect="shimmer-sweep"][data-shimmer-label]::after {
+  content: attr(data-shimmer-label);
 }
 
 @keyframes mm-status-pill-shimmer {

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -11,6 +11,7 @@ describe('executionStatusPillProps', () => {
       className: 'status status-running is-executing',
       'data-state': 'executing',
       'data-effect': 'shimmer-sweep',
+      'data-shimmer-label': 'executing',
     });
 
     expect(executionStatusPillProps('running')).toEqual({

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -16,6 +16,7 @@ export type ExecutionStatusPillProps = Readonly<{
   className: string;
   'data-state'?: 'executing';
   'data-effect'?: 'shimmer-sweep';
+  'data-shimmer-label'?: string;
 }>;
 
 function normalizedExecutionStatusKey(status: string | null | undefined): string {
@@ -44,6 +45,12 @@ function executionStatusBaseClasses(key: string): string {
   return 'status status-neutral';
 }
 
+function executionStatusVisibleLabel(status: string | null | undefined): string {
+  return String(status || 'executing')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
 export function executionStatusPillProps(status: string | null | undefined): ExecutionStatusPillProps {
   const key = normalizedExecutionStatusKey(status);
   const className = executionStatusBaseClasses(key);
@@ -53,6 +60,7 @@ export function executionStatusPillProps(status: string | null | undefined): Exe
       className: `${className} is-executing`,
       'data-state': 'executing',
       'data-effect': 'shimmer-sweep',
+      'data-shimmer-label': executionStatusVisibleLabel(status),
     };
   }
 


### PR DESCRIPTION
## Summary
- restore the executing status pill shimmer to the prior teal/purple sweep instead of the white full-pill overlay
- add a text-clipped letter brightening pass driven by the visible executing label
- update shared CSS/helper/list/detail tests to guard the letter-only shimmer contract

## Root Cause
The latest reflective overlay brightened the entire pill area with a white blend layer, which made the shimmer look detached from the pill border and failed to brighten the EXECUTING letters themselves.

## Validation
- PASS: npm run ui:test -- frontend/src/utils/executionStatusPillClasses.test.ts frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/task-detail.test.tsx
- PARTIAL: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh reached 3999 passed / 1 failed; unrelated failure in tests/unit/workflows/temporal/test_temporal_worker_runtime.py expected workflow_docker_mode=profiles but local runtime produced unrestricted
