### PR TITLE
The Report checkbox should not be present in the floating bar on the create page. It should be near the Propose Tasks checkbox area.

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5680,6 +5680,7 @@ describe("Task Create Entrypoint", () => {
     const repoInput = screen.getByLabelText(/GitHub Repo/);
     const branchSelect = screen.getByLabelText("Branch");
     const publishModeSelect = screen.getByLabelText("Publish Mode");
+    const reportToggle = screen.getByLabelText("Produce report artifact");
     const stepExtension = addStepButton.closest(".queue-step-extension");
     const floatingBar = createButton.closest(".queue-floating-bar");
     const floatingBarRow = createButton.closest(".queue-floating-bar-row");
@@ -5701,9 +5702,13 @@ describe("Task Create Entrypoint", () => {
     expect(publishModeSelect.closest(".queue-floating-bar-row")).toBe(
       floatingBarRow,
     );
+    expect(reportToggle.closest(".queue-floating-bar")).toBeNull();
     expect(createButton.closest('[data-canonical-create-section="Submit"]')).toBe(
       submitSection,
     );
+    expect(
+      reportToggle.closest('[data-canonical-create-section="Execution controls"]'),
+    ).not.toBeNull();
     expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBe(
       submitSection,
     );
@@ -5751,6 +5756,12 @@ describe("Task Create Entrypoint", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
+      screen
+        .getByRole("checkbox", { name: "Propose Tasks" })
+        .compareDocumentPosition(reportToggle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
       addStepButton.compareDocumentPosition(createButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -5775,6 +5786,9 @@ describe("Task Create Entrypoint", () => {
     expect(within(floatingBar as HTMLElement).getByLabelText("Publish Mode")).toBe(
       screen.getByLabelText("Publish Mode"),
     );
+    expect(
+      within(floatingBar as HTMLElement).queryByLabelText("Produce report artifact"),
+    ).toBeNull();
     expect(within(floatingBar as HTMLElement).getByRole("button", { name: "Create" })).toBe(
       createButton,
     );

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -6467,6 +6467,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           />
           Propose Tasks
         </label>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={produceReport}
+            aria-label="Produce report artifact"
+            onChange={(event) => setProduceReport(event.target.checked)}
+          />
+          Report
+        </label>
         </section>
 
         {pageMode.mode === "create" ? (
@@ -6679,15 +6688,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 ) : null}
               </select>
             </div>
-            <label className="checkbox queue-inline-selector queue-inline-selector--report">
-              <input
-                type="checkbox"
-                checked={produceReport}
-                aria-label="Produce report artifact"
-                onChange={(event) => setProduceReport(event.target.checked)}
-              />
-              Report
-            </label>
             <button
               type="submit"
               className={


### PR DESCRIPTION
The Report checkbox should not be present in the floating bar on the create page. It should be near the Propose Tasks checkbox area.