### PR TITLE
[codex] Map final-state PR resolver merge artifacts

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,17 @@
 [
   {
-    "id": 3141071210,
-    "disposition": "not-applicable",
-    "rationale": "The referenced activity-runtime values are already defined before use: info is read from the Temporal activity context, metadata/moonmind_metadata are extracted from result metadata, and summary_payload is built before reportOutput is read."
-  },
-  {
-    "id": 3141071212,
-    "disposition": "not-applicable",
-    "rationale": "TemporalActivityRuntimeError is defined in moonmind/workflows/temporal/activity_runtime.py and is already available in this module."
-  },
-  {
-    "id": 4174446344,
-    "disposition": "not-applicable",
-    "rationale": "This review summary repeats the two Gemini inline comments; both underlying concerns are not applicable to the current code."
-  },
-  {
-    "id": 3141083599,
+    "id": 3142406589,
     "disposition": "addressed",
-    "rationale": "Persisted lastAssistantText is now bounded to 4 KiB with truncation metadata before session-store validation, with focused controller test coverage."
+    "rationale": "Centralized nested final-state artifact extraction in _pr_resolver_final_payload so status and metadata parsing share the same lookup."
   },
   {
-    "id": 3141083600,
+    "id": 3142406592,
     "disposition": "addressed",
-    "rationale": "The Create page now reconstructs reportOutputEnabled for edit/rerun mode and submits reportOutput.enabled=false when the report checkbox is unchecked, with focused draft reconstruction coverage."
+    "rationale": "Added _first_stripped_text so headSha selection skips whitespace-only candidates and falls through to valid nested final SHA values, with adapter tests covering the case."
   },
   {
-    "id": 4174464058,
-    "disposition": "not-applicable",
-    "rationale": "This is the Codex review container comment and contains no actionable code finding beyond the separate inline comments."
+    "id": 4175998021,
+    "disposition": "addressed",
+    "rationale": "Review summary covered by the same final-payload helper and robust SHA selection changes."
   }
 ]

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -83,14 +83,31 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
     if status:
         return status
 
-    final = payload.get("final")
-    if isinstance(final, dict):
+    final = _pr_resolver_final_payload(payload)
+    if final:
         return str(
             final.get("state")
             or final.get("status")
             or final.get("merge_outcome")
             or ""
         ).strip().lower()
+    return ""
+
+
+def _pr_resolver_final_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the nested final-state payload when resolver artifacts include one."""
+
+    final = payload.get("final")
+    return final if isinstance(final, dict) else {}
+
+
+def _first_stripped_text(*values: Any) -> str:
+    """Return the first non-empty value after string normalization."""
+
+    for value in values:
+        candidate = str(value or "").strip()
+        if candidate:
+            return candidate
     return ""
 
 
@@ -308,18 +325,16 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
         metadata["mergeAutomationDisposition"] = (
             "already_merged" if reason == "already_merged" else "merged"
         )
-    final_payload = payload.get("final")
-    final = final_payload if isinstance(final_payload, dict) else {}
-    head_sha = str(
-        payload.get("headSha")
-        or payload.get("head_sha")
-        or payload.get("latestHeadSha")
-        or payload.get("latest_head_sha")
-        or final.get("headRefOid")
-        or final.get("head_sha")
-        or final.get("headSha")
-        or ""
-    ).strip()
+    final = _pr_resolver_final_payload(payload)
+    head_sha = _first_stripped_text(
+        payload.get("headSha"),
+        payload.get("head_sha"),
+        payload.get("latestHeadSha"),
+        payload.get("latest_head_sha"),
+        final.get("headRefOid"),
+        final.get("head_sha"),
+        final.get("headSha"),
+    )
     if head_sha:
         metadata["headSha"] = head_sha
     return metadata

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -73,6 +73,27 @@ _PR_RESOLVER_BLOCKED_STATUSES: frozenset[str] = frozenset(
 )
 _PR_RESOLVER_MERGED_STATUSES: frozenset[str] = frozenset({"merged"})
 
+
+def _pr_resolver_status(payload: dict[str, Any]) -> str:
+    """Return the normalized terminal status from known resolver artifacts."""
+
+    status = str(
+        payload.get("status") or payload.get("merge_outcome") or ""
+    ).strip().lower()
+    if status:
+        return status
+
+    final = payload.get("final")
+    if isinstance(final, dict):
+        return str(
+            final.get("state")
+            or final.get("status")
+            or final.get("merge_outcome")
+            or ""
+        ).strip().lower()
+    return ""
+
+
 @dataclass(frozen=True, slots=True)
 class ManagedProfileLaunchContext:
     """Resolved managed-profile launch context shared across adapters."""
@@ -258,9 +279,7 @@ def _derive_pr_resolver_failure(
     if payload is None:
         return None, None
 
-    status = str(
-        payload.get("status") or payload.get("merge_outcome") or ""
-    ).strip().lower()
+    status = _pr_resolver_status(payload)
     if status not in _PR_RESOLVER_FAILURE_STATUSES:
         return None, None
 
@@ -282,20 +301,23 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
     if payload is None:
         return {}
 
-    status = str(
-        payload.get("status") or payload.get("merge_outcome") or ""
-    ).strip().lower()
+    status = _pr_resolver_status(payload)
     reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
     metadata: dict[str, Any] = {}
     if status in _PR_RESOLVER_MERGED_STATUSES:
         metadata["mergeAutomationDisposition"] = (
             "already_merged" if reason == "already_merged" else "merged"
         )
+    final_payload = payload.get("final")
+    final = final_payload if isinstance(final_payload, dict) else {}
     head_sha = str(
         payload.get("headSha")
         or payload.get("head_sha")
         or payload.get("latestHeadSha")
         or payload.get("latest_head_sha")
+        or final.get("headRefOid")
+        or final.get("head_sha")
+        or final.get("headSha")
         or ""
     ).strip()
     if head_sha:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -2933,6 +2933,7 @@ async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadat
         (
             "{\n"
             '  "generatedAt": "2026-04-25T15:34:55.886536Z",\n'
+            '  "headSha": "   ",\n'
             '  "final": {\n'
             '    "state": "MERGED",\n'
             '    "mergedAt": "2026-04-25T15:34:22Z",\n'

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -2922,3 +2922,89 @@ async def test_fetch_result_maps_merged_pr_resolver_artifact_metadata(
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "already_merged"
     assert result.metadata["headSha"] == "abc123"
+
+async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadata(
+    tmp_path: Path,
+) -> None:
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "generatedAt": "2026-04-25T15:34:55.886536Z",\n'
+            '  "final": {\n'
+            '    "state": "MERGED",\n'
+            '    "mergedAt": "2026-04-25T15:34:22Z",\n'
+            '    "headRefOid": "49061ed20f6b2260ba9564e71f4f896e3f96d3df"\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    run_id = "run-result-pr-final-merged"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=datetime.now(tz=UTC),
+            workspacePath=str(workspace_path),
+        )
+    )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_async_noop,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=run_id,
+        agent_id="codex_cli",
+        locator={
+            "sessionId": "sess:wf-task-1:codex_cli",
+            "sessionEpoch": 1,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Codex managed-session turn completed.",
+            "metadata": {},
+        },
+        status="completed",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert (
+        result.metadata["headSha"]
+        == "49061ed20f6b2260ba9564e71f4f896e3f96d3df"
+    )

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1522,6 +1522,62 @@ async def test_fetch_result_ignores_merged_pr_resolver_artifact(tmp_path: Path):
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "merged"
 
+async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadata(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "generatedAt": "2026-04-25T15:34:55.886536Z",\n'
+            '  "final": {\n'
+            '    "state": "MERGED",\n'
+            '    "mergedAt": "2026-04-25T15:34:22Z",\n'
+            '    "headRefOid": "49061ed20f6b2260ba9564e71f4f896e3f96d3df"\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-final-merged",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-final-merged",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-final-merged", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert (
+        result.metadata["headSha"]
+        == "49061ed20f6b2260ba9564e71f4f896e3f96d3df"
+    )
+
 async def test_fetch_result_maps_already_merged_pr_resolver_artifact_metadata(tmp_path: Path):
     from datetime import UTC, datetime
 

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1537,6 +1537,7 @@ async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadat
         (
             "{\n"
             '  "generatedAt": "2026-04-25T15:34:55.886536Z",\n'
+            '  "headSha": "   ",\n'
             '  "final": {\n'
             '    "state": "MERGED",\n'
             '    "mergedAt": "2026-04-25T15:34:22Z",\n'


### PR DESCRIPTION
## Summary
- Map PR resolver artifacts with nested final.state values into merge automation dispositions.
- Propagate final.headRefOid as the merge automation head SHA.
- Add managed-agent and Codex-session adapter regression coverage for the artifact shape from the failed workflow.

## Root Cause
Workflow mm:07159286-1c6b-49ff-9f7d-fd58a91def18 failed because the resolver child produced a successful run, but the artifact shape used final.state=MERGED instead of top-level status=merged, so merge automation treated the resolver output as missing mergeAutomationDisposition.

## Validation
- ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/adapters/test_codex_session_adapter.py
- MOONMIND_WORKFLOW_DOCKER_MODE=profiles ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_build_runtime_activities_reconciles_managed_sessions_only_on_agent_runtime_fleet
- Full ./tools/test_unit.sh was also run; it reached 4001 passed and failed only because this shell had MOONMIND_WORKFLOW_DOCKER_MODE=unrestricted while that worker-runtime test expects profiles.