### PR TITLE
[codex] Surface child workflow runtime metadata

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -962,6 +962,8 @@ def _serialize_execution(
             _coerce_temporal_scalar(search_attributes.get("mm_target_runtime"))
             or _coerce_temporal_scalar(search_attributes.get("mm_runtime"))
             or _coerce_temporal_scalar(search_attributes.get("runtime"))
+            or _coerce_temporal_scalar(memo.get("targetRuntime"))
+            or _coerce_temporal_scalar(memo.get("target_runtime"))
         ) or None
 
     task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
@@ -996,6 +998,10 @@ def _serialize_execution(
             or _coerce_temporal_scalar(search_attributes.get("mm_skill"))
             or _coerce_temporal_scalar(search_attributes.get("skillId"))
             or _coerce_temporal_scalar(search_attributes.get("skill"))
+            or _coerce_temporal_scalar(memo.get("targetSkill"))
+            or _coerce_temporal_scalar(memo.get("target_skill"))
+            or _coerce_temporal_scalar(memo.get("skillId"))
+            or _coerce_temporal_scalar(memo.get("skill"))
         ) or None
 
     task_payload = params.get("task")

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,17 @@
 [
   {
-    "id": 3141071210,
-    "disposition": "not-applicable",
-    "rationale": "The referenced activity-runtime values are already defined before use: info is read from the Temporal activity context, metadata/moonmind_metadata are extracted from result metadata, and summary_payload is built before reportOutput is read."
-  },
-  {
-    "id": 3141071212,
-    "disposition": "not-applicable",
-    "rationale": "TemporalActivityRuntimeError is defined in moonmind/workflows/temporal/activity_runtime.py and is already available in this module."
-  },
-  {
-    "id": 4174446344,
-    "disposition": "not-applicable",
-    "rationale": "This review summary repeats the two Gemini inline comments; both underlying concerns are not applicable to the current code."
-  },
-  {
-    "id": 3141083599,
+    "id": 3142403429,
     "disposition": "addressed",
-    "rationale": "Persisted lastAssistantText is now bounded to 4 KiB with truncation metadata before session-store validation, with focused controller test coverage."
+    "rationale": "Truncated merge automation child workflow memo targetRuntime to 80 characters and targetSkill to 160 characters, with regression coverage."
   },
   {
-    "id": 3141083600,
-    "disposition": "addressed",
-    "rationale": "The Create page now reconstructs reportOutputEnabled for edit/rerun mode and submits reportOutput.enabled=false when the report checkbox is unchecked, with focused draft reconstruction coverage."
-  },
-  {
-    "id": 4174464058,
+    "id": 4175995633,
     "disposition": "not-applicable",
-    "rationale": "This is the Codex review container comment and contains no actionable code finding beyond the separate inline comments."
+    "rationale": "Review summary only; the two actionable child comments were handled individually."
+  },
+  {
+    "id": 3142403433,
+    "disposition": "addressed",
+    "rationale": "Removed the try/except around workflow.patched in MoonMindRunWorkflow._update_memo so the patch marker follows the standard deterministic workflow pattern."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -168,7 +168,7 @@ class MoonMindMergeAutomationWorkflow:
                 or runtime_payload.get("mode")
                 or runtime_payload.get("targetRuntime")
                 or ""
-            ).strip()
+            ).strip()[:80]
             or None
         )
         target_skill = (
@@ -179,7 +179,7 @@ class MoonMindMergeAutomationWorkflow:
                 or skill_payload.get("name")
                 or initial_parameters.get("targetSkill")
                 or ""
-            ).strip()
+            ).strip()[:160]
             or None
         )
         memo: dict[str, Any] = {

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -145,6 +145,55 @@ class MoonMindMergeAutomationWorkflow:
             attributes["mm_repo"] = [self._input.pull_request.repo]
         return attributes
 
+    @staticmethod
+    def _resolver_child_memo(resolver_request: Mapping[str, Any]) -> dict[str, Any]:
+        initial_parameters = resolver_request.get("initial_parameters")
+        if not isinstance(initial_parameters, Mapping):
+            initial_parameters = {}
+        task_payload = initial_parameters.get("task")
+        if not isinstance(task_payload, Mapping):
+            task_payload = {}
+        runtime_payload = task_payload.get("runtime")
+        if not isinstance(runtime_payload, Mapping):
+            runtime_payload = {}
+        tool_payload = task_payload.get("tool")
+        if not isinstance(tool_payload, Mapping):
+            tool_payload = {}
+        skill_payload = task_payload.get("skill")
+        if not isinstance(skill_payload, Mapping):
+            skill_payload = {}
+        target_runtime = (
+            str(
+                initial_parameters.get("targetRuntime")
+                or runtime_payload.get("mode")
+                or runtime_payload.get("targetRuntime")
+                or ""
+            ).strip()
+            or None
+        )
+        target_skill = (
+            str(
+                tool_payload.get("name")
+                or tool_payload.get("id")
+                or skill_payload.get("id")
+                or skill_payload.get("name")
+                or initial_parameters.get("targetSkill")
+                or ""
+            ).strip()
+            or None
+        )
+        memo: dict[str, Any] = {
+            "entry": "run",
+            "title": str(resolver_request.get("title") or "Resolve PR").strip()
+            or "Resolve PR",
+            "summary": "Resolver child workflow for merge automation.",
+        }
+        if target_runtime:
+            memo["targetRuntime"] = target_runtime
+        if target_skill:
+            memo["targetSkill"] = target_skill
+        return memo
+
     async def _write_json_artifact(self, *, name: str, payload: dict[str, Any]) -> str | None:
         try:
             artifact_ref, _upload_desc = await workflow.execute_activity(
@@ -530,16 +579,21 @@ class MoonMindMergeAutomationWorkflow:
                     f"{resolver_workflow_id}:{len(self._resolver_child_workflow_ids) + 1}"
                 )
                 self._resolver_child_workflow_ids.append(resolver_workflow_id)
+                child_kwargs: dict[str, Any] = {
+                    "id": resolver_workflow_id,
+                    "task_queue": WORKFLOW_TASK_QUEUE,
+                    "search_attributes": self._resolver_search_attributes(),
+                    "cancellation_type": ChildWorkflowCancellationType.TRY_CANCEL,
+                    "static_summary": "Resolving pull request for merge automation",
+                    "static_details": f"Resolve {self._input.pull_request.url}",
+                }
+                if workflow.patched("merge-automation-resolver-child-visibility-memo"):
+                    child_kwargs["memo"] = self._resolver_child_memo(resolver_request)
                 try:
                     resolver_result = await workflow.execute_child_workflow(
                         "MoonMind.Run",
                         resolver_request,
-                        id=resolver_workflow_id,
-                        task_queue=WORKFLOW_TASK_QUEUE,
-                        search_attributes=self._resolver_search_attributes(),
-                        cancellation_type=ChildWorkflowCancellationType.TRY_CANCEL,
-                        static_summary="Resolving pull request for merge automation",
-                        static_details=f"Resolve {self._input.pull_request.url}",
+                        **child_kwargs,
                     )
                 except CancelledError:
                     self._status = STATE_CANCELED

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -236,6 +236,8 @@ class MoonMindRunWorkflow:
         self._entry: Optional[str] = None
         self._repo: Optional[str] = None
         self._integration: Optional[str] = None
+        self._target_runtime: Optional[str] = None
+        self._target_skill: Optional[str] = None
         self._close_status: Optional[str] = None
         self._title: Optional[str] = None
         self._summary: str = "Execution initialized."
@@ -1553,6 +1555,8 @@ class MoonMindRunWorkflow:
             "initialParameters",
             "initial_parameters",
         )
+        self._target_runtime = self._runtime_visibility_from_parameters(parameters)
+        self._target_skill = self._skill_visibility_from_parameters(parameters)
         task_parameters = self._mapping_value(parameters, "task")
         self._declared_dependencies = normalize_dependency_ids(
             task_parameters.get("dependsOn")
@@ -1590,6 +1594,57 @@ class MoonMindRunWorkflow:
             self._scheduled_for = scheduled_for
 
         return workflow_type, parameters, input_ref, plan_ref, scheduled_for
+
+    def _runtime_visibility_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> str | None:
+        task_payload = self._mapping_value(parameters, "task") or {}
+        task_runtime_payload = (
+            self._mapping_value(task_payload, "runtime")
+            if isinstance(task_payload, Mapping)
+            else {}
+        ) or {}
+        runtime_payload = self._mapping_value(parameters, "runtime") or {}
+        return (
+            self._coerce_text(parameters.get("targetRuntime"), max_chars=80)
+            or self._coerce_text(task_runtime_payload.get("mode"), max_chars=80)
+            or self._coerce_text(task_runtime_payload.get("targetRuntime"), max_chars=80)
+            or self._coerce_text(runtime_payload.get("mode"), max_chars=80)
+            or self._coerce_text(runtime_payload.get("targetRuntime"), max_chars=80)
+        )
+
+    def _skill_visibility_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> str | None:
+        direct = (
+            self._coerce_text(parameters.get("targetSkill"), max_chars=160)
+            or self._coerce_text(parameters.get("target_skill"), max_chars=160)
+            or self._coerce_text(parameters.get("skillId"), max_chars=160)
+            or self._coerce_text(parameters.get("skill"), max_chars=160)
+        )
+        if direct:
+            return direct
+        task_payload = self._mapping_value(parameters, "task") or {}
+        if not isinstance(task_payload, Mapping):
+            return None
+        tool_payload = self._mapping_value(task_payload, "tool") or {}
+        skill_payload = self._mapping_value(task_payload, "skill") or {}
+        tool_type = str(
+            tool_payload.get("type") or tool_payload.get("kind") or ""
+        ).strip()
+        if not tool_type or tool_type == "skill":
+            tool_name = (
+                self._coerce_text(tool_payload.get("name"), max_chars=160)
+                or self._coerce_text(tool_payload.get("id"), max_chars=160)
+            )
+            if tool_name:
+                return tool_name
+        return (
+            self._coerce_text(skill_payload.get("id"), max_chars=160)
+            or self._coerce_text(skill_payload.get("name"), max_chars=160)
+        )
 
     async def _run_planning_stage(
         self,
@@ -5021,6 +5076,17 @@ class MoonMindRunWorkflow:
             "title": self._title or "Run",
             "summary": self._summary,
         }
+        try:
+            include_runtime_skill_visibility = workflow.patched(
+                "run-memo-runtime-skill-visibility"
+            )
+        except Exception:
+            include_runtime_skill_visibility = True
+        if include_runtime_skill_visibility:
+            if self._target_runtime:
+                memo_dict["targetRuntime"] = self._target_runtime
+            if self._target_skill:
+                memo_dict["targetSkill"] = self._target_skill
         if self._input_ref:
             memo_dict["input_artifact_ref"] = self._input_ref
         if self._plan_ref:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5076,13 +5076,7 @@ class MoonMindRunWorkflow:
             "title": self._title or "Run",
             "summary": self._summary,
         }
-        try:
-            include_runtime_skill_visibility = workflow.patched(
-                "run-memo-runtime-skill-visibility"
-            )
-        except Exception:
-            include_runtime_skill_visibility = True
-        if include_runtime_skill_visibility:
+        if workflow.patched("run-memo-runtime-skill-visibility"):
             if self._target_runtime:
                 memo_dict["targetRuntime"] = self._target_runtime
             if self._target_skill:

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -210,6 +210,73 @@ def test_list_executions_source_temporal_merges_canonical_parameters(
         assert item["targetRuntime"] == "codex"
         assert item["targetSkill"] == "fix-ci"
 
+def test_list_executions_source_temporal_uses_memo_runtime_and_skill_for_child_runs(
+    client,
+) -> None:
+    """Child workflows can lack canonical DB parameters but still publish compact memo visibility."""
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    test_client, _service, _user, mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        async def _memo():
+            return {
+                "entry": "run",
+                "title": "Resolve PR #1633",
+                "summary": "Resolver child workflow for merge automation.",
+                "targetRuntime": "codex_cli",
+                "targetSkill": "pr-resolver",
+            }
+
+        mock_wf = SimpleNamespace()
+        mock_wf.id = "resolver:pr:1633:head:1045fd00767c:h:f144d66e268f79fd:1"
+        mock_wf.run_id = "run-1"
+        mock_wf.namespace = "moonmind"
+        mock_wf.workflow_type = "MoonMind.Run"
+        mock_wf.status = 2  # COMPLETED
+        mock_wf.memo = _memo
+        mock_wf.search_attributes = {
+            "mm_entry": b'["run"]',
+            "mm_owner_type": b'["user"]',
+            "mm_owner_id": b'["user-123"]',
+            "mm_repo": b'["MoonLadderStudios/Tactics"]',
+        }
+        mock_wf.start_time = datetime.now(UTC)
+        mock_wf.execution_time = mock_wf.start_time
+        mock_wf.close_time = mock_wf.start_time
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = [mock_wf]
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = lambda **kwargs: mock_iterator
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=1))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "workflowType": "MoonMind.Run"},
+        )
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert item["targetRuntime"] == "codex_cli"
+        assert item["targetSkill"] == "pr-resolver"
+        assert item["repository"] == "MoonLadderStudios/Tactics"
+
 def test_list_executions_source_temporal_orders_scheduled_runs_by_latest_scheduled_time(
     client,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -67,6 +67,7 @@ def test_initialize_from_payload_tracks_declared_dependencies(
         "upsert_memo",
         lambda memo: captured_memo.append(dict(memo)),
     )
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
 
     workflow._update_memo()
 
@@ -2019,6 +2020,7 @@ def test_update_memo_persists_pull_request_url_under_canonical_key(
         "upsert_memo",
         lambda memo: captured_memo.append(dict(memo)),
     )
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
 
     workflow._update_memo()
 

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -437,6 +437,20 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
         "targetSkill": "pr-resolver",
     }
 
+def test_merge_automation_child_memo_truncates_runtime_and_skill_visibility() -> None:
+    resolver_request = {
+        "title": "Resolve PR #350",
+        "initial_parameters": {
+            "targetRuntime": "r" * 120,
+            "targetSkill": "s" * 220,
+        },
+    }
+
+    memo = MoonMindMergeAutomationWorkflow._resolver_child_memo(resolver_request)
+
+    assert memo["targetRuntime"] == "r" * 80
+    assert memo["targetSkill"] == "s" * 160
+
 @pytest.mark.asyncio
 async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marker(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -429,6 +429,13 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
     assert search_attributes["mm_owner_type"] == ["user"]
     assert search_attributes["mm_owner_id"] == ["wf-parent"]
     assert search_attributes["mm_repo"] == ["MoonLadderStudios/MoonMind"]
+    assert child_kwargs["memo"] == {
+        "entry": "run",
+        "title": "Resolve PR #350",
+        "summary": "Resolver child workflow for merge automation.",
+        "targetRuntime": "codex",
+        "targetSkill": "pr-resolver",
+    }
 
 @pytest.mark.asyncio
 async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marker(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -222,7 +222,7 @@ async def test_run_integration_poll_completion_invokes_patched_with_stable_id(
     )
 
     assert patch_calls, "workflow.patched should be evaluated for integration poll completion"
-    assert set(patch_calls) == {INTEGRATION_POLL_LOOP_PATCH}
+    assert INTEGRATION_POLL_LOOP_PATCH in patch_calls
     assert mock_run_workflow._external_status == "completed"
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py
@@ -18,6 +18,7 @@ def _patch_workflow_context(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "upsert_search_attributes",

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -386,6 +386,7 @@ async def test_wait_for_dependencies_records_dependency_metadata(monkeypatch):
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",
@@ -463,6 +464,7 @@ async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypa
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: None)
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",
@@ -499,6 +501,7 @@ async def test_wait_for_dependencies_can_be_bypassed_by_operator_signal(monkeypa
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",
@@ -575,6 +578,7 @@ async def test_wait_for_dependencies_reconciles_again_after_timeout(monkeypatch)
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: None)
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",
@@ -611,6 +615,7 @@ async def test_skip_dependency_wait_unblocks_dependency_gate(monkeypatch):
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -355,6 +355,7 @@ def test_run_queries_remain_available_after_completion(
 
 def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> None:
     memo_updates = _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
 
@@ -374,6 +375,22 @@ def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "steps" not in latest_memo
     assert "progress" not in latest_memo
     assert "checks" not in latest_memo
+
+def test_run_memo_surfaces_runtime_and_skill_visibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memo_updates = _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+
+    workflow._title = "Resolve PR #1633"
+    workflow._summary = "Execution initialized."
+    workflow._target_runtime = "codex_cli"
+    workflow._target_skill = "pr-resolver"
+    workflow._update_memo()
+
+    assert memo_updates[-1]["targetRuntime"] == "codex_cli"
+    assert memo_updates[-1]["targetSkill"] == "pr-resolver"
 
 def test_run_groups_child_lineage_and_evidence_into_step_row(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- surface compact runtime and skill metadata from Temporal memo when canonical execution parameters are unavailable
- publish resolver child workflow memo metadata at merge-automation child start
- preserve runtime and skill visibility through MoonMind.Run memo updates

## Root Cause
Merge-automation resolver children are started directly inside Temporal rather than through the normal executions API creation path, so they do not get canonical DB parameter rows. The Tasks List reads compact list metadata instead of full workflow history, so those child rows showed blank runtime and skill fields.

## Validation
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_executions_temporal.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
- git diff --check
