### PR TITLE
[codex] Fix settings profile load failure

### DIFF
--- a/api_service/api/routers/profile.py
+++ b/api_service/api/routers/profile.py
@@ -16,19 +16,6 @@ router = APIRouter()
 async def get_profile_service() -> ProfileService:
     return ProfileService()
 
-def _build_sanitized_response(
-    profile, *, email: str | None = None
-) -> UserProfileReadSanitized:
-    """Build a sanitized response with key-set boolean flags."""
-    return UserProfileReadSanitized(
-        id=profile.id,
-        user_id=profile.user_id,
-        email=email,
-        google_api_key_set=bool(getattr(profile, "google_api_key", None)),
-        openai_api_key_set=bool(getattr(profile, "openai_api_key", None)),
-        anthropic_api_key_set=bool(getattr(profile, "anthropic_api_key", None)),
-    )
-
 @router.get("/me", response_model=UserProfileReadSanitized)
 async def get_current_user_profile(
     user: DBUser = Depends(get_current_user()),
@@ -63,6 +50,4 @@ async def update_current_user_profile(
     updated_profile = await profile_service.update_profile(
         db_session=db, user_id=user.id, profile_data=profile_update_data
     )
-    return _build_sanitized_response(
-        updated_profile, email=getattr(user, "email", None)
-    )
+    return updated_profile.model_copy(update={"email": getattr(user, "email", None)})

--- a/api_service/api/routers/profile.py
+++ b/api_service/api/routers/profile.py
@@ -16,11 +16,14 @@ router = APIRouter()
 async def get_profile_service() -> ProfileService:
     return ProfileService()
 
-def _build_sanitized_response(profile) -> UserProfileReadSanitized:
+def _build_sanitized_response(
+    profile, *, email: str | None = None
+) -> UserProfileReadSanitized:
     """Build a sanitized response with key-set boolean flags."""
     return UserProfileReadSanitized(
         id=profile.id,
         user_id=profile.user_id,
+        email=email,
         google_api_key_set=bool(getattr(profile, "google_api_key", None)),
         openai_api_key_set=bool(getattr(profile, "openai_api_key", None)),
         anthropic_api_key_set=bool(getattr(profile, "anthropic_api_key", None)),
@@ -39,10 +42,10 @@ async def get_current_user_profile(
     """
     if user.id is None:
         raise HTTPException(status_code=400, detail="User ID is missing.")
-    profile = await profile_service.get_or_create_profile(
+    profile = await profile_service.get_or_create_sanitized_profile(
         db_session=db, user_id=user.id
     )
-    return _build_sanitized_response(profile)
+    return profile.model_copy(update={"email": getattr(user, "email", None)})
 
 @router.put("/me", response_model=UserProfileReadSanitized)
 async def update_current_user_profile(
@@ -60,4 +63,6 @@ async def update_current_user_profile(
     updated_profile = await profile_service.update_profile(
         db_session=db, user_id=user.id, profile_data=profile_update_data
     )
-    return _build_sanitized_response(updated_profile)
+    return _build_sanitized_response(
+        updated_profile, email=getattr(user, "email", None)
+    )

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -35,6 +35,18 @@ class UserProfileBaseSchema(BaseModel):
         alias="anthropic_api_key_encrypted",
     )
 
+    @field_validator(
+        "google_api_key",
+        "openai_api_key",
+        "anthropic_api_key",
+        mode="before",
+    )
+    @classmethod
+    def _empty_api_key_is_unset(cls, value: Any) -> Any:
+        if value == "":
+            return None
+        return value
+
 class UserProfileRead(
     UserProfileBaseSchema
 ):  # Renamed UserProfileSchema to UserProfileRead

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -51,6 +51,7 @@ class UserProfileReadSanitized(BaseModel):
 
     id: int
     user_id: uuid.UUID
+    email: str | None = None
     google_api_key_set: bool = False
     openai_api_key_set: bool = False
     anthropic_api_key_set: bool = False

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1043,8 +1043,10 @@ async def startup_event():
                             f"Default user {default_user.email} (ID: {default_user.id}) ensured."
                         )
                         profile_service = ProfileService()
-                        existing_profile = await profile_service.get_profile_by_user_id(
-                            db_session=db_session, user_id=default_user.id
+                        existing_profile = (
+                            await profile_service.get_sanitized_profile_by_user_id(
+                                db_session=db_session, user_id=default_user.id
+                            )
                         )
                         if existing_profile:
                             logger.info(

--- a/api_service/services/profile_service.py
+++ b/api_service/services/profile_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.future import select
 from api_service.api.schemas import (
     UserProfileCreateSchema,
     UserProfileRead,
+    UserProfileReadSanitized,
     UserProfileUpdate,
 )
 from api_service.db.models import (  # User model might be needed for context or future validation
@@ -28,6 +29,74 @@ class ProfileService:
             select(UserProfile).where(UserProfile.user_id == user_id)
         )
         return result.scalars().first()
+
+    async def get_sanitized_profile_by_user_id(
+        self, db_session: AsyncSession, user_id: uuid.UUID
+    ) -> UserProfileReadSanitized | None:
+        """Return profile metadata without decrypting stored secret columns."""
+        result = await db_session.execute(
+            select(
+                UserProfile.id.label("id"),
+                UserProfile.user_id.label("user_id"),
+                UserProfile.google_api_key_encrypted.is_not(None).label(
+                    "google_api_key_set"
+                ),
+                UserProfile.openai_api_key_encrypted.is_not(None).label(
+                    "openai_api_key_set"
+                ),
+                UserProfile.anthropic_api_key_encrypted.is_not(None).label(
+                    "anthropic_api_key_set"
+                ),
+            ).where(UserProfile.user_id == user_id)
+        )
+        row = result.mappings().first()
+        if row is None:
+            return None
+        return UserProfileReadSanitized(**row)
+
+    async def get_or_create_sanitized_profile(
+        self, db_session: AsyncSession, user_id: uuid.UUID
+    ) -> UserProfileReadSanitized:
+        """
+        Retrieves a user's profile metadata, or creates an empty profile if missing.
+
+        This path intentionally avoids loading encrypted secret columns because the
+        Settings profile panel only needs stable identity metadata and key-set flags.
+        """
+        profile = await self.get_sanitized_profile_by_user_id(db_session, user_id)
+        if profile is not None:
+            return profile
+
+        user_exists = await db_session.get(User, user_id)
+        if not user_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User with id {user_id} not found. Cannot create profile.",
+            )
+
+        new_profile = UserProfile(user_id=user_id)
+        db_session.add(new_profile)
+        try:
+            await db_session.commit()
+        except Exception as e:
+            import logging
+
+            logging.error(
+                "Failed to commit transaction while creating profile", exc_info=True
+            )
+            await db_session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to create profile: {str(e)}",
+            )
+
+        profile = await self.get_sanitized_profile_by_user_id(db_session, user_id)
+        if profile is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create profile.",
+            )
+        return profile
 
     async def get_or_create_profile(
         self, db_session: AsyncSession, user_id: uuid.UUID

--- a/api_service/services/profile_service.py
+++ b/api_service/services/profile_service.py
@@ -1,21 +1,26 @@
+import logging
 import uuid
 from typing import Optional
 
 from fastapi import HTTPException, status
+from sqlalchemy import and_, func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-# Updated import to use UserProfileRead and UserProfileUpdate
 from api_service.api.schemas import (
     UserProfileCreateSchema,
     UserProfileRead,
     UserProfileReadSanitized,
     UserProfileUpdate,
 )
-from api_service.db.models import (  # User model might be needed for context or future validation
-    User,
-    UserProfile,
-)
+from api_service.db.models import User, UserProfile
+
+logger = logging.getLogger(__name__)
+
+
+def _key_is_set(column):
+    return and_(column.is_not(None), func.length(column) > 0)
+
 
 class ProfileService:
     async def get_profile_by_user_id(
@@ -30,6 +35,19 @@ class ProfileService:
         )
         return result.scalars().first()
 
+    async def _get_profile_identity_by_user_id(
+        self, db_session: AsyncSession, user_id: uuid.UUID
+    ) -> dict | None:
+        """Return profile identity columns without loading encrypted secret fields."""
+        result = await db_session.execute(
+            select(
+                UserProfile.id.label("id"),
+                UserProfile.user_id.label("user_id"),
+            ).where(UserProfile.user_id == user_id)
+        )
+        row = result.mappings().first()
+        return dict(row) if row is not None else None
+
     async def get_sanitized_profile_by_user_id(
         self, db_session: AsyncSession, user_id: uuid.UUID
     ) -> UserProfileReadSanitized | None:
@@ -38,14 +56,14 @@ class ProfileService:
             select(
                 UserProfile.id.label("id"),
                 UserProfile.user_id.label("user_id"),
-                UserProfile.google_api_key_encrypted.is_not(None).label(
-                    "google_api_key_set"
+                _key_is_set(UserProfile.google_api_key_encrypted).label(
+                    "google_api_key_set",
                 ),
-                UserProfile.openai_api_key_encrypted.is_not(None).label(
-                    "openai_api_key_set"
+                _key_is_set(UserProfile.openai_api_key_encrypted).label(
+                    "openai_api_key_set",
                 ),
-                UserProfile.anthropic_api_key_encrypted.is_not(None).label(
-                    "anthropic_api_key_set"
+                _key_is_set(UserProfile.anthropic_api_key_encrypted).label(
+                    "anthropic_api_key_set",
                 ),
             ).where(UserProfile.user_id == user_id)
         )
@@ -53,6 +71,49 @@ class ProfileService:
         if row is None:
             return None
         return UserProfileReadSanitized(**row)
+
+    async def _ensure_user_exists(
+        self, db_session: AsyncSession, user_id: uuid.UUID
+    ) -> None:
+        user_exists = await db_session.get(User, user_id)
+        if not user_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User with id {user_id} not found. Cannot create profile.",
+            )
+
+    def _new_profile(self, user_id: uuid.UUID) -> UserProfile:
+        profile = UserProfile(user_id=user_id)
+        new_profile_data = UserProfileCreateSchema()
+        for key_in_schema, value in new_profile_data.model_dump(
+            exclude_unset=False, by_alias=True
+        ).items():
+            if hasattr(profile, key_in_schema):
+                setattr(profile, key_in_schema, value)
+        return profile
+
+    async def _commit_profile_creation(
+        self, db_session: AsyncSession, user_id: uuid.UUID
+    ) -> UserProfileReadSanitized:
+        try:
+            await db_session.commit()
+        except Exception:
+            logger.error(
+                "Failed to commit transaction while creating profile", exc_info=True
+            )
+            await db_session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create profile.",
+            )
+
+        profile = await self.get_sanitized_profile_by_user_id(db_session, user_id)
+        if profile is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create profile.",
+            )
+        return profile
 
     async def get_or_create_sanitized_profile(
         self, db_session: AsyncSession, user_id: uuid.UUID
@@ -67,85 +128,37 @@ class ProfileService:
         if profile is not None:
             return profile
 
-        user_exists = await db_session.get(User, user_id)
-        if not user_exists:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"User with id {user_id} not found. Cannot create profile.",
-            )
-
-        new_profile = UserProfile(user_id=user_id)
+        await self._ensure_user_exists(db_session, user_id)
+        new_profile = self._new_profile(user_id)
         db_session.add(new_profile)
-        try:
-            await db_session.commit()
-        except Exception as e:
-            import logging
-
-            logging.error(
-                "Failed to commit transaction while creating profile", exc_info=True
-            )
-            await db_session.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Failed to create profile: {str(e)}",
-            )
-
-        profile = await self.get_sanitized_profile_by_user_id(db_session, user_id)
-        if profile is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create profile.",
-            )
-        return profile
+        return await self._commit_profile_creation(db_session, user_id)
 
     async def get_or_create_profile(
         self, db_session: AsyncSession, user_id: uuid.UUID
     ) -> UserProfileRead:
         """
         Retrieves a user's profile by user_id, or creates a new one if it doesn't exist.
-        The `user_id` is expected to be validated and exist in the `User` table upstream.
+        The `user_id` is expected to be validated and exist in the `User`
+        table upstream.
         """
         profile = await self.get_profile_by_user_id(db_session, user_id)
 
         if not profile:
-            # Ensure the user actually exists before creating a profile for them.
-            # This check might be optional if user_id validity is guaranteed by the caller.
-            user_exists = await db_session.get(User, user_id)
-            if not user_exists:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"User with id {user_id} not found. Cannot create profile.",
-                )
-
-            # Create a new profile with default (empty) values initially
-            # UserProfileCreateSchema can be used here if specific creation defaults are desired
-            # For now, directly creating UserProfile model instance
-            new_profile_data = (
-                UserProfileCreateSchema()
-            )  # Provides default values if any (e.g. None for keys)
-
-            profile = UserProfile(user_id=user_id)
-            # Initialize all keys from schema defaults (which should be None)
-            # This ensures that if new keys are added to the schema and model,
-            # they are initialized here during profile creation.
-            for key_in_schema, value in new_profile_data.model_dump(exclude_unset=False, by_alias=True).items():
-                if hasattr(profile, key_in_schema):
-                    setattr(profile, key_in_schema, value)
+            await self._ensure_user_exists(db_session, user_id)
+            profile = self._new_profile(user_id)
 
             db_session.add(profile)
             try:
                 await db_session.commit()
                 await db_session.refresh(profile)
-            except Exception as e:
-                import logging
-
-                logging.error(
+            except Exception:
+                logger.error(
                     "Failed to commit transaction while creating profile", exc_info=True
                 )
                 await db_session.rollback()
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"Failed to create profile: {str(e)}",
+                    detail="Failed to create profile.",
                 )
 
         return UserProfileRead.model_validate(profile)  # Use UserProfileRead
@@ -160,55 +173,74 @@ class ProfileService:
         db_session: AsyncSession,
         user_id: uuid.UUID,
         profile_data: UserProfileUpdate,
-    ) -> UserProfileRead:  # Use UserProfileUpdate and UserProfileRead
+    ) -> UserProfileReadSanitized:
         """
         Updates an existing user's profile.
         If the profile doesn't exist, it will first be created.
         """
-        profile = await self.get_profile_by_user_id(db_session, user_id)
+        profile = await self._get_profile_identity_by_user_id(db_session, user_id)
         update_data = profile_data.model_dump(exclude_unset=True, by_alias=True)
 
-        # Safety check: `get_profile_by_user_id` should return a profile for the
-        # provided user_id. This guard protects against potential data
-        # inconsistencies where a profile might be associated with a different
-        # user.
-        if profile and profile.user_id != user_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Cannot update another user's profile.",
-            )
-
         if not profile:
-            user_exists = await db_session.get(User, user_id)
-            if not user_exists:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"User with id {user_id} not found. Cannot create or update profile.",
-                )
+            try:
+                await self._ensure_user_exists(db_session, user_id)
+            except HTTPException as exc:
+                if exc.status_code == status.HTTP_404_NOT_FOUND:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=(
+                            f"User with id {user_id} not found. Cannot create or "
+                            "update profile."
+                        ),
+                    )
+                raise
 
-            profile = UserProfile(user_id=user_id)
+            profile = self._new_profile(user_id)
             self._apply_update_data_to_profile(profile, update_data)
             db_session.add(profile)
 
         else:  # Profile exists, update it
             if not update_data:
-                # If no data to update, just return the current profile
-                return UserProfileRead.model_validate(profile)  # Use UserProfileRead
+                profile = await self.get_sanitized_profile_by_user_id(
+                    db_session, user_id
+                )
+                if profile is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Profile for user with id {user_id} not found.",
+                    )
+                return profile
 
-            self._apply_update_data_to_profile(profile, update_data)
-
-        try:
-            await db_session.commit()  # Commit changes (either new profile or updates)
-            await db_session.refresh(profile)
-        except Exception as e:
-            await db_session.rollback()
-            # Log error e
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Failed to update profile: {str(e)}",
+            await db_session.execute(
+                update(UserProfile)
+                .where(UserProfile.user_id == user_id)
+                .values(**update_data)
             )
 
-        return UserProfileRead.model_validate(profile)  # Use UserProfileRead
+        try:
+            await db_session.commit()
+        except Exception:
+            logger.error(
+                "Failed to commit transaction while updating profile", exc_info=True
+            )
+            await db_session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update profile.",
+            )
+
+        profile = await self.get_sanitized_profile_by_user_id(db_session, user_id)
+        if profile is None:
+            if update_data:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Failed to update profile.",
+                )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Profile for user with id {user_id} not found.",
+            )
+        return profile
 
 # Optional: A function to get the service instance, useful for dependency injection
 # async def get_profile_service() -> ProfileService:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,37 @@
 [
   {
-    "id": 3142198018,
+    "id": 3142513612,
     "disposition": "addressed",
-    "rationale": "Valid step and objective attachment selection now only clears the attachment-limit submit message, preserving legacy branch warnings and other unrelated submit warnings."
+    "rationale": "Refactored update_profile to avoid full UserProfile ORM materialization, avoid refresh/model validation on encrypted columns, and return a sanitized response after compact SQL updates."
   },
   {
-    "id": 3142198421,
+    "id": 3142513615,
     "disposition": "addressed",
-    "rationale": "Step attachment counting now uses the existing selected attachment count and step delta instead of constructing a temporary aggregate array, and unrelated submit messages are preserved."
+    "rationale": "Moved logging to a module-level import and logger in profile_service.py."
   },
   {
-    "id": 3142198423,
+    "id": 3142513618,
     "disposition": "addressed",
-    "rationale": "Objective attachment selection now clears submitMessage only when it matches the attachment limit message, so unrelated validation errors remain visible."
+    "rationale": "Shared user-existence checks and default profile construction between sanitized and full profile creation paths."
   },
   {
-    "id": 4175812006,
+    "id": 3142513619,
+    "disposition": "addressed",
+    "rationale": "Replaced inline imports with a module logger and returned generic 500 details for profile create/update commit failures."
+  },
+  {
+    "id": 4176082419,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review summary with no separate actionable request."
+    "rationale": "Review body summary only; individual actionable review comments were handled separately."
   },
   {
-    "id": 4175812328,
+    "id": 4176085869,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review summary; the actionable inline feedback from the same review is addressed separately."
+    "rationale": "Automated Codex review body without actionable findings; the actionable inline Codex comment was handled separately."
+  },
+  {
+    "id": 3142518114,
+    "disposition": "addressed",
+    "rationale": "Normalized blank API key inputs to None and made sanitized key-set flags require non-empty stored values."
   }
 ]

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -13,7 +13,7 @@ import {
 } from '../components/settings/ProviderProfilesManager';
 
 interface ProfileData {
-  id?: string;
+  id?: string | number;
   email?: string;
 }
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6503,6 +6503,8 @@ export interface components {
              * Format: uuid
              */
             user_id: string;
+            /** Email */
+            email?: string | null;
             /**
              * Google Api Key Set
              * @default false

--- a/tests/e2e/test_settings_ui_browser.py
+++ b/tests/e2e/test_settings_ui_browser.py
@@ -14,6 +14,7 @@ else:
     from playwright.sync_api import expect, sync_playwright
 
 from api_service.api.routers.profile import get_profile_service
+from api_service.api.schemas import UserProfileReadSanitized
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from api_service.db.models import User
@@ -32,7 +33,7 @@ class DummyProfileService:
 
     async def update_profile(self, db_session: AsyncSession, user_id, profile_data):
         self.update_called_with = profile_data
-        return None
+        return UserProfileReadSanitized(id=1, user_id=user_id)
 
 TEST_JOB_ID = "123e4567-e89b-12d3-a456-426614174000"
 TEST_OPENAI_API_KEY = "test-openai-api-key"

--- a/tests/unit/api/test_profile.py
+++ b/tests/unit/api/test_profile.py
@@ -11,7 +11,6 @@ from api_service.api.routers.profile import (
     update_current_user_profile,
 )
 from api_service.api.schemas import (
-    UserProfileRead,
     UserProfileReadSanitized,
     UserProfileUpdate,
 )
@@ -34,11 +33,7 @@ MOCK_USER = DBUser(
 MOCK_PROFILE_DATA = {
     "id": 1,
     "user_id": USER_ID,
-    "google_api_key": "test_google_key",
-    "openai_api_key": "test_openai_key",
-    "anthropic_api_key": "test_anthropic_key",
 }
-MOCK_PROFILE_READ_SCHEMA = UserProfileRead(**MOCK_PROFILE_DATA)
 
 # Sanitized version for GET endpoint response testing
 MOCK_PROFILE_READ_SANITIZED_SCHEMA = UserProfileReadSanitized(
@@ -56,11 +51,10 @@ def mock_db_session():
 @pytest.fixture
 def mock_profile_service():
     service = AsyncMock(spec=ProfileService)
-    service.get_or_create_profile = AsyncMock(return_value=MOCK_PROFILE_READ_SCHEMA)
     service.get_or_create_sanitized_profile = AsyncMock(
         return_value=MOCK_PROFILE_READ_SANITIZED_SCHEMA
     )
-    service.update_profile = AsyncMock(return_value=MOCK_PROFILE_READ_SCHEMA)
+    service.update_profile = AsyncMock(return_value=MOCK_PROFILE_READ_SANITIZED_SCHEMA)
     return service
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_profile.py
+++ b/tests/unit/api/test_profile.py
@@ -42,7 +42,11 @@ MOCK_PROFILE_READ_SCHEMA = UserProfileRead(**MOCK_PROFILE_DATA)
 
 # Sanitized version for GET endpoint response testing
 MOCK_PROFILE_READ_SANITIZED_SCHEMA = UserProfileReadSanitized(
-    id=MOCK_PROFILE_DATA["id"], user_id=MOCK_PROFILE_DATA["user_id"]
+    id=MOCK_PROFILE_DATA["id"],
+    user_id=MOCK_PROFILE_DATA["user_id"],
+    google_api_key_set=True,
+    openai_api_key_set=True,
+    anthropic_api_key_set=True,
 )
 
 @pytest.fixture
@@ -53,6 +57,9 @@ def mock_db_session():
 def mock_profile_service():
     service = AsyncMock(spec=ProfileService)
     service.get_or_create_profile = AsyncMock(return_value=MOCK_PROFILE_READ_SCHEMA)
+    service.get_or_create_sanitized_profile = AsyncMock(
+        return_value=MOCK_PROFILE_READ_SANITIZED_SCHEMA
+    )
     service.update_profile = AsyncMock(return_value=MOCK_PROFILE_READ_SCHEMA)
     return service
 
@@ -64,13 +71,14 @@ async def test_get_current_user_profile_success(mock_db_session, mock_profile_se
     )
 
     # Assert
-    mock_profile_service.get_or_create_profile.assert_called_once_with(
+    mock_profile_service.get_or_create_sanitized_profile.assert_called_once_with(
         db_session=mock_db_session, user_id=USER_ID
     )
     # The result is now a UserProfileReadSanitized with key-set flags
     assert isinstance(result, UserProfileReadSanitized)
     assert result.id == MOCK_PROFILE_DATA["id"]
     assert result.user_id == MOCK_PROFILE_DATA["user_id"]
+    assert result.email == MOCK_USER.email
     assert result.google_api_key_set is True  # test data has google_api_key set
     assert result.openai_api_key_set is True  # test data has openai_api_key set
     assert result.anthropic_api_key_set is True
@@ -92,7 +100,7 @@ async def test_get_current_user_profile_user_id_none(
         )
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
     assert exc_info.value.detail == "User ID is missing."
-    mock_profile_service.get_or_create_profile.assert_not_called()
+    mock_profile_service.get_or_create_sanitized_profile.assert_not_called()
 
 @pytest.mark.asyncio
 async def test_update_current_user_profile_success(
@@ -116,6 +124,7 @@ async def test_update_current_user_profile_success(
     assert result.google_api_key_set is True
     assert result.openai_api_key_set is True
     assert result.anthropic_api_key_set is True
+    assert result.email == MOCK_USER.email
     mock_profile_service.update_profile.assert_called_once_with(
         db_session=mock_db_session, user_id=USER_ID, profile_data=update_data
     )

--- a/tests/unit/services/test_profile_service.py
+++ b/tests/unit/services/test_profile_service.py
@@ -1,8 +1,6 @@
 import uuid
-from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import HTTPException, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -10,23 +8,6 @@ from sqlalchemy.orm import sessionmaker
 from api_service.api.schemas import UserProfileUpdate
 from api_service.db.models import User, UserProfile
 from api_service.services.profile_service import ProfileService
-
-@pytest.mark.asyncio
-async def test_update_profile_enforces_ownership():
-    service = ProfileService()
-    db_session = AsyncMock(spec=AsyncSession)
-
-    existing_profile = UserProfile(user_id=uuid.uuid4())
-    service.get_profile_by_user_id = AsyncMock(return_value=existing_profile)
-
-    with pytest.raises(HTTPException) as exc_info:
-        await service.update_profile(
-            db_session=db_session,
-            user_id=uuid.uuid4(),
-            profile_data=UserProfileUpdate(openai_api_key="new"),
-        )
-
-    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
 
 @pytest.mark.asyncio
 async def test_userprofile_read_populates_from_encrypted():
@@ -106,6 +87,135 @@ async def test_sanitized_profile_lookup_does_not_decrypt_secret_columns():
     assert profile.user_id == user_id
     assert profile.openai_api_key_set is True
     assert profile.google_api_key_set is False
+    assert profile.anthropic_api_key_set is True
+
+    await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_sanitized_profile_lookup_treats_empty_key_columns_as_unset():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    user_id = uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(UserProfile.__table__.create)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user (
+                    id,
+                    email,
+                    hashed_password,
+                    is_active,
+                    is_superuser,
+                    is_verified
+                )
+                VALUES (:id, :email, :hashed_password, 1, 0, 1)
+                """
+            ),
+            {
+                "id": user_id.hex,
+                "email": "settings@example.com",
+                "hashed_password": "hashed",
+            },
+        )
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user_profile (
+                    user_id,
+                    openai_api_key_encrypted,
+                    google_api_key_encrypted,
+                    anthropic_api_key_encrypted,
+                    agent_skill_repo_sources_enabled,
+                    agent_skill_local_sources_enabled
+                )
+                VALUES (:user_id, '', NULL, :anthropic, 1, 0)
+                """
+            ),
+            {
+                "user_id": user_id.hex,
+                "anthropic": "also-not-valid",
+            },
+        )
+
+    async with async_session_maker() as session:
+        profile = await ProfileService().get_sanitized_profile_by_user_id(
+            session, user_id
+        )
+
+    assert profile is not None
+    assert profile.openai_api_key_set is False
+    assert profile.google_api_key_set is False
+    assert profile.anthropic_api_key_set is True
+
+    await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_update_profile_returns_sanitized_without_decrypting_existing_keys():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    user_id = uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(UserProfile.__table__.create)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user (
+                    id,
+                    email,
+                    hashed_password,
+                    is_active,
+                    is_superuser,
+                    is_verified
+                )
+                VALUES (:id, :email, :hashed_password, 1, 0, 1)
+                """
+            ),
+            {
+                "id": user_id.hex,
+                "email": "settings@example.com",
+                "hashed_password": "hashed",
+            },
+        )
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user_profile (
+                    user_id,
+                    openai_api_key_encrypted,
+                    google_api_key_encrypted,
+                    anthropic_api_key_encrypted,
+                    agent_skill_repo_sources_enabled,
+                    agent_skill_local_sources_enabled
+                )
+                VALUES (:user_id, :openai, NULL, :anthropic, 1, 0)
+                """
+            ),
+            {
+                "user_id": user_id.hex,
+                "openai": "not-valid-for-current-encryption-key",
+                "anthropic": "also-not-valid",
+            },
+        )
+
+    async with async_session_maker() as session:
+        profile = await ProfileService().update_profile(
+            session,
+            user_id,
+            UserProfileUpdate(google_api_key="new-google", openai_api_key=""),
+        )
+
+    assert profile.user_id == user_id
+    assert profile.google_api_key_set is True
+    assert profile.openai_api_key_set is False
     assert profile.anthropic_api_key_set is True
 
     await engine.dispose()

--- a/tests/unit/services/test_profile_service.py
+++ b/tests/unit/services/test_profile_service.py
@@ -3,10 +3,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException, status
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
 from api_service.api.schemas import UserProfileUpdate
-from api_service.db.models import UserProfile
+from api_service.db.models import User, UserProfile
 from api_service.services.profile_service import ProfileService
 
 @pytest.mark.asyncio
@@ -43,3 +45,67 @@ async def test_userprofile_read_populates_from_encrypted():
     assert read_schema.openai_api_key == "secret-openai"
     assert read_schema.google_api_key == "secret-google"
     assert read_schema.anthropic_api_key == "secret-anthropic"
+
+@pytest.mark.asyncio
+async def test_sanitized_profile_lookup_does_not_decrypt_secret_columns():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    user_id = uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(UserProfile.__table__.create)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user (
+                    id,
+                    email,
+                    hashed_password,
+                    is_active,
+                    is_superuser,
+                    is_verified
+                )
+                VALUES (:id, :email, :hashed_password, 1, 0, 1)
+                """
+            ),
+            {
+                "id": user_id.hex,
+                "email": "settings@example.com",
+                "hashed_password": "hashed",
+            },
+        )
+        await conn.execute(
+            text(
+                """
+                INSERT INTO user_profile (
+                    user_id,
+                    openai_api_key_encrypted,
+                    google_api_key_encrypted,
+                    anthropic_api_key_encrypted,
+                    agent_skill_repo_sources_enabled,
+                    agent_skill_local_sources_enabled
+                )
+                VALUES (:user_id, :openai, NULL, :anthropic, 1, 0)
+                """
+            ),
+            {
+                "user_id": user_id.hex,
+                "openai": "not-valid-for-current-encryption-key",
+                "anthropic": "also-not-valid",
+            },
+        )
+
+    async with async_session_maker() as session:
+        profile = await ProfileService().get_or_create_sanitized_profile(
+            session, user_id
+        )
+
+    assert profile.user_id == user_id
+    assert profile.openai_api_key_set is True
+    assert profile.google_api_key_set is False
+    assert profile.anthropic_api_key_set is True
+
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- avoid decrypting profile secret columns when loading the Settings User / Workspace profile panel
- include the current user email in the sanitized profile response
- keep generated OpenAPI types aligned and add regression coverage for stale encrypted profile values

## Root Cause
The Settings profile request used the full `UserProfile` ORM row, which materialized encrypted secret columns. Existing profile rows encrypted with a different key caused SQLAlchemy decryption to raise `Invalid decryption key`, returning HTTP 500 from `/me`.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_profile.py tests/unit/services/test_profile_service.py`
- `npm run ui:typecheck`
- `npm run api:types`
- `git diff --check`
- `curl http://cs30:8000/me` returned 200 after restarting the API service