### PR TITLE
Instead of saying "Branch", once a github repo loads its branches, I'd prefer for the branch dropdown to default to the default branch, e.g. main.

### DIFF
--- a/api_service/api/routers/task_dashboard.py
+++ b/api_service/api/routers/task_dashboard.py
@@ -133,6 +133,7 @@ class DashboardBranchListResponse(BaseModel):
 
     items: list[DashboardBranchOption] = Field(default_factory=list)
     error: str | None = Field(None)
+    default_branch: str | None = Field(None, alias="defaultBranch")
 
 class _ValidatedSkillZip(BaseModel):
     skill_name: str

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -227,18 +227,21 @@ def _fetch_github_branch_options(
         with httpx.Client(
             timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
         ) as client:
-            metadata_response = client.get(
-                _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
-                    repository=normalized_repository
-                ),
-                headers=headers,
-            )
-            metadata_response.raise_for_status()
-            metadata = metadata_response.json()
-            if isinstance(metadata, Mapping):
-                default_branch = (
-                    str(metadata.get("default_branch") or "").strip() or None
+            try:
+                metadata_response = client.get(
+                    _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                        repository=normalized_repository
+                    ),
+                    headers=headers,
                 )
+                metadata_response.raise_for_status()
+                metadata = metadata_response.json()
+                if isinstance(metadata, dict):
+                    default_branch = (
+                        str(metadata.get("default_branch") or "").strip() or None
+                    )
+            except (httpx.HTTPError, ValueError):
+                pass
             while next_url:
                 response = client.get(
                     next_url,

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -241,6 +241,7 @@ def _fetch_github_branch_options(
                         str(metadata.get("default_branch") or "").strip() or None
                     )
             except (httpx.HTTPError, ValueError):
+                # Branch discovery can still succeed without default-branch metadata.
                 pass
             while next_url:
                 response = client.get(

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -35,6 +35,7 @@ _SSH_GIT_RE = re.compile(
     r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$"
 )
 _GITHUB_REPOSITORY_DISCOVERY_URL = "https://api.github.com/user/repos"
+_GITHUB_REPOSITORY_METADATA_URL_TEMPLATE = "https://api.github.com/repos/{repository}"
 _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE = "https://api.github.com/repos/{repository}/branches"
 _GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS = 5.0
 _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS = 60.0
@@ -42,7 +43,7 @@ _GITHUB_REPOSITORY_OPTIONS_CACHE: dict[
     str, tuple[float, tuple["RepositoryOption", ...], str | None]
 ] = {}
 _GITHUB_BRANCH_OPTIONS_CACHE: dict[
-    str, tuple[float, tuple["BranchOption", ...], str | None]
+    str, tuple[float, tuple["BranchOption", ...], str | None, str | None]
 ] = {}
 
 _JIRA_CREATE_PAGE_SOURCES = {
@@ -204,12 +205,12 @@ def _fetch_github_repository_options(
 def _fetch_github_branch_options(
     token: str,
     repository: str,
-) -> tuple[list[BranchOption], str | None]:
+) -> tuple[list[BranchOption], str | None, str | None]:
     """Fetch credential-visible GitHub branches without exposing secrets."""
 
     normalized_repository = _normalize_repository_value(repository)
     if not token or not normalized_repository:
-        return [], None
+        return [], None, None
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
@@ -217,6 +218,7 @@ def _fetch_github_branch_options(
     }
     options: list[BranchOption] = []
     seen: set[str] = set()
+    default_branch: str | None = None
     next_url: str | None = _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
         repository=normalized_repository
     )
@@ -225,6 +227,18 @@ def _fetch_github_branch_options(
         with httpx.Client(
             timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
         ) as client:
+            metadata_response = client.get(
+                _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                    repository=normalized_repository
+                ),
+                headers=headers,
+            )
+            metadata_response.raise_for_status()
+            metadata = metadata_response.json()
+            if isinstance(metadata, Mapping):
+                default_branch = (
+                    str(metadata.get("default_branch") or "").strip() or None
+                )
             while next_url:
                 response = client.get(
                     next_url,
@@ -251,9 +265,9 @@ def _fetch_github_branch_options(
                         )
                 next_url = response.links.get("next", {}).get("url")
     except (httpx.HTTPError, ValueError):
-        return [], "GitHub branch lookup is unavailable."
+        return [], "GitHub branch lookup is unavailable.", None
 
-    return options, None
+    return options, None, default_branch
 
 def _github_repository_options_cache_key(token: str) -> str:
     return sha256(token.encode("utf-8")).hexdigest()
@@ -281,18 +295,23 @@ def _get_cached_github_repository_options(
 def _get_cached_github_branch_options(
     token: str,
     repository: str,
-) -> tuple[list[BranchOption], str | None]:
+) -> tuple[list[BranchOption], str | None, str | None]:
     now = time.monotonic()
     cache_key = _github_branch_options_cache_key(token, repository)
     cached = _GITHUB_BRANCH_OPTIONS_CACHE.get(cache_key)
     if cached:
-        cached_at, cached_options, cached_error = cached
+        cached_at, cached_options, cached_error, cached_default_branch = cached
         if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
-            return list(cached_options), cached_error
+            return list(cached_options), cached_error, cached_default_branch
 
-    options, error = _fetch_github_branch_options(token, repository)
-    _GITHUB_BRANCH_OPTIONS_CACHE[cache_key] = (now, tuple(options), error)
-    return options, error
+    options, error, default_branch = _fetch_github_branch_options(token, repository)
+    _GITHUB_BRANCH_OPTIONS_CACHE[cache_key] = (
+        now,
+        tuple(options),
+        error,
+        default_branch,
+    )
+    return options, error, default_branch
 
 def _is_create_page_path(initial_path: str) -> bool:
     normalized_path = urlparse(initial_path or "").path.rstrip("/")
@@ -357,7 +376,7 @@ def build_repository_branch_options(repository: str) -> dict[str, Any]:
             "error": "GitHub branch lookup is unavailable.",
         }
 
-    options, error = _get_cached_github_branch_options(
+    options, error, default_branch = _get_cached_github_branch_options(
         github_token,
         normalized_repository,
     )
@@ -366,6 +385,7 @@ def build_repository_branch_options(repository: str) -> dict[str, Any]:
     return {
         "items": [option.to_payload() for option in options],
         "error": error,
+        "defaultBranch": default_branch,
     }
 
 def _jira_create_page_enabled() -> bool:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,32 @@
 [
   {
-    "id": 3142403429,
-    "disposition": "addressed",
-    "rationale": "Truncated merge automation child workflow memo targetRuntime to 80 characters and targetSkill to 160 characters, with regression coverage."
-  },
-  {
-    "id": 4175995633,
+    "id": 4176110163,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; the two actionable child comments were handled individually."
+    "rationale": "Automated review summary; individual actionable comments were classified separately."
   },
   {
-    "id": 3142403433,
+    "id": 3142549713,
     "disposition": "addressed",
-    "rationale": "Removed the try/except around workflow.patched in MoonMindRunWorkflow._update_memo so the patch marker follows the standard deterministic workflow pattern."
+    "rationale": "Changed the repository metadata response type check to dict for the default_branch extraction."
+  },
+  {
+    "id": 3142549717,
+    "disposition": "addressed",
+    "rationale": "Made the repository metadata request best-effort so branch pagination still succeeds if metadata lookup fails."
+  },
+  {
+    "id": 3142549722,
+    "disposition": "addressed",
+    "rationale": "Allowed default branch auto-selection to run when the selected repository changes even if a previous branch is selected."
+  },
+  {
+    "id": 3142550006,
+    "disposition": "addressed",
+    "rationale": "Added backend regression coverage proving branch options are returned when the metadata endpoint fails."
+  },
+  {
+    "id": 4176110370,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper with no separate actionable request beyond the inline comments already addressed."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -28,5 +28,10 @@
     "id": 4176110370,
     "disposition": "not-applicable",
     "rationale": "Automated review wrapper with no separate actionable request beyond the inline comments already addressed."
+  },
+  {
+    "id": 3142571198,
+    "disposition": "addressed",
+    "rationale": "Added an explicit comment explaining that metadata failures are intentionally ignored so branch discovery can continue without default-branch metadata."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -446,6 +446,7 @@ describe("Task Create Entrypoint", () => {
                   source: "github",
                 },
               ],
+              defaultBranch: "main",
               error: null,
             }),
           } as Response);
@@ -5902,6 +5903,9 @@ describe("Task Create Entrypoint", () => {
         ),
       ),
     ).toBe(true);
+    await waitFor(() => {
+      expect((branchInput as HTMLInputElement).value).toBe("main");
+    });
 
     fireEvent.change(branchInput, {
       target: { value: "feature/create-page" },

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5929,6 +5929,51 @@ describe("Task Create Entrypoint", () => {
     expect(JSON.stringify(task)).not.toContain("startingBranch");
   });
 
+  it("updates the selected branch to the default when the repository changes", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/github/branches?repository=MoonLadderStudios%2FOtherRepo",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              { value: "develop", label: "develop", source: "github" },
+              { value: "release", label: "release", source: "github" },
+            ],
+            defaultBranch: "develop",
+            error: null,
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText(
+      "Branch",
+    )) as HTMLInputElement;
+    await waitFor(() => {
+      expect(branchInput.value).toBe("main");
+    });
+
+    fireEvent.change(branchInput, {
+      target: { value: "feature/create-page" },
+    });
+    fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
+      target: { value: "MoonLadderStudios/OtherRepo" },
+    });
+
+    await waitFor(() => {
+      expect(branchInput.value).toBe("develop");
+    });
+  });
+
   it("keeps branch loading text inside the dropdown only", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -293,6 +293,7 @@ interface BranchListResponse {
     source?: string | null;
   }>;
   error?: string | null;
+  defaultBranch?: string | null;
 }
 
 function resolveDefaultProviderProfileId(
@@ -1548,7 +1549,7 @@ async function responseErrorMessage(
 async function readBranchOptions(
   branchLookupEndpoint: string,
   repository: string,
-): Promise<BranchOption[]> {
+): Promise<{ items: BranchOption[]; defaultBranch: string }> {
   const response = await fetch(
     configuredBranchLookupUrl(branchLookupEndpoint, repository),
     { headers: { Accept: "application/json" } },
@@ -1562,7 +1563,7 @@ async function readBranchOptions(
   if (payload.error) {
     throw new Error(payload.error);
   }
-  return (payload.items || [])
+  const items = (payload.items || [])
     .map((item) => {
       const value = String(item.value || "").trim();
       if (!value) {
@@ -1575,6 +1576,10 @@ async function readBranchOptions(
       };
     })
     .filter((item): item is BranchOption => item !== null);
+  return {
+    items,
+    defaultBranch: String(payload.defaultBranch || "").trim(),
+  };
 }
 
 function localJiraErrorMessage(error: unknown, fallback: string): string {
@@ -2275,6 +2280,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [repository, setRepository] = useState(defaultRepository);
   const [providerProfile, setProviderProfile] = useState("");
   const [branch, setBranch] = useState("");
+  const branchDefaultAppliedRepositoryRef = useRef("");
   const [publishMode, setPublishMode] = useState(
     normalizePublishModeForSubmit(defaultPublishMode),
   );
@@ -3863,7 +3869,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       readBranchOptions(branchLookupEndpoint || "", branchLookupRepository),
   });
   const branchOptions = useMemo(() => {
-    const items = branchOptionsQuery.data || [];
+    const items = branchOptionsQuery.data?.items || [];
     const seen = new Set<string>();
     return items.filter((item) => {
       const key = item.value;
@@ -3877,8 +3883,36 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const selectedBranchIsStale = Boolean(
     branch.trim() &&
       branchOptionsQuery.isSuccess &&
-      !(branchOptionsQuery.data || []).some((item) => item.value === branch.trim()),
+      !(branchOptionsQuery.data?.items || []).some(
+        (item) => item.value === branch.trim(),
+      ),
   );
+  useEffect(() => {
+    if (!branchOptionsQuery.isSuccess || branch.trim()) {
+      return;
+    }
+    const defaultBranch = String(
+      branchOptionsQuery.data?.defaultBranch || "",
+    ).trim();
+    if (
+      !defaultBranch ||
+      !branchOptions.some((item) => item.value === defaultBranch)
+    ) {
+      return;
+    }
+    const defaultKey = `${branchLookupRepository}:${defaultBranch}`;
+    if (branchDefaultAppliedRepositoryRef.current === defaultKey) {
+      return;
+    }
+    branchDefaultAppliedRepositoryRef.current = defaultKey;
+    setBranch(defaultBranch);
+  }, [
+    branch,
+    branchLookupRepository,
+    branchOptions,
+    branchOptionsQuery.data?.defaultBranch,
+    branchOptionsQuery.isSuccess,
+  ]);
   const branchControlDisabled =
     !selectedRepositoryForBranchLookup.trim() ||
     !branchLookupEndpoint ||

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3888,7 +3888,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       ),
   );
   useEffect(() => {
-    if (!branchOptionsQuery.isSuccess || branch.trim()) {
+    const isNewRepository =
+      branchLookupRepository &&
+      !branchDefaultAppliedRepositoryRef.current.startsWith(
+        `${branchLookupRepository}:`,
+      );
+    if (
+      !branchOptionsQuery.isSuccess ||
+      (branch.trim() && !isNewRepository)
+    ) {
       return;
     }
     const defaultBranch = String(

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3314,6 +3314,8 @@ export interface components {
             items?: components["schemas"]["DashboardBranchOption"][];
             /** Error */
             error?: string | null;
+            /** Defaultbranch */
+            defaultBranch?: string | null;
         };
         /**
          * DashboardBranchOption

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -473,6 +473,7 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
                 ),
             ],
             None,
+            "main",
         ),
     )
 
@@ -488,10 +489,15 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
             },
         ],
         "error": None,
+        "defaultBranch": "main",
     }
 
 def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
     responses = [
+        {
+            "json": {"default_branch": "main"},
+            "links": {},
+        },
         {
             "json": [{"name": "main"}, {"name": "feature/page-one"}],
             "links": {"next": {"url": "https://api.github.com/page/2"}},
@@ -536,18 +542,28 @@ def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
 
     monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
 
-    options, error = dashboard_view_model._fetch_github_branch_options(
+    options, error, default_branch = dashboard_view_model._fetch_github_branch_options(
         "ghp_test_token",
         "Octo/Repo",
     )
 
     assert error is None
+    assert default_branch == "main"
     assert [option.value for option in options] == [
         "main",
         "feature/page-one",
         "feature/page-two",
     ]
     assert calls == [
+        {
+            "url": "https://api.github.com/repos/Octo/Repo",
+            "headers": {
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer ghp_test_token",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            "params": None,
+        },
         {
             "url": "https://api.github.com/repos/Octo/Repo/branches",
             "headers": {
@@ -577,6 +593,7 @@ def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
         lambda token, repository: (
             [],
             "GitHub failed with ghp_secret_token",
+            None,
         ),
     )
 

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -584,6 +584,64 @@ def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
         },
     ]
 
+def test_fetch_github_branch_options_keeps_branches_when_metadata_fails(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload: object, *, fail: bool = False) -> None:
+            self._payload = payload
+            self._fail = fail
+            self.links = {}
+
+        def raise_for_status(self) -> None:
+            if self._fail:
+                raise dashboard_view_model.httpx.HTTPError("metadata failed")
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            calls.append({"url": url, "params": params})
+            if url == "https://api.github.com/repos/Octo/Repo":
+                return FakeResponse({}, fail=True)
+            return FakeResponse([{"name": "main"}, {"name": "feature/page-one"}])
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    options, error, default_branch = dashboard_view_model._fetch_github_branch_options(
+        "ghp_test_token",
+        "Octo/Repo",
+    )
+
+    assert error is None
+    assert default_branch is None
+    assert [option.value for option in options] == ["main", "feature/page-one"]
+    assert calls == [
+        {"url": "https://api.github.com/repos/Octo/Repo", "params": None},
+        {
+            "url": "https://api.github.com/repos/Octo/Repo/branches",
+            "params": {"per_page": 100},
+        },
+    ]
+
 def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
     monkeypatch.setattr(settings.github, "github_token", "ghp_secret_token")
     monkeypatch.setattr(settings.github, "github_enabled", True)


### PR DESCRIPTION
Instead of saying "Branch", once a github repo loads its branches, I'd prefer for the branch dropdown to default to the default branch, e.g. main.