### PR TITLE
[codex] Fix executing status text brightening

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -412,9 +412,9 @@ describe('Mission Control shared entry', () => {
     expect(missionControlCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
     expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-width:\s*84%/);
     expect(missionControlCss).toMatch(/--mm-executing-letter-edge-padding:\s*3/);
-    expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-direction:\s*-1/);
+    expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-direction:\s*1/);
     expect(missionControlCss).toContain('--mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32)');
-    expect(missionControlCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, rgb(var(--mm-panel)) 32%)');
+    expect(missionControlCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%)');
 
     const shimmerBlock = cssRuleBlocks(
       missionControlCss,

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -408,7 +408,11 @@ describe('Task Detail Entrypoint', () => {
     expect(toolbarStatus?.className).toContain('is-executing');
     expect(toolbarStatus?.className).toContain('status-running');
     expect(toolbarStatus?.dataset.shimmerLabel).toBe('executing');
-    expect(toolbarStatus?.childElementCount).toBe(0);
+    expect(toolbarStatus?.getAttribute('aria-label')).toBe('executing');
+    expect(toolbarStatus?.querySelector('.status-letter-wave')?.getAttribute('aria-hidden')).toBe('true');
+    const glyphs = Array.from(toolbarStatus?.querySelectorAll<HTMLElement>('.status-letter-wave__glyph') || []);
+    expect(glyphs).toHaveLength('executing'.length);
+    expect(glyphs.map((glyph) => glyph.textContent).join('')).toBe('executing');
     expect(toolbarStatus?.textContent).toBe('executing');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-489');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -4,6 +4,7 @@ import Anser from 'anser';
 import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
+import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge';
 import { formatRuntimeLabel } from '../utils/formatters';
@@ -3917,13 +3918,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
           <div className="toolbar-identity-row">
             <p className="page-meta">Task {taskId || '—'}</p>
             {execution ? (
-              <span
-                {...executionStatusPillProps(
-                  execution.rawState || execution.state || execution.status,
-                )}
-              >
-                {execution.rawState || execution.state || execution.status || '—'}
-              </span>
+              <ExecutionStatusPill status={execution.rawState || execution.state || execution.status} />
             ) : null}
           </div>
         </div>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -56,9 +56,9 @@
   --mm-executing-sweep-halo-opacity: 0.14;
   --mm-executing-letter-sweep-width: 84%;
   --mm-executing-letter-edge-padding: 3;
-  --mm-executing-letter-sweep-direction: -1;
+  --mm-executing-letter-sweep-direction: 1;
   --mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32);
-  --mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, rgb(var(--mm-panel)) 32%);
+  --mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%);
   --mm-font-headline: var(--mm-font-sans);
   --mm-font-mono: "IBM Plex Mono", ui-monospace, monospace;
 }

--- a/specs/259-executing-text-brightening/data-model.md
+++ b/specs/259-executing-text-brightening/data-model.md
@@ -16,7 +16,7 @@ Validation rules:
 ## Glyph Wave
 
 - **glyphs**: visible label split into graphemes.
-- **phase index**: glyph order adjusted to match the current right-to-left sweep direction.
+- **phase index**: glyph order adjusted to match the current left-to-right/top-left-to-bottom-right visible sweep direction.
 - **delay**: millisecond CSS custom property derived from `(phaseIndex + edgePadding) / (glyphCount + edgePadding * 2) * 1650`.
 
 State transitions:

--- a/specs/259-executing-text-brightening/research.md
+++ b/specs/259-executing-text-brightening/research.md
@@ -26,10 +26,10 @@ Test implications: Task-list integration verifies executing label becomes one gl
 
 ## DESIGN-REQ-004 Timing And Direction
 
-Decision: Use the CSS token duration with a 1650ms fallback in styles and calculate delays against `1650` ms in component code. Set direction to right-to-left to match current sweep start/end tokens.
+Decision: Use the CSS token duration with a 1650ms fallback in styles and calculate delays against `1650` ms in component code. Set direction to left-to-right/top-left-to-bottom-right to match the visible sweep described by the canonical UI design.
 Evidence: Existing CSS moves from `--mm-executing-sweep-start-x: 135%` to `--mm-executing-sweep-end-x: -135%`.
 Rationale: The foreground wave should feel phase-locked with the physical sweep.
-Alternatives considered: Left-to-right phase order. Rejected for current token geometry.
+Alternatives considered: Right-to-left phase order. Rejected because the visible sweep direction is left-to-right/top-left-to-bottom-right even though oversized background-position tokens move inversely.
 Test implications: Render tests assert every glyph receives a millisecond delay; CSS tests assert the shared duration token.
 
 ## DESIGN-REQ-005 Accessibility

--- a/specs/259-executing-text-brightening/spec.md
+++ b/specs/259-executing-text-brightening/spec.md
@@ -44,14 +44,14 @@ The cleanest patch: implement the glyph-span component and keep the existing bro
 
 - The visible status may be blank, null, or whitespace and must fall back to an em dash label.
 - The visible status may include spaces or extended graphemes in the future and must not split surrogate pairs or grapheme clusters when platform support exists.
-- The existing physical shimmer travels right-to-left, so glyph phase order must match that direction.
+- The visible physical shimmer travels left-to-right/top-left-to-bottom-right, so glyph phase order must match that direction.
 - Multiple executing rows may be visible at once; the effect must remain CSS-driven instead of requiring a JavaScript animation loop.
 
 ## Assumptions
 
 - This story applies the glyph-span component to the task-list table and card status pills requested by the source input.
 - Existing detail and proposal status-pill surfaces can keep the prior shared status-pill plumbing unless a later story expands the glyph effect there.
-- The current sweep token direction (`135%` to `-135%`) means the visible beam travels right-to-left.
+- The current oversized sweep background uses inverse background-position values, but the visible beam travels left-to-right/top-left-to-bottom-right.
 
 ## Source Design Requirements
 


### PR DESCRIPTION
## Summary
- Fix executing status glyph brightening so the highlight actually brightens in dark mode.
- Align the foreground glyph wave direction with the visible left-to-right/top-left-to-bottom-right shimmer sweep.
- Reuse `ExecutionStatusPill` in the task detail toolbar so executing detail status pills get the glyph layer instead of only the background shimmer.
- Update MM-259 spec notes and focused tests to reflect the corrected direction and detail glyph coverage.

## Root Cause
The glyph bright color mixed cyan with `--mm-panel`, which is dark in dark mode, so the highlighted letters could appear as a faint darkening. The glyph direction token was also set to `-1`, causing the foreground wave to move right-to-left while the canonical visible sweep is left-to-right/top-left-to-bottom-right. Detail toolbar status rendering still used a plain span, so it could show the background shimmer without any per-glyph text animation.

## Validation
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/task-detail.test.tsx frontend/src/utils/executionStatusPillClasses.test.ts`
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
