### PR TITLE
[codex] Normalize Jira story source references

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,12 @@
 [
   {
-    "id": 4176110163,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary; individual actionable comments were classified separately."
-  },
-  {
-    "id": 3142549713,
+    "id": 3142669162,
     "disposition": "addressed",
-    "rationale": "Changed the repository metadata response type check to dict for the default_branch extraction."
+    "rationale": "Updated _breakdown_source_path to normalize sourceDocument and source_document independently, so whitespace-only sourceDocument no longer blocks the fallback key."
   },
   {
-    "id": 3142549717,
+    "id": 4176225378,
     "disposition": "addressed",
-    "rationale": "Made the repository metadata request best-effort so branch pagination still succeeds if metadata lookup fails."
-  },
-  {
-    "id": 3142549722,
-    "disposition": "addressed",
-    "rationale": "Allowed default branch auto-selection to run when the selected repository changes even if a previous branch is selected."
-  },
-  {
-    "id": 3142550006,
-    "disposition": "addressed",
-    "rationale": "Added backend regression coverage proving branch options are returned when the metadata endpoint fails."
-  },
-  {
-    "id": 4176110370,
-    "disposition": "not-applicable",
-    "rationale": "Automated review wrapper with no separate actionable request beyond the inline comments already addressed."
-  },
-  {
-    "id": 3142571198,
-    "disposition": "addressed",
-    "rationale": "Added an explicit comment explaining that metadata failures are intentionally ignored so branch discovery can continue without default-branch metadata."
+    "rationale": "Resolved the review summary's requested robustness improvement with code and regression coverage."
   }
 ]

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -517,6 +517,13 @@ metadata surface when `issueTypeId` is not supplied, and creates dependency
 links when `dependencyMode = linear_blocker_chain`. It is not the default path
 for ambiguous Jira requests.
 
+For breakdown-driven Jira output, the canonical traceability shape is
+`sourceReference.path` on every story, with `source.referencePath` or
+`source.path` as a breakdown-level fallback. The tool also accepts path-only
+generated forms, `sourceReference: "<path>"` and top-level
+`sourceDocument: "<path>"`, and normalizes those before validating that no Jira
+mutation can occur without a source document path.
+
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `artifacts/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 
 ---

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -114,6 +114,11 @@ def _breakdown_source_path(value: Any) -> str:
         path = _string(source.get("referencePath") or source.get("path"))
         if path:
             return path
+    source_document = _string(
+        value.get("sourceDocument") or value.get("source_document")
+    )
+    if source_document:
+        return source_document
     return ""
 
 def _story_source_reference(
@@ -124,6 +129,8 @@ def _story_source_reference(
     source_ref = story.get("sourceReference") or story.get("source_reference")
     if isinstance(source_ref, Mapping):
         reference = dict(source_ref)
+    elif isinstance(source_ref, str):
+        reference = {"path": source_ref}
     else:
         reference = {}
     path = _string(reference.get("path") or fallback_path)

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -114,11 +114,10 @@ def _breakdown_source_path(value: Any) -> str:
         path = _string(source.get("referencePath") or source.get("path"))
         if path:
             return path
-    source_document = _string(
-        value.get("sourceDocument") or value.get("source_document")
-    )
-    if source_document:
-        return source_document
+    for key in ("sourceDocument", "source_document"):
+        path = _string(value.get(key))
+        if path:
+            return path
     return ""
 
 def _story_source_reference(

--- a/specs/177-jira-chain-blockers/contracts/story-output-contract.md
+++ b/specs/177-jira-chain-blockers/contracts/story-output-contract.md
@@ -27,9 +27,12 @@ Supported values:
 
 Source references:
 
-- When `storyBreakdownPath` is present, every story must have
- `sourceReference.path`, or the breakdown payload must provide
+- Canonical `moonspec-breakdown` output must put the source path in each
+ story's `sourceReference.path`, or in the breakdown payload's
  `source.referencePath` / `source.path`.
+- For path-only generated output, `story.create_jira_issues` also accepts a
+ string `sourceReference` value or top-level `sourceDocument` as the source
+ document path and normalizes it before Jira mutation.
 - Missing source references fail before Jira mutation and return fallback
  metadata when fallback is enabled.
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -277,7 +277,8 @@ async def test_create_jira_issues_accepts_string_source_reference_from_breakdown
 async def test_create_jira_issues_uses_source_document_as_breakdown_fallback_path():
     service = _FakeJiraService()
     breakdown = {
-        "sourceDocument": "docs/Designs/RuntimeTypes.md",
+        "sourceDocument": " ",
+        "source_document": "docs/Designs/RuntimeTypes.md",
         "stories": [
             {
                 "id": "STORY-001",

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -242,6 +242,81 @@ async def test_create_jira_issues_blocks_story_breakdown_without_source_referenc
     assert "STORY-001" in result.outputs["storyOutput"]["reason"]
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_accepts_string_source_reference_from_breakdown():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "String source",
+                    "sourceReference": "docs/Designs/RuntimeTypes.md",
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    request = service.requests[0]
+    assert request.description.startswith(
+        "Source Reference\nSource Document: docs/Designs/RuntimeTypes.md"
+    )
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_uses_source_document_as_breakdown_fallback_path():
+    service = _FakeJiraService()
+    breakdown = {
+        "sourceDocument": "docs/Designs/RuntimeTypes.md",
+        "stories": [
+            {
+                "id": "STORY-001",
+                "summary": "Top-level source document",
+                "description": "Create a traced story.",
+            }
+        ],
+    }
+
+    async def fetcher(_repo: str, _ref: str, _path: str) -> str:
+        import json
+
+        return json.dumps(breakdown)
+
+    result = await create_jira_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "breakdown-branch",
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+        },
+        jira_service_factory=lambda: service,
+        story_fetcher=fetcher,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    request = service.requests[0]
+    assert request.description.startswith(
+        "Source Reference\nSource Document: docs/Designs/RuntimeTypes.md"
+    )
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_falls_back_to_docs_tmp_when_jira_target_missing():
     result = await create_jira_issues_from_stories(
         {


### PR DESCRIPTION
## Summary
- normalize path-only story source references before Jira story export validation
- accept top-level `sourceDocument` as a breakdown fallback path
- document the canonical and tolerated breakdown traceability shapes

## Root Cause
A breakdown run emitted `sourceReference` as a string and `sourceDocument` at the top level. The Jira export boundary only accepted `sourceReference.path` or `source.referencePath`, so it failed before creating issues even though the source document path was present.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
- Python story-output tests passed: 22 passed
- Frontend suite invoked by the wrapper passed: 14 files, 425 tests