### PR TITLE
MM-518 Policy-gated deployment update API

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/259-executing-text-brightening"
+  "feature_directory": "specs/260-policy-gated-deployment-update"
 }

--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -1,0 +1,194 @@
+"""Typed deployment operation endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from api_service.auth_providers import get_current_user
+from api_service.db.models import User
+from api_service.services.deployment_operations import (
+    DeploymentOperationError,
+    DeploymentOperationsService,
+    DeploymentStackPolicy,
+)
+
+
+router = APIRouter(prefix="/api/v1/operations/deployment", tags=["deployment"])
+
+
+class DeploymentImageRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    repository: str = Field(..., min_length=1)
+    reference: str = Field(..., min_length=1)
+
+
+class DeploymentUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    stack: str = Field(..., min_length=1)
+    image: DeploymentImageRequest
+    mode: str = Field(..., min_length=1)
+    remove_orphans: bool = Field(False, alias="removeOrphans")
+    wait: bool = True
+    run_smoke_check: bool = Field(False, alias="runSmokeCheck")
+    pause_work: bool = Field(False, alias="pauseWork")
+    prune_old_images: bool = Field(False, alias="pruneOldImages")
+    reason: str = Field(..., min_length=1)
+
+
+class DeploymentUpdateResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    deployment_update_run_id: str = Field(..., alias="deploymentUpdateRunId")
+    task_id: str = Field(..., alias="taskId")
+    workflow_id: str = Field(..., alias="workflowId")
+    status: Literal["QUEUED"]
+
+
+class RunningImageModel(BaseModel):
+    service: str
+    image: str
+    image_id: str | None = Field(None, alias="imageId")
+    digest: str | None = None
+
+
+class DeploymentServiceStateModel(BaseModel):
+    name: str
+    state: str
+    health: str | None = None
+
+
+class DeploymentStackStateResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    stack: str
+    project_name: str = Field(..., alias="projectName")
+    configured_image: str = Field(..., alias="configuredImage")
+    running_images: list[RunningImageModel] = Field(..., alias="runningImages")
+    services: list[DeploymentServiceStateModel]
+    last_update_run_id: str | None = Field(None, alias="lastUpdateRunId")
+
+
+class ImageTargetModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    repository: str
+    allowed_references: list[str] = Field(..., alias="allowedReferences")
+    recent_tags: list[str] = Field(..., alias="recentTags")
+    digest_pinning_recommended: bool = Field(..., alias="digestPinningRecommended")
+
+
+class ImageTargetsResponse(BaseModel):
+    stack: str
+    repositories: list[ImageTargetModel]
+
+
+def _get_deployment_service() -> DeploymentOperationsService:
+    return DeploymentOperationsService()
+
+
+def _require_admin(user: User) -> None:
+    if bool(getattr(user, "is_superuser", False)):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "deployment_update_forbidden",
+            "message": "Only administrators can submit deployment updates.",
+        },
+    )
+
+
+def _policy_error(exc: DeploymentOperationError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={"code": exc.code, "message": exc.message},
+    )
+
+
+def _stack_state(policy: DeploymentStackPolicy) -> DeploymentStackStateResponse:
+    return DeploymentStackStateResponse(
+        stack=policy.stack,
+        projectName=policy.project_name,
+        configuredImage=policy.configured_image,
+        runningImages=[
+            RunningImageModel(
+                service="api",
+                image=policy.configured_image,
+                imageId=None,
+                digest=None,
+            )
+        ],
+        services=[
+            DeploymentServiceStateModel(
+                name="api",
+                state="unknown",
+                health=None,
+            )
+        ],
+        lastUpdateRunId=None,
+    )
+
+
+@router.post(
+    "/update",
+    response_model=DeploymentUpdateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_deployment_update(
+    payload: DeploymentUpdateRequest,
+    service: DeploymentOperationsService = Depends(_get_deployment_service),
+    user: User = Depends(get_current_user()),
+) -> DeploymentUpdateResponse:
+    _require_admin(user)
+    try:
+        service.validate_update_request(
+            stack=payload.stack,
+            repository=payload.image.repository,
+            reference=payload.image.reference,
+            mode=payload.mode,
+            reason=payload.reason,
+        )
+    except DeploymentOperationError as exc:
+        raise _policy_error(exc) from exc
+    return DeploymentUpdateResponse(**service.queue_update(stack=payload.stack))
+
+
+@router.get("/stacks/{stack}", response_model=DeploymentStackStateResponse)
+async def get_deployment_stack_state(
+    stack: str,
+    service: DeploymentOperationsService = Depends(_get_deployment_service),
+    _user: User = Depends(get_current_user()),
+) -> DeploymentStackStateResponse:
+    try:
+        policy = service.get_policy(stack)
+    except DeploymentOperationError as exc:
+        raise _policy_error(exc) from exc
+    return _stack_state(policy)
+
+
+@router.get("/image-targets", response_model=ImageTargetsResponse)
+async def list_deployment_image_targets(
+    stack: str = Query(..., min_length=1),
+    service: DeploymentOperationsService = Depends(_get_deployment_service),
+    _user: User = Depends(get_current_user()),
+) -> ImageTargetsResponse:
+    try:
+        policy = service.get_policy(stack)
+    except DeploymentOperationError as exc:
+        raise _policy_error(exc) from exc
+    return ImageTargetsResponse(
+        stack=policy.stack,
+        repositories=[
+            ImageTargetModel(
+                repository=policy.repository,
+                allowedReferences=list(policy.allowed_references),
+                recentTags=list(policy.recent_tags),
+                digestPinningRecommended=policy.allow_mutable_tags,
+            )
+        ],
+    )

--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -6,13 +6,22 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
 from api_service.db.models import User
 from api_service.services.deployment_operations import (
     DeploymentOperationError,
     DeploymentOperationsService,
     DeploymentStackPolicy,
+    DeploymentUpdateSubmission,
+)
+from moonmind.config.settings import settings
+from moonmind.workflows.tasks.routing import TemporalSubmitDisabledError
+from moonmind.workflows.temporal import (
+    TemporalExecutionService,
+    TemporalExecutionValidationError,
 )
 
 
@@ -91,6 +100,27 @@ def _get_deployment_service() -> DeploymentOperationsService:
     return DeploymentOperationsService()
 
 
+def _get_temporal_execution_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> TemporalExecutionService:
+    return TemporalExecutionService(
+        session,
+        namespace=settings.temporal.namespace,
+        integration_task_queue=settings.temporal.activity_integrations_task_queue,
+        integration_poll_initial_seconds=(
+            settings.temporal.integration_poll_initial_seconds
+        ),
+        integration_poll_max_seconds=settings.temporal.integration_poll_max_seconds,
+        integration_poll_jitter_ratio=settings.temporal.integration_poll_jitter_ratio,
+        run_continue_as_new_step_threshold=(
+            settings.temporal.run_continue_as_new_step_threshold
+        ),
+        run_continue_as_new_wait_cycle_threshold=(
+            settings.temporal.run_continue_as_new_wait_cycle_threshold
+        ),
+    )
+
+
 def _require_admin(user: User) -> None:
     if bool(getattr(user, "is_superuser", False)):
         return
@@ -142,11 +172,12 @@ def _stack_state(policy: DeploymentStackPolicy) -> DeploymentStackStateResponse:
 async def submit_deployment_update(
     payload: DeploymentUpdateRequest,
     service: DeploymentOperationsService = Depends(_get_deployment_service),
+    execution_service: TemporalExecutionService = Depends(_get_temporal_execution_service),
     user: User = Depends(get_current_user()),
 ) -> DeploymentUpdateResponse:
     _require_admin(user)
     try:
-        service.validate_update_request(
+        policy = service.validate_update_request(
             stack=payload.stack,
             repository=payload.image.repository,
             reference=payload.image.reference,
@@ -155,7 +186,37 @@ async def submit_deployment_update(
         )
     except DeploymentOperationError as exc:
         raise _policy_error(exc) from exc
-    return DeploymentUpdateResponse(**service.queue_update(stack=payload.stack))
+    try:
+        queued = await service.queue_update(
+            execution_service=execution_service,
+            policy=policy,
+            submission=DeploymentUpdateSubmission(
+                stack=policy.stack,
+                repository=payload.image.repository,
+                reference=payload.image.reference,
+                mode=payload.mode,
+                remove_orphans=payload.remove_orphans,
+                wait=payload.wait,
+                run_smoke_check=payload.run_smoke_check,
+                pause_work=payload.pause_work,
+                prune_old_images=payload.prune_old_images,
+                reason=payload.reason,
+                requested_by_user_id=getattr(user, "id", None),
+            ),
+        )
+    except TemporalSubmitDisabledError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "temporal_submit_disabled", "message": str(exc)},
+        ) from exc
+    except TemporalExecutionValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"code": "deployment_update_queue_invalid", "message": str(exc)},
+        ) from exc
+    except DeploymentOperationError as exc:
+        raise _policy_error(exc) from exc
+    return DeploymentUpdateResponse(**queued)
 
 
 @router.get("/stacks/{stack}", response_model=DeploymentStackStateResponse)

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -32,6 +32,9 @@ from api_service.api.routers import (
 from api_service.api.routers.provider_profiles import router as provider_profiles_router
 from api_service.api.routers.chat import router as chat_router
 from api_service.api.routers.context_protocol import router as context_protocol_router
+from api_service.api.routers.deployment_operations import (
+    router as deployment_operations_router,
+)
 from api_service.api.routers.documents import router as documents_router
 from api_service.api.routers.execution_integrations import (
     router as execution_integrations_router,
@@ -439,6 +442,7 @@ app.include_router(provider_profiles_router, prefix="/api/v1")
 app.include_router(oauth_sessions_router, prefix="/api/v1")
 app.include_router(secrets_router, prefix="/api/v1/secrets")
 app.include_router(proxy_router, prefix="/api/v1")
+app.include_router(deployment_operations_router)
 app.include_router(executions_router)
 app.include_router(execution_integrations_router)
 app.include_router(automation_router)

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -72,7 +72,7 @@ class DeploymentExecutionCreator(Protocol):
         integration: str | None = None,
         summary: str | None = None,
     ) -> Any:
-        ...
+        raise NotImplementedError
 
 
 DEFAULT_DEPLOYMENT_POLICIES: dict[str, DeploymentStackPolicy] = {

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -1,0 +1,116 @@
+"""Policy-gated deployment operation service."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from uuid import uuid4
+
+
+_IMAGE_REFERENCE_PATTERN = re.compile(
+    r"^(?:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}|sha256:[A-Fa-f0-9]{64})$"
+)
+
+
+class DeploymentOperationError(ValueError):
+    """Raised when a deployment operation request violates policy."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class DeploymentStackPolicy:
+    stack: str
+    project_name: str
+    repository: str
+    allowed_references: tuple[str, ...]
+    recent_tags: tuple[str, ...]
+    allow_mutable_tags: bool
+    allow_custom_digest: bool
+    allowed_modes: tuple[str, ...]
+    configured_reference: str
+
+    @property
+    def configured_image(self) -> str:
+        return f"{self.repository}:{self.configured_reference}"
+
+
+DEFAULT_DEPLOYMENT_POLICIES: dict[str, DeploymentStackPolicy] = {
+    "moonmind": DeploymentStackPolicy(
+        stack="moonmind",
+        project_name="moonmind",
+        repository="ghcr.io/moonladderstudios/moonmind",
+        allowed_references=("stable", "latest"),
+        recent_tags=("20260425.1234",),
+        allow_mutable_tags=True,
+        allow_custom_digest=True,
+        allowed_modes=("changed_services", "force_recreate"),
+        configured_reference="stable",
+    )
+}
+
+
+class DeploymentOperationsService:
+    """Validate deployment policy and build typed operation responses."""
+
+    def __init__(
+        self,
+        policies: dict[str, DeploymentStackPolicy] | None = None,
+    ) -> None:
+        self._policies = policies or DEFAULT_DEPLOYMENT_POLICIES
+
+    def get_policy(self, stack: str) -> DeploymentStackPolicy:
+        normalized = str(stack or "").strip()
+        policy = self._policies.get(normalized)
+        if policy is None:
+            raise DeploymentOperationError(
+                "deployment_stack_not_allowed",
+                "Deployment stack is not allowlisted.",
+            )
+        return policy
+
+    def validate_update_request(
+        self,
+        *,
+        stack: str,
+        repository: str,
+        reference: str,
+        mode: str,
+        reason: str,
+    ) -> DeploymentStackPolicy:
+        policy = self.get_policy(stack)
+        if repository != policy.repository:
+            raise DeploymentOperationError(
+                "deployment_repository_not_allowed",
+                "Image repository is not allowlisted for this stack.",
+            )
+        if not _IMAGE_REFERENCE_PATTERN.fullmatch(str(reference or "").strip()):
+            raise DeploymentOperationError(
+                "deployment_image_reference_invalid",
+                "Image reference is invalid.",
+            )
+        if mode not in policy.allowed_modes:
+            raise DeploymentOperationError(
+                "deployment_mode_not_allowed",
+                "Deployment update mode is not permitted by policy.",
+            )
+        if not str(reason or "").strip():
+            raise DeploymentOperationError(
+                "deployment_reason_required",
+                "Deployment update reason is required.",
+            )
+        return policy
+
+    def queue_update(self, *, stack: str) -> dict[str, str]:
+        run_id = f"depupd_{uuid4().hex}"
+        workflow_id = f"MoonMind.DeploymentUpdate/{stack}/{run_id}"
+        return {
+            "deploymentUpdateRunId": run_id,
+            "taskId": workflow_id,
+            "workflowId": workflow_id,
+            "status": "QUEUED",
+        }
+

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -71,7 +71,8 @@ class DeploymentExecutionCreator(Protocol):
         repository: str | None = None,
         integration: str | None = None,
         summary: str | None = None,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
 
 DEFAULT_DEPLOYMENT_POLICIES: dict[str, DeploymentStackPolicy] = {

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from uuid import uuid4
+from typing import Any, Protocol
+from uuid import UUID
 
 
 _IMAGE_REFERENCE_PATTERN = re.compile(
@@ -36,6 +37,41 @@ class DeploymentStackPolicy:
     @property
     def configured_image(self) -> str:
         return f"{self.repository}:{self.configured_reference}"
+
+
+@dataclass(frozen=True)
+class DeploymentUpdateSubmission:
+    stack: str
+    repository: str
+    reference: str
+    mode: str
+    remove_orphans: bool
+    wait: bool
+    run_smoke_check: bool
+    pause_work: bool
+    prune_old_images: bool
+    reason: str
+    requested_by_user_id: UUID | str | None
+
+
+class DeploymentExecutionCreator(Protocol):
+    async def create_execution(
+        self,
+        *,
+        workflow_type: str,
+        owner_id: UUID | str | None,
+        owner_type: str | None = None,
+        title: str | None,
+        input_artifact_ref: str | None,
+        plan_artifact_ref: str | None,
+        manifest_artifact_ref: str | None,
+        failure_policy: str | None,
+        initial_parameters: dict[str, Any] | None,
+        idempotency_key: str | None,
+        repository: str | None = None,
+        integration: str | None = None,
+        summary: str | None = None,
+    ) -> Any: ...
 
 
 DEFAULT_DEPLOYMENT_POLICIES: dict[str, DeploymentStackPolicy] = {
@@ -104,13 +140,112 @@ class DeploymentOperationsService:
             )
         return policy
 
-    def queue_update(self, *, stack: str) -> dict[str, str]:
-        run_id = f"depupd_{uuid4().hex}"
-        workflow_id = f"MoonMind.DeploymentUpdate/{stack}/{run_id}"
+    async def queue_update(
+        self,
+        *,
+        execution_service: DeploymentExecutionCreator,
+        policy: DeploymentStackPolicy,
+        submission: DeploymentUpdateSubmission,
+    ) -> dict[str, str]:
+        initial_parameters = self._build_initial_parameters(
+            policy=policy,
+            submission=submission,
+        )
+        execution = await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=submission.requested_by_user_id,
+            owner_type="user",
+            title=f"Update deployment stack {policy.stack}",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy="fail_fast",
+            initial_parameters=initial_parameters,
+            idempotency_key=self._idempotency_key(
+                policy=policy,
+                submission=submission,
+            ),
+            repository=None,
+            integration="deployment.update_compose_stack",
+            summary=(
+                f"Policy-gated deployment update for {policy.stack} to "
+                f"{submission.repository}:{submission.reference}."
+            ),
+        )
+        workflow_id = str(getattr(execution, "workflow_id", "") or "").strip()
+        run_id = str(getattr(execution, "run_id", "") or "").strip()
+        if not workflow_id or not run_id:
+            raise DeploymentOperationError(
+                "deployment_update_queue_failed",
+                "Deployment update workflow was not created.",
+            )
+        deployment_update_run_id = f"depupd_{run_id.replace('-', '')}"
         return {
-            "deploymentUpdateRunId": run_id,
+            "deploymentUpdateRunId": deployment_update_run_id,
             "taskId": workflow_id,
             "workflowId": workflow_id,
             "status": "QUEUED",
         }
 
+    def _build_initial_parameters(
+        self,
+        *,
+        policy: DeploymentStackPolicy,
+        submission: DeploymentUpdateSubmission,
+    ) -> dict[str, Any]:
+        return {
+            "task": {
+                "instructions": (
+                    "Run the policy-gated deployment update operation for "
+                    f"stack '{policy.stack}' using the typed "
+                    "deployment.update_compose_stack tool contract."
+                ),
+                "operation": {
+                    "type": "deployment.update",
+                    "source": "api.v1.operations.deployment.update",
+                    "jiraIssue": "MM-518",
+                },
+                "plan": [
+                    {
+                        "id": "update-moonmind-deployment",
+                        "title": "Update MoonMind deployment",
+                        "tool": {
+                            "type": "skill",
+                            "name": "deployment.update_compose_stack",
+                            "version": "1.0.0",
+                        },
+                        "inputs": {
+                            "stack": policy.stack,
+                            "image": {
+                                "repository": submission.repository,
+                                "reference": submission.reference,
+                            },
+                            "mode": submission.mode,
+                            "removeOrphans": submission.remove_orphans,
+                            "wait": submission.wait,
+                            "runSmokeCheck": submission.run_smoke_check,
+                            "pauseWork": submission.pause_work,
+                            "pruneOldImages": submission.prune_old_images,
+                            "reason": submission.reason,
+                        },
+                    }
+                ],
+            }
+        }
+
+    def _idempotency_key(
+        self,
+        *,
+        policy: DeploymentStackPolicy,
+        submission: DeploymentUpdateSubmission,
+    ) -> str:
+        return "|".join(
+            [
+                "deployment-update",
+                policy.stack,
+                submission.repository,
+                submission.reference,
+                submission.mode,
+                submission.reason.strip(),
+            ]
+        )[:128]

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-508",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1749"
+  "jira_issue_key": "MM-518",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1768"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -23,5 +23,10 @@
     "id": 4176257392,
     "disposition": "not-applicable",
     "rationale": "Top-level Codex review wrapper with no standalone requested code change."
+  },
+  {
+    "id": 3142727783,
+    "disposition": "addressed",
+    "rationale": "Moved the Protocol stub ellipsis onto its own method body so the line is no longer reported as an ineffective statement."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,27 @@
 [
   {
-    "id": 4176110163,
+    "id": 3142703165,
+    "disposition": "addressed",
+    "rationale": "The update endpoint now queues with the normalized policy stack by passing policy.stack through DeploymentUpdateSubmission."
+  },
+  {
+    "id": 4176254410,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary; individual actionable comments were classified separately."
+    "rationale": "Top-level automated review summary; actionable child feedback is tracked separately."
   },
   {
-    "id": 3142549713,
+    "id": 3142707227,
     "disposition": "addressed",
-    "rationale": "Changed the repository metadata response type check to dict for the default_branch extraction."
+    "rationale": "queue_update now creates a Temporal MoonMind.Run execution record through TemporalExecutionService before returning QUEUED metadata."
   },
   {
-    "id": 3142549717,
+    "id": 3142707228,
     "disposition": "addressed",
-    "rationale": "Made the repository metadata request best-effort so branch pagination still succeeds if metadata lookup fails."
+    "rationale": "Queued run inputs now use the canonical stack from deployment policy, with regression coverage for whitespace-normalized stack input."
   },
   {
-    "id": 3142549722,
-    "disposition": "addressed",
-    "rationale": "Allowed default branch auto-selection to run when the selected repository changes even if a previous branch is selected."
-  },
-  {
-    "id": 3142550006,
-    "disposition": "addressed",
-    "rationale": "Added backend regression coverage proving branch options are returned when the metadata endpoint fails."
-  },
-  {
-    "id": 4176110370,
+    "id": 4176257392,
     "disposition": "not-applicable",
-    "rationale": "Automated review wrapper with no separate actionable request beyond the inline comments already addressed."
-  },
-  {
-    "id": 3142571198,
-    "disposition": "addressed",
-    "rationale": "Added an explicit comment explaining that metadata failures are intentionally ignored so branch discovery can continue without default-branch metadata."
+    "rationale": "Top-level Codex review wrapper with no standalone requested code change."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -27,6 +27,11 @@
   {
     "id": 3142727783,
     "disposition": "addressed",
-    "rationale": "Moved the Protocol stub ellipsis onto its own method body so the line is no longer reported as an ineffective statement."
+    "rationale": "Replaced the Protocol stub ellipsis with raise NotImplementedError."
+  },
+  {
+    "id": 3142733512,
+    "disposition": "addressed",
+    "rationale": "Replaced the Protocol stub ellipsis with raise NotImplementedError as requested by the code-quality bot."
   }
 ]

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -989,6 +989,57 @@ export interface paths {
         patch: operations["proxy_pass_through_patch"];
         trace?: never;
     };
+    "/api/v1/operations/deployment/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Submit Deployment Update */
+        post: operations["submit_deployment_update_api_v1_operations_deployment_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/operations/deployment/stacks/{stack}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Deployment Stack State */
+        get: operations["get_deployment_stack_state_api_v1_operations_deployment_stacks__stack__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/operations/deployment/image-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Deployment Image Targets */
+        get: operations["list_deployment_image_targets_api_v1_operations_deployment_image_targets_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions/{workflow_id}/remediation": {
         parameters: {
             query?: never;
@@ -3366,6 +3417,86 @@ export interface components {
              */
             markdown?: string | null;
         };
+        /** DeploymentImageRequest */
+        DeploymentImageRequest: {
+            /** Repository */
+            repository: string;
+            /** Reference */
+            reference: string;
+        };
+        /** DeploymentServiceStateModel */
+        DeploymentServiceStateModel: {
+            /** Name */
+            name: string;
+            /** State */
+            state: string;
+            /** Health */
+            health?: string | null;
+        };
+        /** DeploymentStackStateResponse */
+        DeploymentStackStateResponse: {
+            /** Stack */
+            stack: string;
+            /** Projectname */
+            projectName: string;
+            /** Configuredimage */
+            configuredImage: string;
+            /** Runningimages */
+            runningImages: components["schemas"]["RunningImageModel"][];
+            /** Services */
+            services: components["schemas"]["DeploymentServiceStateModel"][];
+            /** Lastupdaterunid */
+            lastUpdateRunId?: string | null;
+        };
+        /** DeploymentUpdateRequest */
+        DeploymentUpdateRequest: {
+            /** Stack */
+            stack: string;
+            image: components["schemas"]["DeploymentImageRequest"];
+            /** Mode */
+            mode: string;
+            /**
+             * Removeorphans
+             * @default false
+             */
+            removeOrphans: boolean;
+            /**
+             * Wait
+             * @default true
+             */
+            wait: boolean;
+            /**
+             * Runsmokecheck
+             * @default false
+             */
+            runSmokeCheck: boolean;
+            /**
+             * Pausework
+             * @default false
+             */
+            pauseWork: boolean;
+            /**
+             * Pruneoldimages
+             * @default false
+             */
+            pruneOldImages: boolean;
+            /** Reason */
+            reason: string;
+        };
+        /** DeploymentUpdateResponse */
+        DeploymentUpdateResponse: {
+            /** Deploymentupdaterunid */
+            deploymentUpdateRunId: string;
+            /** Taskid */
+            taskId: string;
+            /** Workflowid */
+            workflowId: string;
+            /**
+             * Status
+             * @constant
+             */
+            status: "QUEUED";
+        };
         /** ErrorModel */
         ErrorModel: {
             /** Detail */
@@ -4112,6 +4243,24 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /** ImageTargetModel */
+        ImageTargetModel: {
+            /** Repository */
+            repository: string;
+            /** Allowedreferences */
+            allowedReferences: string[];
+            /** Recenttags */
+            recentTags: string[];
+            /** Digestpinningrecommended */
+            digestPinningRecommended: boolean;
+        };
+        /** ImageTargetsResponse */
+        ImageTargetsResponse: {
+            /** Stack */
+            stack: string;
+            /** Repositories */
+            repositories: components["schemas"]["ImageTargetModel"][];
         };
         /**
          * IntegrationCallbackRequest
@@ -5399,6 +5548,17 @@ export interface components {
             mode: components["schemas"]["RetryWorkflowMode"];
             /** Notes */
             notes?: string | null;
+        };
+        /** RunningImageModel */
+        RunningImageModel: {
+            /** Service */
+            service: string;
+            /** Image */
+            image: string;
+            /** Imageid */
+            imageId?: string | null;
+            /** Digest */
+            digest?: string | null;
         };
         /**
          * ScheduleCreatedResponse
@@ -8790,6 +8950,101 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_deployment_update_api_v1_operations_deployment_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeploymentUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentUpdateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_deployment_stack_state_api_v1_operations_deployment_stacks__stack__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                stack: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentStackStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_deployment_image_targets_api_v1_operations_deployment_image_targets_get: {
+        parameters: {
+            query: {
+                stack: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageTargetsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/specs/260-policy-gated-deployment-update/checklists/requirements.md
+++ b/specs/260-policy-gated-deployment-update/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Policy-Gated Deployment Update API
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The request is classified as a single-story runtime feature request because the Jira preset brief defines one administrator story with one bounded deployment update API behavior surface.
+- The source implementation document is treated as runtime source requirements, not docs-mode work.
+- The source Jira issue is `MM-518`; the spec preserves the canonical Jira preset brief and maps all referenced source coverage IDs.

--- a/specs/260-policy-gated-deployment-update/contracts/deployment-operations.openapi.yaml
+++ b/specs/260-policy-gated-deployment-update/contracts/deployment-operations.openapi.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  title: Policy-Gated Deployment Operations API
+  version: 0.1.0
+paths:
+  /api/v1/operations/deployment/update:
+    post:
+      summary: Submit a policy-gated deployment update
+      responses:
+        "202":
+          description: Deployment update queued
+        "403":
+          description: Caller is not an administrator
+        "422":
+          description: Request violates deployment policy or schema
+  /api/v1/operations/deployment/stacks/{stack}:
+    get:
+      summary: Read current deployment state for an allowlisted stack
+      parameters:
+        - name: stack
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typed deployment stack state
+        "422":
+          description: Stack is not allowlisted
+  /api/v1/operations/deployment/image-targets:
+    get:
+      summary: List allowed image targets for an allowlisted stack
+      parameters:
+        - name: stack
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typed allowed image target policy
+        "422":
+          description: Stack is not allowlisted

--- a/specs/260-policy-gated-deployment-update/data-model.md
+++ b/specs/260-policy-gated-deployment-update/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Policy-Gated Deployment Update API
+
+## DeploymentUpdateRequest
+
+- `stack`: allowlisted deployment stack key. Required.
+- `image.repository`: allowlisted image repository for the selected stack. Required.
+- `image.reference`: syntactically valid image reference or digest. Required.
+- `mode`: policy-permitted update mode. Required.
+- `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, `pruneOldImages`: typed boolean options.
+- `reason`: non-empty operator reason. Required.
+
+Validation rules:
+- Unknown fields are rejected.
+- Unknown stacks, unapproved repositories, invalid references, unsupported modes, and empty reasons are rejected before workflow or tool execution.
+- Arbitrary shell commands, Compose files, host paths, and updater runner image choices are not part of the model and are rejected as unknown fields.
+
+## DeploymentUpdateRun
+
+- `deploymentUpdateRunId`: generated deployment update run identifier.
+- `taskId`: task or run handle available at submission time.
+- `workflowId`: workflow handle available at submission time.
+- `status`: `QUEUED`.
+
+State transitions:
+- `QUEUED` is the only state emitted by this story's submission API.
+
+## DeploymentStackState
+
+- `stack`: allowlisted stack key.
+- `projectName`: Compose project name.
+- `configuredImage`: configured image reference for the stack.
+- `runningImages`: service image observations with service name, image, image ID, and digest when known.
+- `services`: service state observations with service name, state, and health when known.
+- `lastUpdateRunId`: last deployment update run identifier when known.
+
+## ImageTargetPolicy
+
+- `repository`: allowed image repository.
+- `allowedReferences`: configured allowed mutable references.
+- `recentTags`: known recent tags when available.
+- `digestPinningRecommended`: true when mutable tag usage is allowed and digest pinning should be preferred.
+
+## Persistence
+
+No new persistent table is introduced for `MM-518`. This story defines typed API and policy boundaries; durable execution history and richer deployment state can be layered behind the same contract in later stories.

--- a/specs/260-policy-gated-deployment-update/plan.md
+++ b/specs/260-policy-gated-deployment-update/plan.md
@@ -5,14 +5,14 @@
 
 ## Summary
 
-Implement `MM-518` by adding a typed FastAPI deployment operations surface under `/api/v1/operations/deployment`, backed by a policy service that validates administrator authorization, allowlisted stack/repository/reference/mode/options, and required reason before returning queued deployment run metadata. Read-only endpoints expose typed current stack state and image target policy without caller-controlled host paths, Compose files, runner images, or shell command text. Test strategy is API-router coverage plus service validation through the router, with final full unit-suite verification.
+Implement `MM-518` by adding a typed FastAPI deployment operations surface under `/api/v1/operations/deployment`, backed by a policy service that validates administrator authorization, allowlisted stack/repository/reference/mode/options, and required reason before creating a queued Temporal `MoonMind.Run` deployment operation record. Read-only endpoints expose typed current stack state and image target policy without caller-controlled host paths, Compose files, runner images, or shell command text. Test strategy is API-router coverage plus service validation through the router, with final full unit-suite verification.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
 | FR-001 | implemented_verified | `api_service/api/routers/deployment_operations.py`, `tests/unit/api/routers/test_deployment_operations.py` | no new implementation | final verify |
-| FR-002 | implemented_verified | update response model and submit test in `tests/unit/api/routers/test_deployment_operations.py` | no new implementation | final verify |
+| FR-002 | implemented_verified | update response model, Temporal execution creation, and submit test in `tests/unit/api/routers/test_deployment_operations.py` | no new implementation | final verify |
 | FR-003 | implemented_verified | `_require_admin`, non-admin rejection test | no new implementation | final verify |
 | FR-004 | implemented_verified | dedicated deployment route and admin check independent of task submission routes | no new implementation | final verify |
 | FR-005 | implemented_verified | `DeploymentOperationsService.validate_update_request`, invalid input tests | no new implementation | final verify |
@@ -33,7 +33,7 @@ Implement `MM-518` by adding a typed FastAPI deployment operations surface under
 
 **Language/Version**: Python 3.12  
 **Primary Dependencies**: FastAPI, Pydantic v2, existing `get_current_user()` auth dependency  
-**Storage**: No new persistent storage; policy-backed deterministic responses for this story  
+**Storage**: Existing Temporal execution records only; no new persistent storage or tables  
 **Unit Testing**: pytest through `./tools/test_unit.sh`  
 **Integration Testing**: FastAPI `TestClient` router tests in unit tier; no compose-backed dependency required for this policy/API story  
 **Target Platform**: MoonMind API service on Linux containers  

--- a/specs/260-policy-gated-deployment-update/plan.md
+++ b/specs/260-policy-gated-deployment-update/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Policy-Gated Deployment Update API
+
+**Branch**: `260-policy-gated-deployment-update` | **Date**: 2026-04-25 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/260-policy-gated-deployment-update/spec.md`
+
+## Summary
+
+Implement `MM-518` by adding a typed FastAPI deployment operations surface under `/api/v1/operations/deployment`, backed by a policy service that validates administrator authorization, allowlisted stack/repository/reference/mode/options, and required reason before returning queued deployment run metadata. Read-only endpoints expose typed current stack state and image target policy without caller-controlled host paths, Compose files, runner images, or shell command text. Test strategy is API-router coverage plus service validation through the router, with final full unit-suite verification.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `api_service/api/routers/deployment_operations.py`, `tests/unit/api/routers/test_deployment_operations.py` | no new implementation | final verify |
+| FR-002 | implemented_verified | update response model and submit test in `tests/unit/api/routers/test_deployment_operations.py` | no new implementation | final verify |
+| FR-003 | implemented_verified | `_require_admin`, non-admin rejection test | no new implementation | final verify |
+| FR-004 | implemented_verified | dedicated deployment route and admin check independent of task submission routes | no new implementation | final verify |
+| FR-005 | implemented_verified | `DeploymentOperationsService.validate_update_request`, invalid input tests | no new implementation | final verify |
+| FR-006 | implemented_verified | explicit policy checks for stack, repository, reference, mode, reason plus schema extra-field rejection | no new implementation | final verify |
+| FR-007 | implemented_verified | `DeploymentOperationError` to HTTP error-code mapping and policy error tests | no new implementation | final verify |
+| FR-008 | implemented_verified | `/stacks/{stack}` endpoint and typed state response test | no new implementation | final verify |
+| FR-009 | implemented_verified | `/image-targets` endpoint and typed target response test | no new implementation | final verify |
+| FR-010 | implemented_verified | `digestPinningRecommended` response assertion | no new implementation | final verify |
+| FR-011 | implemented_verified | Pydantic `extra="forbid"` request models and arbitrary command/path rejection test | no new implementation | final verify |
+| FR-012 | implemented_verified | `MM-518` preserved in MoonSpec artifacts and final report plan | no new implementation | final verify |
+| DESIGN-REQ-003 | implemented_verified | update endpoint contract and queued response tests | no new implementation | final verify |
+| DESIGN-REQ-004 | implemented_verified | state and image target endpoints and tests | no new implementation | final verify |
+| DESIGN-REQ-005 | implemented_verified | pre-execution validation service and tests | no new implementation | final verify |
+| DESIGN-REQ-008 | implemented_verified | admin-only submit and allowlisted stack policy | no new implementation | final verify |
+| DESIGN-REQ-018 | implemented_verified | typed request model rejects arbitrary command/path fields | no new implementation | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, Pydantic v2, existing `get_current_user()` auth dependency  
+**Storage**: No new persistent storage; policy-backed deterministic responses for this story  
+**Unit Testing**: pytest through `./tools/test_unit.sh`  
+**Integration Testing**: FastAPI `TestClient` router tests in unit tier; no compose-backed dependency required for this policy/API story  
+**Target Platform**: MoonMind API service on Linux containers  
+**Project Type**: Backend web service  
+**Performance Goals**: Policy validation remains in-process and bounded; no external calls before rejection  
+**Constraints**: Admin-only mutation, no arbitrary shell/host path inputs, no hidden fallback for unsupported values, preserve `MM-518` traceability  
+**Scale/Scope**: One allowlisted deployment stack policy surface and three API operations
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS - the story exposes bounded operation orchestration inputs and does not implement a competing agent/runtime.
+- II. One-Click Agent Deployment: PASS - no required external cloud dependency or new persistent service.
+- VII. Powerful Runtime Configurability: PASS for the story slice - policy is isolated in a service boundary; future runtime config can replace the default policy without changing the API contract.
+- IX. Resilient by Default: PASS - invalid inputs fail before workflow/tool side effects.
+- XI. Spec-Driven Development: PASS - `spec.md` preserves the canonical `MM-518` Jira brief and source coverage IDs.
+- XIII. Pre-release Compatibility: PASS - no compatibility aliases or hidden fallback semantics introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/260-policy-gated-deployment-update/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── deployment-operations.openapi.yaml
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/deployment_operations.py
+├── main.py
+└── services/deployment_operations.py
+
+tests/
+└── unit/api/routers/test_deployment_operations.py
+```
+
+**Structure Decision**: Use the existing API router plus service pattern. Keep request/response models near the router because they define a small public HTTP contract, and keep policy validation in `api_service/services/deployment_operations.py` for focused unit/router testing and future configuration replacement.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/260-policy-gated-deployment-update/quickstart.md
+++ b/specs/260-policy-gated-deployment-update/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Policy-Gated Deployment Update API
+
+## Test-First Commands
+
+Focused unit/API-router validation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py
+```
+
+Full unit validation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Hermetic integration suite:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Story Validation
+
+1. Submit a valid administrator request to `POST /api/v1/operations/deployment/update`.
+2. Confirm the response is `202` and includes `deploymentUpdateRunId`, `taskId` or `workflowId`, and `QUEUED`.
+3. Submit the same request as a non-admin user and confirm `403 deployment_update_forbidden`.
+4. Submit invalid policy values for stack, repository, mode, reference, and reason and confirm `422` responses with explicit error codes.
+5. Submit payloads with `command`, `composeFile`, host-path-like, or runner-choice fields and confirm schema rejection.
+6. Read `/api/v1/operations/deployment/stacks/moonmind` and `/api/v1/operations/deployment/image-targets?stack=moonmind` and confirm the typed response shapes.

--- a/specs/260-policy-gated-deployment-update/research.md
+++ b/specs/260-policy-gated-deployment-update/research.md
@@ -1,0 +1,49 @@
+# Research: Policy-Gated Deployment Update API
+
+## Request Classification
+
+Decision: `MM-518` is a single-story runtime feature request.
+Evidence: `spec.md` preserves one Jira Story with one administrator actor, one deployment update API goal, one source document, and one bounded acceptance set.
+Rationale: The Jira preset brief does not require story splitting; the source document is an implementation/source requirements document for runtime behavior.
+Alternatives considered: Treating `docs/Tools/DockerComposeUpdateSystem.md` as a broad declarative design was rejected because the Jira brief selected sections 7, 10.1, and 13.1-13.3 for one policy-gated API slice.
+Test implications: Unit and API-router tests are required.
+
+## API Boundary
+
+Decision: Add a dedicated FastAPI router at `/api/v1/operations/deployment`.
+Evidence: Existing routers live under `api_service/api/routers/` and are registered in `api_service/main.py`.
+Rationale: Deployment operations are operator-facing API controls, not task template, proxy, or manifest concerns.
+Alternatives considered: Extending the task execution router was rejected because FR-004 requires deployment update permissions to remain distinct from ordinary task submission.
+Test implications: Router tests should import the router directly and override the current-user dependency.
+
+## Policy Validation
+
+Decision: Put stack/repository/reference/mode/reason validation in `api_service/services/deployment_operations.py`.
+Evidence: No existing deployment operation validator exists; service modules contain domain logic separate from routers.
+Rationale: A service boundary keeps policy checks testable and ensures invalid requests fail before any workflow or tool execution.
+Alternatives considered: Inline router validation was rejected because it would mix HTTP details with deployment policy rules.
+Test implications: Router tests cover service behavior through HTTP status and error-code assertions.
+
+## Authorization
+
+Decision: Require `is_superuser` for update submission and authenticated user access for read endpoints.
+Evidence: Existing API tests and dependencies use `get_current_user()` and `is_superuser` for admin-sensitive operations.
+Rationale: The story explicitly requires administrator-only update submission and permission distinct from ordinary task submission; read operations are inspection endpoints with no mutation.
+Alternatives considered: Reusing task submission enablement was rejected because it would violate FR-004.
+Test implications: Include a non-admin submit rejection test.
+
+## Typed Contract And No Arbitrary Shell
+
+Decision: Use Pydantic models with `extra="forbid"` and typed image/update fields.
+Evidence: The source design forbids arbitrary shell commands, Compose paths, host paths, runner images, and unrecognized flags.
+Rationale: Rejecting unknown payload fields at model validation prevents unsafe caller-controlled command surfaces from reaching policy or execution logic.
+Alternatives considered: Accepting flexible `dict` payloads was rejected because it would allow hidden input expansion.
+Test implications: Include a request containing `command` and `composeFile` and assert validation rejection.
+
+## Requirement Coverage Status
+
+Decision: All implementation requirements are new or partial before this story.
+Evidence: Repository search found no deployment operations router/service and no existing `/api/v1/operations/deployment` contract.
+Rationale: Existing auth and router patterns are reusable, but the deployment-specific contract and policy checks are missing.
+Alternatives considered: Marking admin auth as implemented-verified was rejected because no deployment endpoint uses it.
+Test implications: Add targeted tests and run the unit suite.

--- a/specs/260-policy-gated-deployment-update/spec.md
+++ b/specs/260-policy-gated-deployment-update/spec.md
@@ -1,0 +1,120 @@
+# Feature Specification: Policy-Gated Deployment Update API
+
+**Feature Branch**: `260-policy-gated-deployment-update`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-518 as the canonical MoonSpec orchestration input.
+
+Preserve the Jira issue key MM-518 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Jira Issue: MM-518
+Issue Type: Story
+Summary: Policy-gated deployment update API
+Status: In Progress
+
+Source Reference:
+- Source Document: docs/Tools/DockerComposeUpdateSystem.md
+- Source Title: Docker Compose Deployment Update System
+- Source Sections:
+  - 7. API contract
+  - 10.1 Validate request
+  - 13.1 Authorization
+  - 13.2 Allowlisted stacks
+  - 13.3 No arbitrary shell
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-008
+  - DESIGN-REQ-018
+
+Story:
+As a MoonMind administrator, I need typed deployment update APIs that enforce deployment policy before any Compose operation can start, so updates can be submitted and inspected without exposing arbitrary host controls.
+
+Acceptance Criteria:
+- Admin callers can submit a valid update request and receive deploymentUpdateRunId, taskId or workflowId, and QUEUED status.
+- Non-admin callers and ordinary task submitters cannot submit deployment updates.
+- Unknown stacks, caller-provided paths, unapproved repositories, unrecognized flags, invalid references, and missing reasons are rejected before workflow/tool execution.
+- Current deployment state and allowed image-target endpoints return the documented typed shapes.
+- Mutable tag responses identify digest pinning as recommended and preserve requested-reference versus resolved-digest semantics where known.
+- The API does not accept arbitrary shell command text, arbitrary Compose file paths, arbitrary host paths, or updater runner image choices.
+
+Requirements:
+- Expose the documented typed backend endpoints.
+- Bind request validation to deployment policy and admin authorization.
+- Represent unsupported values as explicit errors rather than hidden fallback behavior.
+- Keep deployment update permissions distinct from ordinary task submission."
+
+## User Story - Policy-Gated Deployment Update Requests
+
+**Summary**: As a MoonMind administrator, I want typed deployment update APIs that enforce deployment policy before Compose work can start, so that updates can be submitted and inspected without exposing arbitrary host controls.
+
+**Goal**: Administrators can request and inspect deployment updates through bounded typed operations while unauthorized callers and unsafe inputs are rejected before any deployment workflow or tool execution begins.
+
+**Independent Test**: Can be fully tested by exercising the deployment update endpoints as admin and non-admin callers with valid and invalid request payloads, confirming that accepted requests return queued run metadata and rejected requests never start deployment work.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator and an allowlisted stack, repository, reference, mode, permitted options, and non-empty reason, **When** the administrator submits a deployment update request, **Then** the system returns a deployment update run identifier, a task or workflow identifier, and `QUEUED` status.
+2. **Given** a non-admin caller or an ordinary task submitter, **When** the caller submits a deployment update request, **Then** the system rejects the request before deployment workflow or tool execution.
+3. **Given** a request with an unknown stack, caller-provided path, unapproved repository, unrecognized flag, invalid image reference, or missing reason, **When** the request is submitted, **Then** the system rejects it before deployment workflow or tool execution and reports the unsupported value explicitly.
+4. **Given** a caller with permission to inspect deployment operations, **When** the caller requests current deployment state for an allowlisted stack, **Then** the system returns the documented typed deployment state shape.
+5. **Given** a caller with permission to inspect deployment operations, **When** the caller requests allowed image targets for an allowlisted stack, **Then** the system returns documented repository target data including mutable tag guidance and requested-reference versus resolved-digest semantics where known.
+6. **Given** any deployment update API request, **When** the payload includes arbitrary shell command text, arbitrary Compose file paths, arbitrary host paths, or updater runner image choices, **Then** the system rejects the request before deployment workflow or tool execution.
+
+### Edge Cases
+
+- Empty, whitespace-only, or absent update reasons are rejected.
+- Image references with invalid syntax are rejected before any registry, workflow, or Compose work starts.
+- Requests for stacks that exist in operator infrastructure but are not allowlisted are rejected the same as unknown stacks.
+- Mutable tag target responses still identify digest pinning as recommended when mutable tags are allowed.
+- Rejected requests produce explicit errors without silently falling back to default stacks, repositories, modes, flags, or runner choices.
+
+## Assumptions
+
+- Deployment update submission is restricted to administrator-level authorization; read-only inspection can use the same policy boundary unless existing permissions define a narrower operation-specific read permission.
+- A queued deployment update may expose either a task identifier or workflow identifier when one of those identifiers is the canonical run handle available at submission time.
+- Registry tag discovery may be best effort, but the typed image-target response must preserve configured repository policy and digest-pinning guidance.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a typed deployment update submission operation for allowlisted deployment stacks.
+- **FR-002**: System MUST return a deployment update run identifier, task or workflow identifier, and `QUEUED` status for accepted update requests.
+- **FR-003**: System MUST restrict deployment update submission to administrator callers.
+- **FR-004**: System MUST keep deployment update permission distinct from ordinary task submission permission.
+- **FR-005**: System MUST validate stack name, image repository, image reference syntax, update mode, required reason, and requested options before workflow or tool execution.
+- **FR-006**: System MUST reject unknown stacks, caller-provided paths, unapproved repositories, unrecognized flags, invalid references, and missing reasons before workflow or tool execution.
+- **FR-007**: System MUST represent unsupported request values as explicit errors instead of silently falling back to defaults.
+- **FR-008**: System MUST expose a typed current deployment state read operation for allowlisted stacks.
+- **FR-009**: System MUST expose a typed allowed image-target read operation for allowlisted stacks.
+- **FR-010**: System MUST identify digest pinning as recommended for mutable tag responses and preserve requested-reference versus resolved-digest semantics where known.
+- **FR-011**: System MUST NOT accept arbitrary shell command text, arbitrary Compose file paths, arbitrary host paths, or updater runner image choices through the deployment update APIs.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-518` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Deployment Update Request**: A typed request to update an allowlisted stack using a policy-approved image repository, reference, mode, options, and reason.
+- **Deployment Update Run**: The queued operational record returned after a valid update request is accepted, including the deployment update run identifier and task or workflow identifier.
+- **Deployment Stack State**: The typed visible state of an allowlisted stack, including configured image, running service images, service health, and last update reference when known.
+- **Image Target Policy**: The typed allowed image repository and reference metadata for a stack, including mutable tag allowance and digest-pinning guidance.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-003**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 7.1 requires a typed deployment update submission endpoint with `deploymentUpdateRunId`, task or workflow identifier, and `QUEUED` status in the accepted response. Scope: in scope. Maps to FR-001, FR-002.
+- **DESIGN-REQ-004**: Source `docs/Tools/DockerComposeUpdateSystem.md` sections 7.2 and 7.3 require typed read endpoints for current deployment state and allowed image targets. Scope: in scope. Maps to FR-008, FR-009, FR-010.
+- **DESIGN-REQ-005**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 10.1 requires validation of administrator authorization, allowlisted stack, allowlisted repository, valid image reference, permitted mode, required reason, and permitted options before execution. Scope: in scope. Maps to FR-003, FR-005, FR-006.
+- **DESIGN-REQ-008**: Source `docs/Tools/DockerComposeUpdateSystem.md` sections 13.1 and 13.2 require deployment update authorization to be administrator-only, distinct from ordinary task submission, and constrained to allowlisted stack targets instead of caller-provided paths. Scope: in scope. Maps to FR-003, FR-004, FR-006.
+- **DESIGN-REQ-018**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 13.3 requires typed inputs only and rejection of arbitrary shell commands, unapproved Compose files, host paths, image repositories, updater runner images, and unrecognized flags. Scope: in scope. Maps to FR-006, FR-007, FR-011.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A valid administrator deployment update request for an allowlisted stack receives queued run metadata in one request.
+- **SC-002**: Non-admin and ordinary task submitter attempts to submit deployment updates are rejected in all tested cases.
+- **SC-003**: Every invalid stack, repository, reference, mode, option, path, runner choice, shell command, and missing reason case is rejected before workflow or tool execution.
+- **SC-004**: Current deployment state responses include stack identity, configured image, running service image details, service state, and last update reference when known.
+- **SC-005**: Allowed image-target responses include repository policy, allowed references or recent tags when known, and digest pinning recommendation for mutable tags.
+- **SC-006**: Verification evidence confirms `MM-518`, the canonical Jira preset brief, and DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-008, and DESIGN-REQ-018 remain traceable in MoonSpec artifacts.

--- a/specs/260-policy-gated-deployment-update/tasks.md
+++ b/specs/260-policy-gated-deployment-update/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Policy-Gated Deployment Update API
+
+**Input**: `specs/260-policy-gated-deployment-update/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/deployment-operations.openapi.yaml`, `quickstart.md`
+
+**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`
+**Integration Test Command**: `./tools/test_integration.sh` for the broader hermetic suite when Docker is available; this story's API boundary is covered by FastAPI router tests in the unit tier.
+
+**Source Traceability**: The original `MM-518` Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-012, acceptance scenarios 1-6, edge cases, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-008, and DESIGN-REQ-018.
+
+## Phase 1: Setup
+
+- [X] T001 Create `specs/260-policy-gated-deployment-update/` MoonSpec artifact structure and set `.specify/feature.json`.
+
+## Phase 2: Foundational
+
+- [X] T002 [P] Add failing API-router tests for submit/read contracts and admin authorization in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T003 [P] Add failing validation tests for disallowed stack, repository, mode, missing reason, and arbitrary command/path fields in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T004 Confirm red-first failure for missing deployment operations router with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`.
+
+## Phase 3: Story - Policy-Gated Deployment Update Requests
+
+**Summary**: Administrators can request and inspect deployment updates through bounded typed operations while unsafe inputs fail before workflow or tool execution.
+
+**Independent Test**: Exercise deployment update endpoints as admin and non-admin callers with valid and invalid payloads, confirming queued run metadata for valid admin requests and pre-execution rejection for invalid or unauthorized requests.
+
+**Traceability IDs**: FR-001-FR-012; SC-001-SC-006; DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-008, DESIGN-REQ-018.
+
+### Unit Test Plan
+
+- [X] T005 Cover valid administrator update submission in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T006 Cover non-admin rejection in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T007 Cover explicit policy error codes for invalid stack, repository, mode, and reason in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T008 Cover schema rejection for arbitrary shell and path fields in `tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T009 Cover typed state and image-target read responses in `tests/unit/api/routers/test_deployment_operations.py`.
+
+### Implementation
+
+- [X] T010 Implement deployment policy validation service in `api_service/services/deployment_operations.py`.
+- [X] T011 Implement typed deployment request/response models and endpoints in `api_service/api/routers/deployment_operations.py`.
+- [X] T012 Wire the deployment operations router into `api_service/main.py`.
+- [X] T013 Run focused unit/API-router validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`.
+
+## Final Phase: Polish And Verification
+
+- [X] T014 Preserve `MM-518` and source coverage IDs in `spec.md`, `plan.md`, `tasks.md`, and implementation summary.
+- [X] T015 Run full unit validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T016 Run final `/speckit.verify` equivalent against `specs/260-policy-gated-deployment-update/spec.md`.

--- a/specs/260-policy-gated-deployment-update/tasks.md
+++ b/specs/260-policy-gated-deployment-update/tasks.md
@@ -3,7 +3,7 @@
 **Input**: `specs/260-policy-gated-deployment-update/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/deployment-operations.openapi.yaml`, `quickstart.md`
 
 **Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`
-**Integration Test Command**: `./tools/test_integration.sh` for the broader hermetic suite when Docker is available; this story's API boundary is covered by FastAPI router tests in the unit tier.
+**Integration Test Command**: `./tools/test_integration.sh` for the broader hermetic suite when Docker is available; this story's API contract boundary is covered by FastAPI router tests in the unit tier.
 
 **Source Traceability**: The original `MM-518` Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-012, acceptance scenarios 1-6, edge cases, SC-001 through SC-006, and DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-008, and DESIGN-REQ-018.
 
@@ -33,15 +33,24 @@
 - [X] T008 Cover schema rejection for arbitrary shell and path fields in `tests/unit/api/routers/test_deployment_operations.py`.
 - [X] T009 Cover typed state and image-target read responses in `tests/unit/api/routers/test_deployment_operations.py`.
 
+### Integration Test Plan
+
+- [X] T010 Cover the deployment API contract boundary with FastAPI router tests in `tests/unit/api/routers/test_deployment_operations.py`, including accepted update, rejected unauthorized update, rejected invalid policy values, typed stack state, and typed image-target responses.
+- [X] T011 Attempt broader hermetic integration validation with `./tools/test_integration.sh`; record Docker socket unavailability when the managed workspace cannot run compose-backed integration tests.
+
 ### Implementation
 
-- [X] T010 Implement deployment policy validation service in `api_service/services/deployment_operations.py`.
-- [X] T011 Implement typed deployment request/response models and endpoints in `api_service/api/routers/deployment_operations.py`.
-- [X] T012 Wire the deployment operations router into `api_service/main.py`.
-- [X] T013 Run focused unit/API-router validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`.
+- [X] T012 Implement deployment policy validation service in `api_service/services/deployment_operations.py`.
+- [X] T013 Implement typed deployment request/response models and endpoints in `api_service/api/routers/deployment_operations.py`.
+- [X] T014 Wire the deployment operations router into `api_service/main.py`.
+- [X] T015 Run focused unit/API-router validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py`.
+
+### Story Validation
+
+- [X] T016 Validate the single story end-to-end through the focused API-router suite in `tests/unit/api/routers/test_deployment_operations.py`.
 
 ## Final Phase: Polish And Verification
 
-- [X] T014 Preserve `MM-518` and source coverage IDs in `spec.md`, `plan.md`, `tasks.md`, and implementation summary.
-- [X] T015 Run full unit validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
-- [X] T016 Run final `/speckit.verify` equivalent against `specs/260-policy-gated-deployment-update/spec.md`.
+- [X] T017 Preserve `MM-518` and source coverage IDs in `spec.md`, `plan.md`, `tasks.md`, and implementation summary.
+- [X] T018 Run full unit validation with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T019 Run final `/moonspec-verify` equivalent against `specs/260-policy-gated-deployment-update/spec.md`.

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -8,8 +8,25 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api_service.api.routers.deployment_operations import router
+from api_service.api.routers.deployment_operations import (
+    _get_temporal_execution_service,
+    router,
+)
 from api_service.auth_providers import get_current_user
+
+
+class _FakeExecutionRecord:
+    workflow_id = "mm:deployment-update"
+    run_id = "11111111-2222-3333-4444-555555555555"
+
+
+class _FakeExecutionService:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    async def create_execution(self, **kwargs: object) -> _FakeExecutionRecord:
+        self.requests.append(kwargs)
+        return _FakeExecutionRecord()
 
 
 def _override_user(app: FastAPI, *, is_superuser: bool) -> None:
@@ -30,13 +47,20 @@ def _override_user(app: FastAPI, *, is_superuser: bool) -> None:
         app.dependency_overrides[dependency] = lambda user=user: user
 
 
+def _override_execution_service(app: FastAPI) -> _FakeExecutionService:
+    service = _FakeExecutionService()
+    app.dependency_overrides[_get_temporal_execution_service] = lambda: service
+    return service
+
+
 @pytest.fixture
-def admin_client() -> Iterator[TestClient]:
+def admin_client() -> Iterator[tuple[TestClient, _FakeExecutionService]]:
     app = FastAPI()
     app.include_router(router)
     _override_user(app, is_superuser=True)
+    execution_service = _override_execution_service(app)
     with TestClient(app) as client:
-        yield client
+        yield client, execution_service
 
 
 @pytest.fixture
@@ -44,6 +68,7 @@ def user_client() -> Iterator[TestClient]:
     app = FastAPI()
     app.include_router(router)
     _override_user(app, is_superuser=False)
+    _override_execution_service(app)
     with TestClient(app) as client:
         yield client
 
@@ -66,9 +91,10 @@ def _valid_update_payload() -> dict[str, object]:
 
 
 def test_admin_can_submit_policy_valid_deployment_update(
-    admin_client: TestClient,
+    admin_client: tuple[TestClient, _FakeExecutionService],
 ) -> None:
-    response = admin_client.post(
+    client, execution_service = admin_client
+    response = client.post(
         "/api/v1/operations/deployment/update",
         json=_valid_update_payload(),
     )
@@ -76,8 +102,37 @@ def test_admin_can_submit_policy_valid_deployment_update(
     assert response.status_code == 202
     payload = response.json()
     assert payload["deploymentUpdateRunId"].startswith("depupd_")
-    assert payload["taskId"] or payload["workflowId"]
+    assert payload["taskId"] == "mm:deployment-update"
+    assert payload["workflowId"] == "mm:deployment-update"
     assert payload["status"] == "QUEUED"
+    assert len(execution_service.requests) == 1
+    request = execution_service.requests[0]
+    assert request["workflow_type"] == "MoonMind.Run"
+    assert request["owner_type"] == "user"
+    assert request["integration"] == "deployment.update_compose_stack"
+    parameters = request["initial_parameters"]
+    assert isinstance(parameters, dict)
+    plan = parameters["task"]["plan"]
+    assert plan[0]["tool"]["name"] == "deployment.update_compose_stack"
+    assert plan[0]["inputs"]["stack"] == "moonmind"
+
+
+def test_deployment_update_uses_canonical_policy_stack_for_queued_run(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    payload = _valid_update_payload()
+    payload["stack"] = " moonmind "
+
+    response = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert response.status_code == 202
+    parameters = execution_service.requests[0]["initial_parameters"]
+    assert isinstance(parameters, dict)
+    assert parameters["task"]["plan"][0]["inputs"]["stack"] == "moonmind"
 
 
 def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> None:
@@ -112,31 +167,34 @@ def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> N
     ],
 )
 def test_invalid_deployment_update_policy_inputs_are_rejected_before_execution(
-    admin_client: TestClient,
+    admin_client: tuple[TestClient, _FakeExecutionService],
     field: str,
     value: object,
     code: str,
 ) -> None:
+    client, execution_service = admin_client
     payload = _valid_update_payload()
     payload[field] = value
 
-    response = admin_client.post(
+    response = client.post(
         "/api/v1/operations/deployment/update",
         json=payload,
     )
 
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == code
+    assert execution_service.requests == []
 
 
 def test_arbitrary_shell_and_path_fields_are_not_accepted(
-    admin_client: TestClient,
+    admin_client: tuple[TestClient, _FakeExecutionService],
 ) -> None:
+    client, execution_service = admin_client
     payload = _valid_update_payload()
     payload["command"] = "docker compose up"
     payload["composeFile"] = "/tmp/docker-compose.yaml"
 
-    response = admin_client.post(
+    response = client.post(
         "/api/v1/operations/deployment/update",
         json=payload,
     )
@@ -145,10 +203,14 @@ def test_arbitrary_shell_and_path_fields_are_not_accepted(
     details = response.json()["detail"]
     assert any(error["loc"][-1] == "command" for error in details)
     assert any(error["loc"][-1] == "composeFile" for error in details)
+    assert execution_service.requests == []
 
 
-def test_current_deployment_state_returns_typed_shape(admin_client: TestClient) -> None:
-    response = admin_client.get("/api/v1/operations/deployment/stacks/moonmind")
+def test_current_deployment_state_returns_typed_shape(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, _execution_service = admin_client
+    response = client.get("/api/v1/operations/deployment/stacks/moonmind")
 
     assert response.status_code == 200
     payload = response.json()
@@ -159,8 +221,11 @@ def test_current_deployment_state_returns_typed_shape(admin_client: TestClient) 
     assert payload["services"][0]["state"] == "unknown"
 
 
-def test_allowed_image_targets_return_digest_guidance(admin_client: TestClient) -> None:
-    response = admin_client.get(
+def test_allowed_image_targets_return_digest_guidance(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, _execution_service = admin_client
+    response = client.get(
         "/api/v1/operations/deployment/image-targets",
         params={"stack": "moonmind"},
     )

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterator
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_service.api.routers.deployment_operations import router
+from api_service.auth_providers import get_current_user
+
+
+def _override_user(app: FastAPI, *, is_superuser: bool) -> None:
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="operator@example.com",
+        is_active=True,
+        is_superuser=is_superuser,
+    )
+    dependencies = {
+        dep.call
+        for route in router.routes
+        if route.dependant is not None
+        for dep in route.dependant.dependencies
+        if getattr(dep.call, "__name__", "") == "_current_user_fallback"
+    } or {get_current_user()}
+    for dependency in dependencies:
+        app.dependency_overrides[dependency] = lambda user=user: user
+
+
+@pytest.fixture
+def admin_client() -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(router)
+    _override_user(app, is_superuser=True)
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def user_client() -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(router)
+    _override_user(app, is_superuser=False)
+    with TestClient(app) as client:
+        yield client
+
+
+def _valid_update_payload() -> dict[str, object]:
+    return {
+        "stack": "moonmind",
+        "image": {
+            "repository": "ghcr.io/moonladderstudios/moonmind",
+            "reference": "20260425.1234",
+        },
+        "mode": "changed_services",
+        "removeOrphans": True,
+        "wait": True,
+        "runSmokeCheck": True,
+        "pauseWork": False,
+        "pruneOldImages": False,
+        "reason": "Update to the latest tested MoonMind build",
+    }
+
+
+def test_admin_can_submit_policy_valid_deployment_update(
+    admin_client: TestClient,
+) -> None:
+    response = admin_client.post(
+        "/api/v1/operations/deployment/update",
+        json=_valid_update_payload(),
+    )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["deploymentUpdateRunId"].startswith("depupd_")
+    assert payload["taskId"] or payload["workflowId"]
+    assert payload["status"] == "QUEUED"
+
+
+def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> None:
+    response = user_client.post(
+        "/api/v1/operations/deployment/update",
+        json=_valid_update_payload(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "deployment_update_forbidden"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("stack", "unlisted", "deployment_stack_not_allowed"),
+        (
+            "image",
+            {"repository": "docker.io/library/nginx", "reference": "latest"},
+            "deployment_repository_not_allowed",
+        ),
+        (
+            "image",
+            {
+                "repository": "ghcr.io/moonladderstudios/moonmind",
+                "reference": "../latest",
+            },
+            "deployment_image_reference_invalid",
+        ),
+        ("mode", "shell", "deployment_mode_not_allowed"),
+        ("reason", "   ", "deployment_reason_required"),
+    ],
+)
+def test_invalid_deployment_update_policy_inputs_are_rejected_before_execution(
+    admin_client: TestClient,
+    field: str,
+    value: object,
+    code: str,
+) -> None:
+    payload = _valid_update_payload()
+    payload[field] = value
+
+    response = admin_client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == code
+
+
+def test_arbitrary_shell_and_path_fields_are_not_accepted(
+    admin_client: TestClient,
+) -> None:
+    payload = _valid_update_payload()
+    payload["command"] = "docker compose up"
+    payload["composeFile"] = "/tmp/docker-compose.yaml"
+
+    response = admin_client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    details = response.json()["detail"]
+    assert any(error["loc"][-1] == "command" for error in details)
+    assert any(error["loc"][-1] == "composeFile" for error in details)
+
+
+def test_current_deployment_state_returns_typed_shape(admin_client: TestClient) -> None:
+    response = admin_client.get("/api/v1/operations/deployment/stacks/moonmind")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["stack"] == "moonmind"
+    assert payload["projectName"] == "moonmind"
+    assert payload["configuredImage"].startswith("ghcr.io/moonladderstudios/moonmind:")
+    assert payload["services"][0]["name"] == "api"
+    assert payload["services"][0]["state"] == "unknown"
+
+
+def test_allowed_image_targets_return_digest_guidance(admin_client: TestClient) -> None:
+    response = admin_client.get(
+        "/api/v1/operations/deployment/image-targets",
+        params={"stack": "moonmind"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["stack"] == "moonmind"
+    repository = payload["repositories"][0]
+    assert repository["repository"] == "ghcr.io/moonladderstudios/moonmind"
+    assert repository["digestPinningRecommended"] is True
+    assert "latest" in repository["allowedReferences"]


### PR DESCRIPTION
Jira issue key: MM-518

Active MoonSpec feature path: specs/260-policy-gated-deployment-update

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_deployment_operations.py: PASS
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh: PASS
- ./tools/test_integration.sh: NOT RUN to completion because the managed workspace has no Docker socket at /var/run/docker.sock

Remaining risks:
- Hermetic compose-backed integration validation still needs an environment with Docker access.
- The current stack-state endpoint returns policy-backed typed state placeholders until a future deployment-state collector is wired behind the same contract.