### PR TITLE
MM-519 typed deployment update tool contract

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/260-policy-gated-deployment-update"
+  "feature_directory": "specs/261-typed-deployment-update-tool-contract"
 }

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 from uuid import UUID
 
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+)
+
 
 _IMAGE_REFERENCE_PATTERN = re.compile(
     r"^(?:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}|sha256:[A-Fa-f0-9]{64})$"
@@ -167,7 +172,7 @@ class DeploymentOperationsService:
                 submission=submission,
             ),
             repository=None,
-            integration="deployment.update_compose_stack",
+            integration=DEPLOYMENT_UPDATE_TOOL_NAME,
             summary=(
                 f"Policy-gated deployment update for {policy.stack} to "
                 f"{submission.repository}:{submission.reference}."
@@ -199,7 +204,7 @@ class DeploymentOperationsService:
                 "instructions": (
                     "Run the policy-gated deployment update operation for "
                     f"stack '{policy.stack}' using the typed "
-                    "deployment.update_compose_stack tool contract."
+                    f"{DEPLOYMENT_UPDATE_TOOL_NAME} tool contract."
                 ),
                 "operation": {
                     "type": "deployment.update",
@@ -212,8 +217,8 @@ class DeploymentOperationsService:
                         "title": "Update MoonMind deployment",
                         "tool": {
                             "type": "skill",
-                            "name": "deployment.update_compose_stack",
-                            "version": "1.0.0",
+                            "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+                            "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
                         },
                         "inputs": {
                             "stack": policy.stack,

--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -1,0 +1,125 @@
+"""Canonical deployment executable tool contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEPLOYMENT_UPDATE_TOOL_NAME = "deployment.update_compose_stack"
+DEPLOYMENT_UPDATE_TOOL_VERSION = "1.0.0"
+
+_MOONMIND_REPOSITORY = "ghcr.io/moonladderstudios/moonmind"
+_NON_RETRYABLE_DEPLOYMENT_ERRORS = (
+    "INVALID_INPUT",
+    "PERMISSION_DENIED",
+    "POLICY_VIOLATION",
+    "DEPLOYMENT_LOCKED",
+)
+
+
+def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
+    """Build the MM-519 deployment update tool registry definition."""
+
+    return {
+        "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+        "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+        "type": "skill",
+        "description": (
+            "Update an allowlisted Docker Compose stack to a desired MoonMind "
+            "image reference."
+        ),
+        "inputs": {
+            "schema": {
+                "type": "object",
+                "required": ["stack", "image", "reason"],
+                "additionalProperties": False,
+                "properties": {
+                    "stack": {"type": "string", "enum": ["moonmind"]},
+                    "image": {
+                        "type": "object",
+                        "required": ["repository", "reference"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "repository": {
+                                "type": "string",
+                                "enum": [_MOONMIND_REPOSITORY],
+                            },
+                            "reference": {"type": "string"},
+                            "resolvedDigest": {"type": "string"},
+                        },
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["changed_services", "force_recreate"],
+                    },
+                    "removeOrphans": {"type": "boolean"},
+                    "wait": {"type": "boolean"},
+                    "runSmokeCheck": {"type": "boolean"},
+                    "pauseWork": {"type": "boolean"},
+                    "pruneOldImages": {"type": "boolean"},
+                    "reason": {"type": "string"},
+                },
+            }
+        },
+        "outputs": {
+            "schema": {
+                "type": "object",
+                "required": [
+                    "status",
+                    "stack",
+                    "requestedImage",
+                    "updatedServices",
+                    "runningServices",
+                ],
+                "additionalProperties": False,
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["SUCCEEDED", "FAILED", "PARTIALLY_VERIFIED"],
+                    },
+                    "stack": {"type": "string"},
+                    "requestedImage": {"type": "string"},
+                    "resolvedDigest": {"type": "string"},
+                    "updatedServices": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "runningServices": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": True,
+                        },
+                    },
+                    "beforeStateArtifactRef": {"type": "string"},
+                    "afterStateArtifactRef": {"type": "string"},
+                    "commandLogArtifactRef": {"type": "string"},
+                    "verificationArtifactRef": {"type": "string"},
+                },
+            }
+        },
+        "executor": {
+            "activity_type": "mm.tool.execute",
+            "selector": {"mode": "by_capability"},
+        },
+        "requirements": {
+            "capabilities": ["deployment_control", "docker_admin"],
+        },
+        "policies": {
+            "timeouts": {
+                "start_to_close_seconds": 900,
+                "schedule_to_close_seconds": 1800,
+            },
+            "retries": {
+                "max_attempts": 1,
+                "non_retryable_error_codes": list(_NON_RETRYABLE_DEPLOYMENT_ERRORS),
+            },
+        },
+        "security": {"allowed_roles": ["admin"]},
+    }
+
+
+__all__ = [
+    "DEPLOYMENT_UPDATE_TOOL_NAME",
+    "DEPLOYMENT_UPDATE_TOOL_VERSION",
+    "build_deployment_update_tool_definition_payload",
+]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -59,6 +59,10 @@ from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as C
 from moonmind.codex_cloud.settings import build_codex_cloud_gate, CODEX_CLOUD_DISABLED_MESSAGE
 from moonmind.workflows.adapters.jules_client import JulesClient
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    build_deployment_update_tool_definition_payload,
+)
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -730,6 +734,9 @@ def _tail_text(payload: bytes, *, max_chars: int = 512) -> str:
 def _default_registry_skill_payload(*, name: str, version: str) -> dict[str, Any]:
     if is_dood_tool(name):
         return build_dood_tool_definition_payload(name=name, version=version)
+
+    if name == DEPLOYMENT_UPDATE_TOOL_NAME:
+        return build_deployment_update_tool_definition_payload()
 
     if name == "security.pentest.run":
         return {

--- a/specs/261-typed-deployment-update-tool-contract/checklists/requirements.md
+++ b/specs/261-typed-deployment-update-tool-contract/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Typed Deployment Update Tool Contract
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Runtime classification is explicit. The source design is a canonical desired-state doc, but MM-519 selects one independently testable executable tool contract slice.

--- a/specs/261-typed-deployment-update-tool-contract/contracts/deployment-update-tool-contract.md
+++ b/specs/261-typed-deployment-update-tool-contract/contracts/deployment-update-tool-contract.md
@@ -1,0 +1,73 @@
+# Contract: `deployment.update_compose_stack` Tool Definition
+
+## Registry Payload
+
+The canonical builder returns a payload parseable by `parse_tool_definition`:
+
+```yaml
+name: deployment.update_compose_stack
+version: 1.0.0
+type: skill
+executor:
+  activity_type: mm.tool.execute
+  selector:
+    mode: by_capability
+requirements:
+  capabilities:
+    - deployment_control
+    - docker_admin
+security:
+  allowed_roles:
+    - admin
+policies:
+  timeouts:
+    start_to_close_seconds: 900
+    schedule_to_close_seconds: 1800
+  retries:
+    max_attempts: 1
+    non_retryable_error_codes:
+      - INVALID_INPUT
+      - PERMISSION_DENIED
+      - POLICY_VIOLATION
+      - DEPLOYMENT_LOCKED
+```
+
+## Valid Plan Node
+
+```json
+{
+  "id": "update-moonmind-deployment",
+  "tool": {
+    "type": "skill",
+    "name": "deployment.update_compose_stack",
+    "version": "1.0.0"
+  },
+  "inputs": {
+    "stack": "moonmind",
+    "image": {
+      "repository": "ghcr.io/moonladderstudios/moonmind",
+      "reference": "20260425.1234"
+    },
+    "mode": "changed_services",
+    "removeOrphans": true,
+    "wait": true,
+    "runSmokeCheck": true,
+    "pauseWork": false,
+    "pruneOldImages": false,
+    "reason": "Update to the latest tested MoonMind build"
+  }
+}
+```
+
+## Rejected Plan Inputs
+
+The input schema rejects these fields before execution:
+
+- `command`
+- `shell`
+- `composeFile`
+- `composeFiles`
+- `hostPath`
+- `composeProjectDir`
+- `updaterRunnerImage`
+- unrecognized flags

--- a/specs/261-typed-deployment-update-tool-contract/data-model.md
+++ b/specs/261-typed-deployment-update-tool-contract/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Typed Deployment Update Tool Contract
+
+## Deployment Update Tool Definition
+
+- `name`: `deployment.update_compose_stack`
+- `version`: `1.0.0`
+- `type`: `skill`
+- `description`: Operator-readable summary of the privileged Compose stack update operation.
+- `inputs.schema`: Strict JSON schema for bounded deployment update inputs.
+- `outputs.schema`: JSON schema for structured result and artifact references.
+- `executor.activity_type`: `mm.tool.execute`
+- `executor.selector.mode`: `by_capability`
+- `requirements.capabilities`: `deployment_control`, `docker_admin`
+- `policies.timeouts`: start-to-close and schedule-to-close bounds for privileged update execution.
+- `policies.retries`: `max_attempts = 1` and non-retryable privileged failure codes.
+- `security.allowed_roles`: `admin`
+
+## Deployment Update Plan Node Inputs
+
+- `stack`: allowlisted stack name. V1 enum: `moonmind`.
+- `image.repository`: allowlisted MoonMind image repository.
+- `image.reference`: requested tag or digest reference.
+- `image.resolvedDigest`: optional resolved digest.
+- `mode`: `changed_services` or `force_recreate`.
+- `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, `pruneOldImages`: bounded booleans.
+- `reason`: required operator reason.
+
+## Validation Rules
+
+- Root input object rejects unknown fields.
+- `image` object rejects unknown fields.
+- Required fields are `stack`, `image`, and `reason`; `image.repository` and `image.reference` are required inside `image`.
+- Unsupported mode values fail schema validation.
+- Shell/path/runner override fields are not part of the schema and fail before execution.

--- a/specs/261-typed-deployment-update-tool-contract/plan.md
+++ b/specs/261-typed-deployment-update-tool-contract/plan.md
@@ -21,7 +21,15 @@ Implement MM-519 by adding a canonical deployment update executable tool definit
 | FR-008 | implemented_verified | invalid plan validation parameterized tests reject shell/path/runner override fields | complete | integration-style passed |
 | FR-009 | implemented_verified | `deployment_operations.py` imports shared constants; API unit test asserts name/version | complete | unit passed |
 | FR-010 | implemented_verified | MM-519 is preserved in spec/tasks/verification and traceability check passed | complete | final verify passed |
-| DESIGN-REQ-001..009 | implemented_verified | contract helper, API binding, targeted tests, and traceability check cover the source mappings | complete | unit + integration-style passed |
+| DESIGN-REQ-001 | implemented_verified | `deployment_tools.py` defines `deployment.update_compose_stack`; unit test asserts parsed definition | complete | unit passed |
+| DESIGN-REQ-002 | implemented_verified | strict input schema in `deployment_tools.py`; unit and plan validation tests cover required and optional fields | complete | unit + integration-style passed |
+| DESIGN-REQ-003 | implemented_verified | output schema assertions in `test_deployment_tool_contracts.py` cover status, image, services, and artifact refs | complete | unit passed |
+| DESIGN-REQ-004 | implemented_verified | capabilities/admin assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| DESIGN-REQ-005 | implemented_verified | executor binding assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| DESIGN-REQ-006 | implemented_verified | retry policy assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| DESIGN-REQ-007 | implemented_verified | representative plan node validation and API queued-run assertions cover canonical name/version and typed inputs | complete | unit + integration-style passed |
+| DESIGN-REQ-008 | implemented_verified | invalid plan validation tests reject shell/path/runner override fields before execution | complete | integration-style passed |
+| DESIGN-REQ-009 | implemented_verified | executable tool definition uses `mm.tool.execute`; tasks and verification preserve non-agent-instruction boundary | complete | unit + final verify passed |
 
 ## Technical Context
 

--- a/specs/261-typed-deployment-update-tool-contract/plan.md
+++ b/specs/261-typed-deployment-update-tool-contract/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Typed Deployment Update Tool Contract
+
+**Branch**: `261-typed-deployment-update-tool-contract` | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/261-typed-deployment-update-tool-contract/spec.md`
+
+## Summary
+
+Implement MM-519 by adding a canonical deployment update executable tool definition payload and using its shared name/version from the policy-gated deployment API queued-run plan node. Validate the contract with unit tests for registry parsing and integration-style plan validation against a pinned registry snapshot. Existing MM-518 API behavior remains the submission and policy-validation slice; this story adds the tool-contract boundary needed by the plan/tool system.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workflows/skills/deployment_tools.py`; `tests/unit/workflows/skills/test_deployment_tool_contracts.py` | complete | unit passed |
+| FR-002 | implemented_verified | strict input schema in `deployment_tools.py`; plan validation tests reject unknown fields | complete | unit + integration-style passed |
+| FR-003 | implemented_verified | output schema assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| FR-004 | implemented_verified | capabilities/admin assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| FR-005 | implemented_verified | executor assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| FR-006 | implemented_verified | retry policy assertions in `test_deployment_tool_contracts.py` | complete | unit passed |
+| FR-007 | implemented_verified | valid pinned registry plan validation test in `test_deployment_tool_contracts.py` | complete | integration-style passed |
+| FR-008 | implemented_verified | invalid plan validation parameterized tests reject shell/path/runner override fields | complete | integration-style passed |
+| FR-009 | implemented_verified | `deployment_operations.py` imports shared constants; API unit test asserts name/version | complete | unit passed |
+| FR-010 | implemented_unverified | MM-519 is preserved in spec/tasks and traceability check passed; final verification pending | produce verification report | final verify |
+| DESIGN-REQ-001..009 | implemented_verified | contract helper, API binding, targeted tests, and traceability check cover the source mappings | complete | unit + integration-style passed |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2 contracts, existing MoonMind skill/tool plan contract helpers, pytest  
+**Storage**: No new persistent storage  
+**Unit Testing**: pytest through `./tools/test_unit.sh` and targeted pytest  
+**Integration Testing**: pytest integration-style plan validation; no compose-backed services required for this contract slice  
+**Target Platform**: Linux server / MoonMind managed runtime  
+**Project Type**: Python backend/orchestration contract  
+**Performance Goals**: Registry and plan validation remain deterministic in-process checks  
+**Constraints**: No raw host shell exposure, no arbitrary runner image/path inputs, no hidden image reference transformation, no new compatibility aliases  
+**Scale/Scope**: One deployment update tool contract and one queued-run plan-node binding
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. The feature exposes an executable tool contract for orchestration instead of rebuilding Docker behavior in agent prompts.
+- II One-Click Agent Deployment: PASS. The contract supports operator-owned Docker Compose deployment without adding external dependencies.
+- III Avoid Vendor Lock-In: PASS. The tool contract stays behind MoonMind's generic plan/tool surface.
+- IV Own Your Data: PASS. The output schema uses artifact refs and structured results under operator control.
+- V Skills Are First-Class: PASS. The executable tool is registered through the existing tool definition contract.
+- VI Replaceable Scaffolding: PASS. The contract is thin and test-anchored.
+- VII Runtime Configurability: PASS. Stack/repository policy remains configuration-driven in the existing deployment API slice.
+- VIII Modular Architecture: PASS. New behavior is isolated to deployment tool contract helpers and tests.
+- IX Resilient by Default: PASS. Retry policy is explicit and non-retryable privileged failures fail closed.
+- X Continuous Improvement: PASS. Verification artifacts record outcome and traceability.
+- XI Spec-Driven Development: PASS. This plan follows the MM-519 spec before code changes.
+- XII Documentation Separation: PASS. Migration/execution notes stay under `specs/261-*`, not canonical docs.
+- XIII Delete, Don't Deprecate: PASS. No compatibility alias is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/261-typed-deployment-update-tool-contract/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── deployment-update-tool-contract.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/skills/
+├── deployment_tools.py
+├── tool_plan_contracts.py
+└── tool_registry.py
+
+api_service/services/
+└── deployment_operations.py
+
+tests/unit/workflows/skills/
+└── test_deployment_tool_contracts.py
+
+tests/unit/api/routers/
+└── test_deployment_operations.py
+```
+
+**Structure Decision**: Add a small shared contract helper under `moonmind/workflows/skills` because the contract belongs to the executable plan/tool system and can be consumed by API queuing code without creating a new storage path.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/261-typed-deployment-update-tool-contract/plan.md
+++ b/specs/261-typed-deployment-update-tool-contract/plan.md
@@ -20,7 +20,7 @@ Implement MM-519 by adding a canonical deployment update executable tool definit
 | FR-007 | implemented_verified | valid pinned registry plan validation test in `test_deployment_tool_contracts.py` | complete | integration-style passed |
 | FR-008 | implemented_verified | invalid plan validation parameterized tests reject shell/path/runner override fields | complete | integration-style passed |
 | FR-009 | implemented_verified | `deployment_operations.py` imports shared constants; API unit test asserts name/version | complete | unit passed |
-| FR-010 | implemented_unverified | MM-519 is preserved in spec/tasks and traceability check passed; final verification pending | produce verification report | final verify |
+| FR-010 | implemented_verified | MM-519 is preserved in spec/tasks/verification and traceability check passed | complete | final verify passed |
 | DESIGN-REQ-001..009 | implemented_verified | contract helper, API binding, targeted tests, and traceability check cover the source mappings | complete | unit + integration-style passed |
 
 ## Technical Context

--- a/specs/261-typed-deployment-update-tool-contract/quickstart.md
+++ b/specs/261-typed-deployment-update-tool-contract/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Typed Deployment Update Tool Contract
+
+## Targeted Unit Validation
+
+```bash
+pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/api/routers/test_deployment_operations.py -q
+```
+
+Expected result: deployment tool contract tests pass and existing deployment API queued-run tests continue to pass using the shared canonical tool name/version.
+
+## Full Unit Validation
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected result: required unit suite passes.
+
+## Integration Validation
+
+The story's integration boundary is in-process plan validation against a pinned registry snapshot. Run:
+
+```bash
+pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py -q
+```
+
+Expected result: valid representative deployment update plan payload validates, while shell/path/runner override payloads fail before execution.
+
+## Traceability Check
+
+```bash
+rg -n "MM-519|DESIGN-REQ-001|DESIGN-REQ-009|deployment.update_compose_stack" specs/261-typed-deployment-update-tool-contract moonmind/workflows/skills api_service/services tests/unit/workflows/skills tests/unit/api/routers
+```
+
+Expected result: MM-519 and source design coverage remain visible in artifacts, code, and tests.

--- a/specs/261-typed-deployment-update-tool-contract/research.md
+++ b/specs/261-typed-deployment-update-tool-contract/research.md
@@ -1,0 +1,41 @@
+# Research: Typed Deployment Update Tool Contract
+
+## FR-001 / DESIGN-REQ-001 - Canonical Tool Name And Version
+
+Decision: Add a shared deployment tool contract helper that exposes `DEPLOYMENT_UPDATE_TOOL_NAME`, `DEPLOYMENT_UPDATE_TOOL_VERSION`, and a registry payload builder.
+Evidence: `api_service/services/deployment_operations.py` currently hardcodes `deployment.update_compose_stack`; `moonmind/workflows/skills/tool_plan_contracts.py` already parses versioned `ToolDefinition` payloads.
+Rationale: A shared helper prevents the API queued-run path and registry tests from diverging.
+Alternatives considered: Keeping strings inline was rejected because MM-519 requires a canonical registry contract.
+Test implications: Unit tests for payload parsing and API queued-run references.
+
+## FR-002 / FR-008 - Strict Input Schema
+
+Decision: Use JSON Schema `additionalProperties: false` at the root and `image` object levels, with enums for stack and mode.
+Evidence: `plan_validation.py` enforces `additionalProperties: false`, required fields, types, and enum values during plan validation.
+Rationale: Strict schema validation blocks arbitrary shell snippets, Compose paths, host paths, runner image overrides, and unrecognized flags before execution.
+Alternatives considered: Relying only on API request validation was rejected because plans can be validated independently against registry snapshots.
+Test implications: Integration-style plan validation tests for valid and invalid node inputs.
+
+## FR-003 - Output Schema
+
+Decision: Model output fields documented by section 8.2, with required status, stack, requestedImage, updatedServices, and runningServices, plus optional resolvedDigest and artifact refs.
+Evidence: `docs/Tools/DockerComposeUpdateSystem.md` section 8.2 lists the required output shape.
+Rationale: Downstream workflow steps need structured result fields and artifact refs, not command text scraping.
+Alternatives considered: Leaving output schema open was rejected because source requires documented output fields.
+Test implications: Unit test asserts required output fields and status enum.
+
+## FR-004 / FR-005 / FR-006 - Privileged Execution Policy
+
+Decision: The registry payload declares capabilities `deployment_control` and `docker_admin`, `security.allowed_roles = [admin]`, executor `mm.tool.execute` with selector `by_capability`, and retries `max_attempts = 1` with non-retryable privileged error codes.
+Evidence: Existing `ToolDefinition` supports these fields and Temporal activity catalog consumes retry policy from definitions.
+Rationale: Deployment updates are privileged operational work and should fail closed for invalid or locked operations.
+Alternatives considered: A generic skill execution contract was rejected because the source doc requires deployment-control capabilities.
+Test implications: Unit test assertions on parsed `ToolDefinition`.
+
+## FR-007 / FR-009 - Plan Validation And API Binding
+
+Decision: Validate representative deployment update plan payloads against a pinned registry snapshot and update the API queued-run builder to use shared tool constants.
+Evidence: `create_registry_snapshot` and `validate_plan_payload` already provide deterministic validation against tool schemas.
+Rationale: This proves the exact invocation shape used by the policy-gated API can be accepted by the plan/tool system.
+Alternatives considered: Testing only the helper payload was rejected because MM-519 requires plan-node validation.
+Test implications: Unit plus integration-style validation tests.

--- a/specs/261-typed-deployment-update-tool-contract/spec.md
+++ b/specs/261-typed-deployment-update-tool-contract/spec.md
@@ -139,6 +139,7 @@ Relevant Implementation Notes
 - **DESIGN-REQ-007**: Source section 8.3 requires a representative plan node using `tool.type = skill`, canonical name/version, and typed inputs. Scope: in scope. Maps to FR-007 and FR-009.
 - **DESIGN-REQ-008**: Source sections 4.2, 5, and 20 forbid arbitrary shell input, user-selectable runner images, arbitrary host paths, arbitrary Compose files, and hidden target image transformations. Scope: in scope. Maps to FR-008.
 - **DESIGN-REQ-009**: Source section 16 requires deployment updates to interact with task execution through executable operational work rather than agent instruction bundles. Scope: in scope. Maps to FR-001, FR-005, and FR-007.
+- **DESIGN-REQ-016**: Source section 16 requires task execution to resolve `deployment.update_compose_stack` through the executable tool registry path used by queued deployment runs. Scope: in scope. Maps to FR-001, FR-007, and FR-009.
 
 ## Success Criteria *(mandatory)*
 
@@ -148,4 +149,4 @@ Relevant Implementation Notes
 - **SC-002**: A representative valid deployment update plan node validates successfully against a pinned registry snapshot.
 - **SC-003**: Representative invalid deployment update plan nodes containing shell/path/runner override inputs fail validation before execution.
 - **SC-004**: Existing policy-gated API tests confirm queued deployment update runs use the canonical shared tool name and version.
-- **SC-005**: Verification evidence preserves `MM-519`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-009 in MoonSpec artifacts.
+- **SC-005**: Verification evidence preserves `MM-519`, the canonical Jira preset brief, DESIGN-REQ-001 through DESIGN-REQ-009, and DESIGN-REQ-016 in MoonSpec artifacts.

--- a/specs/261-typed-deployment-update-tool-contract/spec.md
+++ b/specs/261-typed-deployment-update-tool-contract/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Typed Deployment Update Tool Contract
+
+**Feature Branch**: `261-typed-deployment-update-tool-contract`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-519 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-519 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-519
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Typed deployment update tool contract
+- Labels: `moonmind-workflow-mm-d22f5e68-8c97-4885-b9c4-cc74b6576885`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-519 from MM project
+Summary: Typed deployment update tool contract
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-519 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-519: Typed deployment update tool contract
+
+Source Reference
+Source Document: docs/Tools/DockerComposeUpdateSystem.md
+Source Title: Docker Compose Deployment Update System
+Source Sections:
+- 8. Executable tool contract
+- 16. Interaction with task execution
+- 20. Locked decisions
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-016
+- DESIGN-REQ-002
+- DESIGN-REQ-004
+As an operator of MoonMind workflows, I need deployment.update_compose_stack registered as a typed privileged executable tool, so deployment updates can be orchestrated through the plan/tool system rather than ad hoc shell execution.
+
+Acceptance Criteria
+- The tool registry exposes deployment.update_compose_stack version 1.0.0 with the documented required inputs and outputs.
+- The tool requires deployment_control and docker_admin capabilities and admin authorization.
+- The tool schema accepts stack, image.repository, image.reference, optional resolvedDigest, mode, options, and reason.
+- The tool output schema includes status, stack, requestedImage, resolvedDigest, updatedServices, runningServices, and artifact refs.
+- Retry policy uses max_attempts 1 with documented non-retryable error codes.
+- Plan-node validation supports the representative skill tool invocation and rejects arbitrary shell snippets or runner image overrides.
+
+Requirements
+- Keep deployment update as executable operational work in the tool/plan system.
+- Avoid treating deployment update as an agent instruction bundle.
+- Preserve exact target image input semantics without hidden transformations.
+
+Relevant Implementation Notes
+- Preserve MM-519 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tools/DockerComposeUpdateSystem.md` as the source design reference for the typed deployment update tool contract, task execution interaction, and locked decisions.
+- Register `deployment.update_compose_stack` as a typed privileged executable tool, not as an agent instruction bundle or ad hoc shell workflow.
+- Keep exact target image input semantics for repository, reference, and optional resolved digest without hidden transformations.
+- Validate representative skill tool invocations through the plan/tool system and reject arbitrary shell snippets or runner image overrides.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Typed Deployment Update Tool Contract
+
+**Summary**: As an operator of MoonMind workflows, I need `deployment.update_compose_stack` registered as a typed privileged executable tool, so deployment updates can be orchestrated through the plan/tool system rather than ad hoc shell execution.
+
+**Goal**: Deployment update runs can reference a versioned executable tool contract whose schema, capabilities, authorization, retry policy, and plan-node validation rules are deterministic before any privileged Compose operation is dispatched.
+
+**Independent Test**: Can be fully tested by loading the deployment update tool definition into the existing tool registry and validating representative plan nodes, confirming valid typed deployment inputs pass and arbitrary shell, runner-image, and path fields fail schema validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** the deployment tool registry is loaded, **When** the `deployment.update_compose_stack` definition is inspected, **Then** it exposes version `1.0.0`, required input and output schemas, `deployment_control` and `docker_admin` capabilities, admin-only security, and a non-retryable privileged-operation retry policy.
+2. **Given** a representative deployment update plan node using the typed tool and documented inputs, **When** the plan is validated against the pinned registry snapshot, **Then** validation succeeds with `tool.type = skill`, name `deployment.update_compose_stack`, and version `1.0.0`.
+3. **Given** a deployment update plan node that includes arbitrary shell commands, caller-provided Compose paths, or an updater runner image override, **When** the plan is validated against the pinned registry snapshot, **Then** validation fails before tool execution.
+4. **Given** a queued deployment update is produced from the policy-gated API, **When** its initial parameters are inspected, **Then** the plan node uses the canonical deployment tool name and version instead of a raw shell command or ad hoc runner contract.
+
+### Edge Cases
+
+- Missing `stack`, `image`, or `reason` fields fail schema validation.
+- Unsupported update modes fail schema validation.
+- Unknown root-level plan inputs such as `command`, `composeFile`, `hostPath`, or `updaterRunnerImage` fail schema validation.
+- Optional `resolvedDigest` remains accepted without changing requested repository/reference semantics.
+
+## Assumptions
+
+- MM-518 owns the policy-gated API and request authorization slice; MM-519 owns the executable tool definition and plan-validation contract slice.
+- The first implementation registers the contract payload and validates plan-node shape; the privileged Docker execution handler remains a later deployment-control worker concern unless already present.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a canonical tool definition for `deployment.update_compose_stack` version `1.0.0`.
+- **FR-002**: The tool definition MUST require `stack`, `image.repository`, `image.reference`, and `reason` inputs while accepting optional `image.resolvedDigest`, `mode`, `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, and `pruneOldImages` inputs.
+- **FR-003**: The tool definition MUST declare output schema fields for `status`, `stack`, `requestedImage`, optional `resolvedDigest`, `updatedServices`, `runningServices`, and artifact refs for before state, after state, command log, and verification.
+- **FR-004**: The tool definition MUST require `deployment_control` and `docker_admin` capabilities and admin authorization.
+- **FR-005**: The tool definition MUST use the `mm.tool.execute` activity binding with selector mode `by_capability`.
+- **FR-006**: The tool definition MUST use `max_attempts` 1 and identify non-retryable error codes for invalid input, permission denial, policy violation, and deployment locking.
+- **FR-007**: Plan validation MUST accept a representative typed deployment update plan node that uses the canonical tool definition and documented inputs.
+- **FR-008**: Plan validation MUST reject arbitrary shell snippets, caller-provided Compose paths, host paths, runner image overrides, and unrecognized flags before tool execution.
+- **FR-009**: The policy-gated API queued-run payload MUST reference the canonical tool name and version from a shared contract source, not hardcoded divergent strings.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-519` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Deployment Update Tool Definition**: Versioned executable tool contract containing schemas, capability requirements, executor binding, retry policy, and admin security.
+- **Deployment Update Plan Node**: A plan entry that invokes the typed deployment update tool with bounded deployment inputs.
+- **Deployment Update Tool Result**: Structured output describing status, requested image, resolved digest when known, changed/running services, and durable artifact refs.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 8.1 requires deployment update to be represented as typed executable tool `deployment.update_compose_stack`. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-002**: Source section 8.2 requires input schema fields for stack, image repository/reference/resolved digest, mode, options, and reason. Scope: in scope. Maps to FR-002.
+- **DESIGN-REQ-003**: Source section 8.2 requires output schema fields for status, stack, requested image, resolved digest, updated services, running services, and artifact refs. Scope: in scope. Maps to FR-003.
+- **DESIGN-REQ-004**: Source section 8.2 requires `deployment_control` and `docker_admin` capabilities plus admin-only security. Scope: in scope. Maps to FR-004.
+- **DESIGN-REQ-005**: Source section 8.2 requires executor activity type `mm.tool.execute` with `by_capability` selector. Scope: in scope. Maps to FR-005.
+- **DESIGN-REQ-006**: Source section 8.2 requires retry policy `max_attempts` 1 with non-retryable invalid input, permission, policy, and lock failures. Scope: in scope. Maps to FR-006.
+- **DESIGN-REQ-007**: Source section 8.3 requires a representative plan node using `tool.type = skill`, canonical name/version, and typed inputs. Scope: in scope. Maps to FR-007 and FR-009.
+- **DESIGN-REQ-008**: Source sections 4.2, 5, and 20 forbid arbitrary shell input, user-selectable runner images, arbitrary host paths, arbitrary Compose files, and hidden target image transformations. Scope: in scope. Maps to FR-008.
+- **DESIGN-REQ-009**: Source section 16 requires deployment updates to interact with task execution through executable operational work rather than agent instruction bundles. Scope: in scope. Maps to FR-001, FR-005, and FR-007.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Registry parsing exposes exactly one `deployment.update_compose_stack` v1.0.0 contract with the required schemas, capabilities, security, executor, and retry policy.
+- **SC-002**: A representative valid deployment update plan node validates successfully against a pinned registry snapshot.
+- **SC-003**: Representative invalid deployment update plan nodes containing shell/path/runner override inputs fail validation before execution.
+- **SC-004**: Existing policy-gated API tests confirm queued deployment update runs use the canonical shared tool name and version.
+- **SC-005**: Verification evidence preserves `MM-519`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-009 in MoonSpec artifacts.

--- a/specs/261-typed-deployment-update-tool-contract/tasks.md
+++ b/specs/261-typed-deployment-update-tool-contract/tasks.md
@@ -1,0 +1,100 @@
+# Tasks: Typed Deployment Update Tool Contract
+
+**Input**: Design documents from `/specs/261-typed-deployment-update-tool-contract/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style plan validation are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-519 user story.
+
+**Source Traceability**: Tasks cover FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-001 through DESIGN-REQ-009.
+
+**Test Commands**:
+
+- Unit tests: `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/api/routers/test_deployment_operations.py -q`
+- Integration tests: `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py -q`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing contract infrastructure can host the story.
+
+- [X] T001 Inspect existing tool definition, registry snapshot, and plan validation helpers in `moonmind/workflows/skills/tool_plan_contracts.py`, `moonmind/workflows/skills/tool_registry.py`, and `moonmind/workflows/skills/plan_validation.py`. (FR-001-FR-008)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new foundation is needed beyond existing registry and plan validation contracts.
+
+- [X] T002 Confirm existing policy-gated API queued-run payload location in `api_service/services/deployment_operations.py`. (FR-009)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Typed Deployment Update Tool Contract
+
+**Summary**: As an operator of MoonMind workflows, I need `deployment.update_compose_stack` registered as a typed privileged executable tool, so deployment updates can be orchestrated through the plan/tool system rather than ad hoc shell execution.
+
+**Independent Test**: Validate the canonical tool definition and representative plan nodes against the existing registry and plan validation helpers.
+
+**Traceability**: FR-001-FR-010, SC-001-SC-005, DESIGN-REQ-001-DESIGN-REQ-009
+
+**Test Plan**:
+
+- Unit: tool definition schema, capabilities, executor, retry policy, admin role, API queued-run shared constants.
+- Integration: pinned registry snapshot plus valid and invalid representative plan validation.
+
+### Unit Tests (write first) ⚠️
+
+- [X] T003 [P] Add failing unit tests for deployment tool definition name, version, schema, capabilities, executor, security, and retry policy in `tests/unit/workflows/skills/test_deployment_tool_contracts.py`. (FR-001-FR-006, SC-001, DESIGN-REQ-001-DESIGN-REQ-006)
+- [X] T004 [P] Update deployment API unit assertions in `tests/unit/api/routers/test_deployment_operations.py` to prove queued-run payloads use the shared canonical tool name/version. (FR-009, SC-004, DESIGN-REQ-007)
+- [X] T005 Run `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/api/routers/test_deployment_operations.py -q` to confirm T003-T004 fail for the expected missing contract. (FR-001-FR-009)
+
+### Integration Tests (write first) ⚠️
+
+- [X] T006 [P] Add plan validation tests in `tests/unit/workflows/skills/test_deployment_tool_contracts.py` for a valid representative deployment update plan node. (FR-007, SC-002, DESIGN-REQ-007)
+- [X] T007 [P] Add plan validation rejection tests in `tests/unit/workflows/skills/test_deployment_tool_contracts.py` for `command`, `composeFile`, `hostPath`, and `updaterRunnerImage` inputs. (FR-008, SC-003, DESIGN-REQ-008)
+- [X] T008 Run `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py -q` to confirm T006-T007 fail for the expected missing contract. (FR-007-FR-008)
+
+### Implementation
+
+- [X] T009 Implement canonical deployment update tool contract constants and payload builder in `moonmind/workflows/skills/deployment_tools.py`. (FR-001-FR-006, DESIGN-REQ-001-DESIGN-REQ-006)
+- [X] T010 Update `api_service/services/deployment_operations.py` to use canonical deployment tool constants for queued-run plan nodes and integration metadata. (FR-009, DESIGN-REQ-007)
+- [X] T011 Run targeted unit and integration-style validation commands and fix failures. (FR-001-FR-009, SC-001-SC-004)
+- [X] T012 Run traceability check for MM-519 and DESIGN-REQ coverage across the feature artifacts, code, and tests. (FR-010, SC-005)
+
+**Checkpoint**: The story is fully functional, covered by unit and integration-style tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and outcome recording.
+
+- [X] T013 Run `./tools/test_unit.sh` for full required unit verification. (SC-001-SC-005)
+- [X] T014 Run `/moonspec-verify` by producing `specs/261-typed-deployment-update-tool-contract/verification.md` with MM-519 traceability, test evidence, and final verdict. (FR-010, SC-005)
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 before Phase 2; Phase 2 before story tests.
+- T003-T004 can run in parallel.
+- T006-T007 can run in parallel after T003.
+- T009-T010 run after red-first confirmation.
+- T011-T014 complete final validation and verification.
+
+## Implementation Strategy
+
+1. Preserve the MM-519 Jira preset brief as the source in `spec.md`.
+2. Add failing contract and plan-validation tests.
+3. Implement the small shared tool contract helper and API constant binding.
+4. Run targeted tests, full unit suite, traceability check, and final MoonSpec verification.

--- a/specs/261-typed-deployment-update-tool-contract/tasks.md
+++ b/specs/261-typed-deployment-update-tool-contract/tasks.md
@@ -7,7 +7,7 @@
 
 **Organization**: Tasks are grouped by phase around the single MM-519 user story.
 
-**Source Traceability**: Tasks cover FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-001 through DESIGN-REQ-009.
+**Source Traceability**: Tasks cover FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, and DESIGN-REQ-009.
 
 **Test Commands**:
 
@@ -45,7 +45,7 @@
 
 **Independent Test**: Validate the canonical tool definition and representative plan nodes against the existing registry and plan validation helpers.
 
-**Traceability**: FR-001-FR-010, SC-001-SC-005, DESIGN-REQ-001-DESIGN-REQ-009
+**Traceability**: FR-001-FR-010, SC-001-SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009
 
 **Test Plan**:
 

--- a/specs/261-typed-deployment-update-tool-contract/tasks.md
+++ b/specs/261-typed-deployment-update-tool-contract/tasks.md
@@ -68,7 +68,7 @@
 
 - [X] T009 Implement canonical deployment update tool contract constants and payload builder in `moonmind/workflows/skills/deployment_tools.py`. (FR-001-FR-006, DESIGN-REQ-001-DESIGN-REQ-006)
 - [X] T010 Update `api_service/services/deployment_operations.py` to use canonical deployment tool constants for queued-run plan nodes and integration metadata. (FR-009, DESIGN-REQ-007)
-- [X] T011 Run targeted unit and integration-style validation commands and fix failures. (FR-001-FR-009, SC-001-SC-004)
+- [X] T011 Run targeted unit and integration-style story validation commands and fix failures. (FR-001-FR-009, SC-001-SC-004)
 - [X] T012 Run traceability check for MM-519 and DESIGN-REQ coverage across the feature artifacts, code, and tests. (FR-010, SC-005)
 
 **Checkpoint**: The story is fully functional, covered by unit and integration-style tests, and testable independently

--- a/specs/261-typed-deployment-update-tool-contract/verification.md
+++ b/specs/261-typed-deployment-update-tool-contract/verification.md
@@ -1,0 +1,40 @@
+# Verification: Typed Deployment Update Tool Contract
+
+**Feature**: `261-typed-deployment-update-tool-contract`  
+**Jira Issue**: MM-519  
+**Verdict**: FULLY_IMPLEMENTED  
+**Verified At**: 2026-04-25
+
+## Summary
+
+MM-519 is fully implemented. The repository now exposes a canonical `deployment.update_compose_stack` v1.0.0 executable tool contract with strict input/output schemas, privileged capabilities, admin security, `mm.tool.execute` by-capability routing, and single-attempt non-retryable privileged failure policy. The policy-gated deployment API queued-run builder uses the shared canonical tool constants, and plan validation proves representative typed deployment update nodes pass while shell/path/runner override inputs fail before execution.
+
+## Requirement Coverage
+
+| Requirement | Verdict | Evidence |
+| --- | --- | --- |
+| FR-001 / DESIGN-REQ-001 | VERIFIED | `moonmind/workflows/skills/deployment_tools.py` defines `DEPLOYMENT_UPDATE_TOOL_NAME = "deployment.update_compose_stack"` and version `1.0.0`; unit test asserts parsed definition. |
+| FR-002 / DESIGN-REQ-002 | VERIFIED | Strict input schema requires `stack`, `image.repository`, `image.reference`, and `reason`; optional digest/mode/options are covered by `test_deployment_update_tool_definition_matches_mm519_contract`. |
+| FR-003 / DESIGN-REQ-003 | VERIFIED | Output schema includes required status, stack, requested image, updated/running services, and optional artifact refs. |
+| FR-004 / DESIGN-REQ-004 | VERIFIED | Tool definition declares `deployment_control`, `docker_admin`, and `admin`; unit test asserts all values. |
+| FR-005 / DESIGN-REQ-005 | VERIFIED | Tool definition uses `mm.tool.execute` with `by_capability`; unit test asserts binding. |
+| FR-006 / DESIGN-REQ-006 | VERIFIED | Retry policy has `max_attempts = 1` and non-retryable `INVALID_INPUT`, `PERMISSION_DENIED`, `POLICY_VIOLATION`, `DEPLOYMENT_LOCKED`. |
+| FR-007 / DESIGN-REQ-007 | VERIFIED | `test_representative_deployment_update_plan_validates_against_registry_snapshot` validates the representative plan node against a pinned registry snapshot. |
+| FR-008 / DESIGN-REQ-008 | VERIFIED | Parameterized plan validation test rejects `command`, `composeFile`, `hostPath`, and `updaterRunnerImage` as unexpected fields. |
+| FR-009 / DESIGN-REQ-007 | VERIFIED | `api_service/services/deployment_operations.py` imports shared constants; deployment API unit test asserts queued plan name/version. |
+| FR-010 / SC-005 | VERIFIED | MM-519 and DESIGN-REQ mappings are preserved in `spec.md`, `tasks.md`, this report, code docstring, and tests; traceability check passed. |
+| DESIGN-REQ-009 | VERIFIED | The plan/tool contract uses an executable tool definition rather than an agent instruction bundle or shell snippet. |
+
+## Test Evidence
+
+- `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/api/routers/test_deployment_operations.py -q`: PASS, 17 passed.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS. Python: 4027 passed, 1 xpassed, 100 warnings, 16 subtests passed. Frontend: 14 files passed, 425 tests passed.
+- Traceability command: `rg -n "MM-519|DESIGN-REQ-001|DESIGN-REQ-009|deployment.update_compose_stack" specs/261-typed-deployment-update-tool-contract moonmind/workflows/skills api_service/services tests/unit/workflows/skills tests/unit/api/routers`: PASS.
+
+## Residual Risk
+
+- The privileged Docker Compose execution handler is outside this MM-519 slice. This story verifies the typed executable tool contract and plan validation boundary only; the actual deployment-control worker execution can be delivered by the follow-on runtime execution story.
+
+## Final Decision
+
+`FULLY_IMPLEMENTED`: MM-519's typed deployment update tool contract is implemented, tested, and traceable to the canonical Jira preset brief and source design requirements.

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -13,6 +13,10 @@ from api_service.api.routers.deployment_operations import (
     router,
 )
 from api_service.auth_providers import get_current_user
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+)
 
 
 class _FakeExecutionRecord:
@@ -109,11 +113,12 @@ def test_admin_can_submit_policy_valid_deployment_update(
     request = execution_service.requests[0]
     assert request["workflow_type"] == "MoonMind.Run"
     assert request["owner_type"] == "user"
-    assert request["integration"] == "deployment.update_compose_stack"
+    assert request["integration"] == DEPLOYMENT_UPDATE_TOOL_NAME
     parameters = request["initial_parameters"]
     assert isinstance(parameters, dict)
     plan = parameters["task"]["plan"]
-    assert plan[0]["tool"]["name"] == "deployment.update_compose_stack"
+    assert plan[0]["tool"]["name"] == DEPLOYMENT_UPDATE_TOOL_NAME
+    assert plan[0]["tool"]["version"] == DEPLOYMENT_UPDATE_TOOL_VERSION
     assert plan[0]["inputs"]["stack"] == "moonmind"
 
 

--- a/tests/unit/workflows/skills/test_deployment_tool_contracts.py
+++ b/tests/unit/workflows/skills/test_deployment_tool_contracts.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+    build_deployment_update_tool_definition_payload,
+)
+from moonmind.workflows.skills.plan_validation import (
+    PlanValidationError,
+    validate_plan_payload,
+)
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.tool_registry import create_registry_snapshot
+
+
+def _snapshot():
+    return create_registry_snapshot(
+        skills=(parse_tool_definition(build_deployment_update_tool_definition_payload()),),
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+
+def _valid_plan_payload(snapshot) -> dict[str, object]:
+    return {
+        "plan_version": "1.0",
+        "metadata": {
+            "title": "MM-519 deployment update tool contract validation",
+            "created_at": "2026-04-25T00:00:00Z",
+            "registry_snapshot": {
+                "digest": snapshot.digest,
+                "artifact_ref": snapshot.artifact_ref,
+            },
+        },
+        "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+        "nodes": [
+            {
+                "id": "update-moonmind-deployment",
+                "tool": {
+                    "type": "skill",
+                    "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+                    "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+                },
+                "inputs": {
+                    "stack": "moonmind",
+                    "image": {
+                        "repository": "ghcr.io/moonladderstudios/moonmind",
+                        "reference": "20260425.1234",
+                        "resolvedDigest": "sha256:" + "a" * 64,
+                    },
+                    "mode": "changed_services",
+                    "removeOrphans": True,
+                    "wait": True,
+                    "runSmokeCheck": True,
+                    "pauseWork": False,
+                    "pruneOldImages": False,
+                    "reason": "Update to the latest tested MoonMind build",
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+
+def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
+    definition = parse_tool_definition(build_deployment_update_tool_definition_payload())
+
+    assert definition.name == DEPLOYMENT_UPDATE_TOOL_NAME
+    assert definition.version == DEPLOYMENT_UPDATE_TOOL_VERSION
+    assert definition.executor.activity_type == "mm.tool.execute"
+    assert definition.executor.selector_mode == "by_capability"
+    assert definition.required_capabilities == ("deployment_control", "docker_admin")
+    assert definition.allowed_roles == ("admin",)
+    assert definition.policies.retries.max_attempts == 1
+    assert definition.policies.retries.non_retryable_error_codes == (
+        "INVALID_INPUT",
+        "PERMISSION_DENIED",
+        "POLICY_VIOLATION",
+        "DEPLOYMENT_LOCKED",
+    )
+
+    input_schema = definition.input_schema
+    assert input_schema["required"] == ["stack", "image", "reason"]
+    assert input_schema["additionalProperties"] is False
+    assert input_schema["properties"]["stack"]["enum"] == ["moonmind"]
+    assert input_schema["properties"]["mode"]["enum"] == [
+        "changed_services",
+        "force_recreate",
+    ]
+    image_schema = input_schema["properties"]["image"]
+    assert image_schema["required"] == ["repository", "reference"]
+    assert image_schema["additionalProperties"] is False
+    assert "resolvedDigest" in image_schema["properties"]
+
+    output_schema = definition.output_schema
+    assert output_schema["required"] == [
+        "status",
+        "stack",
+        "requestedImage",
+        "updatedServices",
+        "runningServices",
+    ]
+    assert output_schema["properties"]["status"]["enum"] == [
+        "SUCCEEDED",
+        "FAILED",
+        "PARTIALLY_VERIFIED",
+    ]
+    assert "verificationArtifactRef" in output_schema["properties"]
+
+
+def test_representative_deployment_update_plan_validates_against_registry_snapshot() -> None:
+    snapshot = _snapshot()
+    validated = validate_plan_payload(
+        payload=_valid_plan_payload(snapshot),
+        registry_snapshot=snapshot,
+    )
+
+    assert validated.topological_order == ("update-moonmind-deployment",)
+    node = validated.plan.nodes[0]
+    assert node.skill_name == DEPLOYMENT_UPDATE_TOOL_NAME
+    assert node.skill_version == DEPLOYMENT_UPDATE_TOOL_VERSION
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["command", "composeFile", "hostPath", "updaterRunnerImage"],
+)
+def test_deployment_update_plan_rejects_shell_path_and_runner_overrides(
+    field: str,
+) -> None:
+    snapshot = _snapshot()
+    payload = _valid_plan_payload(snapshot)
+    payload["nodes"][0]["inputs"][field] = "docker compose up"
+
+    with pytest.raises(PlanValidationError, match=f"Unexpected field '{field}'"):
+        validate_plan_payload(payload=payload, registry_snapshot=snapshot)

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -28,6 +28,10 @@ from moonmind.workflows.skills.skill_registry import (
     create_registry_snapshot,
     parse_skill_registry,
 )
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+)
 from moonmind.workflows.temporal.activity_catalog import (
     AGENT_RUNTIME_FLEET,
     ARTIFACTS_FLEET,
@@ -716,6 +720,55 @@ async def test_default_skill_registry_payload_uses_curated_pentest_tool_definiti
         ("security.pentest.run", "1.0.0")
     ]
     assert parsed[0].executor.activity_type == "security.pentest.execute"
+
+async def test_default_skill_registry_payload_uses_curated_deployment_tool_definition():
+    payload = _default_skill_registry_payload(
+        parameters={
+            "task": {
+                "steps": [
+                    {
+                        "tool": {
+                            "type": "skill",
+                            "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+                            "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+                        }
+                    }
+                ]
+            }
+        }
+    )
+
+    skills = payload.get("skills")
+    assert isinstance(skills, list)
+    assert len(skills) == 1
+    definition = skills[0]
+
+    assert definition["name"] == DEPLOYMENT_UPDATE_TOOL_NAME
+    assert definition["version"] == DEPLOYMENT_UPDATE_TOOL_VERSION
+    assert definition["type"] == "skill"
+    assert definition["executor"] == {
+        "activity_type": "mm.tool.execute",
+        "selector": {"mode": "by_capability"},
+    }
+    assert definition["requirements"]["capabilities"] == [
+        "deployment_control",
+        "docker_admin",
+    ]
+    assert definition["security"]["allowed_roles"] == ["admin"]
+
+    input_schema = definition["inputs"]["schema"]
+    assert input_schema["required"] == ["stack", "image", "reason"]
+    assert input_schema["additionalProperties"] is False
+    assert input_schema["properties"]["image"]["additionalProperties"] is False
+
+    parsed = parse_skill_registry(payload)
+    assert [(tool.name, tool.version) for tool in parsed] == [
+        (DEPLOYMENT_UPDATE_TOOL_NAME, DEPLOYMENT_UPDATE_TOOL_VERSION)
+    ]
+    assert parsed[0].required_capabilities == (
+        "deployment_control",
+        "docker_admin",
+    )
 
 async def test_curated_pentest_activity_binding_is_registered_on_agent_runtime_fleet():
     bindings = build_activity_bindings(


### PR DESCRIPTION
## Jira

- Jira issue key: MM-519

## MoonSpec

- Active feature path: `specs/261-typed-deployment-update-tool-contract`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests run

- `pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/api/routers/test_deployment_operations.py -q` - PASS, 17 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, Python 4027 passed; frontend 425 passed

## Remaining risks

- The privileged Docker Compose execution handler is outside this MM-519 slice. This PR completes the typed executable tool contract and plan validation boundary.
