### PR TITLE
MM-520 Serialized Compose desired-state execution

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/261-typed-deployment-update-tool-contract"
+  "feature_directory": "specs/262-serialized-compose-desired-state"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,62 @@
 [
   {
-    "id": 3142703165,
+    "id": 3142801124,
     "disposition": "addressed",
-    "rationale": "The update endpoint now queues with the normalized policy stack by passing policy.stack through DeploymentUpdateSubmission."
+    "rationale": "Deployment tool registration is now limited to the privileged agent_runtime fleet instead of every worker dispatcher, keeping stack update locking and execution on the intended deployment-capable worker boundary."
   },
   {
-    "id": 4176254410,
+    "id": 3142801125,
+    "disposition": "addressed",
+    "rationale": "Compose pull and up result mappings are now strictly checked for success signals and non-zero exit codes fail closed before later lifecycle steps."
+  },
+  {
+    "id": 3142801128,
+    "disposition": "addressed",
+    "rationale": "Deployment execution now writes command-log and after-state evidence from a finally path when runner calls fail after before-state capture."
+  },
+  {
+    "id": 3142801130,
+    "disposition": "addressed",
+    "rationale": "deployment.update_compose_stack registration moved inside the agent_runtime fleet setup block rather than using the default disabled runner on all workers."
+  },
+  {
+    "id": 3142801132,
+    "disposition": "addressed",
+    "rationale": "Command-log evidence is persisted before verification on success and in the failure cleanup path when pull or up fails."
+  },
+  {
+    "id": 4176371791,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review summary; actionable child feedback is tracked separately."
+    "rationale": "Top-level automated review summary; its actionable inline findings are tracked by their individual comment IDs."
   },
   {
-    "id": 3142707227,
+    "id": 3142801582,
     "disposition": "addressed",
-    "rationale": "queue_update now creates a Temporal MoonMind.Run execution record through TemporalExecutionService before returning QUEUED metadata."
+    "rationale": "The awaited first deployment task result is now assigned and asserted as COMPLETED."
   },
   {
-    "id": 3142707228,
+    "id": 3142803336,
     "disposition": "addressed",
-    "rationale": "Queued run inputs now use the canonical stack from deployment policy, with regression coverage for whitespace-normalized stack input."
+    "rationale": "_parse_inputs now rejects non-allowlisted stack names at the execution boundary with INVALID_INPUT."
   },
   {
-    "id": 4176257392,
+    "id": 3142803338,
+    "disposition": "addressed",
+    "rationale": "removeOrphans and wait now require real boolean values and reject string payloads with INVALID_INPUT."
+  },
+  {
+    "id": 3142803340,
+    "disposition": "addressed",
+    "rationale": "desiredStateRef was removed from emitted outputs so runtime output stays within the declared tool schema."
+  },
+  {
+    "id": 4176375485,
     "disposition": "not-applicable",
-    "rationale": "Top-level Codex review wrapper with no standalone requested code change."
+    "rationale": "Top-level Codex review wrapper; actionable suggestions are tracked by their individual inline comment IDs."
   },
   {
-    "id": 3142727783,
+    "id": 3142815558,
     "disposition": "addressed",
-    "rationale": "Replaced the Protocol stub ellipsis with raise NotImplementedError."
-  },
-  {
-    "id": 3142733512,
-    "disposition": "addressed",
-    "rationale": "Replaced the Protocol stub ellipsis with raise NotImplementedError as requested by the code-quality bot."
+    "rationale": "The awaited first deployment task result is now assigned and asserted as COMPLETED."
   }
 ]

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -1,0 +1,443 @@
+"""Execution lifecycle for the deployment update tool."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping, Protocol
+
+from .deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+)
+from .tool_plan_contracts import ToolFailure, ToolResult
+
+DEPLOYMENT_RUNNER_MODES = frozenset(
+    {"privileged_worker", "ephemeral_updater_container"}
+)
+DEPLOYMENT_UPDATE_MODES = frozenset({"changed_services", "force_recreate"})
+
+
+class DesiredStateStore(Protocol):
+    async def persist(self, payload: Mapping[str, Any]) -> str:
+        """Persist desired deployment state and return a store reference."""
+
+
+class EvidenceWriter(Protocol):
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        """Write structured deployment evidence and return an artifact ref."""
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeCommandPlan:
+    runner_mode: str
+    pull_args: tuple[str, ...]
+    up_args: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeVerification:
+    succeeded: bool
+    updated_services: tuple[str, ...]
+    running_services: tuple[Mapping[str, Any], ...]
+    details: Mapping[str, Any]
+
+
+class ComposeRunner(Protocol):
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        """Capture before/after state for a deployment stack."""
+
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        """Run the pull command."""
+
+    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        """Run the up command."""
+
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        """Verify the requested desired state is running."""
+
+
+class DeploymentUpdateLockManager:
+    """Nonblocking per-stack lock manager for deployment updates."""
+
+    def __init__(self) -> None:
+        self._guard = asyncio.Lock()
+        self._held: set[str] = set()
+
+    async def acquire(self, stack: str) -> "DeploymentUpdateLockLease":
+        normalized = _required_string(stack, "stack")
+        async with self._guard:
+            if normalized in self._held:
+                raise ToolFailure(
+                    error_code="DEPLOYMENT_LOCKED",
+                    message=f"Deployment update for stack '{normalized}' is already running.",
+                    retryable=False,
+                    details={"stack": normalized},
+                )
+            self._held.add(normalized)
+        return DeploymentUpdateLockLease(self, normalized)
+
+    async def _release(self, stack: str) -> None:
+        async with self._guard:
+            self._held.discard(stack)
+
+
+@dataclass(slots=True)
+class DeploymentUpdateLockLease:
+    _manager: DeploymentUpdateLockManager
+    stack: str
+    _released: bool = False
+
+    async def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        await self._manager._release(self.stack)
+
+    async def __aenter__(self) -> "DeploymentUpdateLockLease":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.release()
+
+
+class InMemoryDesiredStateStore:
+    """Deterministic desired-state store for hermetic execution tests."""
+
+    def __init__(self) -> None:
+        self.records: list[Mapping[str, Any]] = []
+
+    async def persist(self, payload: Mapping[str, Any]) -> str:
+        record = dict(payload)
+        self.records.append(record)
+        return _stable_ref("desired-state", record)
+
+
+class InMemoryEvidenceWriter:
+    """Deterministic evidence writer for hermetic execution tests."""
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        record = dict(payload)
+        self.records.append((kind, record))
+        return _stable_ref(kind, record)
+
+
+class DisabledComposeRunner:
+    """Fail-closed runner used when deployment-control infrastructure is absent."""
+
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message="Deployment update runner is not configured for this worker.",
+            retryable=False,
+            details={"stack": stack, "phase": phase},
+        )
+
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message="Deployment update runner is not configured for this worker.",
+            retryable=False,
+            details={"stack": stack, "command": list(command)},
+        )
+
+    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message="Deployment update runner is not configured for this worker.",
+            retryable=False,
+            details={"stack": stack, "command": list(command)},
+        )
+
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message="Deployment update runner is not configured for this worker.",
+            retryable=False,
+            details={
+                "stack": stack,
+                "requested_image": requested_image,
+                "resolved_digest": resolved_digest,
+            },
+        )
+
+
+@dataclass(slots=True)
+class DeploymentUpdateExecutor:
+    lock_manager: DeploymentUpdateLockManager
+    desired_state_store: DesiredStateStore
+    evidence_writer: EvidenceWriter
+    runner: ComposeRunner
+
+    async def execute(
+        self,
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        context = dict(context or {})
+        parsed = _parse_inputs(inputs)
+        command_plan = build_compose_command_plan(
+            mode=parsed["mode"],
+            remove_orphans=parsed["removeOrphans"],
+            wait=parsed["wait"],
+            runner_mode=str(context.get("deployment_runner_mode") or "privileged_worker"),
+        )
+        source_run_id = str(
+            context.get("source_run_id")
+            or context.get("idempotency_key")
+            or context.get("workflow_id")
+            or ""
+        ).strip() or None
+        operator = str(context.get("operator") or context.get("principal") or "").strip()
+        requested_image = _requested_image(parsed)
+        resolved_digest = parsed["image"].get("resolvedDigest")
+
+        async with await self.lock_manager.acquire(parsed["stack"]):
+            before_state = await self.runner.capture_state(
+                stack=parsed["stack"], phase="before"
+            )
+            before_ref = await self.evidence_writer.write("before-state", before_state)
+
+            desired_payload = {
+                "stack": parsed["stack"],
+                "imageRepository": parsed["image"]["repository"],
+                "requestedReference": parsed["image"]["reference"],
+                "resolvedDigest": resolved_digest,
+                "reason": parsed["reason"],
+                "operator": operator or None,
+                "createdAt": _utc_now(),
+                "sourceRunId": source_run_id,
+            }
+            desired_state_ref = await self.desired_state_store.persist(desired_payload)
+
+            pull_result = await self.runner.pull(
+                stack=parsed["stack"], command=command_plan.pull_args
+            )
+            up_result = await self.runner.up(
+                stack=parsed["stack"], command=command_plan.up_args
+            )
+            command_ref = await self.evidence_writer.write(
+                "command-log",
+                {
+                    "runnerMode": command_plan.runner_mode,
+                    "pull": {"command": list(command_plan.pull_args), "result": pull_result},
+                    "up": {"command": list(command_plan.up_args), "result": up_result},
+                },
+            )
+
+            verification = await self.runner.verify(
+                stack=parsed["stack"],
+                requested_image=requested_image,
+                resolved_digest=resolved_digest,
+            )
+            verification_ref = await self.evidence_writer.write(
+                "verification",
+                {
+                    "succeeded": verification.succeeded,
+                    "details": dict(verification.details),
+                    "requestedImage": requested_image,
+                    "resolvedDigest": resolved_digest,
+                },
+            )
+            after_state = await self.runner.capture_state(
+                stack=parsed["stack"], phase="after"
+            )
+            after_ref = await self.evidence_writer.write("after-state", after_state)
+
+        outputs = {
+            "status": "SUCCEEDED" if verification.succeeded else "FAILED",
+            "stack": parsed["stack"],
+            "requestedImage": requested_image,
+            "resolvedDigest": resolved_digest,
+            "updatedServices": list(verification.updated_services),
+            "runningServices": [dict(service) for service in verification.running_services],
+            "beforeStateArtifactRef": before_ref,
+            "afterStateArtifactRef": after_ref,
+            "commandLogArtifactRef": command_ref,
+            "verificationArtifactRef": verification_ref,
+            "desiredStateRef": desired_state_ref,
+        }
+        return ToolResult(
+            status="COMPLETED" if verification.succeeded else "FAILED",
+            outputs=outputs,
+            progress={"percent": 100},
+        )
+
+
+def build_compose_command_plan(
+    *,
+    mode: str,
+    remove_orphans: bool,
+    wait: bool,
+    runner_mode: str,
+) -> ComposeCommandPlan:
+    normalized_mode = _required_string(mode, "mode")
+    if normalized_mode not in DEPLOYMENT_UPDATE_MODES:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"Unsupported deployment update mode '{normalized_mode}'.",
+            retryable=False,
+            details={"mode": normalized_mode},
+        )
+    normalized_runner = _required_string(runner_mode, "deployment_runner_mode")
+    if normalized_runner not in DEPLOYMENT_RUNNER_MODES:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message=f"Unsupported deployment runner mode '{normalized_runner}'.",
+            retryable=False,
+            details={"runner_mode": normalized_runner},
+        )
+
+    up_args = ["docker", "compose", "up", "-d"]
+    if normalized_mode == "force_recreate":
+        up_args.append("--force-recreate")
+    if remove_orphans:
+        up_args.append("--remove-orphans")
+    if wait:
+        up_args.append("--wait")
+
+    return ComposeCommandPlan(
+        runner_mode=normalized_runner,
+        pull_args=(
+            "docker",
+            "compose",
+            "pull",
+            "--policy",
+            "always",
+            "--ignore-buildable",
+        ),
+        up_args=tuple(up_args),
+    )
+
+
+def build_deployment_update_handler(
+    executor: DeploymentUpdateExecutor | None = None,
+):
+    resolved_executor = executor or DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=DisabledComposeRunner(),
+    )
+
+    async def _handler(
+        inputs: Mapping[str, Any], context: Mapping[str, Any] | None = None
+    ) -> ToolResult:
+        context_executor = None
+        if isinstance(context, Mapping):
+            candidate = context.get("deployment_update_executor")
+            if isinstance(candidate, DeploymentUpdateExecutor):
+                context_executor = candidate
+        return await (context_executor or resolved_executor).execute(inputs, context)
+
+    return _handler
+
+
+def register_deployment_update_tool_handler(
+    dispatcher: Any,
+    *,
+    executor: DeploymentUpdateExecutor | None = None,
+) -> None:
+    dispatcher.register_skill(
+        skill_name=DEPLOYMENT_UPDATE_TOOL_NAME,
+        version=DEPLOYMENT_UPDATE_TOOL_VERSION,
+        handler=build_deployment_update_handler(executor),
+    )
+
+
+def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(inputs, Mapping):
+        raise ToolFailure("INVALID_INPUT", "Deployment inputs must be an object.", False)
+    forbidden = {"command", "composeFile", "hostPath", "updaterRunnerImage"}
+    found_forbidden = sorted(forbidden.intersection(inputs.keys()))
+    if found_forbidden:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message="Deployment update inputs contain forbidden fields.",
+            retryable=False,
+            details={"fields": found_forbidden},
+        )
+
+    image = inputs.get("image")
+    if not isinstance(image, Mapping):
+        raise ToolFailure("INVALID_INPUT", "Deployment image must be an object.", False)
+
+    parsed = {
+        "stack": _required_string(inputs.get("stack"), "stack"),
+        "image": {
+            "repository": _required_string(image.get("repository"), "image.repository"),
+            "reference": _required_string(image.get("reference"), "image.reference"),
+        },
+        "mode": str(inputs.get("mode") or "changed_services").strip(),
+        "removeOrphans": bool(inputs.get("removeOrphans", False)),
+        "wait": bool(inputs.get("wait", True)),
+        "reason": _required_string(inputs.get("reason"), "reason"),
+    }
+    resolved_digest = image.get("resolvedDigest")
+    if resolved_digest is not None and str(resolved_digest).strip():
+        parsed["image"]["resolvedDigest"] = str(resolved_digest).strip()
+    return parsed
+
+
+def _requested_image(parsed: Mapping[str, Any]) -> str:
+    image = parsed["image"]
+    assert isinstance(image, Mapping)
+    reference = str(image["reference"])
+    separator = "@" if reference.startswith("sha256:") else ":"
+    return f"{image['repository']}{separator}{reference}"
+
+
+def _required_string(value: Any, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"{field_name} is required.",
+            retryable=False,
+            details={"field": field_name},
+        )
+    return normalized
+
+
+def _stable_ref(kind: str, payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    digest = hashlib.sha256(kind.encode("utf-8") + b"\0" + encoded).hexdigest()
+    return f"art:sha256:{digest}"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+__all__ = [
+    "ComposeCommandPlan",
+    "ComposeVerification",
+    "DeploymentUpdateExecutor",
+    "DeploymentUpdateLockManager",
+    "DEPLOYMENT_RUNNER_MODES",
+    "DEPLOYMENT_UPDATE_MODES",
+    "DisabledComposeRunner",
+    "InMemoryDesiredStateStore",
+    "InMemoryEvidenceWriter",
+    "build_compose_command_plan",
+    "build_deployment_update_handler",
+    "register_deployment_update_tool_handler",
+]

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -19,6 +19,7 @@ DEPLOYMENT_RUNNER_MODES = frozenset(
     {"privileged_worker", "ephemeral_updater_container"}
 )
 DEPLOYMENT_UPDATE_MODES = frozenset({"changed_services", "force_recreate"})
+DEPLOYMENT_UPDATE_STACKS = frozenset({"moonmind"})
 
 
 class DesiredStateStore(Protocol):
@@ -209,58 +210,110 @@ class DeploymentUpdateExecutor:
         operator = str(context.get("operator") or context.get("principal") or "").strip()
         requested_image = _requested_image(parsed)
         resolved_digest = parsed["image"].get("resolvedDigest")
+        before_ref: str | None = None
+        after_ref: str | None = None
+        command_ref: str | None = None
+        verification_ref: str | None = None
+        verification: ComposeVerification | None = None
+        command_log: dict[str, Any] = {
+            "runnerMode": command_plan.runner_mode,
+            "pull": {"command": list(command_plan.pull_args)},
+            "up": {"command": list(command_plan.up_args)},
+        }
 
         async with await self.lock_manager.acquire(parsed["stack"]):
-            before_state = await self.runner.capture_state(
-                stack=parsed["stack"], phase="before"
-            )
-            before_ref = await self.evidence_writer.write("before-state", before_state)
+            try:
+                before_state = await self.runner.capture_state(
+                    stack=parsed["stack"], phase="before"
+                )
+                before_ref = await self.evidence_writer.write("before-state", before_state)
 
-            desired_payload = {
-                "stack": parsed["stack"],
-                "imageRepository": parsed["image"]["repository"],
-                "requestedReference": parsed["image"]["reference"],
-                "resolvedDigest": resolved_digest,
-                "reason": parsed["reason"],
-                "operator": operator or None,
-                "createdAt": _utc_now(),
-                "sourceRunId": source_run_id,
-            }
-            desired_state_ref = await self.desired_state_store.persist(desired_payload)
-
-            pull_result = await self.runner.pull(
-                stack=parsed["stack"], command=command_plan.pull_args
-            )
-            up_result = await self.runner.up(
-                stack=parsed["stack"], command=command_plan.up_args
-            )
-            command_ref = await self.evidence_writer.write(
-                "command-log",
-                {
-                    "runnerMode": command_plan.runner_mode,
-                    "pull": {"command": list(command_plan.pull_args), "result": pull_result},
-                    "up": {"command": list(command_plan.up_args), "result": up_result},
-                },
-            )
-
-            verification = await self.runner.verify(
-                stack=parsed["stack"],
-                requested_image=requested_image,
-                resolved_digest=resolved_digest,
-            )
-            verification_ref = await self.evidence_writer.write(
-                "verification",
-                {
-                    "succeeded": verification.succeeded,
-                    "details": dict(verification.details),
-                    "requestedImage": requested_image,
+                desired_payload = {
+                    "stack": parsed["stack"],
+                    "imageRepository": parsed["image"]["repository"],
+                    "requestedReference": parsed["image"]["reference"],
                     "resolvedDigest": resolved_digest,
-                },
+                    "reason": parsed["reason"],
+                    "operator": operator or None,
+                    "createdAt": _utc_now(),
+                    "sourceRunId": source_run_id,
+                }
+                await self.desired_state_store.persist(desired_payload)
+
+                pull_result = await self.runner.pull(
+                    stack=parsed["stack"], command=command_plan.pull_args
+                )
+                command_log["pull"]["result"] = pull_result
+                _ensure_command_succeeded("pull", pull_result)
+
+                up_result = await self.runner.up(
+                    stack=parsed["stack"], command=command_plan.up_args
+                )
+                command_log["up"]["result"] = up_result
+                _ensure_command_succeeded("up", up_result)
+                command_ref = await self.evidence_writer.write(
+                    "command-log", command_log
+                )
+
+                verification = await self.runner.verify(
+                    stack=parsed["stack"],
+                    requested_image=requested_image,
+                    resolved_digest=resolved_digest,
+                )
+                verification_ref = await self.evidence_writer.write(
+                    "verification",
+                    {
+                        "succeeded": verification.succeeded,
+                        "details": dict(verification.details),
+                        "requestedImage": requested_image,
+                        "resolvedDigest": resolved_digest,
+                    },
+                )
+            except Exception as exc:
+                _record_command_exception(command_log, exc)
+                raise
+            finally:
+                if (
+                    command_ref is None
+                    and ("result" in command_log["pull"] or "error" in command_log)
+                ):
+                    command_ref = await self.evidence_writer.write(
+                        "command-log", command_log
+                    )
+                if before_ref is not None:
+                    after_state = await self.runner.capture_state(
+                        stack=parsed["stack"], phase="after"
+                    )
+                    after_ref = await self.evidence_writer.write("after-state", after_state)
+
+        if verification is None:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_FAILED",
+                message="Deployment update did not complete verification.",
+                retryable=False,
+                details={"stack": parsed["stack"]},
             )
-            after_state = await self.runner.capture_state(
-                stack=parsed["stack"], phase="after"
+        if after_ref is None:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_EVIDENCE_INCOMPLETE",
+                message="Deployment update completed without after-state evidence.",
+                retryable=False,
+                details={"stack": parsed["stack"]},
             )
-            after_ref = await self.evidence_writer.write("after-state", after_state)
+        if command_ref is None:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_EVIDENCE_INCOMPLETE",
+                message="Deployment update completed without command-log evidence.",
+                retryable=False,
+                details={"stack": parsed["stack"]},
+            )
+        if verification_ref is None:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_EVIDENCE_INCOMPLETE",
+                message="Deployment update completed without verification evidence.",
+                retryable=False,
+                details={"stack": parsed["stack"]},
+            )
 
         outputs = {
             "status": "SUCCEEDED" if verification.succeeded else "FAILED",
@@ -273,7 +326,6 @@ class DeploymentUpdateExecutor:
             "afterStateArtifactRef": after_ref,
             "commandLogArtifactRef": command_ref,
             "verificationArtifactRef": verification_ref,
-            "desiredStateRef": desired_state_ref,
         }
         return ToolResult(
             status="COMPLETED" if verification.succeeded else "FAILED",
@@ -380,15 +432,24 @@ def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(image, Mapping):
         raise ToolFailure("INVALID_INPUT", "Deployment image must be an object.", False)
 
+    stack = _required_string(inputs.get("stack"), "stack")
+    if stack not in DEPLOYMENT_UPDATE_STACKS:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"Unsupported deployment stack '{stack}'.",
+            retryable=False,
+            details={"stack": stack, "allowed_stacks": sorted(DEPLOYMENT_UPDATE_STACKS)},
+        )
+
     parsed = {
-        "stack": _required_string(inputs.get("stack"), "stack"),
+        "stack": stack,
         "image": {
             "repository": _required_string(image.get("repository"), "image.repository"),
             "reference": _required_string(image.get("reference"), "image.reference"),
         },
         "mode": str(inputs.get("mode") or "changed_services").strip(),
-        "removeOrphans": bool(inputs.get("removeOrphans", False)),
-        "wait": bool(inputs.get("wait", True)),
+        "removeOrphans": _optional_bool(inputs, "removeOrphans", default=False),
+        "wait": _optional_bool(inputs, "wait", default=True),
         "reason": _required_string(inputs.get("reason"), "reason"),
     }
     resolved_digest = image.get("resolvedDigest")
@@ -417,6 +478,93 @@ def _required_string(value: Any, field_name: str) -> str:
     return normalized
 
 
+def _optional_bool(
+    inputs: Mapping[str, Any], field_name: str, *, default: bool
+) -> bool:
+    if field_name not in inputs:
+        return default
+    value = inputs[field_name]
+    if not isinstance(value, bool):
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"{field_name} must be a boolean.",
+            retryable=False,
+            details={"field": field_name, "value_type": type(value).__name__},
+        )
+    return value
+
+
+def _ensure_command_succeeded(phase: str, result: Mapping[str, Any]) -> None:
+    if not isinstance(result, Mapping):
+        raise ToolFailure(
+            error_code="DEPLOYMENT_COMMAND_FAILED",
+            message=f"Deployment {phase} command returned an invalid result.",
+            retryable=False,
+            details={"phase": phase, "result_type": type(result).__name__},
+        )
+    for key in ("exitCode", "exit_code", "returncode"):
+        if key in result:
+            try:
+                code = int(result[key])
+            except (TypeError, ValueError) as exc:
+                raise ToolFailure(
+                    error_code="DEPLOYMENT_COMMAND_FAILED",
+                    message=(
+                        f"Deployment {phase} command returned a non-numeric exit code."
+                    ),
+                    retryable=False,
+                    details={"phase": phase, "field": key, "value": result[key]},
+                ) from exc
+            if code != 0:
+                raise ToolFailure(
+                    error_code="DEPLOYMENT_COMMAND_FAILED",
+                    message=f"Deployment {phase} command failed with exit code {code}.",
+                    retryable=False,
+                    details={"phase": phase, "exit_code": code, "result": dict(result)},
+                )
+            return
+    for key in ("ok", "success", "succeeded"):
+        if key in result:
+            if result[key] is not True:
+                raise ToolFailure(
+                    error_code="DEPLOYMENT_COMMAND_FAILED",
+                    message=f"Deployment {phase} command reported failure.",
+                    retryable=False,
+                    details={"phase": phase, "field": key, "result": dict(result)},
+                )
+            return
+    status = str(result.get("status") or "").strip().lower()
+    if status:
+        if status not in {"completed", "succeeded", "success", "ok"}:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message=f"Deployment {phase} command reported status '{status}'.",
+                retryable=False,
+                details={"phase": phase, "status": status, "result": dict(result)},
+            )
+        return
+    raise ToolFailure(
+        error_code="DEPLOYMENT_COMMAND_FAILED",
+        message=f"Deployment {phase} command result did not include a success signal.",
+        retryable=False,
+        details={"phase": phase, "result": dict(result)},
+    )
+
+
+def _record_command_exception(command_log: dict[str, Any], exc: Exception) -> None:
+    if "error" in command_log:
+        return
+    if isinstance(exc, ToolFailure):
+        command_log["error"] = exc.to_payload()
+    else:
+        command_log["error"] = {
+            "error_code": "DEPLOYMENT_COMMAND_EXCEPTION",
+            "message": str(exc),
+            "retryable": False,
+            "details": {"type": type(exc).__name__},
+        }
+
+
 def _stable_ref(kind: str, payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
     digest = hashlib.sha256(kind.encode("utf-8") + b"\0" + encoded).hexdigest()
@@ -433,6 +581,7 @@ __all__ = [
     "DeploymentUpdateExecutor",
     "DeploymentUpdateLockManager",
     "DEPLOYMENT_RUNNER_MODES",
+    "DEPLOYMENT_UPDATE_STACKS",
     "DEPLOYMENT_UPDATE_MODES",
     "DisabledComposeRunner",
     "InMemoryDesiredStateStore",

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -36,6 +36,9 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from api_service.db.base import get_async_session_context
 from moonmind.config.settings import settings
+from moonmind.workflows.skills.deployment_execution import (
+    register_deployment_update_tool_handler,
+)
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
@@ -1180,6 +1183,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
             dispatcher,
             execution_creator=_build_jira_orchestrate_execution_creator(),
         )
+        register_deployment_update_tool_handler(dispatcher)
 
         run_store = None
         run_supervisor = None

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1183,7 +1183,6 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
             dispatcher,
             execution_creator=_build_jira_orchestrate_execution_creator(),
         )
-        register_deployment_update_tool_handler(dispatcher)
 
         run_store = None
         run_supervisor = None
@@ -1231,6 +1230,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 launcher=workload_launcher,
                 workflow_docker_mode=settings.workflow.workflow_docker_mode,
             )
+            register_deployment_update_tool_handler(dispatcher)
 
         bindings = build_worker_activity_bindings(
             fleet=topology.fleet,

--- a/specs/262-serialized-compose-desired-state/checklists/requirements.md
+++ b/specs/262-serialized-compose-desired-state/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Serialized Compose Desired-State Execution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is a single-story runtime feature request from trusted Jira issue `MM-520`.
+- PASS: Source design requirements from `docs/Tools/DockerComposeUpdateSystem.md` sections 9 through 11 are mapped to `FR-*` requirements.

--- a/specs/262-serialized-compose-desired-state/contracts/deployment-update-execution.md
+++ b/specs/262-serialized-compose-desired-state/contracts/deployment-update-execution.md
@@ -1,0 +1,57 @@
+# Deployment Update Execution Contract
+
+Traceability: `MM-520`, FR-001 through FR-012, DESIGN-REQ-001 through DESIGN-REQ-006.
+
+## Tool Handler
+
+The `deployment.update_compose_stack` v1.0.0 handler accepts the existing MM-519 typed tool input:
+
+```json
+{
+  "stack": "moonmind",
+  "image": {
+    "repository": "ghcr.io/moonladderstudios/moonmind",
+    "reference": "20260425.1234",
+    "resolvedDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "mode": "changed_services",
+  "removeOrphans": true,
+  "wait": true,
+  "runSmokeCheck": true,
+  "pauseWork": false,
+  "pruneOldImages": false,
+  "reason": "Update to the latest tested MoonMind build"
+}
+```
+
+## Execution Guarantees
+
+- The handler acquires a per-stack lock before side effects.
+- If the lock is already held, the handler raises non-retryable `DEPLOYMENT_LOCKED`.
+- Before-state capture occurs before desired-state persistence.
+- Desired-state persistence occurs before pull and up commands.
+- Pull is built as typed command arguments equivalent to `docker compose pull --policy always --ignore-buildable`.
+- Up is built as typed command arguments equivalent to `docker compose up -d`, with only the policy-controlled `--force-recreate`, `--remove-orphans`, and `--wait` flags added when applicable.
+- Runner mode is a deployment-controlled value: `privileged_worker` or `ephemeral_updater_container`.
+- Runner image, Compose paths, host paths, shell snippets, and arbitrary flags are not accepted by this contract.
+
+## Result Shape
+
+The handler returns `ToolResult.outputs` matching the existing tool output schema:
+
+```json
+{
+  "status": "SUCCEEDED",
+  "stack": "moonmind",
+  "requestedImage": "ghcr.io/moonladderstudios/moonmind:20260425.1234",
+  "resolvedDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "updatedServices": ["api"],
+  "runningServices": [{"name": "api", "state": "running", "health": "healthy"}],
+  "beforeStateArtifactRef": "artifact:before",
+  "afterStateArtifactRef": "artifact:after",
+  "commandLogArtifactRef": "artifact:commands",
+  "verificationArtifactRef": "artifact:verification"
+}
+```
+
+Verification failure returns `status = FAILED`, never `SUCCEEDED`.

--- a/specs/262-serialized-compose-desired-state/data-model.md
+++ b/specs/262-serialized-compose-desired-state/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Serialized Compose Desired-State Execution
+
+## DeploymentDesiredState
+
+Represents the durable desired image state for an allowlisted deployment stack.
+
+Fields:
+- `stack`: allowlisted stack identifier.
+- `imageRepository`: repository portion of the desired image.
+- `requestedReference`: requested tag or digest reference.
+- `resolvedDigest`: digest-pinned reference when known.
+- `reason`: administrator-provided reason for the update.
+- `operator`: initiating principal when available.
+- `createdAt`: UTC timestamp when desired state is persisted.
+- `sourceRunId`: workflow/run/idempotency identifier when available.
+
+Validation rules:
+- `stack`, `imageRepository`, `requestedReference`, and `reason` are required.
+- `resolvedDigest` remains distinct from `requestedReference`.
+- The store boundary must not accept caller-selected arbitrary file paths.
+
+## DeploymentUpdateLifecycle
+
+Represents the ordered lifecycle for one deployment update invocation.
+
+States:
+- `LOCKED`: per-stack lock acquired.
+- `BEFORE_CAPTURED`: before-state evidence captured.
+- `DESIRED_STATE_PERSISTED`: desired state durably written.
+- `PULLED`: pull command completed.
+- `UPDATED`: up command completed.
+- `VERIFIED`: verification proved the desired state.
+- `FAILED`: lifecycle failed or verification did not prove success.
+- `RELEASED`: per-stack lock released.
+
+Ordering rules:
+- `LOCKED` must precede every side effect.
+- `BEFORE_CAPTURED` must precede `DESIRED_STATE_PERSISTED`.
+- `DESIRED_STATE_PERSISTED` must precede `PULLED` and `UPDATED`.
+- `VERIFIED` must precede a `SUCCEEDED` result.
+- `RELEASED` happens after terminal result construction or failure.
+
+## DeploymentCommandPlan
+
+Represents typed Compose command arguments built from validated tool inputs and policy.
+
+Fields:
+- `runnerMode`: `privileged_worker` or `ephemeral_updater_container`.
+- `pullArgs`: command arguments for image pull.
+- `upArgs`: command arguments for service recreation.
+
+Validation rules:
+- `changed_services` mode never includes `--force-recreate`.
+- `force_recreate` mode includes `--force-recreate`.
+- `removeOrphans` controls only `--remove-orphans`.
+- `wait` controls only `--wait`.
+- No shell snippets, caller paths, arbitrary flags, or runner image choices are represented.
+
+## DeploymentUpdateResult
+
+Represents the typed tool result.
+
+Fields:
+- `status`: `SUCCEEDED` or `FAILED`.
+- `stack`
+- `requestedImage`
+- `resolvedDigest`
+- `updatedServices`
+- `runningServices`
+- `beforeStateArtifactRef`
+- `afterStateArtifactRef`
+- `commandLogArtifactRef`
+- `verificationArtifactRef`
+
+Validation rules:
+- `status` is `SUCCEEDED` only when verification succeeds.
+- Evidence refs are populated from the artifact writer when their lifecycle steps run.
+- `FAILED` verification results still include verification evidence when available.

--- a/specs/262-serialized-compose-desired-state/moonspec_align_report.md
+++ b/specs/262-serialized-compose-desired-state/moonspec_align_report.md
@@ -1,0 +1,21 @@
+# MoonSpec Alignment Report
+
+**Feature**: `specs/262-serialized-compose-desired-state`  
+**Created**: 2026-04-26  
+**Scope**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md`
+
+## Findings
+
+| Finding | Severity | Resolution |
+| --- | --- | --- |
+| `tasks.md` used the legacy final command name `/speckit.verify` while the active MoonSpec orchestration instructions require `/moonspec-verify`. | Low | Updated T023 to use `/moonspec-verify`; no downstream artifact regeneration needed because the task intent and evidence remain unchanged. |
+
+## Gate Re-Check
+
+- Specify gate: PASS. `spec.md` has one story, preserves `MM-520` and the original preset brief, and has no clarification markers.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/deployment-update-execution.md`, and `quickstart.md` exist with explicit unit and integration strategies.
+- Tasks gate: PASS. `tasks.md` covers one story with red-first unit tests, integration tests, implementation tasks, validation, and final `/moonspec-verify` work.
+
+## Regeneration Decision
+
+No downstream artifact regeneration required. The alignment edit changed only command naming in `tasks.md` and did not alter requirements, architecture, contracts, tests, or implementation scope.

--- a/specs/262-serialized-compose-desired-state/plan.md
+++ b/specs/262-serialized-compose-desired-state/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Serialized Compose Desired-State Execution
+
+**Branch**: `262-serialized-compose-desired-state` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/262-serialized-compose-desired-state/spec.md`
+
+## Summary
+
+Implement `MM-520` by adding a hermetic deployment update execution layer for the existing typed `deployment.update_compose_stack` tool. The execution layer will serialize updates per stack, persist a desired-state record before Compose recreation, construct only policy-controlled pull/up command shapes, capture structured evidence refs, and expose a registered tool handler boundary. Existing MM-518 API validation and MM-519 tool-contract work are reused; this story adds the post-validation lifecycle behavior and tests it through injectable fake stores/runners.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `DeploymentUpdateLockManager`, `test_same_stack_lock_contention_fails_before_side_effects`, integration dispatch lock test | complete | unit + integration passed |
+| FR-002 | implemented_verified | `DeploymentUpdateLockManager.acquire()` raises non-retryable `DEPLOYMENT_LOCKED`; unit and integration tests | complete | unit + integration passed |
+| FR-003 | implemented_verified | executor captures before state before persistence; ordering unit test | complete | unit passed |
+| FR-004 | implemented_verified | executor persists desired state before `runner.up`; ordering unit test and integration dispatch | complete | unit + integration passed |
+| FR-005 | implemented_verified | desired-state payload includes stack, repository, requested ref, digest, reason, timestamp, source run ID | complete | unit passed |
+| FR-006 | implemented_verified | `build_compose_command_plan()` omits `--force-recreate` for `changed_services` | complete | unit passed |
+| FR-007 | implemented_verified | `build_compose_command_plan()` adds `--force-recreate` only for `force_recreate` | complete | unit passed |
+| FR-008 | implemented_verified | command builder only adds/removes `--remove-orphans` and `--wait` from booleans | complete | unit passed |
+| FR-009 | implemented_verified | executor writes before, command, verification, and after evidence refs; integration dispatch validates output shape | complete | unit + integration passed |
+| FR-010 | implemented_verified | verification failure test returns failed tool result and `outputs.status = FAILED` | complete | unit passed |
+| FR-011 | implemented_verified | forbidden input and unsupported runner-mode tests; worker dispatcher registration uses fail-closed disabled runner by default | complete | unit passed |
+| FR-012 | implemented_verified | `MM-520` preserved in spec, plan, tasks, contract, quickstart, verification, code/test traceability | complete | traceability grep passed |
+| SCN-001 | implemented_verified | lock contention unit and integration tests | complete | unit + integration passed |
+| SCN-002 | implemented_verified | lifecycle ordering unit test | complete | unit passed |
+| SCN-003 | implemented_verified | changed-services command unit test | complete | unit passed |
+| SCN-004 | implemented_verified | force-recreate command unit test | complete | unit passed |
+| SCN-005 | implemented_verified | flag omission/addition unit test | complete | unit passed |
+| SCN-006 | implemented_verified | verification failure unit test | complete | unit passed |
+| SCN-007 | implemented_verified | forbidden input and closed runner-mode tests | complete | unit passed |
+| DESIGN-REQ-001 | implemented_verified | desired-state payload + ordering tests | complete | unit + integration passed |
+| DESIGN-REQ-002 | implemented_verified | per-stack lock manager + lock tests | complete | unit + integration passed |
+| DESIGN-REQ-003 | implemented_verified | before/persist ordering test and no caller file inputs | complete | unit passed |
+| DESIGN-REQ-004 | implemented_verified | pull/up command builder tests | complete | unit passed |
+| DESIGN-REQ-005 | implemented_verified | evidence refs and verification failure result tests | complete | unit + integration passed |
+| DESIGN-REQ-006 | implemented_verified | closed runner mode and worker handler registration | complete | unit passed |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, existing MoonMind tool dispatcher and `ToolResult` / `ToolFailure` contracts  
+**Storage**: Existing artifact-backed/file-backed boundaries only; no new database tables  
+**Unit Testing**: pytest through `./tools/test_unit.sh` or focused `pytest` during iteration  
+**Integration Testing**: pytest `integration_ci` marker through `./tools/test_integration.sh` when Docker is available; focused hermetic pytest for iteration  
+**Target Platform**: Linux server / MoonMind deployment-control runtime  
+**Project Type**: Backend service and workflow tool execution support  
+**Performance Goals**: Lock acquisition and command construction are constant-time; lifecycle ordering does not add polling beyond runner implementation  
+**Constraints**: No raw shell inputs, no caller-selected Compose paths, no caller-selected runner images, no arbitrary file mutation, no new persistent database table  
+**Scale/Scope**: One allowlisted MoonMind stack and one typed deployment tool lifecycle slice
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Execution stays behind the typed tool boundary and does not reimplement agent behavior.
+- II. One-Click Agent Deployment: PASS. Tests are hermetic; privileged Docker mutation is injectable and not required for local unit tests.
+- III. Avoid Vendor Lock-In: PASS. Runner and store boundaries are protocols rather than Docker CLI-specific business logic.
+- IV. Own Your Data: PASS. Desired-state and evidence records stay in operator-controlled stores/artifacts.
+- V. Skills Are First-Class and Easy to Add: PASS. The work registers a typed executable tool handler.
+- VI. Replaceable Scaffolding: PASS. Runner implementation is isolated behind a small protocol.
+- VII. Runtime Configurability: PASS. Runner mode is explicit and closed; unsupported values fail fast.
+- VIII. Modular and Extensible Architecture: PASS. New behavior is isolated in a deployment execution module.
+- IX. Resilient by Default: PASS. Locking, desired-state persistence before mutation, and verification failure handling are core requirements.
+- X. Facilitate Continuous Improvement: PASS. Structured results and artifacts support later reporting.
+- XI. Spec-Driven Development: PASS. This plan follows `spec.md` and preserves `MM-520`.
+- XII. Canonical Documentation: PASS. Implementation notes live in this feature directory; canonical docs are not rewritten as a migration diary.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/262-serialized-compose-desired-state/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── deployment-update-execution.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/skills/
+├── deployment_execution.py
+├── deployment_tools.py
+└── tool_dispatcher.py
+
+moonmind/workflows/temporal/
+└── worker_runtime.py
+
+tests/unit/workflows/skills/
+├── test_deployment_tool_contracts.py
+└── test_deployment_update_execution.py
+
+tests/integration/temporal/
+└── test_deployment_update_execution_contract.py
+```
+
+**Structure Decision**: Add the execution lifecycle to `moonmind/workflows/skills/` because `deployment.update_compose_stack` is an executable tool contract and the behavior must be testable below Temporal while still available to Temporal skill dispatch.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/262-serialized-compose-desired-state/quickstart.md
+++ b/specs/262-serialized-compose-desired-state/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Serialized Compose Desired-State Execution
+
+## Focused Unit Validation
+
+```bash
+pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q
+pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py -q
+```
+
+Expected coverage:
+- same-stack lock rejection before side effects
+- before-state capture before desired-state persistence
+- desired-state persistence before Compose up
+- changed-services and force-recreate command construction
+- remove-orphans and wait flag construction
+- verification failure returns non-success result
+- runner mode is closed and deployment-controlled
+
+## Hermetic Integration Validation
+
+```bash
+pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q
+```
+
+Expected coverage:
+- `deployment.update_compose_stack` dispatches through the existing `mm.tool.execute` tool dispatcher
+- the handler returns schema-compatible structured output
+- lock contention is surfaced as non-retryable `DEPLOYMENT_LOCKED`
+
+## Final Suite
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+If Docker is unavailable in the managed runtime, record `./tools/test_integration.sh` as blocked by missing Docker socket and keep the hermetic focused integration pytest result as local evidence.

--- a/specs/262-serialized-compose-desired-state/research.md
+++ b/specs/262-serialized-compose-desired-state/research.md
@@ -1,0 +1,49 @@
+# Research: Serialized Compose Desired-State Execution
+
+## FR-001 / FR-002 / DESIGN-REQ-002 Per-Stack Serialization
+
+Decision: Add a small per-stack lock manager used by the deployment update executor. Lock acquisition is nonblocking; contention raises non-retryable `ToolFailure` with `DEPLOYMENT_LOCKED` before side effects.
+Evidence: `api_service/services/deployment_operations.py` queues a typed plan but has no runtime lock. `moonmind/workflows/skills/tool_dispatcher.py` supports non-retryable `ToolFailure`.
+Rationale: The lock belongs at execution time because API validation cannot prevent two already-queued or retried tool invocations from racing.
+Alternatives considered: Queueing same-stack updates was rejected for this story because the Jira acceptance criterion permits rejection or explicit queueing policy, and no queueing policy exists yet.
+Test implications: Unit and hermetic integration tests must prove lock contention happens before runner/store calls.
+
+## FR-003 / FR-004 / FR-005 / DESIGN-REQ-001 / DESIGN-REQ-003 Desired-State Persistence
+
+Decision: Add an injectable desired-state store boundary. The executor captures before state first, then persists a structured desired-state payload containing stack, repository, requested reference, optional resolved digest, reason, timestamp, and source run ID before any Compose `up`.
+Evidence: `docs/Tools/DockerComposeUpdateSystem.md` sections 9.2, 10.3, and 10.4 define the required order. No current production module persists this state.
+Rationale: A boundary allows a later deployment-control worker to write an allowlisted env file or durable state store while unit tests use an in-memory implementation.
+Alternatives considered: Writing directly to an env file in this story was rejected because the allowlisted deployment path is operator-specific and must not be guessed in tests.
+Test implications: Unit tests assert ordered fake events and exact desired-state payload fields.
+
+## FR-006 / FR-007 / FR-008 / DESIGN-REQ-004 Command Construction
+
+Decision: Implement command construction as typed argument vectors, not shell strings. Pull command is always built before up. `changed_services` omits `--force-recreate`; `force_recreate` includes it. `removeOrphans` and `wait` only control `--remove-orphans` and `--wait`.
+Evidence: Existing API tests reject arbitrary `command` and `composeFile` fields. `deployment_tools.py` schema defines the closed modes and booleans.
+Rationale: Argument vectors keep the execution boundary auditable and prevent hidden shell expansion.
+Alternatives considered: Reusing user-provided command text is forbidden by MM-518/MM-519 and the source design.
+Test implications: Unit tests compare exact command argument lists for all mode/flag combinations.
+
+## FR-009 / FR-010 / DESIGN-REQ-005 Evidence And Verification Result
+
+Decision: Add an injectable evidence writer and runner verification result. The executor returns `SUCCEEDED` only when verification succeeds; otherwise it returns `FAILED` with before, after, command log, and verification refs when available.
+Evidence: `deployment_tools.py` output schema already allows artifact refs and status values `SUCCEEDED`, `FAILED`, and `PARTIALLY_VERIFIED`.
+Rationale: Verification must be authoritative for final status and produce evidence even on failure.
+Alternatives considered: Raising on verification failure was rejected because the source design requires a structured result with verification evidence, not only an exception.
+Test implications: Unit tests prove failed verification does not report `SUCCEEDED`; integration test validates tool-dispatch output shape.
+
+## FR-011 / DESIGN-REQ-006 Runner Modes
+
+Decision: Model runner mode as a closed execution-boundary value: `privileged_worker` or `ephemeral_updater_container`. Runner image is not part of tool inputs and cannot be supplied by callers.
+Evidence: `deployment_tools.py` has no runner image input and rejects additional properties; API tests reject arbitrary path/command fields.
+Rationale: The runner mode must be deployment-controlled so privileged Docker access is never operator-provided through the task payload.
+Alternatives considered: Exposing runner image in tool inputs was rejected by source section 11.3.
+Test implications: Unit tests validate accepted runner modes and fail-fast unsupported modes.
+
+## FR-012 Traceability
+
+Decision: Preserve `MM-520`, source sections, and source IDs in all artifacts and verification evidence.
+Evidence: `spec.md` preserves the full normalized Jira preset brief.
+Rationale: Final verification and pull-request metadata need the Jira key and source mapping.
+Alternatives considered: Summary-only traceability was rejected because existing MoonSpec verification depends on preserved input.
+Test implications: Traceability grep and final verification.

--- a/specs/262-serialized-compose-desired-state/spec.md
+++ b/specs/262-serialized-compose-desired-state/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Serialized Compose Desired-State Execution
+
+**Feature Branch**: `262-serialized-compose-desired-state`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-520 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-520 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-520
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Serialized Compose desired-state execution
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-520 from MM project
+Summary: Serialized Compose desired-state execution
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-520 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-520: Serialized Compose desired-state execution
+
+Source Reference
+Source Document: docs/Tools/DockerComposeUpdateSystem.md
+Source Title: Docker Compose Deployment Update System
+Source Sections:
+- 9. Desired state storage
+- 10. Execution lifecycle
+- 11. Updater runner execution model
+Coverage IDs:
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+
+As a deployment administrator, I need MoonMind to persist the requested image and run the policy-controlled Compose update lifecycle under a per-stack lock, so a requested update survives restarts and cannot race with another update.
+
+Acceptance Criteria
+- A second update for the same stack is rejected with DEPLOYMENT_LOCKED or queued only according to explicit policy.
+- Before-state capture occurs before desired-state persistence.
+- The desired image is persisted before Compose up is invoked.
+- changed_services mode runs the documented pull/up behavior without force-recreate.
+- force_recreate mode adds force-recreate behavior only when policy permits it.
+- removeOrphans and wait options adjust command construction only through recognized policy-controlled flags.
+- The executor never edits arbitrary caller-selected files and never accepts caller-selected updater runner images.
+- The privileged Docker access path is restricted to deployment-control infrastructure.
+
+Requirements
+- Serialize update runs per stack.
+- Persist desired target state durably before service recreation.
+- Perform Compose command construction from typed inputs and policy only.
+- Support both privileged worker and ephemeral updater container as implementation modes.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Serialized Compose Desired-State Execution
+
+**Summary**: As a deployment administrator, I need MoonMind to persist the requested image and run the policy-controlled Compose update lifecycle under a per-stack lock, so a requested update survives restarts and cannot race with another update.
+
+**Goal**: Deployment update execution serializes updates per stack, records the desired image before service recreation, and executes only policy-controlled Compose command shapes through deployment-control infrastructure.
+
+**Independent Test**: Can be fully tested by invoking the typed deployment update handler with a fake desired-state store, artifact writer, and Compose runner, then asserting lock behavior, operation order, persisted desired state, command construction, and verification result semantics without mutating a real Docker host.
+
+**Acceptance Scenarios**:
+
+1. **Given** one update is already running for a stack, **When** another update for the same stack starts and policy does not queue concurrent work, **Then** the second update fails before command execution with `DEPLOYMENT_LOCKED`.
+2. **Given** a valid deployment update request, **When** the executor starts the lifecycle, **Then** it captures before state before persisting desired state and persists the requested image before any Compose `up` command is invoked.
+3. **Given** `mode = changed_services`, **When** the executor constructs Compose commands, **Then** it runs pull followed by `up -d` without force-recreate behavior.
+4. **Given** `mode = force_recreate` and policy permits force recreation, **When** the executor constructs Compose commands, **Then** it adds force-recreate behavior only for that mode.
+5. **Given** policy-controlled `removeOrphans` or `wait` options are disabled or false, **When** commands are constructed, **Then** only recognized flags are omitted and no caller-selected arbitrary flags are accepted.
+6. **Given** verification cannot prove the requested desired state, **When** the lifecycle completes command execution, **Then** the run is not marked `SUCCEEDED` and includes verification evidence.
+7. **Given** the executor is invoked, **When** runner infrastructure is selected, **Then** the selection is limited to deployment-controlled modes and never accepts caller-selected runner images or arbitrary files.
+
+### Edge Cases
+
+- Mutable image references preserve the requested reference and optional resolved digest as distinct desired-state values.
+- Lock acquisition failure happens before state capture, persistence, pull, or up commands.
+- Verification failure after services start still produces after-state and verification artifacts.
+- Unsupported mode, unrecognized option values, or unsupported runner mode fails before any side effect.
+- Desired-state persistence failure prevents Compose pull or up from running.
+
+## Assumptions
+
+- MM-518 owns API authorization and policy validation before the tool is queued; MM-519 owns the typed tool contract and plan validation. This story owns execution ordering, locking, desired-state persistence, and command construction after the typed tool is invoked.
+- The first runtime implementation uses injectable store, artifact, and Compose runner boundaries so tests remain hermetic and privileged Docker execution can be provided only by deployment-control infrastructure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST serialize deployment update execution per stack so only one update for a stack can run at a time unless an explicit queueing policy is added.
+- **FR-002**: System MUST return non-retryable `DEPLOYMENT_LOCKED` before any lifecycle side effect when a same-stack update is already running and queueing is not enabled.
+- **FR-003**: System MUST capture before-state evidence before persisting the desired image.
+- **FR-004**: System MUST persist the requested desired image state before invoking any Compose `up` operation.
+- **FR-005**: Persisted desired state MUST include stack, image repository, requested reference, optional resolved digest, reason, created timestamp, and source run identifier when available.
+- **FR-006**: `changed_services` mode MUST construct pull and up behavior without force-recreate.
+- **FR-007**: `force_recreate` mode MUST add force-recreate behavior only when the selected mode is permitted.
+- **FR-008**: `removeOrphans` and `wait` MUST influence command construction only through recognized policy-controlled flags.
+- **FR-009**: System MUST capture command-log, after-state, and verification evidence as structured artifact references.
+- **FR-010**: System MUST NOT mark an update `SUCCEEDED` when verification cannot prove the requested desired state.
+- **FR-011**: System MUST restrict execution runner selection to deployment-controlled privileged worker or ephemeral updater container modes and MUST NOT accept caller-selected runner images or arbitrary files.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-520` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Deployment Desired State**: Durable record of the requested stack image target and audit metadata that survives process restarts.
+- **Deployment Update Lifecycle**: Ordered execution flow containing lock acquisition, before-state capture, desired-state persistence, pull, up, verification, after-state capture, lock release, and structured result reporting.
+- **Deployment Runner Mode**: Deployment-controlled execution boundary for Compose commands, either privileged worker or ephemeral updater container.
+- **Deployment Evidence Artifact**: Structured reference to before-state, after-state, command-log, or verification evidence.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 9.2 requires the requested target image to be persisted before Compose is brought up and to include stack, image repository, requested reference, resolved digest when available, operator, reason, timestamp, and source run ID. Scope: in scope. Maps to FR-004, FR-005.
+- **DESIGN-REQ-002**: Source section 10.2 requires a per-stack deployment lock and `DEPLOYMENT_LOCKED` or explicit queueing policy when another update is running. Scope: in scope. Maps to FR-001, FR-002.
+- **DESIGN-REQ-003**: Source sections 10.3 and 10.4 require before-state capture before desired image persistence and restrict persistence to an allowlisted env file or equivalent deployment-state store. Scope: in scope. Maps to FR-003, FR-004, FR-011.
+- **DESIGN-REQ-004**: Source sections 10.5 and 10.6 require pull before recreate; `changed_services` uses pull/up without force-recreate, while `force_recreate` adds force-recreate only for that mode, and `removeOrphans` / `wait` adjust recognized flags. Scope: in scope. Maps to FR-006, FR-007, FR-008.
+- **DESIGN-REQ-005**: Source sections 10.7 through 10.9 require verification, after-state capture, structured result fields, and failure when desired-state verification cannot prove success. Scope: in scope. Maps to FR-009, FR-010.
+- **DESIGN-REQ-006**: Source section 11 requires execution through deployment-controlled privileged worker or ephemeral updater container modes, with runner image policy controlled by deployment configuration rather than operator input. Scope: in scope. Maps to FR-011.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Same-stack concurrent execution is rejected with `DEPLOYMENT_LOCKED` before any fake runner side effect in tests.
+- **SC-002**: Test evidence proves before-state capture precedes desired-state persistence and desired-state persistence precedes Compose `up`.
+- **SC-003**: Test evidence proves `changed_services` commands omit force-recreate and `force_recreate` commands include it only for that mode.
+- **SC-004**: Test evidence proves `removeOrphans` and `wait` only add or omit recognized flags.
+- **SC-005**: Test evidence proves verification failure produces a non-`SUCCEEDED` result with verification artifact evidence.
+- **SC-006**: Traceability evidence preserves `MM-520`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-006 in MoonSpec artifacts.

--- a/specs/262-serialized-compose-desired-state/tasks.md
+++ b/specs/262-serialized-compose-desired-state/tasks.md
@@ -54,7 +54,7 @@
 - [X] T020 Run traceability grep for `MM-520`, `DESIGN-REQ-001`, and `deployment.update_compose_stack` across the feature artifacts, code, and tests.
 - [X] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification.
 - [X] T022 Run `./tools/test_integration.sh` when Docker is available; otherwise record the exact blocker.
-- [X] T023 Run `/speckit.verify` for `specs/262-serialized-compose-desired-state/` and produce final verification evidence.
+- [X] T023 Run `/moonspec-verify` for `specs/262-serialized-compose-desired-state/` and produce final verification evidence.
 
 ## Dependencies and Execution Order
 

--- a/specs/262-serialized-compose-desired-state/tasks.md
+++ b/specs/262-serialized-compose-desired-state/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: Serialized Compose Desired-State Execution
+
+**Input**: `specs/262-serialized-compose-desired-state/spec.md`, `specs/262-serialized-compose-desired-state/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/deployment-update-execution.md`, `quickstart.md`
+**Unit test command**: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py -q`
+**Integration test command**: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`
+
+**Source Traceability**: `MM-520`; FR-001 through FR-012; SCN-001 through SCN-007; SC-001 through SC-006; DESIGN-REQ-001 through DESIGN-REQ-006.
+
+## Phase 1: Setup
+
+- [X] T001 Verify active feature pointer `.specify/feature.json` references `specs/262-serialized-compose-desired-state`.
+- [X] T002 Confirm existing deployment API/tool contract evidence in `api_service/services/deployment_operations.py`, `moonmind/workflows/skills/deployment_tools.py`, and `tests/unit/workflows/skills/test_deployment_tool_contracts.py`.
+
+## Phase 2: Foundational
+
+- [X] T003 Add deployment update execution module structure in `moonmind/workflows/skills/deployment_execution.py` with injectable lock, desired-state store, artifact writer, and runner boundaries. (FR-001 through FR-011)
+- [X] T004 Register a deployment tool handler helper from `moonmind/workflows/skills/deployment_execution.py` without changing the typed contract in `moonmind/workflows/skills/deployment_tools.py`. (FR-009, FR-011)
+
+## Phase 3: Serialized Compose Desired-State Execution
+
+**Story**: Serialize update runs per stack and persist desired state before policy-controlled Compose recreation.
+
+**Independent Test**: Invoke the typed handler with fake infrastructure and assert lock behavior, ordering, command construction, and result semantics.
+
+**Traceability IDs**: FR-001 through FR-012; SCN-001 through SCN-007; DESIGN-REQ-001 through DESIGN-REQ-006.
+
+### Tests First
+
+- [X] T005 [P] Add failing unit tests for same-stack lock contention and side-effect-free `DEPLOYMENT_LOCKED` in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, FR-002, SCN-001, DESIGN-REQ-002)
+- [X] T006 [P] Add failing unit tests for before-state, desired-state persistence, pull, up, verification, and after-state ordering in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-003, FR-004, SCN-002, DESIGN-REQ-001, DESIGN-REQ-003)
+- [X] T007 [P] Add failing unit tests for desired-state payload fields in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-005, DESIGN-REQ-001)
+- [X] T008 [P] Add failing unit tests for `changed_services`, `force_recreate`, `removeOrphans`, and `wait` command construction in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-006, FR-007, FR-008, SCN-003, SCN-004, SCN-005, DESIGN-REQ-004)
+- [X] T009 [P] Add failing unit tests for verification failure result semantics and evidence refs in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-009, FR-010, SCN-006, DESIGN-REQ-005)
+- [X] T010 [P] Add failing unit tests for closed runner modes and no caller runner image/path inputs in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-011, SCN-007, DESIGN-REQ-006)
+- [X] T011 [P] Add failing hermetic integration test for `mm.tool.execute` dispatch of `deployment.update_compose_stack` in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-001 through FR-011)
+
+### Implementation
+
+- [X] T012 Implement per-stack nonblocking lock manager and `DEPLOYMENT_LOCKED` `ToolFailure` in `moonmind/workflows/skills/deployment_execution.py`. (FR-001, FR-002)
+- [X] T013 Implement desired-state payload creation and store invocation before Compose up in `moonmind/workflows/skills/deployment_execution.py`. (FR-003, FR-004, FR-005)
+- [X] T014 Implement typed pull/up command construction in `moonmind/workflows/skills/deployment_execution.py`. (FR-006, FR-007, FR-008)
+- [X] T015 Implement evidence artifact writer calls, verification result mapping, and structured tool output in `moonmind/workflows/skills/deployment_execution.py`. (FR-009, FR-010)
+- [X] T016 Implement closed deployment runner mode validation and registration helper in `moonmind/workflows/skills/deployment_execution.py`. (FR-011)
+- [X] T017 Wire deployment tool handler registration into `moonmind/workflows/temporal/worker_runtime.py` for the skill dispatcher. (FR-009, FR-011)
+
+### Validation
+
+- [X] T018 Run focused unit tests for deployment execution and tool contract until passing: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py -q`.
+- [X] T019 Run focused hermetic integration test until passing: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`.
+
+## Final Phase: Polish and Verification
+
+- [X] T020 Run traceability grep for `MM-520`, `DESIGN-REQ-001`, and `deployment.update_compose_stack` across the feature artifacts, code, and tests.
+- [X] T021 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification.
+- [X] T022 Run `./tools/test_integration.sh` when Docker is available; otherwise record the exact blocker.
+- [X] T023 Run `/speckit.verify` for `specs/262-serialized-compose-desired-state/` and produce final verification evidence.
+
+## Dependencies and Execution Order
+
+1. T001-T004 before story tests.
+2. T005-T011 before T012-T017.
+3. T012-T017 before T018-T019.
+4. T018-T019 before T020-T023.
+
+## Parallel Examples
+
+- T005 through T011 can be drafted in parallel because they target independent assertions in new test files.
+- T012 through T016 are sequential in one production module.
+
+## Implementation Strategy
+
+Write failing tests first against the new execution boundary, then implement the smallest lifecycle module that satisfies lock, persistence, command construction, evidence, verification, and runner-mode requirements. Keep privileged Docker access injectable and hermetic in tests.

--- a/specs/262-serialized-compose-desired-state/verification.md
+++ b/specs/262-serialized-compose-desired-state/verification.md
@@ -1,0 +1,61 @@
+# MoonSpec Verification Report
+
+**Feature**: Serialized Compose Desired-State Execution  
+**Spec**: `specs/262-serialized-compose-desired-state/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving `MM-520` Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused unit + hermetic integration | `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/integration/temporal/test_deployment_update_execution_contract.py -q` | PASS | 16 passed. Covers lifecycle, lock, command construction, verification failure, and `mm.tool.execute` dispatch. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python: 4036 passed, 1 xpassed, 16 subtests passed. Frontend: 14 files passed, 425 tests passed. |
+| Required integration wrapper | `./tools/test_integration.sh` | NOT RUN | Blocked by missing Docker socket: `dial unix /var/run/docker.sock: connect: no such file or directory`. Focused hermetic integration test above passed locally. |
+| Traceability | `rg -n "MM-520|DESIGN-REQ-001|deployment\\.update_compose_stack" specs/262-serialized-compose-desired-state moonmind/workflows/skills/deployment_execution.py moonmind/workflows/temporal/worker_runtime.py tests/unit/workflows/skills/test_deployment_update_execution.py tests/integration/temporal/test_deployment_update_execution_contract.py` | PASS | `MM-520`, source mappings, and deployment tool references remain present. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `DeploymentUpdateLockManager`; `test_same_stack_lock_contention_fails_before_side_effects`; `test_deployment_update_tool_dispatch_surfaces_deployment_locked` | VERIFIED | Same-stack updates are serialized by nonblocking lock acquisition. |
+| FR-002 | `DeploymentUpdateLockManager.acquire()` raises `ToolFailure("DEPLOYMENT_LOCKED", retryable=False)` | VERIFIED | Lock failure happens before desired-state or runner side effects. |
+| FR-003 | `DeploymentUpdateExecutor.execute()`; lifecycle ordering unit test | VERIFIED | Before-state capture precedes desired-state persistence. |
+| FR-004 | `DeploymentUpdateExecutor.execute()`; lifecycle ordering unit test | VERIFIED | Desired-state persistence precedes pull/up. |
+| FR-005 | desired-state payload assertions in `test_lifecycle_order_persists_desired_state_before_compose_up` | VERIFIED | Payload includes stack, repository, requested ref, digest, reason, timestamp, and source run ID. |
+| FR-006 | `build_compose_command_plan`; `test_changed_services_command_omits_force_recreate` | VERIFIED | `changed_services` omits `--force-recreate`. |
+| FR-007 | `build_compose_command_plan`; `test_force_recreate_and_policy_flags_are_closed` | VERIFIED | `force_recreate` adds `--force-recreate` only for that mode. |
+| FR-008 | `build_compose_command_plan`; flag tests | VERIFIED | Only recognized `--remove-orphans` and `--wait` flags are controlled by booleans. |
+| FR-009 | evidence writer calls; dispatch integration test output assertions | VERIFIED | Before, command log, verification, and after refs are returned. |
+| FR-010 | `test_verification_failure_returns_failed_tool_result_with_evidence_refs` | VERIFIED | Failed verification returns failed result and never `SUCCEEDED`. |
+| FR-011 | forbidden input test, runner mode fail-closed test, worker registration | VERIFIED | Runner mode is closed; caller runner image/path inputs are rejected. |
+| FR-012 | feature artifacts and traceability grep | VERIFIED | `MM-520` remains preserved across artifacts and verification evidence. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| SCN-001 | lock contention unit and integration tests | VERIFIED | `DEPLOYMENT_LOCKED` is non-retryable and side-effect free for the second update. |
+| SCN-002 | lifecycle ordering unit test | VERIFIED | Before capture, desired persistence, and up order are asserted. |
+| SCN-003 | changed-services command unit test | VERIFIED | Pull/up behavior omits force recreate. |
+| SCN-004 | force-recreate command unit test | VERIFIED | Force recreate appears only for the force mode. |
+| SCN-005 | flag command unit test | VERIFIED | `removeOrphans` and `wait` only affect recognized flags. |
+| SCN-006 | verification failure unit test | VERIFIED | Non-success status includes verification evidence. |
+| SCN-007 | runner mode and forbidden input tests | VERIFIED | Execution boundary excludes caller-selected runner images and files. |
+
+## Source Design Coverage
+
+| Source Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-001 | desired-state payload and persistence-before-up test | VERIFIED | Section 9.2 mapped to persisted desired state. |
+| DESIGN-REQ-002 | per-stack lock manager tests | VERIFIED | Section 10.2 mapped to lock behavior. |
+| DESIGN-REQ-003 | lifecycle ordering and forbidden input tests | VERIFIED | Sections 10.3 and 10.4 mapped to ordered capture/persist and no arbitrary files. |
+| DESIGN-REQ-004 | command builder tests | VERIFIED | Sections 10.5 and 10.6 mapped to typed pull/up args. |
+| DESIGN-REQ-005 | evidence/result tests | VERIFIED | Sections 10.7 through 10.9 mapped to verification and structured result. |
+| DESIGN-REQ-006 | runner-mode tests and dispatcher registration | VERIFIED | Section 11 mapped to closed deployment-controlled runner modes. |
+
+## Residual Risk
+
+- The full compose-backed integration wrapper could not run in this managed container because Docker is unavailable. The new story's focused hermetic integration test passed and should run in CI through the required integration pipeline.
+- The default worker registration is fail-closed with `DisabledComposeRunner` unless deployment-control infrastructure supplies a real runner. This is intentional to avoid unsafe host mutation from ordinary workers.

--- a/tests/integration/temporal/test_deployment_update_execution_contract.py
+++ b/tests/integration/temporal/test_deployment_update_execution_contract.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.deployment_execution import (
+    ComposeVerification,
+    DeploymentUpdateExecutor,
+    DeploymentUpdateLockManager,
+    InMemoryDesiredStateStore,
+    InMemoryEvidenceWriter,
+    register_deployment_update_tool_handler,
+)
+from moonmind.workflows.skills.deployment_tools import (
+    DEPLOYMENT_UPDATE_TOOL_NAME,
+    DEPLOYMENT_UPDATE_TOOL_VERSION,
+    build_deployment_update_tool_definition_payload,
+)
+from moonmind.workflows.skills.tool_dispatcher import (
+    ToolActivityDispatcher,
+    execute_tool_activity,
+)
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+from moonmind.workflows.skills.tool_plan_contracts import ToolResult
+from moonmind.workflows.skills.tool_registry import create_registry_snapshot
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+
+
+class HermeticRunner:
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, tuple[str, ...]]] = []
+
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        return {"stack": stack, "phase": phase}
+
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.commands.append(("pull", command))
+        return {"ok": True}
+
+    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.commands.append(("up", command))
+        return {"ok": True}
+
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        return ComposeVerification(
+            succeeded=True,
+            updated_services=("api",),
+            running_services=({"name": "api", "state": "running"},),
+            details={"requestedImage": requested_image, "resolvedDigest": resolved_digest},
+        )
+
+
+def _snapshot():
+    return create_registry_snapshot(
+        skills=(parse_tool_definition(build_deployment_update_tool_definition_payload()),),
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "id": "deploy-moonmind",
+        "tool": {
+            "type": "skill",
+            "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+            "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+        },
+        "inputs": {
+            "stack": "moonmind",
+            "image": {
+                "repository": "ghcr.io/moonladderstudios/moonmind",
+                "reference": "20260425.1234",
+            },
+            "mode": "changed_services",
+            "removeOrphans": True,
+            "wait": True,
+            "reason": "Update to tested build",
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_ci
+async def test_deployment_update_tool_dispatch_returns_structured_result() -> None:
+    runner = HermeticRunner()
+    executor = DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=runner,
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_deployment_update_tool_handler(dispatcher, executor=executor)
+
+    result = await execute_tool_activity(
+        invocation_payload=_payload(),
+        registry_snapshot=_snapshot(),
+        dispatcher=dispatcher,
+        context={"deployment_runner_mode": "privileged_worker"},
+    )
+
+    assert isinstance(result, ToolResult)
+    assert result.status == "COMPLETED"
+    assert result.outputs["status"] == "SUCCEEDED"
+    assert result.outputs["stack"] == "moonmind"
+    assert result.outputs["beforeStateArtifactRef"].startswith("art:sha256:")
+    assert runner.commands[0][0] == "pull"
+    assert runner.commands[1][0] == "up"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_ci
+async def test_deployment_update_tool_dispatch_surfaces_deployment_locked() -> None:
+    lock_manager = DeploymentUpdateLockManager()
+    lease = await lock_manager.acquire("moonmind")
+    executor = DeploymentUpdateExecutor(
+        lock_manager=lock_manager,
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=HermeticRunner(),
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_deployment_update_tool_handler(dispatcher, executor=executor)
+
+    try:
+        with pytest.raises(ToolFailure) as exc_info:
+            await execute_tool_activity(
+                invocation_payload=_payload(),
+                registry_snapshot=_snapshot(),
+                dispatcher=dispatcher,
+            )
+    finally:
+        await lease.release()
+
+    assert exc_info.value.error_code == "DEPLOYMENT_LOCKED"
+    assert exc_info.value.retryable is False

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -65,12 +65,12 @@ class RecordingRunner:
     async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
         self.events.append("runner:pull")
         self.commands.append(("pull", command))
-        return {"stack": stack, "command": list(command)}
+        return {"stack": stack, "command": list(command), "exitCode": 0}
 
     async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
         self.events.append("runner:up")
         self.commands.append(("up", command))
-        return {"stack": stack, "command": list(command)}
+        return {"stack": stack, "command": list(command), "exitCode": 0}
 
     async def verify(
         self,
@@ -143,6 +143,13 @@ def _executor(
     )
 
 
+class FailingUpRunner(RecordingRunner):
+    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.events.append("runner:up")
+        self.commands.append(("up", command))
+        return {"stack": stack, "command": list(command), "exitCode": 17}
+
+
 @pytest.mark.asyncio
 async def test_same_stack_lock_contention_fails_before_side_effects() -> None:
     import asyncio
@@ -167,7 +174,8 @@ async def test_same_stack_lock_contention_fails_before_side_effects() -> None:
     assert second_executor.desired_state_store.records == []
 
     blocking_runner.release_before_capture()
-    await first_task
+    first_result = await first_task
+    assert first_result.status == "COMPLETED"
 
 
 @pytest.mark.asyncio
@@ -263,6 +271,53 @@ async def test_forbidden_runner_image_and_path_inputs_are_rejected() -> None:
 
     assert exc_info.value.error_code == "INVALID_INPUT"
     assert exc_info.value.details["fields"] == ["updaterRunnerImage"]
+
+
+@pytest.mark.asyncio
+async def test_non_allowlisted_stack_is_rejected_at_execution_boundary() -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(stack="other-stack"))
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+    assert exc_info.value.details["stack"] == "other-stack"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["removeOrphans", "wait"])
+async def test_boolean_options_must_be_real_booleans(field: str) -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(**{field: "false"}))
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+    assert exc_info.value.details["field"] == field
+    assert exc_info.value.details["value_type"] == "str"
+
+
+@pytest.mark.asyncio
+async def test_failed_command_result_stops_execution_and_persists_diagnostics() -> None:
+    events: list[str] = []
+    runner = FailingUpRunner(events)
+    executor, _store, evidence, _runner, _events = _executor(runner=runner, events=events)
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs())
+
+    assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert exc_info.value.details["phase"] == "up"
+    assert "runner:verify" not in events
+    assert [kind for kind, _payload in evidence.records] == [
+        "before-state",
+        "command-log",
+        "after-state",
+    ]
+    command_payload = dict(evidence.records[1][1])
+    assert command_payload["pull"]["result"]["exitCode"] == 0
+    assert command_payload["up"]["result"]["exitCode"] == 17
+    assert command_payload["error"]["error_code"] == "DEPLOYMENT_COMMAND_FAILED"
 
 
 def test_unsupported_runner_mode_fails_closed() -> None:

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from moonmind.workflows.skills.deployment_execution import (
+    ComposeVerification,
+    DeploymentUpdateExecutor,
+    DeploymentUpdateLockManager,
+    InMemoryDesiredStateStore,
+    build_compose_command_plan,
+    build_deployment_update_handler,
+)
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+
+
+class RecordingEvidenceWriter:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        self.events.append(f"evidence:{kind}")
+        self.records.append((kind, dict(payload)))
+        return f"art:sha256:{kind.replace('-', ''):0<64}"[:75]
+
+
+class RecordingDesiredStateStore(InMemoryDesiredStateStore):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    async def persist(self, payload: Mapping[str, Any]) -> str:
+        self.events.append("desired:persist")
+        return await super().persist(payload)
+
+
+class RecordingRunner:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        verification_succeeded: bool = True,
+        block_on_before: bool = False,
+    ) -> None:
+        self.events = events
+        self.commands: list[tuple[str, tuple[str, ...]]] = []
+        self.verification_succeeded = verification_succeeded
+        self._before_event = None
+        self._release_event = None
+        if block_on_before:
+            import asyncio
+
+            self._before_event = asyncio.Event()
+            self._release_event = asyncio.Event()
+
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        self.events.append(f"runner:capture:{phase}")
+        if phase == "before" and self._before_event is not None:
+            self._before_event.set()
+            await self._release_event.wait()
+        return {"stack": stack, "phase": phase, "services": ["api"]}
+
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.events.append("runner:pull")
+        self.commands.append(("pull", command))
+        return {"stack": stack, "command": list(command)}
+
+    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.events.append("runner:up")
+        self.commands.append(("up", command))
+        return {"stack": stack, "command": list(command)}
+
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        self.events.append("runner:verify")
+        return ComposeVerification(
+            succeeded=self.verification_succeeded,
+            updated_services=("api",) if self.verification_succeeded else (),
+            running_services=(
+                {"name": "api", "state": "running", "health": "healthy"},
+            ),
+            details={
+                "stack": stack,
+                "requestedImage": requested_image,
+                "resolvedDigest": resolved_digest,
+            },
+        )
+
+    async def wait_until_before_capture_started(self) -> None:
+        assert self._before_event is not None
+        await self._before_event.wait()
+
+    def release_before_capture(self) -> None:
+        assert self._release_event is not None
+        self._release_event.set()
+
+
+def _inputs(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "stack": "moonmind",
+        "image": {
+            "repository": "ghcr.io/moonladderstudios/moonmind",
+            "reference": "20260425.1234",
+            "resolvedDigest": "sha256:" + "a" * 64,
+        },
+        "mode": "changed_services",
+        "removeOrphans": True,
+        "wait": True,
+        "reason": "Update to the latest tested build",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _executor(
+    *,
+    runner: RecordingRunner | None = None,
+    events: list[str] | None = None,
+    lock_manager: DeploymentUpdateLockManager | None = None,
+) -> tuple[DeploymentUpdateExecutor, RecordingDesiredStateStore, RecordingEvidenceWriter, RecordingRunner, list[str]]:
+    events = events if events is not None else []
+    store = RecordingDesiredStateStore(events)
+    evidence = RecordingEvidenceWriter(events)
+    runner = runner or RecordingRunner(events)
+    return (
+        DeploymentUpdateExecutor(
+            lock_manager=lock_manager or DeploymentUpdateLockManager(),
+            desired_state_store=store,
+            evidence_writer=evidence,
+            runner=runner,
+        ),
+        store,
+        evidence,
+        runner,
+        events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_stack_lock_contention_fails_before_side_effects() -> None:
+    import asyncio
+
+    events: list[str] = []
+    lock_manager = DeploymentUpdateLockManager()
+    blocking_runner = RecordingRunner(events, block_on_before=True)
+    first_executor, _store, _evidence, _runner, _events = _executor(
+        runner=blocking_runner, events=events, lock_manager=lock_manager
+    )
+    second_executor, _store2, _evidence2, _runner2, _events2 = _executor(
+        events=[], lock_manager=lock_manager
+    )
+    first_task = asyncio.create_task(first_executor.execute(_inputs()))
+    await blocking_runner.wait_until_before_capture_started()
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await second_executor.execute(_inputs())
+
+    assert exc_info.value.error_code == "DEPLOYMENT_LOCKED"
+    assert exc_info.value.retryable is False
+    assert second_executor.desired_state_store.records == []
+
+    blocking_runner.release_before_capture()
+    await first_task
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_order_persists_desired_state_before_compose_up() -> None:
+    executor, store, _evidence, _runner, events = _executor()
+
+    result = await executor.execute(_inputs(), {"source_run_id": "run-123"})
+
+    assert result.status == "COMPLETED"
+    assert events.index("runner:capture:before") < events.index("desired:persist")
+    assert events.index("desired:persist") < events.index("runner:up")
+    assert store.records[0]["stack"] == "moonmind"
+    assert store.records[0]["imageRepository"] == "ghcr.io/moonladderstudios/moonmind"
+    assert store.records[0]["requestedReference"] == "20260425.1234"
+    assert store.records[0]["resolvedDigest"] == "sha256:" + "a" * 64
+    assert store.records[0]["reason"] == "Update to the latest tested build"
+    assert store.records[0]["sourceRunId"] == "run-123"
+
+
+def test_changed_services_command_omits_force_recreate() -> None:
+    plan = build_compose_command_plan(
+        mode="changed_services",
+        remove_orphans=True,
+        wait=True,
+        runner_mode="privileged_worker",
+    )
+
+    assert plan.pull_args == (
+        "docker",
+        "compose",
+        "pull",
+        "--policy",
+        "always",
+        "--ignore-buildable",
+    )
+    assert plan.up_args == (
+        "docker",
+        "compose",
+        "up",
+        "-d",
+        "--remove-orphans",
+        "--wait",
+    )
+    assert "--force-recreate" not in plan.up_args
+
+
+def test_force_recreate_and_policy_flags_are_closed() -> None:
+    plan = build_compose_command_plan(
+        mode="force_recreate",
+        remove_orphans=False,
+        wait=False,
+        runner_mode="ephemeral_updater_container",
+    )
+
+    assert plan.runner_mode == "ephemeral_updater_container"
+    assert plan.up_args == (
+        "docker",
+        "compose",
+        "up",
+        "-d",
+        "--force-recreate",
+    )
+    assert "--remove-orphans" not in plan.up_args
+    assert "--wait" not in plan.up_args
+
+
+@pytest.mark.asyncio
+async def test_verification_failure_returns_failed_tool_result_with_evidence_refs() -> None:
+    events: list[str] = []
+    runner = RecordingRunner(events, verification_succeeded=False)
+    executor, _store, evidence, _runner, _events = _executor(runner=runner, events=events)
+
+    result = await executor.execute(_inputs())
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "FAILED"
+    assert result.outputs["verificationArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["afterStateArtifactRef"].startswith("art:sha256:")
+    assert [kind for kind, _payload in evidence.records] == [
+        "before-state",
+        "command-log",
+        "verification",
+        "after-state",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forbidden_runner_image_and_path_inputs_are_rejected() -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(updaterRunnerImage="docker:29-cli"))
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+    assert exc_info.value.details["fields"] == ["updaterRunnerImage"]
+
+
+def test_unsupported_runner_mode_fails_closed() -> None:
+    with pytest.raises(ToolFailure) as exc_info:
+        build_compose_command_plan(
+            mode="changed_services",
+            remove_orphans=True,
+            wait=True,
+            runner_mode="caller_selected",
+        )
+
+    assert exc_info.value.error_code == "POLICY_VIOLATION"
+
+
+@pytest.mark.asyncio
+async def test_context_executor_override_supports_registered_handler() -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+    handler = build_deployment_update_handler()
+
+    result = await handler(
+        _inputs(),
+        {
+            "deployment_update_executor": executor,
+            "deployment_runner_mode": "privileged_worker",
+        },
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["requestedImage"] == (
+        "ghcr.io/moonladderstudios/moonmind:20260425.1234"
+    )

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1404,6 +1404,12 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     run_supervisor.reconcile.assert_not_awaited()
     session_controller.reconcile.assert_not_awaited()
     mock_dispatcher_cls.assert_called_once_with()
+    deployment_handler_calls = [
+        call
+        for call in mock_dispatcher_cls.return_value.register_skill.call_args_list
+        if call.kwargs.get("skill_name") == "deployment.update_compose_stack"
+    ]
+    assert deployment_handler_calls == []
     mock_skill_activities_cls.assert_called_once_with(
         dispatcher=mock_dispatcher_cls.return_value,
         artifact_service=ANY,
@@ -1504,6 +1510,12 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
     mock_build_deps.assert_called_once_with()
     run_supervisor.reconcile.assert_awaited_once()
     session_controller.reconcile.assert_awaited_once()
+    deployment_handler_calls = [
+        call
+        for call in mock_dispatcher_cls.return_value.register_skill.call_args_list
+        if call.kwargs.get("skill_name") == "deployment.update_compose_stack"
+    ]
+    assert len(deployment_handler_calls) == 1
     mock_agent_runtime_activities_cls.assert_called_once_with(
         artifact_service=ANY,
         run_store=run_store,


### PR DESCRIPTION
## Summary

Implements MM-520 serialized Compose desired-state execution.

## Jira

- Jira issue key: MM-520

## MoonSpec

- Active feature path: `specs/262-serialized-compose-desired-state`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests Run

- `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/integration/temporal/test_deployment_update_execution_contract.py -q` - PASS, 16 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, Python 4036 passed, frontend 425 passed
- `./tools/test_integration.sh` - NOT RUN locally, Docker socket unavailable in managed runtime

## Remaining Risks

- Full compose-backed integration must run in a Docker-enabled environment; focused hermetic integration passed locally.
- The default worker registration is fail-closed with `DisabledComposeRunner` unless deployment-control infrastructure supplies a real runner.
