### PR TITLE
MM-521 deployment verification artifacts and progress

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/262-serialized-compose-desired-state"
+  "feature_directory": "specs/263-deployment-verification-artifacts-progress"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,5 @@
 {
-  "jira_issue_key": "MM-518",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1768"
+  "jira_issue_key": "MM-521",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1775"
 }
+

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,62 +1,27 @@
 [
   {
-    "id": 3142801124,
-    "disposition": "addressed",
-    "rationale": "Deployment tool registration is now limited to the privileged agent_runtime fleet instead of every worker dispatcher, keeping stack update locking and execution on the intended deployment-capable worker boundary."
-  },
-  {
-    "id": 3142801125,
-    "disposition": "addressed",
-    "rationale": "Compose pull and up result mappings are now strictly checked for success signals and non-zero exit codes fail closed before later lifecycle steps."
-  },
-  {
-    "id": 3142801128,
-    "disposition": "addressed",
-    "rationale": "Deployment execution now writes command-log and after-state evidence from a finally path when runner calls fail after before-state capture."
-  },
-  {
-    "id": 3142801130,
-    "disposition": "addressed",
-    "rationale": "deployment.update_compose_stack registration moved inside the agent_runtime fleet setup block rather than using the default disabled runner on all workers."
-  },
-  {
-    "id": 3142801132,
-    "disposition": "addressed",
-    "rationale": "Command-log evidence is persisted before verification on success and in the failure cleanup path when pull or up fails."
-  },
-  {
-    "id": 4176371791,
+    "id": 4176417120,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review summary; its actionable inline findings are tracked by their individual comment IDs."
+    "rationale": "Bot review summary; no actionable request beyond the inline redaction comment tracked separately."
   },
   {
-    "id": 3142801582,
+    "id": 3142847692,
     "disposition": "addressed",
-    "rationale": "The awaited first deployment task result is now assigned and asserted as COMPLETED."
+    "rationale": "Refined sensitive value redaction to stop at common delimiters and include passwd, with regression coverage for preserving adjacent non-sensitive fields."
   },
   {
-    "id": 3142803336,
-    "disposition": "addressed",
-    "rationale": "_parse_inputs now rejects non-allowlisted stack names at the execution boundary with INVALID_INPUT."
-  },
-  {
-    "id": 3142803338,
-    "disposition": "addressed",
-    "rationale": "removeOrphans and wait now require real boolean values and reject string payloads with INVALID_INPUT."
-  },
-  {
-    "id": 3142803340,
-    "disposition": "addressed",
-    "rationale": "desiredStateRef was removed from emitted outputs so runtime output stays within the declared tool schema."
-  },
-  {
-    "id": 4176375485,
+    "id": 4176419798,
     "disposition": "not-applicable",
-    "rationale": "Top-level Codex review wrapper; actionable suggestions are tracked by their individual inline comment IDs."
+    "rationale": "Bot review wrapper text; actionable Codex findings are tracked by their inline review comment IDs."
   },
   {
-    "id": 3142815558,
+    "id": 3142851408,
     "disposition": "addressed",
-    "rationale": "The awaited first deployment task result is now assigned and asserted as COMPLETED."
+    "rationale": "Returned audit metadata is now passed through recursive redaction, with regression coverage for secret-like verification failure reasons."
+  },
+  {
+    "id": 3142851410,
+    "disposition": "addressed",
+    "rationale": "Deployment execution exceptions now force finalStatus to FAILED even after verification had set a success status, with regression coverage for post-verification evidence failures."
   }
 ]

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Mapping, Protocol
@@ -20,6 +21,19 @@ DEPLOYMENT_RUNNER_MODES = frozenset(
 )
 DEPLOYMENT_UPDATE_MODES = frozenset({"changed_services", "force_recreate"})
 DEPLOYMENT_UPDATE_STACKS = frozenset({"moonmind"})
+DEPLOYMENT_FINAL_STATUSES = frozenset({"SUCCEEDED", "FAILED", "PARTIALLY_VERIFIED"})
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"("
+    r"token|secret|password|passwd|credential|authorization|"
+    r"auth[_-]?header|api[_-]?key|registry[_-]?password"
+    r")",
+    re.IGNORECASE,
+)
+_SENSITIVE_VALUE_PATTERN = re.compile(
+    r"(bearer\s+[A-Za-z0-9._~+/=-]+|token=\S+|password=\S+|secret=\S+)",
+    re.IGNORECASE,
+)
 
 
 class DesiredStateStore(Protocol):
@@ -45,6 +59,7 @@ class ComposeVerification:
     updated_services: tuple[str, ...]
     running_services: tuple[Mapping[str, Any], ...]
     details: Mapping[str, Any]
+    status: str | None = None
 
 
 class ComposeRunner(Protocol):
@@ -80,7 +95,10 @@ class DeploymentUpdateLockManager:
             if normalized in self._held:
                 raise ToolFailure(
                     error_code="DEPLOYMENT_LOCKED",
-                    message=f"Deployment update for stack '{normalized}' is already running.",
+                    message=(
+                        "Deployment update for stack "
+                        f"'{normalized}' is already running."
+                    ),
                     retryable=False,
                     details={"stack": normalized},
                 )
@@ -194,12 +212,19 @@ class DeploymentUpdateExecutor:
         context: Mapping[str, Any] | None = None,
     ) -> ToolResult:
         context = dict(context or {})
+        progress_events: list[dict[str, str]] = []
+        _add_progress(progress_events, "QUEUED", "Deployment update queued.")
+        _add_progress(
+            progress_events, "VALIDATING", "Validating deployment update input."
+        )
         parsed = _parse_inputs(inputs)
         command_plan = build_compose_command_plan(
             mode=parsed["mode"],
             remove_orphans=parsed["removeOrphans"],
             wait=parsed["wait"],
-            runner_mode=str(context.get("deployment_runner_mode") or "privileged_worker"),
+            runner_mode=str(
+                context.get("deployment_runner_mode") or "privileged_worker"
+            ),
         )
         source_run_id = str(
             context.get("source_run_id")
@@ -207,27 +232,82 @@ class DeploymentUpdateExecutor:
             or context.get("workflow_id")
             or ""
         ).strip() or None
-        operator = str(context.get("operator") or context.get("principal") or "").strip()
+        operator = str(
+            context.get("operator") or context.get("principal") or ""
+        ).strip()
+        operator_role = str(
+            context.get("operator_role") or context.get("principal_role") or ""
+        ).strip()
+        workflow_id = str(context.get("workflow_id") or "").strip() or None
+        task_id = (
+            str(context.get("task_id") or context.get("workflow_task_id") or "").strip()
+            or None
+        )
         requested_image = _requested_image(parsed)
         resolved_digest = parsed["image"].get("resolvedDigest")
+        started_at = _utc_now()
         before_ref: str | None = None
         after_ref: str | None = None
         command_ref: str | None = None
         verification_ref: str | None = None
         verification: ComposeVerification | None = None
+        final_status: str | None = None
+        failure_reason: str | None = None
         command_log: dict[str, Any] = {
             "runnerMode": command_plan.runner_mode,
             "pull": {"command": list(command_plan.pull_args)},
             "up": {"command": list(command_plan.up_args)},
         }
 
+        def audit_snapshot(*, completed: bool = False) -> dict[str, Any]:
+            return _compact_mapping(
+                {
+                    "runId": source_run_id,
+                    "workflowId": workflow_id,
+                    "taskId": task_id,
+                    "stack": parsed["stack"],
+                    "operator": operator or None,
+                    "operatorRole": operator_role or None,
+                    "reason": parsed["reason"],
+                    "requestedImage": requested_image,
+                    "resolvedDigest": resolved_digest,
+                    "mode": parsed["mode"],
+                    "options": {
+                        "removeOrphans": parsed["removeOrphans"],
+                        "wait": parsed["wait"],
+                    },
+                    "startedAt": started_at,
+                    "completedAt": _utc_now() if completed else None,
+                    "finalStatus": final_status,
+                    "failureReason": failure_reason,
+                }
+            )
+
+        async def write_evidence(kind: str, payload: Mapping[str, Any]) -> str:
+            enriched = dict(payload)
+            enriched["audit"] = audit_snapshot(completed=final_status is not None)
+            return await self.evidence_writer.write(kind, _redact_sensitive(enriched))
+
+        _add_progress(
+            progress_events, "LOCK_WAITING", "Waiting for deployment update lock."
+        )
         async with await self.lock_manager.acquire(parsed["stack"]):
             try:
+                _add_progress(
+                    progress_events,
+                    "CAPTURING_BEFORE_STATE",
+                    "Capturing current deployment state.",
+                )
                 before_state = await self.runner.capture_state(
                     stack=parsed["stack"], phase="before"
                 )
-                before_ref = await self.evidence_writer.write("before-state", before_state)
+                before_ref = await write_evidence("before-state", before_state)
 
+                _add_progress(
+                    progress_events,
+                    "PERSISTING_DESIRED_STATE",
+                    "Persisting requested deployment state.",
+                )
                 desired_payload = {
                     "stack": parsed["stack"],
                     "imageRepository": parsed["image"]["repository"],
@@ -240,36 +320,50 @@ class DeploymentUpdateExecutor:
                 }
                 await self.desired_state_store.persist(desired_payload)
 
+                _add_progress(
+                    progress_events, "PULLING_IMAGES", "Pulling requested images."
+                )
                 pull_result = await self.runner.pull(
                     stack=parsed["stack"], command=command_plan.pull_args
                 )
                 command_log["pull"]["result"] = pull_result
                 _ensure_command_succeeded("pull", pull_result)
 
+                _add_progress(
+                    progress_events,
+                    "RECREATING_SERVICES",
+                    "Recreating deployment services.",
+                )
                 up_result = await self.runner.up(
                     stack=parsed["stack"], command=command_plan.up_args
                 )
                 command_log["up"]["result"] = up_result
                 _ensure_command_succeeded("up", up_result)
-                command_ref = await self.evidence_writer.write(
-                    "command-log", command_log
-                )
+                command_ref = await write_evidence("command-log", command_log)
 
+                _add_progress(progress_events, "VERIFYING", "Verifying deployed state.")
                 verification = await self.runner.verify(
                     stack=parsed["stack"],
                     requested_image=requested_image,
                     resolved_digest=resolved_digest,
                 )
-                verification_ref = await self.evidence_writer.write(
+                final_status = _verification_final_status(verification)
+                if final_status != "SUCCEEDED":
+                    failure_reason = _verification_failure_reason(verification)
+                verification_ref = await write_evidence(
                     "verification",
                     {
                         "succeeded": verification.succeeded,
+                        "status": final_status,
                         "details": dict(verification.details),
                         "requestedImage": requested_image,
                         "resolvedDigest": resolved_digest,
                     },
                 )
             except Exception as exc:
+                if final_status is None:
+                    final_status = "FAILED"
+                failure_reason = failure_reason or _failure_reason(exc)
                 _record_command_exception(command_log, exc)
                 raise
             finally:
@@ -277,14 +371,17 @@ class DeploymentUpdateExecutor:
                     command_ref is None
                     and ("result" in command_log["pull"] or "error" in command_log)
                 ):
-                    command_ref = await self.evidence_writer.write(
-                        "command-log", command_log
-                    )
+                    command_ref = await write_evidence("command-log", command_log)
                 if before_ref is not None:
+                    _add_progress(
+                        progress_events,
+                        "CAPTURING_AFTER_STATE",
+                        "Capturing deployment state after update.",
+                    )
                     after_state = await self.runner.capture_state(
                         stack=parsed["stack"], phase="after"
                     )
-                    after_ref = await self.evidence_writer.write("after-state", after_state)
+                    after_ref = await write_evidence("after-state", after_state)
 
         if verification is None:
             raise ToolFailure(
@@ -293,6 +390,8 @@ class DeploymentUpdateExecutor:
                 retryable=False,
                 details={"stack": parsed["stack"]},
             )
+        if final_status is None:
+            final_status = _verification_final_status(verification)
         if after_ref is None:
             raise ToolFailure(
                 error_code="DEPLOYMENT_EVIDENCE_INCOMPLETE",
@@ -315,23 +414,114 @@ class DeploymentUpdateExecutor:
                 details={"stack": parsed["stack"]},
             )
 
+        terminal_message = _terminal_progress_message(final_status)
+        _add_progress(progress_events, final_status, terminal_message)
         outputs = {
-            "status": "SUCCEEDED" if verification.succeeded else "FAILED",
+            "status": final_status,
             "stack": parsed["stack"],
             "requestedImage": requested_image,
             "resolvedDigest": resolved_digest,
             "updatedServices": list(verification.updated_services),
-            "runningServices": [dict(service) for service in verification.running_services],
+            "runningServices": [
+                dict(service) for service in verification.running_services
+            ],
             "beforeStateArtifactRef": before_ref,
             "afterStateArtifactRef": after_ref,
             "commandLogArtifactRef": command_ref,
             "verificationArtifactRef": verification_ref,
+            "audit": audit_snapshot(completed=True),
         }
         return ToolResult(
-            status="COMPLETED" if verification.succeeded else "FAILED",
+            status="COMPLETED" if final_status == "SUCCEEDED" else "FAILED",
             outputs=outputs,
-            progress={"percent": 100},
+            progress={
+                "percent": 100,
+                "state": final_status,
+                "message": terminal_message,
+                "events": progress_events,
+            },
         )
+
+
+def _add_progress(events: list[dict[str, str]], state: str, message: str) -> None:
+    events.append({"state": state, "message": message})
+
+
+def _verification_final_status(verification: ComposeVerification) -> str:
+    explicit = str(verification.status or "").strip().upper()
+    if explicit:
+        if explicit not in DEPLOYMENT_FINAL_STATUSES:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_VERIFICATION_INVALID",
+                message=f"Unsupported deployment verification status '{explicit}'.",
+                retryable=False,
+                details={"status": explicit},
+            )
+        if verification.succeeded and explicit != "SUCCEEDED":
+            raise ToolFailure(
+                error_code="DEPLOYMENT_VERIFICATION_INVALID",
+                message="Deployment verification status conflicts with success flag.",
+                retryable=False,
+                details={"status": explicit, "succeeded": verification.succeeded},
+            )
+        if explicit == "SUCCEEDED" and not verification.succeeded:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_VERIFICATION_INVALID",
+                message=(
+                    "Deployment verification success status conflicts "
+                    "with success flag."
+                ),
+                retryable=False,
+                details={"status": explicit, "succeeded": verification.succeeded},
+            )
+        return explicit
+    return "SUCCEEDED" if verification.succeeded else "FAILED"
+
+
+def _verification_failure_reason(verification: ComposeVerification) -> str | None:
+    details = dict(verification.details)
+    for key in ("failureReason", "failure_reason", "message", "reason"):
+        value = details.get(key)
+        if value:
+            return str(value)
+    failed_checks = details.get("failedChecks") or details.get("failed_checks")
+    if failed_checks:
+        return f"Verification checks failed: {failed_checks}"
+    if not verification.succeeded:
+        return "Deployment verification did not prove desired state."
+    return None
+
+
+def _failure_reason(exc: Exception) -> str:
+    if isinstance(exc, ToolFailure):
+        return exc.message
+    return str(exc)
+
+
+def _terminal_progress_message(status: str) -> str:
+    if status == "SUCCEEDED":
+        return "Deployment update succeeded."
+    if status == "PARTIALLY_VERIFIED":
+        return "Deployment update partially verified."
+    return "Deployment update failed."
+
+
+def _compact_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _redact_sensitive(value: Any, key: str | None = None) -> Any:
+    if key and _SENSITIVE_KEY_PATTERN.search(key):
+        return _REDACTED
+    if isinstance(value, Mapping):
+        return {str(k): _redact_sensitive(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_sensitive(item, key) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_sensitive(item, key) for item in value)
+    if isinstance(value, str):
+        return _SENSITIVE_VALUE_PATTERN.sub(_REDACTED, value)
+    return value
 
 
 def build_compose_command_plan(
@@ -417,7 +607,9 @@ def register_deployment_update_tool_handler(
 
 def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(inputs, Mapping):
-        raise ToolFailure("INVALID_INPUT", "Deployment inputs must be an object.", False)
+        raise ToolFailure(
+            "INVALID_INPUT", "Deployment inputs must be an object.", False
+        )
     forbidden = {"command", "composeFile", "hostPath", "updaterRunnerImage"}
     found_forbidden = sorted(forbidden.intersection(inputs.keys()))
     if found_forbidden:
@@ -438,7 +630,10 @@ def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
             error_code="INVALID_INPUT",
             message=f"Unsupported deployment stack '{stack}'.",
             retryable=False,
-            details={"stack": stack, "allowed_stacks": sorted(DEPLOYMENT_UPDATE_STACKS)},
+            details={
+                "stack": stack,
+                "allowed_stacks": sorted(DEPLOYMENT_UPDATE_STACKS),
+            },
         )
 
     parsed = {

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -31,7 +31,8 @@ _SENSITIVE_KEY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SENSITIVE_VALUE_PATTERN = re.compile(
-    r"(bearer\s+[A-Za-z0-9._~+/=-]+|token=\S+|password=\S+|secret=\S+)",
+    r"(bearer\s+[A-Za-z0-9._~+/=-]+|"
+    r"(?:token|password|passwd|secret)=[^ \t\n\r,;&\"']+)",
     re.IGNORECASE,
 )
 
@@ -361,8 +362,7 @@ class DeploymentUpdateExecutor:
                     },
                 )
             except Exception as exc:
-                if final_status is None:
-                    final_status = "FAILED"
+                final_status = "FAILED"
                 failure_reason = failure_reason or _failure_reason(exc)
                 _record_command_exception(command_log, exc)
                 raise
@@ -429,7 +429,7 @@ class DeploymentUpdateExecutor:
             "afterStateArtifactRef": after_ref,
             "commandLogArtifactRef": command_ref,
             "verificationArtifactRef": verification_ref,
-            "audit": audit_snapshot(completed=True),
+            "audit": _redact_sensitive(audit_snapshot(completed=True)),
         }
         return ToolResult(
             status="COMPLETED" if final_status == "SUCCEEDED" else "FAILED",

--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -94,6 +94,10 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
                     "afterStateArtifactRef": {"type": "string"},
                     "commandLogArtifactRef": {"type": "string"},
                     "verificationArtifactRef": {"type": "string"},
+                    "audit": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
                 },
             }
         },

--- a/specs/263-deployment-verification-artifacts-progress/checklists/requirements.md
+++ b/specs/263-deployment-verification-artifacts-progress/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Deployment Verification, Artifacts, and Progress
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: MM-521 is classified as one runtime story and preserves the trusted Jira preset brief.

--- a/specs/263-deployment-verification-artifacts-progress/contracts/deployment-verification-evidence.md
+++ b/specs/263-deployment-verification-artifacts-progress/contracts/deployment-verification-evidence.md
@@ -1,0 +1,38 @@
+# Contract: Deployment Verification Evidence
+
+The `deployment.update_compose_stack` tool result keeps the existing public shape and adds compact audit/progress metadata.
+
+## Output Fields
+
+Required existing fields:
+- `status`: `SUCCEEDED`, `FAILED`, or `PARTIALLY_VERIFIED`
+- `stack`
+- `requestedImage`
+- `updatedServices`
+- `runningServices`
+- `beforeStateArtifactRef`
+- `afterStateArtifactRef`
+- `commandLogArtifactRef`
+- `verificationArtifactRef`
+
+Additional metadata fields:
+- `resolvedDigest`: optional digest evidence
+- `audit`: compact deployment audit metadata
+
+## Progress Payload
+
+`ToolResult.progress` contains:
+
+```json
+{
+  "percent": 100,
+  "state": "SUCCEEDED",
+  "message": "Deployment update succeeded.",
+  "events": [
+    {"state": "VALIDATING", "message": "Validating deployment update input."},
+    {"state": "CAPTURING_BEFORE_STATE", "message": "Capturing current deployment state."}
+  ]
+}
+```
+
+Progress events must not include raw command output, environment dumps, auth headers, tokens, or command logs.

--- a/specs/263-deployment-verification-artifacts-progress/data-model.md
+++ b/specs/263-deployment-verification-artifacts-progress/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Deployment Verification, Artifacts, and Progress
+
+## Deployment Verification Result
+
+- `status`: one of `SUCCEEDED`, `FAILED`, `PARTIALLY_VERIFIED`.
+- `updated_services`: services changed or verified as updated.
+- `running_services`: structured service state evidence.
+- `details`: verification checks, failure reasons, and smoke-check evidence from the runner.
+
+Validation:
+- Unsupported status values fail closed.
+- `succeeded=True` is treated as `SUCCEEDED`.
+- `PARTIALLY_VERIFIED` is allowed only as a final non-success tool result.
+
+## Deployment Evidence Artifact
+
+- `kind`: before-state, command-log, verification, or after-state.
+- `payload`: recursively redacted structured mapping.
+- `artifactRef`: opaque artifact reference returned by the evidence writer.
+
+Validation:
+- Secret-like keys and values are redacted before writing.
+- Required refs are returned for phases reached by the lifecycle.
+
+## Deployment Audit Metadata
+
+- `runId`, `workflowId`, `taskId` when available.
+- `stack`, `operator`, `operatorRole`, `reason`.
+- `requestedImage`, `resolvedDigest`, `mode`, `options`.
+- `startedAt`, `completedAt`, `finalStatus`, `failureReason` when applicable.
+
+Validation:
+- Metadata is compact and contains no raw credentials.
+- Missing optional IDs are omitted or null, not invented.
+
+## Deployment Progress Event
+
+- `state`: documented lifecycle value.
+- `message`: short operator-visible progress text.
+
+Validation:
+- Detailed command output is excluded from progress events.
+- Terminal state matches final status.

--- a/specs/263-deployment-verification-artifacts-progress/moonspec_align_report.md
+++ b/specs/263-deployment-verification-artifacts-progress/moonspec_align_report.md
@@ -1,0 +1,24 @@
+# MoonSpec Align Report: Deployment Verification, Artifacts, and Progress
+
+**Feature**: `specs/263-deployment-verification-artifacts-progress/`
+**Jira**: `MM-521`
+**Date**: 2026-04-26
+
+## Alignment Decision
+
+Artifact drift was limited to `research.md`. The research decisions were still valid, but several evidence statements described the pre-implementation repository gaps after `plan.md`, `tasks.md`, code, and tests had already moved to implemented and verified behavior.
+
+## Remediation
+
+- Updated `research.md` evidence for FR-001 through FR-008 to describe the current implemented behavior and test evidence.
+- Left `spec.md`, `plan.md`, `data-model.md`, `contracts/deployment-verification-evidence.md`, `quickstart.md`, and `tasks.md` unchanged because their requirements, design strategy, task order, and verification status still match the implementation.
+
+## Downstream Gate Check
+
+- Specify gate remains valid: one story, no clarification markers, original MM-521 Jira preset brief preserved.
+- Plan gate remains valid: `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist and contain explicit unit and integration strategies.
+- Tasks gate remains valid: `tasks.md` covers one story with red-first unit tests, integration tests, implementation tasks, validation, and final `/moonspec-verify` work.
+
+## Remaining Risk
+
+The full compose-backed integration wrapper remains blocked in this managed container because the Docker socket is unavailable at `unix:///var/run/docker.sock`. Focused hermetic unit and dispatch tests passed before alignment, and this alignment changed only MoonSpec artifacts.

--- a/specs/263-deployment-verification-artifacts-progress/plan.md
+++ b/specs/263-deployment-verification-artifacts-progress/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Deployment Verification, Artifacts, and Progress
+
+**Branch**: `263-deployment-verification-artifacts-progress` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/263-deployment-verification-artifacts-progress/spec.md`
+
+## Summary
+
+Implement `MM-521` by completing the existing `deployment.update_compose_stack` executor verification surface: represent partial verification explicitly, attach audit metadata to durable evidence and final outputs, recursively redact sensitive values before artifact publication, and expose bounded lifecycle progress states. Existing MM-520 execution code already writes the four required artifact refs and fails non-successful verification; this story adds the missing semantics and regression tests without changing the public tool name or broadening deployment policy.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `DeploymentUpdateExecutor.execute()` derives final status through `_verification_final_status()` and focused unit/integration tests pass | complete | unit + integration passed |
+| FR-002 | implemented_verified | failed and partial verification return non-`SUCCEEDED` statuses with artifact refs | complete | unit passed |
+| FR-003 | implemented_verified | `ComposeVerification.status` supports `PARTIALLY_VERIFIED` and invalid statuses fail closed | complete | unit passed |
+| FR-004 | implemented_verified | executor returns before, command, verification, and after refs; partial-status tests cover refs | complete | unit + integration passed |
+| FR-005 | implemented_verified | executor raises `DEPLOYMENT_EVIDENCE_INCOMPLETE` when after, command, or verification refs are missing | complete | final verification passed |
+| FR-006 | implemented_verified | audit metadata is attached to verification evidence and final outputs | complete | unit passed |
+| FR-007 | implemented_verified | recursive redaction runs before evidence writer publication | complete | unit passed |
+| FR-008 | implemented_verified | `ToolResult.progress` contains bounded lifecycle events, state, and short terminal message | complete | unit + integration passed |
+| FR-009 | implemented_verified | MM-521 preserved in spec, plan, tasks, quickstart, verification, code/test traceability | complete | traceability grep passed |
+| DESIGN-REQ-001 | implemented_verified | verification status classification covers success, failed, and partial outcomes | complete | unit passed |
+| DESIGN-REQ-002 | implemented_verified | failed/partial proof never returns `SUCCEEDED` and includes artifact refs | complete | unit + integration passed |
+| DESIGN-REQ-003 | implemented_verified | required artifact refs and audit metadata are present in evidence/final output | complete | unit passed |
+| DESIGN-REQ-004 | implemented_verified | recursive redaction removes secret-like keys and values before artifact publication | complete | unit passed |
+| DESIGN-REQ-005 | implemented_verified | progress includes documented lifecycle states with short messages and no command output | complete | unit + integration passed |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: existing MoonMind `ToolResult` / `ToolFailure`, pytest, Pydantic v2 at API boundaries  
+**Storage**: existing artifact refs and in-memory test stores only; no new persistent database tables  
+**Unit Testing**: pytest via focused `pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q` and final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration Testing**: hermetic `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`; full compose-backed `./tools/test_integration.sh` only when Docker is available  
+**Target Platform**: MoonMind deployment-control runtime  
+**Project Type**: backend workflow skill execution  
+**Performance Goals**: redaction and audit wrapping are linear in evidence payload size; progress payload remains compact  
+**Constraints**: no raw credentials in logs/artifacts, no arbitrary Docker command inputs, no new storage, preserve existing deployment tool contract name/version  
+**Scale/Scope**: one typed deployment update executor and its unit/integration test boundary
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Work stays behind the existing typed tool adapter.
+- II. One-Click Agent Deployment: PASS. Tests use fake runner/store boundaries and do not require Docker for unit coverage.
+- III. Avoid Vendor Lock-In: PASS. Evidence handling is generic Python data processing around the existing runner protocol.
+- IV. Own Your Data: PASS. Evidence remains in operator-controlled artifact refs.
+- V. Skills Are First-Class and Easy to Add: PASS. The executable skill contract is preserved.
+- VI. Replaceable Scaffolding: PASS. Redaction/audit helpers remain small and replaceable.
+- VII. Runtime Configurability: PASS. No hidden fallback for unsupported values; status values are explicit.
+- VIII. Modular and Extensible Architecture: PASS. Changes are scoped to deployment execution and tests.
+- IX. Resilient by Default: PASS. Success is gated on verification and evidence completeness.
+- X. Facilitate Continuous Improvement: PASS. Structured output and progress support operator diagnosis.
+- XI. Spec-Driven Development: PASS. This plan follows MM-521 spec artifacts.
+- XII. Canonical Documentation: PASS. Migration/implementation details remain in this feature directory.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden semantic transforms are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/263-deployment-verification-artifacts-progress/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── deployment-verification-evidence.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/skills/
+├── deployment_execution.py
+└── deployment_tools.py
+
+tests/unit/workflows/skills/
+└── test_deployment_update_execution.py
+
+tests/integration/temporal/
+└── test_deployment_update_execution_contract.py
+```
+
+**Structure Decision**: Keep all runtime behavior in `moonmind/workflows/skills/deployment_execution.py` because this is the existing executable tool boundary for `deployment.update_compose_stack`.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/263-deployment-verification-artifacts-progress/quickstart.md
+++ b/specs/263-deployment-verification-artifacts-progress/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Deployment Verification, Artifacts, and Progress
+
+## Focused Unit Validation
+
+```bash
+pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q
+```
+
+Expected evidence:
+- successful verification returns `SUCCEEDED` with required artifact refs
+- partial verification returns `PARTIALLY_VERIFIED` and non-success tool status
+- evidence payloads are recursively redacted
+- audit metadata includes MM-521-relevant deployment context
+- progress events contain documented lifecycle states and short messages only
+
+## Focused Integration Validation
+
+```bash
+pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q
+```
+
+Expected evidence:
+- `deployment.update_compose_stack` dispatch returns structured result fields through the tool activity boundary
+- artifact refs and progress metadata survive the dispatcher boundary
+
+## Final Validation
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Run `./tools/test_integration.sh` when Docker is available; otherwise record the Docker socket blocker.

--- a/specs/263-deployment-verification-artifacts-progress/research.md
+++ b/specs/263-deployment-verification-artifacts-progress/research.md
@@ -1,0 +1,49 @@
+# Research: Deployment Verification, Artifacts, and Progress
+
+## FR-001 / FR-002 Verification Success Gate
+
+Decision: Preserve the existing verification-gates-success shape and make status derivation explicit.
+Evidence: `DeploymentUpdateExecutor.execute()` currently sets `outputs.status` to `SUCCEEDED` only when `ComposeVerification.succeeded` is true and returns `FAILED` otherwise.
+Rationale: The runner remains the boundary that proves Compose/smoke-check state; the executor should classify the result consistently and never infer success from command completion alone.
+Alternatives considered: Re-run verification inside the executor; rejected because runner implementations own environment-specific checks.
+Test implications: Unit tests for succeeded, failed, and partial status classification; integration dispatch test for structured output.
+
+## FR-003 Partial Verification
+
+Decision: Extend `ComposeVerification` with an optional `status` field constrained to `SUCCEEDED`, `FAILED`, or `PARTIALLY_VERIFIED`; `succeeded=True` still maps to `SUCCEEDED` and unsupported status values fail closed.
+Evidence: The tool contract already allows `PARTIALLY_VERIFIED`; current dataclass only exposes a boolean.
+Rationale: This is the narrowest change that represents partial verification explicitly without changing the public tool contract.
+Alternatives considered: Use ad hoc `details["status"]`; rejected because it hides a billing/operationally relevant status in untyped detail data.
+Test implications: Unit test partial verification result and invalid status fail-fast behavior.
+
+## FR-004 / FR-005 Artifact Completeness
+
+Decision: Keep existing fail-closed artifact checks and add status coverage proving all final statuses include artifact refs.
+Evidence: Executor already raises `DEPLOYMENT_EVIDENCE_INCOMPLETE` when after, command, or verification refs are missing.
+Rationale: Behavior is present but needs MM-521-specific coverage for partial verification.
+Alternatives considered: Make evidence refs optional on failures; rejected by source design.
+Test implications: Unit and integration tests assert refs on successful and partial outcomes.
+
+## FR-006 Audit Metadata
+
+Decision: Build compact audit metadata from executor context and typed inputs, include it in evidence payloads and final outputs.
+Evidence: Current context parsing includes `source_run_id` and operator, but artifact payloads do not consistently carry workflow/task IDs, role, mode, options, final status, timestamps, or failure reason.
+Rationale: Audit metadata belongs at the executor boundary because it knows lifecycle timing, final status, requested image, and context identifiers.
+Alternatives considered: Leave audit to the API queue record; rejected because MM-521 requires audit output for every run and artifacts.
+Test implications: Unit tests assert audit fields on verification evidence and final outputs.
+
+## FR-007 Redaction
+
+Decision: Apply recursive redaction immediately before evidence writer calls.
+Evidence: Evidence writer currently receives raw runner payloads.
+Rationale: Redacting at publication boundary protects every artifact kind while preserving runner internals for hermetic tests.
+Alternatives considered: Require every runner to redact; rejected because it is easy to miss and less enforceable.
+Test implications: Unit test nested secret-like keys and values in state and command output.
+
+## FR-008 Progress Lifecycle
+
+Decision: Record lifecycle progress events as compact `{state, message}` entries in `ToolResult.progress`, using documented states for phases reached by this executor.
+Evidence: Current progress is only `{"percent": 100}`.
+Rationale: The executor already knows phase order; compact state/message events satisfy Mission Control needs without embedding command output.
+Alternatives considered: Stream live progress externally only; rejected because final output still needs deterministic evidence in tests.
+Test implications: Unit and integration tests assert lifecycle states and absence of raw command output in progress.

--- a/specs/263-deployment-verification-artifacts-progress/research.md
+++ b/specs/263-deployment-verification-artifacts-progress/research.md
@@ -3,7 +3,7 @@
 ## FR-001 / FR-002 Verification Success Gate
 
 Decision: Preserve the existing verification-gates-success shape and make status derivation explicit.
-Evidence: `DeploymentUpdateExecutor.execute()` currently sets `outputs.status` to `SUCCEEDED` only when `ComposeVerification.succeeded` is true and returns `FAILED` otherwise.
+Evidence: `DeploymentUpdateExecutor.execute()` now derives terminal status through `_verification_final_status()`, returning `SUCCEEDED` only for proven success and returning `FAILED` or `PARTIALLY_VERIFIED` for unproven desired state.
 Rationale: The runner remains the boundary that proves Compose/smoke-check state; the executor should classify the result consistently and never infer success from command completion alone.
 Alternatives considered: Re-run verification inside the executor; rejected because runner implementations own environment-specific checks.
 Test implications: Unit tests for succeeded, failed, and partial status classification; integration dispatch test for structured output.
@@ -11,7 +11,7 @@ Test implications: Unit tests for succeeded, failed, and partial status classifi
 ## FR-003 Partial Verification
 
 Decision: Extend `ComposeVerification` with an optional `status` field constrained to `SUCCEEDED`, `FAILED`, or `PARTIALLY_VERIFIED`; `succeeded=True` still maps to `SUCCEEDED` and unsupported status values fail closed.
-Evidence: The tool contract already allows `PARTIALLY_VERIFIED`; current dataclass only exposes a boolean.
+Evidence: `ComposeVerification.status` now carries explicit terminal status values, the tool output schema accepts the audit-enriched result shape, and invalid statuses raise `DEPLOYMENT_VERIFICATION_INVALID`.
 Rationale: This is the narrowest change that represents partial verification explicitly without changing the public tool contract.
 Alternatives considered: Use ad hoc `details["status"]`; rejected because it hides a billing/operationally relevant status in untyped detail data.
 Test implications: Unit test partial verification result and invalid status fail-fast behavior.
@@ -19,7 +19,7 @@ Test implications: Unit test partial verification result and invalid status fail
 ## FR-004 / FR-005 Artifact Completeness
 
 Decision: Keep existing fail-closed artifact checks and add status coverage proving all final statuses include artifact refs.
-Evidence: Executor already raises `DEPLOYMENT_EVIDENCE_INCOMPLETE` when after, command, or verification refs are missing.
+Evidence: Executor raises `DEPLOYMENT_EVIDENCE_INCOMPLETE` when after, command, or verification refs are missing, and partial-status coverage verifies before, command, verification, and after refs remain present.
 Rationale: Behavior is present but needs MM-521-specific coverage for partial verification.
 Alternatives considered: Make evidence refs optional on failures; rejected by source design.
 Test implications: Unit and integration tests assert refs on successful and partial outcomes.
@@ -27,7 +27,7 @@ Test implications: Unit and integration tests assert refs on successful and part
 ## FR-006 Audit Metadata
 
 Decision: Build compact audit metadata from executor context and typed inputs, include it in evidence payloads and final outputs.
-Evidence: Current context parsing includes `source_run_id` and operator, but artifact payloads do not consistently carry workflow/task IDs, role, mode, options, final status, timestamps, or failure reason.
+Evidence: Audit metadata is now constructed from context and typed inputs, attached to verification evidence and final outputs, and covered by unit tests for run/workflow/task IDs, operator role, mode, options, status, timestamps, and failure reason.
 Rationale: Audit metadata belongs at the executor boundary because it knows lifecycle timing, final status, requested image, and context identifiers.
 Alternatives considered: Leave audit to the API queue record; rejected because MM-521 requires audit output for every run and artifacts.
 Test implications: Unit tests assert audit fields on verification evidence and final outputs.
@@ -35,7 +35,7 @@ Test implications: Unit tests assert audit fields on verification evidence and f
 ## FR-007 Redaction
 
 Decision: Apply recursive redaction immediately before evidence writer calls.
-Evidence: Evidence writer currently receives raw runner payloads.
+Evidence: `_redact_sensitive()` now recursively processes evidence payloads before publication, and unit tests cover nested secret-like keys and values in state and command output.
 Rationale: Redacting at publication boundary protects every artifact kind while preserving runner internals for hermetic tests.
 Alternatives considered: Require every runner to redact; rejected because it is easy to miss and less enforceable.
 Test implications: Unit test nested secret-like keys and values in state and command output.
@@ -43,7 +43,7 @@ Test implications: Unit test nested secret-like keys and values in state and com
 ## FR-008 Progress Lifecycle
 
 Decision: Record lifecycle progress events as compact `{state, message}` entries in `ToolResult.progress`, using documented states for phases reached by this executor.
-Evidence: Current progress is only `{"percent": 100}`.
+Evidence: `ToolResult.progress` now contains bounded lifecycle events, current state, percent, and short messages; tests verify raw command output is absent from progress.
 Rationale: The executor already knows phase order; compact state/message events satisfy Mission Control needs without embedding command output.
 Alternatives considered: Stream live progress externally only; rejected because final output still needs deterministic evidence in tests.
 Test implications: Unit and integration tests assert lifecycle states and absence of raw command output in progress.

--- a/specs/263-deployment-verification-artifacts-progress/spec.md
+++ b/specs/263-deployment-verification-artifacts-progress/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Deployment Verification, Artifacts, and Progress
+
+**Feature Branch**: `263-deployment-verification-artifacts-progress`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-521 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-521 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-521
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Deployment verification, artifacts, and progress
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-521 from MM project
+Summary: Deployment verification, artifacts, and progress
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Tools/DockerComposeUpdateSystem.md
+Source Title: Docker Compose Deployment Update System
+Source Sections:
+- 12. Verification model
+- 14. Audit and artifacts
+- 19. Observability
+Coverage IDs:
+- DESIGN-REQ-012
+- DESIGN-REQ-013
+- DESIGN-REQ-014
+- DESIGN-REQ-017
+
+As an administrator reviewing an update, I need MoonMind to verify the deployed state and preserve audit artifacts, so a run is only successful when the desired state is proven and the before/after evidence is durable.
+
+Acceptance Criteria
+- A run is marked SUCCEEDED only when expected services are running, health checks pass when present, image IDs match the requested target or resolved digest where applicable, requested smoke checks pass, and orphan expectations hold.
+- If verification cannot prove the requested desired state, the final status is FAILED or PARTIALLY_VERIFIED, never SUCCEEDED.
+- Every run writes beforeStateArtifactRef, commandLogArtifactRef, verificationArtifactRef, and afterStateArtifactRef.
+- Audit output includes run/workflow/task IDs where applicable, stack, operator identity and role, reason, image request, resolved digest, mode, options, timestamps, final status, and failure reason when applicable.
+- Secrets, auth tokens, registry credentials, and sensitive environment variables are redacted from artifacts and logs.
+- Progress states include the documented lifecycle values with short messages; detailed command output remains in artifacts.
+
+Requirements
+- Make verification a success gate.
+- Store durable audit and artifact evidence for every run.
+- Redact sensitive values before artifact publication or UI display.
+- Represent partial verification explicitly.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-521 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime behavior story from `docs/Tools/DockerComposeUpdateSystem.md`; it does not require `moonspec-breakdown`.
+
+## User Story - Deployment Verification Evidence
+
+**Summary**: As an administrator reviewing an update, I need MoonMind to verify the deployed state and preserve audit artifacts, so a run is only successful when the desired state is proven and the before/after evidence is durable.
+
+**Goal**: Deployment update execution reports success only after verification proves desired state, always preserves durable redacted evidence, emits audit metadata, represents partial verification explicitly, and exposes lifecycle progress states without leaking detailed command output into workflow state.
+
+**Independent Test**: Invoke the typed deployment update executor with fake runner, artifact writer, and context, then assert success gating, failed and partially verified outcomes, required artifact refs, redacted artifact payloads, audit metadata, and progress lifecycle messages without touching a real Docker host.
+
+**Acceptance Scenarios**:
+
+1. **Given** verification proves services are running and expected image evidence matches, **When** the update completes, **Then** the result status is `SUCCEEDED` and required artifact refs are present.
+2. **Given** verification cannot prove desired state, **When** the update completes, **Then** the result status is `FAILED` or `PARTIALLY_VERIFIED`, never `SUCCEEDED`, and verification evidence explains the failed checks.
+3. **Given** a deployment update succeeds, fails verification, or partially verifies, **When** the run result is produced, **Then** before-state, command-log, verification, and after-state artifact refs are present whenever the lifecycle reached those phases.
+4. **Given** audit context is available, **When** evidence is written, **Then** audit output includes run/workflow/task IDs where applicable, stack, operator identity and role, reason, image request, resolved digest, mode, options, timestamps, final status, and failure reason when applicable.
+5. **Given** command output or captured state contains secret-like values, **When** artifacts are written, **Then** secrets, auth tokens, registry credentials, and sensitive environment values are redacted before publication.
+6. **Given** a deployment update progresses through lifecycle phases, **When** progress is reported, **Then** documented progress states and short messages are exposed while detailed command output remains only in artifacts.
+
+### Edge Cases
+
+- Verification that reports a partial state uses `PARTIALLY_VERIFIED` instead of `FAILED` when enough structured evidence identifies partial completion.
+- Missing after-state, command-log, or verification artifacts fail closed rather than claiming success.
+- Secret-like values are redacted recursively from nested mappings and lists before artifact refs are generated.
+- Progress reporting remains bounded to lifecycle state names and short messages even when runner command output is verbose.
+
+## Assumptions
+
+- MM-518 owns admin authorization and queuing, MM-519 owns the typed executable tool contract, and MM-520 owns locking, desired-state persistence, and command construction. This story owns final verification semantics, audit/evidence completeness, redaction, and progress reporting inside the deployment update executor.
+- Verification remains hermetic in tests through the existing injectable runner boundary.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST mark a deployment update `SUCCEEDED` only when verification proves the requested desired state.
+- **FR-002**: System MUST return `FAILED` or `PARTIALLY_VERIFIED`, never `SUCCEEDED`, when verification cannot prove the requested desired state.
+- **FR-003**: System MUST support explicit `PARTIALLY_VERIFIED` verification results when verification evidence identifies partial completion.
+- **FR-004**: System MUST write and return `beforeStateArtifactRef`, `commandLogArtifactRef`, `verificationArtifactRef`, and `afterStateArtifactRef` for every lifecycle that reaches the corresponding phases.
+- **FR-005**: System MUST fail closed instead of returning success when required command-log, verification, or after-state evidence is missing.
+- **FR-006**: Audit evidence MUST include run/workflow/task IDs when available, stack, operator identity and role, reason, image request, resolved digest, mode, options, timestamps, final status, and failure reason when applicable.
+- **FR-007**: Artifact payloads and command logs MUST redact secrets, auth tokens, registry credentials, password-like values, and sensitive environment variables before publication.
+- **FR-008**: Progress output MUST include documented lifecycle states with short messages and MUST NOT embed detailed command output.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-521` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Deployment Verification Result**: Structured verification outcome containing final status, updated services, running services, and check details.
+- **Deployment Evidence Artifact**: Redacted durable artifact reference for before-state, command-log, verification, or after-state data.
+- **Deployment Audit Metadata**: Operator and workflow context attached to deployment evidence and final result output.
+- **Deployment Progress Event**: Bounded lifecycle state and short message suitable for workflow/UI display.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 12 requires Compose-level and optional smoke-check verification before success. Scope: in scope. Maps to FR-001, FR-002, FR-003.
+- **DESIGN-REQ-002**: Source section 12.3 requires failed proof to produce `FAILED` or `PARTIALLY_VERIFIED`, never `SUCCEEDED`, and link to artifacts. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-005.
+- **DESIGN-REQ-003**: Source section 14 requires every run to record audit metadata and required before, command, verification, and after artifacts. Scope: in scope. Maps to FR-004, FR-006.
+- **DESIGN-REQ-004**: Source section 14.3 requires command logs and state captures to redact secrets, auth tokens, registry credentials, and sensitive environment variables. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-005**: Source section 19 requires progress states `QUEUED`, `VALIDATING`, `LOCK_WAITING`, `CAPTURING_BEFORE_STATE`, `PERSISTING_DESIRED_STATE`, `PULLING_IMAGES`, `RECREATING_SERVICES`, `VERIFYING`, `CAPTURING_AFTER_STATE`, `SUCCEEDED`, `FAILED`, and `PARTIALLY_VERIFIED` with short messages and detailed command output only in artifacts. Scope: in scope. Maps to FR-008.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests prove successful verification returns `SUCCEEDED` only with all required artifact refs.
+- **SC-002**: Unit tests prove failed and partial verification results never return `SUCCEEDED` and preserve verification evidence.
+- **SC-003**: Unit tests prove recursive redaction removes secret-like values from command and state artifact payloads.
+- **SC-004**: Unit tests prove audit metadata contains run/workflow/task identifiers and operator context when provided.
+- **SC-005**: Unit or integration tests prove progress contains lifecycle states and short messages without raw command output.
+- **SC-006**: Integration tests prove the `deployment.update_compose_stack` dispatch boundary returns the structured evidence and final status shape.
+- **SC-007**: Traceability evidence preserves `MM-521`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-005 in MoonSpec artifacts.

--- a/specs/263-deployment-verification-artifacts-progress/tasks.md
+++ b/specs/263-deployment-verification-artifacts-progress/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: Deployment Verification, Artifacts, and Progress
+
+**Input**: `specs/263-deployment-verification-artifacts-progress/spec.md`, `specs/263-deployment-verification-artifacts-progress/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/deployment-verification-evidence.md`, `quickstart.md`
+**Unit test command**: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q`
+**Integration test command**: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`
+
+**Source Traceability**: `MM-521`; FR-001 through FR-009; SCN-001 through SCN-006; SC-001 through SC-007; DESIGN-REQ-001 through DESIGN-REQ-005.
+
+## Phase 1: Setup
+
+- [X] T001 Verify active feature pointer `.specify/feature.json` references `specs/263-deployment-verification-artifacts-progress`. (FR-009)
+- [X] T002 Confirm existing deployment execution evidence in `moonmind/workflows/skills/deployment_execution.py`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, and `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-001, FR-004, FR-005)
+
+## Phase 2: Foundational
+
+- [X] T003 Add deployment verification status, audit, redaction, and progress helper test coverage to `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001 through FR-008)
+- [X] T004 Add deployment dispatch progress/evidence assertions to `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-004, FR-008, SC-006)
+
+## Phase 3: Deployment Verification Evidence
+
+**Story**: Gate deployment success on proven verification while preserving redacted durable evidence, audit metadata, and progress states.
+
+**Independent Test**: Invoke the typed deployment update executor with fake runner, artifact writer, and context, then assert success gating, failed and partially verified outcomes, required artifact refs, redacted artifact payloads, audit metadata, and progress lifecycle messages.
+
+**Traceability IDs**: FR-001 through FR-009; DESIGN-REQ-001 through DESIGN-REQ-005.
+
+### Tests First
+
+- [X] T005 [P] Add failing unit tests for partial verification status and unsupported status fail-fast behavior in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-002)
+- [X] T006 [P] Add failing unit tests for all final statuses returning required artifact refs in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-004, FR-005, SC-001, SC-002)
+- [X] T007 [P] Add failing unit tests for audit metadata in verification evidence and final outputs in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-006, DESIGN-REQ-003, SC-004)
+- [X] T008 [P] Add failing unit tests for recursive evidence redaction in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-007, DESIGN-REQ-004, SC-003)
+- [X] T009 [P] Add failing unit tests for bounded progress lifecycle states and messages in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-008, DESIGN-REQ-005, SC-005)
+- [X] T010 Add failing integration assertion for progress metadata and artifact refs through `deployment.update_compose_stack` dispatch in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-004, FR-008, SC-006)
+
+### Implementation
+
+- [X] T011 Extend `ComposeVerification` and status derivation in `moonmind/workflows/skills/deployment_execution.py` to support `PARTIALLY_VERIFIED` and fail closed on unsupported status. (FR-001, FR-002, FR-003)
+- [X] T012 Add audit metadata construction and attach audit data to evidence payloads and final outputs in `moonmind/workflows/skills/deployment_execution.py`. (FR-006)
+- [X] T013 Add recursive evidence redaction before artifact writes in `moonmind/workflows/skills/deployment_execution.py`. (FR-007)
+- [X] T014 Add bounded lifecycle progress events and terminal state metadata in `moonmind/workflows/skills/deployment_execution.py`. (FR-008)
+- [X] T015 Preserve existing evidence completeness checks and update structured output assembly in `moonmind/workflows/skills/deployment_execution.py`. (FR-004, FR-005)
+
+### Validation
+
+- [X] T016 Run focused unit tests: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q`. (FR-001 through FR-008)
+- [X] T017 Run focused integration tests: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`. (SC-006)
+
+## Final Phase: Polish and Verification
+
+- [X] T018 Run traceability grep for `MM-521`, `DESIGN-REQ-001`, and `PARTIALLY_VERIFIED` across feature artifacts, code, and tests. (FR-009, SC-007)
+- [X] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification.
+- [X] T020 Run `./tools/test_integration.sh` when Docker is available; otherwise record the exact blocker. Blocked: Docker socket unavailable at `unix:///var/run/docker.sock` in this managed container.
+- [X] T021 Run `/moonspec-verify` for `specs/263-deployment-verification-artifacts-progress/` and produce final verification evidence.
+
+## Dependencies and Execution Order
+
+1. T001-T004 before story tests.
+2. T005-T010 before T011-T015.
+3. T011-T015 before T016-T017.
+4. T016-T017 before T018-T021.
+
+## Parallel Examples
+
+- T005 through T009 can be drafted in parallel because they add independent assertions in one test module, but final file edits must be integrated sequentially.
+- T007 and T008 validate different helper behavior and can be reasoned about independently.
+
+## Implementation Strategy
+
+Write failing tests for missing MM-521 semantics first, then implement the smallest executor changes needed for explicit partial status, audit metadata, recursive redaction, and bounded progress. Preserve the existing public tool name/version and current evidence completeness behavior.

--- a/specs/263-deployment-verification-artifacts-progress/verification.md
+++ b/specs/263-deployment-verification-artifacts-progress/verification.md
@@ -1,0 +1,67 @@
+# MoonSpec Verification Report
+
+**Feature**: Deployment Verification, Artifacts, and Progress
+**Spec**: `specs/263-deployment-verification-artifacts-progress/spec.md`
+**Original Request Source**: `spec.md` Input preserving MM-521 Jira preset brief
+**Verdict**: FULLY_IMPLEMENTED
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused unit/integration | `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/integration/temporal/test_deployment_update_execution_contract.py -q` | PASS | 25 passed. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 4045 Python tests passed, 16 subtests passed, 425 frontend tests passed. Existing warnings only. |
+| Integration wrapper | `./tools/test_integration.sh` | NOT RUN | Docker socket unavailable: `dial unix /var/run/docker.sock: connect: no such file or directory`. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/workflows/skills/deployment_execution.py`, focused tests | VERIFIED | Success is derived from verified final status only. |
+| FR-002 | `test_verification_failure_returns_failed_tool_result_with_evidence_refs`, `test_partial_verification_returns_partial_status_with_artifact_refs` | VERIFIED | Failed and partial proof never return `SUCCEEDED`. |
+| FR-003 | `ComposeVerification.status`, `test_partial_verification_returns_partial_status_with_artifact_refs`, `test_unsupported_verification_status_fails_closed` | VERIFIED | Partial status is explicit; unsupported status fails closed. |
+| FR-004 | executor output assembly and focused dispatch test | VERIFIED | Required artifact refs are returned. |
+| FR-005 | existing `DEPLOYMENT_EVIDENCE_INCOMPLETE` checks | VERIFIED | Missing evidence cannot return success. |
+| FR-006 | `test_audit_metadata_is_attached_to_verification_evidence_and_outputs` | VERIFIED | Audit metadata includes run/workflow/task/operator/final status fields. |
+| FR-007 | `test_evidence_payloads_are_recursively_redacted_before_publication` | VERIFIED | Secret-like nested values are redacted before writer publication. |
+| FR-008 | `test_progress_contains_lifecycle_states_without_command_output`, integration dispatch test | VERIFIED | Progress contains bounded lifecycle states/messages only. |
+| FR-009 | `rg -n "MM-521|DESIGN-REQ-001|PARTIALLY_VERIFIED" ...` | VERIFIED | MM-521 and source mappings are preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| SCN-001 | success path unit and integration dispatch tests | VERIFIED | Success includes artifact refs and audit/progress. |
+| SCN-002 | failed and partial verification unit tests | VERIFIED | Non-proven state is not successful. |
+| SCN-003 | existing and new artifact-ref assertions | VERIFIED | Evidence refs are durable result outputs. |
+| SCN-004 | audit metadata unit test | VERIFIED | Audit fields are attached to verification evidence and final output. |
+| SCN-005 | redaction unit test | VERIFIED | Secret-like data does not reach evidence writer. |
+| SCN-006 | progress unit and integration tests | VERIFIED | Progress is compact and excludes raw command output. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-001 | final status derivation and tests | VERIFIED | Verification gates success. |
+| DESIGN-REQ-002 | failed/partial tests and artifact refs | VERIFIED | Failed proof links to evidence and never succeeds. |
+| DESIGN-REQ-003 | artifact refs and audit test | VERIFIED | Run/evidence audit metadata is present. |
+| DESIGN-REQ-004 | recursive redaction test | VERIFIED | Sensitive data is redacted at artifact publication boundary. |
+| DESIGN-REQ-005 | progress tests | VERIFIED | Lifecycle states and short messages are exposed. |
+| Constitution XI/XII | feature artifacts and implementation diff | VERIFIED | Spec-driven runtime change; canonical docs unchanged. |
+
+## Original Request Alignment
+
+- PASS: MM-521 is preserved as the canonical MoonSpec input. Runtime behavior now verifies deployed state before success, preserves audit/evidence artifacts, redacts sensitive values, represents partial verification, and reports bounded progress states.
+
+## Gaps
+
+- None in implementation or focused validation. Full compose-backed integration could not run because Docker is unavailable in this managed container.
+
+## Remaining Work
+
+- Run `./tools/test_integration.sh` in an environment with Docker socket access before merge if required by the integration CI policy.
+
+## Decision
+
+- FULLY_IMPLEMENTED. The MM-521 single-story runtime behavior is implemented and verified by unit, focused integration, full unit-wrapper, and traceability evidence.

--- a/tests/integration/temporal/test_deployment_update_execution_contract.py
+++ b/tests/integration/temporal/test_deployment_update_execution_contract.py
@@ -54,13 +54,18 @@ class HermeticRunner:
             succeeded=True,
             updated_services=("api",),
             running_services=({"name": "api", "state": "running"},),
-            details={"requestedImage": requested_image, "resolvedDigest": resolved_digest},
+            details={
+                "requestedImage": requested_image,
+                "resolvedDigest": resolved_digest,
+            },
         )
 
 
 def _snapshot():
     return create_registry_snapshot(
-        skills=(parse_tool_definition(build_deployment_update_tool_definition_payload()),),
+        skills=(
+            parse_tool_definition(build_deployment_update_tool_definition_payload()),
+        ),
         artifact_store=InMemoryArtifactStore(),
     )
 
@@ -113,6 +118,10 @@ async def test_deployment_update_tool_dispatch_returns_structured_result() -> No
     assert result.outputs["status"] == "SUCCEEDED"
     assert result.outputs["stack"] == "moonmind"
     assert result.outputs["beforeStateArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["verificationArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["audit"]["finalStatus"] == "SUCCEEDED"
+    assert result.progress["state"] == "SUCCEEDED"
+    assert [event["state"] for event in result.progress["events"]][-1] == "SUCCEEDED"
     assert runner.commands[0][0] == "pull"
     assert runner.commands[1][0] == "up"
 

--- a/tests/unit/workflows/skills/test_deployment_tool_contracts.py
+++ b/tests/unit/workflows/skills/test_deployment_tool_contracts.py
@@ -18,7 +18,9 @@ from moonmind.workflows.skills.tool_registry import create_registry_snapshot
 
 def _snapshot():
     return create_registry_snapshot(
-        skills=(parse_tool_definition(build_deployment_update_tool_definition_payload()),),
+        skills=(
+            parse_tool_definition(build_deployment_update_tool_definition_payload()),
+        ),
         artifact_store=InMemoryArtifactStore(),
     )
 
@@ -65,7 +67,9 @@ def _valid_plan_payload(snapshot) -> dict[str, object]:
 
 
 def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
-    definition = parse_tool_definition(build_deployment_update_tool_definition_payload())
+    definition = parse_tool_definition(
+        build_deployment_update_tool_definition_payload()
+    )
 
     assert definition.name == DEPLOYMENT_UPDATE_TOOL_NAME
     assert definition.version == DEPLOYMENT_UPDATE_TOOL_VERSION
@@ -108,9 +112,11 @@ def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
         "PARTIALLY_VERIFIED",
     ]
     assert "verificationArtifactRef" in output_schema["properties"]
+    assert "audit" in output_schema["properties"]
 
 
-def test_representative_deployment_update_plan_validates_against_registry_snapshot() -> None:
+def test_representative_deployment_update_plan_validates_against_registry_snapshot(
+) -> None:
     snapshot = _snapshot()
     validated = validate_plan_payload(
         payload=_valid_plan_payload(snapshot),

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -167,6 +167,7 @@ class SecretRecordingRunner(RecordingRunner):
             "stack": stack,
             "phase": phase,
             "services": ["api"],
+            "diagnostics": "token=super-secret,log_level=info",
             "environment": {
                 "API_TOKEN": "token=super-secret",
                 "REGISTRY_PASSWORD": "registry-password",
@@ -182,6 +183,7 @@ class SecretRecordingRunner(RecordingRunner):
             "command": list(command),
             "exitCode": 0,
             "authHeader": "Bearer secret-token",
+            "stdout": "passwd=hunter2;mode=ok",
         }
 
 
@@ -201,6 +203,35 @@ class InvalidStatusRunner(RecordingRunner):
             details={"failedChecks": ["image-id"]},
             status="UNKNOWN",
         )
+
+
+class SecretVerificationFailureRunner(RecordingRunner):
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        self.events.append("runner:verify")
+        return ComposeVerification(
+            succeeded=False,
+            updated_services=(),
+            running_services=(),
+            details={
+                "message": "health check failed with token=super-secret,log_level=info",
+                "requestedImage": requested_image,
+                "resolvedDigest": resolved_digest,
+            },
+        )
+
+
+class VerificationEvidenceFailureWriter(RecordingEvidenceWriter):
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        if kind == "verification":
+            self.events.append("evidence:verification:failed")
+            raise RuntimeError("verification evidence write failed")
+        return await super().write(kind, payload)
 
 
 @pytest.mark.asyncio
@@ -503,6 +534,52 @@ async def test_evidence_payloads_are_recursively_redacted_before_publication() -
         payload for kind, payload in evidence.records if kind == "before-state"
     )
     assert before_payload["environment"]["NORMAL_VALUE"] == "visible"
+    assert before_payload["diagnostics"] == "[REDACTED],log_level=info"
+    command_payload = next(
+        payload for kind, payload in evidence.records if kind == "command-log"
+    )
+    assert command_payload["pull"]["result"]["stdout"] == "[REDACTED];mode=ok"
+
+
+@pytest.mark.asyncio
+async def test_output_audit_failure_reason_is_redacted() -> None:
+    events: list[str] = []
+    executor, _store, _evidence, _runner, _events = _executor(
+        runner=SecretVerificationFailureRunner(events), events=events
+    )
+
+    result = await executor.execute(_inputs())
+
+    audit = result.outputs["audit"]
+    assert audit["failureReason"] == (
+        "health check failed with [REDACTED],log_level=info"
+    )
+    assert "super-secret" not in json.dumps(result.outputs)
+
+
+@pytest.mark.asyncio
+async def test_post_verification_exception_marks_audit_failed() -> None:
+    events: list[str] = []
+    runner = RecordingRunner(events)
+    store = RecordingDesiredStateStore(events)
+    evidence = VerificationEvidenceFailureWriter(events)
+    executor = DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=store,
+        evidence_writer=evidence,
+        runner=runner,
+    )
+
+    with pytest.raises(RuntimeError, match="verification evidence write failed"):
+        await executor.execute(_inputs())
+
+    after_payload = next(
+        payload for kind, payload in evidence.records if kind == "after-state"
+    )
+    assert after_payload["audit"]["finalStatus"] == "FAILED"
+    assert after_payload["audit"]["failureReason"] == (
+        "verification evidence write failed"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Mapping
 
 import pytest
@@ -42,11 +43,13 @@ class RecordingRunner:
         events: list[str],
         *,
         verification_succeeded: bool = True,
+        verification_status: str | None = None,
         block_on_before: bool = False,
     ) -> None:
         self.events = events
         self.commands: list[tuple[str, tuple[str, ...]]] = []
         self.verification_succeeded = verification_succeeded
+        self.verification_status = verification_status
         self._before_event = None
         self._release_event = None
         if block_on_before:
@@ -91,6 +94,7 @@ class RecordingRunner:
                 "requestedImage": requested_image,
                 "resolvedDigest": resolved_digest,
             },
+            status=self.verification_status,
         )
 
     async def wait_until_before_capture_started(self) -> None:
@@ -124,7 +128,13 @@ def _executor(
     runner: RecordingRunner | None = None,
     events: list[str] | None = None,
     lock_manager: DeploymentUpdateLockManager | None = None,
-) -> tuple[DeploymentUpdateExecutor, RecordingDesiredStateStore, RecordingEvidenceWriter, RecordingRunner, list[str]]:
+) -> tuple[
+    DeploymentUpdateExecutor,
+    RecordingDesiredStateStore,
+    RecordingEvidenceWriter,
+    RecordingRunner,
+    list[str],
+]:
     events = events if events is not None else []
     store = RecordingDesiredStateStore(events)
     evidence = RecordingEvidenceWriter(events)
@@ -148,6 +158,49 @@ class FailingUpRunner(RecordingRunner):
         self.events.append("runner:up")
         self.commands.append(("up", command))
         return {"stack": stack, "command": list(command), "exitCode": 17}
+
+
+class SecretRecordingRunner(RecordingRunner):
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        self.events.append(f"runner:capture:{phase}")
+        return {
+            "stack": stack,
+            "phase": phase,
+            "services": ["api"],
+            "environment": {
+                "API_TOKEN": "token=super-secret",
+                "REGISTRY_PASSWORD": "registry-password",
+                "NORMAL_VALUE": "visible",
+            },
+        }
+
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.events.append("runner:pull")
+        self.commands.append(("pull", command))
+        return {
+            "stack": stack,
+            "command": list(command),
+            "exitCode": 0,
+            "authHeader": "Bearer secret-token",
+        }
+
+
+class InvalidStatusRunner(RecordingRunner):
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        self.events.append("runner:verify")
+        return ComposeVerification(
+            succeeded=False,
+            updated_services=(),
+            running_services=(),
+            details={"failedChecks": ["image-id"]},
+            status="UNKNOWN",
+        )
 
 
 @pytest.mark.asyncio
@@ -243,10 +296,13 @@ def test_force_recreate_and_policy_flags_are_closed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_verification_failure_returns_failed_tool_result_with_evidence_refs() -> None:
+async def test_verification_failure_returns_failed_tool_result_with_evidence_refs(
+) -> None:
     events: list[str] = []
     runner = RecordingRunner(events, verification_succeeded=False)
-    executor, _store, evidence, _runner, _events = _executor(runner=runner, events=events)
+    executor, _store, evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
 
     result = await executor.execute(_inputs())
 
@@ -301,7 +357,9 @@ async def test_boolean_options_must_be_real_booleans(field: str) -> None:
 async def test_failed_command_result_stops_execution_and_persists_diagnostics() -> None:
     events: list[str] = []
     runner = FailingUpRunner(events)
-    executor, _store, evidence, _runner, _events = _executor(runner=runner, events=events)
+    executor, _store, evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
 
     with pytest.raises(ToolFailure) as exc_info:
         await executor.execute(_inputs())
@@ -349,3 +407,126 @@ async def test_context_executor_override_supports_registered_handler() -> None:
     assert result.outputs["requestedImage"] == (
         "ghcr.io/moonladderstudios/moonmind:20260425.1234"
     )
+
+@pytest.mark.asyncio
+async def test_partial_verification_returns_partial_status_with_artifact_refs() -> None:
+    events: list[str] = []
+    runner = RecordingRunner(
+        events, verification_succeeded=False, verification_status="PARTIALLY_VERIFIED"
+    )
+    executor, _store, evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
+
+    result = await executor.execute(_inputs())
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "PARTIALLY_VERIFIED"
+    assert result.outputs["beforeStateArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["commandLogArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["verificationArtifactRef"].startswith("art:sha256:")
+    assert result.outputs["afterStateArtifactRef"].startswith("art:sha256:")
+    assert [kind for kind, _payload in evidence.records] == [
+        "before-state",
+        "command-log",
+        "verification",
+        "after-state",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_verification_status_fails_closed() -> None:
+    events: list[str] = []
+    executor, _store, _evidence, _runner, _events = _executor(
+        runner=InvalidStatusRunner(events), events=events
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs())
+
+    assert exc_info.value.error_code == "DEPLOYMENT_VERIFICATION_INVALID"
+    assert "runner:capture:after" in events
+
+
+@pytest.mark.asyncio
+async def test_audit_metadata_is_attached_to_verification_evidence_and_outputs(
+) -> None:
+    executor, _store, evidence, _runner, _events = _executor()
+
+    result = await executor.execute(
+        _inputs(),
+        {
+            "source_run_id": "run-123",
+            "workflow_id": "workflow-456",
+            "task_id": "task-789",
+            "operator": "operator@example.com",
+            "operator_role": "admin",
+        },
+    )
+
+    audit = result.outputs["audit"]
+    assert audit["runId"] == "run-123"
+    assert audit["workflowId"] == "workflow-456"
+    assert audit["taskId"] == "task-789"
+    assert audit["operator"] == "operator@example.com"
+    assert audit["operatorRole"] == "admin"
+    assert audit["stack"] == "moonmind"
+    assert audit["requestedImage"] == "ghcr.io/moonladderstudios/moonmind:20260425.1234"
+    assert audit["resolvedDigest"] == "sha256:" + "a" * 64
+    assert audit["mode"] == "changed_services"
+    assert audit["options"]["removeOrphans"] is True
+    assert audit["finalStatus"] == "SUCCEEDED"
+    assert audit["startedAt"] <= audit["completedAt"]
+
+    verification_payload = next(
+        payload for kind, payload in evidence.records if kind == "verification"
+    )
+    assert verification_payload["audit"]["workflowId"] == "workflow-456"
+    assert verification_payload["audit"]["finalStatus"] == "SUCCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_evidence_payloads_are_recursively_redacted_before_publication() -> None:
+    events: list[str] = []
+    executor, _store, evidence, _runner, _events = _executor(
+        runner=SecretRecordingRunner(events), events=events
+    )
+
+    await executor.execute(_inputs())
+
+    serialized = json.dumps([payload for _kind, payload in evidence.records])
+    assert "super-secret" not in serialized
+    assert "registry-password" not in serialized
+    assert "secret-token" not in serialized
+    assert "[REDACTED]" in serialized
+    before_payload = next(
+        payload for kind, payload in evidence.records if kind == "before-state"
+    )
+    assert before_payload["environment"]["NORMAL_VALUE"] == "visible"
+
+
+@pytest.mark.asyncio
+async def test_progress_contains_lifecycle_states_without_command_output() -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+
+    result = await executor.execute(_inputs())
+
+    progress = result.progress
+    assert progress["state"] == "SUCCEEDED"
+    assert progress["message"] == "Deployment update succeeded."
+    states = [event["state"] for event in progress["events"]]
+    assert states == [
+        "QUEUED",
+        "VALIDATING",
+        "LOCK_WAITING",
+        "CAPTURING_BEFORE_STATE",
+        "PERSISTING_DESIRED_STATE",
+        "PULLING_IMAGES",
+        "RECREATING_SERVICES",
+        "VERIFYING",
+        "CAPTURING_AFTER_STATE",
+        "SUCCEEDED",
+    ]
+    serialized = json.dumps(progress)
+    assert "exitCode" not in serialized
+    assert "docker" not in serialized


### PR DESCRIPTION
## Summary
- Implements MM-521 deployment verification semantics for `deployment.update_compose_stack`.
- Adds explicit `PARTIALLY_VERIFIED` handling, fail-closed invalid statuses, audit metadata, recursive evidence redaction, and bounded lifecycle progress events.
- Adds MoonSpec artifacts under `specs/263-deployment-verification-artifacts-progress/`.

## Jira
- MM-521

## Active MoonSpec Feature Path
- `specs/263-deployment-verification-artifacts-progress/`

## Verification Verdict
- `FULLY_IMPLEMENTED`

## Tests Run
- PASS: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q` (`17 passed`)
- PASS: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` (`2 passed`)
- PASS: focused combined suite recorded in MoonSpec verification (`25 passed`)
- PASS: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` recorded in MoonSpec verification (`4045` Python tests, `425` frontend tests)

## Remaining Risks
- `./tools/test_integration.sh` was not run because this managed container has no Docker socket at `unix:///var/run/docker.sock`.
