### PR TITLE
MM-522 Settings Operations deployment update UI

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,22 @@
 [
   {
-    "id": 4176417120,
+    "id": 3142898352,
+    "disposition": "addressed",
+    "rationale": "Replaced index-based recent deployment action keys with keys derived from action identifiers, URLs, or stable action fields."
+  },
+  {
+    "id": 4176457752,
     "disposition": "not-applicable",
-    "rationale": "Bot review summary; no actionable request beyond the inline redaction comment tracked separately."
+    "rationale": "Top-level bot review summary; the inline recommendation it referenced was handled separately."
   },
   {
-    "id": 3142847692,
+    "id": 3142899981,
     "disposition": "addressed",
-    "rationale": "Refined sensitive value redaction to stop at common delimiters and include passwd, with regression coverage for preserving adjacent non-sensitive fields."
+    "rationale": "Changed missing or empty allowedModes metadata to default to changed_services only and added frontend coverage."
   },
   {
-    "id": 4176419798,
+    "id": 4176458909,
     "disposition": "not-applicable",
-    "rationale": "Bot review wrapper text; actionable Codex findings are tracked by their inline review comment IDs."
-  },
-  {
-    "id": 3142851408,
-    "disposition": "addressed",
-    "rationale": "Returned audit metadata is now passed through recursive redaction, with regression coverage for secret-like verification failure reasons."
-  },
-  {
-    "id": 3142851410,
-    "disposition": "addressed",
-    "rationale": "Deployment execution exceptions now force finalStatus to FAILED even after verification had set a success status, with regression coverage for post-verification evidence failures."
+    "rationale": "Top-level automated review wrapper with no independent actionable request."
   }
 ]

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -169,6 +169,47 @@ describe('OperationsSettingsSection deployment update card', () => {
     expect(within(card).queryByLabelText(/updater runner/i)).toBeNull();
   });
 
+  it('defaults missing deployment mode policy to changed services only', async () => {
+    fetchSpy.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/api/workers') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workerSnapshot,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => stackState,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...imageTargets,
+            repositories: imageTargets.repositories.map(({ allowedModes, ...repository }) => repository),
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: `Unhandled ${url}`,
+        json: async () => ({}),
+      } as Response);
+    });
+
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    const mode = await within(card).findByLabelText(/update mode/i);
+    expect(within(mode).getByRole('option', { name: /restart changed services/i })).toBeTruthy();
+    expect(within(mode).queryByRole('option', { name: /force recreate all services/i })).toBeNull();
+    expect(within(card).queryByText(/recreate every service/i)).toBeNull();
+  });
+
   it('requires a reason, confirms restart details, and submits the typed deployment payload', async () => {
     renderOperations();
 

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '../../utils/test-utils';
+import { renderWithClient } from '../../utils/test-utils';
+import { OperationsSettingsSection } from './OperationsSettingsSection';
+
+const workerSnapshot = {
+  system: {
+    workersPaused: false,
+    mode: 'running',
+    version: 'test',
+    updatedAt: '2026-04-26T00:00:00Z',
+    reason: 'Normal operation',
+  },
+  metrics: {
+    queued: 1,
+    running: 2,
+    staleRunning: 0,
+    isDrained: true,
+  },
+  audit: { latest: [] },
+};
+
+const stackState = {
+  stack: 'moonmind',
+  projectName: 'moonmind',
+  configuredImage: 'ghcr.io/moonladderstudios/moonmind:stable',
+  version: '2026.04.25',
+  runningImages: [
+    {
+      service: 'api',
+      image: 'ghcr.io/moonladderstudios/moonmind:stable',
+      imageId: 'sha256:api-image',
+      digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    },
+  ],
+  services: [
+    { name: 'api', state: 'running', health: 'healthy' },
+    { name: 'worker', state: 'running', health: 'healthy' },
+  ],
+  lastUpdateRunId: 'depupd_recent',
+  recentActions: [
+    {
+      status: 'SUCCEEDED',
+      requestedImage: 'ghcr.io/moonladderstudios/moonmind:20260425.1234',
+      resolvedDigest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      operator: 'admin@example.com',
+      reason: 'Routine release',
+      startedAt: '2026-04-25T18:00:00Z',
+      completedAt: '2026-04-25T18:04:00Z',
+      runDetailUrl: '/tasks/depupd_recent',
+      logsArtifactUrl: '/api/artifacts/logs',
+      rawCommandLogUrl: null,
+      beforeSummary: 'stable',
+      afterSummary: '20260425.1234',
+    },
+  ],
+};
+
+const imageTargets = {
+  stack: 'moonmind',
+  repositories: [
+    {
+      repository: 'ghcr.io/moonladderstudios/moonmind',
+      allowedReferences: ['stable', 'latest'],
+      recentTags: ['20260425.1234'],
+      digestPinningRecommended: true,
+      allowedModes: ['changed_services', 'force_recreate'],
+    },
+  ],
+};
+
+describe('OperationsSettingsSection deployment update card', () => {
+  let fetchSpy: MockInstance;
+  let confirmSpy: MockInstance;
+
+  beforeEach(() => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/api/workers') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workerSnapshot,
+        } as Response);
+      }
+      if (url === '/api/worker-action') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workerSnapshot,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => stackState,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => imageTargets,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/update') {
+        return Promise.resolve({
+          ok: true,
+          status: 202,
+          json: async () => ({
+            deploymentUpdateRunId: 'depupd_queued',
+            taskId: 'mm:deployment-update',
+            workflowId: 'mm:deployment-update',
+            status: 'QUEUED',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: `Unhandled ${url}`,
+        json: async () => ({}),
+      } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    confirmSpy.mockRestore();
+  });
+
+  function renderOperations() {
+    renderWithClient(
+      <OperationsSettingsSection
+        workerPauseConfig={{
+          get: '/api/workers',
+          post: '/api/worker-action',
+          pollIntervalMs: 60_000,
+        }}
+      />,
+    );
+  }
+
+  it('renders deployment state inside Operations without top-level deployment navigation', async () => {
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    await within(card).findByText('ghcr.io/moonladderstudios/moonmind:stable');
+    expect(within(card).getAllByText('moonmind').length).toBeGreaterThanOrEqual(2);
+    expect(within(card).getByText('ghcr.io/moonladderstudios/moonmind:stable')).toBeTruthy();
+    expect(within(card).getByText(/sha256:api-image/i)).toBeTruthy();
+    expect(within(card).getByText(/healthy/i)).toBeTruthy();
+    expect(within(card).getByText(/depupd_recent/i)).toBeTruthy();
+    expect(screen.queryByRole('navigation', { name: /deployment/i })).toBeNull();
+  });
+
+  it('prefers recent release tags, warns for mutable tags, and omits runner image controls', async () => {
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    const reference = (await within(card).findByLabelText(/target reference/i)) as HTMLSelectElement;
+    expect(reference.value).toBe('20260425.1234');
+
+    fireEvent.change(reference, { target: { value: 'latest' } });
+    expect(within(card).getByText(/latest may resolve differently/i)).toBeTruthy();
+
+    const mode = within(card).getByLabelText(/update mode/i) as HTMLSelectElement;
+    expect(mode.value).toBe('changed_services');
+    expect(within(mode).getByRole('option', { name: /force recreate all services/i })).toBeTruthy();
+    expect(within(card).getByText(/recreate every service/i)).toBeTruthy();
+    expect(within(card).queryByLabelText(/updater runner/i)).toBeNull();
+  });
+
+  it('requires a reason, confirms restart details, and submits the typed deployment payload', async () => {
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    fireEvent.click(
+      await within(card).findByRole('button', { name: /submit deployment update/i }),
+    );
+    expect(within(card).getByText(/reason is required/i)).toBeTruthy();
+
+    fireEvent.change(within(card).getByLabelText(/target reference/i), {
+      target: { value: 'latest' },
+    });
+    fireEvent.change(within(card).getByLabelText(/reason/i), {
+      target: { value: 'Routine operations update' },
+    });
+    fireEvent.click(within(card).getByRole('button', { name: /submit deployment update/i }));
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Current image: ghcr.io/moonladderstudios/moonmind:stable'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Target image: ghcr.io/moonladderstudios/moonmind:latest'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Mode: Restart changed services'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Stack: moonmind'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Expected affected services: api, worker'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Mutable tag warning'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Services may restart'));
+    });
+
+    await waitFor(() => {
+      const updateCall = fetchSpy.mock.calls.find(([url]) => String(url) === '/api/v1/operations/deployment/update');
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(String(updateCall?.[1]?.body))).toMatchObject({
+        stack: 'moonmind',
+        image: {
+          repository: 'ghcr.io/moonladderstudios/moonmind',
+          reference: 'latest',
+        },
+        mode: 'changed_services',
+        removeOrphans: true,
+        wait: true,
+        runSmokeCheck: false,
+        pauseWork: false,
+        pruneOldImages: false,
+        reason: 'Routine operations update',
+      });
+    });
+    expect(await within(card).findByText(/deployment update queued/i)).toBeTruthy();
+  });
+
+  it('renders recent deployment context and hides raw command-log links by default', async () => {
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    await within(card).findByText('SUCCEEDED');
+    expect(within(card).getByText('SUCCEEDED')).toBeTruthy();
+    expect(within(card).getByText(/Routine release/i)).toBeTruthy();
+    expect(within(card).getByText(/admin@example.com/i)).toBeTruthy();
+    expect(within(card).getByRole('link', { name: /run detail/i }).getAttribute('href')).toBe(
+      '/tasks/depupd_recent',
+    );
+    expect(within(card).getByRole('link', { name: /logs artifact/i }).getAttribute('href')).toBe(
+      '/api/artifacts/logs',
+    );
+    expect(within(card).queryByRole('link', { name: /raw command/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
@@ -38,10 +38,127 @@ const WorkerSnapshotSchema = z.object({
 
 type WorkerSnapshot = z.infer<typeof WorkerSnapshotSchema>;
 
+const DeploymentStackStateSchema = z
+  .object({
+    stack: z.string(),
+    projectName: z.string(),
+    configuredImage: z.string(),
+    version: z.string().optional().nullable(),
+    build: z.string().optional().nullable(),
+    runningImages: z
+      .array(
+        z
+          .object({
+            service: z.string(),
+            image: z.string(),
+            imageId: z.string().optional().nullable(),
+            digest: z.string().optional().nullable(),
+          })
+          .passthrough(),
+      )
+      .default([]),
+    services: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            state: z.string(),
+            health: z.string().optional().nullable(),
+          })
+          .passthrough(),
+      )
+      .default([]),
+    lastUpdateRunId: z.string().optional().nullable(),
+    recentActions: z
+      .array(
+        z
+          .object({
+            status: z.string().optional().nullable(),
+            requestedImage: z.string().optional().nullable(),
+            resolvedDigest: z.string().optional().nullable(),
+            operator: z.string().optional().nullable(),
+            reason: z.string().optional().nullable(),
+            startedAt: z.string().optional().nullable(),
+            completedAt: z.string().optional().nullable(),
+            runDetailUrl: z.string().optional().nullable(),
+            logsArtifactUrl: z.string().optional().nullable(),
+            rawCommandLogUrl: z.string().optional().nullable(),
+            rawCommandLogPermitted: z.boolean().optional(),
+            beforeSummary: z.string().optional().nullable(),
+            afterSummary: z.string().optional().nullable(),
+          })
+          .passthrough(),
+      )
+      .optional()
+      .default([]),
+  })
+  .passthrough();
+
+const ImageTargetsSchema = z
+  .object({
+    stack: z.string(),
+    repositories: z.array(
+      z
+        .object({
+          repository: z.string(),
+          allowedReferences: z.array(z.string()).default([]),
+          recentTags: z.array(z.string()).default([]),
+          digestPinningRecommended: z.boolean().default(false),
+          allowedModes: z.array(z.string()).optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+type DeploymentStackState = z.infer<typeof DeploymentStackStateSchema>;
+type ImageTargets = z.infer<typeof ImageTargetsSchema>;
+type ImageTargetRepository = ImageTargets['repositories'][number];
+
 export interface WorkerPauseConfig {
   get: string;
   post: string;
   pollIntervalMs?: number;
+}
+
+const DEPLOYMENT_STACK = 'moonmind';
+
+function uniqueStrings(values: string[]): string[] {
+  return values.filter((value, index) => value && values.indexOf(value) === index);
+}
+
+function isMutableReference(reference: string): boolean {
+  const normalized = reference.trim().toLowerCase();
+  return normalized === 'latest' || normalized === 'stable';
+}
+
+function preferredReference(repository: ImageTargetRepository | undefined): string {
+  if (!repository) {
+    return '';
+  }
+  const digest = repository.allowedReferences.find((reference) =>
+    reference.startsWith('sha256:'),
+  );
+  return digest || repository.recentTags[0] || repository.allowedReferences[0] || '';
+}
+
+function modeLabel(mode: string): string {
+  if (mode === 'force_recreate') {
+    return 'Force recreate all services';
+  }
+  return 'Restart changed services';
+}
+
+function modeDescription(mode: string): string {
+  if (mode === 'force_recreate') {
+    return 'Pull images and recreate every service in the allowlisted stack.';
+  }
+  return 'Pull images and recreate services whose image or configuration changed.';
+}
+
+function affectedServices(state: DeploymentStackState | undefined): string {
+  const names = state?.services.map((service) => service.name).filter(Boolean) ?? [];
+  return names.length > 0 ? names.join(', ') : 'services reported by deployment policy';
 }
 
 export function OperationsSettingsSection({
@@ -53,9 +170,22 @@ export function OperationsSettingsSection({
   const [notice, setNotice] = useState<{ level: 'ok' | 'error'; text: string } | null>(
     null,
   );
+  const [deploymentNotice, setDeploymentNotice] = useState<{
+    level: 'ok' | 'error';
+    text: string;
+  } | null>(null);
   const [pauseMode, setPauseMode] = useState('drain');
   const [pauseReason, setPauseReason] = useState('');
   const [resumeReason, setResumeReason] = useState('');
+  const [targetRepository, setTargetRepository] = useState('');
+  const [targetReference, setTargetReference] = useState('');
+  const [updateMode, setUpdateMode] = useState('changed_services');
+  const [removeOrphans, setRemoveOrphans] = useState(true);
+  const [waitForServices, setWaitForServices] = useState(true);
+  const [runSmokeCheck, setRunSmokeCheck] = useState(false);
+  const [pauseWork, setPauseWork] = useState(false);
+  const [pruneOldImages, setPruneOldImages] = useState(false);
+  const [deploymentReason, setDeploymentReason] = useState('');
 
   const {
     data: snapshot,
@@ -133,6 +263,184 @@ export function OperationsSettingsSection({
     },
   });
 
+  const {
+    data: deploymentState,
+    isLoading: isDeploymentStateLoading,
+    isError: isDeploymentStateError,
+    error: deploymentStateError,
+  } = useQuery<DeploymentStackState>({
+    queryKey: ['deployment-stack', DEPLOYMENT_STACK],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/v1/operations/deployment/stacks/${DEPLOYMENT_STACK}`,
+        { headers: { Accept: 'application/json' } },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch deployment state: ${response.statusText}`);
+      }
+      return DeploymentStackStateSchema.parse(await response.json());
+    },
+  });
+
+  const {
+    data: imageTargets,
+    isLoading: areImageTargetsLoading,
+    isError: areImageTargetsError,
+    error: imageTargetsError,
+  } = useQuery<ImageTargets>({
+    queryKey: ['deployment-image-targets', DEPLOYMENT_STACK],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/v1/operations/deployment/image-targets?stack=${encodeURIComponent(
+          DEPLOYMENT_STACK,
+        )}`,
+        { headers: { Accept: 'application/json' } },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch deployment image targets: ${response.statusText}`);
+      }
+      return ImageTargetsSchema.parse(await response.json());
+    },
+  });
+
+  const activeTargetRepository = useMemo(
+    () =>
+      imageTargets?.repositories.find(
+        (repository) => repository.repository === targetRepository,
+      ) ?? imageTargets?.repositories[0],
+    [imageTargets, targetRepository],
+  );
+
+  const referenceOptions = useMemo(
+    () =>
+      uniqueStrings([
+        ...(activeTargetRepository?.recentTags ?? []),
+        ...(activeTargetRepository?.allowedReferences ?? []),
+      ]),
+    [activeTargetRepository],
+  );
+
+  const allowedModes = useMemo(
+    () => activeTargetRepository?.allowedModes ?? ['changed_services', 'force_recreate'],
+    [activeTargetRepository],
+  );
+
+  useEffect(() => {
+    const firstRepository = imageTargets?.repositories[0];
+    if (!firstRepository) {
+      return;
+    }
+    if (!targetRepository) {
+      setTargetRepository(firstRepository.repository);
+    }
+    if (!targetReference) {
+      setTargetReference(preferredReference(firstRepository));
+    }
+  }, [imageTargets, targetReference, targetRepository]);
+
+  useEffect(() => {
+    if (allowedModes.length > 0 && !allowedModes.includes(updateMode)) {
+      setUpdateMode(allowedModes[0] ?? 'changed_services');
+    }
+  }, [allowedModes, updateMode]);
+
+  const deploymentMutation = useMutation({
+    mutationFn: async () => {
+      const repository = targetRepository || activeTargetRepository?.repository || '';
+      const reference = targetReference.trim();
+      const reason = deploymentReason.trim();
+      if (!repository || !reference) {
+        throw new Error('Target image is required.');
+      }
+      if (!reason) {
+        throw new Error('Deployment update reason is required.');
+      }
+
+      const targetImage = `${repository}:${reference}`;
+      const confirmation = [
+        'Submit deployment update?',
+        `Current image: ${deploymentState?.configuredImage || 'Unavailable'}`,
+        `Target image: ${targetImage}`,
+        `Mode: ${modeLabel(updateMode)}`,
+        `Stack: ${deploymentState?.stack || DEPLOYMENT_STACK}`,
+        `Expected affected services: ${affectedServices(deploymentState)}`,
+        isMutableReference(reference)
+          ? 'Mutable tag warning: this tag may resolve differently over time.'
+          : null,
+        'Services may restart during this operation.',
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      if (!window.confirm(confirmation)) {
+        return null;
+      }
+
+      const response = await fetch('/api/v1/operations/deployment/update', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          stack: deploymentState?.stack || DEPLOYMENT_STACK,
+          image: {
+            repository,
+            reference,
+          },
+          mode: updateMode,
+          removeOrphans,
+          wait: waitForServices,
+          runSmokeCheck,
+          pauseWork,
+          pruneOldImages,
+          reason,
+        }),
+      });
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        const detail =
+          typeof errorPayload.detail?.message === 'string'
+            ? errorPayload.detail.message
+            : typeof errorPayload.detail === 'string'
+              ? errorPayload.detail
+              : `Server error: ${response.status}`;
+        throw new Error(detail);
+      }
+      return response.json() as Promise<{ deploymentUpdateRunId: string; status: string }>;
+    },
+    onSuccess: (result) => {
+      if (!result) {
+        return;
+      }
+      setDeploymentNotice({
+        level: 'ok',
+        text: `Deployment update queued: ${result.deploymentUpdateRunId}`,
+      });
+      setDeploymentReason('');
+      queryClient.invalidateQueries({ queryKey: ['deployment-stack', DEPLOYMENT_STACK] });
+    },
+    onError: (mutationError: Error) => {
+      setDeploymentNotice({
+        level: 'error',
+        text: mutationError.message,
+      });
+    },
+  });
+
+  const handleDeploymentSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setDeploymentNotice(null);
+    if (!deploymentReason.trim()) {
+      setDeploymentNotice({
+        level: 'error',
+        text: 'Deployment update reason is required.',
+      });
+      return;
+    }
+    deploymentMutation.mutate();
+  };
+
   const handlePause = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!pauseMode || !pauseReason) {
@@ -163,14 +471,6 @@ export function OperationsSettingsSection({
     actionMutation.mutate({ action: 'resume', reason: resumeReason, forceResume });
   };
 
-  if (!workerPauseConfig) {
-    return (
-      <section className="rounded-3xl border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 p-6 text-sm text-amber-900 dark:text-amber-400 shadow-sm">
-        Worker pause controls are not configured for this deployment.
-      </section>
-    );
-  }
-
   const system = snapshot?.system ?? {};
   const metrics = snapshot?.metrics ?? {};
   const isPaused = Boolean(system.workersPaused);
@@ -192,6 +492,346 @@ export function OperationsSettingsSection({
         </div>
       </section>
 
+      <section
+        className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm"
+        aria-label="Deployment Update"
+      >
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <h4 className="text-lg font-semibold text-slate-900 dark:text-white">
+              Deployment Update
+            </h4>
+            <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
+              Update the configured MoonMind image for the allowlisted Compose stack.
+            </p>
+          </div>
+          {deploymentNotice ? (
+            <div
+              className={`rounded-2xl border px-4 py-3 text-sm ${
+                deploymentNotice.level === 'error'
+                  ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400'
+                  : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-900/20 dark:text-emerald-400'
+              }`}
+            >
+              {deploymentNotice.text}
+            </div>
+          ) : null}
+        </div>
+
+        {isDeploymentStateLoading || areImageTargetsLoading ? (
+          <p className="mt-5 text-sm text-slate-500 dark:text-slate-400">
+            Loading deployment controls...
+          </p>
+        ) : isDeploymentStateError || areImageTargetsError ? (
+          <p className="mt-5 text-sm text-rose-700 dark:text-rose-400">
+            {((deploymentStateError || imageTargetsError) as Error).message}
+          </p>
+        ) : (
+          <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(360px,0.8fr)]">
+            <div className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-800/50">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Stack
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {deploymentState?.stack || DEPLOYMENT_STACK}
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-800/50">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Compose project
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {deploymentState?.projectName || '-'}
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-800/50">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Version/build
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {deploymentState?.version || deploymentState?.build || 'Unavailable'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
+                  Current deployment
+                </h5>
+                <dl className="mt-3 space-y-3 text-sm">
+                  <div>
+                    <dt className="font-medium text-slate-500 dark:text-slate-400">
+                      Configured image
+                    </dt>
+                    <dd className="break-all text-slate-900 dark:text-white">
+                      {deploymentState?.configuredImage || 'Unavailable'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500 dark:text-slate-400">
+                      Running image evidence
+                    </dt>
+                    <dd className="space-y-1 text-slate-900 dark:text-white">
+                      {deploymentState?.runningImages.length ? (
+                        deploymentState.runningImages.map((image) => (
+                          <div key={`${image.service}-${image.image}`}>
+                            {image.service}: {image.imageId || image.digest || 'Unavailable'}
+                          </div>
+                        ))
+                      ) : (
+                        <span>Unavailable</span>
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500 dark:text-slate-400">
+                      Health summary
+                    </dt>
+                    <dd className="text-slate-900 dark:text-white">
+                      {deploymentState?.services.length
+                        ? deploymentState.services
+                            .map(
+                              (service) =>
+                                `${service.name}: ${service.state}${
+                                  service.health ? ` / ${service.health}` : ''
+                                }`,
+                            )
+                            .join(', ')
+                        : 'Unavailable'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500 dark:text-slate-400">
+                      Last update result
+                    </dt>
+                    <dd className="text-slate-900 dark:text-white">
+                      {deploymentState?.lastUpdateRunId || 'No previous update'}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
+                  Recent deployment actions
+                </h5>
+                <div className="mt-3 space-y-3">
+                  {deploymentState?.recentActions.length ? (
+                    deploymentState.recentActions.map((action, index) => (
+                      <div
+                        key={`${action.startedAt || action.requestedImage || 'deployment'}-${index}`}
+                        className="rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-800/50"
+                      >
+                        <div className="font-semibold text-slate-900 dark:text-white">
+                          {action.status || 'UNKNOWN'}
+                        </div>
+                        <div className="mt-1 break-all text-slate-600 dark:text-slate-400">
+                          {action.requestedImage || 'Requested image unavailable'}
+                        </div>
+                        {action.resolvedDigest ? (
+                          <div className="mt-1 break-all text-xs text-slate-500 dark:text-slate-400">
+                            Resolved digest: {action.resolvedDigest}
+                          </div>
+                        ) : null}
+                        <div className="mt-2 text-slate-600 dark:text-slate-400">
+                          {action.operator || 'Unknown operator'} |{' '}
+                          {action.reason || '(no reason)'}
+                        </div>
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                          {action.startedAt || '-'} {'->'} {action.completedAt || '-'}
+                        </div>
+                        {(action.beforeSummary || action.afterSummary) ? (
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                            {action.beforeSummary || '-'} {'->'} {action.afterSummary || '-'}
+                          </div>
+                        ) : null}
+                        <div className="mt-3 flex flex-wrap gap-3">
+                          {action.runDetailUrl ? (
+                            <a
+                              className="text-sm font-medium text-sky-700 hover:text-sky-600 dark:text-sky-400"
+                              href={action.runDetailUrl}
+                            >
+                              Run detail
+                            </a>
+                          ) : null}
+                          {action.logsArtifactUrl ? (
+                            <a
+                              className="text-sm font-medium text-sky-700 hover:text-sky-600 dark:text-sky-400"
+                              href={action.logsArtifactUrl}
+                            >
+                              Logs artifact
+                            </a>
+                          ) : null}
+                          {action.rawCommandLogPermitted && action.rawCommandLogUrl ? (
+                            <a
+                              className="text-sm font-medium text-sky-700 hover:text-sky-600 dark:text-sky-400"
+                              href={action.rawCommandLogUrl}
+                            >
+                              Raw command log
+                            </a>
+                          ) : null}
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                      No recent deployment update actions.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <form
+              className="space-y-4 rounded-2xl border border-slate-200 p-5 dark:border-slate-800"
+              onSubmit={handleDeploymentSubmit}
+              noValidate
+            >
+              <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
+                Update target
+              </h5>
+              <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Image repository</span>
+                <select
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  value={targetRepository}
+                  onChange={(event) => {
+                    const nextRepository = event.target.value;
+                    setTargetRepository(nextRepository);
+                    const repository = imageTargets?.repositories.find(
+                      (candidate) => candidate.repository === nextRepository,
+                    );
+                    setTargetReference(preferredReference(repository));
+                  }}
+                >
+                  {imageTargets?.repositories.map((repository) => (
+                    <option key={repository.repository} value={repository.repository}>
+                      {repository.repository}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Target reference</span>
+                <select
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  value={targetReference}
+                  onChange={(event) => setTargetReference(event.target.value)}
+                >
+                  {referenceOptions.map((reference) => (
+                    <option key={reference} value={reference}>
+                      {reference}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {isMutableReference(targetReference) ? (
+                <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-300">
+                  {targetReference} may resolve differently over time. Digest-pinned or
+                  release-tagged updates are preferred.
+                </div>
+              ) : null}
+              <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Update mode</span>
+                <select
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  value={updateMode}
+                  onChange={(event) => setUpdateMode(event.target.value)}
+                >
+                  {allowedModes.map((mode) => (
+                    <option key={mode} value={mode}>
+                      {modeLabel(mode)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                {modeDescription(updateMode)}
+              </p>
+              {allowedModes.includes('force_recreate') ? (
+                <p className="text-sm text-amber-700 dark:text-amber-300">
+                  Force recreate all services will recreate every service in the
+                  allowlisted stack.
+                </p>
+              ) : null}
+
+              <fieldset className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+                <legend className="font-medium">Options</legend>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={removeOrphans}
+                    onChange={(event) => setRemoveOrphans(event.target.checked)}
+                  />
+                  Remove orphan containers
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={waitForServices}
+                    onChange={(event) => setWaitForServices(event.target.checked)}
+                  />
+                  Wait for services
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={runSmokeCheck}
+                    onChange={(event) => setRunSmokeCheck(event.target.checked)}
+                  />
+                  Run smoke check
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={pauseWork}
+                    onChange={(event) => setPauseWork(event.target.checked)}
+                  />
+                  Pause or drain new task work
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={pruneOldImages}
+                    onChange={(event) => setPruneOldImages(event.target.checked)}
+                  />
+                  Prune old images after success
+                </label>
+              </fieldset>
+
+              <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Reason</span>
+                <input
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  type="text"
+                  maxLength={200}
+                  value={deploymentReason}
+                  onChange={(event) => setDeploymentReason(event.target.value)}
+                  required
+                />
+              </label>
+
+              <button
+                type="submit"
+                disabled={deploymentMutation.isPending}
+                className="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+              >
+                Submit deployment update
+              </button>
+            </form>
+          </div>
+        )}
+      </section>
+
+      {!workerPauseConfig ? (
+        <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900 shadow-sm dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-400">
+          Worker pause controls are not configured for this deployment.
+        </section>
+      ) : null}
+
+      {workerPauseConfig ? (
       <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
         {notice ? (
           <div
@@ -347,6 +987,7 @@ export function OperationsSettingsSection({
           </div>
         )}
       </section>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -84,6 +84,8 @@ const DeploymentStackStateSchema = z
             logsArtifactUrl: z.string().optional().nullable(),
             rawCommandLogUrl: z.string().optional().nullable(),
             rawCommandLogPermitted: z.boolean().optional(),
+            id: z.union([z.string(), z.number()]).optional().nullable(),
+            runId: z.string().optional().nullable(),
             beforeSummary: z.string().optional().nullable(),
             afterSummary: z.string().optional().nullable(),
           })
@@ -114,6 +116,7 @@ const ImageTargetsSchema = z
 type DeploymentStackState = z.infer<typeof DeploymentStackStateSchema>;
 type ImageTargets = z.infer<typeof ImageTargetsSchema>;
 type ImageTargetRepository = ImageTargets['repositories'][number];
+type DeploymentAction = DeploymentStackState['recentActions'][number];
 
 export interface WorkerPauseConfig {
   get: string;
@@ -159,6 +162,28 @@ function modeDescription(mode: string): string {
 function affectedServices(state: DeploymentStackState | undefined): string {
   const names = state?.services.map((service) => service.name).filter(Boolean) ?? [];
   return names.length > 0 ? names.join(', ') : 'services reported by deployment policy';
+}
+
+function deploymentActionKey(action: DeploymentAction): string {
+  return String(
+    action.id ||
+      action.runId ||
+      action.runDetailUrl ||
+      action.logsArtifactUrl ||
+      action.rawCommandLogUrl ||
+      [
+        action.startedAt,
+        action.completedAt,
+        action.requestedImage,
+        action.resolvedDigest,
+        action.operator,
+        action.reason,
+        action.status,
+      ]
+        .filter(Boolean)
+        .join('|') ||
+      'deployment-action',
+  );
 }
 
 export function OperationsSettingsSection({
@@ -321,7 +346,10 @@ export function OperationsSettingsSection({
   );
 
   const allowedModes = useMemo(
-    () => activeTargetRepository?.allowedModes ?? ['changed_services', 'force_recreate'],
+    () => {
+      const explicitModes = activeTargetRepository?.allowedModes?.filter(Boolean) ?? [];
+      return explicitModes.length > 0 ? explicitModes : ['changed_services'];
+    },
     [activeTargetRepository],
   );
 
@@ -619,9 +647,9 @@ export function OperationsSettingsSection({
                 </h5>
                 <div className="mt-3 space-y-3">
                   {deploymentState?.recentActions.length ? (
-                    deploymentState.recentActions.map((action, index) => (
+                    deploymentState.recentActions.map((action) => (
                       <div
-                        key={`${action.startedAt || action.requestedImage || 'deployment'}-${index}`}
+                        key={deploymentActionKey(action)}
                         className="rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-800/50"
                       >
                         <div className="font-semibold text-slate-900 dark:text-white">

--- a/specs/264-settings-operations-deployment-update-ui/checklists/requirements.md
+++ b/specs/264-settings-operations-deployment-update-ui/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Settings Operations Deployment Update UI
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: `MM-522` is classified as one runtime UI story and preserves the trusted Jira preset brief.

--- a/specs/264-settings-operations-deployment-update-ui/contracts/deployment-update-settings-card.md
+++ b/specs/264-settings-operations-deployment-update-ui/contracts/deployment-update-settings-card.md
@@ -1,0 +1,37 @@
+# Contract: Deployment Update Settings Card
+
+## Placement
+
+The Deployment Update card is rendered inside `Settings -> Operations` at `/tasks/settings?section=operations`. It is not added as a top-level navigation item.
+
+## Read Endpoints
+
+- `GET /api/v1/operations/deployment/stacks/moonmind`
+- `GET /api/v1/operations/deployment/image-targets?stack=moonmind`
+
+The card must tolerate optional future fields on stack state for recent action summaries and links.
+
+## Submit Endpoint
+
+`POST /api/v1/operations/deployment/update`
+
+```json
+{
+  "stack": "moonmind",
+  "image": {
+    "repository": "ghcr.io/moonladderstudios/moonmind",
+    "reference": "20260425.1234"
+  },
+  "mode": "changed_services",
+  "removeOrphans": true,
+  "wait": true,
+  "runSmokeCheck": false,
+  "pauseWork": false,
+  "pruneOldImages": false,
+  "reason": "Operator supplied reason"
+}
+```
+
+## Confirmation
+
+Before submission the UI confirmation must include current image, target image, mode, stack, affected service summary, mutable-tag warning when applicable, and a service restart warning.

--- a/specs/264-settings-operations-deployment-update-ui/data-model.md
+++ b/specs/264-settings-operations-deployment-update-ui/data-model.md
@@ -1,0 +1,31 @@
+# Data Model: Settings Operations Deployment Update UI
+
+## DeploymentStackState
+
+- `stack`: allowlisted stack identifier.
+- `projectName`: Compose project name.
+- `configuredImage`: configured MoonMind image reference.
+- `runningImages`: service image evidence; each item may include `imageId` or `digest`.
+- `services`: service state and optional health.
+- `lastUpdateRunId`: optional recent run identifier.
+- Optional UI-only tolerated fields: `version`, `build`, `recentActions`.
+
+## ImageTargets
+
+- `stack`: stack identifier.
+- `repositories`: allowlisted repositories with `allowedReferences`, `recentTags`, and `digestPinningRecommended`.
+
+## DeploymentUpdateForm
+
+- `stack`
+- `repository`
+- `reference`
+- `mode`: `changed_services` by default, `force_recreate` only when available.
+- `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, `pruneOldImages`
+- `reason`: required before submit.
+
+## Validation Rules
+
+- Target image controls expose repository/reference only; updater runner image is not a form field.
+- Mutable references such as `latest` produce a visible warning and confirmation warning.
+- Submit is blocked when reason is blank or no target repository/reference is available.

--- a/specs/264-settings-operations-deployment-update-ui/moonspec_align_report.md
+++ b/specs/264-settings-operations-deployment-update-ui/moonspec_align_report.md
@@ -1,0 +1,48 @@
+# MoonSpec Align Report: Settings Operations Deployment Update UI
+
+**Feature**: `specs/264-settings-operations-deployment-update-ui`
+**Date**: 2026-04-26
+**Result**: PASS
+
+## Findings And Remediation
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| `tasks.md` was updated after planning to add explicit unit/integration test plans and `/moonspec-verify` wording, but no alignment report recorded the downstream gate status. | Low | Added this alignment report and rechecked task coverage, story count, source traceability, and verification wording. |
+| Final verification evidence did not explicitly state that the task list now uses `/moonspec-verify`. | Low | Updated `verification.md` notes to record that final task wording is aligned with `/moonspec-verify`. |
+
+## Gate Checks
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Specify | PASS | `spec.md` preserves the original `MM-522` Jira preset brief and contains one user story. |
+| Plan | PASS | `plan.md`, `research.md`, `quickstart.md`, `data-model.md`, and `contracts/deployment-update-settings-card.md` exist; unit and integration strategies are explicit. |
+| Tasks | PASS | `tasks.md` has exactly one story phase, red-first test tasks, unit and integration plans, implementation tasks, story validation, and final `/moonspec-verify` work. |
+| Traceability | PASS | `MM-522`, `DESIGN-REQ-001`, `DESIGN-REQ-002`, `DESIGN-REQ-016`, and `DESIGN-REQ-017` remain present across the feature artifacts. |
+
+## Validation Commands
+
+```bash
+python - <<'PY'
+from pathlib import Path
+text = Path('specs/264-settings-operations-deployment-update-ui/tasks.md').read_text()
+checks = {
+    'story_sections': text.count('## Phase 3: Story'),
+    'red_first_tests': 'failing UI test' in text,
+    'unit_plan': '**Unit Test Plan**' in text,
+    'integration_plan': '**Integration Test Plan**' in text and './tools/test_unit.sh --ui-args' in text,
+    'implementation_tasks': 'Implement deployment state/target queries' in text,
+    'story_validation': 'Run focused UI test command' in text and 'traceability check' in text,
+    'moonspec_verify': '/moonspec-verify' in text,
+    'old_speckit_verify': '/speckit.verify' in text,
+}
+for key, value in checks.items():
+    print(f'{key}={value}')
+PY
+
+rg -n "MM-522|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-016|DESIGN-REQ-017" specs/264-settings-operations-deployment-update-ui
+```
+
+## Remaining Risks
+
+None found.

--- a/specs/264-settings-operations-deployment-update-ui/plan.md
+++ b/specs/264-settings-operations-deployment-update-ui/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Settings Operations Deployment Update UI
+
+**Branch**: `264-settings-operations-deployment-update-ui` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime feature specification from `specs/264-settings-operations-deployment-update-ui/spec.md`, generated from Jira issue `MM-522`.
+
+## Summary
+
+Add the missing Mission Control Settings Operations Deployment Update card on top of the existing deployment operation API endpoints. The implementation will extend `OperationsSettingsSection` to fetch stack state and image targets, render current deployment evidence, provide target/mode/options/reason controls, require browser confirmation before POSTing to the typed update endpoint, and render recent action fields when provided. Verification is frontend-first with focused React/Vitest coverage plus existing backend route tests for the typed deployment endpoint.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `OperationsSettingsSection.tsx`; focused UI test asserts card under Operations and no deployment navigation | complete | Vitest passed |
+| FR-002 | implemented_verified | UI fetches/renders stack state, configured image, running evidence, health, and last run | complete | Vitest passed |
+| FR-003 | implemented_verified | UI fetches image targets and exposes repository/reference controls without runner image controls | complete | Vitest passed |
+| FR-004 | implemented_verified | `preferredReference()` chooses digest/recent tag before mutable tags | complete | Vitest passed |
+| FR-005 | implemented_verified | mutable reference warning renders for `latest`/`stable` | complete | Vitest passed |
+| FR-006 | implemented_verified | mode defaults to `changed_services`; force recreate offered only from allowed mode data/fallback with warning | complete | Vitest passed |
+| FR-007 | implemented_verified | frontend reason guard and backend validation remain present | complete | Vitest passed |
+| FR-008 | implemented_verified | confirmation text includes current image, target, mode, stack, services, mutable warning, and restart warning | complete | Vitest passed |
+| FR-009 | implemented_verified | UI posts typed payload to `/api/v1/operations/deployment/update` | complete | Vitest passed |
+| FR-010 | implemented_verified | UI renders last update and optional recent action fields defensively | complete | Vitest passed |
+| FR-011 | implemented_verified | raw command-log link renders only when explicitly permitted and present | complete | Vitest passed |
+| FR-012 | implemented_verified | MM-522 preserved in artifacts and verification | complete | rg passed |
+| DESIGN-REQ-001 | implemented_verified | Settings Operations placement and no top-level deployment nav covered | complete | Vitest passed |
+| DESIGN-REQ-002 | implemented_verified | Current deployment, target, mode/options, reason, and confirmation covered | complete | Vitest passed |
+| DESIGN-REQ-016 | implemented_verified | target image controls exist; updater runner controls absent | complete | Vitest passed |
+| DESIGN-REQ-017 | implemented_verified | concise recent action fields and gated log links covered | complete | Vitest passed |
+| SC-001 | implemented_verified | focused UI test | complete | Vitest passed |
+| SC-002 | implemented_verified | focused UI test | complete | Vitest passed |
+| SC-003 | implemented_verified | focused UI test | complete | Vitest passed |
+| SC-004 | implemented_verified | focused UI test | complete | Vitest passed |
+| SC-005 | implemented_verified | traceability grep | complete | rg passed |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but backend endpoints already exist  
+**Primary Dependencies**: React, TanStack Query, Zod, Vitest, Testing Library, existing FastAPI deployment endpoints  
+**Storage**: No new persistent storage  
+**Testing**: `npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx`; final `./tools/test_unit.sh` when feasible  
+**Target Platform**: Mission Control browser UI  
+**Project Type**: Web frontend over existing FastAPI backend  
+**Performance Goals**: Load deployment state and targets without blocking worker pause controls; keep polling bounded to existing query defaults  
+**Constraints**: No top-level navigation; no updater runner image control; no raw logs link unless explicitly allowed  
+**Scale/Scope**: One Settings Operations card for the allowlisted `moonmind` stack
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing typed deployment operation endpoints.
+- II. One-Click Agent Deployment: PASS. Builds on Docker Compose deployment update controls.
+- III. Avoid Vendor Lock-In: PASS. UI uses MoonMind's typed operation API, not provider-specific calls.
+- IV. Own Your Data: PASS. Reads operator-controlled deployment state.
+- V. Skills First-Class: PASS. Does not redefine executable skill contracts.
+- VI. Replaceable Scaffolding: PASS. UI stays thin over existing contracts and tests.
+- VII. Runtime Configurability: PASS. Uses API-provided policy/target data instead of hardcoded runner controls.
+- VIII. Modular Architecture: PASS. Scope limited to Settings Operations component.
+- IX. Resilient by Default: PASS. Confirmation and fail-closed backend validation remain in place.
+- X. Continuous Improvement: PASS. Verification artifacts and traceability are produced.
+- XI. Spec-Driven Development: PASS. This plan follows `spec.md`.
+- XII. Canonical Docs Separation: PASS. No canonical doc migration checklist is added.
+- XIII. Pre-release Compatibility: PASS. No compatibility aliases or internal contract transforms.
+
+## Project Structure
+
+```text
+frontend/src/components/settings/OperationsSettingsSection.tsx
+frontend/src/components/settings/OperationsSettingsSection.test.tsx
+specs/264-settings-operations-deployment-update-ui/
+```
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/264-settings-operations-deployment-update-ui/plan.md
+++ b/specs/264-settings-operations-deployment-update-ui/plan.md
@@ -45,6 +45,14 @@ Add the missing Mission Control Settings Operations Deployment Update card on to
 **Constraints**: No top-level navigation; no updater runner image control; no raw logs link unless explicitly allowed  
 **Scale/Scope**: One Settings Operations card for the allowlisted `moonmind` stack
 
+## Test Strategy
+
+**Unit test strategy**: Use focused React/Vitest coverage in `frontend/src/components/settings/OperationsSettingsSection.test.tsx` for pure UI decisions and component-local behavior: release-tag defaulting, mutable-tag warnings, mode availability, reason validation, confirmation text construction, typed request payload construction, absence of updater runner controls, and raw command-log link gating.
+
+**Integration test strategy**: Use the same component test as a browser-facing integration boundary by rendering `OperationsSettingsSection` with TanStack Query and mocked `fetch` responses for the real deployment operation endpoints: `GET /api/v1/operations/deployment/stacks/{stack}`, `GET /api/v1/operations/deployment/image-targets`, and `POST /api/v1/operations/deployment/update`. Run it through the repository unit runner with `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` so Python unit coverage and targeted frontend behavior are verified together.
+
+**Existing backend contract evidence**: Keep `tests/unit/api/routers/test_deployment_operations.py` as the backend route contract evidence for authorization, policy validation, state shape, image target shape, and typed submission queueing. This story does not require new backend integration tests because it consumes already-tested endpoints without changing their contract.
+
 ## Constitution Check
 
 - I. Orchestrate, Don't Recreate: PASS. Uses existing typed deployment operation endpoints.

--- a/specs/264-settings-operations-deployment-update-ui/quickstart.md
+++ b/specs/264-settings-operations-deployment-update-ui/quickstart.md
@@ -1,0 +1,16 @@
+# Quickstart: Settings Operations Deployment Update UI
+
+1. Open `/tasks/settings?section=operations`.
+2. Confirm the Deployment Update card appears under Operations.
+3. Confirm current stack, Compose project, configured image, service health, and last update context render.
+4. Select `latest` and verify a mutable-tag warning appears.
+5. Enter a reason and submit; verify confirmation includes current image, target image, mode, stack, affected services, mutable warning, and restart warning.
+6. Confirm the request posts to `/api/v1/operations/deployment/update`.
+
+## Validation Commands
+
+```bash
+npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx
+./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx
+rg -n "MM-522|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-016|DESIGN-REQ-017" specs/264-settings-operations-deployment-update-ui
+```

--- a/specs/264-settings-operations-deployment-update-ui/research.md
+++ b/specs/264-settings-operations-deployment-update-ui/research.md
@@ -1,0 +1,41 @@
+# Research: Settings Operations Deployment Update UI
+
+## Classification
+
+Decision: Treat `MM-522` as a single-story runtime UI feature.
+Evidence: The preserved Jira brief names one actor, one Settings Operations card, one source design slice, and one acceptance set.
+Rationale: The story is independently testable through the Settings UI with mocked deployment endpoints.
+Alternatives considered: Running breakdown was rejected because the brief already selects one bounded story.
+Test implications: UI integration tests cover the story.
+
+## Existing Backend Surface
+
+Decision: Reuse existing deployment operation endpoints.
+Evidence: `api_service/api/routers/deployment_operations.py` exposes `GET /api/v1/operations/deployment/stacks/{stack}`, `GET /api/v1/operations/deployment/image-targets`, and `POST /api/v1/operations/deployment/update`; `tests/unit/api/routers/test_deployment_operations.py` covers the typed backend shape.
+Rationale: MM-518 through MM-521 already built the backend and executable contract foundations.
+Alternatives considered: Adding a new endpoint was rejected because it would duplicate the existing typed operation contract.
+Test implications: Frontend tests can mock the existing endpoints; backend route tests remain existing evidence.
+
+## Operations UI Gap
+
+Decision: Extend `OperationsSettingsSection` rather than adding a new top-level page.
+Evidence: `frontend/src/entrypoints/settings.tsx` already routes `section=operations` to `OperationsSettingsSection`; current component only renders worker pause controls.
+Rationale: Source section 6.1 requires Settings -> Operations placement.
+Alternatives considered: A top-level deployment page was rejected by the Jira acceptance criteria.
+Test implications: Test rendering the component and assert no top-level deployment navigation is introduced.
+
+## Target Selection And Confirmation
+
+Decision: Prefer recent release tags or digest references over mutable tags by default, warn for `latest`, and use `window.confirm` for the first confirmation implementation.
+Evidence: Image target response exposes `recentTags`, `allowedReferences`, and `digestPinningRecommended`.
+Rationale: This satisfies the source UX without adding a new modal framework.
+Alternatives considered: Blocking until backend returns resolved digest for all tags was rejected because UI can warn and backend remains authoritative.
+Test implications: UI tests assert default selection, mutable warning, confirmation text, and POST payload.
+
+## Recent Actions
+
+Decision: Render currently available last update run id and defensively render richer optional recent action fields if the API later includes them.
+Evidence: Current `DeploymentStackStateResponse` includes `lastUpdateRunId`; the source design requires richer recent action presentation when available.
+Rationale: The UI can avoid overclaiming unavailable data while remaining forward-compatible with optional fields in response JSON.
+Alternatives considered: Adding persistent recent-action storage was rejected as outside this UI story and contrary to the existing no-new-storage plan.
+Test implications: UI tests include optional recent action fields in mocked responses.

--- a/specs/264-settings-operations-deployment-update-ui/spec.md
+++ b/specs/264-settings-operations-deployment-update-ui/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Settings Operations Deployment Update UI
+
+**Feature Branch**: `264-settings-operations-deployment-update-ui`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**:
+
+```text
+# MM-522 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-522
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Settings Operations deployment update UI
+- Labels: `moonmind-workflow-mm-d22f5e68-8c97-4885-b9c4-cc74b6576885`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-522 from MM project
+Summary: Settings Operations deployment update UI
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Tools/DockerComposeUpdateSystem.md
+Source Title: Docker Compose Deployment Update System
+Source Sections:
+- 6. Settings -> Operations UX
+- 17. Interaction with Settings information architecture
+- 18. UI copy recommendations
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+
+As a MoonMind administrator, I need a Settings -> Operations Deployment Update card that shows current deployment state and lets me submit a confirmed target image update, so I can update MoonMind without SSH access.
+
+Acceptance Criteria
+- The Deployment Update card appears under /tasks/settings?section=operations and not as top-level navigation.
+- Current deployment shows stack name, Compose project, configured image, running image ID or digest when available, version/build when available, health summary, and last run result.
+- Update target controls prefer digest-pinned or release-tagged choices and show a mutable-tag warning for latest or other mutable references.
+- Update mode defaults to Restart changed services and offers Force recreate all services only when policy permits it, with the documented warning.
+- The operator must enter a reason and confirm current image, target image, mode, stack, expected affected services, mutable tag warning when applicable, and restart warning before submission.
+- Recent actions show status, requested image, resolved digest, operator, reason, timestamps, run detail link, logs artifact link, and before/after summary.
+- Raw command-log links are hidden or disabled for users without operational-admin permissions.
+
+Requirements
+- Expose the operator-facing deployment update workflow in Settings Operations.
+- Make target MoonMind image the primary UI choice.
+- Keep updater runner image internal and absent from ordinary UI controls.
+- Use concise progress states and artifact links for review.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-522 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+```
+
+## Classification
+
+Input classification: single-story feature request. The brief selects one independently testable runtime UI behavior story from `docs/Tools/DockerComposeUpdateSystem.md`: an Operations page Deployment Update card that reads existing deployment state/target data, collects a policy-valid update request, confirms the restart-sensitive action, and displays recent update context.
+
+## User Story - Deployment Update Operations Card
+
+**Summary**: As a MoonMind administrator, I need a Deployment Update card under Settings Operations so I can inspect current deployment state and submit a confirmed MoonMind image update without SSH access.
+
+**Goal**: The Operations settings surface provides an operator-facing deployment update workflow with current stack state, target image controls, default restart mode, reason and confirmation requirements, mutable-tag warnings, recent action context, and no ordinary control for the privileged updater runner image.
+
+**Independent Test**: Render the Settings Operations page with mocked deployment endpoints, verify the card appears only in the Operations section, inspect displayed current state and target controls, submit a mutable-tag update, confirm the dialog text, and assert the request payload uses the typed deployment update endpoint without exposing updater runner image controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator opens `/tasks/settings?section=operations`, **When** deployment state and image targets load, **Then** the Deployment Update card appears in the Operations section with current stack, Compose project, configured image, running image evidence when available, health summary, and last run result.
+2. **Given** image targets include release tags and mutable tags, **When** the card renders, **Then** the target controls prefer a release-tagged choice when available and show a warning when the selected reference is mutable such as `latest`.
+3. **Given** the policy allows both update modes, **When** the card renders, **Then** Restart changed services is selected by default and Force recreate all services is available with a restart warning.
+4. **Given** the operator enters a target and reason, **When** they submit the update, **Then** confirmation includes current image, target image, mode, stack, affected service summary, mutable-tag warning when applicable, and service restart warning before the typed update request is sent.
+5. **Given** recent deployment update data is available, **When** the card renders, **Then** recent actions include status, requested image, resolved digest, operator, reason, timestamps, run detail link, logs artifact link, and before/after summary when those fields are present.
+6. **Given** the operator lacks operational-admin artifact permissions, **When** raw command-log links are not allowed by the response, **Then** the card does not expose raw command-log links.
+
+### Edge Cases
+
+- Deployment endpoints may fail independently from worker pause controls; the deployment card reports its own loading/error state without hiding the rest of Operations.
+- If running image ID or digest is unavailable, the card shows that evidence as unavailable rather than inventing values.
+- If only mutable targets are available, the card still allows policy-provided references but keeps the mutable-tag warning visible.
+- If Force recreate all services is not policy-provided by target metadata, the UI does not offer it.
+
+## Assumptions
+
+- MM-518 through MM-521 own authorization, queueing, typed tool contract, desired-state persistence, locking, execution, verification, and artifacts. This story owns the Mission Control Settings Operations UI behavior over the existing deployment endpoints.
+- The initial current-state endpoint may expose placeholder or partial state; the UI must render available fields without implying stronger evidence than the response contains.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Settings Operations section MUST render a Deployment Update card and MUST NOT add deployment update as top-level Mission Control navigation.
+- **FR-002**: The card MUST fetch and display current deployment state, including stack, Compose project, configured image, running image ID or digest when available, service health summary, and last update result when available.
+- **FR-003**: The card MUST fetch image target metadata and expose target image selection centered on the MoonMind image repository and reference, not on updater runner images.
+- **FR-004**: The initial selected target reference MUST prefer a recent release tag or digest-pinned target when available before mutable tags such as `latest`.
+- **FR-005**: Selecting a mutable reference such as `latest` MUST show a warning that the tag may resolve differently over time.
+- **FR-006**: The update mode control MUST default to Restart changed services and MUST offer Force recreate all services only when policy metadata or local allowed-mode data permits it, with the documented warning.
+- **FR-007**: The card MUST require a non-empty reason before submitting a deployment update request.
+- **FR-008**: Before submitting, the card MUST require confirmation that includes current image, target image, mode, stack, expected affected services, mutable-tag warning when applicable, and restart warning.
+- **FR-009**: On confirmation, the card MUST call the typed deployment update endpoint with stack, image repository/reference, mode, options, and reason using the existing API contract.
+- **FR-010**: Recent deployment update actions MUST show available status, requested image, resolved digest, operator, reason, timestamps, run detail link, logs artifact link, and before/after summary fields.
+- **FR-011**: The card MUST hide or disable raw command-log links when the response does not expose an operational-admin-permitted link.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-522` and this canonical Jira preset brief.
+
+### Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 6.1 requires deployment update to live under Settings -> Operations. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-002**: Source section 6.2 requires the card to show current deployment state, target image controls, update mode, options, reason, and confirmation details. Scope: in scope. Maps to FR-002 through FR-009.
+- **DESIGN-REQ-016**: Source section 6.2 and core invariants require the UI to select target deployment image and keep the privileged updater runner image internal. Scope: in scope. Maps to FR-003.
+- **DESIGN-REQ-017**: Source section 6.3 and UI copy guidance require concise recent action/progress context and artifact links while hiding raw command logs from users without operational-admin permissions. Scope: in scope. Maps to FR-010 and FR-011.
+
+### Success Criteria *(mandatory)*
+
+- **SC-001**: A UI test verifies the Deployment Update card renders under `/tasks/settings?section=operations` with current deployment state and no top-level navigation item.
+- **SC-002**: A UI test verifies default target selection prefers a recent release tag over `latest` and shows mutable-tag warning when `latest` is selected.
+- **SC-003**: A UI test verifies confirmation text and the submitted deployment update payload.
+- **SC-004**: A UI test verifies updater runner image controls are absent and raw command-log links are hidden unless explicitly exposed.
+- **SC-005**: Traceability evidence preserves `MM-522` and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-016, and DESIGN-REQ-017 across MoonSpec artifacts.

--- a/specs/264-settings-operations-deployment-update-ui/tasks.md
+++ b/specs/264-settings-operations-deployment-update-ui/tasks.md
@@ -22,6 +22,10 @@
 
 **Traceability IDs**: FR-001 through FR-012; SC-001 through SC-005; DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-016, DESIGN-REQ-017.
 
+**Unit Test Plan**: Use focused React/Vitest assertions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx` for release-tag defaulting, mutable warnings, mode availability, reason validation, confirmation text, request payload construction, updater runner control absence, and raw command-log link gating.
+
+**Integration Test Plan**: Render `OperationsSettingsSection` with TanStack Query and mocked real deployment operation endpoints (`GET /api/v1/operations/deployment/stacks/{stack}`, `GET /api/v1/operations/deployment/image-targets`, `POST /api/v1/operations/deployment/update`) through `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx`.
+
 - [X] T004 [P] Add failing UI test for rendering the Deployment Update card with current deployment state and no top-level deployment navigation in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-001, FR-002, SC-001, DESIGN-REQ-001)
 - [X] T005 [P] Add failing UI test for target defaulting to a recent release tag, mutable-tag warning, allowed modes, and absence of updater runner image controls in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-004, DESIGN-REQ-002, DESIGN-REQ-016)
 - [X] T006 [P] Add failing UI test for reason validation, confirmation content, and typed POST payload in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-007, FR-008, FR-009, SC-003)
@@ -29,7 +33,7 @@
 - [X] T008 Implement deployment state/target queries, card sections, target/mode/options/reason controls, confirmation, submit mutation, recent actions rendering, and gated log links in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-001 through FR-011)
 - [X] T009 Run focused UI test command and mark T004-T008 complete when passing. (SC-001 through SC-004)
 - [X] T010 Run traceability check for `MM-522` and source design IDs in `specs/264-settings-operations-deployment-update-ui`. (FR-012, SC-005)
-- [X] T011 Run `/speckit.verify` equivalent and record final verification in `specs/264-settings-operations-deployment-update-ui/verification.md`. (FR-001 through FR-012)
+- [X] T011 Run `/moonspec-verify` equivalent and record final verification in `specs/264-settings-operations-deployment-update-ui/verification.md`. (FR-001 through FR-012)
 
 ## Dependencies
 

--- a/specs/264-settings-operations-deployment-update-ui/tasks.md
+++ b/specs/264-settings-operations-deployment-update-ui/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Settings Operations Deployment Update UI
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md)
+**Prerequisites**: Existing deployment operations endpoints and Settings Operations component
+**Unit Test Command**: `npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx`
+**Integration Test Command**: `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx`
+
+**Source Traceability**: `MM-522`; FR-001 through FR-012; SC-001 through SC-005; DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-016, DESIGN-REQ-017.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm existing Settings Operations and deployment endpoint files in `frontend/src/components/settings/OperationsSettingsSection.tsx`, `frontend/src/entrypoints/settings.tsx`, and `api_service/api/routers/deployment_operations.py`. (FR-001, FR-009)
+- [X] T002 Create MoonSpec artifacts under `specs/264-settings-operations-deployment-update-ui`. (FR-012, SC-005)
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm backend deployment endpoints already expose state, image target, and submit contracts in `tests/unit/api/routers/test_deployment_operations.py`. (FR-002, FR-003, FR-009)
+
+## Phase 3: Story - Deployment Update Operations Card
+
+**Independent Test**: Render Operations settings with mocked deployment endpoints, submit a mutable-tag update after confirmation, and verify the UI displays state/target/recent context while omitting updater runner controls and raw command-log links.
+
+**Traceability IDs**: FR-001 through FR-012; SC-001 through SC-005; DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-016, DESIGN-REQ-017.
+
+- [X] T004 [P] Add failing UI test for rendering the Deployment Update card with current deployment state and no top-level deployment navigation in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-001, FR-002, SC-001, DESIGN-REQ-001)
+- [X] T005 [P] Add failing UI test for target defaulting to a recent release tag, mutable-tag warning, allowed modes, and absence of updater runner image controls in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-004, DESIGN-REQ-002, DESIGN-REQ-016)
+- [X] T006 [P] Add failing UI test for reason validation, confirmation content, and typed POST payload in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-007, FR-008, FR-009, SC-003)
+- [X] T007 [P] Add failing UI test for recent deployment actions and hidden raw command-log links in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-010, FR-011, SC-004, DESIGN-REQ-017)
+- [X] T008 Implement deployment state/target queries, card sections, target/mode/options/reason controls, confirmation, submit mutation, recent actions rendering, and gated log links in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-001 through FR-011)
+- [X] T009 Run focused UI test command and mark T004-T008 complete when passing. (SC-001 through SC-004)
+- [X] T010 Run traceability check for `MM-522` and source design IDs in `specs/264-settings-operations-deployment-update-ui`. (FR-012, SC-005)
+- [X] T011 Run `/speckit.verify` equivalent and record final verification in `specs/264-settings-operations-deployment-update-ui/verification.md`. (FR-001 through FR-012)
+
+## Dependencies
+
+T001-T003 precede T004-T008. T004-T007 can be authored in parallel. T008 follows red-first test creation. T009-T011 follow implementation.

--- a/specs/264-settings-operations-deployment-update-ui/verification.md
+++ b/specs/264-settings-operations-deployment-update-ui/verification.md
@@ -1,0 +1,35 @@
+# Verification: Settings Operations Deployment Update UI
+
+**Original Request Source**: `spec.md` Input preserving `MM-522` Jira preset brief
+**Verdict**: `FULLY_IMPLEMENTED`
+
+## Evidence
+
+| Check | Command / Evidence | Result |
+| --- | --- | --- |
+| Focused UI behavior | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/OperationsSettingsSection.test.tsx` | PASS: 4 tests |
+| TypeScript | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS |
+| Frontend lint | `./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/components/settings/OperationsSettingsSection.tsx frontend/src/components/settings/OperationsSettingsSection.test.tsx` | PASS |
+| Canonical unit runner | `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` | PASS: Python phase 4047 passed, 1 xpassed, 16 subtests; UI phase 1 file passed, 4 tests |
+| Traceability | `rg -n "MM-522|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-016|DESIGN-REQ-017" specs/264-settings-operations-deployment-update-ui` | PASS |
+
+## Requirement Coverage
+
+| ID | Verdict | Evidence |
+| --- | --- | --- |
+| FR-001 / DESIGN-REQ-001 / SC-001 | VERIFIED | Deployment Update card renders in `OperationsSettingsSection`; test asserts no deployment top-level nav. |
+| FR-002 / DESIGN-REQ-002 | VERIFIED | Test asserts stack, configured image, running evidence, health, and last update result render. |
+| FR-003 / DESIGN-REQ-016 / SC-004 | VERIFIED | Test asserts target image controls exist and updater runner image controls are absent. |
+| FR-004 / SC-002 | VERIFIED | Test asserts target reference defaults to recent release tag `20260425.1234`. |
+| FR-005 / SC-002 | VERIFIED | Test asserts mutable tag warning when `latest` is selected. |
+| FR-006 | VERIFIED | Test asserts default `changed_services` mode and force-recreate option/warning. |
+| FR-007 | VERIFIED | Test asserts blank reason is blocked with an error. |
+| FR-008 / SC-003 | VERIFIED | Test asserts confirmation includes current image, target image, mode, stack, affected services, mutable warning, and restart warning. |
+| FR-009 / SC-003 | VERIFIED | Test asserts typed POST payload to `/api/v1/operations/deployment/update`. |
+| FR-010 / DESIGN-REQ-017 | VERIFIED | Test asserts recent action status, requested image context, operator, reason, run detail link, and logs artifact link. |
+| FR-011 / DESIGN-REQ-017 / SC-004 | VERIFIED | Test asserts raw command-log link is hidden unless explicitly permitted. |
+| FR-012 / SC-005 | VERIFIED | `MM-522` and source design IDs are preserved in artifacts. |
+
+## Notes
+
+- Verification completed after remediation with the canonical unit runner, focused UI test, typecheck, lint, and traceability checks passing.

--- a/specs/264-settings-operations-deployment-update-ui/verification.md
+++ b/specs/264-settings-operations-deployment-update-ui/verification.md
@@ -33,3 +33,4 @@
 ## Notes
 
 - Verification completed after remediation with the canonical unit runner, focused UI test, typecheck, lint, and traceability checks passing.
+- Alignment pass confirmed `tasks.md` now uses `/moonspec-verify` wording and retains one-story task coverage with explicit unit and integration plans.


### PR DESCRIPTION
## Jira

- Issue: MM-522

## MoonSpec

- Active feature path: `specs/264-settings-operations-deployment-update-ui`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary

Implements the Settings -> Operations Deployment Update card for MoonMind deployment updates.

Changes include:
- Adds the Deployment Update card to the existing Operations settings surface without adding top-level navigation.
- Fetches deployment state and image target metadata from the typed deployment operations endpoints.
- Adds target image, mode, options, reason, confirmation, submit, recent action, and gated log-link UI behavior.
- Adds focused UI coverage and MoonSpec artifacts preserving the Jira preset brief and source design mappings.

## Tests Run

- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/OperationsSettingsSection.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
- `./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/components/settings/OperationsSettingsSection.tsx frontend/src/components/settings/OperationsSettingsSection.test.tsx`
- `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx`

## Remaining Risks

- TDD red-first failures were not re-created after the branch was already implemented; the task list preserves the red-first sequence and final verification is green.
- Git remote push succeeded, but the local remote-tracking ref update hit root-owned `.git/logs` metadata in this managed workspace. GitHub PR state was verified from the remote.