### PR TITLE
MM-523 explicit deployment failure and rollback controls

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/263-deployment-verification-artifacts-progress"
+  "feature_directory": "specs/265-explicit-failure-and-rollback-controls"
 }

--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
@@ -14,8 +14,11 @@ from api_service.db.models import User
 from api_service.services.deployment_operations import (
     DeploymentOperationError,
     DeploymentOperationsService,
+    DeploymentRecentAction,
     DeploymentStackPolicy,
     DeploymentUpdateSubmission,
+    RollbackEligibilityDecision,
+    RollbackImageTarget,
 )
 from moonmind.config.settings import settings
 from moonmind.workflows.tasks.routing import TemporalSubmitDisabledError
@@ -23,6 +26,7 @@ from moonmind.workflows.temporal import (
     TemporalExecutionService,
     TemporalExecutionValidationError,
 )
+from moonmind.workflows.skills.deployment_tools import DEPLOYMENT_UPDATE_TOOL_NAME
 
 
 router = APIRouter(prefix="/api/v1/operations/deployment", tags=["deployment"])
@@ -188,34 +192,228 @@ def _policy_error(exc: DeploymentOperationError) -> HTTPException:
     )
 
 
-def _recent_action_model(action) -> DeploymentRecentActionModel:
+def _enum_text(value: object) -> str | None:
+    resolved = getattr(value, "value", value)
+    if resolved is None:
+        return None
+    text = str(resolved).strip()
+    return text or None
+
+
+def _iso_text(value: object) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    text = str(value).strip()
+    return text or None
+
+
+def _deployment_plan_inputs(record: object) -> dict[str, Any]:
+    parameters = getattr(record, "parameters", None)
+    if not isinstance(parameters, dict):
+        return {}
+    task = parameters.get("task")
+    if not isinstance(task, dict):
+        return {}
+    plan = task.get("plan")
+    if not isinstance(plan, list):
+        return {}
+    for step in plan:
+        if not isinstance(step, dict):
+            continue
+        tool = step.get("tool")
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("name") != DEPLOYMENT_UPDATE_TOOL_NAME:
+            continue
+        inputs = step.get("inputs")
+        return dict(inputs) if isinstance(inputs, dict) else {}
+    return {}
+
+
+def _deployment_operation(record: object) -> dict[str, Any]:
+    parameters = getattr(record, "parameters", None)
+    if not isinstance(parameters, dict):
+        return {}
+    task = parameters.get("task")
+    if not isinstance(task, dict):
+        return {}
+    operation = task.get("operation")
+    return dict(operation) if isinstance(operation, dict) else {}
+
+
+def _artifact_url(ref: object) -> str | None:
+    if not isinstance(ref, str) or not ref.strip():
+        return None
+    return f"/api/artifacts/{ref.strip()}"
+
+
+def _rollback_target_from_summary(
+    *,
+    before_summary: str | None,
+    policy: DeploymentStackPolicy,
+) -> RollbackImageTarget | None:
+    if not before_summary:
+        return None
+    candidate = before_summary.strip()
+    prefix = f"{policy.repository}:"
+    if not candidate.startswith(prefix):
+        return None
+    reference = candidate.removeprefix(prefix).strip()
+    if not reference:
+        return None
+    try:
+        policy_service = DeploymentOperationsService({policy.stack: policy})
+        policy_service.validate_update_request(
+            stack=policy.stack,
+            repository=policy.repository,
+            reference=reference,
+            mode=policy.allowed_modes[0],
+            reason="Validate rollback target",
+            operation_kind="update",
+        )
+    except DeploymentOperationError:
+        return None
+    return RollbackImageTarget(repository=policy.repository, reference=reference)
+
+
+def _recent_action_from_execution_record(
+    record: object,
+    *,
+    policy: DeploymentStackPolicy,
+) -> DeploymentRecentAction | None:
+    inputs = _deployment_plan_inputs(record)
+    if inputs.get("stack") != policy.stack:
+        return None
+    image = inputs.get("image")
+    if not isinstance(image, dict):
+        image = {}
+    repository = str(image.get("repository") or policy.repository).strip()
+    reference = str(image.get("reference") or "").strip()
+    requested_image = f"{repository}:{reference}" if repository and reference else None
+    operation = _deployment_operation(record)
+    operation_kind = str(
+        inputs.get("operationKind") or operation.get("kind") or "update"
+    ).strip()
+    state_text = (_enum_text(getattr(record, "state", None)) or "unknown").upper()
+    close_status = _enum_text(getattr(record, "close_status", None))
+    status_text = (close_status or state_text).upper()
+    if operation_kind == "rollback":
+        kind = "rollback"
+    elif status_text in {"FAILED", "TERMINATED", "CANCELED", "CANCELLED", "FAILURE"}:
+        kind = "failure"
+    else:
+        kind = "update"
+    run_id = str(getattr(record, "run_id", "") or "").strip()
+    action_id = (
+        f"depupd_{run_id.replace('-', '')}"
+        if run_id
+        else str(getattr(record, "workflow_id", "deployment-update"))
+    )
+    artifact_refs = [
+        ref for ref in getattr(record, "artifact_refs", []) or [] if isinstance(ref, str)
+    ]
+    before_summary = None
+    after_summary = None
+    memo = getattr(record, "memo", None)
+    if isinstance(memo, dict):
+        before_summary = (
+            memo.get("deploymentBeforeSummary")
+            or memo.get("beforeSummary")
+            or memo.get("before_summary")
+        )
+        after_summary = (
+            memo.get("deploymentAfterSummary")
+            or memo.get("afterSummary")
+            or memo.get("after_summary")
+            or memo.get("summary")
+        )
+    before_summary = str(before_summary).strip() if before_summary else None
+    after_summary = str(after_summary).strip() if after_summary else None
+    target_image = _rollback_target_from_summary(
+        before_summary=before_summary,
+        policy=policy,
+    )
+    evidence_ref = artifact_refs[0] if artifact_refs else None
+    eligibility = RollbackEligibilityDecision(
+        eligible=target_image is not None,
+        target_image=target_image,
+        source_action_id=action_id,
+        reason=None if target_image else "Before-state evidence is missing.",
+        evidence_ref=evidence_ref,
+    )
+    return DeploymentRecentAction(
+        id=action_id,
+        kind=kind,
+        status=status_text,
+        requested_image=requested_image,
+        resolved_digest=str(image.get("digest") or "").strip() or None,
+        operator=str(getattr(record, "owner_id", "") or "").strip() or None,
+        reason=str(inputs.get("reason") or "").strip() or None,
+        started_at=_iso_text(getattr(record, "started_at", None)),
+        completed_at=_iso_text(getattr(record, "closed_at", None)),
+        run_detail_url=f"/tasks/{getattr(record, 'workflow_id', '')}",
+        logs_artifact_url=_artifact_url(evidence_ref),
+        raw_command_log_url=None,
+        raw_command_log_permitted=False,
+        run_id=run_id or None,
+        before_summary=before_summary,
+        after_summary=after_summary,
+        rollback_eligibility=eligibility,
+    )
+
+
+async def _recent_actions_from_executions(
+    *,
+    execution_service: TemporalExecutionService,
+    policy: DeploymentStackPolicy,
+) -> tuple[DeploymentRecentAction, ...]:
+    try:
+        result = await execution_service.list_executions(
+            workflow_type="MoonMind.Run",
+            integration=DEPLOYMENT_UPDATE_TOOL_NAME,
+            page_size=10,
+        )
+    except Exception:
+        return ()
+    actions: list[DeploymentRecentAction] = []
+    for record in getattr(result, "items", ()) or ():
+        action = _recent_action_from_execution_record(record, policy=policy)
+        if action is not None:
+            actions.append(action)
+    return tuple(actions)
+
+
+def _recent_action_model(action: DeploymentRecentAction) -> DeploymentRecentActionModel:
     eligibility = action.rollback_eligibility
     return DeploymentRecentActionModel(
         id=action.id,
         kind=action.kind,
         status=action.status,
-        requestedImage=action.requested_image,
-        resolvedDigest=action.resolved_digest,
+        requested_image=action.requested_image,
+        resolved_digest=action.resolved_digest,
         operator=action.operator,
         reason=action.reason,
-        startedAt=action.started_at,
-        completedAt=action.completed_at,
-        runDetailUrl=action.run_detail_url,
-        logsArtifactUrl=action.logs_artifact_url,
-        rawCommandLogUrl=(
+        started_at=action.started_at,
+        completed_at=action.completed_at,
+        run_detail_url=action.run_detail_url,
+        logs_artifact_url=action.logs_artifact_url,
+        raw_command_log_url=(
             action.raw_command_log_url
             if action.raw_command_log_permitted
             else None
         ),
-        rawCommandLogPermitted=action.raw_command_log_permitted,
-        runId=action.run_id,
-        beforeSummary=action.before_summary,
-        afterSummary=action.after_summary,
-        rollbackEligibility=(
+        raw_command_log_permitted=action.raw_command_log_permitted,
+        run_id=action.run_id,
+        before_summary=action.before_summary,
+        after_summary=action.after_summary,
+        rollback_eligibility=(
             RollbackEligibilityModel(
                 eligible=eligibility.eligible,
-                sourceActionId=eligibility.source_action_id,
-                targetImage=(
+                source_action_id=eligibility.source_action_id,
+                target_image=(
                     RollbackImageTargetModel(
                         repository=eligibility.target_image.repository,
                         reference=eligibility.target_image.reference,
@@ -224,7 +422,7 @@ def _recent_action_model(action) -> DeploymentRecentActionModel:
                     else None
                 ),
                 reason=eligibility.reason,
-                evidenceRef=eligibility.evidence_ref,
+                evidence_ref=eligibility.evidence_ref,
             )
             if eligibility
             else None
@@ -235,16 +433,22 @@ def _recent_action_model(action) -> DeploymentRecentActionModel:
 def _stack_state(
     policy: DeploymentStackPolicy,
     service: DeploymentOperationsService,
+    recent_actions: tuple[DeploymentRecentAction, ...] | None = None,
 ) -> DeploymentStackStateResponse:
+    actions = (
+        recent_actions
+        if recent_actions is not None
+        else service.recent_actions(policy.stack)
+    )
     return DeploymentStackStateResponse(
         stack=policy.stack,
-        projectName=policy.project_name,
-        configuredImage=policy.configured_image,
-        runningImages=[
+        project_name=policy.project_name,
+        configured_image=policy.configured_image,
+        running_images=[
             RunningImageModel(
                 service="api",
                 image=policy.configured_image,
-                imageId=None,
+                image_id=None,
                 digest=None,
             )
         ],
@@ -255,11 +459,8 @@ def _stack_state(
                 health=None,
             )
         ],
-        lastUpdateRunId=None,
-        recentActions=[
-            _recent_action_model(action)
-            for action in service.recent_actions(policy.stack)
-        ],
+        last_update_run_id=None,
+        recent_actions=[_recent_action_model(action) for action in actions],
     )
 
 
@@ -328,13 +529,22 @@ async def submit_deployment_update(
 async def get_deployment_stack_state(
     stack: str,
     service: DeploymentOperationsService = Depends(_get_deployment_service),
+    execution_service: TemporalExecutionService = Depends(
+        _get_temporal_execution_service
+    ),
     _user: User = Depends(get_current_user()),
 ) -> DeploymentStackStateResponse:
     try:
         policy = service.get_policy(stack)
     except DeploymentOperationError as exc:
         raise _policy_error(exc) from exc
-    return _stack_state(policy, service)
+    recent_actions = service.recent_actions(policy.stack)
+    if not recent_actions:
+        recent_actions = await _recent_actions_from_executions(
+            execution_service=execution_service,
+            policy=policy,
+        )
+    return _stack_state(policy, service, recent_actions=recent_actions)
 
 
 @router.get("/image-targets", response_model=ImageTargetsResponse)

--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -47,6 +47,11 @@ class DeploymentUpdateRequest(BaseModel):
     pause_work: bool = Field(False, alias="pauseWork")
     prune_old_images: bool = Field(False, alias="pruneOldImages")
     reason: str = Field(..., min_length=1)
+    operation_kind: Literal["update", "rollback"] = Field("update", alias="operationKind")
+    rollback_source_action_id: str | None = Field(
+        None, alias="rollbackSourceActionId"
+    )
+    confirmation: str | None = None
 
 
 class DeploymentUpdateResponse(BaseModel):
@@ -80,6 +85,48 @@ class DeploymentStackStateResponse(BaseModel):
     running_images: list[RunningImageModel] = Field(..., alias="runningImages")
     services: list[DeploymentServiceStateModel]
     last_update_run_id: str | None = Field(None, alias="lastUpdateRunId")
+    recent_actions: list["DeploymentRecentActionModel"] = Field(
+        default_factory=list, alias="recentActions"
+    )
+
+
+class RollbackImageTargetModel(BaseModel):
+    repository: str
+    reference: str
+
+
+class RollbackEligibilityModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    eligible: bool
+    source_action_id: str | None = Field(None, alias="sourceActionId")
+    target_image: RollbackImageTargetModel | None = Field(None, alias="targetImage")
+    reason: str | None = None
+    evidence_ref: str | None = Field(None, alias="evidenceRef")
+
+
+class DeploymentRecentActionModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    kind: str
+    status: str
+    requested_image: str | None = Field(None, alias="requestedImage")
+    resolved_digest: str | None = Field(None, alias="resolvedDigest")
+    operator: str | None = None
+    reason: str | None = None
+    started_at: str | None = Field(None, alias="startedAt")
+    completed_at: str | None = Field(None, alias="completedAt")
+    run_detail_url: str | None = Field(None, alias="runDetailUrl")
+    logs_artifact_url: str | None = Field(None, alias="logsArtifactUrl")
+    raw_command_log_url: str | None = Field(None, alias="rawCommandLogUrl")
+    raw_command_log_permitted: bool = Field(False, alias="rawCommandLogPermitted")
+    run_id: str | None = Field(None, alias="runId")
+    before_summary: str | None = Field(None, alias="beforeSummary")
+    after_summary: str | None = Field(None, alias="afterSummary")
+    rollback_eligibility: RollbackEligibilityModel | None = Field(
+        None, alias="rollbackEligibility"
+    )
 
 
 class ImageTargetModel(BaseModel):
@@ -129,6 +176,7 @@ def _require_admin(user: User) -> None:
         detail={
             "code": "deployment_update_forbidden",
             "message": "Only administrators can submit deployment updates.",
+            "failureClass": "authorization_failure",
         },
     )
 
@@ -140,7 +188,54 @@ def _policy_error(exc: DeploymentOperationError) -> HTTPException:
     )
 
 
-def _stack_state(policy: DeploymentStackPolicy) -> DeploymentStackStateResponse:
+def _recent_action_model(action) -> DeploymentRecentActionModel:
+    eligibility = action.rollback_eligibility
+    return DeploymentRecentActionModel(
+        id=action.id,
+        kind=action.kind,
+        status=action.status,
+        requestedImage=action.requested_image,
+        resolvedDigest=action.resolved_digest,
+        operator=action.operator,
+        reason=action.reason,
+        startedAt=action.started_at,
+        completedAt=action.completed_at,
+        runDetailUrl=action.run_detail_url,
+        logsArtifactUrl=action.logs_artifact_url,
+        rawCommandLogUrl=(
+            action.raw_command_log_url
+            if action.raw_command_log_permitted
+            else None
+        ),
+        rawCommandLogPermitted=action.raw_command_log_permitted,
+        runId=action.run_id,
+        beforeSummary=action.before_summary,
+        afterSummary=action.after_summary,
+        rollbackEligibility=(
+            RollbackEligibilityModel(
+                eligible=eligibility.eligible,
+                sourceActionId=eligibility.source_action_id,
+                targetImage=(
+                    RollbackImageTargetModel(
+                        repository=eligibility.target_image.repository,
+                        reference=eligibility.target_image.reference,
+                    )
+                    if eligibility.target_image
+                    else None
+                ),
+                reason=eligibility.reason,
+                evidenceRef=eligibility.evidence_ref,
+            )
+            if eligibility
+            else None
+        ),
+    )
+
+
+def _stack_state(
+    policy: DeploymentStackPolicy,
+    service: DeploymentOperationsService,
+) -> DeploymentStackStateResponse:
     return DeploymentStackStateResponse(
         stack=policy.stack,
         projectName=policy.project_name,
@@ -161,6 +256,10 @@ def _stack_state(policy: DeploymentStackPolicy) -> DeploymentStackStateResponse:
             )
         ],
         lastUpdateRunId=None,
+        recentActions=[
+            _recent_action_model(action)
+            for action in service.recent_actions(policy.stack)
+        ],
     )
 
 
@@ -183,6 +282,9 @@ async def submit_deployment_update(
             reference=payload.image.reference,
             mode=payload.mode,
             reason=payload.reason,
+            operation_kind=payload.operation_kind,
+            confirmation=payload.confirmation,
+            rollback_source_action_id=payload.rollback_source_action_id,
         )
     except DeploymentOperationError as exc:
         raise _policy_error(exc) from exc
@@ -202,6 +304,9 @@ async def submit_deployment_update(
                 prune_old_images=payload.prune_old_images,
                 reason=payload.reason,
                 requested_by_user_id=getattr(user, "id", None),
+                operation_kind=payload.operation_kind,
+                rollback_source_action_id=payload.rollback_source_action_id,
+                confirmation=payload.confirmation,
             ),
         )
     except TemporalSubmitDisabledError as exc:
@@ -229,7 +334,7 @@ async def get_deployment_stack_state(
         policy = service.get_policy(stack)
     except DeploymentOperationError as exc:
         raise _policy_error(exc) from exc
-    return _stack_state(policy)
+    return _stack_state(policy, service)
 
 
 @router.get("/image-targets", response_model=ImageTargetsResponse)

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -57,6 +57,45 @@ class DeploymentUpdateSubmission:
     prune_old_images: bool
     reason: str
     requested_by_user_id: UUID | str | None
+    operation_kind: str = "update"
+    rollback_source_action_id: str | None = None
+    confirmation: str | None = None
+
+
+@dataclass(frozen=True)
+class RollbackImageTarget:
+    repository: str
+    reference: str
+
+
+@dataclass(frozen=True)
+class RollbackEligibilityDecision:
+    eligible: bool
+    target_image: RollbackImageTarget | None = None
+    source_action_id: str | None = None
+    reason: str | None = None
+    evidence_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class DeploymentRecentAction:
+    id: str
+    kind: str
+    status: str
+    requested_image: str | None = None
+    resolved_digest: str | None = None
+    operator: str | None = None
+    reason: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    run_detail_url: str | None = None
+    logs_artifact_url: str | None = None
+    raw_command_log_url: str | None = None
+    raw_command_log_permitted: bool = False
+    run_id: str | None = None
+    before_summary: str | None = None
+    after_summary: str | None = None
+    rollback_eligibility: RollbackEligibilityDecision | None = None
 
 
 class DeploymentExecutionCreator(Protocol):
@@ -101,8 +140,10 @@ class DeploymentOperationsService:
     def __init__(
         self,
         policies: dict[str, DeploymentStackPolicy] | None = None,
+        recent_actions: dict[str, tuple[DeploymentRecentAction, ...]] | None = None,
     ) -> None:
         self._policies = policies or DEFAULT_DEPLOYMENT_POLICIES
+        self._recent_actions = recent_actions or {}
 
     def get_policy(self, stack: str) -> DeploymentStackPolicy:
         normalized = str(stack or "").strip()
@@ -122,6 +163,9 @@ class DeploymentOperationsService:
         reference: str,
         mode: str,
         reason: str,
+        operation_kind: str = "update",
+        confirmation: str | None = None,
+        rollback_source_action_id: str | None = None,
     ) -> DeploymentStackPolicy:
         policy = self.get_policy(stack)
         if repository != policy.repository:
@@ -144,7 +188,28 @@ class DeploymentOperationsService:
                 "deployment_reason_required",
                 "Deployment update reason is required.",
             )
+        normalized_operation = str(operation_kind or "update").strip()
+        if normalized_operation not in {"update", "rollback"}:
+            raise DeploymentOperationError(
+                "deployment_operation_kind_invalid",
+                "Deployment operation kind is invalid.",
+            )
+        if normalized_operation == "rollback":
+            if not str(confirmation or "").strip():
+                raise DeploymentOperationError(
+                    "deployment_confirmation_required",
+                    "Rollback confirmation is required.",
+                )
+            if not str(rollback_source_action_id or "").strip():
+                raise DeploymentOperationError(
+                    "deployment_rollback_source_required",
+                    "Rollback source action is required.",
+                )
         return policy
+
+    def recent_actions(self, stack: str) -> tuple[DeploymentRecentAction, ...]:
+        policy = self.get_policy(stack)
+        return self._recent_actions.get(policy.stack, ())
 
     async def queue_update(
         self,
@@ -199,6 +264,25 @@ class DeploymentOperationsService:
         policy: DeploymentStackPolicy,
         submission: DeploymentUpdateSubmission,
     ) -> dict[str, Any]:
+        plan_inputs = {
+            "stack": policy.stack,
+            "image": {
+                "repository": submission.repository,
+                "reference": submission.reference,
+            },
+            "mode": submission.mode,
+            "removeOrphans": submission.remove_orphans,
+            "wait": submission.wait,
+            "runSmokeCheck": submission.run_smoke_check,
+            "pauseWork": submission.pause_work,
+            "pruneOldImages": submission.prune_old_images,
+            "reason": submission.reason,
+            "operationKind": submission.operation_kind,
+        }
+        if submission.rollback_source_action_id:
+            plan_inputs["rollbackSourceActionId"] = submission.rollback_source_action_id
+        if submission.confirmation:
+            plan_inputs["confirmation"] = submission.confirmation
         return {
             "task": {
                 "instructions": (
@@ -209,7 +293,9 @@ class DeploymentOperationsService:
                 "operation": {
                     "type": "deployment.update",
                     "source": "api.v1.operations.deployment.update",
-                    "jiraIssue": "MM-518",
+                    "jiraIssue": "MM-523",
+                    "kind": submission.operation_kind,
+                    "rollbackSourceActionId": submission.rollback_source_action_id,
                 },
                 "plan": [
                     {
@@ -220,20 +306,7 @@ class DeploymentOperationsService:
                             "name": DEPLOYMENT_UPDATE_TOOL_NAME,
                             "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
                         },
-                        "inputs": {
-                            "stack": policy.stack,
-                            "image": {
-                                "repository": submission.repository,
-                                "reference": submission.reference,
-                            },
-                            "mode": submission.mode,
-                            "removeOrphans": submission.remove_orphans,
-                            "wait": submission.wait,
-                            "runSmokeCheck": submission.run_smoke_check,
-                            "pauseWork": submission.pause_work,
-                            "pruneOldImages": submission.prune_old_images,
-                            "reason": submission.reason,
-                        },
+                        "inputs": plan_inputs,
                     }
                 ],
             }

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from typing import Any, Protocol
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
@@ -318,6 +318,11 @@ class DeploymentOperationsService:
         policy: DeploymentStackPolicy,
         submission: DeploymentUpdateSubmission,
     ) -> str:
+        explicit_action_key = (
+            uuid4().hex
+            if submission.operation_kind == "rollback"
+            else submission.reason.strip()
+        )
         return "|".join(
             [
                 "deployment-update",
@@ -325,6 +330,6 @@ class DeploymentOperationsService:
                 submission.repository,
                 submission.reference,
                 submission.mode,
-                submission.reason.strip(),
+                explicit_action_key,
             ]
         )[:128]

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,5 +1,4 @@
 {
-  "jira_issue_key": "MM-521",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1775"
+  "jira_issue_key": "MM-523",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1778"
 }
-

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,27 @@
 [
   {
-    "id": 3142898352,
+    "id": 3142955427,
     "disposition": "addressed",
-    "rationale": "Replaced index-based recent deployment action keys with keys derived from action identifiers, URLs, or stable action fields."
+    "rationale": "Updated _recent_action_model to use Pydantic field names and added a DeploymentRecentAction type hint."
   },
   {
-    "id": 4176457752,
+    "id": 4176503639,
     "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary; the inline recommendation it referenced was handled separately."
+    "rationale": "Broad review summary with no separate actionable request beyond the linked model-construction comment."
   },
   {
-    "id": 3142899981,
+    "id": 4176505945,
+    "disposition": "not-applicable",
+    "rationale": "Informational automated Codex review wrapper with no actionable code finding."
+  },
+  {
+    "id": 3142958549,
     "disposition": "addressed",
-    "rationale": "Changed missing or empty allowedModes metadata to default to changed_services only and added frontend coverage."
+    "rationale": "Deployment stack state now falls back to persisted Temporal deployment execution history when no injected recent actions are present."
   },
   {
-    "id": 4176458909,
-    "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper with no independent actionable request."
+    "id": 3142958551,
+    "disposition": "addressed",
+    "rationale": "Rollback submissions now produce fresh server-side idempotency keys and the UI includes a request timestamp in the rollback reason."
   }
 ]

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -56,6 +56,47 @@ const stackState = {
   ],
 };
 
+const stackStateWithRollback = {
+  ...stackState,
+  recentActions: [
+    {
+      status: 'FAILED',
+      requestedImage: 'ghcr.io/moonladderstudios/moonmind:20260425.1234',
+      operator: 'admin@example.com',
+      reason: 'Routine release failed',
+      startedAt: '2026-04-25T18:00:00Z',
+      completedAt: '2026-04-25T18:04:00Z',
+      runDetailUrl: '/tasks/depupd_recent',
+      logsArtifactUrl: '/api/artifacts/logs',
+      beforeSummary: 'ghcr.io/moonladderstudios/moonmind:stable',
+      afterSummary: 'verification failed',
+      rollbackEligibility: {
+        eligible: true,
+        sourceActionId: 'depupd_recent',
+        targetImage: {
+          repository: 'ghcr.io/moonladderstudios/moonmind',
+          reference: 'stable',
+        },
+        evidenceRef: 'art:sha256:before',
+      },
+    },
+    {
+      status: 'FAILED',
+      requestedImage: 'ghcr.io/moonladderstudios/moonmind:latest',
+      operator: 'admin@example.com',
+      reason: 'Unsafe rollback evidence',
+      startedAt: '2026-04-25T19:00:00Z',
+      completedAt: '2026-04-25T19:04:00Z',
+      rollbackEligibility: {
+        eligible: false,
+        sourceActionId: 'depupd_unsafe',
+        targetImage: null,
+        reason: 'Before-state evidence is missing.',
+      },
+    },
+  ],
+};
+
 const imageTargets = {
   stack: 'moonmind',
   repositories: [
@@ -273,5 +314,92 @@ describe('OperationsSettingsSection deployment update card', () => {
       '/api/artifacts/logs',
     );
     expect(within(card).queryByRole('link', { name: /raw command/i })).toBeNull();
+  });
+
+  it('renders rollback only for eligible recent deployment actions', async () => {
+    fetchSpy.mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/api/workers') {
+        return Promise.resolve({ ok: true, json: async () => workerSnapshot } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => stackStateWithRollback,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+        return Promise.resolve({ ok: true, json: async () => imageTargets } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) } as Response);
+    });
+
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    expect(await within(card).findByRole('button', { name: /roll back to stable/i })).toBeTruthy();
+    expect(within(card).queryByRole('button', { name: /roll back to latest/i })).toBeNull();
+    expect(within(card).getByText(/before-state evidence is missing/i)).toBeTruthy();
+  });
+
+  it('confirms rollback and submits the typed deployment rollback payload', async () => {
+    fetchSpy.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url === '/api/workers') {
+        return Promise.resolve({ ok: true, json: async () => workerSnapshot } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => stackStateWithRollback,
+        } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+        return Promise.resolve({ ok: true, json: async () => imageTargets } as Response);
+      }
+      if (url === '/api/v1/operations/deployment/update') {
+        return Promise.resolve({
+          ok: true,
+          status: 202,
+          json: async () => ({
+            deploymentUpdateRunId: 'depupd_rollback',
+            taskId: 'mm:deployment-update',
+            workflowId: 'mm:deployment-update',
+            status: 'QUEUED',
+            body: init?.body,
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) } as Response);
+    });
+
+    renderOperations();
+
+    const card = await screen.findByRole('region', { name: /deployment update/i });
+    fireEvent.click(await within(card).findByRole('button', { name: /roll back to stable/i }));
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Rollback deployment?'));
+      expect(confirmSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Target image: ghcr.io/moonladderstudios/moonmind:stable'),
+      );
+    });
+
+    await waitFor(() => {
+      const updateCall = fetchSpy.mock.calls.find(([url]) => String(url) === '/api/v1/operations/deployment/update');
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(String(updateCall?.[1]?.body))).toMatchObject({
+        stack: 'moonmind',
+        image: {
+          repository: 'ghcr.io/moonladderstudios/moonmind',
+          reference: 'stable',
+        },
+        operationKind: 'rollback',
+        rollbackSourceActionId: 'depupd_recent',
+        confirmation: expect.stringContaining('Rollback to ghcr.io/moonladderstudios/moonmind:stable confirmed'),
+        reason: expect.stringContaining('Rollback after failed update depupd_recent'),
+      });
+    });
+    expect(await within(card).findByText(/deployment rollback queued/i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -496,6 +496,7 @@ export function OperationsSettingsSection({
       if (!window.confirm(confirmation)) {
         return null;
       }
+      const requestedAt = new Date().toISOString();
       const confirmationText = `Rollback to ${targetImage} confirmed from ${sourceActionId}`;
       const response = await fetch('/api/v1/operations/deployment/update', {
         method: 'POST',
@@ -512,7 +513,7 @@ export function OperationsSettingsSection({
           runSmokeCheck: false,
           pauseWork: false,
           pruneOldImages: false,
-          reason: `Rollback after failed update ${sourceActionId}`,
+          reason: `Rollback after failed update ${sourceActionId} at ${requestedAt}`,
           operationKind: 'rollback',
           rollbackSourceActionId: sourceActionId,
           confirmation: confirmationText,

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -88,6 +88,22 @@ const DeploymentStackStateSchema = z
             runId: z.string().optional().nullable(),
             beforeSummary: z.string().optional().nullable(),
             afterSummary: z.string().optional().nullable(),
+            rollbackEligibility: z
+              .object({
+                eligible: z.boolean(),
+                sourceActionId: z.string().optional().nullable(),
+                targetImage: z
+                  .object({
+                    repository: z.string(),
+                    reference: z.string(),
+                  })
+                  .optional()
+                  .nullable(),
+                reason: z.string().optional().nullable(),
+                evidenceRef: z.string().optional().nullable(),
+              })
+              .optional()
+              .nullable(),
           })
           .passthrough(),
       )
@@ -456,6 +472,82 @@ export function OperationsSettingsSection({
     },
   });
 
+  const rollbackMutation = useMutation({
+    mutationFn: async (action: DeploymentAction) => {
+      const eligibility = action.rollbackEligibility;
+      const target = eligibility?.targetImage;
+      if (!eligibility?.eligible || !target) {
+        throw new Error(eligibility?.reason || 'Rollback target is not available.');
+      }
+      const targetImage = `${target.repository}:${target.reference}`;
+      const sourceActionId = String(
+        eligibility.sourceActionId || action.id || action.runId || '',
+      ).trim();
+      if (!sourceActionId) {
+        throw new Error('Rollback source action is required.');
+      }
+      const confirmation = [
+        'Rollback deployment?',
+        `Target image: ${targetImage}`,
+        `Source action: ${sourceActionId}`,
+        `Stack: ${deploymentState?.stack || DEPLOYMENT_STACK}`,
+        'Services may restart during this operation.',
+      ].join('\n');
+      if (!window.confirm(confirmation)) {
+        return null;
+      }
+      const confirmationText = `Rollback to ${targetImage} confirmed from ${sourceActionId}`;
+      const response = await fetch('/api/v1/operations/deployment/update', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          stack: deploymentState?.stack || DEPLOYMENT_STACK,
+          image: target,
+          mode: 'changed_services',
+          removeOrphans: true,
+          wait: true,
+          runSmokeCheck: false,
+          pauseWork: false,
+          pruneOldImages: false,
+          reason: `Rollback after failed update ${sourceActionId}`,
+          operationKind: 'rollback',
+          rollbackSourceActionId: sourceActionId,
+          confirmation: confirmationText,
+        }),
+      });
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        const detail =
+          typeof errorPayload.detail?.message === 'string'
+            ? errorPayload.detail.message
+            : typeof errorPayload.detail === 'string'
+              ? errorPayload.detail
+              : `Server error: ${response.status}`;
+        throw new Error(detail);
+      }
+      return response.json() as Promise<{ deploymentUpdateRunId: string; status: string }>;
+    },
+    onSuccess: (result) => {
+      if (!result) {
+        return;
+      }
+      setDeploymentNotice({
+        level: 'ok',
+        text: `Deployment rollback queued: ${result.deploymentUpdateRunId}`,
+      });
+      queryClient.invalidateQueries({ queryKey: ['deployment-stack', DEPLOYMENT_STACK] });
+    },
+    onError: (mutationError: Error) => {
+      setDeploymentNotice({
+        level: 'error',
+        text: mutationError.message,
+      });
+    },
+  });
+
   const handleDeploymentSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setDeploymentNotice(null);
@@ -699,6 +791,22 @@ export function OperationsSettingsSection({
                             >
                               Raw command log
                             </a>
+                          ) : null}
+                          {action.rollbackEligibility?.eligible &&
+                          action.rollbackEligibility.targetImage ? (
+                            <button
+                              type="button"
+                              className="text-sm font-medium text-sky-700 hover:text-sky-600 dark:text-sky-400"
+                              onClick={() => rollbackMutation.mutate(action)}
+                            >
+                              Roll back to {action.rollbackEligibility.targetImage.reference}
+                            </button>
+                          ) : action.rollbackEligibility &&
+                            !action.rollbackEligibility.eligible &&
+                            action.rollbackEligibility.reason ? (
+                            <span className="text-sm text-slate-500 dark:text-slate-400">
+                              {action.rollbackEligibility.reason}
+                            </span>
                           ) : null}
                         </div>
                       </div>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3424,6 +3424,45 @@ export interface components {
             /** Reference */
             reference: string;
         };
+        /** DeploymentRecentActionModel */
+        DeploymentRecentActionModel: {
+            /** Id */
+            id: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Requestedimage */
+            requestedImage?: string | null;
+            /** Resolveddigest */
+            resolvedDigest?: string | null;
+            /** Operator */
+            operator?: string | null;
+            /** Reason */
+            reason?: string | null;
+            /** Startedat */
+            startedAt?: string | null;
+            /** Completedat */
+            completedAt?: string | null;
+            /** Rundetailurl */
+            runDetailUrl?: string | null;
+            /** Logsartifacturl */
+            logsArtifactUrl?: string | null;
+            /** Rawcommandlogurl */
+            rawCommandLogUrl?: string | null;
+            /**
+             * Rawcommandlogpermitted
+             * @default false
+             */
+            rawCommandLogPermitted: boolean;
+            /** Runid */
+            runId?: string | null;
+            /** Beforesummary */
+            beforeSummary?: string | null;
+            /** Aftersummary */
+            afterSummary?: string | null;
+            rollbackEligibility?: components["schemas"]["RollbackEligibilityModel"] | null;
+        };
         /** DeploymentServiceStateModel */
         DeploymentServiceStateModel: {
             /** Name */
@@ -3447,6 +3486,8 @@ export interface components {
             services: components["schemas"]["DeploymentServiceStateModel"][];
             /** Lastupdaterunid */
             lastUpdateRunId?: string | null;
+            /** Recentactions */
+            recentActions?: components["schemas"]["DeploymentRecentActionModel"][];
         };
         /** DeploymentUpdateRequest */
         DeploymentUpdateRequest: {
@@ -3482,6 +3523,16 @@ export interface components {
             pruneOldImages: boolean;
             /** Reason */
             reason: string;
+            /**
+             * Operationkind
+             * @default update
+             * @enum {string}
+             */
+            operationKind: "update" | "rollback";
+            /** Rollbacksourceactionid */
+            rollbackSourceActionId?: string | null;
+            /** Confirmation */
+            confirmation?: string | null;
         };
         /** DeploymentUpdateResponse */
         DeploymentUpdateResponse: {
@@ -5548,6 +5599,25 @@ export interface components {
             mode: components["schemas"]["RetryWorkflowMode"];
             /** Notes */
             notes?: string | null;
+        };
+        /** RollbackEligibilityModel */
+        RollbackEligibilityModel: {
+            /** Eligible */
+            eligible: boolean;
+            /** Sourceactionid */
+            sourceActionId?: string | null;
+            targetImage?: components["schemas"]["RollbackImageTargetModel"] | null;
+            /** Reason */
+            reason?: string | null;
+            /** Evidenceref */
+            evidenceRef?: string | null;
+        };
+        /** RollbackImageTargetModel */
+        RollbackImageTargetModel: {
+            /** Repository */
+            repository: string;
+            /** Reference */
+            reference: string;
         };
         /** RunningImageModel */
         RunningImageModel: {

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -101,7 +101,10 @@ class DeploymentUpdateLockManager:
                         f"'{normalized}' is already running."
                     ),
                     retryable=False,
-                    details={"stack": normalized},
+                    details={
+                        "stack": normalized,
+                        "failureClass": "deployment_lock_unavailable",
+                    },
                 )
             self._held.add(normalized)
         return DeploymentUpdateLockLease(self, normalized)
@@ -162,7 +165,11 @@ class DisabledComposeRunner:
             error_code="POLICY_VIOLATION",
             message="Deployment update runner is not configured for this worker.",
             retryable=False,
-            details={"stack": stack, "phase": phase},
+            details={
+                "stack": stack,
+                "phase": phase,
+                "failureClass": "policy_violation",
+            },
         )
 
     async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
@@ -170,7 +177,11 @@ class DisabledComposeRunner:
             error_code="POLICY_VIOLATION",
             message="Deployment update runner is not configured for this worker.",
             retryable=False,
-            details={"stack": stack, "command": list(command)},
+            details={
+                "stack": stack,
+                "command": list(command),
+                "failureClass": "policy_violation",
+            },
         )
 
     async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
@@ -178,7 +189,11 @@ class DisabledComposeRunner:
             error_code="POLICY_VIOLATION",
             message="Deployment update runner is not configured for this worker.",
             retryable=False,
-            details={"stack": stack, "command": list(command)},
+            details={
+                "stack": stack,
+                "command": list(command),
+                "failureClass": "policy_violation",
+            },
         )
 
     async def verify(
@@ -196,6 +211,7 @@ class DisabledComposeRunner:
                 "stack": stack,
                 "requested_image": requested_image,
                 "resolved_digest": resolved_digest,
+                "failureClass": "policy_violation",
             },
         )
 
@@ -431,6 +447,15 @@ class DeploymentUpdateExecutor:
             "verificationArtifactRef": verification_ref,
             "audit": _redact_sensitive(audit_snapshot(completed=True)),
         }
+        if final_status != "SUCCEEDED":
+            outputs["failure"] = {
+                "class": "verification_failure",
+                "reason": _redact_sensitive(
+                    failure_reason
+                    or "Deployment verification did not prove desired state."
+                ),
+                "retryable": False,
+            }
         return ToolResult(
             status="COMPLETED" if final_status == "SUCCEEDED" else "FAILED",
             outputs=outputs,
@@ -455,14 +480,21 @@ def _verification_final_status(verification: ComposeVerification) -> str:
                 error_code="DEPLOYMENT_VERIFICATION_INVALID",
                 message=f"Unsupported deployment verification status '{explicit}'.",
                 retryable=False,
-                details={"status": explicit},
+                details={
+                    "status": explicit,
+                    "failureClass": "verification_failure",
+                },
             )
         if verification.succeeded and explicit != "SUCCEEDED":
             raise ToolFailure(
                 error_code="DEPLOYMENT_VERIFICATION_INVALID",
                 message="Deployment verification status conflicts with success flag.",
                 retryable=False,
-                details={"status": explicit, "succeeded": verification.succeeded},
+                details={
+                    "status": explicit,
+                    "succeeded": verification.succeeded,
+                    "failureClass": "verification_failure",
+                },
             )
         if explicit == "SUCCEEDED" and not verification.succeeded:
             raise ToolFailure(
@@ -472,7 +504,11 @@ def _verification_final_status(verification: ComposeVerification) -> str:
                     "with success flag."
                 ),
                 retryable=False,
-                details={"status": explicit, "succeeded": verification.succeeded},
+                details={
+                    "status": explicit,
+                    "succeeded": verification.succeeded,
+                    "failureClass": "verification_failure",
+                },
             )
         return explicit
     return "SUCCEEDED" if verification.succeeded else "FAILED"
@@ -537,7 +573,7 @@ def build_compose_command_plan(
             error_code="INVALID_INPUT",
             message=f"Unsupported deployment update mode '{normalized_mode}'.",
             retryable=False,
-            details={"mode": normalized_mode},
+            details={"mode": normalized_mode, "failureClass": "invalid_input"},
         )
     normalized_runner = _required_string(runner_mode, "deployment_runner_mode")
     if normalized_runner not in DEPLOYMENT_RUNNER_MODES:
@@ -545,7 +581,10 @@ def build_compose_command_plan(
             error_code="POLICY_VIOLATION",
             message=f"Unsupported deployment runner mode '{normalized_runner}'.",
             retryable=False,
-            details={"runner_mode": normalized_runner},
+            details={
+                "runner_mode": normalized_runner,
+                "failureClass": "policy_violation",
+            },
         )
 
     up_args = ["docker", "compose", "up", "-d"]
@@ -608,7 +647,10 @@ def register_deployment_update_tool_handler(
 def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(inputs, Mapping):
         raise ToolFailure(
-            "INVALID_INPUT", "Deployment inputs must be an object.", False
+            "INVALID_INPUT",
+            "Deployment inputs must be an object.",
+            False,
+            details={"failureClass": "invalid_input"},
         )
     forbidden = {"command", "composeFile", "hostPath", "updaterRunnerImage"}
     found_forbidden = sorted(forbidden.intersection(inputs.keys()))
@@ -617,12 +659,17 @@ def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
             error_code="INVALID_INPUT",
             message="Deployment update inputs contain forbidden fields.",
             retryable=False,
-            details={"fields": found_forbidden},
+            details={"fields": found_forbidden, "failureClass": "invalid_input"},
         )
 
     image = inputs.get("image")
     if not isinstance(image, Mapping):
-        raise ToolFailure("INVALID_INPUT", "Deployment image must be an object.", False)
+        raise ToolFailure(
+            "INVALID_INPUT",
+            "Deployment image must be an object.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
 
     stack = _required_string(inputs.get("stack"), "stack")
     if stack not in DEPLOYMENT_UPDATE_STACKS:
@@ -633,6 +680,7 @@ def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
             details={
                 "stack": stack,
                 "allowed_stacks": sorted(DEPLOYMENT_UPDATE_STACKS),
+                "failureClass": "invalid_input",
             },
         )
 
@@ -668,7 +716,7 @@ def _required_string(value: Any, field_name: str) -> str:
             error_code="INVALID_INPUT",
             message=f"{field_name} is required.",
             retryable=False,
-            details={"field": field_name},
+            details={"field": field_name, "failureClass": "invalid_input"},
         )
     return normalized
 
@@ -684,7 +732,11 @@ def _optional_bool(
             error_code="INVALID_INPUT",
             message=f"{field_name} must be a boolean.",
             retryable=False,
-            details={"field": field_name, "value_type": type(value).__name__},
+            details={
+                "field": field_name,
+                "value_type": type(value).__name__,
+                "failureClass": "invalid_input",
+            },
         )
     return value
 
@@ -695,7 +747,11 @@ def _ensure_command_succeeded(phase: str, result: Mapping[str, Any]) -> None:
             error_code="DEPLOYMENT_COMMAND_FAILED",
             message=f"Deployment {phase} command returned an invalid result.",
             retryable=False,
-            details={"phase": phase, "result_type": type(result).__name__},
+            details={
+                "phase": phase,
+                "result_type": type(result).__name__,
+                "failureClass": _command_failure_class(phase),
+            },
         )
     for key in ("exitCode", "exit_code", "returncode"):
         if key in result:
@@ -708,14 +764,24 @@ def _ensure_command_succeeded(phase: str, result: Mapping[str, Any]) -> None:
                         f"Deployment {phase} command returned a non-numeric exit code."
                     ),
                     retryable=False,
-                    details={"phase": phase, "field": key, "value": result[key]},
+                    details={
+                        "phase": phase,
+                        "field": key,
+                        "value": result[key],
+                        "failureClass": _command_failure_class(phase),
+                    },
                 ) from exc
             if code != 0:
                 raise ToolFailure(
                     error_code="DEPLOYMENT_COMMAND_FAILED",
                     message=f"Deployment {phase} command failed with exit code {code}.",
                     retryable=False,
-                    details={"phase": phase, "exit_code": code, "result": dict(result)},
+                    details={
+                        "phase": phase,
+                        "exit_code": code,
+                        "result": dict(result),
+                        "failureClass": _command_failure_class(phase),
+                    },
                 )
             return
     for key in ("ok", "success", "succeeded"):
@@ -725,7 +791,12 @@ def _ensure_command_succeeded(phase: str, result: Mapping[str, Any]) -> None:
                     error_code="DEPLOYMENT_COMMAND_FAILED",
                     message=f"Deployment {phase} command reported failure.",
                     retryable=False,
-                    details={"phase": phase, "field": key, "result": dict(result)},
+                    details={
+                        "phase": phase,
+                        "field": key,
+                        "result": dict(result),
+                        "failureClass": _command_failure_class(phase),
+                    },
                 )
             return
     status = str(result.get("status") or "").strip().lower()
@@ -735,15 +806,32 @@ def _ensure_command_succeeded(phase: str, result: Mapping[str, Any]) -> None:
                 error_code="DEPLOYMENT_COMMAND_FAILED",
                 message=f"Deployment {phase} command reported status '{status}'.",
                 retryable=False,
-                details={"phase": phase, "status": status, "result": dict(result)},
+                details={
+                    "phase": phase,
+                    "status": status,
+                    "result": dict(result),
+                    "failureClass": _command_failure_class(phase),
+                },
             )
         return
     raise ToolFailure(
         error_code="DEPLOYMENT_COMMAND_FAILED",
         message=f"Deployment {phase} command result did not include a success signal.",
         retryable=False,
-        details={"phase": phase, "result": dict(result)},
+        details={
+            "phase": phase,
+            "result": dict(result),
+            "failureClass": _command_failure_class(phase),
+        },
     )
+
+
+def _command_failure_class(phase: str) -> str:
+    if phase == "pull":
+        return "image_pull_failure"
+    if phase == "up":
+        return "service_recreation_failure"
+    return "compose_config_validation_failure"
 
 
 def _record_command_exception(command_log: dict[str, Any], exc: Exception) -> None:

--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -57,6 +57,12 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
                     "pauseWork": {"type": "boolean"},
                     "pruneOldImages": {"type": "boolean"},
                     "reason": {"type": "string"},
+                    "operationKind": {
+                        "type": "string",
+                        "enum": ["update", "rollback"],
+                    },
+                    "rollbackSourceActionId": {"type": "string"},
+                    "confirmation": {"type": "string"},
                 },
             }
         },
@@ -97,6 +103,16 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
                     "audit": {
                         "type": "object",
                         "additionalProperties": True,
+                    },
+                    "failure": {
+                        "type": "object",
+                        "required": ["class", "reason", "retryable"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "class": {"type": "string"},
+                            "reason": {"type": "string"},
+                            "retryable": {"type": "boolean"},
+                        },
                     },
                 },
             }

--- a/specs/265-explicit-failure-and-rollback-controls/checklists/requirements.md
+++ b/specs/265-explicit-failure-and-rollback-controls/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Explicit Failure and Rollback Controls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: MM-523 is classified as one runtime story and preserves the trusted Jira preset brief.
+- PASS: The source design mapping covers the Jira-cited sections from `docs/Tools/DockerComposeUpdateSystem.md` and maps every in-scope source requirement to functional requirements.

--- a/specs/265-explicit-failure-and-rollback-controls/contracts/deployment-failure-rollback-controls.md
+++ b/specs/265-explicit-failure-and-rollback-controls/contracts/deployment-failure-rollback-controls.md
@@ -88,6 +88,7 @@ Rollback submits to the same typed update endpoint:
   "pauseWork": false,
   "pruneOldImages": false,
   "reason": "Rollback after failed update depupd_recent",
+  "confirmation": "Rollback to ghcr.io/moonladderstudios/moonmind:stable confirmed",
   "operationKind": "rollback",
   "rollbackSourceActionId": "depupd_recent"
 }

--- a/specs/265-explicit-failure-and-rollback-controls/contracts/deployment-failure-rollback-controls.md
+++ b/specs/265-explicit-failure-and-rollback-controls/contracts/deployment-failure-rollback-controls.md
@@ -1,0 +1,96 @@
+# Contract: Deployment Failure and Rollback Controls
+
+## Tool Output Additions
+
+`deployment.update_compose_stack` keeps the existing `ToolResult.outputs` shape and may add compact failure metadata when status is not `SUCCEEDED`:
+
+```json
+{
+  "status": "FAILED",
+  "stack": "moonmind",
+  "requestedImage": "ghcr.io/moonladderstudios/moonmind:20260425.1234",
+  "beforeStateArtifactRef": "art:sha256:before",
+  "afterStateArtifactRef": "art:sha256:after",
+  "commandLogArtifactRef": "art:sha256:commands",
+  "verificationArtifactRef": "art:sha256:verification",
+  "failure": {
+    "class": "verification_failure",
+    "reason": "Deployment verification did not prove desired state.",
+    "retryable": false
+  },
+  "audit": {
+    "workflowId": "workflow-123",
+    "taskId": "task-456",
+    "operator": "admin@example.com",
+    "operatorRole": "admin",
+    "finalStatus": "FAILED"
+  }
+}
+```
+
+Failure metadata must not contain raw command output, credentials, tokens, environment dumps, or unredacted artifact content.
+
+## Deployment Stack State Additions
+
+`GET /api/v1/operations/deployment/stacks/{stack}` may include bounded recent actions:
+
+```json
+{
+  "stack": "moonmind",
+  "recentActions": [
+    {
+      "id": "depupd_recent",
+      "kind": "failure",
+      "status": "FAILED",
+      "requestedImage": "ghcr.io/moonladderstudios/moonmind:20260425.1234",
+      "operator": "admin@example.com",
+      "reason": "Routine release",
+      "startedAt": "2026-04-26T00:00:00Z",
+      "completedAt": "2026-04-26T00:05:00Z",
+      "runDetailUrl": "/tasks/depupd_recent",
+      "logsArtifactUrl": "/api/artifacts/logs",
+      "rawCommandLogPermitted": false,
+      "beforeSummary": "ghcr.io/moonladderstudios/moonmind:stable",
+      "afterSummary": "verification failed",
+      "rollbackEligibility": {
+        "eligible": true,
+        "targetImage": {
+          "repository": "ghcr.io/moonladderstudios/moonmind",
+          "reference": "stable"
+        },
+        "sourceActionId": "depupd_recent",
+        "evidenceRef": "art:sha256:before"
+      }
+    }
+  ]
+}
+```
+
+When rollback is not safe, `rollbackEligibility.eligible` is false and `reason` explains why. The response must omit or disable raw command-log URLs unless operational-admin policy permits them.
+
+## Rollback Submission
+
+Rollback submits to the same typed update endpoint:
+
+`POST /api/v1/operations/deployment/update`
+
+```json
+{
+  "stack": "moonmind",
+  "image": {
+    "repository": "ghcr.io/moonladderstudios/moonmind",
+    "reference": "stable"
+  },
+  "mode": "changed_services",
+  "removeOrphans": true,
+  "wait": true,
+  "runSmokeCheck": false,
+  "pauseWork": false,
+  "pruneOldImages": false,
+  "reason": "Rollback after failed update depupd_recent",
+  "operationKind": "rollback",
+  "rollbackSourceActionId": "depupd_recent"
+}
+```
+
+The endpoint must preserve the same admin, policy, allowlist, queue, lock, artifact, and verification behavior as forward updates. Unsupported rollback metadata or unsafe targets fail closed.

--- a/specs/265-explicit-failure-and-rollback-controls/data-model.md
+++ b/specs/265-explicit-failure-and-rollback-controls/data-model.md
@@ -1,0 +1,66 @@
+# Data Model: Explicit Failure and Rollback Controls
+
+## Deployment Failure Result
+
+- `status`: `FAILED` or `PARTIALLY_VERIFIED`.
+- `failureClass`: one of `invalid_input`, `authorization_failure`, `policy_violation`, `deployment_lock_unavailable`, `compose_config_validation_failure`, `image_pull_failure`, `service_recreation_failure`, `verification_failure`, or `evidence_failure`.
+- `failureReason`: non-empty actionable operator-facing reason.
+- `retryable`: false by default for privileged deployment-control failures.
+- `artifactRefs`: available before-state, command-log, verification, and after-state refs when lifecycle phases reached them.
+- `audit`: run/workflow/task IDs where available, operator, role, reason, requested image, mode, timestamps, and final status.
+
+Validation rules:
+- `SUCCEEDED` is never valid when `failureClass` is present.
+- Failure records must redact secrets before publication or UI display.
+- Missing evidence must fail closed and record the missing phase when possible.
+
+## Rollback Eligibility Decision
+
+- `eligible`: boolean.
+- `sourceActionId`: recent deployment action or run identifier that produced before-state evidence.
+- `targetImage`: previous safe image reference when eligible.
+- `reason`: short operator-facing explanation when ineligible.
+- `evidenceRef`: before-state artifact ref or trusted projection source used to derive the target.
+
+Validation rules:
+- Eligibility is true only when before-state evidence identifies exactly one allowlisted repository/reference or digest target.
+- Missing, ambiguous, malformed, non-allowlisted, or untrusted evidence makes eligibility false.
+- The decision does not mutate deployment state.
+
+## Rollback Request
+
+- `stack`: allowlisted stack, currently `moonmind`.
+- `image.repository`: allowlisted MoonMind image repository.
+- `image.reference`: target previous image tag or digest from rollback eligibility.
+- `mode`: normal deployment update mode, usually `changed_services` unless the operator explicitly chooses another policy-allowed mode.
+- `reason`: required operator reason.
+- `confirmation`: operator confirmation that the rollback target and restart implications are understood.
+- `sourceActionId`: optional recent action used to derive rollback target.
+- `operationKind`: `rollback`.
+
+Validation rules:
+- Rollback uses the same typed deployment update path as forward updates.
+- Admin authorization, reason, confirmation, deployment lock, before/after artifacts, and verification remain required.
+- Rollback cannot include shell commands, runner images, host paths, non-allowlisted stacks, or non-allowlisted repositories.
+
+## Deployment Audit Action
+
+- `id` or `runId`: stable action identifier.
+- `kind`: `update`, `failure`, or `rollback`.
+- `status`: final deployment status.
+- `requestedImage`: target image.
+- `resolvedDigest`: optional digest evidence.
+- `operator`: visible operator identity when available.
+- `reason`: update or rollback reason.
+- `startedAt` / `completedAt`: lifecycle timestamps.
+- `runDetailUrl`: link to the run detail page when available.
+- `logsArtifactUrl`: redacted logs or command artifact link when available.
+- `rawCommandLogUrl`: present only when operational-admin policy permits.
+- `beforeSummary` / `afterSummary`: compact before/after evidence.
+- `rollbackEligibility`: optional rollback eligibility decision for failed or previous actions.
+
+State transitions:
+- `update submitted` -> `failure result` may produce a recent `failure` action.
+- `failure action` -> `rollback eligible` only when trusted before-state evidence is sufficient.
+- `rollback eligible` -> `rollback submitted` only after explicit admin confirmation.
+- `rollback submitted` -> normal deployment update lifecycle with its own artifacts and audit action.

--- a/specs/265-explicit-failure-and-rollback-controls/moonspec_align_report.md
+++ b/specs/265-explicit-failure-and-rollback-controls/moonspec_align_report.md
@@ -1,0 +1,24 @@
+# MoonSpec Align Report: Explicit Failure and Rollback Controls
+
+## Summary
+
+Alignment completed for MM-523 after task generation. The feature remains a single runtime story with no `moonspec-breakdown` split required.
+
+## Findings And Remediation
+
+| Finding | Resolution | Files Updated |
+| --- | --- | --- |
+| Rollback request confirmation was required by `spec.md` and `data-model.md`, but the contract example and task details did not consistently carry confirmation through the API/UI payload. | Added explicit `confirmation` to the rollback contract example, quickstart end-to-end check, and relevant unit/UI/API task descriptions. | `contracts/deployment-failure-rollback-controls.md`, `quickstart.md`, `tasks.md` |
+| Implemented-verified rows for no-default-retry and allowlist boundaries were present in `plan.md`, but final validation task did not name the existing test evidence. | Expanded the final unit verification task to include existing retry-policy and allowlist boundary test files. | `tasks.md` |
+
+## Validation
+
+- One story phase remains in `tasks.md`.
+- Unit and integration tests still precede implementation tasks.
+- Red-first confirmation remains before production implementation.
+- MM-523 and source design mappings remain preserved.
+- `spec.md`, `plan.md`, `research.md`, `data-model.md`, contract, `quickstart.md`, and `tasks.md` remain aligned.
+
+## Script Notes
+
+`.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` is blocked by the current non-numbered branch name `run-jira-orchestrate-for-mm-523-explicit-9be53fc7`. Alignment used the active feature directory from `.specify/feature.json`: `specs/265-explicit-failure-and-rollback-controls`.

--- a/specs/265-explicit-failure-and-rollback-controls/plan.md
+++ b/specs/265-explicit-failure-and-rollback-controls/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Explicit Failure and Rollback Controls
+
+**Branch**: `run-jira-orchestrate-for-mm-523-explicit-9be53fc7` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/265-explicit-failure-and-rollback-controls/spec.md`
+
+**Setup Note**: `.specify/scripts/bash/setup-plan.sh --json` could not complete because the active branch name is `run-jira-orchestrate-for-mm-523-explicit-9be53fc7`, while the script currently requires numbered feature-branch naming. Planning proceeds from the existing `.specify/feature.json` and feature directory.
+
+## Summary
+
+Implement `MM-523` by completing explicit failure and rollback controls for the existing `deployment.update_compose_stack` path. The current deployment executor already fails verification closed, emits audit/progress evidence, redacts artifacts, uses a max-attempts-one tool retry policy, and enforces allowlisted typed inputs. The missing work is to make failure classes first-class in outputs and recent actions, expose rollback eligibility only when trusted before-state evidence can safely identify a previous image target, submit rollback as the same admin-confirmed typed deployment update path, and add regression coverage proving no silent retry or rollback happens by default.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `DeploymentUpdateExecutor.execute()` returns failed/partial verification and command failures with reasons, but failure-class coverage is not complete for every documented class | add failure-class normalization and tests for invalid input, authorization, policy, lock, compose validation, image pull, service recreation, and verification failure | unit + integration |
+| FR-002 | implemented_verified | `deployment_tools.py` sets `policies.retries.max_attempts = 1`; executor has no internal retry loop; `test_deployment_tool_contracts.py` covers retry policy | no new implementation; preserve with MM-523 traceability | final verify |
+| FR-003 | implemented_unverified | API update submission queues a new typed update each time; no MM-523 test proves retry is a distinct explicit operator action after failure | add verification test showing a second submission is a new audited update request, not automatic retry continuation | unit/API |
+| FR-004 | partial | `DeploymentOperationsService.queue_update()` already queues typed deployment updates to any policy-valid reference; there is no rollback-specific eligibility or submission metadata | model rollback as a normal typed update with rollback metadata and previous-image target from trusted evidence | unit + frontend |
+| FR-005 | partial | admin authorization, reason validation, lock, before/after artifacts, and verification exist for normal updates; rollback-specific confirmation and evidence requirements are missing | require rollback confirmation and safe target evidence before using the same update path | unit + frontend + integration |
+| FR-006 | missing | frontend has no rollback action and backend state response has no rollback eligibility | expose rollback eligibility derived from before-state/recent-action evidence and render rollback only when safe | unit + frontend |
+| FR-007 | missing | no explicit unsafe/ambiguous rollback withholding behavior exists | add fail-closed eligibility states and UI/API tests for missing, ambiguous, or unsafe before-state evidence | unit + frontend |
+| FR-008 | implemented_unverified | no automatic rollback path was found; existing code has no rollback call on failure | add regression tests proving failure does not enqueue rollback or mutate target without explicit policy/input | unit + integration |
+| FR-009 | partial | executor audit output exists and frontend schema can render `recentActions`, but API stack state currently returns no recent deployment action records | surface failure/rollback records in deployment stack state using existing execution/artifact evidence; render status/reason/timestamps/links | API + frontend |
+| FR-010 | implemented_verified | API schema forbids extra fields; service rejects non-allowlisted stack/repository/mode; executor rejects forbidden runner/path fields; existing tests cover these boundaries | no broadening; extend rollback through the same allowlisted update contract only | final verify |
+| FR-011 | missing | MM-523 exists in `spec.md` and this plan, but downstream artifacts are not generated yet | preserve MM-523 in research, data model, contract, quickstart, tasks, implementation notes, verification, commit, and PR metadata | traceability grep |
+| SC-001 | partial | command and verification failure tests exist; full failure-class matrix does not | add matrix tests | unit |
+| SC-002 | implemented_verified | tool retry policy max attempts one is tested | final verification only | none beyond final verify |
+| SC-003 | implemented_unverified | repeated API submission naturally creates a new execution; no explicit post-failure proof | add API/service test | unit/API |
+| SC-004 | partial | normal update has admin/reason/lock/artifact/verification; rollback path missing | add rollback request/eligibility tests | unit + frontend |
+| SC-005 | missing | no rollback eligibility model | add backend eligibility tests and UI rendering tests | unit + frontend |
+| SC-006 | implemented_unverified | no auto-rollback code found | add regression test around failed execution | unit + integration |
+| SC-007 | partial | frontend can render recent actions if present; backend state lacks real recent failure/rollback data | add API and UI tests | API + frontend |
+| SC-008 | partial | MM-523 traceability present in spec and plan | preserve through generated artifacts and final verification | traceability grep |
+| DESIGN-REQ-001 | partial | several failure modes fail closed; not all documented classes are represented as explicit classes | add failure-class output mapping | unit |
+| DESIGN-REQ-002 | implemented_verified | max-attempts-one policy and no executor retry loop | no new implementation | final verify |
+| DESIGN-REQ-003 | partial | normal update path has required controls; rollback path missing | implement rollback through same typed update path with explicit metadata | unit + frontend |
+| DESIGN-REQ-004 | missing | no rollback eligibility/action surface | add safe-evidence eligibility and silent rollback guard tests | unit + frontend |
+| DESIGN-REQ-005 | implemented_verified | existing API/executor reject shell/path/runner/non-allowlisted inputs | preserve boundary | final verify |
+| DESIGN-REQ-006 | partial | allowlists and artifacts exist; recent action visibility and rollback audit output are incomplete | add recent failure/rollback action surface using existing execution/artifact evidence | API + frontend |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control Settings UI  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async session fixtures where API projection is needed, Temporal execution service/projection models, React, TanStack Query, Vitest, pytest  
+**Storage**: Existing Temporal execution records and artifact-backed deployment evidence; no new persistent database tables planned  
+**Unit Testing**: pytest via focused deployment executor/API tests and final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`; Vitest via `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` or `npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx` during focused iteration  
+**Integration Testing**: hermetic pytest for `tests/integration/temporal/test_deployment_update_execution_contract.py` and any new `integration_ci` deployment dispatch coverage; final `./tools/test_integration.sh` when Docker is available  
+**Target Platform**: MoonMind deployment-control runtime and Mission Control Settings Operations  
+**Project Type**: backend workflow skill execution plus FastAPI API and React UI surface  
+**Performance Goals**: rollback eligibility and recent-action projection should inspect bounded recent execution/artifact metadata and keep UI payloads compact  
+**Constraints**: no raw credentials in artifacts/logs/UI; no arbitrary Docker or shell input; no silent rollback; no hidden compatibility aliases; rollback must reuse the typed allowlisted update path  
+**Scale/Scope**: one deployment update story spanning executor failure classification, deployment operation API projection/submission metadata, and Settings Operations rollback controls
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Work stays on the existing typed tool and Mission Control orchestration surface.
+- II. One-Click Agent Deployment: PASS. Unit coverage uses fake runner/store/projection boundaries; integration coverage stays hermetic.
+- III. Avoid Vendor Lock-In: PASS. No provider-exclusive behavior is introduced.
+- IV. Own Your Data: PASS. Rollback eligibility uses operator-owned execution/artifact evidence.
+- V. Skills Are First-Class and Easy to Add: PASS. The executable deployment tool contract remains the runtime boundary.
+- VI. Replaceable Scaffolding: PASS. Rollback eligibility and failure classification remain explicit, small contracts.
+- VII. Runtime Configurability: PASS. Unsupported values fail closed; rollback is not silently enabled.
+- VIII. Modular and Extensible Architecture: PASS. Changes are scoped to deployment execution, deployment operations API, and Operations UI.
+- IX. Resilient by Default: PASS. Failure handling is explicit and rollback is operator-driven.
+- X. Facilitate Continuous Improvement: PASS. Recent actions and audit output improve operator diagnosis.
+- XI. Spec-Driven Development: PASS. Plan follows the MM-523 spec and preserves traceability.
+- XII. Canonical Documentation: PASS. Implementation details stay in feature artifacts, not canonical docs.
+- XIII. Pre-Release Compatibility Policy: PASS. No internal compatibility aliases or deprecated rollback paths are planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/265-explicit-failure-and-rollback-controls/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── deployment-failure-rollback-controls.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/workflows/skills/
+├── deployment_execution.py
+└── deployment_tools.py
+
+api_service/api/routers/
+└── deployment_operations.py
+
+api_service/services/
+└── deployment_operations.py
+
+frontend/src/components/settings/
+├── OperationsSettingsSection.tsx
+└── OperationsSettingsSection.test.tsx
+
+tests/unit/workflows/skills/
+└── test_deployment_update_execution.py
+
+tests/unit/api/routers/
+└── test_deployment_operations.py
+
+tests/integration/temporal/
+└── test_deployment_update_execution_contract.py
+```
+
+**Structure Decision**: Extend the existing deployment update tool, deployment operation API, and Settings Operations card because MM-523 constrains behavior in the current deployment-control workflow rather than introducing a separate rollback service.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/265-explicit-failure-and-rollback-controls/quickstart.md
+++ b/specs/265-explicit-failure-and-rollback-controls/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Explicit Failure and Rollback Controls
+
+## Focused Unit Validation
+
+1. Add failing unit tests for deployment failure classes:
+
+```bash
+pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q
+```
+
+Expected initial failures should cover missing normalized failure-class metadata and incomplete failure-class matrix coverage.
+
+2. Add failing API tests for rollback eligibility and explicit retry submission:
+
+```bash
+pytest tests/unit/api/routers/test_deployment_operations.py -q
+```
+
+Expected initial failures should cover missing recent action rollback eligibility, rollback metadata validation, and explicit second submission behavior.
+
+3. Add focused UI tests for rollback visibility and confirmation:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx
+```
+
+During local frontend iteration after dependencies are prepared, this may also be run as:
+
+```bash
+npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx
+```
+
+## Hermetic Integration Validation
+
+Add or update integration coverage for the typed deployment update dispatch boundary:
+
+```bash
+pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q
+```
+
+The integration test should prove failed deployment execution exposes failure metadata and does not enqueue or perform rollback without explicit operator input.
+
+When Docker is available for the required hermetic CI suite:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Final Verification Commands
+
+Run the full required unit suite from the managed-agent container:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Run traceability checks:
+
+```bash
+rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests
+```
+
+## End-to-End Story Check
+
+1. A failed deployment update produces `FAILED` or `PARTIALLY_VERIFIED`, a non-empty failure class/reason, and redacted artifact/audit refs.
+2. The system does not automatically retry or roll back after failure.
+3. Deployment stack state exposes rollback only for recent actions with trusted before-state evidence.
+4. Rollback confirmation submits the same typed deployment update endpoint with a policy-valid previous image target and rollback metadata.
+5. Recent actions show failure and rollback records with status, requested image, operator, reason, timestamps, run detail link, logs artifact link, and before/after summary.

--- a/specs/265-explicit-failure-and-rollback-controls/quickstart.md
+++ b/specs/265-explicit-failure-and-rollback-controls/quickstart.md
@@ -67,3 +67,4 @@ rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" spe
 3. Deployment stack state exposes rollback only for recent actions with trusted before-state evidence.
 4. Rollback confirmation submits the same typed deployment update endpoint with a policy-valid previous image target and rollback metadata.
 5. Recent actions show failure and rollback records with status, requested image, operator, reason, timestamps, run detail link, logs artifact link, and before/after summary.
+6. Rollback requests without explicit confirmation fail closed before queueing a deployment update.

--- a/specs/265-explicit-failure-and-rollback-controls/research.md
+++ b/specs/265-explicit-failure-and-rollback-controls/research.md
@@ -1,0 +1,73 @@
+# Research: Explicit Failure and Rollback Controls
+
+## FR-001 / DESIGN-REQ-001 Failure Classification
+
+Decision: Treat failure classification as partial and complete it at the deployment executor/API boundary.
+Evidence: `DeploymentUpdateExecutor.execute()` records verification failures and command failures with final `FAILED` or `PARTIALLY_VERIFIED`; `_parse_inputs()` and `DeploymentUpdateLockManager` raise fail-closed `ToolFailure`s; tests cover command failure, non-allowlisted stack, forbidden fields, lock contention, failed verification, and invalid verification status. There is no complete MM-523 matrix for invalid input, authorization, policy, unavailable lock, Compose validation, image pull, service recreation, and verification failure as named failure classes.
+Rationale: Operators need consistent failure records, not just exceptions or partial command payloads. The executor is the point that knows lifecycle phase and evidence refs, while the API owns authorization and policy validation.
+Alternatives considered: Leave failures as raw exception codes; rejected because the spec requires clear documented failure classes and actionable reasons.
+Test implications: Unit matrix for executor/service failure classes and one integration dispatch assertion for failure-class propagation.
+
+## FR-002 / DESIGN-REQ-002 No Automatic Multi-Attempt Retry
+
+Decision: Treat as implemented verified and preserve the behavior.
+Evidence: `moonmind/workflows/skills/deployment_tools.py` declares `policies.retries.max_attempts = 1`; `tests/unit/workflows/skills/test_deployment_tool_contracts.py` asserts retry policy; `DeploymentUpdateExecutor` has no internal retry loop.
+Rationale: The existing executable tool contract already makes deployment updates single-attempt by default.
+Alternatives considered: Add another retry guard in the executor; rejected because it would duplicate the registry policy and create two sources of truth.
+Test implications: No new implementation; final verification should include the existing retry-policy test and a traceability check.
+
+## FR-003 Explicit Retry As New Operator Action
+
+Decision: Add verification that re-running after failure is a new audited update submission.
+Evidence: `DeploymentOperationsService.queue_update()` creates a new `MoonMind.Run` request for each accepted submission, but there is no test that ties this behavior to post-failure retry semantics.
+Rationale: The desired behavior can be satisfied by the existing typed update queue path if tests prove a retry is explicit and separately auditable.
+Alternatives considered: Add a special retry endpoint; rejected because the source design says re-running uses the same audited path.
+Test implications: Unit/API test with two explicit submissions and distinct idempotency/audit context.
+
+## FR-004 / FR-005 / DESIGN-REQ-003 Rollback Uses Normal Update Path
+
+Decision: Implement rollback as a typed deployment update submission with rollback metadata and a previous image target derived from trusted before-state evidence.
+Evidence: Normal update submission already requires admin authorization, reason, policy-valid image, lock, artifacts, and verification. No rollback-specific eligibility, confirmation, or metadata exists in `DeploymentOperationsService`, `DeploymentUpdateRequest`, or `OperationsSettingsSection`.
+Rationale: Reusing the existing update path preserves allowlists, audit, artifacts, and verification without creating a second privileged deployment mechanism.
+Alternatives considered: Introduce a dedicated rollback executor; rejected because it would duplicate the deployment update safety boundary.
+Test implications: Backend tests for rollback request metadata and policy validation; frontend tests for confirmation and request payload; integration test that rollback still dispatches `deployment.update_compose_stack`.
+
+## FR-006 / FR-007 / DESIGN-REQ-004 Rollback Eligibility
+
+Decision: Add a fail-closed rollback eligibility contract to deployment stack state/recent actions.
+Evidence: `DeploymentStackStateResponse` currently has no rollback fields, while the frontend schema is permissive and renders recent actions only when provided. No code determines whether before-state artifacts can safely produce a previous image target.
+Rationale: The UI can offer rollback only when the backend provides trusted eligibility from prior evidence. Missing, ambiguous, or unsafe evidence must withhold the action.
+Alternatives considered: Let the browser infer rollback targets from displayed current image; rejected because the source requires before-state artifact evidence, not UI guesses.
+Test implications: Unit tests for eligible, missing, ambiguous, and unsafe evidence; frontend tests that rollback controls appear only for eligible actions.
+
+## FR-008 No Silent Rollback
+
+Decision: Add explicit regression tests around failed execution and failed update projection proving no rollback is enqueued or submitted without operator action.
+Evidence: No automatic rollback code path was found in `DeploymentUpdateExecutor`, `DeploymentOperationsService`, or `OperationsSettingsSection`.
+Rationale: Absence of a code path should be locked with tests because silent rollback is a high-risk operational behavior.
+Alternatives considered: Add a config flag for automatic rollback now; rejected because the spec says automatic rollback requires a separately documented explicit policy.
+Test implications: Unit and integration regression tests for failure with no rollback submission.
+
+## FR-009 / DESIGN-REQ-006 Recent Action And Audit Visibility
+
+Decision: Surface failure and rollback records through deployment stack state using existing execution/artifact metadata rather than adding a new table.
+Evidence: Executor outputs contain audit and artifact refs; frontend `OperationsSettingsSection` can render `recentActions`; API `_stack_state()` currently returns only placeholder state and no recent action list.
+Rationale: Operators need visible recent action records. Existing execution rows and artifact refs are the durable source for the current pre-release design.
+Alternatives considered: Add a new deployment action table; rejected because existing execution/artifact records should be sufficient for this bounded story.
+Test implications: API tests for recent failure/rollback action fields; frontend tests for visibility of status, reason, timestamps, links, before/after summary, and hidden raw command log unless permitted.
+
+## FR-010 / DESIGN-REQ-005 Scope Boundaries
+
+Decision: Preserve existing allowlisted typed update boundaries for rollback.
+Evidence: `DeploymentUpdateRequest` forbids extra fields, service validation rejects non-allowlisted stack/repository/mode, executor rejects forbidden runner/path fields, and existing unit tests cover these denials.
+Rationale: Rollback is just another target-image update and must not expand into arbitrary GitOps, Kubernetes, host path, runner image, or shell management.
+Alternatives considered: Accept arbitrary previous image strings outside policy for rollback convenience; rejected because it violates the source non-goals.
+Test implications: Final verification plus rollback-specific negative tests for non-allowlisted target evidence.
+
+## FR-011 / SC-008 Traceability
+
+Decision: Preserve MM-523 and the canonical Jira preset brief across all feature artifacts and final delivery metadata.
+Evidence: `spec.md` and `plan.md` contain MM-523 and the preserved brief. Downstream artifacts are not yet generated.
+Rationale: Final verification needs to compare implementation against the original Jira input.
+Alternatives considered: Keep only a Jira issue key; rejected because `/speckit.verify` depends on source-request preservation.
+Test implications: Traceability grep across specs, code comments only where useful, tests, verification, commit, and PR body.

--- a/specs/265-explicit-failure-and-rollback-controls/spec.md
+++ b/specs/265-explicit-failure-and-rollback-controls/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Explicit Failure and Rollback Controls
+
+**Feature Branch**: `265-explicit-failure-and-rollback-controls`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-523 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-523 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-523
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Explicit failure and rollback controls
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-523 from MM project
+Summary: Explicit failure and rollback controls
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Tools/DockerComposeUpdateSystem.md
+Source Title: Docker Compose Deployment Update System
+Source Sections:
+- 15. Failure and rollback semantics
+- 4.2 Non-goals
+- 20. Locked decisions
+
+Coverage IDs:
+- DESIGN-REQ-015
+- DESIGN-REQ-018
+- DESIGN-REQ-003
+- DESIGN-REQ-013
+
+As an operations administrator, I need failed updates and rollbacks to remain explicit audited actions, so partial deployment changes do not trigger hidden retries or silent rollbacks.
+
+Acceptance Criteria
+- Each documented failure class produces a clear failed or partially verified result and actionable failure reason.
+- Deployment updates do not perform automatic multi-attempt retries by default.
+- A rollback request is submitted as a normal deployment update to a previous image reference, with admin authorization, reason, confirmation, lock acquisition, before/after artifacts, and verification.
+- The UI or API offers rollback only when before-state artifacts contain enough information to construct a safe target image reference.
+- The system never silently rolls back after failure unless an explicit separate policy enables automatic rollback.
+- Rollback and failure records remain visible in recent actions and audit output.
+
+Requirements
+- Keep retries and rollback operator-driven by default.
+- Preserve the same security, audit, artifact, and verification requirements for rollback as for forward updates.
+- Do not expand the feature into general GitOps, Kubernetes, or non-allowlisted stack management.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-523 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime behavior story from `docs/Tools/DockerComposeUpdateSystem.md`; it does not require `moonspec-breakdown`.
+
+## User Story - Explicit Failure and Rollback Controls
+
+**Summary**: As an operations administrator, I need failed updates and rollbacks to remain explicit audited actions, so partial deployment changes do not trigger hidden retries or silent rollbacks.
+
+**Goal**: Deployment update execution reports failures clearly, keeps retries and rollbacks operator-driven by default, exposes rollback only when safe before-state evidence exists, and records rollback and failure outcomes as visible audited actions.
+
+**Independent Test**: Exercise deployment update failure and rollback decision flows with controlled update outcomes and artifact evidence, then verify final statuses, retry behavior, rollback eligibility, required authorization inputs, audit records, and absence of silent rollback.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployment update hits a documented failure class, **When** the run completes, **Then** the result is failed or partially verified with a clear actionable failure reason.
+2. **Given** a deployment update fails after partially changing services, **When** the failure is reported, **Then** no automatic multi-attempt retry is started by default.
+3. **Given** an operator requests rollback to a previous image reference, **When** rollback is submitted, **Then** it follows the normal deployment update path with admin authorization, reason, confirmation, lock acquisition, before/after artifacts, and verification.
+4. **Given** before-state artifacts contain enough information to construct a safe previous image target, **When** rollback options are shown, **Then** the rollback action is available with the safe target reference.
+5. **Given** before-state artifacts do not contain enough safe target information, **When** rollback options are shown, **Then** the rollback action is unavailable.
+6. **Given** a deployment update fails, **When** no explicit separate automatic rollback policy is enabled, **Then** the system does not silently roll back.
+7. **Given** a rollback or failure occurs, **When** recent actions and audit output are inspected, **Then** the rollback or failure record remains visible with relevant outcome details.
+
+### Edge Cases
+
+- A rollback request without admin authorization, reason, confirmation, lock acquisition, artifacts, or verification fails closed before making deployment changes.
+- A previous image reference that cannot be safely reconstructed from before-state evidence is not offered as a rollback target.
+- Failure classes caused by invalid input, authorization, policy, unavailable lock, Compose validation, image pull, service recreation, or verification each produce a clear terminal result.
+- Re-running a failed update is treated as a new explicit operator action through the audited deployment path.
+- Non-allowlisted stacks, host paths, repositories, runner images, and arbitrary shell-style update targets remain outside rollback scope.
+
+## Assumptions
+
+- Earlier deployment-update stories own the base admin-only typed update flow, allowlist policy, desired-state persistence, and artifact capture. This story owns explicit failure behavior, retry defaults, rollback eligibility, rollback submission semantics, and audit visibility.
+- Any future automatic rollback behavior requires a separate explicit policy and is out of scope for the default behavior in this story.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST produce a clear failed or partially verified result with an actionable failure reason for each documented deployment update failure class.
+- **FR-002**: System MUST NOT perform automatic multi-attempt deployment update retries by default after a failure.
+- **FR-003**: System MUST treat re-running a failed deployment update as an explicit operator action that follows the audited deployment update path.
+- **FR-004**: System MUST treat rollback as an explicit deployment update to a previous image reference.
+- **FR-005**: Rollback submission MUST require admin authorization, a reason, confirmation, deployment lock acquisition, before and after artifacts, and verification.
+- **FR-006**: System MUST offer a rollback action only when before-state artifacts contain enough information to construct a safe previous image target.
+- **FR-007**: System MUST withhold rollback actions when before-state evidence is missing, ambiguous, unsafe, or insufficient to construct the target image reference.
+- **FR-008**: System MUST NOT silently roll back after failure unless a separately documented explicit automatic rollback policy enables that behavior.
+- **FR-009**: System MUST keep rollback and failure records visible in recent actions and audit output.
+- **FR-010**: System MUST keep rollback scope limited to the same allowlisted deployment update boundaries as forward updates and MUST NOT expand into general GitOps, Kubernetes, non-allowlisted stack management, or arbitrary shell execution.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-523` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Deployment Failure Result**: Terminal or partial outcome containing failure class, final status, actionable reason, and audit visibility metadata.
+- **Rollback Eligibility Decision**: Determination of whether before-state evidence can safely produce a previous image target.
+- **Rollback Request**: Explicit operator action containing authorization, reason, confirmation, target image reference, lock, artifacts, and verification outcome.
+- **Deployment Audit Record**: Recent-action and audit-visible record for failure, retry-by-new-action, or rollback outcomes.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tools/DockerComposeUpdateSystem.md` section 15.1 requires fast failure on invalid input, authorization failure, policy violation, unavailable deployment lock, Compose config validation failure, image pull failure, service recreation failure, and verification failure. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-002**: Source section 15.2 requires deployment updates not to use automatic multi-attempt retries by default and requires re-running an update to be an explicit operator action through the same audited path. Scope: in scope. Maps to FR-002, FR-003.
+- **DESIGN-REQ-003**: Source section 15.3 requires rollback to be an explicit deployment update to a previous image reference with admin authorization, reason, confirmation, deployment lock, before/after artifacts, and verification. Scope: in scope. Maps to FR-004, FR-005.
+- **DESIGN-REQ-004**: Source section 15.3 requires rollback UI availability only when before-state artifacts can construct a safe target image reference and forbids silent rollback unless an explicit separate policy enables it. Scope: in scope. Maps to FR-006, FR-007, FR-008.
+- **DESIGN-REQ-005**: Source section 4.2 excludes general Docker UI, general shell runner, non-admin Docker controls, arbitrary updater runner images, general GitOps or Kubernetes replacement, non-allowlisted stacks or host paths, deployment updates as agent instruction skills, and silent rollback without explicit auditable policy. Scope: in scope. Maps to FR-008, FR-010.
+- **DESIGN-REQ-006**: Source section 20 locks decisions that stack names, Compose paths, image repositories, and runner images are allowlisted; arbitrary shell input is not accepted; desired image state is persisted before Compose is brought up; and before/after state plus command logs are written as artifacts. Scope: in scope. Maps to FR-005, FR-009, FR-010.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests cover all documented failure classes and verify each produces a failed or partially verified result with a non-empty actionable reason.
+- **SC-002**: Tests prove a failed deployment update does not start any automatic second update attempt by default.
+- **SC-003**: Tests prove an explicit retry follows the normal audited deployment update path as a distinct operator action.
+- **SC-004**: Tests prove rollback submission is rejected unless authorization, reason, confirmation, lock, before/after artifacts, and verification are present.
+- **SC-005**: Tests prove rollback is offered only when before-state evidence safely identifies a previous image target and is withheld otherwise.
+- **SC-006**: Tests prove failure does not trigger silent rollback when no explicit automatic rollback policy is enabled.
+- **SC-007**: Tests or verification evidence prove rollback and failure outcomes remain visible in recent actions and audit output.
+- **SC-008**: Traceability evidence preserves `MM-523`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-006 in MoonSpec artifacts.

--- a/specs/265-explicit-failure-and-rollback-controls/tasks.md
+++ b/specs/265-explicit-failure-and-rollback-controls/tasks.md
@@ -1,0 +1,174 @@
+# Tasks: Explicit Failure and Rollback Controls
+
+**Input**: Design documents from `specs/265-explicit-failure-and-rollback-controls/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/deployment-failure-rollback-controls.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: Explicit Failure and Rollback Controls for MM-523.
+
+**Source Traceability**: The original MM-523 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-011, acceptance scenarios 1 through 7, edge cases, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-006.
+
+**Requirement Status Summary**:
+
+- Code and tests required: FR-001, FR-004, FR-005, FR-006, FR-007, FR-009, FR-011; DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-006; SC-001, SC-004, SC-005, SC-007, SC-008.
+- Verification tests plus conditional fallback: FR-003, FR-008; SC-003, SC-006.
+- Already verified, preserve through final validation: FR-002, FR-010; SC-002; DESIGN-REQ-002, DESIGN-REQ-005.
+
+**Test Commands**:
+
+- Unit tests: `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q`
+- UI unit tests: `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx`
+- Integration tests: `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`
+- Final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final integration suite: `./tools/test_integration.sh` when Docker is available
+- Final verification: `/speckit.verify`
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active feature artifacts and test surfaces are ready.
+
+- [ ] T001 Verify `.specify/feature.json` points to `specs/265-explicit-failure-and-rollback-controls` and record the branch-name prerequisite-script blocker in `specs/265-explicit-failure-and-rollback-controls/tasks.md`. (FR-011, SC-008)
+- [ ] T002 Inspect current deployment implementation and test entry points in `moonmind/workflows/skills/deployment_execution.py`, `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, `frontend/src/components/settings/OperationsSettingsSection.tsx`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, `tests/unit/api/routers/test_deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-001-FR-010)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared test fixtures and contract expectations before story implementation.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T003 [P] Add shared failing-test fixtures for deployment failure classes, rollback-safe before-state evidence, unsafe before-state evidence, and rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, FR-006, FR-007, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T004 [P] Add shared fake recent-action/projection fixtures for deployment stack state and rollback submission tests in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, FR-004, FR-005, FR-009, SC-003, SC-007)
+- [ ] T005 [P] Add mock deployment stack state entries for eligible and ineligible rollback actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, SC-005)
+
+**Checkpoint**: Foundation ready for red-first story tests.
+
+---
+
+## Phase 3: Story - Explicit Failure and Rollback Controls
+
+**Summary**: As an operations administrator, I need failed updates and rollbacks to remain explicit audited actions, so partial deployment changes do not trigger hidden retries or silent rollbacks.
+
+**Independent Test**: Exercise deployment update failure and rollback decision flows with controlled update outcomes and artifact evidence, then verify final statuses, retry behavior, rollback eligibility, required authorization inputs, audit records, and absence of silent rollback.
+
+**Traceability**: FR-001 through FR-011; acceptance scenarios 1-7; SC-001 through SC-008; DESIGN-REQ-001 through DESIGN-REQ-006.
+
+### Unit Tests (write first)
+
+- [ ] T006 [P] Add failing unit test matrix for normalized failure classes and actionable reasons in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
+- [ ] T007 [P] Add failing unit tests for rollback eligibility from safe, missing, ambiguous, malformed, and non-allowlisted before-state evidence in `tests/unit/api/routers/test_deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
+- [ ] T008 [P] Add failing unit tests proving rollback submission uses the normal typed update path with `operationKind=rollback`, `rollbackSourceActionId`, admin authorization, reason, and policy-valid target in `tests/unit/api/routers/test_deployment_operations.py`. (FR-004, FR-005, SC-004, DESIGN-REQ-003)
+- [ ] T009 [P] Add verification-first unit test proving two explicit deployment update submissions are distinct audited operator actions, not automatic retry continuation, in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, SC-003, DESIGN-REQ-002)
+- [ ] T010 [P] Add verification-first unit test proving failed deployment execution does not enqueue or perform rollback without explicit rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-008, SC-006, DESIGN-REQ-004)
+- [ ] T011 [P] Add failing API unit tests for recent failure and rollback action fields in deployment stack state in `tests/unit/api/routers/test_deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
+- [ ] T012 [P] Add failing UI unit tests for rendering rollback controls only on eligible recent actions and withholding them for unsafe actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, acceptance scenarios 4-5)
+- [ ] T013 [P] Add failing UI unit test for rollback confirmation and submitted typed deployment payload in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-004, FR-005, acceptance scenario 3)
+- [ ] T014 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` to confirm T006-T013 fail for the expected missing behavior. (SC-001, SC-003, SC-004, SC-005, SC-006, SC-007)
+
+### Integration Tests (write first)
+
+- [ ] T015 [P] Add failing hermetic integration test for failed `deployment.update_compose_stack` dispatch exposing failure metadata without automatic rollback in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-001, FR-008, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T016 [P] Add failing hermetic integration test proving rollback dispatch still invokes `deployment.update_compose_stack` through the existing typed tool contract in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-005)
+- [ ] T017 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` to confirm T015-T016 fail for the expected missing behavior. (SC-004, SC-006)
+
+### Red-First Confirmation
+
+- [ ] T018 Confirm and record in `specs/265-explicit-failure-and-rollback-controls/tasks.md` that T006-T017 were run before production implementation and failed for missing MM-523 behavior rather than fixture or syntax errors. (FR-001-FR-009, SC-001-SC-007)
+
+### Conditional Fallback For Implemented-Unverified Rows
+
+- [ ] T019 If T009 fails, update explicit retry/audit request handling in `api_service/services/deployment_operations.py` so repeated operator submissions remain separate audited update requests. (FR-003, SC-003)
+- [ ] T020 If T010 or T015 shows an automatic rollback path, remove that path in `moonmind/workflows/skills/deployment_execution.py` or `api_service/services/deployment_operations.py` and require explicit rollback metadata instead. (FR-008, SC-006, DESIGN-REQ-004)
+
+### Implementation
+
+- [ ] T021 Add deployment failure-class normalization and failure metadata output in `moonmind/workflows/skills/deployment_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
+- [ ] T022 Update deployment tool output schema for compact failure metadata in `moonmind/workflows/skills/deployment_tools.py`. (FR-001, DESIGN-REQ-001)
+- [ ] T023 Add rollback eligibility and recent deployment action models to `api_service/api/routers/deployment_operations.py`. (FR-006, FR-007, FR-009, DESIGN-REQ-004, DESIGN-REQ-006)
+- [ ] T024 Implement rollback eligibility derivation and fail-closed unsafe evidence handling in `api_service/services/deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
+- [ ] T025 Extend rollback submission metadata and normal typed update queue construction in `api_service/services/deployment_operations.py`. (FR-004, FR-005, DESIGN-REQ-003)
+- [ ] T026 Wire rollback request fields through `DeploymentUpdateRequest` and queue response handling in `api_service/api/routers/deployment_operations.py`. (FR-004, FR-005)
+- [ ] T027 Surface bounded failure and rollback recent actions in deployment stack state from existing execution/artifact evidence in `api_service/api/routers/deployment_operations.py` and `api_service/services/deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
+- [ ] T028 Add rollback eligibility schema, rollback action rendering, unsafe-action withholding, and rollback confirmation flow in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-004, FR-005, FR-006, FR-007, acceptance scenarios 3-5)
+- [ ] T029 Preserve allowlisted boundaries for rollback targets and raw command-log hiding in `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-010, DESIGN-REQ-005)
+
+### Story Validation
+
+- [ ] T030 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and fix only MM-523-related failures. (FR-001-FR-010)
+- [ ] T031 Run `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` and fix only MM-523-related failures. (FR-004-FR-009)
+- [ ] T032 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` and fix only MM-523-related failures. (FR-001, FR-004, FR-005, FR-008)
+- [ ] T033 Run traceability grep `rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests` and update missing traceability in feature artifacts or tests. (FR-011, SC-008)
+
+**Checkpoint**: MM-523 story is functionally complete, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [ ] T034 [P] Review `moonmind/workflows/skills/deployment_execution.py` and `api_service/services/deployment_operations.py` for secret hygiene and remove any unredacted failure or rollback evidence from outputs. (FR-001, FR-009, security guardrail)
+- [ ] T035 [P] Review `frontend/src/components/settings/OperationsSettingsSection.tsx` for accessible rollback button labels, confirmation text, and no overlapping or misleading UI states. (FR-004, FR-006, FR-007)
+- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification. (SC-001-SC-008)
+- [ ] T037 Run `./tools/test_integration.sh` when Docker is available; if unavailable, record the Docker availability blocker and the focused hermetic integration evidence from T032 in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (SC-004, SC-006)
+- [ ] T038 Run `/speckit.verify` after implementation and tests pass, preserving MM-523, final verdict, tests run, and remaining risks in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (FR-011, SC-008)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on Phase 1 and blocks story test authoring.
+- Phase 3 depends on Phase 2. Unit and integration tests must be written and confirmed failing before implementation tasks T021-T029.
+- Phase 4 depends on the story being implemented and focused tests passing.
+
+### Within The Story
+
+- T006-T013 may be authored in parallel after T003-T005 because they touch separate test files.
+- T014 must run after T006-T013 and before implementation.
+- T015-T016 may be authored in parallel because they add separate integration scenarios in the same file but do not depend on production changes; coordinate edits if one agent owns the file.
+- T017 must run after T015-T016 and before implementation.
+- T018 must complete before T019-T029.
+- T019-T020 are conditional fallback tasks only if verification-first tests fail.
+- T021-T022 precede integration validation for tool output.
+- T023-T027 precede UI implementation T028 because the UI consumes API shape.
+- T030-T033 validate the complete story before polish.
+
+## Parallel Opportunities
+
+- T003, T004, and T005 can run in parallel.
+- T006, T007, T008, T009, T010, T011, T012, and T013 can run in parallel by file ownership groups.
+- T015 and T016 can run in parallel if the integration test file is coordinated.
+- T034 and T035 can run in parallel after story validation.
+
+## Parallel Example
+
+```bash
+# Backend executor tests
+Task: "T006 Add failing unit test matrix in tests/unit/workflows/skills/test_deployment_update_execution.py"
+Task: "T010 Add no-silent-rollback verification test in tests/unit/workflows/skills/test_deployment_update_execution.py"
+
+# API and UI tests
+Task: "T007/T008/T011 Add API tests in tests/unit/api/routers/test_deployment_operations.py"
+Task: "T012/T013 Add UI tests in frontend/src/components/settings/OperationsSettingsSection.test.tsx"
+```
+
+## Implementation Strategy
+
+1. Preserve the existing typed deployment update tool and API route names.
+2. Write red-first unit, UI, and integration tests for missing and partial MM-523 behavior.
+3. Run focused tests and confirm failures before production changes.
+4. Implement failure metadata first, then backend rollback eligibility/submission/recent action projection, then UI rollback controls.
+5. Preserve already-verified no-default-retry and allowlist boundaries through final validation rather than rewriting them.
+6. Run focused tests, full unit verification, available integration verification, and final `/speckit.verify`.
+
+## Notes
+
+- This task list covers one story only.
+- Do not add a separate rollback executor or new persistent deployment action table unless implementation proves existing execution/artifact evidence cannot satisfy the contract; if that happens, update `plan.md` and `data-model.md` before changing scope.
+- Rollback must remain an explicit operator action through the normal typed deployment update path.
+- No production implementation task may start until red-first confirmation T018 is complete.

--- a/specs/265-explicit-failure-and-rollback-controls/tasks.md
+++ b/specs/265-explicit-failure-and-rollback-controls/tasks.md
@@ -28,8 +28,8 @@
 
 **Purpose**: Confirm the active feature artifacts and test surfaces are ready.
 
-- [ ] T001 Verify `.specify/feature.json` points to `specs/265-explicit-failure-and-rollback-controls` and record the branch-name prerequisite-script blocker in `specs/265-explicit-failure-and-rollback-controls/tasks.md`. (FR-011, SC-008)
-- [ ] T002 Inspect current deployment implementation and test entry points in `moonmind/workflows/skills/deployment_execution.py`, `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, `frontend/src/components/settings/OperationsSettingsSection.tsx`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, `tests/unit/api/routers/test_deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-001-FR-010)
+- [X] T001 Verify `.specify/feature.json` points to `specs/265-explicit-failure-and-rollback-controls` and record the branch-name prerequisite-script blocker in `specs/265-explicit-failure-and-rollback-controls/tasks.md`. (FR-011, SC-008)
+- [X] T002 Inspect current deployment implementation and test entry points in `moonmind/workflows/skills/deployment_execution.py`, `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, `frontend/src/components/settings/OperationsSettingsSection.tsx`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, `tests/unit/api/routers/test_deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-001-FR-010)
 
 ---
 
@@ -39,9 +39,9 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T003 [P] Add shared failing-test fixtures for deployment failure classes, rollback-safe before-state evidence, unsafe before-state evidence, and rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, FR-006, FR-007, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T004 [P] Add shared fake recent-action/projection fixtures for deployment stack state and rollback submission tests in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, FR-004, FR-005, FR-009, SC-003, SC-007)
-- [ ] T005 [P] Add mock deployment stack state entries for eligible and ineligible rollback actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, SC-005)
+- [X] T003 [P] Add shared failing-test fixtures for deployment failure classes, rollback-safe before-state evidence, unsafe before-state evidence, and rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, FR-006, FR-007, DESIGN-REQ-001, DESIGN-REQ-004)
+- [X] T004 [P] Add shared fake recent-action/projection fixtures for deployment stack state and rollback submission tests in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, FR-004, FR-005, FR-009, SC-003, SC-007)
+- [X] T005 [P] Add mock deployment stack state entries for eligible and ineligible rollback actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, SC-005)
 
 **Checkpoint**: Foundation ready for red-first story tests.
 
@@ -57,49 +57,51 @@
 
 ### Unit Tests (write first)
 
-- [ ] T006 [P] Add failing unit test matrix for normalized failure classes and actionable reasons in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
-- [ ] T007 [P] Add failing unit tests for rollback eligibility from safe, missing, ambiguous, malformed, and non-allowlisted before-state evidence in `tests/unit/api/routers/test_deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
-- [ ] T008 [P] Add failing unit tests proving rollback submission uses the normal typed update path with `operationKind=rollback`, `rollbackSourceActionId`, admin authorization, explicit confirmation, reason, and policy-valid target in `tests/unit/api/routers/test_deployment_operations.py`. (FR-004, FR-005, SC-004, DESIGN-REQ-003)
-- [ ] T009 [P] Add verification-first unit test proving two explicit deployment update submissions are distinct audited operator actions, not automatic retry continuation, in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, SC-003, DESIGN-REQ-002)
-- [ ] T010 [P] Add verification-first unit test proving failed deployment execution does not enqueue or perform rollback without explicit rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-008, SC-006, DESIGN-REQ-004)
-- [ ] T011 [P] Add failing API unit tests for recent failure and rollback action fields in deployment stack state in `tests/unit/api/routers/test_deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
-- [ ] T012 [P] Add failing UI unit tests for rendering rollback controls only on eligible recent actions and withholding them for unsafe actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, acceptance scenarios 4-5)
-- [ ] T013 [P] Add failing UI unit test for rollback confirmation text and submitted typed deployment payload including explicit confirmation metadata in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-004, FR-005, acceptance scenario 3)
-- [ ] T014 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` to confirm T006-T013 fail for the expected missing behavior. (SC-001, SC-003, SC-004, SC-005, SC-006, SC-007)
+- [X] T006 [P] Add failing unit test matrix for normalized failure classes and actionable reasons in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
+- [X] T007 [P] Add failing unit tests for rollback eligibility from safe, missing, ambiguous, malformed, and non-allowlisted before-state evidence in `tests/unit/api/routers/test_deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
+- [X] T008 [P] Add failing unit tests proving rollback submission uses the normal typed update path with `operationKind=rollback`, `rollbackSourceActionId`, admin authorization, explicit confirmation, reason, and policy-valid target in `tests/unit/api/routers/test_deployment_operations.py`. (FR-004, FR-005, SC-004, DESIGN-REQ-003)
+- [X] T009 [P] Add verification-first unit test proving two explicit deployment update submissions are distinct audited operator actions, not automatic retry continuation, in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, SC-003, DESIGN-REQ-002)
+- [X] T010 [P] Add verification-first unit test proving failed deployment execution does not enqueue or perform rollback without explicit rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-008, SC-006, DESIGN-REQ-004)
+- [X] T011 [P] Add failing API unit tests for recent failure and rollback action fields in deployment stack state in `tests/unit/api/routers/test_deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
+- [X] T012 [P] Add failing UI unit tests for rendering rollback controls only on eligible recent actions and withholding them for unsafe actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, acceptance scenarios 4-5)
+- [X] T013 [P] Add failing UI unit test for rollback confirmation text and submitted typed deployment payload including explicit confirmation metadata in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-004, FR-005, acceptance scenario 3)
+- [X] T014 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` to confirm T006-T013 fail for the expected missing behavior. (SC-001, SC-003, SC-004, SC-005, SC-006, SC-007)
 
 ### Integration Tests (write first)
 
-- [ ] T015 [P] Add failing hermetic integration test for failed `deployment.update_compose_stack` dispatch exposing failure metadata without automatic rollback in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-001, FR-008, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T016 [P] Add failing hermetic integration test proving rollback dispatch still invokes `deployment.update_compose_stack` through the existing typed tool contract in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-005)
-- [ ] T017 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` to confirm T015-T016 fail for the expected missing behavior. (SC-004, SC-006)
+- [X] T015 [P] Add failing hermetic integration test for failed `deployment.update_compose_stack` dispatch exposing failure metadata without automatic rollback in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-001, FR-008, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-004)
+- [X] T016 [P] Add failing hermetic integration test proving rollback dispatch still invokes `deployment.update_compose_stack` through the existing typed tool contract in `tests/integration/temporal/test_deployment_update_execution_contract.py`. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-005)
+- [X] T017 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` to confirm T015-T016 fail for the expected missing behavior. (SC-004, SC-006)
 
 ### Red-First Confirmation
 
-- [ ] T018 Confirm and record in `specs/265-explicit-failure-and-rollback-controls/tasks.md` that T006-T017 were run before production implementation and failed for missing MM-523 behavior rather than fixture or syntax errors. (FR-001-FR-009, SC-001-SC-007)
+- [X] T018 Confirm and record in `specs/265-explicit-failure-and-rollback-controls/tasks.md` that T006-T017 were run before production implementation and failed for missing MM-523 behavior rather than fixture or syntax errors. (FR-001-FR-009, SC-001-SC-007)
+
+Red-first evidence: Before production implementation, the focused Python unit run failed during collection on missing rollback/recent-action service models, the focused integration run failed with missing `outputs["failure"]`, and the UI target initially could not reach Vitest until npm dependencies were prepared and the local binary was used because the managed workspace path contains a colon. After implementation, all focused and full unit commands listed below passed.
 
 ### Conditional Fallback For Implemented-Unverified Rows
 
-- [ ] T019 If T009 fails, update explicit retry/audit request handling in `api_service/services/deployment_operations.py` so repeated operator submissions remain separate audited update requests. (FR-003, SC-003)
-- [ ] T020 If T010 or T015 shows an automatic rollback path, remove that path in `moonmind/workflows/skills/deployment_execution.py` or `api_service/services/deployment_operations.py` and require explicit rollback metadata instead. (FR-008, SC-006, DESIGN-REQ-004)
+- [X] T019 If T009 fails, update explicit retry/audit request handling in `api_service/services/deployment_operations.py` so repeated operator submissions remain separate audited update requests. (FR-003, SC-003)
+- [X] T020 If T010 or T015 shows an automatic rollback path, remove that path in `moonmind/workflows/skills/deployment_execution.py` or `api_service/services/deployment_operations.py` and require explicit rollback metadata instead. (FR-008, SC-006, DESIGN-REQ-004)
 
 ### Implementation
 
-- [ ] T021 Add deployment failure-class normalization and failure metadata output in `moonmind/workflows/skills/deployment_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
-- [ ] T022 Update deployment tool output schema for compact failure metadata in `moonmind/workflows/skills/deployment_tools.py`. (FR-001, DESIGN-REQ-001)
-- [ ] T023 Add rollback eligibility and recent deployment action models to `api_service/api/routers/deployment_operations.py`. (FR-006, FR-007, FR-009, DESIGN-REQ-004, DESIGN-REQ-006)
-- [ ] T024 Implement rollback eligibility derivation and fail-closed unsafe evidence handling in `api_service/services/deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
-- [ ] T025 Extend rollback submission metadata, explicit confirmation validation, and normal typed update queue construction in `api_service/services/deployment_operations.py`. (FR-004, FR-005, DESIGN-REQ-003)
-- [ ] T026 Wire rollback request fields, including `confirmation`, through `DeploymentUpdateRequest` and queue response handling in `api_service/api/routers/deployment_operations.py`. (FR-004, FR-005)
-- [ ] T027 Surface bounded failure and rollback recent actions in deployment stack state from existing execution/artifact evidence in `api_service/api/routers/deployment_operations.py` and `api_service/services/deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
-- [ ] T028 Add rollback eligibility schema, rollback action rendering, unsafe-action withholding, and rollback confirmation flow in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-004, FR-005, FR-006, FR-007, acceptance scenarios 3-5)
-- [ ] T029 Preserve allowlisted boundaries for rollback targets and raw command-log hiding in `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-010, DESIGN-REQ-005)
+- [X] T021 Add deployment failure-class normalization and failure metadata output in `moonmind/workflows/skills/deployment_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
+- [X] T022 Update deployment tool output schema for compact failure metadata in `moonmind/workflows/skills/deployment_tools.py`. (FR-001, DESIGN-REQ-001)
+- [X] T023 Add rollback eligibility and recent deployment action models to `api_service/api/routers/deployment_operations.py`. (FR-006, FR-007, FR-009, DESIGN-REQ-004, DESIGN-REQ-006)
+- [X] T024 Implement rollback eligibility derivation and fail-closed unsafe evidence handling in `api_service/services/deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
+- [X] T025 Extend rollback submission metadata, explicit confirmation validation, and normal typed update queue construction in `api_service/services/deployment_operations.py`. (FR-004, FR-005, DESIGN-REQ-003)
+- [X] T026 Wire rollback request fields, including `confirmation`, through `DeploymentUpdateRequest` and queue response handling in `api_service/api/routers/deployment_operations.py`. (FR-004, FR-005)
+- [X] T027 Surface bounded failure and rollback recent actions in deployment stack state from existing execution/artifact evidence in `api_service/api/routers/deployment_operations.py` and `api_service/services/deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
+- [X] T028 Add rollback eligibility schema, rollback action rendering, unsafe-action withholding, and rollback confirmation flow in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-004, FR-005, FR-006, FR-007, acceptance scenarios 3-5)
+- [X] T029 Preserve allowlisted boundaries for rollback targets and raw command-log hiding in `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-010, DESIGN-REQ-005)
 
 ### Story Validation
 
-- [ ] T030 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and fix only MM-523-related failures. (FR-001-FR-010)
-- [ ] T031 Run `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` and fix only MM-523-related failures. (FR-004-FR-009)
-- [ ] T032 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` and fix only MM-523-related failures. (FR-001, FR-004, FR-005, FR-008)
-- [ ] T033 Run traceability grep `rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests` and update missing traceability in feature artifacts or tests. (FR-011, SC-008)
+- [X] T030 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and fix only MM-523-related failures. (FR-001-FR-010)
+- [X] T031 Run `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` and fix only MM-523-related failures. (FR-004-FR-009)
+- [X] T032 Run `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` and fix only MM-523-related failures. (FR-001, FR-004, FR-005, FR-008)
+- [X] T033 Run traceability grep `rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests` and update missing traceability in feature artifacts or tests. (FR-011, SC-008)
 
 **Checkpoint**: MM-523 story is functionally complete, covered by unit and integration tests, and independently testable.
 
@@ -109,11 +111,11 @@
 
 **Purpose**: Strengthen the completed story without expanding scope.
 
-- [ ] T034 [P] Review `moonmind/workflows/skills/deployment_execution.py` and `api_service/services/deployment_operations.py` for secret hygiene and remove any unredacted failure or rollback evidence from outputs. (FR-001, FR-009, security guardrail)
-- [ ] T035 [P] Review `frontend/src/components/settings/OperationsSettingsSection.tsx` for accessible rollback button labels, confirmation text, and no overlapping or misleading UI states. (FR-004, FR-006, FR-007)
-- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification, including existing retry-policy and allowlist boundary coverage in `tests/unit/workflows/skills/test_deployment_tool_contracts.py`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, and `tests/unit/api/routers/test_deployment_operations.py`. (FR-002, FR-010, SC-001-SC-008, DESIGN-REQ-002, DESIGN-REQ-005)
-- [ ] T037 Run `./tools/test_integration.sh` when Docker is available; if unavailable, record the Docker availability blocker and the focused hermetic integration evidence from T032 in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (SC-004, SC-006)
-- [ ] T038 Run `/speckit.verify` after implementation and tests pass, preserving MM-523, final verdict, tests run, and remaining risks in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (FR-011, SC-008)
+- [X] T034 [P] Review `moonmind/workflows/skills/deployment_execution.py` and `api_service/services/deployment_operations.py` for secret hygiene and remove any unredacted failure or rollback evidence from outputs. (FR-001, FR-009, security guardrail)
+- [X] T035 [P] Review `frontend/src/components/settings/OperationsSettingsSection.tsx` for accessible rollback button labels, confirmation text, and no overlapping or misleading UI states. (FR-004, FR-006, FR-007)
+- [X] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification, including existing retry-policy and allowlist boundary coverage in `tests/unit/workflows/skills/test_deployment_tool_contracts.py`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, and `tests/unit/api/routers/test_deployment_operations.py`. (FR-002, FR-010, SC-001-SC-008, DESIGN-REQ-002, DESIGN-REQ-005)
+- [X] T037 Run `./tools/test_integration.sh` when Docker is available; if unavailable, record the Docker availability blocker and the focused hermetic integration evidence from T032 in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (SC-004, SC-006)
+- [X] T038 Run `/speckit.verify` after implementation and tests pass, preserving MM-523, final verdict, tests run, and remaining risks in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (FR-011, SC-008)
 
 ---
 

--- a/specs/265-explicit-failure-and-rollback-controls/tasks.md
+++ b/specs/265-explicit-failure-and-rollback-controls/tasks.md
@@ -59,12 +59,12 @@
 
 - [ ] T006 [P] Add failing unit test matrix for normalized failure classes and actionable reasons in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-001, SC-001, DESIGN-REQ-001)
 - [ ] T007 [P] Add failing unit tests for rollback eligibility from safe, missing, ambiguous, malformed, and non-allowlisted before-state evidence in `tests/unit/api/routers/test_deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
-- [ ] T008 [P] Add failing unit tests proving rollback submission uses the normal typed update path with `operationKind=rollback`, `rollbackSourceActionId`, admin authorization, reason, and policy-valid target in `tests/unit/api/routers/test_deployment_operations.py`. (FR-004, FR-005, SC-004, DESIGN-REQ-003)
+- [ ] T008 [P] Add failing unit tests proving rollback submission uses the normal typed update path with `operationKind=rollback`, `rollbackSourceActionId`, admin authorization, explicit confirmation, reason, and policy-valid target in `tests/unit/api/routers/test_deployment_operations.py`. (FR-004, FR-005, SC-004, DESIGN-REQ-003)
 - [ ] T009 [P] Add verification-first unit test proving two explicit deployment update submissions are distinct audited operator actions, not automatic retry continuation, in `tests/unit/api/routers/test_deployment_operations.py`. (FR-003, SC-003, DESIGN-REQ-002)
 - [ ] T010 [P] Add verification-first unit test proving failed deployment execution does not enqueue or perform rollback without explicit rollback metadata in `tests/unit/workflows/skills/test_deployment_update_execution.py`. (FR-008, SC-006, DESIGN-REQ-004)
 - [ ] T011 [P] Add failing API unit tests for recent failure and rollback action fields in deployment stack state in `tests/unit/api/routers/test_deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
 - [ ] T012 [P] Add failing UI unit tests for rendering rollback controls only on eligible recent actions and withholding them for unsafe actions in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-006, FR-007, acceptance scenarios 4-5)
-- [ ] T013 [P] Add failing UI unit test for rollback confirmation and submitted typed deployment payload in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-004, FR-005, acceptance scenario 3)
+- [ ] T013 [P] Add failing UI unit test for rollback confirmation text and submitted typed deployment payload including explicit confirmation metadata in `frontend/src/components/settings/OperationsSettingsSection.test.tsx`. (FR-004, FR-005, acceptance scenario 3)
 - [ ] T014 Run `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` and `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` to confirm T006-T013 fail for the expected missing behavior. (SC-001, SC-003, SC-004, SC-005, SC-006, SC-007)
 
 ### Integration Tests (write first)
@@ -88,8 +88,8 @@
 - [ ] T022 Update deployment tool output schema for compact failure metadata in `moonmind/workflows/skills/deployment_tools.py`. (FR-001, DESIGN-REQ-001)
 - [ ] T023 Add rollback eligibility and recent deployment action models to `api_service/api/routers/deployment_operations.py`. (FR-006, FR-007, FR-009, DESIGN-REQ-004, DESIGN-REQ-006)
 - [ ] T024 Implement rollback eligibility derivation and fail-closed unsafe evidence handling in `api_service/services/deployment_operations.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-004)
-- [ ] T025 Extend rollback submission metadata and normal typed update queue construction in `api_service/services/deployment_operations.py`. (FR-004, FR-005, DESIGN-REQ-003)
-- [ ] T026 Wire rollback request fields through `DeploymentUpdateRequest` and queue response handling in `api_service/api/routers/deployment_operations.py`. (FR-004, FR-005)
+- [ ] T025 Extend rollback submission metadata, explicit confirmation validation, and normal typed update queue construction in `api_service/services/deployment_operations.py`. (FR-004, FR-005, DESIGN-REQ-003)
+- [ ] T026 Wire rollback request fields, including `confirmation`, through `DeploymentUpdateRequest` and queue response handling in `api_service/api/routers/deployment_operations.py`. (FR-004, FR-005)
 - [ ] T027 Surface bounded failure and rollback recent actions in deployment stack state from existing execution/artifact evidence in `api_service/api/routers/deployment_operations.py` and `api_service/services/deployment_operations.py`. (FR-009, SC-007, DESIGN-REQ-006)
 - [ ] T028 Add rollback eligibility schema, rollback action rendering, unsafe-action withholding, and rollback confirmation flow in `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-004, FR-005, FR-006, FR-007, acceptance scenarios 3-5)
 - [ ] T029 Preserve allowlisted boundaries for rollback targets and raw command-log hiding in `api_service/services/deployment_operations.py`, `api_service/api/routers/deployment_operations.py`, and `frontend/src/components/settings/OperationsSettingsSection.tsx`. (FR-010, DESIGN-REQ-005)
@@ -111,7 +111,7 @@
 
 - [ ] T034 [P] Review `moonmind/workflows/skills/deployment_execution.py` and `api_service/services/deployment_operations.py` for secret hygiene and remove any unredacted failure or rollback evidence from outputs. (FR-001, FR-009, security guardrail)
 - [ ] T035 [P] Review `frontend/src/components/settings/OperationsSettingsSection.tsx` for accessible rollback button labels, confirmation text, and no overlapping or misleading UI states. (FR-004, FR-006, FR-007)
-- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification. (SC-001-SC-008)
+- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification, including existing retry-policy and allowlist boundary coverage in `tests/unit/workflows/skills/test_deployment_tool_contracts.py`, `tests/unit/workflows/skills/test_deployment_update_execution.py`, and `tests/unit/api/routers/test_deployment_operations.py`. (FR-002, FR-010, SC-001-SC-008, DESIGN-REQ-002, DESIGN-REQ-005)
 - [ ] T037 Run `./tools/test_integration.sh` when Docker is available; if unavailable, record the Docker availability blocker and the focused hermetic integration evidence from T032 in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (SC-004, SC-006)
 - [ ] T038 Run `/speckit.verify` after implementation and tests pass, preserving MM-523, final verdict, tests run, and remaining risks in `specs/265-explicit-failure-and-rollback-controls/verification.md`. (FR-011, SC-008)
 

--- a/specs/265-explicit-failure-and-rollback-controls/verification.md
+++ b/specs/265-explicit-failure-and-rollback-controls/verification.md
@@ -1,0 +1,67 @@
+# MoonSpec Verification Report
+
+**Feature**: Explicit Failure and Rollback Controls  
+**Spec**: `/work/agent_jobs/mm:e212af07-0a0e-4425-9ae8-5eb4e25d071e/repo/specs/265-explicit-failure-and-rollback-controls/spec.md`  
+**Original Request Source**: `spec.md` preserved Jira preset brief for `MM-523`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Focused unit | `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` | PASS | `42 passed in 0.47s`; covers failure classes, explicit retry, rollback submission, recent actions, admin and policy gates. |
+| Focused UI | `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` | PASS | Runs full Python unit suite first, then targeted Vitest: `4059 passed, 1 xpassed`; UI target `7 passed`. |
+| Focused integration | `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` | PASS | `4 passed in 0.03s`; covers tool dispatch failure metadata and rollback through existing typed tool contract. |
+| TypeScript | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS | No type errors. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | `4059 passed, 1 xpassed`; frontend unit suite `432 passed`. |
+| Hermetic integration suite | `./tools/test_integration.sh` | NOT RUN | Docker unavailable: cannot connect to `/var/run/docker.sock`. Focused `integration_ci` test passed outside compose. |
+| Traceability | `rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests` | PASS | Traceability present in artifacts, implementation, and tests. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `deployment_execution.py` failure output and `failureClass` details; backend tests cover invalid input, authorization, policy, lock, compose config, image pull, service recreation, verification | VERIFIED | Failure results are terminal/actionable and redacted where needed. |
+| FR-002 | Existing tool policy remains max attempts one; full unit suite includes deployment tool contract tests | VERIFIED | No automatic multi-attempt retry path added. |
+| FR-003 | API test `test_explicit_retry_submission_creates_distinct_audited_update_request` | VERIFIED | Re-run creates a separate request/idempotency key. |
+| FR-004 | Service/router rollback fields and tests for `operationKind=rollback` | VERIFIED | Rollback is a typed deployment update. |
+| FR-005 | API admin gate, confirmation validation, normal queued tool inputs, integration rollback dispatch | VERIFIED | Rollback requires admin, reason, confirmation and uses existing execution path for lock/artifacts/verification. |
+| FR-006 | Recent-action rollback eligibility models, API tests, UI rendering tests | VERIFIED | Rollback is offered only for eligible target image evidence. |
+| FR-007 | API/UI ineligible rollback tests | VERIFIED | Unsafe or missing evidence withholds rollback. |
+| FR-008 | Unit and integration tests assert failed execution does not emit rollback | VERIFIED | No silent rollback path exists by default. |
+| FR-009 | Recent-action response models and API/UI tests | VERIFIED | Failure/rollback records remain visible without exposing raw command logs by default. |
+| FR-010 | Existing allowlist validation plus rollback through same validated request path | VERIFIED | No shell, non-allowlisted stack, host path, or general GitOps expansion added. |
+| FR-011 | `MM-523` in spec artifacts, queued operation metadata, tasks, and this verification file | VERIFIED | Commit/PR metadata should also preserve `MM-523`. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| SCN-1 failure classes | Focused unit and integration tests | VERIFIED | Documented classes are asserted across API/tool failure surfaces. |
+| SCN-2 no automatic retry | Existing retry policy plus explicit retry test | VERIFIED | Default behavior remains single-attempt. |
+| SCN-3 rollback submission | API/UI/integration rollback tests | VERIFIED | Explicit confirmation and typed payload verified. |
+| SCN-4 eligible rollback action | API/UI tests | VERIFIED | Eligible target renders rollback button. |
+| SCN-5 unsafe rollback hidden | API/UI tests | VERIFIED | Unsafe target is not actionable and reason is shown. |
+| SCN-6 no silent rollback | Unit and integration tests | VERIFIED | Failed output does not include rollback action/continuation. |
+| SCN-7 audit visibility | Recent-action models and UI/API tests | VERIFIED | Recent action fields remain visible, raw command logs hidden unless permitted. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-001 | `failureClass` mappings and failure output tests | VERIFIED | Includes invalid input, authorization, policy, lock, compose config, pull, recreate, verification. |
+| DESIGN-REQ-002 | Max-attempts-one policy and explicit retry test | VERIFIED | Retry is a separate operator action. |
+| DESIGN-REQ-003 | Rollback request fields and typed tool dispatch tests | VERIFIED | Rollback uses existing update path. |
+| DESIGN-REQ-004 | Eligibility models plus no-silent-rollback tests | VERIFIED | Fail-closed rollback availability. |
+| DESIGN-REQ-005 | Existing allowlist and raw command hiding tests | VERIFIED | No out-of-scope executor added. |
+| DESIGN-REQ-006 | Desired-state/artifact path preserved; recent action fields exposed | VERIFIED | Tests preserve existing artifact/allowlist boundaries. |
+| Constitution IX/XI | TDD evidence, failure classification, and spec traceability | VERIFIED | Required unit and focused integration evidence are present. |
+
+## Gaps
+
+- Full compose-backed integration suite was not runnable in this workspace because Docker is unavailable.
+
+## Decision
+
+MM-523 is fully implemented with focused unit, UI, integration, typecheck, full unit, and traceability evidence. The remaining integration-suite gap is environmental, not an implementation gap.

--- a/tests/integration/temporal/test_deployment_update_execution_contract.py
+++ b/tests/integration/temporal/test_deployment_update_execution_contract.py
@@ -61,6 +61,26 @@ class HermeticRunner:
         )
 
 
+class FailedVerificationRunner(HermeticRunner):
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        return ComposeVerification(
+            succeeded=False,
+            updated_services=(),
+            running_services=({"name": "api", "state": "running"},),
+            details={
+                "message": "health check failed",
+                "requestedImage": requested_image,
+                "resolvedDigest": resolved_digest,
+            },
+        )
+
+
 def _snapshot():
     return create_registry_snapshot(
         skills=(
@@ -90,6 +110,22 @@ def _payload() -> dict[str, object]:
             "reason": "Update to tested build",
         },
     }
+
+
+def _rollback_payload() -> dict[str, object]:
+    payload = _payload()
+    inputs = dict(payload["inputs"])
+    inputs["image"] = {
+        "repository": "ghcr.io/moonladderstudios/moonmind",
+        "reference": "stable",
+    }
+    inputs["operationKind"] = "rollback"
+    inputs["rollbackSourceActionId"] = "depupd_recent"
+    inputs["confirmation"] = (
+        "Rollback to ghcr.io/moonladderstudios/moonmind:stable confirmed"
+    )
+    payload["inputs"] = inputs
+    return payload
 
 
 @pytest.mark.asyncio
@@ -153,3 +189,62 @@ async def test_deployment_update_tool_dispatch_surfaces_deployment_locked() -> N
 
     assert exc_info.value.error_code == "DEPLOYMENT_LOCKED"
     assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_ci
+async def test_deployment_update_tool_dispatch_failed_verification_has_failure_metadata(
+) -> None:
+    executor = DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=FailedVerificationRunner(),
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_deployment_update_tool_handler(dispatcher, executor=executor)
+
+    result = await execute_tool_activity(
+        invocation_payload=_payload(),
+        registry_snapshot=_snapshot(),
+        dispatcher=dispatcher,
+        context={"deployment_runner_mode": "privileged_worker"},
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "FAILED"
+    assert result.outputs["failure"] == {
+        "class": "verification_failure",
+        "reason": "health check failed",
+        "retryable": False,
+    }
+    assert "rollback" not in str(result.outputs).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.integration_ci
+async def test_rollback_dispatch_uses_existing_deployment_update_tool_contract(
+) -> None:
+    runner = HermeticRunner()
+    executor = DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=runner,
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_deployment_update_tool_handler(dispatcher, executor=executor)
+
+    result = await execute_tool_activity(
+        invocation_payload=_rollback_payload(),
+        registry_snapshot=_snapshot(),
+        dispatcher=dispatcher,
+        context={"deployment_runner_mode": "privileged_worker"},
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["requestedImage"] == (
+        "ghcr.io/moonladderstudios/moonmind:stable"
+    )

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -9,10 +9,17 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api_service.api.routers.deployment_operations import (
+    _get_deployment_service,
     _get_temporal_execution_service,
     router,
 )
 from api_service.auth_providers import get_current_user
+from api_service.services.deployment_operations import (
+    DeploymentOperationsService,
+    DeploymentRecentAction,
+    RollbackEligibilityDecision,
+    RollbackImageTarget,
+)
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     DEPLOYMENT_UPDATE_TOOL_VERSION,
@@ -57,6 +64,12 @@ def _override_execution_service(app: FastAPI) -> _FakeExecutionService:
     return service
 
 
+def _override_deployment_service(
+    app: FastAPI, service: DeploymentOperationsService
+) -> None:
+    app.dependency_overrides[_get_deployment_service] = lambda: service
+
+
 @pytest.fixture
 def admin_client() -> Iterator[tuple[TestClient, _FakeExecutionService]]:
     app = FastAPI()
@@ -92,6 +105,69 @@ def _valid_update_payload() -> dict[str, object]:
         "pruneOldImages": False,
         "reason": "Update to the latest tested MoonMind build",
     }
+
+
+def _rollback_payload(**overrides: object) -> dict[str, object]:
+    payload = _valid_update_payload()
+    payload.update(
+        {
+            "image": {
+                "repository": "ghcr.io/moonladderstudios/moonmind",
+                "reference": "stable",
+            },
+            "reason": "Rollback after failed update depupd_recent",
+            "operationKind": "rollback",
+            "rollbackSourceActionId": "depupd_recent",
+            "confirmation": (
+                "Rollback to ghcr.io/moonladderstudios/moonmind:stable confirmed"
+            ),
+        }
+    )
+    payload.update(overrides)
+    return payload
+
+
+def _recent_action_service(*, eligible: bool = True) -> DeploymentOperationsService:
+    eligibility = RollbackEligibilityDecision(
+        eligible=eligible,
+        target_image=(
+            RollbackImageTarget(
+                repository="ghcr.io/moonladderstudios/moonmind",
+                reference="stable",
+            )
+            if eligible
+            else None
+        ),
+        source_action_id="depupd_recent",
+        evidence_ref="art:sha256:before",
+        reason=None if eligible else "Before-state evidence is missing.",
+    )
+    return DeploymentOperationsService(
+        recent_actions={
+            "moonmind": (
+                DeploymentRecentAction(
+                    id="depupd_recent",
+                    kind="failure",
+                    status="FAILED",
+                    requested_image=(
+                        "ghcr.io/moonladderstudios/moonmind:20260425.1234"
+                    ),
+                    resolved_digest=None,
+                    operator="admin@example.com",
+                    reason="Routine release failed",
+                    started_at="2026-04-25T18:00:00Z",
+                    completed_at="2026-04-25T18:04:00Z",
+                    run_detail_url="/tasks/depupd_recent",
+                    logs_artifact_url="/api/artifacts/logs",
+                    raw_command_log_url=None,
+                    raw_command_log_permitted=False,
+                    before_summary="ghcr.io/moonladderstudios/moonmind:stable",
+                    after_summary="verification failed",
+                    rollback_eligibility=eligibility,
+                ),
+            )
+        }
+    )
 
 
 def test_admin_can_submit_policy_valid_deployment_update(
@@ -140,6 +216,30 @@ def test_deployment_update_uses_canonical_policy_stack_for_queued_run(
     assert parameters["task"]["plan"][0]["inputs"]["stack"] == "moonmind"
 
 
+def test_explicit_retry_submission_creates_distinct_audited_update_request(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+
+    first = client.post(
+        "/api/v1/operations/deployment/update",
+        json=_valid_update_payload(),
+    )
+    second_payload = _valid_update_payload()
+    second_payload["reason"] = "Explicit retry after failed deployment update"
+    second = client.post(
+        "/api/v1/operations/deployment/update",
+        json=second_payload,
+    )
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert len(execution_service.requests) == 2
+    assert execution_service.requests[0]["idempotency_key"] != (
+        execution_service.requests[1]["idempotency_key"]
+    )
+
+
 def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> None:
     response = user_client.post(
         "/api/v1/operations/deployment/update",
@@ -148,6 +248,7 @@ def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> N
 
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "deployment_update_forbidden"
+    assert response.json()["detail"]["failureClass"] == "authorization_failure"
 
 
 @pytest.mark.parametrize(
@@ -226,6 +327,45 @@ def test_current_deployment_state_returns_typed_shape(
     assert payload["services"][0]["state"] == "unknown"
 
 
+def test_deployment_state_returns_recent_failure_action_with_rollback_eligibility(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, _execution_service = admin_client
+    _override_deployment_service(client.app, _recent_action_service())
+
+    response = client.get("/api/v1/operations/deployment/stacks/moonmind")
+
+    assert response.status_code == 200
+    action = response.json()["recentActions"][0]
+    assert action["kind"] == "failure"
+    assert action["status"] == "FAILED"
+    assert action["rollbackEligibility"] == {
+        "eligible": True,
+        "sourceActionId": "depupd_recent",
+        "targetImage": {
+            "repository": "ghcr.io/moonladderstudios/moonmind",
+            "reference": "stable",
+        },
+        "reason": None,
+        "evidenceRef": "art:sha256:before",
+    }
+
+
+def test_deployment_state_withholds_rollback_for_missing_before_state_evidence(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, _execution_service = admin_client
+    _override_deployment_service(client.app, _recent_action_service(eligible=False))
+
+    response = client.get("/api/v1/operations/deployment/stacks/moonmind")
+
+    assert response.status_code == 200
+    eligibility = response.json()["recentActions"][0]["rollbackEligibility"]
+    assert eligibility["eligible"] is False
+    assert eligibility["targetImage"] is None
+    assert eligibility["reason"] == "Before-state evidence is missing."
+
+
 def test_allowed_image_targets_return_digest_guidance(
     admin_client: tuple[TestClient, _FakeExecutionService],
 ) -> None:
@@ -242,3 +382,42 @@ def test_allowed_image_targets_return_digest_guidance(
     assert repository["repository"] == "ghcr.io/moonladderstudios/moonmind"
     assert repository["digestPinningRecommended"] is True
     assert "latest" in repository["allowedReferences"]
+
+
+def test_admin_can_submit_rollback_through_typed_deployment_update(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+
+    response = client.post(
+        "/api/v1/operations/deployment/update",
+        json=_rollback_payload(),
+    )
+
+    assert response.status_code == 202
+    parameters = execution_service.requests[0]["initial_parameters"]
+    assert isinstance(parameters, dict)
+    operation = parameters["task"]["operation"]
+    plan_inputs = parameters["task"]["plan"][0]["inputs"]
+    assert operation["kind"] == "rollback"
+    assert operation["rollbackSourceActionId"] == "depupd_recent"
+    assert plan_inputs["operationKind"] == "rollback"
+    assert plan_inputs["rollbackSourceActionId"] == "depupd_recent"
+    assert plan_inputs["confirmation"].startswith("Rollback to")
+    assert plan_inputs["image"]["reference"] == "stable"
+
+
+def test_rollback_submission_requires_explicit_confirmation(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    payload = _rollback_payload(confirmation=" ")
+
+    response = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "deployment_confirmation_required"
+    assert execution_service.requests == []

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -34,10 +34,14 @@ class _FakeExecutionRecord:
 class _FakeExecutionService:
     def __init__(self) -> None:
         self.requests: list[dict[str, object]] = []
+        self.execution_items: list[object] = []
 
     async def create_execution(self, **kwargs: object) -> _FakeExecutionRecord:
         self.requests.append(kwargs)
         return _FakeExecutionRecord()
+
+    async def list_executions(self, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(items=self.execution_items)
 
 
 def _override_user(app: FastAPI, *, is_superuser: bool) -> None:
@@ -366,6 +370,65 @@ def test_deployment_state_withholds_rollback_for_missing_before_state_evidence(
     assert eligibility["reason"] == "Before-state evidence is missing."
 
 
+def test_deployment_state_projects_recent_actions_from_execution_history(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    execution_service.execution_items = [
+        SimpleNamespace(
+            workflow_id="mm:workflow-history",
+            run_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            owner_id="admin@example.com",
+            state="failed",
+            close_status="failed",
+            parameters={
+                "task": {
+                    "operation": {"kind": "update"},
+                    "plan": [
+                        {
+                            "tool": {
+                                "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+                                "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+                            },
+                            "inputs": {
+                                "stack": "moonmind",
+                                "image": {
+                                    "repository": (
+                                        "ghcr.io/moonladderstudios/moonmind"
+                                    ),
+                                    "reference": "20260425.1234",
+                                },
+                                "mode": "changed_services",
+                                "reason": "Routine release failed",
+                                "operationKind": "update",
+                            },
+                        }
+                    ],
+                }
+            },
+            memo={"summary": "Deployment update failed."},
+            artifact_refs=["art_before"],
+            started_at="2026-04-25T18:00:00Z",
+            closed_at="2026-04-25T18:04:00Z",
+        )
+    ]
+
+    response = client.get("/api/v1/operations/deployment/stacks/moonmind")
+
+    assert response.status_code == 200
+    action = response.json()["recentActions"][0]
+    assert action["id"] == "depupd_aaaaaaaabbbbccccddddeeeeeeeeeeee"
+    assert action["kind"] == "failure"
+    assert action["status"] == "FAILED"
+    assert action["requestedImage"] == (
+        "ghcr.io/moonladderstudios/moonmind:20260425.1234"
+    )
+    assert action["reason"] == "Routine release failed"
+    assert action["runDetailUrl"] == "/tasks/mm:workflow-history"
+    assert action["rollbackEligibility"]["eligible"] is False
+    assert action["rollbackEligibility"]["evidenceRef"] == "art_before"
+
+
 def test_allowed_image_targets_return_digest_guidance(
     admin_client: tuple[TestClient, _FakeExecutionService],
 ) -> None:
@@ -405,6 +468,28 @@ def test_admin_can_submit_rollback_through_typed_deployment_update(
     assert plan_inputs["rollbackSourceActionId"] == "depupd_recent"
     assert plan_inputs["confirmation"].startswith("Rollback to")
     assert plan_inputs["image"]["reference"] == "stable"
+
+
+def test_repeated_rollback_submissions_are_distinct_explicit_actions(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+
+    first = client.post(
+        "/api/v1/operations/deployment/update",
+        json=_rollback_payload(),
+    )
+    second = client.post(
+        "/api/v1/operations/deployment/update",
+        json=_rollback_payload(),
+    )
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert len(execution_service.requests) == 2
+    assert execution_service.requests[0]["idempotency_key"] != (
+        execution_service.requests[1]["idempotency_key"]
+    )
 
 
 def test_rollback_submission_requires_explicit_confirmation(

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -10,6 +10,7 @@ from moonmind.workflows.skills.deployment_execution import (
     DeploymentUpdateExecutor,
     DeploymentUpdateLockManager,
     InMemoryDesiredStateStore,
+    _ensure_command_succeeded,
     build_compose_command_plan,
     build_deployment_update_handler,
 )
@@ -160,6 +161,13 @@ class FailingUpRunner(RecordingRunner):
         return {"stack": stack, "command": list(command), "exitCode": 17}
 
 
+class FailingPullRunner(RecordingRunner):
+    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+        self.events.append("runner:pull")
+        self.commands.append(("pull", command))
+        return {"stack": stack, "command": list(command), "exitCode": 23}
+
+
 class SecretRecordingRunner(RecordingRunner):
     async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
         self.events.append(f"runner:capture:{phase}")
@@ -255,6 +263,7 @@ async def test_same_stack_lock_contention_fails_before_side_effects() -> None:
 
     assert exc_info.value.error_code == "DEPLOYMENT_LOCKED"
     assert exc_info.value.retryable is False
+    assert exc_info.value.details["failureClass"] == "deployment_lock_unavailable"
     assert second_executor.desired_state_store.records == []
 
     blocking_runner.release_before_capture()
@@ -350,6 +359,82 @@ async def test_verification_failure_returns_failed_tool_result_with_evidence_ref
 
 
 @pytest.mark.asyncio
+async def test_verification_failure_outputs_failure_class_and_actionable_reason(
+) -> None:
+    events: list[str] = []
+    runner = SecretVerificationFailureRunner(events)
+    executor, _store, _evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
+
+    result = await executor.execute(_inputs())
+
+    assert result.outputs["failure"] == {
+        "class": "verification_failure",
+        "reason": "health check failed with [REDACTED],log_level=info",
+        "retryable": False,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected_class"),
+    [
+        (_inputs(stack="other-stack"), "invalid_input"),
+        (_inputs(updaterRunnerImage="docker:29-cli"), "invalid_input"),
+    ],
+)
+async def test_invalid_input_failures_include_normalized_failure_class(
+    payload: dict[str, object], expected_class: str
+) -> None:
+    executor, _store, _evidence, _runner, _events = _executor()
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(payload)
+
+    assert exc_info.value.details["failureClass"] == expected_class
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("runner", "expected_phase", "expected_class"),
+    [
+        (FailingPullRunner, "pull", "image_pull_failure"),
+        (FailingUpRunner, "up", "service_recreation_failure"),
+    ],
+)
+async def test_command_failures_include_normalized_failure_class(
+    runner: type[RecordingRunner], expected_phase: str, expected_class: str
+) -> None:
+    events: list[str] = []
+    executor, _store, _evidence, _runner, _events = _executor(
+        runner=runner(events), events=events
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs())
+
+    assert exc_info.value.details["phase"] == expected_phase
+    assert exc_info.value.details["failureClass"] == expected_class
+
+
+@pytest.mark.asyncio
+async def test_failed_execution_does_not_emit_rollback_without_explicit_request(
+) -> None:
+    events: list[str] = []
+    runner = RecordingRunner(events, verification_succeeded=False)
+    executor, _store, _evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
+
+    result = await executor.execute(_inputs())
+
+    serialized = json.dumps(result.outputs)
+    assert "rollback" not in serialized.lower()
+    assert result.outputs["status"] == "FAILED"
+
+
+@pytest.mark.asyncio
 async def test_forbidden_runner_image_and_path_inputs_are_rejected() -> None:
     executor, _store, _evidence, _runner, _events = _executor()
 
@@ -419,6 +504,15 @@ def test_unsupported_runner_mode_fails_closed() -> None:
         )
 
     assert exc_info.value.error_code == "POLICY_VIOLATION"
+    assert exc_info.value.details["failureClass"] == "policy_violation"
+
+
+def test_compose_config_validation_failure_has_normalized_class() -> None:
+    with pytest.raises(ToolFailure) as exc_info:
+        _ensure_command_succeeded("config", {"status": "invalid"})
+
+    assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert exc_info.value.details["failureClass"] == "compose_config_validation_failure"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Jira issue

MM-523

## Active MoonSpec feature path

`specs/265-explicit-failure-and-rollback-controls`

## Verification verdict

FULLY_IMPLEMENTED, recorded in `specs/265-explicit-failure-and-rollback-controls/verification.md`.

## Summary

Implements explicit failure and rollback controls for the policy-gated deployment update path.

- Adds normalized deployment failure metadata and failure-class coverage for invalid input, authorization, policy, deployment lock, Compose config, image pull, service recreation, and verification failures.
- Adds explicit rollback request metadata (`operationKind=rollback`, `rollbackSourceActionId`, `confirmation`) through the API and queued typed deployment tool inputs.
- Exposes recent deployment action rollback eligibility and renders UI rollback controls only for eligible safe targets, while withholding unsafe actions.
- Preserves MM-523 MoonSpec traceability in tasks and verification artifacts.

## Tests run

- `pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/api/routers/test_deployment_operations.py -q` PASS: 42 tests.
- `pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` PASS: 4 tests.
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` PASS.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS: 4059 Python tests plus 432 frontend tests.
- `./tools/test_unit.sh --ui-args frontend/src/components/settings/OperationsSettingsSection.test.tsx` PASS.
- `rg -n "MM-523|DESIGN-REQ-001|rollbackEligibility|operationKind|failureClass" specs/265-explicit-failure-and-rollback-controls moonmind api_service frontend/src tests` PASS.

## Remaining risks

- `./tools/test_integration.sh` was not runnable in this managed workspace because Docker is unavailable at `/var/run/docker.sock`; focused hermetic integration coverage passed outside compose and the blocker is recorded in the verification report.
