### PR TITLE
[codex] Fix executing text sweep timing

### DIFF
--- a/docs/UI/EffectShimmerSweep.md
+++ b/docs/UI/EffectShimmerSweep.md
@@ -127,6 +127,14 @@ motion:
     allow_overlap_between_cycles: false
     idle_gap_present: false
     center_pause_present: false
+
+  foreground_text:
+    timing_source: physical_sweep_center
+    first_glyph_phase_ratio: 0.20
+    last_glyph_phase_ratio: 0.38
+    glyph_pulse_duration_ratio: 0.05
+    idle_tail_present: true
+    note: matching cycle duration alone is insufficient because background-position percentage travel is measured against the oversized background image; the foreground wave must complete quickly, then remain inactive until the next outer cycle
 ```
 
 ## Theme Binding
@@ -268,8 +276,11 @@ implementation_shape:
     glyph_brightening:
       strategy: split_visible_label_into_grapheme_spans
       animation: css_only
-      timing: use_shorter_letter_cycle_duration
-      edge_padding_chars: 3
+      timing: faster_active_sweep_inside_shared_outer_cycle
+      first_glyph_phase_ratio: 0.20
+      last_glyph_phase_ratio: 0.38
+      glyph_pulse_duration_ratio: 0.05
+      idle_tail_present: true
       accessibility:
         parent_exposes_complete_label: true
         visual_glyphs_are_hidden_from_assistive_tech: true
@@ -313,6 +324,8 @@ effect_tokens:
   --mm-executing-sweep-layer-offset-x: -12%
   --mm-executing-sweep-layer-offset-y: -10%
   --mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)
+  --mm-executing-letter-sweep-start-ratio: 0.2
+  --mm-executing-letter-sweep-travel-ratio: 0.18
 ```
 
 ## Non-Goals

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -412,7 +412,8 @@ describe('Mission Control shared entry', () => {
     expect(missionControlCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
     expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-width:\s*84%/);
     expect(missionControlCss).toContain('--mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)');
-    expect(missionControlCss).toMatch(/--mm-executing-letter-edge-padding:\s*3/);
+    expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-start-ratio:\s*0\.2/);
+    expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-travel-ratio:\s*0\.18/);
     expect(missionControlCss).toMatch(/--mm-executing-letter-sweep-direction:\s*1/);
     expect(missionControlCss).toContain('--mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32)');
     expect(missionControlCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%)');
@@ -468,11 +469,13 @@ describe('Mission Control shared entry', () => {
     expect(glyphBlock).toContain('animation-name: mm-executing-letter-brighten');
     expect(glyphBlock).toContain('animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))');
     expect(glyphBlock).toContain('var(--mm-executing-letter-sweep-direction)');
-    expect(glyphBlock).toContain('var(--mm-executing-letter-edge-padding)');
+    expect(glyphBlock).toContain('--mm-letter-phase-max: max(calc(var(--mm-letter-count, 1) - 1), 1)');
+    expect(glyphBlock).toContain('var(--mm-executing-letter-sweep-start-ratio)');
+    expect(glyphBlock).toContain('var(--mm-executing-letter-sweep-travel-ratio)');
     expect(glyphBlock).toContain('animation-delay: calc(var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms)) * var(--mm-letter-delay-ratio))');
     expect(glyphBlock).not.toContain('will-change');
     expect(missionControlCss).toMatch(
-      /@keyframes mm-executing-letter-brighten\s*\{[\s\S]*?0%\s*\{[\s\S]*?var\(--mm-executing-letter-bright[\s\S]*?5%\s*\{[\s\S]*?brightness\(1\.14\)[\s\S]*?8%,\s*100%\s*\{[\s\S]*?brightness\(1\)/,
+      /@keyframes mm-executing-letter-brighten\s*\{[\s\S]*?0%\s*\{[\s\S]*?var\(--mm-executing-letter-bright[\s\S]*?3%\s*\{[\s\S]*?brightness\(1\.14\)[\s\S]*?5%,\s*100%\s*\{[\s\S]*?brightness\(1\)/,
     );
     expect(missionControlCss).toMatch(
       /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.status-letter-wave__glyph\s*\{[\s\S]*?animation: none !important;[\s\S]*?text-shadow: none !important;[\s\S]*?filter: none !important;/,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -56,7 +56,8 @@
   --mm-executing-sweep-halo-opacity: 0.14;
   --mm-executing-letter-sweep-width: 84%;
   --mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration);
-  --mm-executing-letter-edge-padding: 3;
+  --mm-executing-letter-sweep-start-ratio: 0.2;
+  --mm-executing-letter-sweep-travel-ratio: 0.18;
   --mm-executing-letter-sweep-direction: 1;
   --mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32);
   --mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%);
@@ -1376,7 +1377,8 @@ tr[data-proposal-id].proposal-consuming td {
   --mm-letter-phase-forward: calc((1 + var(--mm-executing-letter-sweep-direction)) / 2 * var(--mm-letter-index, 0));
   --mm-letter-phase-reverse: calc((1 - var(--mm-executing-letter-sweep-direction)) / 2 * (var(--mm-letter-count, 1) - 1 - var(--mm-letter-index, 0)));
   --mm-letter-phase: calc(var(--mm-letter-phase-forward) + var(--mm-letter-phase-reverse));
-  --mm-letter-delay-ratio: calc((var(--mm-letter-phase) + var(--mm-executing-letter-edge-padding)) / (var(--mm-letter-count, 1) + (var(--mm-executing-letter-edge-padding) * 2)));
+  --mm-letter-phase-max: max(calc(var(--mm-letter-count, 1) - 1), 1);
+  --mm-letter-delay-ratio: calc(var(--mm-executing-letter-sweep-start-ratio) + ((var(--mm-letter-phase) / var(--mm-letter-phase-max)) * var(--mm-executing-letter-sweep-travel-ratio)));
   animation-name: mm-executing-letter-brighten;
   animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms));
   animation-timing-function: linear;
@@ -1393,7 +1395,7 @@ tr[data-proposal-id].proposal-consuming td {
     filter: brightness(1.22);
   }
 
-  5% {
+  3% {
     color: var(--mm-executing-letter-bright, currentColor);
     text-shadow:
       0 0 0.2rem var(--mm-executing-letter-halo, rgb(var(--mm-accent-2) / 0.24)),
@@ -1401,7 +1403,7 @@ tr[data-proposal-id].proposal-consuming td {
     filter: brightness(1.14);
   }
 
-  8%,
+  5%,
   100% {
     text-shadow: none;
     filter: brightness(1);

--- a/specs/259-executing-text-brightening/contracts/execution-status-pill.md
+++ b/specs/259-executing-text-brightening/contracts/execution-status-pill.md
@@ -15,7 +15,8 @@ It renders:
 
 - The executing host continues to use `mm-status-pill-shimmer` and `--mm-executing-sweep-cycle-duration`.
 - `.status-letter-wave` is the foreground visual layer above the physical sweep.
-- `.status-letter-wave__glyph` uses `animation-name: mm-executing-letter-brighten`, `animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))`, and `animation-delay` derived from `--mm-executing-letter-cycle-duration` with `--mm-executing-sweep-cycle-duration` fallback, `--mm-executing-letter-edge-padding`, `--mm-executing-letter-sweep-direction`, `--mm-letter-count`, and `--mm-letter-index`.
+- `.status-letter-wave__glyph` uses `animation-name: mm-executing-letter-brighten`, `animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))`, and `animation-delay` derived from `--mm-executing-letter-cycle-duration` with `--mm-executing-sweep-cycle-duration` fallback, `--mm-executing-letter-sweep-start-ratio`, `--mm-executing-letter-sweep-travel-ratio`, `--mm-executing-letter-sweep-direction`, `--mm-letter-count`, and `--mm-letter-index`.
+- The foreground text wave completes during a shorter active window inside the shared outer cycle and stays inactive for the rest of the cycle.
 - Reduced motion disables glyph animation, text shadow, and filter.
 
 ## Task-List Integration Contract

--- a/specs/259-executing-text-brightening/data-model.md
+++ b/specs/259-executing-text-brightening/data-model.md
@@ -17,7 +17,8 @@ Validation rules:
 
 - **glyphs**: visible label split into graphemes.
 - **phase index**: glyph order adjusted to match the current left-to-right/top-left-to-bottom-right visible sweep direction.
-- **delay**: CSS animation-delay derived from `(phaseIndex + edgePadding) / (glyphCount + edgePadding * 2) * var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))`.
+- **delay**: CSS animation-delay derived from `letterSweepStartRatio + ((phaseIndex / max(glyphCount - 1, 1)) * letterSweepTravelRatio)`, multiplied by `var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))`.
+- **active window**: the foreground text wave uses the shared outer cycle but completes its glyph-to-glyph travel quickly, then remains inactive until the next cycle.
 
 State transitions:
 

--- a/specs/259-executing-text-brightening/plan.md
+++ b/specs/259-executing-text-brightening/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Add a task-list `ExecutionStatusPill` component that keeps status normalization in `executionStatusPillProps()`, renders non-executing states as plain text, and renders executing states as a parent status pill with an accessible label plus hidden per-grapheme visual spans. Replace the task-list table and card status span call sites with the component. Update Mission Control CSS so the existing executing physical sweep remains on the host and the new glyph spans run a CSS-only brightening pulse using the shared sweep duration token. Validate with focused Vitest coverage, typecheck, lint, and the repo unit runner where available.
+Add a task-list `ExecutionStatusPill` component that keeps status normalization in `executionStatusPillProps()`, renders non-executing states as plain text, and renders executing states as a parent status pill with an accessible label plus hidden per-grapheme visual spans. Replace the task-list table and card status span call sites with the component. Update Mission Control CSS so the existing executing physical sweep remains on the host and the new glyph spans run a CSS-only brightening pulse using the shared sweep duration token as the outer cycle, with a faster active text-sweep window and inactive tail. Validate with focused Vitest coverage, typecheck, lint, and the repo unit runner where available.
 
 ## Requirement Status
 
@@ -18,7 +18,7 @@ Add a task-list `ExecutionStatusPill` component that keeps status normalization 
 | FR-003 | implemented_verified | CSS keyframes and no timer/state animation in `ExecutionStatusPill.tsx` | complete | typecheck + lint passed |
 | FR-004 | implemented_verified | `.status-letter-wave__glyph` render assertions | complete | integration test passed |
 | FR-005 | implemented_verified | `Intl.Segmenter` with `Array.from` fallback in component | complete | typecheck passed |
-| FR-006 | implemented_verified | `--mm-executing-sweep-cycle-duration` CSS and per-glyph delay assertions | complete | CSS unit + integration tests passed |
+| FR-006 | implemented_verified | `--mm-executing-sweep-cycle-duration`, active-window ratio CSS, and per-glyph delay assertions | complete | CSS unit + integration tests passed |
 | FR-007 | implemented_verified | `aria-label` and `aria-hidden` task-list assertions | complete | integration test passed |
 | FR-008 | implemented_verified | reduced-motion glyph suppression assertions | complete | CSS unit test passed |
 | FR-009 | implemented_verified | component delegates to `executionStatusPillProps()` | complete | integration test passed |

--- a/specs/259-executing-text-brightening/quickstart.md
+++ b/specs/259-executing-text-brightening/quickstart.md
@@ -26,5 +26,5 @@ If the managed workspace path prevents `npm run` from resolving local binaries, 
 
 - Executing task-list table and card pills have `data-effect="shimmer-sweep"`, `aria-label="executing"`, `.status-letter-wave[aria-hidden="true"]`, and one `.status-letter-wave__glyph` per visible letter.
 - Non-executing task-list pills have no executing shimmer metadata and no glyph-wave markup.
-- CSS keeps the existing physical sweep and adds `mm-executing-letter-brighten` with the shared duration token.
+- CSS keeps the existing physical sweep and adds `mm-executing-letter-brighten` with the shared duration token, faster active text-sweep ratios, and an inactive tail before the next cycle.
 - Reduced-motion CSS disables glyph animation, text shadow, and filter.

--- a/specs/259-executing-text-brightening/research.md
+++ b/specs/259-executing-text-brightening/research.md
@@ -26,11 +26,11 @@ Test implications: Task-list integration verifies executing label becomes one gl
 
 ## DESIGN-REQ-004 Timing And Direction
 
-Decision: Use the CSS token duration with the configured sweep fallback in styles and calculate per-glyph phase ratios from glyph index/count in component code. Set direction to left-to-right/top-left-to-bottom-right to match the visible sweep described by the canonical UI design.
-Evidence: Existing CSS moves from `--mm-executing-sweep-start-x: 135%` to `--mm-executing-sweep-end-x: -135%`.
-Rationale: The foreground wave should feel phase-locked with the physical sweep.
+Decision: Use the CSS token duration with the configured sweep fallback as the outer cycle, but run the foreground text wave through a shorter active phase inside that cycle. Calculate per-glyph phase ratios from glyph index/count, start the first glyph at the configured active-window ratio, sweep across the word using a smaller travel ratio, then leave the glyphs inactive for the rest of the cycle. Set direction to left-to-right/top-left-to-bottom-right to match the visible sweep described by the canonical UI design.
+Evidence: Existing CSS moves from `--mm-executing-sweep-start-x: 135%` to `--mm-executing-sweep-end-x: -135%`, but the oversized background layers mean equal cycle duration alone does not produce equal perceived sweep speed.
+Rationale: The foreground wave should feel phase-locked with the physical sweep; a faster text active window plus idle tail matches the visual sweep better than stretching glyph delays across the full outer cycle.
 Alternatives considered: Right-to-left phase order. Rejected because the visible sweep direction is left-to-right/top-left-to-bottom-right even though oversized background-position tokens move inversely.
-Test implications: Render tests assert every glyph receives a millisecond delay; CSS tests assert the shared duration token.
+Test implications: Render tests assert every glyph receives index/count values; CSS tests assert the shared duration token plus the active-window start and travel ratios.
 
 ## DESIGN-REQ-005 Accessibility
 

--- a/specs/259-executing-text-brightening/spec.md
+++ b/specs/259-executing-text-brightening/spec.md
@@ -35,7 +35,7 @@ The cleanest patch: implement the glyph-span component and keep the existing bro
 **Acceptance Scenarios**:
 
 1. **Given** a task-list table row or card row is executing, **When** the status pill renders, **Then** the visible label is represented by one hidden visual glyph span containing one styled span per grapheme.
-2. **Given** an executing task-list status pill is rendered, **When** the letter wave is active, **Then** each glyph receives a deterministic CSS delay so the brightening wave enters and exits smoothly with edge padding.
+2. **Given** an executing task-list status pill is rendered, **When** the letter wave is active, **Then** each glyph receives a deterministic CSS delay so the brightening wave crosses quickly inside the shared outer cycle and remains inactive until the next cycle.
 3. **Given** the executing status pill renders its glyph layer, **When** assistive technology reads the pill, **Then** it receives the complete status phrase from the parent label rather than individual letters.
 4. **Given** a task-list status is not executing, **When** the pill renders, **Then** it keeps the existing plain status text and does not receive glyph-wave markup or executing shimmer metadata.
 5. **Given** reduced-motion preference is active, **When** executing pills are visible, **Then** the physical sweep and glyph brightening animations are disabled while the active executing treatment remains recognizable.
@@ -75,7 +75,7 @@ The cleanest patch: implement the glyph-span component and keep the existing bro
 - **FR-003**: The text-brightening layer MUST be CSS-driven and MUST NOT use a JavaScript animation loop or periodic React rerender.
 - **FR-004**: The executing text-brightening layer MUST render one visual glyph span per visible grapheme.
 - **FR-005**: The glyph splitting MUST use platform grapheme segmentation when available and fall back safely when it is not.
-- **FR-006**: The glyph brightening animation MUST use `--mm-executing-sweep-cycle-duration` with the configured sweep fallback and per-glyph delays with edge padding.
+- **FR-006**: The glyph brightening animation MUST use `--mm-executing-sweep-cycle-duration` with the configured sweep fallback as the outer cycle, with per-glyph delays constrained to a faster active text-sweep window followed by an inactive tail.
 - **FR-007**: The executing glyph layer MUST be hidden from assistive technology while the parent status pill exposes the full readable label.
 - **FR-008**: Reduced-motion styling MUST disable glyph brightening animation, text shadow, and filter effects.
 - **FR-009**: Executing status detection MUST continue to use `executionStatusPillProps()` as the central selector contract.

--- a/specs/259-executing-text-brightening/verification.md
+++ b/specs/259-executing-text-brightening/verification.md
@@ -1,6 +1,7 @@
 # Verification: Executing Text Brightening Sweep
 
 **Date**: 2026-04-25  
+**Last Refreshed**: 2026-04-26  
 **Spec**: `specs/259-executing-text-brightening/spec.md`  
 **Verdict**: FULLY_IMPLEMENTED
 
@@ -12,7 +13,7 @@
 | FR-002, FR-004, DESIGN-REQ-003 | `frontend/src/components/ExecutionStatusPill.tsx` renders `.status-letter-wave__glyph` spans for executing labels; `frontend/src/entrypoints/tasks-list.test.tsx` verifies one glyph per `executing` letter in table and card pills. | PASS |
 | FR-003, DESIGN-REQ-002 | The component computes static CSS custom-property delays only; repeated motion is CSS keyframes in `mission-control.css`. No timer or animation loop is introduced. | PASS |
 | FR-005 | `ExecutionStatusPill.tsx` uses `Intl.Segmenter` when available and falls back to `Array.from`. Typecheck passed. | PASS |
-| FR-006, DESIGN-REQ-004 | Glyph CSS uses `var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))` and render tests verify each glyph receives index/count values for CSS delay calculation. | PASS |
+| FR-006, DESIGN-REQ-004 | Glyph CSS uses `var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms))` as the outer cycle, with `--mm-executing-letter-sweep-start-ratio` and `--mm-executing-letter-sweep-travel-ratio` defining a faster active text wave followed by an inactive tail. Render tests verify each glyph receives index/count values for CSS delay calculation. | PASS |
 | FR-007, DESIGN-REQ-005 | Executing parent pill has `aria-label`; visual glyph wrapper has `aria-hidden="true"` and preserves full `textContent`. | PASS |
 | FR-008, DESIGN-REQ-006 | Reduced-motion CSS disables glyph animation, text shadow, and filter. | PASS |
 | FR-009, DESIGN-REQ-007 | `ExecutionStatusPill` delegates status metadata to `executionStatusPillProps()`. Existing executing metadata assertions still pass. | PASS |
@@ -23,6 +24,8 @@
 
 - `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/mission-control.test.tsx`: PASS
   - Python unit suite: 4000 passed, 1 xpassed, 16 subtests passed.
+  - Focused frontend tests: 2 files passed, 45 tests passed.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx`: PASS on 2026-04-26
   - Focused frontend tests: 2 files passed, 45 tests passed.
 - `./node_modules/.bin/vitest run --config frontend/vite.config.ts`: PASS
   - Full frontend tests: 14 files passed, 424 tests passed.


### PR DESCRIPTION
## Summary
- make the executing text brightening wave complete during a shorter active window inside the shared shimmer cycle
- leave the glyph wave inactive for the rest of the cycle so it aligns with the next physical sweep
- update the shimmer docs and MoonSpec artifacts to describe the active-window timing model

## Root Cause
The glyph brightening used the same outer duration as the physical sweep, but its active delays were spread too broadly across the cycle. That made the text sweep look visually slower even though the duration token matched.

## Validation
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx