### PR TITLE
[codex] Fix Jira story breakdown handoff

### DIFF
--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -505,17 +505,21 @@ the planner may use the narrower deterministic batch tool:
  "dependencyMode": "linear_blocker_chain"
  }
  },
+ "storyBreakdownArtifactRef": "art_01ABC...",
  "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json"
  }
 }
 ```
 
 `story.create_jira_issues` is backed by `mm.tool.execute` and requires
-`integration:jira`. It creates one Jira issue per story from inline `stories` or
+`integration:jira`. It creates one Jira issue per story from inline `stories`,
+from `storyBreakdownArtifactRef`, from previous step story-output payloads, or
 from `storyBreakdownPath`, resolves `issueTypeName` through the trusted Jira
 metadata surface when `issueTypeId` is not supplied, and creates dependency
-links when `dependencyMode = linear_blocker_chain`. It is not the default path
-for ambiguous Jira requests.
+links when `dependencyMode = linear_blocker_chain`. Repository path reads are a
+publication fallback; workflow-local story handoff should use inline stories or
+artifact refs so Jira creation does not depend on a protected branch push. It is
+not the default path for ambiguous Jira requests.
 
 For breakdown-driven Jira output, the canonical traceability shape is
 `sourceReference.path` on every story, with `source.referencePath` or

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -39,6 +39,10 @@ StoryFetcher = Callable[
     [str, str, str],
     str | Awaitable[str],
 ]
+ArtifactReader = Callable[
+    [str],
+    str | bytes | Awaitable[str | bytes],
+]
 JiraServiceFactory = Callable[[], JiraToolService]
 ExecutionCreator = Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]]
 
@@ -822,10 +826,18 @@ async def create_jira_issues_from_stories(
     *,
     jira_service_factory: JiraServiceFactory = JiraToolService,
     story_fetcher: StoryFetcher = _default_github_story_fetcher,
+    artifact_reader: ArtifactReader | None = None,
 ) -> ToolResult:
     """Create one Jira issue per story, or report story-breakdown fallback metadata."""
 
+    previous_outputs = _mapping(
+        (_context or {}).get("previousOutputs")
+        or (_context or {}).get("previous_outputs")
+    )
     story_output = _mapping(inputs.get("storyOutput") or inputs.get("story_output"))
+    previous_story_output = _mapping(
+        previous_outputs.get("storyOutput") or previous_outputs.get("story_output")
+    )
     story_output_mode = str(
         story_output.get("mode") or story_output.get("target") or ""
     ).strip().lower()
@@ -886,9 +898,61 @@ async def create_jira_issues_from_stories(
         or inputs.get("storyBreakdown")
         or inputs.get("story_breakdown")
         or inputs.get("storyBreakdownJson")
+        or previous_outputs.get("stories")
+        or previous_outputs.get("storyBreakdown")
+        or previous_outputs.get("story_breakdown")
+        or previous_outputs.get("storyBreakdownJson")
+        or previous_story_output.get("stories")
+        or previous_story_output.get("storyBreakdown")
+        or previous_story_output.get("story_breakdown")
+        or previous_story_output.get("storyBreakdownJson")
     )
     breakdown_source_path = _breakdown_source_path(raw_story_payload)
     stories = _coerce_story_payload(raw_story_payload)
+    if not stories:
+        artifact_ref = _string(
+            inputs.get("storyBreakdownArtifactRef")
+            or inputs.get("story_breakdown_artifact_ref")
+            or story_output.get("storyBreakdownArtifactRef")
+            or story_output.get("story_breakdown_artifact_ref")
+            or previous_outputs.get("storyBreakdownArtifactRef")
+            or previous_outputs.get("story_breakdown_artifact_ref")
+            or previous_story_output.get("storyBreakdownArtifactRef")
+            or previous_story_output.get("story_breakdown_artifact_ref")
+        )
+        if artifact_ref:
+            try:
+                if artifact_reader is None:
+                    raise ValueError(
+                        "storyBreakdownArtifactRef was provided, but this worker "
+                        "has no artifact reader configured."
+                    )
+                artifact_payload = artifact_reader(artifact_ref)
+                if inspect.isawaitable(artifact_payload):
+                    artifact_payload = await artifact_payload  # type: ignore[assignment]
+                if isinstance(artifact_payload, bytes):
+                    artifact_payload = artifact_payload.decode(
+                        "utf-8", errors="replace"
+                    )
+                parsed_payload: Any = artifact_payload
+                if isinstance(artifact_payload, str) and artifact_payload.strip():
+                    try:
+                        parsed_payload = json.loads(artifact_payload)
+                    except json.JSONDecodeError:
+                        parsed_payload = artifact_payload
+                breakdown_source_path = _breakdown_source_path(parsed_payload)
+                stories = _coerce_story_payload(parsed_payload)
+            except Exception as exc:
+                if fallback_for_missing_stories:
+                    return _fallback_result(
+                        reason=(
+                            "Unable to read story breakdown artifact for Jira "
+                            f"output: {exc}"
+                        ),
+                        inputs=inputs,
+                        dependency_mode=dependency_mode,
+                    )
+                raise
     if not stories:
         repo = _string(inputs.get("repository") or inputs.get("repo"))
         ref = _string(
@@ -899,6 +963,8 @@ async def create_jira_issues_from_stories(
         path = _string(
             inputs.get("storyBreakdownPath")
             or story_output.get("storyBreakdownPath")
+            or previous_outputs.get("storyBreakdownPath")
+            or previous_story_output.get("storyBreakdownPath")
         )
         if repo and ref and path:
             try:
@@ -914,6 +980,26 @@ async def create_jira_issues_from_stories(
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
+                push_status = _string(
+                    previous_outputs.get("push_status")
+                    or previous_outputs.get("pushStatus")
+                )
+                push_branch = _string(
+                    previous_outputs.get("push_branch")
+                    or previous_outputs.get("pushBranch")
+                )
+                if (
+                    push_status == "protected_branch"
+                    and push_branch
+                    and ref == push_branch
+                ):
+                    raise ValueError(
+                        "Unable to read story breakdown for Jira output because "
+                        f"the previous step produced it on protected branch '{push_branch}' "
+                        "and it was not published. Jira story creation requires inline "
+                        "stories, storyBreakdownArtifactRef, or a readable repo/ref/path "
+                        "from a published handoff branch."
+                    ) from exc
                 if fallback_for_missing_stories:
                     return _fallback_result(
                         reason=f"Unable to read story breakdown for Jira output: {exc}",
@@ -1117,11 +1203,22 @@ def register_story_output_tool_handlers(
     dispatcher: Any,
     *,
     execution_creator: ExecutionCreator | None = None,
+    artifact_reader: ArtifactReader | None = None,
 ) -> None:
+    async def _create_jira_issues(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await create_jira_issues_from_stories(
+            inputs,
+            context,
+            artifact_reader=artifact_reader,
+        )
+
     dispatcher.register_skill(
         skill_name=JIRA_CREATE_ISSUES_TOOL_NAME,
         version="1.0",
-        handler=create_jira_issues_from_stories,
+        handler=_create_jira_issues,
     )
 
     async def _create_jira_orchestrate_tasks(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -759,9 +759,9 @@ def _build_runtime_planner():
                 existing={**story_output_payload, **node_inputs},
             )
             node_inputs.update(story_paths)
-            if story_output_mode == "jira" and not (
-                node_inputs.get("targetBranch") or node_inputs.get("branch")
-            ):
+            if story_output_mode == "jira" and not node_inputs.get("targetBranch"):
+                if node_inputs.get("branch") and not node_inputs.get("startingBranch"):
+                    node_inputs["startingBranch"] = node_inputs["branch"]
                 prefix = _derive_pr_branch_prefix(
                     task_payload=task_payload,
                     publish_payload=publish_payload,
@@ -1179,9 +1179,19 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
         planner = _build_runtime_planner()
 
         dispatcher = SkillActivityDispatcher()
+
+        async def _read_story_output_artifact(artifact_ref: str) -> bytes:
+            _artifact, payload = await artifact_service.read(
+                artifact_id=artifact_ref,
+                principal="system:story_output",
+                allow_restricted_raw=True,
+            )
+            return payload
+
         register_story_output_tool_handlers(
             dispatcher,
             execution_creator=_build_jira_orchestrate_execution_creator(),
+            artifact_reader=_read_story_output_artifact,
         )
 
         run_store = None

--- a/specs/266-jira-story-breakdown-handoff/plan.md
+++ b/specs/266-jira-story-breakdown-handoff/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: Jira Story Breakdown Handoff
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. The change keeps agent generation and deterministic Jira creation in their existing boundaries.
+- IV Own Your Data: PASS. Artifact refs become a first-class handoff input before external GitHub fetches.
+- V Skills Are First-Class: PASS. The executable `story.create_jira_issues` contract is clarified and tested.
+- IX Resilient by Default: PASS. Protected source branches no longer masquerade as writable handoff branches, and failures become actionable.
+- XI Spec-Driven Development: PASS. This feature artifact records the behavior change and test scope.
+- XII Canonical Documentation: PASS. Long-lived docs describe desired contract behavior, while rollout notes stay in this feature directory.
+- XIII Pre-Release Velocity: PASS. No compatibility shim is added; callers are updated to the stricter handoff behavior.
+
+## Technical Approach
+
+- Update `worker_runtime._build_runtime_planner()` so Jira story-output setup only treats explicit `targetBranch` as a writable handoff branch. If only `branch` is present, copy it to `startingBranch` and generate a new target branch.
+- Extend `story.create_jira_issues` to resolve stories from direct inputs, previous step outputs, and `storyBreakdownArtifactRef` before falling back to repository path fetches.
+- Wire the production story-output handler to an artifact reader backed by `TemporalArtifactService`.
+- Improve the protected-branch failure path to explain the missing handoff payload.
+- Update `docs/Tasks/SkillAndPlanContracts.md` and focused unit tests.
+
+## Validation
+
+- Run targeted unit tests:
+  - `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+  - `tests/unit/workflows/temporal/test_story_output_tools.py`
+- Run full unit verification with `./tools/test_unit.sh`.

--- a/specs/266-jira-story-breakdown-handoff/spec.md
+++ b/specs/266-jira-story-breakdown-handoff/spec.md
@@ -1,0 +1,20 @@
+# Feature Specification: Jira Story Breakdown Handoff
+
+## User Story
+
+As an operator running Jira Breakdown orchestration, I want generated story breakdown output to be consumed reliably by the Jira creation step even when the source branch is protected, so the workflow can create Jira stories without depending on an unpublished local commit.
+
+## Requirements
+
+- The planner MUST treat `branch` as the source/base branch for Jira story-output workflows, not as the writable handoff branch.
+- When Jira story output needs repository publication, the planner MUST create a distinct `targetBranch` if one was not explicitly supplied.
+- `story.create_jira_issues` MUST prefer inline story payloads, prior step story-output payloads, and `storyBreakdownArtifactRef` before fetching `storyBreakdownPath` from GitHub.
+- If the previous step reports `push_status = protected_branch` and Jira creation cannot read the generated story breakdown, the failure MUST name the protected-branch handoff problem instead of surfacing only a raw GitHub 404.
+- Regression tests MUST cover the protected-branch planner case, artifact-backed Jira creation, previous-output Jira creation, and the improved protected-branch error.
+
+## Acceptance Criteria
+
+- Given a Jira Breakdown workflow with `git.branch = main`, when the plan is generated, then the breakdown and Jira steps share a generated `targetBranch` that is not `main`, and `startingBranch` remains `main`.
+- Given `storyBreakdownArtifactRef`, when `story.create_jira_issues` runs, then it reads the artifact and does not fetch the repository path.
+- Given prior step outputs containing stories, when `story.create_jira_issues` runs, then it creates Jira issues from those stories.
+- Given a protected-branch publish failure and no readable handoff payload, when `story.create_jira_issues` runs, then it fails with an actionable protected-branch handoff message.

--- a/specs/266-jira-story-breakdown-handoff/tasks.md
+++ b/specs/266-jira-story-breakdown-handoff/tasks.md
@@ -7,4 +7,4 @@
 - [X] Update the executable tool contract documentation.
 - [X] Add focused unit regression tests.
 - [X] Run targeted unit tests and full unit verification.
-- [ ] Commit, push, and open a non-draft PR.
+- [X] Commit, push, and open a non-draft PR.

--- a/specs/266-jira-story-breakdown-handoff/tasks.md
+++ b/specs/266-jira-story-breakdown-handoff/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Jira Story Breakdown Handoff
+
+- [X] Update Jira story-output planner branch handling so `branch` remains the source branch and generated handoff output uses `targetBranch`.
+- [X] Add artifact-ref and previous-output story payload resolution to `story.create_jira_issues`.
+- [X] Wire production story-output tool registration to an artifact reader.
+- [X] Add protected-branch error messaging for missing unpublished story breakdown handoffs.
+- [X] Update the executable tool contract documentation.
+- [X] Add focused unit regression tests.
+- [X] Run targeted unit tests and full unit verification.
+- [ ] Commit, push, and open a non-draft PR.

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -175,6 +176,129 @@ async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_
     assert "Source Document: docs/Designs/RuntimeTypes.md" in request.description
     assert "Section 1" in request.description
     assert "DESIGN-REQ-001" in request.description
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_reads_story_breakdown_artifact_before_repo_path():
+    service = _FakeJiraService()
+    breakdown = {
+        "source": {
+            "referencePath": "docs/Designs/RuntimeTypes.md",
+            "title": "Runtime Types",
+        },
+        "stories": [
+            {
+                "id": "STORY-001",
+                "summary": "Create artifact-backed Jira story",
+                "description": "As an operator, I can export from a durable artifact.",
+                "sourceReference": {
+                    "sections": ["Section 1"],
+                    "coverageIds": ["DESIGN-REQ-001"],
+                },
+            }
+        ],
+    }
+    fetch_calls: list[tuple[str, str, str]] = []
+    artifact_reads: list[str] = []
+
+    async def artifact_reader(ref: str) -> bytes:
+        artifact_reads.append(ref)
+        return json.dumps(breakdown).encode("utf-8")
+
+    async def fetcher(repo: str, ref: str, path: str) -> str:
+        fetch_calls.append((repo, ref, path))
+        raise AssertionError("repo fetch should not run when artifact ref is present")
+
+    result = await create_jira_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "breakdown-branch",
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "storyBreakdownArtifactRef": "art_story_breakdown",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "none",
+                },
+            },
+        },
+        jira_service_factory=lambda: service,
+        story_fetcher=fetcher,
+        artifact_reader=artifact_reader,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert artifact_reads == ["art_story_breakdown"]
+    assert fetch_calls == []
+    assert service.requests[0].summary == "Create artifact-backed Jira story"
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_reads_story_payload_from_previous_outputs():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+        },
+        {
+            "previousOutputs": {
+                "storyOutput": {
+                    "stories": [
+                        {
+                            "id": "STORY-001",
+                            "summary": "Create previous-output Jira story",
+                            "description": "As an operator, I can reuse prior output.",
+                            "sourceReference": {
+                                "path": "docs/Designs/RuntimeTypes.md",
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert service.requests[0].summary == "Create previous-output Jira story"
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_explains_protected_branch_handoff_failure():
+    async def fetcher(_repo: str, _ref: str, _path: str) -> str:
+        raise RuntimeError("404 Not Found")
+
+    with pytest.raises(ValueError, match="protected branch 'main'"):
+        await create_jira_issues_from_stories(
+            {
+                "repository": "MoonLadderStudios/Tactics",
+                "branch": "main",
+                "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+                "storyOutput": {
+                    "mode": "jira",
+                    "fallback": "fail",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeId": "10001",
+                        "dependencyMode": "none",
+                    },
+                },
+            },
+            {
+                "previousOutputs": {
+                    "push_status": "protected_branch",
+                    "push_branch": "main",
+                }
+            },
+            story_fetcher=fetcher,
+        )
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_preserves_source_reference_when_description_truncates():

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -367,6 +367,62 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
         "linear_blocker_chain"
     )
 
+def test_runtime_planner_jira_breakdown_treats_branch_as_base_branch():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Docs\\TacticsFrontend\\InitiativeOrderBar.md",
+                "instructions": "Break down Docs\\TacticsFrontend\\InitiativeOrderBar.md.",
+                "repository": "MoonLadderStudios/Tactics",
+                "git": {"branch": "main"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "breakdown",
+                        "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                        "instructions": "Extract MoonSpec stories.",
+                    },
+                    {
+                        "id": "jira",
+                        "tool": {"type": "skill", "name": "story.create_jira_issues"},
+                        "instructions": "Create Jira issues from the generated breakdown.",
+                        "storyOutput": {
+                            "mode": "jira",
+                            "jira": {
+                                "projectKey": "MM",
+                                "issueTypeName": "Story",
+                                "dependencyMode": "linear_blocker_chain",
+                            },
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    breakdown = plan["nodes"][0]
+    jira = plan["nodes"][1]
+
+    assert breakdown["inputs"]["branch"] == "main"
+    assert breakdown["inputs"]["startingBranch"] == "main"
+    assert breakdown["inputs"]["targetBranch"] != "main"
+    assert breakdown["inputs"]["targetBranch"].startswith(
+        "docs-tacticsfrontend-initiativeorderbar-"
+    )
+    assert breakdown["inputs"]["publishMode"] == "branch"
+    assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
+    assert jira["inputs"]["branch"] == "main"
+    assert jira["inputs"]["startingBranch"] == "main"
+
 def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
@@ -1494,10 +1550,14 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
     mock_binding.handler = "agent_runtime_handler"
     mock_build_bindings.return_value = [mock_binding]
 
-    with patch(
-        "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
-        side_effect=_fake_session_context,
+    with (
+        patch("moonmind.workflows.temporal.worker_runtime.settings") as mock_settings,
+        patch(
+            "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
+            side_effect=_fake_session_context,
+        ),
     ):
+        mock_settings.workflow.workflow_docker_mode = "profiles"
         resources, handlers = await _build_runtime_activities(topology)
 
     assert handlers == [


### PR DESCRIPTION
## Summary

Fixes Jira Breakdown orchestration so generated story breakdowns are handed to Jira creation reliably instead of assuming a protected source branch contains unpublished files.

## Root Cause

The planner treated `branch` as a usable handoff branch for Jira story output. In protected-branch runs, the breakdown agent could commit `artifacts/story-breakdowns/.../stories.json` locally on `main` but could not push it, while `story.create_jira_issues` then fetched that path from GitHub `main` and failed with a 404.

## Changes

- Treat `branch` as the source/base branch and generate a distinct `targetBranch` for Jira story-output handoffs.
- Let `story.create_jira_issues` consume prior step story payloads and `storyBreakdownArtifactRef` before falling back to repo/ref/path fetches.
- Wire story-output tool registration to a Temporal artifact reader.
- Improve the protected-branch handoff error message.
- Add MoonSpec artifacts, contract docs, and regression tests.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_story_output_tools.py`
- `./tools/test_unit.sh`
