### PR TITLE
The branch field used to just show Branch before it was set. Now when you set github repo, it will automatically pull the default branch name. I actua

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5991,6 +5991,83 @@ describe("Task Create Entrypoint", () => {
     expect(task.git).toEqual({ branch: "develop" });
   });
 
+  it("submits the fetched default branch even when it is not in the loaded options", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{ value: "release", label: "release", source: "github" }],
+            defaultBranch: "trunk",
+            error: null,
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText(
+      "Branch",
+    )) as HTMLInputElement;
+    await waitFor(() => {
+      expect(branchInput.disabled).toBe(false);
+    });
+    expect(branchInput.value).toBe("");
+
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Use the hidden repository default branch." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const payload = latestCreateRequest().payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(task.git).toEqual({ branch: "trunk" });
+  });
+
+  it("omits git branch when a user explicitly clears the branch field", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText(
+      "Branch",
+    )) as HTMLInputElement;
+    await waitFor(() => {
+      expect(branchInput.disabled).toBe(false);
+    });
+
+    fireEvent.change(branchInput, {
+      target: { value: "feature/create-page" },
+    });
+    fireEvent.change(branchInput, {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Submit with an intentionally blank branch." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const payload = latestCreateRequest().payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(task).not.toHaveProperty("git");
+  });
+
   it("keeps branch loading text inside the dropdown only", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5904,8 +5904,10 @@ describe("Task Create Entrypoint", () => {
       ),
     ).toBe(true);
     await waitFor(() => {
-      expect((branchInput as HTMLInputElement).value).toBe("main");
+      expect((branchInput as HTMLInputElement).disabled).toBe(false);
     });
+    expect((branchInput as HTMLInputElement).value).toBe("");
+    expect((branchInput as HTMLInputElement).placeholder).toBe("Branch");
 
     fireEvent.change(branchInput, {
       target: { value: "feature/create-page" },
@@ -5929,7 +5931,7 @@ describe("Task Create Entrypoint", () => {
     expect(JSON.stringify(task)).not.toContain("startingBranch");
   });
 
-  it("updates the selected branch to the default when the repository changes", async () => {
+  it("keeps the branch field empty when repository defaults are available", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -5959,19 +5961,34 @@ describe("Task Create Entrypoint", () => {
       "Branch",
     )) as HTMLInputElement;
     await waitFor(() => {
-      expect(branchInput.value).toBe("main");
+      expect(branchInput.disabled).toBe(false);
     });
+    expect(branchInput.value).toBe("");
 
-    fireEvent.change(branchInput, {
-      target: { value: "feature/create-page" },
-    });
     fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
       target: { value: "MoonLadderStudios/OtherRepo" },
     });
 
     await waitFor(() => {
-      expect(branchInput.value).toBe("develop");
+      expect(branchInput.disabled).toBe(false);
     });
+    expect(branchInput.value).toBe("");
+
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Use the repository default branch." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const payload = latestCreateRequest().payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(task.git).toEqual({ branch: "develop" });
   });
 
   it("keeps branch loading text inside the dropdown only", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2280,7 +2280,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [repository, setRepository] = useState(defaultRepository);
   const [providerProfile, setProviderProfile] = useState("");
   const [branch, setBranch] = useState("");
-  const branchDefaultAppliedRepositoryRef = useRef("");
   const [publishMode, setPublishMode] = useState(
     normalizePublishModeForSubmit(defaultPublishMode),
   );
@@ -3880,6 +3879,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return true;
     });
   }, [branchOptionsQuery.data]);
+  const defaultBranch = useMemo(() => {
+    const value = String(branchOptionsQuery.data?.defaultBranch || "").trim();
+    if (!value || !branchOptions.some((item) => item.value === value)) {
+      return "";
+    }
+    return value;
+  }, [branchOptions, branchOptionsQuery.data?.defaultBranch]);
+  const effectiveBranch = branch.trim() || defaultBranch;
   const selectedBranchIsStale = Boolean(
     branch.trim() &&
       branchOptionsQuery.isSuccess &&
@@ -3887,40 +3894,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         (item) => item.value === branch.trim(),
       ),
   );
-  useEffect(() => {
-    const isNewRepository =
-      branchLookupRepository &&
-      !branchDefaultAppliedRepositoryRef.current.startsWith(
-        `${branchLookupRepository}:`,
-      );
-    if (
-      !branchOptionsQuery.isSuccess ||
-      (branch.trim() && !isNewRepository)
-    ) {
-      return;
-    }
-    const defaultBranch = String(
-      branchOptionsQuery.data?.defaultBranch || "",
-    ).trim();
-    if (
-      !defaultBranch ||
-      !branchOptions.some((item) => item.value === defaultBranch)
-    ) {
-      return;
-    }
-    const defaultKey = `${branchLookupRepository}:${defaultBranch}`;
-    if (branchDefaultAppliedRepositoryRef.current === defaultKey) {
-      return;
-    }
-    branchDefaultAppliedRepositoryRef.current = defaultKey;
-    setBranch(defaultBranch);
-  }, [
-    branch,
-    branchLookupRepository,
-    branchOptions,
-    branchOptionsQuery.data?.defaultBranch,
-    branchOptionsQuery.isSuccess,
-  ]);
   const branchControlDisabled =
     !selectedRepositoryForBranchLookup.trim() ||
     !branchLookupEndpoint ||
@@ -5191,10 +5164,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             },
           }
         : {}),
-      ...(branch.trim()
+      ...(effectiveBranch
         ? {
             git: {
-              branch: branch.trim(),
+              branch: effectiveBranch,
             },
           }
         : {}),

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2280,6 +2280,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [repository, setRepository] = useState(defaultRepository);
   const [providerProfile, setProviderProfile] = useState("");
   const [branch, setBranch] = useState("");
+  const [branchTouched, setBranchTouched] = useState(false);
   const [publishMode, setPublishMode] = useState(
     normalizePublishModeForSubmit(defaultPublishMode),
   );
@@ -2628,6 +2629,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
     if (draft.branch) {
       setBranch(draft.branch);
+      setBranchTouched(false);
     }
     if (draft.legacyBranchWarning) {
       setSubmitMessage(draft.legacyBranchWarning);
@@ -3881,12 +3883,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }, [branchOptionsQuery.data]);
   const defaultBranch = useMemo(() => {
     const value = String(branchOptionsQuery.data?.defaultBranch || "").trim();
-    if (!value || !branchOptions.some((item) => item.value === value)) {
-      return "";
-    }
     return value;
-  }, [branchOptions, branchOptionsQuery.data?.defaultBranch]);
-  const effectiveBranch = branch.trim() || defaultBranch;
+  }, [branchOptionsQuery.data?.defaultBranch]);
+  const effectiveBranch =
+    branch.trim() ||
+    (!branchTouched && pageMode.mode === "create" ? defaultBranch : "");
   const selectedBranchIsStale = Boolean(
     branch.trim() &&
       branchOptionsQuery.isSuccess &&
@@ -6703,7 +6704,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   branchOptionsQuery.isLoading ? "Loading branches..." : "Branch"
                 }
                 disabled={branchControlDisabled}
-                onChange={(event) => setBranch(event.target.value)}
+                onChange={(event) => {
+                  setBranchTouched(true);
+                  setBranch(event.target.value);
+                }}
               />
             </div>
             <div


### PR DESCRIPTION
The branch field used to just show Branch before it was set. Now when you set github repo, it will automatically pull the default branch name. I actually preferred the way it worked before and want to go back. It should just show "Branch" but use the default branch by default. Then if you click in it you can easily paste if you want to change it without having to delete what's there. This was better and we should go back to this behavior.