### PR TITLE
MM-526 add channel overlay MoonSpec artifacts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/265-explicit-failure-and-rollback-controls"
+  "feature_directory": "specs/267-grid-ui-marker-baseline"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/267-grid-ui-marker-baseline"
+  "feature_directory": "specs/268-channel-overlay-api"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,32 @@
 [
   {
-    "id": 3144051956,
+    "id": 3144071649,
     "disposition": "addressed",
-    "rationale": "Removed the redundant 2600ms nested fallback from the executing letter animation duration and delay so the root sweep duration variable remains the single default."
+    "rationale": "Renamed the contradictory non-interference wording in the acceptance criteria to Movement overlay interference bug class."
   },
   {
-    "id": 4177370118,
-    "disposition": "not-applicable",
-    "rationale": "Review summary only; the actionable inline CSS and test feedback from the same review was handled in the code changes."
+    "id": 3144071660,
+    "disposition": "addressed",
+    "rationale": "Updated acceptance scenario 3 to describe the Movement overlay interference bug class."
   },
   {
-    "id": 3144051959,
+    "id": 3144071663,
     "disposition": "addressed",
-    "rationale": "Updated the Mission Control CSS assertions to match the simplified animation-duration and animation-delay variable usage."
+    "rationale": "Updated FR-003 to require regression coverage for the Movement overlay interference bug class."
+  },
+  {
+    "id": 3144071664,
+    "disposition": "addressed",
+    "rationale": "Added the -w flag to the T006 ripgrep command for whole-word API matching."
+  },
+  {
+    "id": 3144071666,
+    "disposition": "addressed",
+    "rationale": "Added the -w flag to the quickstart ripgrep command for whole-word API matching."
+  },
+  {
+    "id": 4177385866,
+    "disposition": "addressed",
+    "rationale": "Addressed the review summary by updating the contradictory bug-class wording and both ripgrep commands."
   }
 ]

--- a/specs/267-grid-ui-marker-baseline/checklists/requirements.md
+++ b/specs/267-grid-ui-marker-baseline/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Grid UI Marker Baseline
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The trusted `MM-525` Jira preset brief is preserved in `spec.md` `**Input**`.
+- PASS: The spec records that `Docs/TacticsFrontend/GridUiOverlaySystem.md` is not present in this checkout and treats the trusted Jira brief as canonical.
+- PASS: The story is a runtime baseline story, not a documentation-only task.

--- a/specs/267-grid-ui-marker-baseline/contracts/diagnostic-evidence.md
+++ b/specs/267-grid-ui-marker-baseline/contracts/diagnostic-evidence.md
@@ -1,0 +1,23 @@
+# Contract: Grid UI Marker Diagnostic Evidence
+
+## Purpose
+
+Diagnostics for this story must provide enough structured evidence to distinguish producer churn from renderer churn during Grid UI marker/decal operations.
+
+## Required Event Fields
+
+| Field | Requirement |
+| --- | --- |
+| `source` | Identifies the producer, renderer, or lifecycle source of the operation. |
+| `markerType` | Identifies the marker/decal category affected by the operation. |
+| `reason` | Explains why the operation occurred. |
+| `ownerController` | Identifies the owning controller when available, or records an explicit unknown/null owner state. |
+| `tileCount` | Reports how many tiles or locations are affected. |
+| `operationType` | Identifies spawn, queued spawn, clear, clear all, decal spawn, or decal clear operation category. |
+
+## Validation Expectations
+
+- Producer-originated events and renderer-originated events must be distinguishable without relying on log message prose.
+- Clear operations that affect zero tiles must still include all required fields.
+- Diagnostic evidence must be available to automated tests or test fixtures in the target project.
+- Event shape and validation evidence must preserve `MM-525` traceability.

--- a/specs/267-grid-ui-marker-baseline/data-model.md
+++ b/specs/267-grid-ui-marker-baseline/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Grid UI Marker Baseline
+
+This story does not introduce persistent storage. It does require checked-in baseline artifacts and diagnostic evidence in the target Tactics frontend project.
+
+## Marker/Decal Mutation Call Site
+
+- **Purpose**: Represents one direct invocation of a named marker/decal mutation API.
+- **Required Fields**:
+  - Source file path
+  - Line or stable source location
+  - Invoked API name
+  - Producer role
+  - Marker/decal type when knowable
+  - Clear/spawn operation category
+  - Notes for ambiguous context
+- **Validation Rules**:
+  - Every direct use of the named APIs in the target source tree must have one inventory entry.
+  - Every entry must have exactly one producer role from the canonical role list.
+
+## Producer Role
+
+- **Allowed Values**:
+  - selected movement
+  - hover movement
+  - attack targeting
+  - ability preview
+  - focus/selection
+  - path/ghost path
+  - phase clear
+  - teardown clear
+  - debug/demo utility
+- **Validation Rules**:
+  - Roles are mutually exclusive per call-site entry for this baseline.
+  - Broad lifecycle clears must not be classified as producer-owned overlay clears.
+
+## Diagnostic Event
+
+- **Purpose**: Captures producer or renderer churn evidence for marker/decal activity.
+- **Required Fields**:
+  - source
+  - marker type
+  - reason
+  - owner controller
+  - tile count
+  - operation type
+- **Validation Rules**:
+  - Events must allow maintainers to distinguish producer churn from renderer churn.
+  - Events with zero tiles or unknown owner controller still need all required field keys.
+
+## Movement Overlay Interference Scenario
+
+- **Purpose**: Captures the known bug class where clearing one Movement producer can erase another Movement producer's overlay.
+- **Required Fields**:
+  - First Movement producer identity
+  - Second Movement producer identity
+  - Initial tile sets or equivalent marker state
+  - Clear operation source
+  - Observed remaining overlay state
+- **Validation Rules**:
+  - The automated test must prove the current interference behavior or its corrected baseline expectation.
+  - The test must be traceable to `MM-525`.

--- a/specs/267-grid-ui-marker-baseline/plan.md
+++ b/specs/267-grid-ui-marker-baseline/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Grid UI Marker Baseline
+
+**Branch**: `267-grid-ui-marker-baseline` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/267-grid-ui-marker-baseline/spec.md`
+
+## Summary
+
+Deliver `MM-525` by adding baseline evidence for the current Grid UI marker/decal lifecycle: a checked-in direct mutation inventory, producer-role classifications, regression coverage for Movement overlay interference, preservation of existing lifecycle/idempotence expectations, and diagnostic evidence that distinguishes producer churn from renderer churn. Repository gap analysis found that the referenced Tactics frontend source document and implementation are not present in this checkout, so implementation cannot safely proceed in this repository without the target source tree.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | No `SpawnTileMarkers`, `QueueSpawnTileMarkers`, `ClearTileMarkers`, `SpawnDecalsAtLocations`, or `ClearSpecifiedDecals` references exist in this checkout. | Requires target Tactics frontend source tree before inventory can be authored. | unit + integration in target project |
+| FR-002 | missing | No target call sites exist in this checkout to classify. | Requires target Tactics frontend source tree and gameplay context. | inventory validation |
+| FR-003 | missing | No Movement overlay implementation or tests exist in this checkout. | Requires target tests for two Movement producers and clear behavior. | unit or controller test first |
+| FR-004 | missing | No existing Grid UI marker lifecycle/idempotence tests exist in this checkout. | Requires target test suite or equivalent assertions. | existing lifecycle/idempotence tests |
+| FR-005 | missing | No marker/decal diagnostic event surface exists in this checkout. | Requires target diagnostic implementation or test hooks. | unit + integration diagnostics validation |
+| FR-006 | implemented_unverified | Spec explicitly constrains scope to baseline and no ownership semantics code has been changed. | Preserve as implementation guard when target source is available. | final verification |
+| FR-007 | implemented_verified | `spec.md` preserves `MM-525` and the canonical Jira preset brief. | Preserve through any downstream artifacts, commits, and PR metadata. | final verification |
+| SCN-001 | missing | No target APIs are present to inventory. | Requires target source tree. | inventory validation |
+| SCN-002 | missing | No target call sites are present to classify. | Requires target source tree. | inventory validation |
+| SCN-003 | missing | No Movement overlay behavior is present. | Requires target tests. | unit/controller test |
+| SCN-004 | missing | No lifecycle/idempotence tests are present. | Requires target test suite. | unit + integration |
+| SCN-005 | missing | No diagnostic surface is present. | Requires target diagnostics. | unit + integration |
+| DESIGN-REQ-001 | missing | Source design document is not present; Jira brief is preserved. | Requires target source/design artifact. | final verification |
+| DESIGN-REQ-002 | missing | No named APIs are present. | Requires target source tree. | inventory validation |
+| DESIGN-REQ-003 | missing | No call sites are present. | Requires target source tree. | inventory validation |
+| DESIGN-REQ-004 | missing | No Movement overlay implementation exists. | Requires target tests. | unit/controller test |
+| DESIGN-REQ-005 | missing | No existing lifecycle/idempotence tests exist. | Requires target test suite. | unit + integration |
+| DESIGN-REQ-006 | missing | No diagnostic event surface exists. | Requires target diagnostics. | unit + integration |
+| DESIGN-REQ-007 | implemented_unverified | No ownership semantics have been changed in this repo. | Preserve as a target implementation guard. | final verification |
+
+## Technical Context
+
+**Language/Version**: Target appears to be a Tactics frontend runtime, likely Unreal/C++ from API naming, but the target source tree is unavailable in this checkout.  
+**Primary Dependencies**: Target Grid UI marker/decal runtime and diagnostics system unavailable in this checkout.  
+**Storage**: Checked-in source inventory file in the target project; no persistent storage expected.  
+**Unit Testing**: Target project unit/controller tests required; unavailable in this checkout.  
+**Integration Testing**: Target project lifecycle/diagnostic integration tests required; unavailable in this checkout.  
+**Target Platform**: Tactics frontend runtime; exact platform cannot be verified from this checkout.  
+**Project Type**: Runtime frontend/game UI feature baseline; target project unavailable.  
+**Performance Goals**: Inventory and diagnostics must preserve current runtime behavior; no ownership semantics migration in this story.  
+**Constraints**: Do not change marker ownership semantics; preserve `MM-525` traceability; do not invent target files or APIs when the target source tree is absent.  
+**Scale/Scope**: One baseline story covering existing direct marker/decal mutation call sites and related diagnostics.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The plan does not replace provider behavior or MoonMind orchestration.
+- **II. One-Click Agent Deployment**: PASS. No deployment path changes.
+- **III. Avoid Vendor Lock-In**: PASS. No vendor-specific lock-in introduced.
+- **IV. Own Your Data**: PASS. Jira-derived source context is preserved in local MoonSpec artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime changes.
+- **VI. Scientific Method / Tests Are Anchor**: PASS with blocker. The plan requires tests before runtime changes, but target test harness is absent.
+- **VII. Powerful Runtime Configurability**: PASS. No runtime configuration changes.
+- **VIII. Modular and Extensible Architecture**: PASS. No architecture changes are proposed without target source.
+- **IX. Resilient by Default**: PASS. No workflow/activity contract changes.
+- **X. Facilitate Continuous Improvement**: PASS. The blocker is captured as structured evidence.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Spec artifacts exist before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Feature-local artifacts hold execution notes.
+- **XIII. Pre-release Compatibility Policy**: PASS. No compatibility aliases or transforms introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/267-grid-ui-marker-baseline/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── diagnostic-evidence.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+# Current checkout contains MoonMind orchestration code only.
+api_service/
+frontend/
+moonmind/
+docs/
+specs/
+
+# Required target paths are absent from this checkout.
+Docs/TacticsFrontend/GridUiOverlaySystem.md
+Tactics frontend Grid UI runtime source
+Tactics frontend marker lifecycle tests
+```
+
+**Structure Decision**: Do not map implementation tasks onto the MoonMind codebase. The requested runtime story belongs to the referenced Tactics frontend target source tree, which is not present here. This repository can preserve MoonSpec artifacts and blocker evidence only until the target source tree is available.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/267-grid-ui-marker-baseline/quickstart.md
+++ b/specs/267-grid-ui-marker-baseline/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Grid UI Marker Baseline
+
+## Prerequisite
+
+This MoonSpec story requires the target Tactics frontend source tree containing `Docs/TacticsFrontend/GridUiOverlaySystem.md`, Grid UI marker/decal runtime code, and marker lifecycle tests. Those files are not present in this checkout.
+
+## Target Validation Flow
+
+1. Confirm the target source document exists:
+
+   ```bash
+   test -f Docs/TacticsFrontend/GridUiOverlaySystem.md
+   ```
+
+2. Locate every direct mutation API use:
+
+   ```bash
+   rg -w -n "SpawnTileMarkers|SpawnTileMarkersFromIndexes|QueueSpawnTileMarkers|QueueSpawnTileMarkersFromIndexes|ClearTileMarkers|ClearAllTileMarkers|SpawnDecalsAtLocations|ClearSpecifiedDecals" .
+   ```
+
+3. Create or update the checked-in inventory with source path, source location, invoked API, producer role, operation category, and notes.
+
+4. Add red-first automated coverage for the Movement overlay interference bug class.
+
+5. Add or update lifecycle/idempotence tests preserving existing Grid UI marker behavior.
+
+6. Add or update diagnostic validation for source, marker type, reason, owner controller, tile count, and operation type.
+
+7. Run the target project's unit test suite.
+
+8. Run the target project's integration or controller-level marker lifecycle suite.
+
+9. Run MoonSpec verification and confirm `MM-525` and the canonical Jira preset brief are preserved in all delivery metadata.
+
+## Current Checkout Result
+
+The current repository cannot execute the target validation flow because the Tactics frontend source tree is unavailable.

--- a/specs/267-grid-ui-marker-baseline/research.md
+++ b/specs/267-grid-ui-marker-baseline/research.md
@@ -1,0 +1,73 @@
+# Research: Grid UI Marker Baseline
+
+## Classification
+
+Decision: `MM-525` is a single-story runtime feature request.
+Evidence: The Jira preset brief names one outcome: establish an observable baseline for existing Grid UI marker lifecycle before ownership semantics change.
+Rationale: The story has one actor, one target subsystem, and one independently testable output set: inventory, baseline tests, and diagnostic evidence.
+Alternatives considered: Treating the source document as a broad design was rejected because the Jira brief already selected a phase-0 baseline slice.
+Test implications: Unit and integration tests are required in the target Tactics frontend project.
+
+## Source Availability
+
+Decision: Implementation is blocked in this checkout because the target source tree is absent.
+Evidence: Repository searches found no `Docs/TacticsFrontend/GridUiOverlaySystem.md`, no `AGridUI`, no `SpawnTileMarkers`, no `QueueSpawnTileMarkers`, no `ClearTileMarkers`, no `SpawnDecalsAtLocations`, and no `ClearSpecifiedDecals`.
+Rationale: Inventing target files or APIs in the MoonMind repository would violate the preserved Jira request and produce non-executable evidence.
+Alternatives considered: Creating documentation-only inventory placeholders was rejected because runtime mode is selected and the Jira acceptance criteria require checked-in inventory and automated tests against actual marker lifecycle behavior.
+Test implications: No target unit or integration test can be written in this checkout.
+
+## FR-001 Direct Mutation Inventory
+
+Decision: Status is `missing`.
+Evidence: No direct mutation APIs named by the brief exist in the current repository.
+Rationale: Inventory must be derived from actual target call sites, not prompt text.
+Alternatives considered: Using the Jira brief as the inventory was rejected because it names APIs but not source locations.
+Test implications: Requires an inventory validation check in the target project.
+
+## FR-002 Producer Role Classification
+
+Decision: Status is `missing`.
+Evidence: No target call sites exist to classify.
+Rationale: Producer roles require surrounding gameplay and lifecycle context.
+Alternatives considered: Pre-populating every role from the brief was rejected because roles must map to concrete call sites.
+Test implications: Requires inventory validation or review-backed automated consistency check.
+
+## FR-003 Movement Overlay Interference Regression
+
+Decision: Status is `missing`.
+Evidence: No Movement overlay producer code or test harness exists in this checkout.
+Rationale: The regression must exercise current behavior where one Movement producer can erase another Movement producer's overlay.
+Alternatives considered: Adding a synthetic MoonMind unit test was rejected because it would not validate the target Grid UI runtime.
+Test implications: Requires red-first target unit/controller coverage.
+
+## FR-004 Lifecycle And Idempotence Preservation
+
+Decision: Status is `missing`.
+Evidence: No existing Grid UI marker lifecycle/idempotence tests are present.
+Rationale: Equivalent assertions must be anchored in the target test suite.
+Alternatives considered: Marking this verified from absence of changes was rejected because the requirement asks for passing lifecycle/idempotence evidence.
+Test implications: Requires target unit and/or integration suite execution.
+
+## FR-005 Diagnostic Evidence
+
+Decision: Status is `missing`.
+Evidence: No marker/decal diagnostic event surface exists in this checkout.
+Rationale: The diagnostic fields must be emitted or observable by the target runtime.
+Alternatives considered: Documenting expected fields only was rejected because runtime mode requires validation.
+Test implications: Requires unit and integration validation of diagnostic event shape.
+
+## FR-006 Ownership Semantics Guard
+
+Decision: Status is `implemented_unverified`.
+Evidence: No target runtime code has been changed in this checkout.
+Rationale: The story constrains future target implementation, but final proof requires inspecting target changes when they exist.
+Alternatives considered: Marking verified was rejected because the target source tree is absent.
+Test implications: Final verification must confirm no ownership semantics migration was included.
+
+## FR-007 Jira Traceability
+
+Decision: Status is `implemented_verified` for MoonSpec artifacts created so far.
+Evidence: `specs/267-grid-ui-marker-baseline/spec.md` preserves `MM-525` and the canonical Jira preset brief.
+Rationale: Traceability can be satisfied in this repository's MoonSpec artifacts even though runtime implementation is blocked.
+Alternatives considered: Deferring traceability until implementation was rejected because MoonSpec artifacts are already available.
+Test implications: Final verification should confirm `MM-525` is preserved in all delivery metadata.

--- a/specs/267-grid-ui-marker-baseline/spec.md
+++ b/specs/267-grid-ui-marker-baseline/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Grid UI Marker Baseline
+
+**Feature Branch**: `267-grid-ui-marker-baseline`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-525 as the canonical Moon Spec orchestration input.
+
+Preserve the Jira issue key MM-525 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Jira issue: MM-525
+Issue type: Story
+Status: In Progress
+Summary: Inventory current Grid UI marker mutations and lock baseline regression coverage
+
+Source Reference:
+Source Document: Docs/TacticsFrontend/GridUiOverlaySystem.md
+Source Title: Grid UI Overlay System
+Source Sections:
+- 1. Purpose
+- 4. Core Principle
+- 18. Diagnostics
+- 20. Testing Strategy
+- 21. Migration Rules
+
+Coverage IDs:
+- plan.phase0
+- doc.diagnostics
+- doc.testing.controller
+- doc.testing.integration
+
+Canonical Brief:
+Establish an observable baseline for the existing Grid UI marker lifecycle before changing ownership semantics. Inventory all direct marker/decal mutation call sites, classify each producer role, and add focused regression coverage for the known bug class where one producer clears another producer's Movement overlay.
+
+Acceptance Criteria:
+- A checked-in inventory identifies direct uses of SpawnTileMarkers, SpawnTileMarkersFromIndexes, QueueSpawnTileMarkers, QueueSpawnTileMarkersFromIndexes, ClearTileMarkers, ClearAllTileMarkers, SpawnDecalsAtLocations, and ClearSpecifiedDecals.
+- Each call site is categorized by producer role: selected movement, hover movement, attack targeting, ability preview, focus/selection, path/ghost path, phase clear, teardown clear, or debug/demo utility.
+- At least one automated test captures the current Movement overlay interference bug class where clearing one Movement producer can erase another Movement producer's overlay.
+- Existing Grid UI marker lifecycle/idempotence tests still pass or are updated with equivalent assertions.
+- Diagnostics can distinguish producer churn from renderer churn with source, marker type, reason, owner controller, tile count, and operation type.
+
+Jira labels:
+diagnostics, grid-ui-overlay, jira, moonmind-workflow-mm-2e552d30-1728-450d-808a-968369cc4f9a, moonspec-breakdown, phase-0, tacticsfrontend, tests"
+
+## User Story - Baseline Grid UI Marker Lifecycle
+
+**Summary**: As a tactics frontend maintainer, I want the current Grid UI marker and decal mutation lifecycle inventoried and regression-covered so that later ownership changes can be made against a known, observable baseline.
+
+**Goal**: Establish traceable baseline evidence for every direct marker/decal mutation producer and preserve automated coverage for the known Movement overlay interference bug class before changing ownership semantics.
+
+**Independent Test**: Can be fully tested by reviewing the checked-in mutation inventory and running the marker lifecycle unit/integration tests that prove direct producer classifications, Movement overlay interference coverage, existing lifecycle/idempotence behavior, and diagnostic event detail are all present.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Grid UI marker lifecycle contains direct mutation APIs, **When** maintainers review the baseline inventory, **Then** every direct use of SpawnTileMarkers, SpawnTileMarkersFromIndexes, QueueSpawnTileMarkers, QueueSpawnTileMarkersFromIndexes, ClearTileMarkers, ClearAllTileMarkers, SpawnDecalsAtLocations, and ClearSpecifiedDecals is listed with its source location.
+2. **Given** an inventoried marker/decal mutation call site, **When** maintainers inspect its classification, **Then** the call site is assigned exactly one producer role from selected movement, hover movement, attack targeting, ability preview, focus/selection, path/ghost path, phase clear, teardown clear, or debug/demo utility.
+3. **Given** two Movement overlay producers are active, **When** one producer clears its Movement overlay, **Then** automated regression coverage demonstrates whether another producer's Movement overlay can be erased and captures the current Movement overlay interference bug class as baseline evidence.
+4. **Given** existing Grid UI marker lifecycle and idempotence expectations, **When** the baseline test suite runs, **Then** those expectations still pass or equivalent assertions document the same behavior.
+5. **Given** marker producer or renderer activity changes, **When** diagnostics are emitted, **Then** diagnostic evidence includes source, marker type, reason, owner controller, tile count, and operation type so producer churn can be distinguished from renderer churn.
+
+### Edge Cases
+
+- A direct mutation call site is used only by a debug or demo utility and still requires inventory coverage without being treated as production gameplay behavior.
+- A clear operation has broad scope, such as phase or teardown cleanup, and must be classified separately from producer-owned overlay cleanup.
+- A call site's producer role is ambiguous from the call alone and requires neighboring gameplay context to avoid misclassification.
+- Diagnostic events may have zero affected tiles or unknown owner controller context and still need enough structured detail to distinguish producer churn from renderer churn.
+
+## Assumptions
+
+- The referenced source document `Docs/TacticsFrontend/GridUiOverlaySystem.md` is not present in this checkout; the trusted MM-525 Jira brief is the canonical source for this story.
+- Runtime mode applies: the story requires product/test artifacts for the Grid UI marker lifecycle, not documentation-only changes.
+- If the target Tactics frontend source tree is unavailable in this repository, implementation must stop at the first stage that proves the required source or tests cannot be located.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirement |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | MM-525 Source Sections 1, 4; Coverage ID `plan.phase0` | Establish a baseline inventory before changing Grid UI marker ownership semantics. | In scope | FR-001, FR-002 |
+| DESIGN-REQ-002 | MM-525 Acceptance Criteria; Coverage ID `plan.phase0` | Inventory direct uses of SpawnTileMarkers, SpawnTileMarkersFromIndexes, QueueSpawnTileMarkers, QueueSpawnTileMarkersFromIndexes, ClearTileMarkers, ClearAllTileMarkers, SpawnDecalsAtLocations, and ClearSpecifiedDecals. | In scope | FR-001 |
+| DESIGN-REQ-003 | MM-525 Acceptance Criteria; Source Section 4 | Classify each direct mutation call site by one producer role from the canonical role list. | In scope | FR-002 |
+| DESIGN-REQ-004 | MM-525 Acceptance Criteria; Coverage ID `doc.testing.controller` | Add automated coverage for the current bug class where clearing one Movement producer can erase another Movement producer's overlay. | In scope | FR-003 |
+| DESIGN-REQ-005 | MM-525 Acceptance Criteria; Coverage ID `doc.testing.integration` | Preserve existing Grid UI marker lifecycle/idempotence behavior through existing or equivalent tests. | In scope | FR-004 |
+| DESIGN-REQ-006 | MM-525 Source Section 18; Coverage ID `doc.diagnostics` | Diagnostics must expose source, marker type, reason, owner controller, tile count, and operation type so producer churn and renderer churn are distinguishable. | In scope | FR-005 |
+| DESIGN-REQ-007 | MM-525 Source Section 21 | Do not change ownership semantics as part of this baseline story. | In scope | FR-006 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST include a checked-in inventory of every direct use of SpawnTileMarkers, SpawnTileMarkersFromIndexes, QueueSpawnTileMarkers, QueueSpawnTileMarkersFromIndexes, ClearTileMarkers, ClearAllTileMarkers, SpawnDecalsAtLocations, and ClearSpecifiedDecals.
+- **FR-002**: The inventory MUST categorize every listed call site with exactly one producer role from selected movement, hover movement, attack targeting, ability preview, focus/selection, path/ghost path, phase clear, teardown clear, or debug/demo utility.
+- **FR-003**: The test suite MUST include automated regression coverage for the current Movement overlay interference bug class where clearing one Movement producer can erase another Movement producer's overlay.
+- **FR-004**: Existing Grid UI marker lifecycle and idempotence expectations MUST continue to pass, or equivalent assertions MUST preserve the same observable guarantees.
+- **FR-005**: Diagnostic evidence for marker/decal producer and renderer activity MUST include source, marker type, reason, owner controller, tile count, and operation type.
+- **FR-006**: The baseline story MUST NOT change Grid UI marker ownership semantics beyond the minimum test or diagnostic instrumentation required to observe current behavior.
+- **FR-007**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-525` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Marker/Decal Mutation Call Site**: A source location that directly invokes one of the marker or decal mutation APIs named by the Jira brief.
+- **Producer Role**: The gameplay, lifecycle, or utility responsibility assigned to a mutation call site for baseline analysis.
+- **Movement Overlay Producer**: A producer that emits Movement marker overlays and may interfere with another Movement overlay producer during clear operations.
+- **Diagnostic Event**: Structured evidence describing producer or renderer activity with source, marker type, reason, owner controller, tile count, and operation type.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of direct uses of the named marker/decal mutation APIs present in the available target source tree are represented in the checked-in inventory.
+- **SC-002**: 100% of inventoried call sites have exactly one producer-role classification from the canonical role list.
+- **SC-003**: At least one automated test fails on the known Movement overlay interference bug class before implementation or baseline assertion adjustment, then passes with the accepted baseline evidence.
+- **SC-004**: All existing or equivalent Grid UI marker lifecycle/idempotence tests pass in the final validation run.
+- **SC-005**: Diagnostic validation confirms every required diagnostic field is present for producer and renderer churn evidence.
+- **SC-006**: Final verification can trace `MM-525`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-007 through the active MoonSpec artifacts and test evidence.

--- a/specs/267-grid-ui-marker-baseline/tasks.md
+++ b/specs/267-grid-ui-marker-baseline/tasks.md
@@ -1,0 +1,151 @@
+# Tasks: Grid UI Marker Baseline
+
+**Input**: Design documents from `/specs/267-grid-ui-marker-baseline/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: `Baseline Grid UI Marker Lifecycle`.
+
+**Source Traceability**: `MM-525`, FR-001 through FR-007, SCN-001 through SCN-005, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-007.
+
+**Test Commands**:
+
+- Unit tests: target Tactics frontend unit/controller test command for Grid UI marker lifecycle tests
+- Integration tests: target Tactics frontend integration or controller-level lifecycle/diagnostic test command
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when paths differ and dependencies are complete
+- Each task includes a target path. `TARGET_PROJECT_ROOT` means the root of the Tactics frontend repository/workspace containing `Docs/TacticsFrontend/GridUiOverlaySystem.md`; this root is not present in the current MoonMind checkout.
+
+## Phase 1: Setup
+
+**Purpose**: Establish the target runtime workspace and preserve traceability before any story implementation.
+
+- [ ] T001 Verify `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiOverlaySystem.md` exists and records source sections 1, 4, 18, 20, and 21 for MM-525. (DESIGN-REQ-001, DESIGN-REQ-007)
+- [ ] T002 Verify `TARGET_PROJECT_ROOT` contains Grid UI marker/decal runtime source with the named mutation APIs before editing implementation files. (FR-001, SC-001)
+- [ ] T003 Verify target unit/controller test command for Grid UI marker lifecycle tests and record it in `specs/267-grid-ui-marker-baseline/quickstart.md`. (FR-003, FR-004)
+- [ ] T004 Verify target integration or controller-level diagnostic/lifecycle test command and record it in `specs/267-grid-ui-marker-baseline/quickstart.md`. (FR-004, FR-005)
+- [ ] T005 Preserve `MM-525` and the canonical Jira preset brief in any target implementation notes or delivery metadata. (FR-007, SC-006)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Build the inventory and test harness prerequisites that block story implementation.
+
+**CRITICAL**: No story implementation work can begin until T001 through T009 are complete.
+
+- [ ] T006 Run `rg -w -n "SpawnTileMarkers|SpawnTileMarkersFromIndexes|QueueSpawnTileMarkers|QueueSpawnTileMarkersFromIndexes|ClearTileMarkers|ClearAllTileMarkers|SpawnDecalsAtLocations|ClearSpecifiedDecals" TARGET_PROJECT_ROOT` and save the complete result set in `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md`. (FR-001, DESIGN-REQ-002)
+- [ ] T007 Create the checked-in mutation inventory table in `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md` with source path, source location, invoked API, marker/decal type, operation category, producer role, and notes. (FR-001, FR-002, SC-001, SC-002)
+- [ ] T008 Classify every inventory row in `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md` with exactly one role from selected movement, hover movement, attack targeting, ability preview, focus/selection, path/ghost path, phase clear, teardown clear, or debug/demo utility. (FR-002, DESIGN-REQ-003)
+- [ ] T009 Identify or create target test fixture locations for Movement overlay producers, lifecycle/idempotence behavior, and diagnostic evidence in `TARGET_PROJECT_ROOT/Tests/GridUi/`. (FR-003, FR-004, FR-005)
+
+**Checkpoint**: Inventory and target test harness locations are ready; red-first story tests can begin.
+
+---
+
+## Phase 3: Story - Baseline Grid UI Marker Lifecycle
+
+**Summary**: As a tactics frontend maintainer, I want the current Grid UI marker and decal mutation lifecycle inventoried and regression-covered so that later ownership changes can be made against a known, observable baseline.
+
+**Independent Test**: Review the checked-in inventory and run target unit/controller plus integration diagnostics tests to prove call-site coverage, producer classifications, Movement overlay interference coverage, lifecycle/idempotence preservation, and diagnostic event detail.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007.
+
+**Test Plan**:
+
+- Unit: inventory completeness validation, producer-role validation, Movement overlay interference regression, diagnostic event field validation.
+- Integration: lifecycle/idempotence preservation and producer-vs-renderer diagnostic evidence across the target Grid UI marker lifecycle.
+
+### Unit Tests (write first)
+
+- [ ] T010 [P] Add failing unit/controller test for inventory completeness against direct named API uses in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerInventoryTests.*`. (FR-001, SCN-001, SC-001, DESIGN-REQ-002)
+- [ ] T011 [P] Add failing unit/controller test for exactly-one producer role per inventory row in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerInventoryTests.*`. (FR-002, SCN-002, SC-002, DESIGN-REQ-003)
+- [ ] T012 [P] Add failing unit/controller regression test for two Movement overlay producers where clearing one producer can erase another producer's overlay in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMovementOverlayInterferenceTests.*`. (FR-003, SCN-003, SC-003, DESIGN-REQ-004)
+- [ ] T013 [P] Add failing unit/controller test for diagnostic event fields in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerDiagnosticsTests.*`. (FR-005, SCN-005, SC-005, DESIGN-REQ-006)
+- [ ] T014 Run the target unit/controller test command for T010 through T013 and confirm each new test fails for the expected baseline gap before production or inventory implementation. (FR-001, FR-002, FR-003, FR-005)
+
+### Integration Tests (write first)
+
+- [ ] T015 [P] Add failing integration or controller-level lifecycle/idempotence test in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerLifecycleIntegrationTests.*`. (FR-004, SCN-004, SC-004, DESIGN-REQ-005)
+- [ ] T016 [P] Add failing integration or controller-level diagnostic churn test that distinguishes producer churn from renderer churn in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerDiagnosticsIntegrationTests.*`. (FR-005, SCN-005, SC-005, DESIGN-REQ-006)
+- [ ] T017 Run the target integration test command for T015 and T016 and confirm each new test fails for the expected baseline gap before implementation. (FR-004, FR-005)
+
+### Implementation
+
+- [ ] T018 Complete the source-location inventory in `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md` until T010 passes. (FR-001, SC-001, DESIGN-REQ-002)
+- [ ] T019 Complete producer-role classifications in `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md` until T011 passes. (FR-002, SC-002, DESIGN-REQ-003)
+- [ ] T020 Add the minimum baseline test fixtures or instrumentation in the target Grid UI marker runtime source under `TARGET_PROJECT_ROOT/Source/` needed for T012 without changing ownership semantics. (FR-003, FR-006, DESIGN-REQ-004, DESIGN-REQ-007)
+- [ ] T021 Preserve or update equivalent lifecycle/idempotence assertions in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerLifecycleIntegrationTests.*` until T015 passes. (FR-004, DESIGN-REQ-005)
+- [ ] T022 Add or expose diagnostic evidence fields in the target Grid UI marker diagnostics path under `TARGET_PROJECT_ROOT/Source/` until T013 and T016 pass. (FR-005, DESIGN-REQ-006)
+- [ ] T023 Run the target unit/controller test command and fix failures without expanding scope beyond MM-525. (FR-001, FR-002, FR-003, FR-005, FR-006)
+- [ ] T024 Run the target integration test command and fix failures without expanding scope beyond MM-525. (FR-004, FR-005, FR-006)
+
+**Checkpoint**: The story is functional in the target project, red-first tests now pass, and ownership semantics have not been migrated.
+
+---
+
+## Phase 4: Story Validation And Polish
+
+**Purpose**: Validate the completed single story and preserve delivery traceability.
+
+- [ ] T025 Run the quickstart validation in `specs/267-grid-ui-marker-baseline/quickstart.md` against `TARGET_PROJECT_ROOT`. (SC-001, SC-002, SC-003, SC-004, SC-005)
+- [ ] T026 Verify `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiMarkerMutationInventory.md` covers 100% of named direct API uses reported by `rg`. (FR-001, SC-001)
+- [ ] T027 Verify all final target test outputs preserve or reference `MM-525` where project conventions support traceability. (FR-007, SC-006)
+- [ ] T028 Run `/moonspec-verify` for `specs/267-grid-ui-marker-baseline/spec.md` and record the final verdict. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Must confirm the target Tactics frontend workspace exists.
+- **Foundational (Phase 2)**: Depends on Setup and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational and must follow red-first testing.
+- **Validation And Polish (Phase 4)**: Depends on story implementation and passing target tests.
+
+### Within The Story
+
+- T010 through T013 must be written and fail before T018 through T022.
+- T015 and T016 must be written and fail before T021 and T022.
+- T018 and T019 depend on T006 through T008.
+- T020 depends on T012 and must not migrate ownership semantics.
+- T022 depends on `contracts/diagnostic-evidence.md`.
+- T028 is last.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel after T001 and T002.
+- T010, T011, T012, and T013 can be authored in parallel because they target distinct test concerns.
+- T015 and T016 can be authored in parallel.
+- T018 and T019 can run in parallel after inventory source locations are stable.
+
+## Parallel Example: Story Phase
+
+```text
+Task: "Add failing unit/controller test for inventory completeness in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerInventoryTests.*"
+Task: "Add failing unit/controller regression test for Movement overlay interference in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMovementOverlayInterferenceTests.*"
+Task: "Add failing integration diagnostic churn test in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiMarkerDiagnosticsIntegrationTests.*"
+```
+
+## Implementation Strategy
+
+1. Stop immediately if `TARGET_PROJECT_ROOT` is unavailable; the current MoonMind checkout does not contain the target runtime source.
+2. Complete setup and foundational inventory tasks.
+3. Write red-first unit/controller tests and confirm expected failures.
+4. Write red-first integration/controller tests and confirm expected failures.
+5. Complete the inventory, classifications, baseline fixtures, and diagnostics until tests pass.
+6. Run target unit and integration suites.
+7. Run quickstart validation.
+8. Run `/moonspec-verify`.
+
+## Notes
+
+- This task list covers one story only.
+- Do not run `moonspec-breakdown`; `MM-525` is already a single-story runtime request.
+- Do not change Grid UI marker ownership semantics in this story.
+- Do not map target runtime implementation onto the MoonMind repository; use the Tactics frontend workspace that contains the named APIs.

--- a/specs/268-channel-overlay-api/checklists/requirements.md
+++ b/specs/268-channel-overlay-api/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Channel-Owned Overlay Intent API
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details beyond preserved source/API terms required by the Jira brief
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders where possible while preserving required domain terms
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic except where Jira explicitly requires AGridUI-facing API behavior
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No avoidable implementation details leak into specification
+
+## Notes
+
+- The source design document is absent from this checkout, so the trusted MM-526 Jira preset brief is preserved as the canonical source.
+- The story is classified as a single-story runtime feature request.

--- a/specs/268-channel-overlay-api/contracts/overlay-api-contract.md
+++ b/specs/268-channel-overlay-api/contracts/overlay-api-contract.md
@@ -1,0 +1,44 @@
+# Contract: AGridUI Overlay API
+
+Source story: `MM-526`.
+
+## Public Runtime Surface
+
+AGridUI exposes a runtime-facing overlay API with these operations:
+
+```text
+SetOverlayLayer(channel, markerType, tileIndexes, reason, styleId, priorityOverride, stacking, visible)
+ClearOverlayLayer(channel)
+```
+
+Contract requirements:
+
+- `channel` must be one of the required Overlay Channel values.
+- `tileIndexes` are the canonical overlay input for setting layer geometry.
+- `SetOverlayLayer` stores or replaces one channel's desired layer state.
+- `ClearOverlayLayer` clears only the requested channel.
+- Both operations produce deterministic revision changes observable by tests or diagnostics.
+- The operations must be callable from the target runtime's public/Blueprint-facing surface where applicable.
+
+## Rendering Contract
+
+- Active channel layers reduce into the existing marker/decal rendering path.
+- The reducer must not require a controller/renderer split in this story.
+- Clearing HoverMoveRange must not clear PlanningMoveRange when both map to Movement visuals.
+- Existing decal pooling and idempotence behavior remains valid.
+
+## Legacy Compatibility Contract
+
+- Existing marker APIs remain callable.
+- Legacy calls route through LegacyCompatibility.
+- Warning diagnostics are emitted for non-approved legacy call sites when diagnostics are enabled.
+- Compatibility routing must not mutate unrelated overlay channels.
+
+## Required Contract Tests
+
+- API-facing test for SetOverlayLayer retaining all required layer fields.
+- API-facing test for ClearOverlayLayer clearing only the requested channel.
+- Channel-isolation test with HoverMoveRange and PlanningMoveRange both producing Movement visuals.
+- Reducer integration test proving active layers render through the existing marker/decal path.
+- Legacy compatibility test proving old marker calls still render and diagnostics emit for non-approved call sites when enabled.
+- Decal pooling/idempotence regression test or equivalent target assertion.

--- a/specs/268-channel-overlay-api/data-model.md
+++ b/specs/268-channel-overlay-api/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: Channel-Owned Overlay Intent API
+
+## Overlay Channel
+
+Represents a named ownership lane for overlay intent.
+
+Required values:
+
+- PlanningMoveRange
+- HoverMoveRange
+- AttackTargeting
+- AbilityPreview
+- DangerPreview
+- ActiveSelection
+- TargetPreview
+- GhostPath
+- Debug
+- LegacyCompatibility
+
+Validation rules:
+
+- A layer belongs to exactly one channel.
+- Channel names must be stable and testable because clear semantics operate by channel identity, not only marker visual type.
+- LegacyCompatibility is reserved for old marker API routing and must not be used as a generic fallback for new producers.
+
+## Overlay Layer State
+
+Represents desired overlay intent for one channel.
+
+Required fields:
+
+- channel
+- marker type
+- tile indexes
+- reason
+- style id
+- priority override
+- stacking flag
+- visibility flag
+- revision
+
+Validation rules:
+
+- Tile indexes are the canonical spatial input for SetOverlayLayer.
+- Revision changes whenever a channel layer is set or cleared.
+- Invisible layers may remain in state but must not contribute visible marker decals.
+- Empty tile index sets must have deterministic state and clear behavior.
+
+## Overlay Reducer
+
+Represents AGridUI behavior that converts active layer state into existing marker/decal render commands.
+
+Rules:
+
+- Reduction uses active per-channel state as input.
+- Reduction must preserve existing marker/decal renderer ownership boundaries for this story.
+- Layers sharing the same marker visual type must remain independently clearable by channel.
+- Priority override and stacking flag must influence deterministic output where target renderer semantics support them.
+
+## Legacy Compatibility Route
+
+Represents routing for old marker APIs while producers migrate later.
+
+Rules:
+
+- Old marker API calls continue to render through LegacyCompatibility.
+- Non-approved legacy call sites emit warning diagnostics when diagnostics are enabled.
+- Approved legacy call sites may render without warning noise.
+- Compatibility routing must not hide or mutate unrelated channel state.
+
+## State Transitions
+
+- SetOverlayLayer(channel, layer): creates or replaces the desired state for that channel and advances the channel revision.
+- ClearOverlayLayer(channel): clears only the desired state for that channel and advances that channel revision.
+- Legacy marker API call: routes through LegacyCompatibility and participates in reducer output.
+- Reduce active layers: reads current desired state and produces existing renderer-compatible marker/decal output.

--- a/specs/268-channel-overlay-api/plan.md
+++ b/specs/268-channel-overlay-api/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Channel-Owned Overlay Intent API
+
+**Branch**: `268-channel-overlay-api` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/268-channel-overlay-api/spec.md`
+
+## Summary
+
+Deliver `MM-526` by adding channel-owned desired overlay state to AGridUI: explicit overlay channel and layer state models, BlueprintCallable SetOverlayLayer and ClearOverlayLayer APIs using tile indexes, per-channel storage, reducer behavior into the existing marker/decal renderer, legacy marker compatibility routing, warning diagnostics for non-approved legacy calls, and preservation of existing decal pooling/idempotence behavior. Repository gap analysis found that the referenced Tactics frontend source document and runtime implementation are not present in this checkout, so implementation cannot safely proceed in this repository without the target source tree.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | No `AGridUI`, `EGridOverlayChannel`, or target Grid UI runtime files exist in this checkout. | Requires target Tactics frontend source tree before channel model can be added. | unit + integration in target project |
+| FR-002 | missing | No target overlay layer state type exists in this checkout. | Requires target AGridUI data model files. | unit serialization/state tests |
+| FR-003 | missing | No BlueprintCallable or equivalent AGridUI API surface exists in this checkout. | Requires target AGridUI public interface files. | API/Blueprint-facing tests |
+| FR-004 | missing | No target marker/decal renderer path exists in this checkout. | Requires target reducer and existing renderer path. | unit + integration rendering tests |
+| FR-005 | missing | No Movement overlay channel implementation exists in this checkout. | Requires target channel-state clear logic. | unit/controller channel-isolation test |
+| FR-006 | missing | No legacy marker API surface or diagnostics exists in this checkout. | Requires target legacy API routing and diagnostic hooks. | unit + integration diagnostics tests |
+| FR-007 | missing | No target decal pooling/idempotence tests exist in this checkout. | Requires target test suite or equivalent assertions. | existing target tests |
+| FR-008 | implemented_unverified | Spec and plan preserve the boundary not to split controller/renderer responsibilities or migrate producers. | Preserve as implementation guard when target source is available. | final verification |
+| FR-009 | implemented_verified | `spec.md` preserves `MM-526` and the canonical Jira preset brief. | Preserve through downstream artifacts, commits, and PR metadata. | final verification |
+| SCN-001 | missing | No target overlay layer state exists. | Requires target source tree. | unit state tests |
+| SCN-002 | missing | No target channel clear logic exists. | Requires target source tree. | unit channel-isolation test |
+| SCN-003 | missing | No target reducer/renderer path exists. | Requires target renderer integration. | integration renderer test |
+| SCN-004 | missing | No legacy marker API routing or diagnostic surface exists. | Requires target source tree. | unit + integration diagnostics tests |
+| SCN-005 | missing | No decal pooling/idempotence tests exist in this checkout. | Requires target test suite. | existing/equivalent lifecycle tests |
+| DESIGN-REQ-001 | missing | Source design document and target AGridUI implementation are absent. | Requires target source/design artifact. | final verification |
+| DESIGN-REQ-002 | missing | No target channel enum/model exists. | Requires target source tree. | unit model tests |
+| DESIGN-REQ-003 | missing | No target layer state model exists. | Requires target source tree. | unit state tests |
+| DESIGN-REQ-004 | missing | No target API surface exists. | Requires target AGridUI public API. | API-facing tests |
+| DESIGN-REQ-005 | missing | No target reducer/renderer exists. | Requires target source tree. | unit + integration tests |
+| DESIGN-REQ-006 | missing | No Movement channel isolation logic exists. | Requires target source tree. | unit/controller test |
+| DESIGN-REQ-007 | missing | No legacy compatibility route exists. | Requires target source tree. | unit + diagnostics tests |
+| DESIGN-REQ-008 | missing | No target decal pooling/idempotence tests exist. | Requires target test suite. | existing/equivalent tests |
+| DESIGN-REQ-009 | implemented_unverified | Spec and plan explicitly constrain scope. | Preserve as implementation guard. | final verification |
+
+## Technical Context
+
+**Language/Version**: Target appears to be a Tactics frontend runtime, likely Unreal/C++ from AGridUI and BlueprintCallable naming, but the target source tree is unavailable in this checkout.  
+**Primary Dependencies**: Target AGridUI runtime, marker/decal renderer, diagnostics, and Blueprint-facing API system unavailable in this checkout.  
+**Storage**: In-memory per-channel overlay state inside AGridUI; no persistent storage expected.  
+**Unit Testing**: Target project unit/controller tests required; unavailable in this checkout.
+**Integration Testing**: Target project rendering/lifecycle/diagnostic integration tests required; unavailable in this checkout.
+**Target Platform**: Tactics frontend runtime; exact platform cannot be verified from this checkout.  
+**Project Type**: Runtime frontend/game UI feature; target project unavailable.  
+**Performance Goals**: Overlay reduction must preserve existing marker/decal rendering behavior and decal pooling/idempotence expectations.  
+**Constraints**: Preserve `MM-526` traceability; use runtime mode; do not split controller/renderer responsibilities; do not migrate individual gameplay producers beyond compatibility routing; do not invent target files or APIs when the target source tree is absent.  
+**Scale/Scope**: One AGridUI overlay API story covering channel model, layer state, channel isolation, reducer behavior, legacy compatibility, diagnostics, and existing decal test preservation.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The plan does not replace provider behavior or MoonMind orchestration.
+- **II. One-Click Agent Deployment**: PASS. No deployment path changes.
+- **III. Avoid Vendor Lock-In**: PASS. No vendor-specific MoonMind integration introduced.
+- **IV. Own Your Data**: PASS. Jira-derived source context is preserved in local MoonSpec artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime changes.
+- **VI. Scientific Method / Tests Are Anchor**: PASS with blocker. The plan requires tests before runtime changes, but the target test harness is absent.
+- **VII. Powerful Runtime Configurability**: PASS. No MoonMind runtime configuration changes.
+- **VIII. Modular and Extensible Architecture**: PASS. The target implementation is scoped to AGridUI and existing renderer boundaries.
+- **IX. Resilient by Default**: PASS. No workflow/activity contract changes.
+- **X. Facilitate Continuous Improvement**: PASS. The blocker is captured as structured evidence.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Spec artifacts exist before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Feature-local artifacts hold execution notes.
+- **XIII. Pre-release Compatibility Policy**: PASS. No compatibility aliases or hidden transforms are introduced in MoonMind internal contracts.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/268-channel-overlay-api/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── overlay-api-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+# Current checkout contains MoonMind orchestration code only.
+api_service/
+frontend/
+moonmind/
+docs/
+specs/
+
+# Required target paths are absent from this checkout.
+Docs/TacticsFrontend/GridUiOverlaySystem.md
+Tactics frontend AGridUI runtime source
+Tactics frontend marker/decal renderer source
+Tactics frontend Grid UI tests
+```
+
+**Structure Decision**: Do not map implementation tasks onto the MoonMind codebase. The requested runtime story belongs to the referenced Tactics frontend target source tree, which is not present here. This repository can preserve MoonSpec artifacts and blocker evidence only until the target source tree is available.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/268-channel-overlay-api/quickstart.md
+++ b/specs/268-channel-overlay-api/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart: Channel-Owned Overlay Intent API
+
+## Scope
+
+This quickstart validates `MM-526` in the target Tactics frontend repository. The current MoonMind checkout does not contain the target AGridUI runtime source or tests.
+
+## Prerequisites
+
+1. Set `TARGET_PROJECT_ROOT` to the root of the Tactics frontend workspace containing `Docs/TacticsFrontend/GridUiOverlaySystem.md`.
+2. Confirm `TARGET_PROJECT_ROOT` contains AGridUI runtime source and the existing marker/decal renderer tests.
+3. Preserve `MM-526` in implementation notes, verification output, commit text, and pull request metadata.
+
+## Validation Steps
+
+1. Confirm the source design exists:
+
+```bash
+test -f "$TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiOverlaySystem.md"
+```
+
+2. Confirm target AGridUI/runtime source exists:
+
+```bash
+rg -n "AGridUI|SpawnTileMarkers|ClearTileMarkers|SpawnDecalsAtLocations|ClearSpecifiedDecals" "$TARGET_PROJECT_ROOT"
+```
+
+3. Run the target unit/controller tests for:
+
+- overlay channel model values
+- overlay layer state field retention
+- SetOverlayLayer and ClearOverlayLayer API behavior
+- HoverMoveRange versus PlanningMoveRange channel isolation
+- legacy marker API compatibility diagnostics
+
+4. Run the target integration tests for:
+
+- reducer output into the existing marker/decal rendering path
+- existing decal pooling/idempotence behavior
+- legacy compatibility behavior across approved and non-approved call sites
+
+5. Run MoonSpec verification against `specs/268-channel-overlay-api/spec.md` and confirm the verdict preserves `MM-526`.
+
+## Current Checkout Result
+
+The target Tactics frontend source tree is absent from this MoonMind checkout, so target unit and integration commands cannot be run here.

--- a/specs/268-channel-overlay-api/research.md
+++ b/specs/268-channel-overlay-api/research.md
@@ -1,0 +1,89 @@
+# Research: Channel-Owned Overlay Intent API
+
+## Input Classification
+
+Decision: `MM-526` is a single-story runtime feature request.
+Evidence: The trusted Jira preset brief has one bounded AGridUI outcome: introduce channel-owned overlay state and compatibility routing while preserving the current decal renderer.
+Rationale: The brief lists one target surface, one source document, one coherent acceptance set, and explicit scope boundaries.
+Alternatives considered: Treating the referenced Grid UI Overlay System document as a broad design was rejected because the Jira issue already selects one phase-1 AGridUI story.
+Test implications: Unit and integration tests are both required once the target Tactics frontend source tree is available.
+
+## Target Source Availability
+
+Decision: Implementation is blocked in this checkout because the target Tactics frontend source tree is absent.
+Evidence: Repository search found no `Docs/TacticsFrontend/GridUiOverlaySystem.md`, no `AGridUI`, no `EGridOverlayChannel`, no Unreal project files, and no Grid UI marker/decal runtime tests.
+Rationale: Creating placeholder AGridUI files in the MoonMind repository would not implement the requested runtime behavior and would violate the source-bound scope.
+Alternatives considered: Implementing a mock overlay model inside MoonMind was rejected because the Jira brief targets the Tactics frontend runtime.
+Test implications: Target unit/controller and integration commands cannot run in this checkout.
+
+## FR-001 Channel Model
+
+Decision: missing.
+Evidence: No target AGridUI channel model exists in this checkout.
+Rationale: The required enum/model must live in the target runtime and include exactly the channel names from the Jira brief.
+Alternatives considered: Recording the model only in documentation was rejected because selected mode is runtime.
+Test implications: Add unit/model coverage in the target project.
+
+## FR-002 Layer State
+
+Decision: missing.
+Evidence: No target FGridOverlayLayerState or equivalent exists in this checkout.
+Rationale: The required state fields are observable runtime behavior because the reducer and clear semantics depend on them.
+Alternatives considered: Inferring state only from rendered decals was rejected because channel-owned desired state must be explicit.
+Test implications: Add unit state-retention tests.
+
+## FR-003 Public API
+
+Decision: missing.
+Evidence: No BlueprintCallable SetOverlayLayer or ClearOverlayLayer target API exists in this checkout.
+Rationale: The Jira brief requires tile indexes as canonical overlay input through AGridUI-facing APIs.
+Alternatives considered: Adding only private helper methods was rejected because the public API contract is explicit.
+Test implications: Add API-facing or Blueprint-equivalent tests.
+
+## FR-004 Reducer To Existing Renderer
+
+Decision: missing.
+Evidence: No target marker/decal renderer path is present in this checkout.
+Rationale: The story must preserve the existing renderer and reduce desired channel state into that path.
+Alternatives considered: Splitting controller and renderer responsibilities was rejected by the Jira brief.
+Test implications: Add reducer unit coverage and renderer integration coverage.
+
+## FR-005 Channel Isolation
+
+Decision: missing.
+Evidence: No target Movement overlay channel implementation exists in this checkout.
+Rationale: The core bug-prevention behavior is that clearing one channel cannot clear unrelated channel state even when visuals share a marker type.
+Alternatives considered: Clearing by marker type was rejected because it recreates the known producer-interference class.
+Test implications: Add a two-channel Movement visual regression test.
+
+## FR-006 Legacy Compatibility Diagnostics
+
+Decision: missing.
+Evidence: No legacy marker API or diagnostic surface exists in this checkout.
+Rationale: Old marker APIs must keep working through LegacyCompatibility during migration, with warning diagnostics for non-approved call sites when enabled.
+Alternatives considered: Removing old marker APIs immediately was rejected because compatibility routing is an explicit requirement.
+Test implications: Add unit and integration diagnostic tests.
+
+## FR-007 Existing Decal Pooling And Idempotence
+
+Decision: missing.
+Evidence: No target decal pooling/idempotence tests exist in this checkout.
+Rationale: The feature must preserve current rendering lifecycle guarantees while adding desired-state channels.
+Alternatives considered: Relying only on new overlay tests was rejected because existing lifecycle behavior must remain covered.
+Test implications: Run existing target tests or add equivalent assertions.
+
+## FR-008 Scope Boundary
+
+Decision: implemented_unverified.
+Evidence: `spec.md` and `plan.md` preserve the no-split/no-producer-migration boundary, and no target code has been changed.
+Rationale: This remains an implementation guard for the target project.
+Alternatives considered: Migrating producers in the same story was rejected because the Jira issue only requires AGridUI API and compatibility routing.
+Test implications: Final verification must confirm no out-of-scope producer migration or renderer split occurred.
+
+## FR-009 Traceability
+
+Decision: implemented_verified.
+Evidence: `spec.md` preserves `MM-526` and the canonical Jira preset brief.
+Rationale: Downstream artifacts can trace requirements and delivery metadata back to Jira.
+Alternatives considered: Summarizing the issue without the key was rejected because the user explicitly required preserving `MM-526`.
+Test implications: Final verification must preserve the issue key in evidence.

--- a/specs/268-channel-overlay-api/spec.md
+++ b/specs/268-channel-overlay-api/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Channel-Owned Overlay Intent API
+
+**Feature Branch**: `268-channel-overlay-api`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-526 as the canonical Moon Spec orchestration input.
+
+Jira issue: MM-526 from MM project
+
+Summary:
+Add channel-owned overlay intent API inside AGridUI with legacy compatibility routing
+
+Source Reference:
+Source Document: Docs/TacticsFrontend/GridUiOverlaySystem.md
+Source Title: Grid UI Overlay System
+Source Sections:
+- 7.1 AGridUI
+- 8. Data Model
+- 9. Public API Contract
+- 10. Channel Semantics
+- 24. Compatibility With Existing Concepts
+
+Coverage IDs:
+- plan.phase1
+- doc.api.preferred
+- doc.compatibility
+- doc.channel-isolation
+
+Brief:
+Introduce the desired-state channel model inside the existing AGridUI surface while preserving the current decal renderer. Add overlay channel and layer state types, SetOverlayLayer and ClearOverlayLayer APIs, transient channel state, a simple marker-type union reducer, and compatibility routing for old marker APIs.
+
+Acceptance Criteria:
+- EGridOverlayChannel includes PlanningMoveRange, HoverMoveRange, AttackTargeting, AbilityPreview, DangerPreview, ActiveSelection, TargetPreview, GhostPath, Debug, and LegacyCompatibility.
+- FGridOverlayLayerState stores channel, marker type, tile indexes, reason, style id, priority override, stacking flag, visibility flag, and revision.
+- AGridUI exposes BlueprintCallable SetOverlayLayer and ClearOverlayLayer APIs using tile indexes as canonical overlay input.
+- AGridUI stores per-channel overlay state and reduces active channel layers into existing marker rendering without splitting controller/renderer responsibilities yet.
+- ClearOverlayLayer(HoverMoveRange) does not clear PlanningMoveRange when both resolve to Movement visuals.
+- Legacy marker APIs still work through LegacyCompatibility and emit warning diagnostics when enabled for non-approved call sites.
+- Existing decal pooling/idempotence tests still pass.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-526 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata."
+
+## User Story - Channel-Owned AGridUI Overlay Layers
+
+**Summary**: As a tactics frontend maintainer, I want AGridUI to accept overlay intent by explicit channel so multiple gameplay producers can own, update, and clear their overlays without erasing unrelated producer state.
+
+**Goal**: Add a channel-owned desired-state overlay API inside AGridUI that preserves current decal rendering behavior, isolates channel cleanup, and routes legacy marker calls through a compatibility channel until later migration stories move producers to the new API.
+
+**Independent Test**: Can be fully tested by exercising AGridUI with multiple overlay channels, verifying SetOverlayLayer and ClearOverlayLayer update only the requested channel, confirming the reducer still renders expected marker visuals through the existing decal path, validating legacy API routing and diagnostics, and rerunning the existing decal pooling/idempotence tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** AGridUI receives overlay layer intent for each supported gameplay channel, **When** the layer is stored, **Then** the channel identity, marker type, tile indexes, reason, style id, priority override, stacking flag, visibility flag, and revision are retained as layer state.
+2. **Given** multiple channels produce Movement visuals, **When** ClearOverlayLayer is called for HoverMoveRange, **Then** PlanningMoveRange remains active and continues to contribute Movement visuals.
+3. **Given** active overlay layers exist across channels, **When** AGridUI reduces layers for rendering, **Then** the existing marker/decal renderer receives the correct union of active layers without splitting controller and renderer responsibilities in this story.
+4. **Given** a caller uses the old marker API, **When** compatibility routing is enabled, **Then** the call still renders through LegacyCompatibility and emits warning diagnostics for non-approved call sites when diagnostics are enabled.
+5. **Given** existing decal pooling and idempotence expectations, **When** the target test suite runs after the new channel APIs are added, **Then** those expectations still pass or equivalent assertions preserve the same observable guarantees.
+
+### Edge Cases
+
+- A layer has an empty tile index set and still needs a deterministic revision and clear behavior.
+- A channel sets an invisible layer that should remain in desired state without contributing visible marker decals.
+- Multiple active layers share marker visuals but differ by priority override or stacking flag.
+- A legacy marker call arrives from an approved call site and should preserve behavior without warning noise.
+- A legacy marker call arrives from a non-approved call site while diagnostics are disabled and must not disrupt rendering.
+
+## Assumptions
+
+- The referenced source document `Docs/TacticsFrontend/GridUiOverlaySystem.md` is not present in this checkout; the trusted MM-526 Jira brief is the canonical source for this story.
+- Runtime mode applies: the implementation target is the Tactics frontend Grid UI runtime, not MoonMind documentation.
+- If the target Tactics frontend source tree is unavailable in this repository, implementation must stop at the first stage that proves the required source or tests cannot be located.
+- This story introduces channel-owned overlay state inside AGridUI while preserving the existing decal renderer boundary; producer migrations beyond legacy compatibility routing are out of scope.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirement |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | MM-526 Source Section 7.1; Coverage ID `plan.phase1` | Introduce desired-state overlay channel support inside the existing AGridUI surface. | In scope | FR-001, FR-003 |
+| DESIGN-REQ-002 | MM-526 Acceptance Criteria; Source Section 8 | Define EGridOverlayChannel with PlanningMoveRange, HoverMoveRange, AttackTargeting, AbilityPreview, DangerPreview, ActiveSelection, TargetPreview, GhostPath, Debug, and LegacyCompatibility. | In scope | FR-001 |
+| DESIGN-REQ-003 | MM-526 Acceptance Criteria; Source Section 8 | Define FGridOverlayLayerState with channel, marker type, tile indexes, reason, style id, priority override, stacking flag, visibility flag, and revision. | In scope | FR-002 |
+| DESIGN-REQ-004 | MM-526 Acceptance Criteria; Source Section 9 | Expose BlueprintCallable SetOverlayLayer and ClearOverlayLayer APIs using tile indexes as canonical overlay input. | In scope | FR-003 |
+| DESIGN-REQ-005 | MM-526 Acceptance Criteria; Source Section 10 | Store overlay state per channel and reduce active layers into the existing marker rendering path without splitting controller and renderer responsibilities. | In scope | FR-004 |
+| DESIGN-REQ-006 | MM-526 Acceptance Criteria; Coverage ID `doc.channel-isolation` | Clearing HoverMoveRange must not clear PlanningMoveRange when both resolve to Movement visuals. | In scope | FR-005 |
+| DESIGN-REQ-007 | MM-526 Acceptance Criteria; Source Section 24; Coverage ID `doc.compatibility` | Preserve legacy marker APIs through LegacyCompatibility and emit warning diagnostics for non-approved call sites when enabled. | In scope | FR-006 |
+| DESIGN-REQ-008 | MM-526 Acceptance Criteria | Existing decal pooling and idempotence tests must still pass or retain equivalent assertions. | In scope | FR-007 |
+| DESIGN-REQ-009 | MM-526 Scope boundary | Do not migrate individual gameplay producers or split controller/renderer responsibilities in this story. | In scope | FR-008 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: AGridUI MUST define an overlay channel model containing PlanningMoveRange, HoverMoveRange, AttackTargeting, AbilityPreview, DangerPreview, ActiveSelection, TargetPreview, GhostPath, Debug, and LegacyCompatibility.
+- **FR-002**: AGridUI MUST store overlay layer state with channel, marker type, tile indexes, reason, style id, priority override, stacking flag, visibility flag, and revision.
+- **FR-003**: AGridUI MUST expose BlueprintCallable SetOverlayLayer and ClearOverlayLayer operations that use tile indexes as the canonical overlay input.
+- **FR-004**: AGridUI MUST store desired overlay state per channel and reduce active channel layers into the existing marker/decal rendering path.
+- **FR-005**: ClearOverlayLayer for one channel MUST NOT clear or mutate unrelated channel state, including the case where HoverMoveRange and PlanningMoveRange both resolve to Movement visuals.
+- **FR-006**: Legacy marker APIs MUST continue to render through LegacyCompatibility and MUST emit warning diagnostics for non-approved call sites when diagnostics are enabled.
+- **FR-007**: Existing decal pooling and idempotence behavior MUST continue to pass through existing or equivalent automated tests.
+- **FR-008**: This story MUST NOT split AGridUI controller and renderer responsibilities or migrate individual gameplay producers beyond compatibility routing required for old marker APIs.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-526` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Overlay Channel**: A named ownership lane for one gameplay, selection, debug, or compatibility overlay producer.
+- **Overlay Layer State**: The desired overlay state stored for one channel, including visual intent, tile indexes, visibility, priority, stacking, and revision.
+- **Overlay Reducer**: The AGridUI behavior that converts active channel layer state into the existing marker/decal rendering representation.
+- **Legacy Compatibility Route**: The compatibility path that keeps old marker APIs working while associating their output with LegacyCompatibility.
+- **Warning Diagnostic**: Structured evidence emitted for non-approved legacy marker calls when diagnostics are enabled.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All ten required overlay channel names are represented in the target AGridUI channel model.
+- **SC-002**: Automated validation proves every required FGridOverlayLayerState field is retained when a layer is set.
+- **SC-003**: Blueprint or equivalent runtime-facing tests can call SetOverlayLayer and ClearOverlayLayer using tile indexes.
+- **SC-004**: A channel-isolation test proves clearing HoverMoveRange leaves PlanningMoveRange active when both use Movement visuals.
+- **SC-005**: Existing marker/decal renderer tests or equivalent integration tests prove reduced channel layers continue to render through the current decal path.
+- **SC-006**: Legacy API tests prove old marker calls still render through LegacyCompatibility and warning diagnostics are emitted for non-approved call sites when enabled.
+- **SC-007**: Final validation preserves passing decal pooling/idempotence coverage.
+- **SC-008**: Final verification can trace `MM-526`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-009 through active MoonSpec artifacts and test evidence.

--- a/specs/268-channel-overlay-api/tasks.md
+++ b/specs/268-channel-overlay-api/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: Channel-Owned Overlay Intent API
+
+**Input**: Design documents from `/specs/268-channel-overlay-api/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: `Channel-Owned AGridUI Overlay Layers`.
+
+**Source Traceability**: `MM-526`, FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-009.
+
+**Test Commands**:
+
+- Unit tests: target Tactics frontend unit/controller test command for AGridUI overlay API tests
+- Integration tests: target Tactics frontend integration/controller-level command for marker/decal renderer and diagnostics tests
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when paths differ and dependencies are complete
+- Each task includes a target path. `TARGET_PROJECT_ROOT` means the root of the Tactics frontend repository/workspace containing `Docs/TacticsFrontend/GridUiOverlaySystem.md`; this root is not present in the current MoonMind checkout.
+
+## Phase 1: Setup
+
+**Purpose**: Establish the target runtime workspace and preserve traceability before any story implementation.
+
+- [ ] T001 Verify `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/GridUiOverlaySystem.md` exists and records source sections 7.1, 8, 9, 10, and 24 for MM-526. (DESIGN-REQ-001, DESIGN-REQ-009)
+- [ ] T002 Verify `TARGET_PROJECT_ROOT` contains AGridUI runtime source, marker/decal renderer source, legacy marker APIs, and existing decal pooling/idempotence tests before editing implementation files. (FR-001, FR-007)
+- [ ] T003 Verify target unit/controller test command for AGridUI overlay channel, layer state, and API tests and record it in `specs/268-channel-overlay-api/quickstart.md`. (FR-001, FR-002, FR-003)
+- [ ] T004 Verify target integration test command for marker/decal renderer, channel isolation, diagnostics, and legacy compatibility tests and record it in `specs/268-channel-overlay-api/quickstart.md`. (FR-004, FR-005, FR-006, FR-007)
+- [ ] T005 Preserve `MM-526` and the canonical Jira preset brief in any target implementation notes or delivery metadata. (FR-009, SC-008)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add or locate the target test harness and public contract locations that block story implementation.
+
+**CRITICAL**: No story implementation work can begin until T001 through T009 are complete.
+
+- [ ] T006 Identify target AGridUI header/interface and implementation files for the overlay channel model, layer state, and BlueprintCallable API in `TARGET_PROJECT_ROOT/Source/`. (FR-001, FR-002, FR-003)
+- [ ] T007 Identify target marker/decal renderer integration points and reducer location in `TARGET_PROJECT_ROOT/Source/`. (FR-004, DESIGN-REQ-005)
+- [ ] T008 Identify target legacy marker API call surface and approved legacy call-site policy location in `TARGET_PROJECT_ROOT/Source/` or `TARGET_PROJECT_ROOT/Docs/TacticsFrontend/`. (FR-006, DESIGN-REQ-007)
+- [ ] T009 Identify or create target test fixture locations for overlay model, API, channel isolation, reducer integration, legacy diagnostics, and decal pooling/idempotence tests in `TARGET_PROJECT_ROOT/Tests/GridUi/`. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007)
+
+**Checkpoint**: Target source and test harness locations are ready; red-first story tests can begin.
+
+---
+
+## Phase 3: Story - Channel-Owned AGridUI Overlay Layers
+
+**Summary**: As a tactics frontend maintainer, I want AGridUI to accept overlay intent by explicit channel so multiple gameplay producers can own, update, and clear their overlays without erasing unrelated producer state.
+
+**Independent Test**: Exercise AGridUI with multiple overlay channels, verify SetOverlayLayer and ClearOverlayLayer update only the requested channel, confirm reducer output still renders through the existing decal path, validate legacy API routing and diagnostics, and rerun decal pooling/idempotence tests.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, SC-008, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009.
+
+**Test Plan**:
+
+- Unit: channel model values, layer state retention, public API behavior, channel-isolated clear semantics, legacy compatibility diagnostics.
+- Integration: active layer reduction into the existing marker/decal renderer, existing decal pooling/idempotence preservation, and end-to-end legacy compatibility behavior.
+
+### Unit Tests (write first)
+
+- [ ] T010 [P] Add failing unit/controller test for all required EGridOverlayChannel values in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayChannelTests.*`. (FR-001, SC-001, DESIGN-REQ-002)
+- [ ] T011 [P] Add failing unit/controller test for FGridOverlayLayerState retaining channel, marker type, tile indexes, reason, style id, priority override, stacking flag, visibility flag, and revision in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayLayerStateTests.*`. (FR-002, SC-002, DESIGN-REQ-003)
+- [ ] T012 [P] Add failing API-facing test for BlueprintCallable SetOverlayLayer and ClearOverlayLayer using tile indexes in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayApiTests.*`. (FR-003, SC-003, DESIGN-REQ-004)
+- [ ] T013 [P] Add failing unit/controller test proving ClearOverlayLayer(HoverMoveRange) does not clear PlanningMoveRange when both resolve to Movement visuals in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayChannelIsolationTests.*`. (FR-005, SC-004, DESIGN-REQ-006)
+- [ ] T014 [P] Add failing unit/controller test for legacy marker API routing through LegacyCompatibility and warning diagnostics for non-approved call sites when enabled in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayLegacyCompatibilityTests.*`. (FR-006, SC-006, DESIGN-REQ-007)
+- [ ] T015 Run the target unit/controller test command for T010 through T014 and confirm each new test fails for the expected missing behavior before production implementation. (FR-001, FR-002, FR-003, FR-005, FR-006)
+
+### Integration Tests (write first)
+
+- [ ] T016 [P] Add failing integration/controller-level test proving active channel layers reduce into the existing marker/decal renderer in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayRendererIntegrationTests.*`. (FR-004, SC-005, DESIGN-REQ-005)
+- [ ] T017 [P] Add failing integration/controller-level test preserving existing decal pooling/idempotence behavior after channel overlay operations in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiDecalPoolingIntegrationTests.*`. (FR-007, SC-007, DESIGN-REQ-008)
+- [ ] T018 [P] Add failing integration/controller-level test proving legacy API calls still render through LegacyCompatibility without mutating unrelated channels in `TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayLegacyIntegrationTests.*`. (FR-006, FR-008, DESIGN-REQ-007, DESIGN-REQ-009)
+- [ ] T019 Run the target integration test command for T016 through T018 and confirm each new test fails for the expected missing behavior before implementation. (FR-004, FR-006, FR-007, FR-008)
+
+### Implementation
+
+- [ ] T020 Add EGridOverlayChannel to the target AGridUI runtime source in `TARGET_PROJECT_ROOT/Source/` until T010 passes. (FR-001, DESIGN-REQ-002)
+- [ ] T021 Add FGridOverlayLayerState to the target AGridUI runtime source in `TARGET_PROJECT_ROOT/Source/` until T011 passes. (FR-002, DESIGN-REQ-003)
+- [ ] T022 Add BlueprintCallable SetOverlayLayer and ClearOverlayLayer APIs using tile indexes in `TARGET_PROJECT_ROOT/Source/` until T012 passes. (FR-003, DESIGN-REQ-004)
+- [ ] T023 Add per-channel overlay state storage and revision behavior in `TARGET_PROJECT_ROOT/Source/` until T011 and T012 pass. (FR-002, FR-003)
+- [ ] T024 Add channel-isolated clear behavior in `TARGET_PROJECT_ROOT/Source/` until T013 passes. (FR-005, DESIGN-REQ-006)
+- [ ] T025 Add reducer behavior from active channel layers into the existing marker/decal rendering path in `TARGET_PROJECT_ROOT/Source/` until T016 passes. (FR-004, DESIGN-REQ-005)
+- [ ] T026 Route legacy marker APIs through LegacyCompatibility and add warning diagnostics for non-approved call sites when enabled in `TARGET_PROJECT_ROOT/Source/` until T014 and T018 pass. (FR-006, DESIGN-REQ-007)
+- [ ] T027 Preserve existing decal pooling/idempotence behavior and update equivalent assertions only when target behavior remains unchanged in `TARGET_PROJECT_ROOT/Tests/GridUi/` until T017 passes. (FR-007, DESIGN-REQ-008)
+- [ ] T028 Review implementation to confirm it does not split controller/renderer responsibilities or migrate individual gameplay producers beyond compatibility routing. (FR-008, DESIGN-REQ-009)
+- [ ] T029 Run the target unit/controller test command and fix failures without expanding scope beyond MM-526. (FR-001, FR-002, FR-003, FR-005, FR-006, FR-008)
+- [ ] T030 Run the target integration test command and fix failures without expanding scope beyond MM-526. (FR-004, FR-006, FR-007, FR-008)
+
+**Checkpoint**: The story is functional in the target project, red-first tests now pass, channel ownership is isolated, and the existing renderer boundary is preserved.
+
+---
+
+## Phase 4: Story Validation And Polish
+
+**Purpose**: Validate the completed single story and preserve delivery traceability.
+
+- [ ] T031 Run the quickstart validation in `specs/268-channel-overlay-api/quickstart.md` against `TARGET_PROJECT_ROOT`. (SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007)
+- [ ] T032 Verify all final target test outputs preserve or reference `MM-526` where project conventions support traceability. (FR-009, SC-008)
+- [ ] T033 Run `/moonspec-verify` for `specs/268-channel-overlay-api/spec.md` and record the final verdict. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Must confirm the target Tactics frontend workspace exists.
+- **Foundational (Phase 2)**: Depends on Setup and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational and must follow red-first testing.
+- **Validation And Polish (Phase 4)**: Depends on story implementation and passing target tests.
+
+### Within The Story
+
+- T010 through T014 must be written and fail before T020 through T026.
+- T016 through T018 must be written and fail before T025 through T027.
+- T024 depends on T020 through T023.
+- T025 depends on T020 through T024.
+- T026 depends on `contracts/overlay-api-contract.md`.
+- T033 is last.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel after T001 and T002.
+- T010 through T014 can be authored in parallel because they target distinct test concerns.
+- T016 through T018 can be authored in parallel.
+- T020 and T021 can begin in parallel after red-first tests are confirmed, if target source ownership allows.
+
+## Parallel Example: Story Phase
+
+```text
+Task: "Add failing unit/controller test for all required EGridOverlayChannel values in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayChannelTests.*"
+Task: "Add failing unit/controller test proving ClearOverlayLayer(HoverMoveRange) does not clear PlanningMoveRange in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayChannelIsolationTests.*"
+Task: "Add failing integration/controller-level test proving active channel layers reduce into the existing marker/decal renderer in TARGET_PROJECT_ROOT/Tests/GridUi/GridUiOverlayRendererIntegrationTests.*"
+```
+
+## Implementation Strategy
+
+1. Stop immediately if `TARGET_PROJECT_ROOT` is unavailable; the current MoonMind checkout does not contain the target runtime source.
+2. Complete setup and foundational source/test location tasks.
+3. Write red-first unit/controller tests and confirm expected failures.
+4. Write red-first integration/controller tests and confirm expected failures.
+5. Add channel model, layer state, public APIs, per-channel storage, channel-isolated clear behavior, reducer behavior, legacy compatibility routing, and diagnostics until tests pass.
+6. Run target unit and integration suites.
+7. Run quickstart validation.
+8. Run `/moonspec-verify`.
+
+## Notes
+
+- This task list covers one story only.
+- Do not run `moonspec-breakdown`; `MM-526` is already a single-story runtime request.
+- Do not split controller/renderer responsibilities in this story.
+- Do not migrate individual gameplay producers beyond compatibility routing required for old marker APIs.
+- Do not map target runtime implementation onto the MoonMind repository; use the Tactics frontend workspace that contains AGridUI and the marker/decal renderer.


### PR DESCRIPTION
## Jira

- Jira issue key: MM-526

## MoonSpec

- Active feature path: `specs/268-channel-overlay-api`

## Verification

- Verdict: ADDITIONAL_WORK_NEEDED
- Reason: Target Tactics frontend workspace is not available in this checkout, so runtime implementation and TDD evidence could not be produced.

## Tests run

- `SPECIFY_FEATURE=268-channel-overlay-api .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS
- Checklist scan: PASS, 21 complete / 0 incomplete
- MoonSpec alignment gate: PASS
- Target unit tests: NOT RUN, `TARGET_PROJECT_ROOT` is not set
- Target integration tests: NOT RUN, no AGridUI/Tactics frontend workspace is present

## Remaining risks

- Implementation is blocked until `TARGET_PROJECT_ROOT` points to the Tactics frontend workspace containing AGridUI and the marker/decal renderer.
- No red-first unit or integration test evidence exists yet for the runtime behavior.
- No Jira Code Review transition should happen until implementation and verification complete.
