### PR TITLE
[codex] fix Jira breakdown handoff branch

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,17 @@
 [
   {
-    "id": 3143105240,
-    "disposition": "addressed",
-    "rationale": "Updated the canonical shimmer acceptance criteria so glyph brightening stays on the same timing as the sweep instead of a shorter independent cycle."
+    "id": 4177457111,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary stated there was no feedback to address."
   },
   {
-    "id": 3143105242,
+    "id": 3144162425,
     "disposition": "addressed",
-    "rationale": "Changed the documented letter-cycle token to reference --mm-executing-sweep-cycle-duration, preserving phase alignment."
+    "rationale": "Planner now generates a synthetic targetBranch only when a MoonSpec breakdown step will create a new story breakdown artifact, preserving authored branch-only Jira import flows."
   },
   {
-    "id": 3143105244,
-    "disposition": "addressed",
-    "rationale": "Changed --mm-executing-letter-cycle-duration to var(--mm-executing-sweep-cycle-duration) and compressed the active keyframe window to 8% so the pulse feels faster without duration drift."
-  },
-  {
-    "id": 3143105247,
-    "disposition": "addressed",
-    "rationale": "Restored nested CSS fallbacks for glyph animation duration and delay: letter duration, then sweep duration, then 2200ms."
-  },
-  {
-    "id": 3143105248,
-    "disposition": "addressed",
-    "rationale": "Updated Mission Control CSS contract tests to assert the nested fallback logic and compressed 8% keyframe reset."
-  },
-  {
-    "id": 4176625480,
-    "disposition": "addressed",
-    "rationale": "Addressed the summary review by keeping shimmer and letter cycles synchronized while documenting and testing the shared timing contract."
+    "id": 4177457338,
+    "disposition": "not-applicable",
+    "rationale": "Automated Codex review wrapper contained no separate actionable feedback beyond discussion_r3144162425."
   }
 ]

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -716,6 +716,7 @@ def _build_runtime_planner():
             or ""
         ).strip().lower()
         should_prepare_story_breakdown = bool(story_output_payload)
+        creates_story_breakdown_artifact = False
 
         # --- Expand task.steps[] or stepCount into multiple plan nodes ---
         has_multi_steps = (
@@ -729,6 +730,9 @@ def _build_runtime_planner():
                 for step in raw_steps
                 if isinstance(step, Mapping)
             }
+            creates_story_breakdown_artifact = bool(
+                step_tool_names & _MOONSPEC_BREAKDOWN_TOOLS
+            )
             if not story_output_payload:
                 for step in raw_steps:
                     if not isinstance(step, Mapping):
@@ -748,9 +752,12 @@ def _build_runtime_planner():
                 step_tool_names & (_JIRA_STORY_OUTPUT_TOOLS | _MOONSPEC_BREAKDOWN_TOOLS)
             )
         elif selected_skill_name:
+            creates_story_breakdown_artifact = (
+                selected_skill_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS
+            )
             should_prepare_story_breakdown = (
                 should_prepare_story_breakdown
-                or selected_skill_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS
+                or creates_story_breakdown_artifact
             )
 
         if should_prepare_story_breakdown:
@@ -759,7 +766,11 @@ def _build_runtime_planner():
                 existing={**story_output_payload, **node_inputs},
             )
             node_inputs.update(story_paths)
-            if story_output_mode == "jira" and not node_inputs.get("targetBranch"):
+            if (
+                story_output_mode == "jira"
+                and creates_story_breakdown_artifact
+                and not node_inputs.get("targetBranch")
+            ):
                 if node_inputs.get("branch") and not node_inputs.get("startingBranch"):
                     node_inputs["startingBranch"] = node_inputs["branch"]
                 prefix = _derive_pr_branch_prefix(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -759,9 +759,9 @@ def _build_runtime_planner():
                 existing={**story_output_payload, **node_inputs},
             )
             node_inputs.update(story_paths)
-            if story_output_mode == "jira" and not (
-                node_inputs.get("targetBranch") or node_inputs.get("branch")
-            ):
+            if story_output_mode == "jira" and not node_inputs.get("targetBranch"):
+                if node_inputs.get("branch") and not node_inputs.get("startingBranch"):
+                    node_inputs["startingBranch"] = node_inputs["branch"]
                 prefix = _derive_pr_branch_prefix(
                     task_payload=task_payload,
                     publish_payload=publish_payload,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -427,6 +427,51 @@ def test_runtime_planner_uses_head_branch_for_jira_story_breakdown_from_main():
         == breakdown["inputs"]["storyBreakdownPath"]
     )
 
+def test_runtime_planner_preserves_authored_branch_for_jira_story_import():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Import existing breakdown into Jira",
+                "instructions": "Create Jira issues from an existing breakdown.",
+                "repository": "MoonLadderStudios/MoonMind",
+                "git": {"branch": "feature/authored-breakdown"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "tool": {"type": "skill", "name": "story.create_jira_issues"},
+                "storyOutput": {
+                    "mode": "jira",
+                    "storyBreakdownPath": "artifacts/story-breakdowns/import/stories.json",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeName": "Story",
+                    },
+                },
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+
+    assert node["tool"] == {
+        "type": "skill",
+        "name": "story.create_jira_issues",
+        "version": "1.0",
+    }
+    assert node["inputs"]["branch"] == "feature/authored-breakdown"
+    assert node["inputs"]["storyBreakdownPath"] == (
+        "artifacts/story-breakdowns/import/stories.json"
+    )
+    assert "targetBranch" not in node["inputs"]
+    assert "startingBranch" not in node["inputs"]
+
 def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -367,6 +367,66 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
         "linear_blocker_chain"
     )
 
+def test_runtime_planner_uses_head_branch_for_jira_story_breakdown_from_main():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Docs\\TacticsFrontend\\InitiativeOrderBar.md",
+                "instructions": "Docs\\TacticsFrontend\\InitiativeOrderBar.md",
+                "repository": "MoonLadderStudios/Tactics",
+                "git": {"branch": "main"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "breakdown",
+                        "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                        "instructions": "Extract MoonSpec stories.",
+                    },
+                    {
+                        "id": "jira",
+                        "tool": {"type": "skill", "name": "story.create_jira_issues"},
+                        "instructions": "Create Jira issues from the generated breakdown.",
+                        "storyOutput": {
+                            "mode": "jira",
+                            "fallback": "fail",
+                            "jira": {
+                                "projectKey": "MM",
+                                "issueTypeName": "Story",
+                                "dependencyMode": "linear_blocker_chain",
+                            },
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    breakdown = plan["nodes"][0]
+    jira = plan["nodes"][1]
+
+    assert breakdown["inputs"]["branch"] == "main"
+    assert breakdown["inputs"]["startingBranch"] == "main"
+    assert breakdown["inputs"]["targetBranch"].startswith(
+        "docs-tacticsfrontend-initiativeorderbar-"
+    )
+    assert breakdown["inputs"]["targetBranch"] != "main"
+    assert breakdown["inputs"]["publishMode"] == "branch"
+    assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
+    assert jira["inputs"]["branch"] == "main"
+    assert (
+        jira["inputs"]["storyBreakdownPath"]
+        == breakdown["inputs"]["storyBreakdownPath"]
+    )
+
 def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Treat `branch` as the source/base ref for Jira story breakdown handoffs.
- Always generate a distinct `targetBranch` when Jira output needs a generated story breakdown and no target branch was provided.
- Add a regression test for the protected-`main` failure mode.

## Root Cause
Jira breakdown orchestration reused `branch: main` as the handoff ref, so the breakdown agent committed generated `stories.json` locally but the protected-branch push was skipped. The Jira creation tool then tried to fetch the generated path from GitHub `main` and received 404.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'jira_story_breakdown_from_main or shares_story_breakdown_path_for_jira_breakdown_preset'`\n- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'runtime_planner' tests/unit/workflows/temporal/test_story_output_tools.py`\n- `MOONMIND_FORCE_LOCAL_TESTS=1 MOONMIND_WORKFLOW_DOCKER_MODE=profiles ./tools/test_unit.sh`