### PR TITLE
[codex] Preserve snapshot details on rerun

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,22 @@
 [
   {
-    "id": 4177457111,
+    "id": 3144342995,
+    "disposition": "addressed",
+    "rationale": "Changed authoritative snapshot patch merging so snapshot top-level parameters overlay thinned execution parameters, preserving details such as requiredCapabilities."
+  },
+  {
+    "id": 4177624347,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary stated there was no feedback to address."
+    "rationale": "Review summary only; the actionable merge-order concern is tracked and addressed under comment 3144342995."
   },
   {
-    "id": 3144162425,
+    "id": 3144346169,
     "disposition": "addressed",
-    "rationale": "Planner now generates a synthetic targetBranch only when a MoonSpec breakdown step will create a new story breakdown artifact, preserving authored branch-only Jira import flows."
+    "rationale": "Gated artifact.draft handling on execution.taskInputSnapshot.reconstructionMode=authoritative and added regression coverage for regular artifacts with a draft key."
   },
   {
-    "id": 4177457338,
+    "id": 4177626871,
     "disposition": "not-applicable",
-    "rationale": "Automated Codex review wrapper contained no separate actionable feedback beyond discussion_r3144162425."
-  },
-  {
-    "id": 3144190036,
-    "disposition": "addressed",
-    "rationale": "Centralized Jira project default resolution, reused it for schema defaults and submitted input overrides, and now replaces explicit TOOL placeholders with repository or single-allowed project defaults."
-  },
-  {
-    "id": 3144190038,
-    "disposition": "addressed",
-    "rationale": "Simplified the effective schema loop with mutually exclusive branches and moved configured repository lookup outside the loop."
-  },
-  {
-    "id": 4177478709,
-    "disposition": "not-applicable",
-    "rationale": "Informational review summary; the actionable child comments from this review were handled separately."
-  },
-  {
-    "id": 3144190046,
-    "disposition": "addressed",
-    "rationale": "Replaced repeated default lookups with a single schema default map built once per contextual override pass."
-  },
-  {
-    "id": 3144192988,
-    "disposition": "addressed",
-    "rationale": "Required repository inputs without a value now skip generic autofill instead of falling back to feature request or instruction text."
-  },
-  {
-    "id": 4177481852,
-    "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper; the actionable repository autofill comment from this review was handled separately."
+    "rationale": "Automated review wrapper text only; the actionable Codex review comment is tracked and addressed under comment 3144346169."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1007,6 +1007,104 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Acomplex-rerun?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:complex-rerun",
+              workflowType: "MoonMind.Run",
+              state: "completed",
+              targetRuntime: "codex_cli",
+              targetSkill: "jira-breakdown-orchestrate",
+              taskSkills: ["jira-breakdown-orchestrate"],
+              profileId: "codex_default",
+              model: "gpt-5.5",
+              effort: "high",
+              repository: "MoonLadderStudios/Tactics",
+              publishMode: "none",
+              inputArtifactRef: "complex-input",
+              taskInputSnapshot: {
+                available: true,
+                artifactRef: "complex-rerun-snapshot",
+                snapshotVersion: 1,
+                sourceKind: "create",
+                reconstructionMode: "authoritative",
+                disabledReasons: {},
+                fallbackEvidenceRefs: [],
+              },
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                requiredCapabilities: ["codex_cli", "git"],
+                task: {
+                  title: "Break down the Grid UI overlay plan.",
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.5",
+                    effort: "high",
+                    profileId: "codex_default",
+                  },
+                  git: { branch: "main" },
+                  publish: { mode: "none" },
+                  tool: {
+                    type: "skill",
+                    name: "jira-breakdown-orchestrate",
+                    version: "1.0",
+                  },
+                  skill: {
+                    name: "jira-breakdown-orchestrate",
+                    version: "1.0",
+                  },
+                  steps: [
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                      title: "Break down declarative design",
+                      instructions: "Break down the Grid UI overlay plan.",
+                      skill: {
+                        id: "moonspec-breakdown",
+                        requiredCapabilities: ["git"],
+                      },
+                    },
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                      title: "Create Jira stories",
+                      skill: { id: "story.create_jira_issues" },
+                      storyOutput: {
+                        mode: "jira",
+                        fallback: "fail",
+                        jira: {
+                          projectKey: "MM",
+                          issueTypeName: "Story",
+                          dependencyMode: "linear_blocker_chain",
+                        },
+                      },
+                    },
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                      title: "Create dependent Jira Orchestrate tasks",
+                      skill: { id: "story.create_jira_orchestrate_tasks" },
+                      jiraOrchestration: {
+                        task: {
+                          repository: "MoonLadderStudios/MoonMind",
+                          orchestrationMode: "runtime",
+                          runtime: { mode: "codex_cli" },
+                          publish: {
+                            mode: "pr",
+                            mergeAutomation: { enabled: true },
+                          },
+                        },
+                        traceability: { sourceIssueKey: "" },
+                      },
+                    },
+                  ],
+                },
+              },
+              actions: {
+                canUpdateInputs: false,
+                canRerun: true,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aunsupported?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -1306,6 +1404,18 @@ describe("Task Create Entrypoint", () => {
               applied: "continue_as_new",
               message: "Rerun requested. New execution created.",
               execution: { workflowId: "mm:rerun-created" },
+              continueAsNewCause: "manual_rerun",
+            }),
+          } as Response);
+        }
+        if (url === "/api/executions/mm%3Acomplex-rerun/update") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              accepted: true,
+              applied: "continue_as_new",
+              message: "Rerun requested. New execution created.",
+              execution: { workflowId: "mm:complex-rerun-created" },
               continueAsNewCause: "manual_rerun",
             }),
           } as Response);
@@ -1613,6 +1723,139 @@ describe("Task Create Entrypoint", () => {
                     stepOrdinal: 0,
                   },
                 ],
+              }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/complex-rerun-snapshot/download") {
+          return Promise.resolve({
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                snapshotVersion: 1,
+                source: { kind: "create" },
+                draft: {
+                  repository: "MoonLadderStudios/Tactics",
+                  requiredCapabilities: ["codex_cli", "git"],
+                  targetRuntime: "codex_cli",
+                  taskShape: "multi_step",
+                  task: {
+                    title: "Break down the Grid UI overlay plan.",
+                    instructions: "Break down the Grid UI overlay plan.",
+                    runtime: {
+                      mode: "codex_cli",
+                      model: "gpt-5.5",
+                      effort: "high",
+                      profileId: "codex_default",
+                    },
+                    git: { branch: "main" },
+                    publish: { mode: "none" },
+                    tool: {
+                      type: "skill",
+                      name: "jira-breakdown-orchestrate",
+                      version: "1.0",
+                      requiredCapabilities: ["git"],
+                    },
+                    skill: {
+                      id: "jira-breakdown-orchestrate",
+                      args: {},
+                      requiredCapabilities: ["git"],
+                    },
+                    skills: {
+                      include: [{ name: "jira-breakdown-orchestrate" }],
+                    },
+                    appliedStepTemplates: [
+                      {
+                        slug: "jira-breakdown-orchestrate",
+                        version: "1.0.0",
+                        inputs: {
+                          feature_request: "Break down the Grid UI overlay plan.",
+                          jira_project_key: "MM",
+                          jira_issue_type: "Story",
+                          jira_dependency_mode: "linear_blocker_chain",
+                          repository: "MoonLadderStudios/MoonMind",
+                          orchestration_mode: "runtime",
+                          runtime_mode: "codex_cli",
+                          publish_mode: "pr",
+                          source_issue_key: "",
+                        },
+                        stepIds: [
+                          "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                          "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                          "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                        ],
+                        appliedAt: "2026-04-26T19:29:23.784091+00:00",
+                        capabilities: ["git"],
+                      },
+                    ],
+                    steps: [
+                      {
+                        id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                        title: "Break down declarative design",
+                        instructions: "Break down the Grid UI overlay plan.",
+                        tool: {
+                          type: "skill",
+                          name: "moonspec-breakdown",
+                          version: "1.0",
+                          requiredCapabilities: ["git"],
+                        },
+                        skill: {
+                          id: "moonspec-breakdown",
+                          args: {},
+                          requiredCapabilities: ["git"],
+                        },
+                      },
+                      {
+                        id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                        title: "Create Jira stories",
+                        tool: {
+                          type: "skill",
+                          name: "story.create_jira_issues",
+                          version: "1.0",
+                          inputs: {},
+                        },
+                        skill: {
+                          id: "story.create_jira_issues",
+                          args: {},
+                        },
+                        storyOutput: {
+                          mode: "jira",
+                          fallback: "fail",
+                          jira: {
+                            projectKey: "MM",
+                            issueTypeName: "Story",
+                            dependencyMode: "linear_blocker_chain",
+                          },
+                        },
+                      },
+                      {
+                        id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                        title: "Create dependent Jira Orchestrate tasks",
+                        tool: {
+                          type: "skill",
+                          name: "story.create_jira_orchestrate_tasks",
+                          version: "1.0",
+                          inputs: {},
+                        },
+                        skill: {
+                          id: "story.create_jira_orchestrate_tasks",
+                          args: {},
+                        },
+                        jiraOrchestration: {
+                          task: {
+                            repository: "MoonLadderStudios/MoonMind",
+                            orchestrationMode: "runtime",
+                            runtime: { mode: "codex_cli" },
+                            publish: {
+                              mode: "pr",
+                              mergeAutomation: { enabled: true },
+                            },
+                          },
+                          traceability: { sourceIssueKey: "" },
+                        },
+                      },
+                    ],
+                  },
+                },
               }),
           } as Response);
         }
@@ -2950,6 +3193,107 @@ describe("Task Create Entrypoint", () => {
     expect(
       window.sessionStorage.getItem("moonmind.temporalTaskEditing.notice"),
     ).toBe("Rerun was requested and the latest execution view is ready.");
+  });
+
+  it("preserves authoritative snapshot details when requesting a complex rerun", async () => {
+    window.history.pushState(
+      {},
+      "Task Rerun",
+      "/tasks/new?rerunExecutionId=mm%3Acomplex-rerun",
+    );
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Rerun Task" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([url]) => String(url) === "/api/artifacts/complex-rerun-snapshot/download",
+        ),
+      ).toBeTruthy();
+      expect(
+        (screen.getAllByLabelText("Instructions")[0] as HTMLTextAreaElement)
+          .value,
+      ).toBe("Break down the Grid UI overlay plan.");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Rerun Task" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Acomplex-rerun/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions/mm%3Acomplex-rerun/update")
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+
+    expect(request).toMatchObject({
+      updateName: "RequestRerun",
+      parametersPatch: {
+        repository: "MoonLadderStudios/Tactics",
+        requiredCapabilities: ["codex_cli", "git"],
+        targetRuntime: "codex_cli",
+        task: {
+          appliedStepTemplates: [
+            expect.objectContaining({
+              slug: "jira-breakdown-orchestrate",
+              inputs: expect.objectContaining({
+                jira_dependency_mode: "linear_blocker_chain",
+                orchestration_mode: "runtime",
+                publish_mode: "pr",
+              }),
+              stepIds: [
+                "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                "tpl:jira-breakdown-orchestrate:1.0.0:03",
+              ],
+            }),
+          ],
+          steps: [
+            expect.objectContaining({
+              id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+              tool: expect.objectContaining({
+                name: "moonspec-breakdown",
+                requiredCapabilities: ["git"],
+              }),
+              skill: expect.objectContaining({
+                id: "moonspec-breakdown",
+                requiredCapabilities: ["git"],
+              }),
+            }),
+            expect.objectContaining({
+              id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+              storyOutput: {
+                mode: "jira",
+                fallback: "fail",
+                jira: {
+                  projectKey: "MM",
+                  issueTypeName: "Story",
+                  dependencyMode: "linear_blocker_chain",
+                },
+              },
+            }),
+            expect.objectContaining({
+              id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+              jiraOrchestration: {
+                task: {
+                  repository: "MoonLadderStudios/MoonMind",
+                  orchestrationMode: "runtime",
+                  runtime: { mode: "codex_cli" },
+                  publish: {
+                    mode: "pr",
+                    mergeAutomation: { enabled: true },
+                  },
+                },
+                traceability: { sourceIssueKey: "" },
+              },
+            }),
+          ],
+        },
+      },
+    });
   });
 
   it("shows backend stale-state failures without redirecting from rerun mode", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -933,6 +933,35 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Aregular-draft-artifact-edit?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:regular-draft-artifact-edit",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              model: "gpt-5.4",
+              effort: "medium",
+              repository: "MoonLadderStudios/MoonMind",
+              inputArtifactRef: "regular-draft-artifact",
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                task: {
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.4",
+                    effort: "medium",
+                  },
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aattachment-edit?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -1034,7 +1063,7 @@ describe("Task Create Entrypoint", () => {
               },
               inputParameters: {
                 targetRuntime: "codex_cli",
-                requiredCapabilities: ["codex_cli", "git"],
+                requiredCapabilities: ["codex_cli"],
                 task: {
                   title: "Break down the Grid UI overlay plan.",
                   runtime: {
@@ -1385,6 +1414,17 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Aregular-draft-artifact-edit/update") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              accepted: true,
+              applied: "immediate",
+              message: "Inputs updated.",
+              execution: { workflowId: "mm:regular-draft-artifact-edit" },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aattachment-edit/update") {
           return Promise.resolve({
             ok: true,
@@ -1659,6 +1699,35 @@ describe("Task Create Entrypoint", () => {
                   },
                   publish: { mode: "pr" },
                   tool: { type: "skill", name: "speckit-orchestrate" },
+                },
+              }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/regular-draft-artifact/download") {
+          return Promise.resolve({
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                repository: "MoonLadderStudios/MoonMind",
+                requiredCapabilities: ["artifact-sibling-capability"],
+                operatorNote: "Preserve sibling field outside draft.",
+                draft: {
+                  task: {
+                    instructions: "Regular artifact draft instructions.",
+                    runtime: {
+                      mode: "codex_cli",
+                      model: "gpt-5.4",
+                      effort: "medium",
+                    },
+                  },
+                },
+                task: {
+                  instructions: "Regular artifact task instructions.",
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.4",
+                    effort: "medium",
+                  },
                 },
               }),
           } as Response);
@@ -3773,6 +3842,43 @@ describe("Task Create Entrypoint", () => {
     expect(
       window.sessionStorage.getItem("moonmind.temporalTaskEditing.notice"),
     ).toBe("Changes were scheduled for the next safe point.");
+  });
+
+  it("does not treat a regular input artifact draft key as an authoritative snapshot", async () => {
+    renderForEdit("mm:regular-draft-artifact-edit");
+
+    const instructions = (await screen.findByLabelText(
+      "Instructions",
+    )) as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(instructions.value).toBe("Regular artifact draft instructions.");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Aregular-draft-artifact-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) =>
+          String(url) ===
+          "/api/executions/mm%3Aregular-draft-artifact-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+    expect(request).toMatchObject({
+      updateName: "UpdateInputs",
+      parametersPatch: {
+        repository: "MoonLadderStudios/MoonMind",
+        operatorNote: "Preserve sibling field outside draft.",
+        task: {
+          instructions: "Regular artifact draft instructions.",
+        },
+      },
+    });
   });
 
   it("retains unchanged persisted attachment refs when editing an artifact-backed execution", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -579,6 +579,7 @@ function mergeRecordValues(
 }
 
 function artifactInputParametersForPatch(
+  execution: TemporalTaskEditingExecutionContract,
   artifactInput?: Record<string, unknown> | undefined,
 ): {
   parameters: Record<string, unknown>;
@@ -586,7 +587,10 @@ function artifactInputParametersForPatch(
 } {
   const artifactRecord = recordValue(artifactInput);
   const snapshotDraft = recordValue(artifactRecord.draft);
-  if (Object.keys(snapshotDraft).length > 0) {
+  if (
+    execution.taskInputSnapshot?.reconstructionMode === "authoritative" &&
+    Object.keys(snapshotDraft).length > 0
+  ) {
     return {
       parameters: snapshotDraft,
       fromAuthoritativeDraft: true,
@@ -607,11 +611,15 @@ function buildEditParametersPatch({
   artifactInput?: Record<string, unknown> | undefined;
   submittedPayload: Record<string, unknown>;
 }): Record<string, unknown> {
-  const artifactBase = artifactInputParametersForPatch(artifactInput);
+  const artifactBase = artifactInputParametersForPatch(execution, artifactInput);
   const executionParameters = recordValue(execution.inputParameters);
   const baseParameters = mergeRecordValues(
-    artifactBase.parameters,
-    executionParameters,
+    artifactBase.fromAuthoritativeDraft
+      ? executionParameters
+      : artifactBase.parameters,
+    artifactBase.fromAuthoritativeDraft
+      ? artifactBase.parameters
+      : executionParameters,
   );
   const submittedTask = recordValue(submittedPayload.task);
   const artifactBaseTask = recordValue(artifactBase.parameters.task);
@@ -620,9 +628,7 @@ function buildEditParametersPatch({
     artifactBase.fromAuthoritativeDraft
       ? executionTask
       : artifactBaseTask,
-    artifactBase.fromAuthoritativeDraft
-      ? artifactBaseTask
-      : recordValue(baseParameters.task),
+    recordValue(baseParameters.task),
   );
   const editTask = { ...submittedTask };
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -578,6 +578,26 @@ function mergeRecordValues(
   };
 }
 
+function artifactInputParametersForPatch(
+  artifactInput?: Record<string, unknown> | undefined,
+): {
+  parameters: Record<string, unknown>;
+  fromAuthoritativeDraft: boolean;
+} {
+  const artifactRecord = recordValue(artifactInput);
+  const snapshotDraft = recordValue(artifactRecord.draft);
+  if (Object.keys(snapshotDraft).length > 0) {
+    return {
+      parameters: snapshotDraft,
+      fromAuthoritativeDraft: true,
+    };
+  }
+  return {
+    parameters: artifactRecord,
+    fromAuthoritativeDraft: false,
+  };
+}
+
 function buildEditParametersPatch({
   execution,
   artifactInput,
@@ -587,14 +607,22 @@ function buildEditParametersPatch({
   artifactInput?: Record<string, unknown> | undefined;
   submittedPayload: Record<string, unknown>;
 }): Record<string, unknown> {
+  const artifactBase = artifactInputParametersForPatch(artifactInput);
+  const executionParameters = recordValue(execution.inputParameters);
   const baseParameters = mergeRecordValues(
-    recordValue(artifactInput),
-    recordValue(execution.inputParameters),
+    artifactBase.parameters,
+    executionParameters,
   );
   const submittedTask = recordValue(submittedPayload.task);
+  const artifactBaseTask = recordValue(artifactBase.parameters.task);
+  const executionTask = recordValue(executionParameters.task);
   const baseTask = mergeRecordValues(
-    recordValue(recordValue(artifactInput).task),
-    recordValue(baseParameters.task),
+    artifactBase.fromAuthoritativeDraft
+      ? executionTask
+      : artifactBaseTask,
+    artifactBase.fromAuthoritativeDraft
+      ? artifactBaseTask
+      : recordValue(baseParameters.task),
   );
   const editTask = { ...submittedTask };
 


### PR DESCRIPTION
## Summary

- Preserve authoritative task input snapshot drafts when building edit/rerun parameter patches.
- Keep complex reruns from dropping hidden workflow details such as applied template inputs, step tool settings, story output, Jira orchestration, and required capabilities.
- Add a Create-page regression covering a multi-step Jira breakdown rerun shape.

## Root Cause

The rerun draft loader could read authoritative task input snapshots from `artifact.draft`, but the submit patch builder only preserved `artifact.task`. Snapshot-backed reruns therefore rendered from richer data but submitted a thinner replacement payload.

## Validation

- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`

This PR is opened ready for review, not as a draft.