### PR TITLE
[codex] Add configurable Jira board preset option

### DIFF
--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -340,11 +340,20 @@ class TaskTemplateInputSchema(BaseModel):
     name: str
     label: str
     type: Literal[
-        "text", "textarea", "markdown", "enum", "boolean", "user", "team", "repo_path"
+        "text",
+        "textarea",
+        "markdown",
+        "enum",
+        "boolean",
+        "user",
+        "team",
+        "repo_path",
+        "jira_board",
     ]
     required: bool = False
     default: Any = None
     options: list[str] = Field(default_factory=list)
+    placeholder: Optional[str] = None
 
 class TaskTemplateStepSkillSchema(BaseModel):
     """Skill payload attached to a template step."""

--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -29,6 +29,11 @@ inputs:
     type: text
     required: true
     default: Story
+  - name: jira_board_id
+    label: Jira Board
+    type: jira_board
+    required: false
+    default: ""
   - name: jira_dependency_mode
     label: Jira Dependency Mode
     type: enum
@@ -94,6 +99,7 @@ steps:
 
       Use the runtime-provided story breakdown JSON path.
       Every Jira issue must include the Source Document path from the story breakdown.
+      {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
@@ -104,6 +110,7 @@ steps:
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
+        boardId: "{{ inputs.jira_board_id }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues

--- a/api_service/data/task_step_templates/jira-breakdown.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown.yaml
@@ -28,6 +28,11 @@ inputs:
     type: text
     required: true
     default: Story
+  - name: jira_board_id
+    label: Jira Board
+    type: jira_board
+    required: false
+    default: ""
   - name: jira_dependency_mode
     label: Jira Dependency Mode
     type: enum
@@ -56,6 +61,7 @@ steps:
 
       Use the runtime-provided story breakdown JSON path.
       Every Jira issue must include the Source Document path from the story breakdown.
+      {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
@@ -65,6 +71,7 @@ steps:
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
+        boardId: "{{ inputs.jira_board_id }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -836,6 +836,7 @@ class TaskTemplateCatalogService:
                     )
             else:
                 normalized_options = []
+            placeholder = str(raw_input.get("placeholder") or "").strip()
             names.add(name)
             validated.append(
                 {
@@ -845,11 +846,7 @@ class TaskTemplateCatalogService:
                     "required": bool(raw_input.get("required", False)),
                     "default": raw_input.get("default"),
                     **({"options": normalized_options} if normalized_options else {}),
-                    **(
-                        {"placeholder": str(raw_input.get("placeholder") or "").strip()}
-                        if str(raw_input.get("placeholder") or "").strip()
-                        else {}
-                    ),
+                    **({"placeholder": placeholder} if placeholder else {}),
                 }
             )
         return validated

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -48,7 +48,17 @@ _FORBIDDEN_STEP_KEYS = frozenset(
     }
 )
 _SUPPORTED_INPUT_TYPES = frozenset(
-    {"text", "textarea", "markdown", "enum", "boolean", "user", "team", "repo_path"}
+    {
+        "text",
+        "textarea",
+        "markdown",
+        "enum",
+        "boolean",
+        "user",
+        "team",
+        "repo_path",
+        "jira_board",
+    }
 )
 _JIRA_BREAKDOWN_SLUG = "jira-breakdown"
 _JIRA_BREAKDOWN_ORCHESTRATE_SLUG = "jira-breakdown-orchestrate"
@@ -835,6 +845,11 @@ class TaskTemplateCatalogService:
                     "required": bool(raw_input.get("required", False)),
                     "default": raw_input.get("default"),
                     **({"options": normalized_options} if normalized_options else {}),
+                    **(
+                        {"placeholder": str(raw_input.get("placeholder") or "").strip()}
+                        if str(raw_input.get("placeholder") or "").strip()
+                        else {}
+                    ),
                 }
             )
         return validated

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,37 @@
 [
   {
-    "id": 4177457111,
+    "id": 3144367004,
+    "disposition": "addressed",
+    "rationale": "Preset text inputs now preserve in-progress whitespace while typing; values are trimmed only when resolving inputs for expansion. Added a regression test for trailing-space editing."
+  },
+  {
+    "id": 4177646619,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary stated there was no feedback to address."
+    "rationale": "Review summary comment. The actionable inline comments from the same review were addressed individually."
   },
   {
-    "id": 3144162425,
+    "id": 3144367005,
     "disposition": "addressed",
-    "rationale": "Planner now generates a synthetic targetBranch only when a MoonSpec breakdown step will create a new story breakdown artifact, preserving authored branch-only Jira import flows."
+    "rationale": "Template input placeholder normalization now assigns the stripped value once and reuses it."
   },
   {
-    "id": 4177457338,
+    "id": 3144367007,
+    "disposition": "addressed",
+    "rationale": "Apply now relies on the React Query preset detail result instead of performing a duplicate manual fetch; the Apply button is disabled while preset details are loading."
+  },
+  {
+    "id": 3144369447,
+    "disposition": "addressed",
+    "rationale": "Changing presets clears both visible template input state and the hidden template input memory ref. Added a regression test for stale remembered values after switching presets."
+  },
+  {
+    "id": 3144369448,
+    "disposition": "addressed",
+    "rationale": "Boolean preset options are now stored as booleans from checkbox changes and resolved without treating the string false as truthy. Added a regression test for unchecked boolean submission."
+  },
+  {
+    "id": 4177649280,
     "disposition": "not-applicable",
-    "rationale": "Automated Codex review wrapper contained no separate actionable feedback beyond discussion_r3144162425."
-  },
-  {
-    "id": 3144190036,
-    "disposition": "addressed",
-    "rationale": "Centralized Jira project default resolution, reused it for schema defaults and submitted input overrides, and now replaces explicit TOOL placeholders with repository or single-allowed project defaults."
-  },
-  {
-    "id": 3144190038,
-    "disposition": "addressed",
-    "rationale": "Simplified the effective schema loop with mutually exclusive branches and moved configured repository lookup outside the loop."
-  },
-  {
-    "id": 4177478709,
-    "disposition": "not-applicable",
-    "rationale": "Informational review summary; the actionable child comments from this review were handled separately."
-  },
-  {
-    "id": 3144190046,
-    "disposition": "addressed",
-    "rationale": "Replaced repeated default lookups with a single schema default map built once per contextual override pass."
-  },
-  {
-    "id": 3144192988,
-    "disposition": "addressed",
-    "rationale": "Required repository inputs without a value now skip generic autofill instead of falling back to feature request or instruction text."
-  },
-  {
-    "id": 4177481852,
-    "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper; the actionable repository autofill comment from this review was handled separately."
+    "rationale": "Automated review summary. The actionable inline comments were addressed individually."
   }
 ]

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -377,6 +377,7 @@ It exposes:
 
 - `Preset`
 - `Feature Request / Initial Instructions`
+- preset-declared option controls, including Jira project or Jira board selectors when the selected preset declares those inputs
 - objective-scoped image inputs when attachment policy is enabled
 - `Apply`
 - `Save Current Steps as Preset` when preset saving is enabled
@@ -410,6 +411,7 @@ Rules:
 - when non-empty, it is preferred over primary-step instructions for objective text resolution
 - objective-scoped attachments are the matching structured input source for this field
 - changing preset objective text or objective-scoped attachments must not silently rewrite already expanded steps
+- changing a preset-declared option such as Jira board selection must not rewrite already expanded steps until the user explicitly reapplies the preset
 
 ### 8.4 Reapply behavior
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -121,6 +121,14 @@ function withJiraIntegration(payload: BootPayload = mockPayload): BootPayload {
   };
 }
 
+async function clickApplyButton() {
+  const button = screen.getByRole("button", { name: "Apply" }) as HTMLButtonElement;
+  await waitFor(() => {
+    expect(button.disabled).toBe(false);
+  });
+  fireEvent.click(button);
+}
+
 function withAttachmentPolicy(payload: BootPayload = mockPayload): BootPayload {
   const initialData = payload.initialData as {
     dashboardConfig: {
@@ -5050,7 +5058,7 @@ describe("Task Create Entrypoint", () => {
       screen.getByLabelText("Feature Request / Initial Instructions"),
       { target: { value: "docs/Design.md" } },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
 
     await waitFor(() => {
       const expandCall = fetchSpy.mock.calls.find(([url]) =>
@@ -5061,6 +5069,258 @@ describe("Task Create Entrypoint", () => {
       expect(expandCall).toBeTruthy();
       const body = JSON.parse(String(expandCall?.[1]?.body || "{}"));
       expect(body.inputs.jira_board_id).toBe("7");
+    });
+  });
+
+  it("preserves typed preset text spacing and submits unchecked boolean inputs", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "option-demo",
+                scope: "global",
+                title: "Option Demo",
+                description: "Preset options.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/option-demo?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "option-demo",
+            scope: "global",
+            title: "Option Demo",
+            description: "Preset options.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Feature Request",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "notes",
+                label: "Notes",
+                type: "text",
+                required: false,
+              },
+              {
+                name: "enabled",
+                label: "Enabled",
+                type: "boolean",
+                required: false,
+                default: true,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/option-demo:expand?scope=global")) {
+        const body = JSON.parse(String(init?.body || "{}"));
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:option-demo:1.0.0:01",
+                title: "Options",
+                instructions: JSON.stringify(body.inputs),
+              },
+            ],
+            appliedTemplate: {
+              slug: "option-demo",
+              version: "1.0.0",
+              inputs: body.inputs,
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const notesInput = (await screen.findByLabelText("Notes")) as HTMLInputElement;
+    fireEvent.change(notesInput, { target: { value: "hello " } });
+    expect(notesInput.value).toBe("hello ");
+    fireEvent.click(screen.getByLabelText("Enabled"));
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      { target: { value: "Build configurable options." } },
+    );
+    await clickApplyButton();
+
+    await waitFor(() => {
+      const expandCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).startsWith(
+          "/api/task-step-templates/option-demo:expand?scope=global",
+        ),
+      );
+      expect(expandCall).toBeTruthy();
+      const body = JSON.parse(String(expandCall?.[1]?.body || "{}"));
+      expect(body.inputs.notes).toBe("hello");
+      expect(body.inputs.enabled).toBe(false);
+    });
+  });
+
+  it("clears remembered preset input values when switching presets", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "preset-a",
+                scope: "global",
+                title: "Preset A",
+                description: "First preset.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+              {
+                slug: "preset-b",
+                scope: "global",
+                title: "Preset B",
+                description: "Second preset.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/preset-a?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "preset-a",
+            scope: "global",
+            title: "Preset A",
+            description: "First preset.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Feature Request",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "jira_dependency_mode",
+                label: "Jira Dependency Mode",
+                type: "enum",
+                required: true,
+                default: "linear_blocker_chain",
+                options: ["linear_blocker_chain", "none"],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/preset-b?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "preset-b",
+            scope: "global",
+            title: "Preset B",
+            description: "Second preset.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Feature Request",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "jira_dependency_mode",
+                label: "Jira Dependency Mode",
+                type: "enum",
+                required: true,
+                default: "none",
+                options: ["linear_blocker_chain", "none"],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/preset-b:expand?scope=global")) {
+        const body = JSON.parse(String(init?.body || "{}"));
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:preset-b:1.0.0:01",
+                title: "Preset B",
+                instructions: body.inputs.jira_dependency_mode,
+              },
+            ],
+            appliedTemplate: {
+              slug: "preset-b",
+              version: "1.0.0",
+              inputs: body.inputs,
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.value === "global::::preset-a",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(presetSelect, { target: { value: "global::::preset-a" } });
+    await screen.findByLabelText("Jira Dependency Mode");
+    fireEvent.change(screen.getByLabelText("Jira Dependency Mode"), {
+      target: { value: "linear_blocker_chain" },
+    });
+    fireEvent.change(presetSelect, { target: { value: "global::::preset-b" } });
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Jira Dependency Mode") as HTMLSelectElement).value,
+      ).toBe("none");
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      { target: { value: "Build the second preset." } },
+    );
+    await clickApplyButton();
+
+    await waitFor(() => {
+      const expandCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).startsWith("/api/task-step-templates/preset-b:expand?scope=global"),
+      );
+      expect(expandCall).toBeTruthy();
+      const body = JSON.parse(String(expandCall?.[1]?.body || "{}"));
+      expect(body.inputs.jira_dependency_mode).toBe("none");
     });
   });
 
@@ -5299,7 +5559,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(presetSelect, {
       target: { value: "global::::pr-resolver" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
 
     await screen.findByDisplayValue("Resolve the current branch PR.");
     await waitFor(() => {
@@ -6842,7 +7102,7 @@ describe("Task Create Entrypoint", () => {
       },
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
 
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
@@ -7007,7 +7267,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Route Jira child tasks correctly." },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -7080,7 +7340,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -7124,7 +7384,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -7208,7 +7468,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -7313,7 +7573,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -8774,7 +9034,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -8837,7 +9097,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: importedText },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -8881,7 +9141,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -8945,7 +9205,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );
@@ -9392,7 +9652,7 @@ describe("Task Create Entrypoint", () => {
         target: { value: "Task Create" },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await clickApplyButton();
     await screen.findByDisplayValue(
       "Clarify the {{ inputs.feature_name }} scope.",
     );

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4945,6 +4945,125 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("passes a preset-selected Jira board into Jira Breakdown expansion", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown",
+                scope: "global",
+                title: "Jira Breakdown",
+                description: "Create Jira stories from a breakdown.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/jira-breakdown?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-breakdown",
+            scope: "global",
+            title: "Jira Breakdown",
+            description: "Create Jira stories from a breakdown.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Declarative Design Path or Text",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "jira_project_key",
+                label: "Jira Project Key",
+                type: "text",
+                required: true,
+                default: "ENG",
+              },
+              {
+                name: "jira_board_id",
+                label: "Jira Board",
+                type: "jira_board",
+                required: false,
+                default: "42",
+              },
+              {
+                name: "jira_dependency_mode",
+                label: "Jira Dependency Mode",
+                type: "enum",
+                required: true,
+                default: "none",
+                options: ["none", "linear_blocker_chain"],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith("/api/task-step-templates/jira-breakdown:expand?scope=global")
+      ) {
+        const body = JSON.parse(String(init?.body || "{}"));
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-breakdown:1.0.0:01",
+                title: "Create Jira stories",
+                instructions: `Selected Jira board ID: ${body.inputs.jira_board_id}`,
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-breakdown",
+              version: "1.0.0",
+              inputs: body.inputs,
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    const boardSelect = (await screen.findByLabelText(
+      "Jira Board",
+    )) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(boardSelect.options).some((option) => option.value === "7"),
+      ).toBe(true);
+    });
+    fireEvent.change(boardSelect, { target: { value: "7" } });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      { target: { value: "docs/Design.md" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      const expandCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).startsWith(
+          "/api/task-step-templates/jira-breakdown:expand?scope=global",
+        ),
+      );
+      expect(expandCall).toBeTruthy();
+      const body = JSON.parse(String(expandCall?.[1]?.body || "{}"));
+      expect(body.inputs.jira_board_id).toBe("7");
+    });
+  });
+
   it("preserves draft publish mode in edit mode when Jira Breakdown is the selected preset", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -359,10 +359,12 @@ interface TaskTemplateInputDefinition {
     | "boolean"
     | "user"
     | "team"
-    | "repo_path";
+    | "repo_path"
+    | "jira_board";
   required?: boolean;
   default?: unknown;
   options?: string[];
+  placeholder?: string | null;
 }
 
 interface TaskTemplateSummary {
@@ -1476,6 +1478,16 @@ function isFeatureRequestInputKey(rawKey: string): boolean {
   );
 }
 
+function isJiraProjectInputKey(rawKey: string): boolean {
+  const normalizedKey = normalizeTemplateInputKey(rawKey);
+  return normalizedKey === "jiraprojectkey";
+}
+
+function isRepositoryInputKey(rawKey: string): boolean {
+  const normalizedKey = normalizeTemplateInputKey(rawKey);
+  return normalizedKey === "repository" || normalizedKey === "repo";
+}
+
 export function resolveObjectiveInstructions(
   featureRequest: string,
   primaryInstructions: string,
@@ -2302,6 +2314,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedDependencies, setSelectedDependencies] = useState<string[]>([]);
   const [dependencyMessage, setDependencyMessage] = useState<string | null>(null);
   const [selectedPresetKey, setSelectedPresetKey] = useState("");
+  const [templateInputValues, setTemplateInputValues] = useState<
+    Record<string, string>
+  >({});
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
   const [presetReapplyNeeded, setPresetReapplyNeeded] = useState(false);
   const [appliedTemplateFeatureRequest, setAppliedTemplateFeatureRequest] =
@@ -3052,6 +3067,109 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
   const selectedPreset =
     templateItems.find((item) => item.key === selectedPresetKey) || null;
+  const selectedPresetDetailQuery = useQuery({
+    queryKey: [
+      "task-create",
+      "template-detail",
+      selectedPreset?.scope,
+      selectedPreset?.scopeRef || "",
+      selectedPreset?.slug,
+    ],
+    enabled: Boolean(taskTemplateCatalogEnabled && selectedPreset),
+    queryFn: async (): Promise<TaskTemplateDetail> => {
+      if (!selectedPreset) {
+        throw new Error("Choose a preset first.");
+      }
+      const response = await fetch(
+        withQueryParams(
+          interpolatePath(taskTemplateDetailEndpoint, {
+            slug: selectedPreset.slug,
+          }),
+          {
+            scope: selectedPreset.scope,
+            scopeRef: selectedPreset.scopeRef || undefined,
+          },
+        ),
+        { headers: { Accept: "application/json" } },
+      );
+      if (!response.ok) {
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load preset details."),
+        );
+      }
+      return (await response.json()) as TaskTemplateDetail;
+    },
+  });
+  const selectedPresetInputs = selectedPresetDetailQuery.data?.inputs || [];
+  const visiblePresetInputs = selectedPresetInputs.filter(
+    (definition) => !isFeatureRequestInputKey(definition.name),
+  );
+  const presetJiraProjectInput = visiblePresetInputs.find((definition) =>
+    isJiraProjectInputKey(definition.name),
+  );
+  const presetJiraBoardInput = visiblePresetInputs.find(
+    (definition) => definition.type === "jira_board",
+  );
+  const presetJiraProjectKey = String(
+    (presetJiraProjectInput
+      ? templateInputValues[presetJiraProjectInput.name] ??
+        presetJiraProjectInput.default
+      : "") ||
+      jiraIntegration?.defaultProjectKey ||
+      "",
+  ).trim();
+  const presetNeedsJiraProjects = Boolean(
+    jiraIntegration?.enabled &&
+      (presetJiraProjectInput || presetJiraBoardInput),
+  );
+  const presetJiraProjectsQuery = useQuery({
+    queryKey: [
+      "task-create",
+      "preset-jira",
+      "projects",
+      jiraIntegration?.endpoints.projects,
+    ],
+    enabled: presetNeedsJiraProjects,
+    queryFn: async (): Promise<JiraProject[]> => {
+      const endpoint = jiraIntegration?.endpoints.projects || "";
+      const response = await fetch(endpoint, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load Jira projects."),
+        );
+      }
+      return readJiraItems<JiraProject>(await response.json());
+    },
+  });
+  const presetJiraBoardsQuery = useQuery({
+    queryKey: [
+      "task-create",
+      "preset-jira",
+      "boards",
+      jiraIntegration?.endpoints.boards,
+      presetJiraProjectKey,
+    ],
+    enabled: Boolean(
+      jiraIntegration?.enabled && presetJiraBoardInput && presetJiraProjectKey,
+    ),
+    queryFn: async (): Promise<JiraBoard[]> => {
+      const endpoint = interpolatePath(
+        jiraIntegration?.endpoints.boards || "",
+        { projectKey: presetJiraProjectKey },
+      );
+      const response = await fetch(endpoint, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load Jira boards."),
+        );
+      }
+      return readJiraItems<JiraBoard>(await response.json());
+    },
+  });
   const selectedPresetDeleteEnabled =
     taskTemplateSaveEnabled && selectedPreset?.scope === "personal";
   const deletePresetTooltip = selectedPreset
@@ -4071,16 +4189,24 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         : [];
       const key = name.toLowerCase();
       const isFeatureRequestKey = isFeatureRequestInputKey(name);
-      const isJiraProjectKey = key === "jira_project_key" || key === "jiraprojectkey";
-      const isRepositoryInput = key === "repository" || key === "repo";
+      const isJiraProjectKey = isJiraProjectInputKey(name);
+      const isRepositoryInput = isRepositoryInputKey(name);
 
       let value: unknown = null;
       let valueSource = "";
       const remembered = templateInputMemoryRef.current[name];
       const defaultValue = definition.default;
+      const explicitInputValue = templateInputValues[name];
 
       if (isFeatureRequestKey && explicitFeatureRequest) {
         value = explicitFeatureRequest;
+        valueSource = "manual";
+      } else if (
+        explicitInputValue !== undefined &&
+        explicitInputValue !== null &&
+        String(explicitInputValue).trim() !== ""
+      ) {
+        value = explicitInputValue;
         valueSource = "manual";
       } else if (isRepositoryInput && repositoryValue) {
         value = repositoryValue;
@@ -4156,7 +4282,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       }
 
       values[name] = normalized;
-      if (!isJiraProjectKey && !isRepositoryInput) {
+      if (!isRepositoryInput) {
         templateInputMemoryRef.current[name] = normalized;
       }
       if (valueSource === "assumed" || valueSource === "draft") {
@@ -4165,6 +4291,48 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     });
 
     return { values, assumptions };
+  }
+
+  function templateInputDisplayValue(
+    definition: TaskTemplateInputDefinition,
+  ): string {
+    const explicit = templateInputValues[definition.name];
+    if (explicit !== undefined) {
+      return explicit;
+    }
+    if (definition.type === "jira_board") {
+      return String(definition.default || jiraIntegration?.defaultBoardId || "").trim();
+    }
+    if (isJiraProjectInputKey(definition.name)) {
+      return String(
+        definition.default || jiraIntegration?.defaultProjectKey || "",
+      ).trim();
+    }
+    if (isRepositoryInputKey(definition.name)) {
+      return String(definition.default || repository || defaultRepository || "").trim();
+    }
+    return String(definition.default ?? "").trim();
+  }
+
+  function updateTemplateInputValue(
+    definition: TaskTemplateInputDefinition,
+    value: string,
+  ) {
+    const normalized = value.trim();
+    setTemplateInputValues((current) => {
+      const next = { ...current, [definition.name]: normalized };
+      if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
+        next[presetJiraBoardInput.name] = "";
+      }
+      return next;
+    });
+    templateInputMemoryRef.current[definition.name] = normalized;
+    if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
+      templateInputMemoryRef.current[presetJiraBoardInput.name] = "";
+    }
+    if (appliedTemplates.length > 0) {
+      setPresetReapplyNeeded(true);
+    }
   }
 
   async function handleApplyPreset() {
@@ -4182,26 +4350,29 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         scope: selectedPreset.scope,
         scopeRef: selectedPreset.scopeRef || undefined,
       };
-      const detailResponse = await fetch(
-        withQueryParams(
-          interpolatePath(taskTemplateDetailEndpoint, {
-            slug: selectedPreset.slug,
-          }),
-          scopeParams,
-        ),
-        {
-          headers: { Accept: "application/json" },
-        },
-      );
-      if (!detailResponse.ok) {
-        throw new Error(
-          await responseErrorMessage(
-            detailResponse,
-            "Failed to load preset details.",
+      let detail = selectedPresetDetailQuery.data;
+      if (!detail) {
+        const detailResponse = await fetch(
+          withQueryParams(
+            interpolatePath(taskTemplateDetailEndpoint, {
+              slug: selectedPreset.slug,
+            }),
+            scopeParams,
           ),
+          {
+            headers: { Accept: "application/json" },
+          },
         );
+        if (!detailResponse.ok) {
+          throw new Error(
+            await responseErrorMessage(
+              detailResponse,
+              "Failed to load preset details.",
+            ),
+          );
+        }
+        detail = (await detailResponse.json()) as TaskTemplateDetail;
       }
-      const detail = (await detailResponse.json()) as TaskTemplateDetail;
       const { values: inputs, assumptions } = resolveTemplateInputs(
         detail.inputs || [],
       );
@@ -6134,6 +6305,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 value={selectedPresetKey}
                 onChange={(event) => {
                   setSelectedPresetKey(event.target.value);
+                  setTemplateInputValues({});
                   setTemplateMessage(null);
                   setPresetReapplyNeeded(false);
                 }}
@@ -6175,6 +6347,167 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   handleTemplateFeatureRequestChange(event.target.value)
                 }
               />
+              {selectedPresetDetailQuery.isError ? (
+                <p className="notice small">Failed to load preset options.</p>
+              ) : null}
+              {visiblePresetInputs.length > 0 ? (
+                <div className="grid-2">
+                  {visiblePresetInputs.map((definition) => {
+                    const inputId = `queue-template-input-${definition.name}`;
+                    const value = templateInputDisplayValue(definition);
+                    if (
+                      isJiraProjectInputKey(definition.name) &&
+                      jiraIntegration?.enabled
+                    ) {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            disabled={
+                              presetJiraProjectsQuery.isLoading ||
+                              presetJiraProjectsQuery.isError
+                            }
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            <option value="">Select project...</option>
+                            {(presetJiraProjectsQuery.data || []).map((project) => (
+                              <option
+                                key={project.projectKey}
+                                value={project.projectKey}
+                              >
+                                {project.name
+                                  ? `${project.name} (${project.projectKey})`
+                                  : project.projectKey}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "jira_board") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            disabled={
+                              !presetJiraProjectKey ||
+                              presetJiraBoardsQuery.isLoading ||
+                              presetJiraBoardsQuery.isError
+                            }
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            <option value="">No board selected</option>
+                            {(presetJiraBoardsQuery.data || []).map((board) => (
+                              <option key={board.id} value={board.id}>
+                                {board.name || board.id}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "enum") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            {(definition.options || []).map((option) => (
+                              <option key={option} value={option}>
+                                {option}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "boolean") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <input
+                            id={inputId}
+                            type="checkbox"
+                            checked={value === "true"}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.checked ? "true" : "false",
+                              )
+                            }
+                          />
+                        </label>
+                      );
+                    }
+                    if (
+                      definition.type === "textarea" ||
+                      definition.type === "markdown"
+                    ) {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <textarea
+                            id={inputId}
+                            value={value}
+                            placeholder={definition.placeholder || ""}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          />
+                        </label>
+                      );
+                    }
+                    return (
+                      <label key={definition.name} htmlFor={inputId}>
+                        {definition.label}
+                        <input
+                          id={inputId}
+                          type="text"
+                          value={value}
+                          placeholder={definition.placeholder || ""}
+                          onChange={(event) =>
+                            updateTemplateInputValue(
+                              definition,
+                              event.target.value,
+                            )
+                          }
+                        />
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : null}
+              {presetJiraProjectsQuery.isError ? (
+                <p className="notice small">Failed to load Jira projects.</p>
+              ) : null}
+              {presetJiraBoardsQuery.isError ? (
+                <p className="notice small">Failed to load Jira boards.</p>
+              ) : null}
               {attachmentPolicy.enabled ? (
                 <div className="queue-step-attachments">
                   <label>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2315,7 +2315,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [dependencyMessage, setDependencyMessage] = useState<string | null>(null);
   const [selectedPresetKey, setSelectedPresetKey] = useState("");
   const [templateInputValues, setTemplateInputValues] = useState<
-    Record<string, string>
+    Record<string, string | boolean>
   >({});
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
   const [presetReapplyNeeded, setPresetReapplyNeeded] = useState(false);
@@ -4269,7 +4269,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
       let normalized: unknown;
       if (inputType === "boolean") {
-        normalized = Boolean(value);
+        if (typeof value === "boolean") {
+          normalized = value;
+        } else {
+          const lowered = String(value).trim().toLowerCase();
+          normalized = ["1", "true", "yes", "on"].includes(lowered);
+        }
       } else {
         normalized = String(value).trim();
       }
@@ -4298,7 +4303,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   ): string {
     const explicit = templateInputValues[definition.name];
     if (explicit !== undefined) {
-      return explicit;
+      return String(explicit);
     }
     if (definition.type === "jira_board") {
       return String(definition.default || jiraIntegration?.defaultBoardId || "").trim();
@@ -4316,9 +4321,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
   function updateTemplateInputValue(
     definition: TaskTemplateInputDefinition,
-    value: string,
+    value: string | boolean,
   ) {
-    const normalized = value.trim();
+    const normalized = value;
     setTemplateInputValues((current) => {
       const next = { ...current, [definition.name]: normalized };
       if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
@@ -4341,6 +4346,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       setTemplateMessage("Choose a preset first.");
       return;
     }
+    const detail = selectedPresetDetailQuery.data;
+    if (!detail) {
+      setTemplateMessage(
+        selectedPresetDetailQuery.isError
+          ? "Failed to load preset details."
+          : "Preset options are still loading.",
+      );
+      return;
+    }
     setIsApplyingPreset(true);
     setPresetReapplyNeeded(false);
     setTemplateMessage("Applying preset...");
@@ -4350,29 +4364,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         scope: selectedPreset.scope,
         scopeRef: selectedPreset.scopeRef || undefined,
       };
-      let detail = selectedPresetDetailQuery.data;
-      if (!detail) {
-        const detailResponse = await fetch(
-          withQueryParams(
-            interpolatePath(taskTemplateDetailEndpoint, {
-              slug: selectedPreset.slug,
-            }),
-            scopeParams,
-          ),
-          {
-            headers: { Accept: "application/json" },
-          },
-        );
-        if (!detailResponse.ok) {
-          throw new Error(
-            await responseErrorMessage(
-              detailResponse,
-              "Failed to load preset details.",
-            ),
-          );
-        }
-        detail = (await detailResponse.json()) as TaskTemplateDetail;
-      }
       const { values: inputs, assumptions } = resolveTemplateInputs(
         detail.inputs || [],
       );
@@ -5579,8 +5570,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the task starts";
   const publishModeTooltip = "Select how MoonMind publishes task changes";
+  const applyPresetDisabled = Boolean(
+    isApplyingPreset || (selectedPreset && selectedPresetDetailQuery.isLoading),
+  );
   const applyPresetTooltip = presetReapplyNeeded
     ? "Reapply the selected preset to update preset-derived steps"
+    : selectedPreset && selectedPresetDetailQuery.isLoading
+      ? "Loading preset options..."
     : "Apply the selected preset to the task draft";
   const modeLoadError =
     pageMode.mode !== "create" && !temporalTaskEditingEnabled
@@ -6306,6 +6302,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 onChange={(event) => {
                   setSelectedPresetKey(event.target.value);
                   setTemplateInputValues({});
+                  templateInputMemoryRef.current = {};
                   setTemplateMessage(null);
                   setPresetReapplyNeeded(false);
                 }}
@@ -6454,7 +6451,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             onChange={(event) =>
                               updateTemplateInputValue(
                                 definition,
-                                event.target.checked ? "true" : "false",
+                                event.target.checked,
                               )
                             }
                           />
@@ -6646,9 +6643,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 type="button"
                 id="queue-template-apply"
                 onClick={handleApplyPreset}
-                aria-disabled={isApplyingPreset}
+                aria-disabled={applyPresetDisabled}
                 aria-busy={isApplyingPreset}
                 title={applyPresetTooltip}
+                disabled={applyPresetDisabled}
               >
                 {presetReapplyNeeded ? "Reapply preset" : "Apply"}
               </button>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6349,7 +6349,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "text" | "textarea" | "markdown" | "enum" | "boolean" | "user" | "team" | "repo_path";
+            type: "text" | "textarea" | "markdown" | "enum" | "boolean" | "user" | "team" | "repo_path" | "jira_board";
             /**
              * Required
              * @default false
@@ -6359,6 +6359,8 @@ export interface components {
             default?: unknown;
             /** Options */
             options?: string[];
+            /** Placeholder */
+            placeholder?: string | null;
         };
         /**
          * TaskTemplateListResponseSchema

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -997,6 +997,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
                 "jira": {
                     "projectKey": "TOOL",
                     "issueTypeName": "Story",
+                    "boardId": "",
                     "dependencyMode": "linear_blocker_chain",
                 },
             }
@@ -1054,6 +1055,7 @@ async def test_jira_breakdown_uses_single_allowed_project_as_runtime_default(
             assert expanded["steps"][1]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
+                "boardId": "",
                 "dependencyMode": "none",
             }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
@@ -1120,6 +1122,7 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 "jira": {
                     "projectKey": "GAME",
                     "issueTypeName": "Story",
+                    "boardId": "",
                     "dependencyMode": "linear_blocker_chain",
                 },
             }
@@ -1168,6 +1171,7 @@ async def test_jira_breakdown_replaces_tool_placeholder_with_single_allowed_proj
             assert expanded["steps"][1]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
+                "boardId": "",
                 "dependencyMode": "none",
             }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
@@ -1405,6 +1409,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
                     "jira_issue_type": "Story",
+                    "jira_board_id": "84",
                     "jira_dependency_mode": "linear_blocker_chain",
                     "repository": "MoonLadderStudios/MoonMind",
                     "orchestration_mode": "runtime",
@@ -1421,6 +1426,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
             assert expanded["steps"][1]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
+                "boardId": "84",
                 "dependencyMode": "linear_blocker_chain",
             }
             downstream = expanded["steps"][2]
@@ -1428,6 +1434,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
             assert "Create one Jira Orchestrate task" in downstream["instructions"]
             assert "dependsOn" in downstream["instructions"]
             assert "MM-404" in downstream["instructions"]
+            assert "Selected Jira board ID: 84" in expanded["steps"][1]["instructions"]
             assert downstream["jiraOrchestration"]["task"] == {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},


### PR DESCRIPTION
## Summary
- Added a `jira_board` preset input type and surfaced it in task template API/OpenAPI contracts.
- Updated Jira Breakdown and Jira Breakdown and Orchestrate presets to accept a selected Jira board without hardcoded MM Board instructions.
- Rendered preset-declared option controls on the Create page and passed selected values into preset expansion.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/test_task_step_templates_service.py -q`
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `npm run ui:typecheck`
- `npm run api:types`
- `npm run ui:lint -- frontend/src/entrypoints/task-create.tsx frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Full unit result: 4073 Python tests passed, plus frontend unit suite 15 files / 436 tests passed.
