### PR TITLE
When I try to use Settings > Operations and choose update, it says only administrators can submit deployment updates. It also asks me to give a reason

### DIFF
--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -50,7 +50,7 @@ class DeploymentUpdateRequest(BaseModel):
     run_smoke_check: bool = Field(False, alias="runSmokeCheck")
     pause_work: bool = Field(False, alias="pauseWork")
     prune_old_images: bool = Field(False, alias="pruneOldImages")
-    reason: str = Field(..., min_length=1)
+    reason: str | None = None
     operation_kind: Literal["update", "rollback"] = Field("update", alias="operationKind")
     rollback_source_action_id: str | None = Field(
         None, alias="rollbackSourceActionId"
@@ -173,6 +173,8 @@ def _get_temporal_execution_service(
 
 
 def _require_admin(user: User) -> None:
+    if settings.oidc.AUTH_PROVIDER == "disabled":
+        return
     if bool(getattr(user, "is_superuser", False)):
         return
     raise HTTPException(

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -186,7 +186,7 @@ async def get_or_create_default_user(
         email=default_email,
         hashed_password=hashed_password,
         is_active=True,
-        is_superuser=False,  # Default user is not superuser unless specified
+        is_superuser=True,
         is_verified=True,
         # oidc_provider and oidc_subject can be null or set to 'disabled_auth_default'
         oidc_provider="default",

--- a/api_service/auth_providers.py
+++ b/api_service/auth_providers.py
@@ -71,7 +71,9 @@ def get_current_user():
             ):
                 from types import SimpleNamespace as _SimpleNamespace
 
-                return _SimpleNamespace(id=None, email="stub@example.com")
+                return _SimpleNamespace(
+                    id=None, email="stub@example.com", is_superuser=True
+                )
 
             async def _load_default_user() -> User | None:
                 from api_service.db.base import get_async_session_context
@@ -84,6 +86,10 @@ def get_current_user():
             try:
                 user_obj = await asyncio.wait_for(_load_default_user(), timeout=1.0)
                 if user_obj is not None:
+                    # Disabled auth is single-user local mode; treat that principal
+                    # as the local administrator even if the persisted row predates
+                    # this policy.
+                    user_obj.is_superuser = True
                     return user_obj
             except (Exception, asyncio.TimeoutError):
                 # Preserve fallback behaviour while surfacing lookup failures.
@@ -95,7 +101,7 @@ def get_current_user():
             # Fallback: lightweight stub with the minimal attributes used in code
             from types import SimpleNamespace
 
-            return SimpleNamespace(id=None, email="stub@example.com")
+            return SimpleNamespace(id=None, email="stub@example.com", is_superuser=True)
 
         _cached_current_user_dependency = _current_user_fallback
 

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -317,7 +317,7 @@ class DeploymentOperationsService:
         normalized_reason = str(submission.reason or "").strip()
         explicit_action_key = (
             uuid4().hex
-            if submission.operation_kind == "rollback" or not normalized_reason
+            if submission.operation_kind == "rollback"
             else normalized_reason
         )
         return "|".join(

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -55,7 +55,7 @@ class DeploymentUpdateSubmission:
     run_smoke_check: bool
     pause_work: bool
     prune_old_images: bool
-    reason: str
+    reason: str | None
     requested_by_user_id: UUID | str | None
     operation_kind: str = "update"
     rollback_source_action_id: str | None = None
@@ -162,7 +162,7 @@ class DeploymentOperationsService:
         repository: str,
         reference: str,
         mode: str,
-        reason: str,
+        reason: str | None,
         operation_kind: str = "update",
         confirmation: str | None = None,
         rollback_source_action_id: str | None = None,
@@ -182,11 +182,6 @@ class DeploymentOperationsService:
             raise DeploymentOperationError(
                 "deployment_mode_not_allowed",
                 "Deployment update mode is not permitted by policy.",
-            )
-        if not str(reason or "").strip():
-            raise DeploymentOperationError(
-                "deployment_reason_required",
-                "Deployment update reason is required.",
             )
         normalized_operation = str(operation_kind or "update").strip()
         if normalized_operation not in {"update", "rollback"}:
@@ -276,9 +271,10 @@ class DeploymentOperationsService:
             "runSmokeCheck": submission.run_smoke_check,
             "pauseWork": submission.pause_work,
             "pruneOldImages": submission.prune_old_images,
-            "reason": submission.reason,
             "operationKind": submission.operation_kind,
         }
+        if submission.reason and submission.reason.strip():
+            plan_inputs["reason"] = submission.reason.strip()
         if submission.rollback_source_action_id:
             plan_inputs["rollbackSourceActionId"] = submission.rollback_source_action_id
         if submission.confirmation:
@@ -318,10 +314,11 @@ class DeploymentOperationsService:
         policy: DeploymentStackPolicy,
         submission: DeploymentUpdateSubmission,
     ) -> str:
+        normalized_reason = str(submission.reason or "").strip()
         explicit_action_key = (
             uuid4().hex
-            if submission.operation_kind == "rollback"
-            else submission.reason.strip()
+            if submission.operation_kind == "rollback" or not normalized_reason
+            else normalized_reason
         )
         return "|".join(
             [

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,12 @@
 [
   {
-    "id": 3144342995,
+    "id": 3144433181,
     "disposition": "addressed",
-    "rationale": "Changed authoritative snapshot patch merging so snapshot top-level parameters overlay thinned execution parameters, preserving details such as requiredCapabilities."
+    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
   },
   {
-    "id": 4177624347,
-    "disposition": "not-applicable",
-    "rationale": "Review summary only; the actionable merge-order concern is tracked and addressed under comment 3144342995."
-  },
-  {
-    "id": 3144346169,
+    "id": 4177704240,
     "disposition": "addressed",
-    "rationale": "Gated artifact.draft handling on execution.taskInputSnapshot.reconstructionMode=authoritative and added regression coverage for regular artifacts with a draft key."
-  },
-  {
-    "id": 4177626871,
-    "disposition": "not-applicable",
-    "rationale": "Automated review wrapper text only; the actionable Codex review comment is tracked and addressed under comment 3144346169."
+    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
   }
 ]

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -251,22 +251,17 @@ describe('OperationsSettingsSection deployment update card', () => {
     expect(within(card).queryByText(/recreate every service/i)).toBeNull();
   });
 
-  it('requires a reason, confirms restart details, and submits the typed deployment payload', async () => {
+  it('submits the typed deployment payload without requiring a reason', async () => {
     renderOperations();
 
     const card = await screen.findByRole('region', { name: /deployment update/i });
+
+    fireEvent.change(await within(card).findByLabelText(/target reference/i), {
+      target: { value: 'latest' },
+    });
     fireEvent.click(
       await within(card).findByRole('button', { name: /submit deployment update/i }),
     );
-    expect(within(card).getByText(/reason is required/i)).toBeTruthy();
-
-    fireEvent.change(within(card).getByLabelText(/target reference/i), {
-      target: { value: 'latest' },
-    });
-    fireEvent.change(within(card).getByLabelText(/reason/i), {
-      target: { value: 'Routine operations update' },
-    });
-    fireEvent.click(within(card).getByRole('button', { name: /submit deployment update/i }));
 
     await waitFor(() => {
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Current image: ghcr.io/moonladderstudios/moonmind:stable'));
@@ -293,8 +288,8 @@ describe('OperationsSettingsSection deployment update card', () => {
         runSmokeCheck: false,
         pauseWork: false,
         pruneOldImages: false,
-        reason: 'Routine operations update',
       });
+      expect(JSON.parse(String(updateCall?.[1]?.body))).not.toHaveProperty('reason');
     });
     expect(await within(card).findByText(/deployment update queued/i)).toBeTruthy();
   });

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -396,9 +396,6 @@ export function OperationsSettingsSection({
       if (!repository || !reference) {
         throw new Error('Target image is required.');
       }
-      if (!reason) {
-        throw new Error('Deployment update reason is required.');
-      }
 
       const targetImage = `${repository}:${reference}`;
       const confirmation = [
@@ -438,7 +435,7 @@ export function OperationsSettingsSection({
           runSmokeCheck,
           pauseWork,
           pruneOldImages,
-          reason,
+          ...(reason ? { reason } : {}),
         }),
       });
       if (!response.ok) {
@@ -552,13 +549,6 @@ export function OperationsSettingsSection({
   const handleDeploymentSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setDeploymentNotice(null);
-    if (!deploymentReason.trim()) {
-      setDeploymentNotice({
-        level: 'error',
-        text: 'Deployment update reason is required.',
-      });
-      return;
-    }
     deploymentMutation.mutate();
   };
 
@@ -939,14 +929,13 @@ export function OperationsSettingsSection({
               </fieldset>
 
               <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Reason</span>
+                <span>Reason (optional)</span>
                 <input
                   className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
                   type="text"
                   maxLength={200}
                   value={deploymentReason}
                   onChange={(event) => setDeploymentReason(event.target.value)}
-                  required
                 />
               </label>
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3522,7 +3522,7 @@ export interface components {
              */
             pruneOldImages: boolean;
             /** Reason */
-            reason: string;
+            reason?: string | null;
             /**
              * Operationkind
              * @default update

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -693,7 +693,7 @@ def _parse_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
         "mode": str(inputs.get("mode") or "changed_services").strip(),
         "removeOrphans": _optional_bool(inputs, "removeOrphans", default=False),
         "wait": _optional_bool(inputs, "wait", default=True),
-        "reason": _required_string(inputs.get("reason"), "reason"),
+        "reason": _optional_string(inputs.get("reason")),
     }
     resolved_digest = image.get("resolvedDigest")
     if resolved_digest is not None and str(resolved_digest).strip():
@@ -719,6 +719,11 @@ def _required_string(value: Any, field_name: str) -> str:
             details={"field": field_name, "failureClass": "invalid_input"},
         )
     return normalized
+
+
+def _optional_string(value: Any) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
 
 
 def _optional_bool(

--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -30,7 +30,7 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
         "inputs": {
             "schema": {
                 "type": "object",
-                "required": ["stack", "image", "reason"],
+                "required": ["stack", "image"],
                 "additionalProperties": False,
                 "properties": {
                     "stack": {"type": "string", "enum": ["moonmind"]},

--- a/specs/261-typed-deployment-update-tool-contract/data-model.md
+++ b/specs/261-typed-deployment-update-tool-contract/data-model.md
@@ -23,12 +23,12 @@
 - `image.resolvedDigest`: optional resolved digest.
 - `mode`: `changed_services` or `force_recreate`.
 - `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, `pruneOldImages`: bounded booleans.
-- `reason`: required operator reason.
+- `reason`: optional operator reason.
 
 ## Validation Rules
 
 - Root input object rejects unknown fields.
 - `image` object rejects unknown fields.
-- Required fields are `stack`, `image`, and `reason`; `image.repository` and `image.reference` are required inside `image`.
+- Required fields are `stack` and `image`; `image.repository` and `image.reference` are required inside `image`.
 - Unsupported mode values fail schema validation.
 - Shell/path/runner override fields are not part of the schema and fail before execution.

--- a/specs/262-serialized-compose-desired-state/data-model.md
+++ b/specs/262-serialized-compose-desired-state/data-model.md
@@ -9,13 +9,13 @@ Fields:
 - `imageRepository`: repository portion of the desired image.
 - `requestedReference`: requested tag or digest reference.
 - `resolvedDigest`: digest-pinned reference when known.
-- `reason`: administrator-provided reason for the update.
+- `reason`: optional administrator-provided reason for the update.
 - `operator`: initiating principal when available.
 - `createdAt`: UTC timestamp when desired state is persisted.
 - `sourceRunId`: workflow/run/idempotency identifier when available.
 
 Validation rules:
-- `stack`, `imageRepository`, `requestedReference`, and `reason` are required.
+- `stack`, `imageRepository`, and `requestedReference` are required.
 - `resolvedDigest` remains distinct from `requestedReference`.
 - The store boundary must not accept caller-selected arbitrary file paths.
 

--- a/specs/264-settings-operations-deployment-update-ui/data-model.md
+++ b/specs/264-settings-operations-deployment-update-ui/data-model.md
@@ -22,10 +22,10 @@
 - `reference`
 - `mode`: `changed_services` by default, `force_recreate` only when available.
 - `removeOrphans`, `wait`, `runSmokeCheck`, `pauseWork`, `pruneOldImages`
-- `reason`: required before submit.
+- `reason`: optional operator note.
 
 ## Validation Rules
 
 - Target image controls expose repository/reference only; updater runner image is not a form field.
 - Mutable references such as `latest` produce a visible warning and confirmation warning.
-- Submit is blocked when reason is blank or no target repository/reference is available.
+- Submit is blocked when no target repository/reference is available.

--- a/specs/265-explicit-failure-and-rollback-controls/data-model.md
+++ b/specs/265-explicit-failure-and-rollback-controls/data-model.md
@@ -33,14 +33,14 @@ Validation rules:
 - `image.repository`: allowlisted MoonMind image repository.
 - `image.reference`: target previous image tag or digest from rollback eligibility.
 - `mode`: normal deployment update mode, usually `changed_services` unless the operator explicitly chooses another policy-allowed mode.
-- `reason`: required operator reason.
+- `reason`: optional operator reason.
 - `confirmation`: operator confirmation that the rollback target and restart implications are understood.
 - `sourceActionId`: optional recent action used to derive rollback target.
 - `operationKind`: `rollback`.
 
 Validation rules:
 - Rollback uses the same typed deployment update path as forward updates.
-- Admin authorization, reason, confirmation, deployment lock, before/after artifacts, and verification remain required.
+- Admin authorization, confirmation, deployment lock, before/after artifacts, and verification remain required.
 - Rollback cannot include shell commands, runner images, host paths, non-allowlisted stacks, or non-allowlisted repositories.
 
 ## Deployment Audit Action

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -245,6 +245,30 @@ def test_explicit_retry_submission_creates_distinct_audited_update_request(
     )
 
 
+def test_repeated_update_submission_without_reason_reuses_idempotency_key(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    payload = _valid_update_payload()
+    payload.pop("reason")
+
+    first = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+    second = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert len(execution_service.requests) == 2
+    assert execution_service.requests[0]["idempotency_key"] == (
+        execution_service.requests[1]["idempotency_key"]
+    )
+
+
 def test_non_admin_cannot_submit_deployment_update(
     user_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -20,6 +20,7 @@ from api_service.services.deployment_operations import (
     RollbackEligibilityDecision,
     RollbackImageTarget,
 )
+from moonmind.config.settings import settings
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     DEPLOYMENT_UPDATE_TOOL_VERSION,
@@ -244,7 +245,10 @@ def test_explicit_retry_submission_creates_distinct_audited_update_request(
     )
 
 
-def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> None:
+def test_non_admin_cannot_submit_deployment_update(
+    user_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "default")
     response = user_client.post(
         "/api/v1/operations/deployment/update",
         json=_valid_update_payload(),
@@ -253,6 +257,20 @@ def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> N
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "deployment_update_forbidden"
     assert response.json()["detail"]["failureClass"] == "authorization_failure"
+
+
+def test_disabled_auth_user_can_submit_deployment_update_as_default_admin(
+    user_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled")
+
+    response = user_client.post(
+        "/api/v1/operations/deployment/update",
+        json=_valid_update_payload(),
+    )
+
+    assert response.status_code == 202
+    assert response.json()["status"] == "QUEUED"
 
 
 @pytest.mark.parametrize(
@@ -273,7 +291,6 @@ def test_non_admin_cannot_submit_deployment_update(user_client: TestClient) -> N
             "deployment_image_reference_invalid",
         ),
         ("mode", "shell", "deployment_mode_not_allowed"),
-        ("reason", "   ", "deployment_reason_required"),
     ],
 )
 def test_invalid_deployment_update_policy_inputs_are_rejected_before_execution(
@@ -294,6 +311,25 @@ def test_invalid_deployment_update_policy_inputs_are_rejected_before_execution(
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == code
     assert execution_service.requests == []
+
+
+def test_deployment_update_reason_is_optional(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    payload = _valid_update_payload()
+    payload.pop("reason")
+
+    response = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert response.status_code == 202
+    parameters = execution_service.requests[0]["initial_parameters"]
+    assert isinstance(parameters, dict)
+    plan_inputs = parameters["task"]["plan"][0]["inputs"]
+    assert "reason" not in plan_inputs
 
 
 def test_arbitrary_shell_and_path_fields_are_not_accepted(

--- a/tests/unit/workflows/skills/test_deployment_tool_contracts.py
+++ b/tests/unit/workflows/skills/test_deployment_tool_contracts.py
@@ -86,7 +86,7 @@ def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
     )
 
     input_schema = definition.input_schema
-    assert input_schema["required"] == ["stack", "image", "reason"]
+    assert input_schema["required"] == ["stack", "image"]
     assert input_schema["additionalProperties"] is False
     assert input_schema["properties"]["stack"]["enum"] == ["moonmind"]
     assert input_schema["properties"]["mode"]["enum"] == [

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -757,7 +757,7 @@ async def test_default_skill_registry_payload_uses_curated_deployment_tool_defin
     assert definition["security"]["allowed_roles"] == ["admin"]
 
     input_schema = definition["inputs"]["schema"]
-    assert input_schema["required"] == ["stack", "image", "reason"]
+    assert input_schema["required"] == ["stack", "image"]
     assert input_schema["additionalProperties"] is False
     assert input_schema["properties"]["image"]["additionalProperties"] is False
 


### PR DESCRIPTION
When I try to use Settings > Operations and choose update, it says only administrators can submit deployment updates. It also asks me to give a reason. I do not want a reason to be mandatory with updates. Also, when running in no auth mode or whatever the mode is where I just use the default user and that's it, there should be no requirement to be an administrator any longer since the sole user should be considered an administrator.