### PR TITLE
[codex] Prevent unit tests from leaking Temporal workflows

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,27 @@
 [
   {
-    "id": 3144433181,
+    "id": 3144649411,
     "disposition": "addressed",
-    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
+    "rationale": "Moved the docker compose run -e flag before the pytest service token in tools/test_integration.sh so the environment option is parsed by compose."
   },
   {
-    "id": 4177704240,
+    "id": 4177919845,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary comment with no distinct actionable request beyond the inline comments."
+  },
+  {
+    "id": 3144652319,
     "disposition": "addressed",
-    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
+    "rationale": "Imported ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV and TemporalClientAdapter at module scope in tests/unit/conftest.py."
+  },
+  {
+    "id": 3144652324,
+    "disposition": "addressed",
+    "rationale": "Replaced the hardcoded Temporal live-test environment variable string with ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV."
+  },
+  {
+    "id": 4177922493,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary comment that restates the same maintainability feedback addressed by the inline comments."
   }
 ]

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -42,6 +43,7 @@ MANAGED_SESSION_RECONCILE_SCHEDULE_ID = "mm-operational:managed-session-reconcil
 MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE = (
     "mm-operational:managed-session-reconcile:{{.ScheduleTime}}"
 )
+ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
 
 def _is_rpc_status(exc: BaseException, status_name: str) -> bool:
     """Check whether *exc* is a Temporal ``RPCError`` with the given gRPC status.
@@ -157,6 +159,16 @@ class TemporalClientAdapter:
         """Get or initialize the Temporal client connection."""
         if self._client is not None:
             return self._client
+        if (
+            os.getenv("PYTEST_CURRENT_TEST")
+            and os.getenv(ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV) != "1"
+        ):
+            raise RuntimeError(
+                "Refusing to open an implicit live Temporal connection while pytest "
+                f"is running. Pass an injected Temporal client/adapter, or set "
+                f"{ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV}=1 for tests that intentionally "
+                "use a live Temporal server."
+            )
         async with self._lock:
             if self._client is None:
                 self._client = await Client.connect(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,11 @@
-"""Exclude test modules that reference the deleted agent_queue system."""
+"""Unit-test collection and external-side-effect guards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
 
 collect_ignore_glob = [
     "api/routers/test_task_runs.py",
@@ -6,3 +13,34 @@ collect_ignore_glob = [
     "api/routers/test_agent_queue_artifacts.py",
     "mcp/test_tool_registry.py",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class _DummyWorkflowStartResult:
+    workflow_id: str
+    run_id: str
+
+
+@pytest.fixture(autouse=True)
+def prevent_live_temporal_lifecycle_calls(monkeypatch):
+    """Keep unit tests from starting/signaling/canceling real Temporal workflows."""
+
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    async def mock_start_workflow(self, *args, **kwargs):
+        workflow_id = kwargs.get("workflow_id") or kwargs.get("id") or "mm:unit-test"
+        return _DummyWorkflowStartResult(workflow_id=workflow_id, run_id=str(uuid4()))
+
+    async def mock_noop(*args, **kwargs):
+        return None
+
+    async def mock_describe_workflow(*args, **kwargs):
+        return None
+
+    monkeypatch.setenv("MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS", "0")
+    monkeypatch.setattr(TemporalClientAdapter, "start_workflow", mock_start_workflow)
+    monkeypatch.setattr(TemporalClientAdapter, "update_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "signal_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "cancel_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "terminate_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "describe_workflow", mock_describe_workflow)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,11 @@ from uuid import uuid4
 
 import pytest
 
+from moonmind.workflows.temporal.client import (
+    ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV,
+    TemporalClientAdapter,
+)
+
 collect_ignore_glob = [
     "api/routers/test_task_runs.py",
     "api/routers/test_mcp_tools.py",
@@ -25,8 +30,6 @@ class _DummyWorkflowStartResult:
 def prevent_live_temporal_lifecycle_calls(monkeypatch):
     """Keep unit tests from starting/signaling/canceling real Temporal workflows."""
 
-    from moonmind.workflows.temporal.client import TemporalClientAdapter
-
     async def mock_start_workflow(self, *args, **kwargs):
         workflow_id = kwargs.get("workflow_id") or kwargs.get("id") or "mm:unit-test"
         return _DummyWorkflowStartResult(workflow_id=workflow_id, run_id=str(uuid4()))
@@ -37,7 +40,7 @@ def prevent_live_temporal_lifecycle_calls(monkeypatch):
     async def mock_describe_workflow(*args, **kwargs):
         return None
 
-    monkeypatch.setenv("MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS", "0")
+    monkeypatch.setenv(ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV, "0")
     monkeypatch.setattr(TemporalClientAdapter, "start_workflow", mock_start_workflow)
     monkeypatch.setattr(TemporalClientAdapter, "update_workflow", mock_noop)
     monkeypatch.setattr(TemporalClientAdapter, "signal_workflow", mock_noop)

--- a/tests/unit/workflows/temporal/test_temporal_client.py
+++ b/tests/unit/workflows/temporal/test_temporal_client.py
@@ -39,6 +39,34 @@ async def test_temporal_client_uses_shared_pydantic_data_converter(monkeypatch):
 
     assert captured["data_converter"] is MOONMIND_TEMPORAL_DATA_CONVERTER
 
+
+async def test_default_adapter_refuses_implicit_live_connection_under_pytest(
+    monkeypatch,
+):
+    monkeypatch.delenv("MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS", raising=False)
+    adapter = TemporalClientAdapter()
+
+    with pytest.raises(RuntimeError, match="implicit live Temporal connection"):
+        await adapter.get_client()
+
+
+async def test_default_adapter_allows_explicit_live_connection_opt_in(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_connect(address, *, namespace, data_converter):
+        captured["address"] = address
+        captured["namespace"] = namespace
+        captured["data_converter"] = data_converter
+        return AsyncMock()
+
+    monkeypatch.setenv("MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS", "1")
+    monkeypatch.setattr(temporal_client_module.Client, "connect", fake_connect)
+
+    connected = await TemporalClientAdapter().get_client()
+
+    assert connected is not None
+    assert captured["data_converter"] is MOONMIND_TEMPORAL_DATA_CONVERTER
+
 # ---- get_drain_metrics ----
 
 async def test_get_drain_metrics_counts_running_workflows(adapter):

--- a/tools/test_integration.sh
+++ b/tools/test_integration.sh
@@ -40,8 +40,9 @@ export MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1
 # --timeout-method=thread: use thread-based timeout (works with async tests)
 # --durations=10: print the 10 slowest tests at the end
 run_tests() {
-  "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" run --rm pytest \
+  "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" run --rm \
     -e MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1 \
+    pytest \
     bash -lc "pytest tests/integration -m 'integration_ci' --tb=short --timeout 120 --timeout-method=thread --durations=10"
 }
 

--- a/tools/test_integration.sh
+++ b/tools/test_integration.sh
@@ -30,6 +30,8 @@ if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
   echo "Created Docker network: $NETWORK_NAME"
 fi
 
+export MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1
+
 # Build pytest service
 "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" build pytest
 
@@ -39,6 +41,7 @@ fi
 # --durations=10: print the 10 slowest tests at the end
 run_tests() {
   "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" run --rm pytest \
+    -e MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1 \
     bash -lc "pytest tests/integration -m 'integration_ci' --tb=short --timeout 120 --timeout-method=thread --durations=10"
 }
 

--- a/tools/test_unit.sh
+++ b/tools/test_unit.sh
@@ -83,6 +83,7 @@ if ! is_in_container && is_wsl && [[ "${MOONMIND_FORCE_LOCAL_TESTS:-0}" != "1" ]
 fi
 
 export MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1
+export MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0
 
 # Clear worker-specific overrides so WorkflowSettings-based tests use
 # repository defaults instead of container env hints.


### PR DESCRIPTION
## Summary
- Prevent implicit live Temporal connections from pytest unless explicitly opted in.
- Add unit-suite Temporal lifecycle no-op guards so DB-focused tests cannot start real workflows.
- Mark unit and integration runners with opposite live-Temporal policies.

## Root Cause
Unit tests instantiated `TemporalExecutionService` without an injected adapter. Because the service created a default `TemporalClientAdapter`, DB fixture tests could start real workflows when a local Temporal stack was running.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_temporal_client.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/services/test_manifests_service.py tests/unit/workflows/temporal/test_manifest_ingest.py`
- `./tools/test_unit.sh --python-only`
- `./tools/test_unit.sh --dashboard-only` (passed on rerun; first run hit an existing Live Logs frontend flake)
- `git diff --check`
- Temporal visibility check after test runs showed no new `mm:` workflows
