### PR TITLE
[codex] Scope task list workflows

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9,7 +9,7 @@ import os
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Literal, Optional, cast
 from urllib.parse import quote, urlsplit
 from uuid import uuid4
 
@@ -105,6 +105,13 @@ from moonmind.workflows import get_temporal_artifact_service
 router = APIRouter(prefix="/api/executions", tags=["executions"])
 _TEMPORAL_SOURCE = "temporal"
 _ALLOWED_OWNER_TYPES = {"user", "system", "service"}
+_TEMPORAL_LIST_SCOPES = {"tasks", "user", "system", "all"}
+_TEMPORAL_SCOPE_QUERIES = {
+    "tasks": 'WorkflowType="MoonMind.Run" AND mm_entry="run"',
+    "user": '(WorkflowType="MoonMind.Run" OR WorkflowType="MoonMind.ManifestIngest")',
+    "system": 'WorkflowType!="MoonMind.Run" AND WorkflowType!="MoonMind.ManifestIngest"',
+    "all": "",
+}
 _DASHBOARD_STATUS_BY_STATE: dict[MoonMindWorkflowState, str] = {
     MoonMindWorkflowState.SCHEDULED: "queued",
     MoonMindWorkflowState.INITIALIZING: "queued",
@@ -130,6 +137,7 @@ _GITHUB_PULL_REQUEST_PATH_PATTERN = re.compile(
     r"^/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+$",
     re.IGNORECASE,
 )
+
 
 class RemediationApprovalStateModel(BaseModel):
     requestId: str | None = None
@@ -244,6 +252,38 @@ def _is_execution_admin(user: User | None) -> bool:
 def _owner_id(user: User | None) -> str | None:
     value = getattr(user, "id", None)
     return str(value) if value is not None else None
+
+
+def _normalize_temporal_list_scope(
+    scope: str | None,
+    *,
+    workflow_type: str | None,
+    entry: str | None,
+) -> Literal["tasks", "user", "system", "all"]:
+    """Return the product-facing Temporal list scope.
+
+    The default task dashboard view is intentionally not a raw Temporal
+    namespace browser. Explicit workflow-type or entry filters keep the older
+    API behavior unless the caller pins a scope.
+    """
+
+    normalized = str(scope or "").strip().lower()
+    if not normalized:
+        return "all" if workflow_type or entry else "tasks"
+    if normalized not in _TEMPORAL_LIST_SCOPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_temporal_list_scope",
+                "message": (
+                    "scope must be one of: "
+                    + ", ".join(sorted(_TEMPORAL_LIST_SCOPES))
+                    + "."
+                ),
+            },
+        )
+    return cast(Literal["tasks", "user", "system", "all"], normalized)
+
 
 def _canonicalize_execution_identifier(raw_identifier: str) -> tuple[str, bool]:
     canonical = TemporalExecutionRecord.canonicalize_identifier(raw_identifier)
@@ -1169,7 +1209,7 @@ def _serialize_execution(
 
     started_at = getattr(record, "started_at", None)
     created_at = getattr(record, "created_at", None) or started_at or record.updated_at
-    scheduled_for = getattr(record, "scheduled_for", None) or created_at
+    scheduled_for = getattr(record, "scheduled_for", None)
 
     return ExecutionModel(
         task_id=record.workflow_id,
@@ -3933,6 +3973,7 @@ async def list_executions(
     entry: Optional[str] = Query(None, alias="entry"),
     repo: Optional[str] = Query(None, alias="repo"),
     integration: Optional[str] = Query(None, alias="integration"),
+    scope: Optional[str] = Query(None, alias="scope"),
     page_size: int = Query(50, alias="pageSize", ge=1, le=200),
     next_page_token: Optional[str] = Query(None, alias="nextPageToken"),
     source: Optional[str] = Query(None),
@@ -3978,6 +4019,14 @@ async def list_executions(
                 return v.replace('"', '\\"')
 
             query_parts = []
+            temporal_scope = _normalize_temporal_list_scope(
+                scope,
+                workflow_type=workflow_type,
+                entry=entry,
+            )
+            scope_query = _TEMPORAL_SCOPE_QUERIES[temporal_scope]
+            if scope_query:
+                query_parts.append(scope_query)
             if workflow_type:
                 query_parts.append(f'WorkflowType="{escape_val(workflow_type)}"')
             if state:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,17 @@
 [
   {
-    "id": 3144433181,
+    "id": 3144756846,
     "disposition": "addressed",
-    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
+    "rationale": "Persisted explicit task scope when entry or workflow filters are active and added a tasks-list URL regression test."
   },
   {
-    "id": 4177704240,
-    "disposition": "addressed",
-    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
+    "id": 4178025727,
+    "disposition": "not-applicable",
+    "rationale": "Automated Codex review summary; the actionable child review comment is tracked separately."
+  },
+  {
+    "id": 4178026060,
+    "disposition": "not-applicable",
+    "rationale": "Gemini review body explicitly stated there was no feedback to address."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -85,6 +85,24 @@ describe('Tasks List Entrypoint', () => {
     expect((screen.getByLabelText('Workflow Type') as HTMLSelectElement).disabled).toBe(false);
   });
 
+  it('keeps explicit task scope in the URL when entry filters are active', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const baselineCalls = fetchSpy.mock.calls.length;
+
+    fireEvent.change(screen.getByLabelText('Entry'), { target: { value: 'run' } });
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+    });
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=tasks&entry=run',
+    );
+    expect(window.location.search).toContain('scope=tasks');
+    expect(window.location.search).toContain('entry=run');
+  });
+
   it('renders executing task-list pills with the shared shimmer selector contract while keeping non-executing pills plain', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -284,6 +284,23 @@ describe('Tasks List Entrypoint', () => {
     expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
   });
 
+  it('preserves the default task scope in shared URLs when entry filters are set', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const baselineCalls = fetchSpy.mock.calls.length;
+
+    fireEvent.change(screen.getByLabelText('Entry'), { target: { value: 'manifest' } });
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+    });
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=tasks&entry=manifest',
+    );
+    expect(window.location.search).toBe('?scope=tasks&entry=manifest&limit=50');
+  });
+
   it('labels the lifecycle filter as status and exposes canonical status options', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -40,6 +40,9 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=tasks',
+    );
 
     const scheduledHeaderButton = await screen.findByRole('button', {
       name: /Scheduled\. Sorted descending\. Activate to sort ascending\./i,
@@ -61,6 +64,26 @@ describe('Tasks List Entrypoint', () => {
     });
   });
 
+  it('defaults to user task scope but exposes raw all-workflows scope', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    const scopeFilter = screen.getByLabelText('Scope') as HTMLSelectElement;
+    expect(scopeFilter.value).toBe('tasks');
+    expect((screen.getByLabelText('Workflow Type') as HTMLSelectElement).disabled).toBe(true);
+
+    const baselineCalls = fetchSpy.mock.calls.length;
+    fireEvent.change(scopeFilter, { target: { value: 'all' } });
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+    });
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=all',
+    );
+    expect((screen.getByLabelText('Workflow Type') as HTMLSelectElement).disabled).toBe(false);
+  });
 
   it('renders executing task-list pills with the shared shimmer selector contract while keeping non-executing pills plain', async () => {
     fetchSpy.mockResolvedValue({
@@ -228,7 +251,9 @@ describe('Tasks List Entrypoint', () => {
     await waitFor(() => {
       expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
     });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe('/api/executions?source=temporal&pageSize=50&repo=owner%2Frepo');
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=tasks&repo=owner%2Frepo',
+    );
 
     fireEvent.change(screen.getByLabelText('Repository'), {
       target: { value: 'owner/repo ' },
@@ -273,7 +298,9 @@ describe('Tasks List Entrypoint', () => {
     await waitFor(() => {
       expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
     });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe('/api/executions?source=temporal&pageSize=50&state=completed');
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      '/api/executions?source=temporal&pageSize=50&scope=tasks&state=completed',
+    );
   });
 
   it('renders pagination as arrow buttons beside the table summary', async () => {

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -18,7 +18,15 @@ type ListDashboardConfig = {
   };
 };
 
-const WORKFLOW_TYPES = ['MoonMind.Run', 'MoonMind.ManifestIngest'] as const;
+const USER_WORKFLOW_TYPES = ['MoonMind.Run', 'MoonMind.ManifestIngest'] as const;
+const SYSTEM_WORKFLOW_TYPES = ['MoonMind.ProviderProfileManager'] as const;
+const WORKFLOW_TYPES = [...USER_WORKFLOW_TYPES, ...SYSTEM_WORKFLOW_TYPES] as const;
+const LIST_SCOPES = [
+  ['tasks', 'Tasks'],
+  ['user', 'User Workflows'],
+  ['system', 'System Workflows'],
+  ['all', 'All Workflows'],
+] as const;
 const TEMPORAL_STATUSES = [
   'scheduled',
   'initializing',
@@ -104,6 +112,15 @@ function summarizeRuntime(runtime: string | null | undefined): string {
   return label === '—' ? '' : label;
 }
 
+function normalizeListScope(raw: string | null): string {
+  const candidate = (raw || '').trim().toLowerCase();
+  return LIST_SCOPES.some(([value]) => value === candidate) ? candidate : 'tasks';
+}
+
+function scopeLabel(value: string): string {
+  return LIST_SCOPES.find(([scopeValue]) => scopeValue === value)?.[1] || value;
+}
+
 function dependencyListSummary(row: ExecutionRow): string {
   const blocked = Boolean(
     row.blockedOnDependencies ||
@@ -168,6 +185,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
   const initial = useMemo(() => new URLSearchParams(window.location.search), []);
 
+  const [listScope, setListScope] = useState(() =>
+    normalizeListScope(initial.get('scope') || (initial.get('workflowType') || initial.get('entry') ? 'all' : null)),
+  );
   const [workflowType, setWorkflowType] = useState(() => initial.get('workflowType') || '');
   const [temporalState, setTemporalState] = useState(() => (initial.get('state') || '').toLowerCase());
   const [entry, setEntry] = useState(() => (initial.get('entry') || '').toLowerCase());
@@ -183,10 +203,16 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     return 'desc';
   });
   const normalizedRepository = repository.trim();
+  const workflowTypeOptions = useMemo(() => {
+    if (listScope === 'user') return USER_WORKFLOW_TYPES;
+    if (listScope === 'system') return SYSTEM_WORKFLOW_TYPES;
+    return WORKFLOW_TYPES;
+  }, [listScope]);
 
   const syncUrl = useCallback(() => {
     const params = new URLSearchParams();
-    if (workflowType) params.set('workflowType', workflowType);
+    if (listScope !== 'tasks') params.set('scope', listScope);
+    if (listScope !== 'tasks' && workflowType) params.set('workflowType', workflowType);
     if (temporalState) params.set('state', temporalState);
     if (entry) params.set('entry', entry);
     if (normalizedRepository) params.set('repo', normalizedRepository);
@@ -198,6 +224,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     }
     replaceUrlQuery(params);
   }, [
+    listScope,
     workflowType,
     temporalState,
     entry,
@@ -216,6 +243,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     'tasks-list',
     'temporal',
     pageSize,
+    listScope,
     workflowType,
     temporalState,
     entry,
@@ -230,8 +258,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       const params = new URLSearchParams();
       params.set('source', 'temporal');
       params.set('pageSize', String(pageSize));
+      params.set('scope', listScope);
       if (listCursor) params.set('nextPageToken', listCursor);
-      if (workflowType) params.set('workflowType', workflowType);
+      if (listScope !== 'tasks' && workflowType) params.set('workflowType', workflowType);
       if (temporalState) params.set('state', temporalState);
       if (entry) params.set('entry', entry);
       if (normalizedRepository) params.set('repo', normalizedRepository);
@@ -316,15 +345,17 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const activeFilters = useMemo(
     () =>
       [
-        workflowType ? ['Workflow', workflowType] : null,
+        listScope !== 'tasks' ? ['Scope', scopeLabel(listScope)] : null,
+        listScope !== 'tasks' && workflowType ? ['Workflow', workflowType] : null,
         temporalState ? ['Status', temporalState] : null,
         entry ? ['Entry', entry] : null,
         normalizedRepository ? ['Repository', normalizedRepository] : null,
       ].filter((filter): filter is [string, string] => Boolean(filter)),
-    [workflowType, temporalState, entry, normalizedRepository],
+    [listScope, workflowType, temporalState, entry, normalizedRepository],
   );
   const hasActiveFilters = activeFilters.length > 0;
   const clearFilters = useCallback(() => {
+    setListScope('tasks');
     setWorkflowType('');
     setTemporalState('');
     setEntry('');
@@ -363,17 +394,44 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
         <form className="task-list-control-grid" onSubmit={(event) => event.preventDefault()}>
           <label>
+            Scope
+            <select
+              value={listScope}
+              disabled={!listEnabled}
+              onChange={(event) => {
+                const nextScope = normalizeListScope(event.target.value);
+                setListScope(nextScope);
+                const nextWorkflowTypes =
+                  nextScope === 'user'
+                    ? USER_WORKFLOW_TYPES
+                    : nextScope === 'system'
+                      ? SYSTEM_WORKFLOW_TYPES
+                      : WORKFLOW_TYPES;
+                if (nextScope === 'tasks' || !nextWorkflowTypes.some((type) => type === workflowType)) {
+                  setWorkflowType('');
+                }
+                resetToFirstPage();
+              }}
+            >
+              {LIST_SCOPES.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
             Workflow Type
             <select
               value={workflowType}
-              disabled={!listEnabled}
+              disabled={!listEnabled || listScope === 'tasks'}
               onChange={(event) => {
                 setWorkflowType(event.target.value);
                 resetToFirstPage();
               }}
             >
               <option value="">All Types</option>
-              {WORKFLOW_TYPES.map((workflow) => (
+              {workflowTypeOptions.map((workflow) => (
                 <option key={workflow} value={workflow}>
                   {workflow}
                 </option>

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -211,7 +211,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
   const syncUrl = useCallback(() => {
     const params = new URLSearchParams();
-    if (listScope !== 'tasks') params.set('scope', listScope);
+    const scopeSensitiveFilterActive = Boolean(entry || workflowType);
+    if (listScope !== 'tasks' || scopeSensitiveFilterActive) params.set('scope', listScope);
     if (listScope !== 'tasks' && workflowType) params.set('workflowType', workflowType);
     if (temporalState) params.set('state', temporalState);
     if (entry) params.set('entry', entry);

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -9246,6 +9246,7 @@ export interface operations {
                 entry?: string | null;
                 repo?: string | null;
                 integration?: string | null;
+                scope?: string | null;
                 pageSize?: number;
                 nextPageToken?: string | null;
                 source?: string | null;

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2641,7 +2641,7 @@ def test_serialize_execution_treats_system_owner_id_as_system_owner_type() -> No
     assert payload.owner_type == "system"
     assert payload.owner_id == "system"
 
-def test_serialize_execution_uses_created_at_for_immediate_schedule() -> None:
+def test_serialize_execution_leaves_immediate_run_unscheduled() -> None:
     created_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
     record = SimpleNamespace(
         close_status=None,
@@ -2665,10 +2665,10 @@ def test_serialize_execution_uses_created_at_for_immediate_schedule() -> None:
 
     payload = _serialize_execution(record)
 
-    assert payload.scheduled_for == created_at
+    assert payload.scheduled_for is None
     assert payload.created_at == created_at
 
-def test_serialize_execution_falls_back_to_updated_at_for_created_at() -> None:
+def test_serialize_execution_falls_back_to_updated_at_without_scheduled_time() -> None:
     updated_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
     record = SimpleNamespace(
         close_status=None,
@@ -2692,7 +2692,7 @@ def test_serialize_execution_falls_back_to_updated_at_for_created_at() -> None:
     payload = _serialize_execution(record)
 
     assert payload.created_at == updated_at
-    assert payload.scheduled_for == updated_at
+    assert payload.scheduled_for is None
 
 def test_serialize_execution_surfaces_runtime_model_effort_from_parameters() -> None:
     """Ensure runtime/model/effort stored in record.parameters are surfaced."""

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -118,6 +119,80 @@ def test_list_executions_source_temporal_bypasses_db_and_queries_temporal(
         assert item["state"] == "awaiting_external"
         assert item["entry"] == "run"
         assert item["waitingReason"] == "external_completion"
+
+
+def test_list_executions_source_temporal_defaults_to_task_scope(client) -> None:
+    test_client, _service, _user, _mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = []
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=0))
+
+        response = test_client.get("/api/executions", params={"source": "temporal"})
+
+        assert response.status_code == 200
+        expected_query = (
+            'WorkflowType="MoonMind.Run" AND mm_entry="run" '
+            'AND mm_owner_id="user-123"'
+        )
+        mock_client.count_workflows.assert_awaited_once_with(query=expected_query)
+        mock_client.list_workflows.assert_called_once()
+        assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
+
+
+def test_list_executions_source_temporal_scope_all_keeps_raw_temporal_query(
+    client,
+) -> None:
+    test_client, _service, _user, _mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = []
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=0))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "scope": "all"},
+        )
+
+        assert response.status_code == 200
+        expected_query = 'mm_owner_id="user-123"'
+        mock_client.count_workflows.assert_awaited_once_with(query=expected_query)
+        assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
+
+
+def test_list_executions_source_temporal_rejects_unknown_scope(client) -> None:
+    test_client, _service, _user, _mock_session = client
+
+    response = test_client.get(
+        "/api/executions",
+        params={"source": "temporal", "scope": "surprise"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_temporal_list_scope"
+
 
 def test_task_detail_instructions_include_task_and_step_text() -> None:
     assert executions_module._derive_full_task_instructions(
@@ -440,14 +515,8 @@ def test_list_executions_source_temporal_orders_immediate_runs_by_updated_at(
         "mm:wf-older-created-newer-updated",
         "mm:wf-newer-created-older-updated",
     ]
-    assert (
-        datetime.fromisoformat(items[0]["scheduledFor"].replace("Z", "+00:00"))
-        == older_created
-    )
-    assert (
-        datetime.fromisoformat(items[1]["scheduledFor"].replace("Z", "+00:00"))
-        == newer_created
-    )
+    assert items[0]["scheduledFor"] is None
+    assert items[1]["scheduledFor"] is None
 
 def test_describe_execution_source_temporal_syncs_projection(client) -> None:
     test_client, service, user, _mock_session = client


### PR DESCRIPTION
## Summary

- Add a Temporal execution list `scope` filter so the default task list reads user task runs instead of the raw Temporal namespace.
- Add Tasks/User Workflows/System Workflows/All Workflows scope controls to the Tasks list UI.
- Stop synthesizing `scheduledFor` from created/updated time for immediate unscheduled executions so internal workflows do not look scheduled.

## Root Cause

The Tasks list queried `source=temporal` without a default workflow scope. That made the backend call Temporal visibility with an empty query and count every retained workflow, including support workflows and continued-as-new histories.

## Validation

- `npm run ui:typecheck`
- `npm run ui:lint`
- `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`
- targeted API tests for Temporal execution scope and schedule serialization
- `./tools/test_unit.sh`