### PR TITLE
[codex] Preserve rerun instruction snapshots

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2861,10 +2861,8 @@ def _artifact_id_from_ref(value: Any) -> str | None:
     ref = _coerce_artifact_ref(value)
     if not ref:
         return None
-    if ref.startswith("artifact://"):
-        ref = ref.removeprefix("artifact://")
-        if ref.startswith("input/"):
-            ref = ref.removeprefix("input/")
+    ref = ref.removeprefix("artifact://")
+    ref = ref.removeprefix("input/")
     return ref.strip() or None
 
 
@@ -2928,8 +2926,6 @@ def _merge_task_preserving_artifact_instructions(
             if artifact_step_instructions and not parameter_step_instructions:
                 step["instructions"] = artifact_step.get("instructions")
             merged_steps.append(step)
-        if len(artifact_steps) > len(parameter_steps):
-            merged_steps.extend(artifact_steps[len(parameter_steps) :])
         merged["steps"] = merged_steps
     return merged
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2856,6 +2856,137 @@ def _snapshot_source_payload_from_parameters(
     }
     return payload, task
 
+
+def _artifact_id_from_ref(value: Any) -> str | None:
+    ref = _coerce_artifact_ref(value)
+    if not ref:
+        return None
+    if ref.startswith("artifact://"):
+        ref = ref.removeprefix("artifact://")
+        if ref.startswith("input/"):
+            ref = ref.removeprefix("input/")
+    return ref.strip() or None
+
+
+def _snapshot_task_from_artifact_payload(
+    artifact_payload: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    draft = artifact_payload.get("draft")
+    source = draft if isinstance(draft, Mapping) else artifact_payload
+    task_value = source.get("task") if isinstance(source, Mapping) else None
+    task = dict(task_value) if isinstance(task_value, Mapping) else {}
+    instructions = str(source.get("instructions") or "").strip()
+    if instructions and not str(task.get("instructions") or "").strip():
+        task["instructions"] = instructions
+    capabilities_value = source.get("requiredCapabilities")
+    target_runtime = source.get("targetRuntime") or artifact_payload.get(
+        "targetRuntime"
+    )
+    if not target_runtime and isinstance(source.get("runtime"), str):
+        target_runtime = source.get("runtime")
+    payload = {
+        "repository": source.get("repository") or artifact_payload.get("repository"),
+        "targetRuntime": target_runtime,
+        "requiredCapabilities": (
+            list(capabilities_value) if isinstance(capabilities_value, list) else []
+        ),
+    }
+    return payload, task
+
+
+def _merge_task_preserving_artifact_instructions(
+    artifact_task: Mapping[str, Any],
+    parameter_task: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged = {**dict(artifact_task), **dict(parameter_task)}
+    artifact_instructions = str(artifact_task.get("instructions") or "").strip()
+    parameter_instructions = str(parameter_task.get("instructions") or "").strip()
+    if artifact_instructions and not parameter_instructions:
+        merged["instructions"] = artifact_task.get("instructions")
+
+    artifact_steps = artifact_task.get("steps")
+    parameter_steps = parameter_task.get("steps")
+    if isinstance(artifact_steps, list) and isinstance(parameter_steps, list):
+        merged_steps: list[Any] = []
+        for index, parameter_step in enumerate(parameter_steps):
+            if not isinstance(parameter_step, Mapping):
+                merged_steps.append(parameter_step)
+                continue
+            artifact_step = (
+                artifact_steps[index]
+                if index < len(artifact_steps)
+                and isinstance(artifact_steps[index], Mapping)
+                else {}
+            )
+            step = {**dict(artifact_step), **dict(parameter_step)}
+            artifact_step_instructions = str(
+                artifact_step.get("instructions") or ""
+            ).strip()
+            parameter_step_instructions = str(
+                parameter_step.get("instructions") or ""
+            ).strip()
+            if artifact_step_instructions and not parameter_step_instructions:
+                step["instructions"] = artifact_step.get("instructions")
+            merged_steps.append(step)
+        if len(artifact_steps) > len(parameter_steps):
+            merged_steps.extend(artifact_steps[len(parameter_steps) :])
+        merged["steps"] = merged_steps
+    return merged
+
+
+async def _snapshot_source_payload_from_parameters_and_artifact(
+    *,
+    session: AsyncSession,
+    user: User,
+    record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
+    parameters: Mapping[str, Any],
+    input_artifact_ref: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    parameter_payload, parameter_task = _snapshot_source_payload_from_parameters(
+        parameters
+    )
+    artifact_ref = (
+        input_artifact_ref
+        or str(parameters.get("inputArtifactRef") or "").strip()
+        or str(getattr(record, "input_ref", None) or "").strip()
+    )
+    artifact_id = _artifact_id_from_ref(artifact_ref)
+    if not artifact_id:
+        return parameter_payload, parameter_task
+    try:
+        artifact_service = get_temporal_artifact_service(session)
+        _artifact, body = await artifact_service.read(
+            artifact_id=artifact_id,
+            principal=str(getattr(user, "id", "") or "system"),
+            allow_restricted_raw=True,
+        )
+        decoded = json.loads(body.decode("utf-8"))
+    except Exception as exc:
+        logger.warning(
+            "Failed to hydrate task input snapshot from artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        return parameter_payload, parameter_task
+    if not isinstance(decoded, Mapping):
+        return parameter_payload, parameter_task
+
+    artifact_payload, artifact_task = _snapshot_task_from_artifact_payload(decoded)
+    payload = {
+        **artifact_payload,
+        **{
+            key: value
+            for key, value in parameter_payload.items()
+            if value not in (None, [], "")
+        },
+    }
+    if artifact_task and parameter_task:
+        return payload, _merge_task_preserving_artifact_instructions(
+            artifact_task,
+            parameter_task,
+        )
+    return payload, parameter_task or artifact_task
+
 async def _persist_original_task_input_snapshot(
     *,
     session: AsyncSession,
@@ -2943,6 +3074,7 @@ async def _persist_original_task_input_snapshot(
             target_record.artifact_refs = refs
     return completed.artifact_id
 
+
 async def _persist_original_task_input_snapshot_from_parameters(
     *,
     session: AsyncSession,
@@ -2953,12 +3085,19 @@ async def _persist_original_task_input_snapshot_from_parameters(
     source_kind: str,
     source_workflow_id: str | None = None,
     source_run_id: str | None = None,
+    input_artifact_ref: str | None = None,
 ) -> str:
     workflow_type_value = _enum_value(getattr(record, "workflow_type", None))
     if workflow_type_value != "MoonMind.Run":
         return ""
-    snapshot_payload, snapshot_task = _snapshot_source_payload_from_parameters(
-        parameters
+    snapshot_payload, snapshot_task = (
+        await _snapshot_source_payload_from_parameters_and_artifact(
+            session=session,
+            user=user,
+            record=record,
+            parameters=parameters,
+            input_artifact_ref=input_artifact_ref,
+        )
     )
     if not snapshot_task:
         return ""
@@ -3916,6 +4055,7 @@ async def create_execution(
         user=user,
         parameters=dict(getattr(record, "parameters", None) or {}),
         source_kind="create",
+        input_artifact_ref=getattr(record, "input_ref", None),
     )
     if snapshot_ref:
         await session.commit()
@@ -4385,6 +4525,7 @@ async def update_execution(
             ),
             source_workflow_id=record.workflow_id,
             source_run_id=getattr(record, "run_id", None),
+            input_artifact_ref=payload.input_artifact_ref,
         )
     if is_task_editing_update:
         accepted = bool(update_result.get("accepted", True))
@@ -4765,6 +4906,7 @@ async def rerun_execution(
         source_kind="rerun",
         source_workflow_id=canonical.workflow_id,
         source_run_id=canonical.run_id,
+        input_artifact_ref=canonical.input_ref,
     )
 
     canonical_workflow_id, alias_used = _canonicalize_execution_identifier(workflow_id)

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3144433181,
+    "id": 3144759361,
     "disposition": "addressed",
-    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
+    "rationale": "Updated _artifact_id_from_ref to strip artifact:// and input/ independently, and added unit coverage for input/art-full-input and artifact://input/art-full-input refs."
   },
   {
-    "id": 4177704240,
+    "id": 4178027939,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the actionable artifact-ref robustness feedback is tracked and addressed by comment 3144759361."
+  },
+  {
+    "id": 3144764304,
     "disposition": "addressed",
-    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
+    "rationale": "Removed artifact tail-step reintroduction from the snapshot merge and added unit coverage proving edited rerun step deletions are preserved."
+  },
+  {
+    "id": 4178032734,
+    "disposition": "not-applicable",
+    "rationale": "Codex review metadata wrapper only; the actionable feedback is tracked and addressed by comment 3144764304."
   }
 ]

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -17,6 +17,8 @@ from temporalio.service import RPCError, RPCStatusCode
 
 from api_service.api.routers.executions import (
     _get_service,
+    _artifact_id_from_ref,
+    _merge_task_preserving_artifact_instructions,
     get_temporal_client,
     _serialize_execution,
     router,
@@ -4172,6 +4174,27 @@ def test_request_rerun_update_snapshot_hydrates_instructions_from_input_artifact
     assert steps[0]["instructions"] == "First step instructions."
     assert steps[1]["instructions"] == "Second step instructions."
     session.commit.assert_awaited_once()
+
+
+def test_task_input_snapshot_artifact_id_strips_input_prefix_without_scheme() -> None:
+    assert _artifact_id_from_ref("input/art-full-input") == "art-full-input"
+    assert _artifact_id_from_ref("artifact://input/art-full-input") == "art-full-input"
+
+
+def test_task_input_snapshot_merge_preserves_step_deletions() -> None:
+    merged = _merge_task_preserving_artifact_instructions(
+        {
+            "steps": [
+                {"id": "step-1", "title": "First", "instructions": "Original first"},
+                {"id": "step-2", "title": "Second", "instructions": "Original second"},
+            ]
+        },
+        {"steps": [{"id": "step-1", "title": "First edited"}]},
+    )
+
+    assert merged["steps"] == [
+        {"id": "step-1", "title": "First edited", "instructions": "Original first"}
+    ]
 
 
 def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Iterator
@@ -4056,6 +4057,122 @@ def test_request_rerun_update_redirects_response_to_created_rerun_execution() ->
         assert service.describe_execution.await_args_list[-1].args == (
             "mm:rerun-created",
         )
+
+
+def test_request_rerun_update_snapshot_hydrates_instructions_from_input_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    source_record = _build_execution_record(has_task_input_snapshot=False)
+    rerun_record = _build_execution_record(has_task_input_snapshot=False)
+    rerun_record.workflow_id = "mm:rerun-created"
+    rerun_record.run_id = "run-rerun"
+    rerun_record.input_ref = "art-full-input"
+    rerun_record.parameters = {
+        "repository": "Moon/Mind",
+        "targetRuntime": "codex_cli",
+        "task": {
+            "title": "Hydrated rerun",
+            "steps": [
+                {"id": "step-1", "title": "First"},
+                {"id": "step-2", "title": "Second"},
+            ],
+        },
+    }
+    service.describe_execution.side_effect = [source_record, rerun_record]
+    service.update_execution.return_value = {
+        "accepted": True,
+        "applied": "continue_as_new",
+        "message": "Rerun requested. New execution created.",
+        "continue_as_new_cause": "manual_rerun",
+        "workflow_id": "mm:rerun-created",
+    }
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    user = _override_user_dependencies(app, is_superuser=True)
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard, "temporal_task_editing_enabled", True
+    )
+    artifact_payload = {
+        "repository": "Moon/Mind",
+        "targetRuntime": "codex_cli",
+        "task": {
+            "title": "Hydrated rerun",
+            "instructions": "Top-level rerun instructions.",
+            "steps": [
+                {
+                    "id": "step-1",
+                    "title": "First",
+                    "instructions": "First step instructions.",
+                },
+                {
+                    "id": "step-2",
+                    "title": "Second",
+                    "instructions": "Second step instructions.",
+                },
+            ],
+        },
+    }
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(
+                SimpleNamespace(artifact_id="art-full-input"),
+                json.dumps(artifact_payload).encode("utf-8"),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+    captured_task_payload: dict[str, object] = {}
+
+    async def _persist_snapshot(**kwargs) -> str:
+        captured_task_payload.update(kwargs["task_payload"])
+        target_record = kwargs["record"]
+        target_record.memo = {
+            **dict(target_record.memo or {}),
+            "task_input_snapshot_ref": "art_snapshot_hydrated",
+            "task_input_snapshot_version": 1,
+            "task_input_snapshot_source_kind": "rerun",
+        }
+        return "art_snapshot_hydrated"
+
+    persist_mock = AsyncMock(side_effect=_persist_snapshot)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._persist_original_task_input_snapshot",
+        persist_mock,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/update",
+            json={
+                "updateName": "RequestRerun",
+                "idempotencyKey": "rerun-1",
+                "inputArtifactRef": "artifact://input/art-full-input",
+                "parametersPatch": rerun_record.parameters,
+            },
+        )
+
+    assert response.status_code == 200
+    artifact_service.read.assert_awaited_once_with(
+        artifact_id="art-full-input",
+        principal=str(user.id),
+        allow_restricted_raw=True,
+    )
+    persist_mock.assert_awaited_once()
+    assert captured_task_payload["instructions"] == "Top-level rerun instructions."
+    steps = captured_task_payload["steps"]
+    assert steps[0]["instructions"] == "First step instructions."
+    assert steps[1]["instructions"] == "Second step instructions."
+    session.commit.assert_awaited_once()
+
 
 def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:
     metrics = Mock()


### PR DESCRIPTION
## Summary
- hydrate rerun/edit task snapshots from the submitted input artifact before persisting them
- preserve top-level and per-step instructions when the inline parameters patch has been size-trimmed
- add an API regression test for stripped rerun parameters plus a full input artifact

## Root Cause
Rerun submission trims large inline instructions from the parameters patch, but the backend snapshot writer persisted that trimmed payload as the authoritative task input snapshot without re-reading the full input artifact.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3 -m compileall api_service/api/routers/executions.py tests/unit/api/routers/test_executions.py`
- `./tools/test_unit.sh`
- `git diff --check -- api_service/api/routers/executions.py tests/unit/api/routers/test_executions.py`