### PR TITLE
[codex] Improve report output summaries

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2457,6 +2457,8 @@ def _report_output_instruction(report_output: Mapping[str, Any]) -> str:
     return (
         "\n\nMoonMind report output contract:\n"
         "- Finish with a concise final report suitable for a `report.primary` artifact.\n"
+        "- If the task asks a question or requests a topic report, answer that "
+        "request directly in the final report body.\n"
         "- Include outcome, commands or tools run, key evidence, failures or "
         "skipped work, and recommended next action.\n"
         "- Do not include secrets, raw credentials, cookies, tokens, or full "

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 3144433181,
+    "id": 3144759291,
     "disposition": "addressed",
-    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
+    "rationale": "Moved generic completion summary normalization to a shared helper that strips trailing periods and updated the activity runtime to use it."
   },
   {
-    "id": 4177704240,
+    "id": 4178027876,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the actionable line comments from the same review were handled individually."
+  },
+  {
+    "id": 3144759293,
     "disposition": "addressed",
-    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
+    "rationale": "Workflow completion now uses the shared generic-summary helper and chooses the first non-generic, non-transient candidate."
+  },
+  {
+    "id": 3144767903,
+    "disposition": "addressed",
+    "rationale": "Completion text now prefers the latest meaningful step summary over a stale prior operator summary."
+  },
+  {
+    "id": 3144767906,
+    "disposition": "addressed",
+    "rationale": "Pull request URL completion text is now appended only when the current publish mode is pr."
+  },
+  {
+    "id": 4178036111,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper text with no standalone actionable request."
   }
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -46,6 +46,9 @@ from moonmind.schemas.temporal_activity_models import (
     PlanGenerateInput,
 )
 from moonmind.workflows.tasks.routing import _coerce_bool
+from moonmind.workflows.temporal.completion_summary import (
+    is_generic_completion_summary,
+)
 from moonmind.auth.env_shaping import _should_filter_base_env_var
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
@@ -3403,25 +3406,15 @@ class TemporalAgentRuntimeActivities:
                     return value.strip()
             return ""
 
-        def _is_generic_completion_summary(value: Any) -> bool:
-            normalized = " ".join(str(value or "").strip().lower().split())
-            return normalized in {
-                "",
-                "completed with status completed",
-                "workflow completed successfully",
-                "codex managed-session turn completed.",
-                "codex managed-session turn completed",
-                "agent run completed without a textual report body.",
-                "agent run completed without a textual report body",
-            } or normalized.startswith("process exited with code")
-
         result_summary = result_dict.get("summary") or result_dict.get("raw", "")
         operator_summary = self._sanitize_operator_summary(
             _metadata_text("operator_summary", "operatorSummary")
         )
         effective_summary = (
             operator_summary
-            if operator_summary and _is_generic_completion_summary(result_summary)
+            if operator_summary
+            and not is_generic_completion_summary(operator_summary)
+            and is_generic_completion_summary(result_summary)
             else result_summary
         )
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3396,9 +3396,38 @@ class TemporalAgentRuntimeActivities:
         instruction_ref = str(metadata.get("instructionRef") or "").strip()
         resolved_skillset_ref = str(metadata.get("resolvedSkillsetRef") or "").strip()
 
+        def _metadata_text(*keys: str) -> str:
+            for key in keys:
+                value = metadata.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            return ""
+
+        def _is_generic_completion_summary(value: Any) -> bool:
+            normalized = " ".join(str(value or "").strip().lower().split())
+            return normalized in {
+                "",
+                "completed with status completed",
+                "workflow completed successfully",
+                "codex managed-session turn completed.",
+                "codex managed-session turn completed",
+                "agent run completed without a textual report body.",
+                "agent run completed without a textual report body",
+            } or normalized.startswith("process exited with code")
+
+        result_summary = result_dict.get("summary") or result_dict.get("raw", "")
+        operator_summary = self._sanitize_operator_summary(
+            _metadata_text("operator_summary", "operatorSummary")
+        )
+        effective_summary = (
+            operator_summary
+            if operator_summary and _is_generic_completion_summary(result_summary)
+            else result_summary
+        )
+
         # Build summary payload for the artifact
         summary_payload: dict[str, Any] = {
-            "summary": result_dict.get("summary") or result_dict.get("raw", ""),
+            "summary": effective_summary,
             "output_refs": result_dict.get("output_refs") or result_dict.get("outputRefs") or [],
             "failure_class": result_dict.get("failure_class") or result_dict.get("failureClass"),
             "provider_error_code": result_dict.get("provider_error_code") or result_dict.get("providerErrorCode"),
@@ -3453,12 +3482,11 @@ class TemporalAgentRuntimeActivities:
         def _report_body() -> str:
             assistant_text = ""
             for key in ("assistantText", "lastAssistantText"):
-                value = metadata.get(key)
-                if isinstance(value, str) and value.strip():
-                    assistant_text = value.strip()
+                assistant_text = _metadata_text(key)
+                if assistant_text:
                     break
             summary_text = str(summary_payload.get("summary") or "").strip()
-            body = assistant_text or summary_text
+            body = assistant_text or operator_summary or summary_text
             if not body:
                 body = "Agent run completed without a textual report body."
             if body.lstrip().startswith("#"):

--- a/moonmind/workflows/temporal/completion_summary.py
+++ b/moonmind/workflows/temporal/completion_summary.py
@@ -1,0 +1,17 @@
+"""Completion summary classification helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_generic_completion_summary(value: Any) -> bool:
+    normalized = " ".join(str(value or "").strip().lower().split()).rstrip(".")
+    return normalized in {
+        "",
+        "completed",
+        "completed with status completed",
+        "workflow completed successfully",
+        "codex managed-session turn completed",
+        "agent run completed without a textual report body",
+    } or normalized.startswith("process exited with code")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -67,6 +67,9 @@ from moonmind.workflows.temporal.step_ledger import (
     upsert_step_check,
     update_step_row,
 )
+from moonmind.workflows.temporal.completion_summary import (
+    is_generic_completion_summary,
+)
 from moonmind.workflows.temporal.activity_catalog import (
     ARTIFACTS_TASK_QUEUE,
     INTEGRATIONS_TASK_QUEUE,
@@ -2775,6 +2778,7 @@ class MoonMindRunWorkflow:
             or normalized.startswith("executing plan step")
             or (normalized.startswith("executed") and "plan step" in normalized)
         )
+
     def _resolve_publish_payload(self, parameters: Mapping[str, Any]) -> dict[str, Any]:
         task_payload = self._mapping_value(parameters, "task")
         publish_payload = self._mapping_value(parameters, "publish")
@@ -3037,16 +3041,20 @@ class MoonMindRunWorkflow:
                 max_chars=1600,
             )
         )
-        if operator_summary:
+        meaningful_operator_summary = (
+            operator_summary
+            if operator_summary and not is_generic_completion_summary(operator_summary)
+            else None
+        )
+        if meaningful_operator_summary:
             self._operator_summary = operator_summary
 
+        step_summary = meaningful_operator_summary or self._coerce_text(
+            outputs.get("summary") or outputs.get("message"),
+            max_chars=1600,
+        )
         self._last_step_summary = self._sanitize_operator_summary(
-            self._coerce_text(
-                operator_summary
-                or outputs.get("summary")
-                or outputs.get("message"),
-                max_chars=1600,
-            )
+            step_summary
         )
 
         self._last_diagnostics_ref = self._coerce_text(
@@ -3218,6 +3226,7 @@ class MoonMindRunWorkflow:
         self,
         *,
         publish_detail: str | None = None,
+        publish_mode: str = "",
     ) -> str:
         parts = ["Workflow completed successfully"]
         detail = self._coerce_text(publish_detail, max_chars=180)
@@ -3229,21 +3238,25 @@ class MoonMindRunWorkflow:
 
         operator_summary = self._coerce_text(self._operator_summary, max_chars=700)
         last_step_summary = self._coerce_text(self._last_step_summary, max_chars=700)
-        final_summary = operator_summary or last_step_summary
-        if final_summary and not self._is_transient_summary(final_summary):
-            final_summary_lower = final_summary.lower()
-            if final_summary_lower not in {
-                "completed with status completed",
-                "workflow completed successfully",
-            } and not final_summary_lower.startswith("process exited with code"):
-                parts.append(f"Final result: {final_summary}")
+        final_summary = None
+        for candidate in (last_step_summary, operator_summary):
+            if (
+                candidate
+                and not self._is_transient_summary(candidate)
+                and not is_generic_completion_summary(candidate)
+            ):
+                final_summary = candidate
+                break
+        if final_summary:
+            parts.append(f"Final result: {final_summary}")
 
-        pull_request_url = self._coerce_text(
-            self._publish_context.get("pullRequestUrl"),
-            max_chars=200,
-        )
-        if pull_request_url:
-            parts.append(f"Pull request: {pull_request_url}")
+        if publish_mode == "pr":
+            pull_request_url = self._coerce_text(
+                self._publish_context.get("pullRequestUrl"),
+                max_chars=200,
+            )
+            if pull_request_url:
+                parts.append(f"Pull request: {pull_request_url}")
 
         if len(parts) == 1:
             return parts[0]
@@ -3257,7 +3270,11 @@ class MoonMindRunWorkflow:
     ) -> tuple[str, str, bool]:
         publish_mode = self._publish_mode(parameters)
         if publish_mode == "none":
-            return ("success", self._compose_success_completion_message(), False)
+            return (
+                "success",
+                self._compose_success_completion_message(publish_mode=publish_mode),
+                False,
+            )
 
         if self._publish_status == "skipped":
             if publish_mode == "pr":
@@ -3275,6 +3292,7 @@ class MoonMindRunWorkflow:
                 "success",
                 self._compose_success_completion_message(
                     publish_detail=self._publish_reason,
+                    publish_mode=publish_mode,
                 ),
                 False,
             )
@@ -3296,10 +3314,18 @@ class MoonMindRunWorkflow:
             )
 
         if self._publish_status == "published":
+            publish_detail = self._publish_reason
+            if (
+                publish_mode == "pr"
+                and publish_detail
+                and publish_detail.startswith("Jira issue output succeeded")
+            ):
+                publish_detail = None
             return (
                 "success",
                 self._compose_success_completion_message(
-                    publish_detail=self._publish_reason,
+                    publish_detail=publish_detail,
+                    publish_mode=publish_mode,
                 ),
                 False,
             )
@@ -3317,7 +3343,11 @@ class MoonMindRunWorkflow:
                 True,
             )
 
-        return ("success", self._compose_success_completion_message(), False)
+        return (
+            "success",
+            self._compose_success_completion_message(publish_mode=publish_mode),
+            False,
+        )
 
     def _merge_automation_request(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3214,6 +3214,42 @@ class MoonMindRunWorkflow:
         reason = ". ".join(part.rstrip(".") for part in parts if part)
         return f"{reason}." if reason else "publish skipped: no local changes"
 
+    def _compose_success_completion_message(
+        self,
+        *,
+        publish_detail: str | None = None,
+    ) -> str:
+        parts = ["Workflow completed successfully"]
+        detail = self._coerce_text(publish_detail, max_chars=180)
+        if detail and detail.lower() not in {
+            "completed",
+            "workflow completed successfully",
+        }:
+            parts.append(detail)
+
+        operator_summary = self._coerce_text(self._operator_summary, max_chars=700)
+        last_step_summary = self._coerce_text(self._last_step_summary, max_chars=700)
+        final_summary = operator_summary or last_step_summary
+        if final_summary and not self._is_transient_summary(final_summary):
+            final_summary_lower = final_summary.lower()
+            if final_summary_lower not in {
+                "completed with status completed",
+                "workflow completed successfully",
+            } and not final_summary_lower.startswith("process exited with code"):
+                parts.append(f"Final result: {final_summary}")
+
+        pull_request_url = self._coerce_text(
+            self._publish_context.get("pullRequestUrl"),
+            max_chars=200,
+        )
+        if pull_request_url:
+            parts.append(f"Pull request: {pull_request_url}")
+
+        if len(parts) == 1:
+            return parts[0]
+        message = ". ".join(part.rstrip(".") for part in parts if part)
+        return f"{message}." if message else "Workflow completed successfully"
+
     def _determine_publish_completion(
         self,
         *,
@@ -3221,7 +3257,7 @@ class MoonMindRunWorkflow:
     ) -> tuple[str, str, bool]:
         publish_mode = self._publish_mode(parameters)
         if publish_mode == "none":
-            return ("success", "Workflow completed successfully", False)
+            return ("success", self._compose_success_completion_message(), False)
 
         if self._publish_status == "skipped":
             if publish_mode == "pr":
@@ -3237,7 +3273,9 @@ class MoonMindRunWorkflow:
         if self._publish_status == "not_required":
             return (
                 "success",
-                self._publish_reason or "Workflow completed successfully",
+                self._compose_success_completion_message(
+                    publish_detail=self._publish_reason,
+                ),
                 False,
             )
 
@@ -3258,7 +3296,13 @@ class MoonMindRunWorkflow:
             )
 
         if self._publish_status == "published":
-            return ("success", "Workflow completed successfully", False)
+            return (
+                "success",
+                self._compose_success_completion_message(
+                    publish_detail=self._publish_reason,
+                ),
+                False,
+            )
 
         if (
             publish_mode == "pr"
@@ -3273,7 +3317,7 @@ class MoonMindRunWorkflow:
                 True,
             )
 
-        return ("success", "Workflow completed successfully", False)
+        return ("success", self._compose_success_completion_message(), False)
 
     def _merge_automation_request(
         self,

--- a/specs/258-explicit-report-output-contract/spec.md
+++ b/specs/258-explicit-report-output-contract/spec.md
@@ -16,6 +16,7 @@ As an operator, I want tasks to explicitly request a final report artifact so Mo
 - **FR-003**: When report output is enabled, MoonMind MUST publish a report bundle through the existing artifact publication boundary using `report.primary` and final-report metadata.
 - **FR-004**: Existing generic `output.primary`, `output.summary`, and `output.agent_result` behavior MUST remain unchanged when report output is not enabled.
 - **FR-005**: If a required report cannot be published, the run MUST fail visibly instead of silently completing without a canonical report.
+- **FR-006**: For question-answering or topic-report requests, the primary report body and completed execution summary MUST prefer the agent's captured final answer/operator summary over generic lifecycle messages such as "Workflow completed successfully" or "Completed with status completed".
 
 ## Source Design
 

--- a/specs/258-explicit-report-output-contract/tasks.md
+++ b/specs/258-explicit-report-output-contract/tasks.md
@@ -7,3 +7,4 @@
 - [x] T005 Add fail-closed behavior for required report publication failures.
 - [x] T006 Add focused unit tests for workflow/activity boundaries.
 - [x] T007 Run targeted unit verification.
+- [x] T008 Prefer captured final-answer/operator summaries over generic completion text in report artifacts and terminal execution summaries.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -857,9 +857,9 @@ def test_create_task_shaped_execution_preserves_report_output_contract(
     assert initial_parameters["task"]["reportOutput"] == initial_parameters[
         "reportOutput"
     ]
-    assert "MoonMind report output contract" in initial_parameters["task"][
-        "instructions"
-    ]
+    task_instructions = initial_parameters["task"]["instructions"]
+    assert "MoonMind report output contract" in task_instructions
+    assert "answer that request directly in the final report body" in task_instructions
 
 def test_create_task_shaped_execution_prefers_task_publish_mode_alias_over_top_publish(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1997,9 +1997,9 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
 
             result = await activities.agent_runtime_publish_artifacts(
                 AgentRunResult(
-                    summary="Completed integration tests.",
+                    summary="Completed with status completed",
                     metadata={
-                        "assistantText": "# Integration test report\n\nAll tests passed.",
+                        "operator_summary": "# Integration test report\n\nAll tests passed.",
                         "moonmind": {
                             "reportOutput": {
                                 "enabled": True,
@@ -2033,6 +2033,12 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
             assert reports[0].metadata_json["report_type"] == "integration_test_report"
             assert reports[0].metadata_json["report_scope"] == "final"
             assert reports[0].metadata_json["is_final_report"] is True
+            _artifact, path = await service.read_path(
+                artifact_id=reports[0].artifact_id,
+                principal="system:agent_runtime",
+            )
+            body = path.read_bytes()
+            assert body.decode("utf-8") == "# Integration test report\n\nAll tests passed.\n"
 
 async def test_agent_runtime_publish_artifacts_fails_required_report_on_publish_error(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1997,7 +1997,7 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
 
             result = await activities.agent_runtime_publish_artifacts(
                 AgentRunResult(
-                    summary="Completed with status completed",
+                    summary="Completed.",
                     metadata={
                         "operator_summary": "# Integration test report\n\nAll tests passed.",
                         "moonmind": {

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1003,6 +1003,34 @@ def test_determine_publish_completion_allows_integration_pr_without_local_pr_url
     assert message == "Workflow completed successfully"
     assert publish_failure is False
 
+def test_determine_publish_completion_includes_operator_summary_for_report_runs(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "summary": "Completed with status completed",
+                "operator_summary": (
+                    "The report explains that lunar regolith can shield habitats "
+                    "from radiation and micrometeorites."
+                ),
+            }
+        },
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "none"}
+    )
+
+    assert status == "success"
+    assert (
+        "Final result: The report explains that lunar regolith can shield habitats"
+        in message
+    )
+    assert "Completed with status completed" not in message
+    assert publish_failure is False
+
 def test_determine_publish_completion_fails_for_unknown_branch_publish_outcome(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1031,6 +1031,81 @@ def test_determine_publish_completion_includes_operator_summary_for_report_runs(
     assert "Completed with status completed" not in message
     assert publish_failure is False
 
+def test_determine_publish_completion_prefers_latest_step_summary_over_stale_operator_summary(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "operator_summary": "Prepared the initial deployment notes.",
+            }
+        },
+    )
+    mock_run_workflow._record_execution_context(
+        node_id="step-2",
+        execution_result={
+            "outputs": {
+                "summary": "Published the final report bundle.",
+            }
+        },
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "none"}
+    )
+
+    assert status == "success"
+    assert "Final result: Published the final report bundle" in message
+    assert "Prepared the initial deployment notes" not in message
+    assert publish_failure is False
+
+def test_determine_publish_completion_uses_meaningful_summary_after_generic_operator_summary(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "operator_summary": "Completed.",
+                "summary": "Wrote the operator-facing completion report.",
+            }
+        },
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "none"}
+    )
+
+    assert status == "success"
+    assert "Final result: Wrote the operator-facing completion report" in message
+    assert "Final result: Completed" not in message
+    assert publish_failure is False
+
+def test_determine_publish_completion_omits_pull_request_url_when_publish_mode_none(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._publish_context["pullRequestUrl"] = (
+        "https://github.com/org/repo/pull/123"
+    )
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "summary": "Referenced an existing pull request.",
+            }
+        },
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "none"}
+    )
+
+    assert status == "success"
+    assert "Referenced an existing pull request" in message
+    assert "Pull request:" not in message
+    assert publish_failure is False
+
 def test_determine_publish_completion_fails_for_unknown_branch_publish_outcome(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## Summary

- Make explicit report-output requests instruct agents to answer question/topic report requests in the final report body.
- Prefer captured assistant/operator final text over generic lifecycle summaries when publishing report artifacts.
- Include the final agent result in successful workflow summaries when available.

## Root Cause

Report bundle publication could fall back to generic managed-run summaries such as `Completed with status completed`, so topic-report requests could produce a report artifact that only said the workflow finished.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py::test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py::test_determine_publish_completion_includes_operator_summary_for_report_runs tests/unit/workflows/temporal/workflows/test_run_integration.py::test_determine_publish_completion_allows_integration_pr_without_local_pr_url`
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_preserves_report_output_contract`
- Frontend suite launched by the unit wrapper: `440 passed`
