### PR TITLE
[codex] Fix pr-resolver final-state disposition mapping

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,12 @@
 [
   {
-    "id": 3144433181,
+    "id": 3144784832,
     "disposition": "addressed",
-    "rationale": "Deployment update idempotency now uses the normalized reason only for update submissions, so omitted reasons produce a stable key segment while rollback submissions remain distinct. Covered by tests/unit/api/routers/test_deployment_operations.py."
+    "rationale": "Added top-level state plus nested final_state/finalState resolver status candidates and covered them with a focused unit test."
   },
   {
-    "id": 4177704240,
-    "disposition": "addressed",
-    "rationale": "Top-level review summarized the same deployment update idempotency issue; the service fix and regression test address that concern."
+    "id": 4178053000,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the actionable linked review comment was addressed."
   }
 ]

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -101,6 +101,7 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
 
     status = _first_terminal_pr_resolver_status(
         payload.get("status"),
+        payload.get("state"),
         payload.get("merge_outcome"),
         payload.get("outcome"),
         payload.get("final_state"),
@@ -116,6 +117,8 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
             final.get("status"),
             final.get("merge_outcome"),
             final.get("outcome"),
+            final.get("final_state"),
+            final.get("finalState"),
         )
     return ""
 

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -103,6 +103,8 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
         payload.get("status"),
         payload.get("merge_outcome"),
         payload.get("outcome"),
+        payload.get("final_state"),
+        payload.get("finalState"),
     )
     if status:
         return status
@@ -357,6 +359,8 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
         payload.get("latest_head_sha"),
         payload.get("headOid"),
         payload.get("head_oid"),
+        payload.get("headCommit"),
+        payload.get("head_commit"),
         final.get("headRefOid"),
         final.get("headSha"),
         final.get("head_sha"),
@@ -364,6 +368,8 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
         final.get("latest_head_sha"),
         final.get("headOid"),
         final.get("head_oid"),
+        final.get("headCommit"),
+        final.get("head_commit"),
     )
     if head_sha:
         metadata["headSha"] = head_sha

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -2923,6 +2923,92 @@ async def test_fetch_result_maps_merged_pr_resolver_artifact_metadata(
     assert result.metadata["mergeAutomationDisposition"] == "already_merged"
     assert result.metadata["headSha"] == "abc123"
 
+
+async def test_fetch_result_maps_final_state_field_pr_resolver_artifact_metadata(
+    tmp_path: Path,
+) -> None:
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "pr": 1643,\n'
+            '  "url": "https://github.com/MoonLadderStudios/Tactics/pull/1643",\n'
+            '  "final_state": "merged",\n'
+            '  "head_commit": "d00d0200ac76b6425d8ba03cf7859382ad50ce5e"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    run_id = "run-result-pr-final-state-merged"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=datetime.now(tz=UTC),
+            workspacePath=str(workspace_path),
+        )
+    )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_async_noop,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=run_id,
+        agent_id="codex_cli",
+        locator={
+            "sessionId": "sess:wf-task-1:codex_cli",
+            "sessionEpoch": 1,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Codex managed-session turn completed.",
+            "metadata": {},
+        },
+        status="completed",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert (
+        result.metadata["headSha"]
+        == "d00d0200ac76b6425d8ba03cf7859382ad50ce5e"
+    )
+
+
 async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadata(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -36,6 +36,7 @@ from moonmind.auth.env_shaping import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
+    _pr_resolver_status,
     build_managed_profile_launch_context,
 )
 from moonmind.workflows.temporal.artifacts import (
@@ -47,6 +48,20 @@ from moonmind.workflows.temporal.artifacts import (
 from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
 
 pytestmark = [pytest.mark.asyncio]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"state": "MERGED"}, "merged"),
+        ({"final": {"final_state": "MERGED"}}, "merged"),
+        ({"final": {"finalState": "MERGED"}}, "merged"),
+    ],
+)
+async def test_pr_resolver_status_accepts_final_state_aliases(
+    payload: dict[str, Any], expected: str
+) -> None:
+    assert _pr_resolver_status(payload) == expected
 
 # ---------------------------------------------------------------------------
 # DB fixture


### PR DESCRIPTION
## Summary
- Recognize `final_state` / `finalState` in pr-resolver artifacts as terminal resolver status fields.
- Recognize `head_commit` / `headCommit` as PR head SHA metadata for merge automation.
- Add a Codex session adapter regression test using the artifact shape produced by the failed resolver run.

## Root Cause
A resolver child successfully merged a PR but emitted `final_state: "merged"` and `head_commit: ...`. The merge automation adapter only derived `mergeAutomationDisposition` from `status`, `merge_outcome`, `outcome`, or nested final fields, so the parent merge gate treated the successful resolver as generic success and failed because the disposition was missing.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py -q`
- `./tools/test_unit.sh`