### PR TITLE
[codex] Handle nested pr-resolver merge outcomes

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -127,7 +127,12 @@ def _pr_resolver_final_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Return the nested final-state payload when resolver artifacts include one."""
 
     final = payload.get("final")
-    return final if isinstance(final, dict) else {}
+    if isinstance(final, dict):
+        return final
+    merge_outcome = payload.get("mergeOutcome")
+    if isinstance(merge_outcome, dict):
+        return merge_outcome
+    return {}
 
 
 def _first_stripped_text(*values: Any) -> str:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -56,6 +56,7 @@ pytestmark = [pytest.mark.asyncio]
         ({"state": "MERGED"}, "merged"),
         ({"final": {"final_state": "MERGED"}}, "merged"),
         ({"final": {"finalState": "MERGED"}}, "merged"),
+        ({"mergeOutcome": {"state": "MERGED"}}, "merged"),
     ],
 )
 async def test_pr_resolver_status_accepts_final_state_aliases(
@@ -1756,6 +1757,65 @@ async def test_fetch_result_maps_outcome_merged_pr_resolver_artifact_metadata(
     assert (
         result.metadata["headSha"]
         == "1abd16796a984860ca922cd1d6d22c42db34be6b"
+    )
+
+
+async def test_fetch_result_maps_nested_merge_outcome_pr_resolver_artifact_metadata(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "pr": 1644,\n'
+            '  "url": "https://github.com/MoonLadderStudios/Tactics/pull/1644",\n'
+            '  "mergeOutcome": {\n'
+            '    "state": "MERGED",\n'
+            '    "mergedAt": "2026-04-27T07:04:59Z",\n'
+            '    "headSha": "35c8dabd1008114bc13438e654a168b7dccb380b"\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-nested-merge-outcome",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-nested-merge-outcome",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-nested-merge-outcome", pr_resolver_expected=True
+    )
+
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert (
+        result.metadata["headSha"]
+        == "35c8dabd1008114bc13438e654a168b7dccb380b"
     )
 
 


### PR DESCRIPTION
## Summary
- Teach managed pr-resolver result parsing to recognize nested `mergeOutcome` objects as final resolver payloads.
- Preserve the merged head SHA from that payload so merge automation can receive `mergeAutomationDisposition=merged` and `headSha`.
- Add regression coverage for the artifact shape produced by workflow `mm:a372d364-db59-46a4-ae14-0f58c3ba1865`.

## Root Cause
The resolver child for PR #1644 completed successfully and wrote `artifacts/pr_resolver_result.json` with `mergeOutcome.state = "MERGED"`. The managed adapter only inspected top-level status aliases and nested `final`, so the parent `MoonMind.Run` returned success without `mergeAutomationDisposition`. `MoonMind.MergeAutomation` then failed with `resolver_disposition_invalid`.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/adapters/test_managed_agent_adapter.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --no-xdist`
