### PR TITLE
Refine Jira Breakdown and Orchestrate publish options

### DIFF
--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -42,11 +42,6 @@ inputs:
     options:
       - linear_blocker_chain
       - none
-  - name: repository
-    label: Repository
-    type: text
-    required: true
-    default: ""
   - name: orchestration_mode
     label: Orchestration Mode
     type: enum
@@ -55,25 +50,14 @@ inputs:
     options:
       - runtime
       - docs
-  - name: runtime_mode
-    label: Runtime Mode
-    type: enum
-    required: true
-    default: codex_cli
-    options:
-      - codex_cli
-      - gemini_cli
-      - claude_code
-      - codex_cloud
-      - jules
   - name: publish_mode
     label: Publish Mode
     type: enum
     required: true
-    default: pr
+    default: pr_with_merge_automation
     options:
-      - none
       - pr
+      - pr_with_merge_automation
   - name: source_issue_key
     label: Source Jira Issue Key
     type: text
@@ -126,13 +110,13 @@ steps:
       Report created tasks, skipped stories, dependency edges, partial failures, and no-downstream-task outcomes honestly.
     jiraOrchestration:
       task:
-        repository: "{{ inputs.repository }}"
+        repository: "{{ context.repository }}"
         runtime:
-          mode: "{{ inputs.runtime_mode }}"
+          mode: "{{ context.targetRuntime }}"
         publish:
-          mode: "{{ inputs.publish_mode }}"
+          mode: "pr"
           mergeAutomation:
-            enabled: true
+            enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
         orchestrationMode: "{{ inputs.orchestration_mode }}"
       traceability:
         sourceIssueKey: "{{ inputs.source_issue_key }}"

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -68,6 +68,7 @@ _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS = frozenset(
 _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
+_NATIVE_BOOLEAN_TEMPLATE_PATTERN = re.compile(r"^\{\{.*\}\}$", re.DOTALL)
 _STEP_RESERVED_KEYS = frozenset(
     {
         "id",
@@ -285,7 +286,12 @@ def _render_value(
 ) -> Any:
     if isinstance(value, str):
         rendered = env.from_string(value).render(**variables)
-        return rendered.strip()
+        stripped = rendered.strip()
+        if _NATIVE_BOOLEAN_TEMPLATE_PATTERN.match(value.strip()):
+            lowered = stripped.lower()
+            if lowered in {"true", "false"}:
+                return lowered == "true"
+        return stripped
     if isinstance(value, list):
         return [_render_value(env, item, variables=variables) for item in value]
     if isinstance(value, dict):

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,27 @@
 [
   {
-    "id": 3144759361,
+    "id": 3148978246,
     "disposition": "addressed",
-    "rationale": "Updated _artifact_id_from_ref to strip artifact:// and input/ independently, and added unit coverage for input/art-full-input and artifact://input/art-full-input refs."
+    "rationale": "Restored the Jira Breakdown and Orchestrate parent task publish default to none while keeping repository and publish controls active for child-task inheritance."
   },
   {
-    "id": 4178027939,
-    "disposition": "not-applicable",
-    "rationale": "Review summary only; the actionable artifact-ref robustness feedback is tracked and addressed by comment 3144759361."
-  },
-  {
-    "id": 3144764304,
+    "id": 3148978254,
     "disposition": "addressed",
-    "rationale": "Removed artifact tail-step reintroduction from the snapshot merge and added unit coverage proving edited rerun step deletions are preserved."
+    "rationale": "Made mergeAutomation propagation require a mapping before reading enabled or unpacking the value, with regression coverage for boolean input."
   },
   {
-    "id": 4178032734,
+    "id": 4182817543,
     "disposition": "not-applicable",
-    "rationale": "Codex review metadata wrapper only; the actionable feedback is tracked and addressed by comment 3144764304."
+    "rationale": "Automated review summary; the concrete referenced findings are tracked by review comments 3148978246 and 3148978254."
+  },
+  {
+    "id": 4182820069,
+    "disposition": "not-applicable",
+    "rationale": "Automated review header and metadata only; no separate actionable feedback was present."
+  },
+  {
+    "id": 3148980366,
+    "disposition": "addressed",
+    "rationale": "Restored non-publishing default behavior for the jira-breakdown-orchestrate parent execution and added focused UI regression coverage."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5349,7 +5349,7 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
-  it("sets parent publish mode to none when selecting the Jira Breakdown and Orchestrate preset", async () => {
+  it("keeps parent publish controls active when selecting the Jira Breakdown and Orchestrate preset", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -5399,8 +5399,92 @@ describe("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("none");
+      ).toBe("pr");
     });
+  });
+
+  it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown-orchestrate",
+                scope: "global",
+                title: "Jira Breakdown and Orchestrate",
+                description: "Create dependent Jira Orchestrate tasks.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-breakdown-orchestrate?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-breakdown-orchestrate",
+            scope: "global",
+            title: "Jira Breakdown and Orchestrate",
+            description: "Create dependent Jira Orchestrate tasks.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Declarative Design Path or Text",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "jira_project_key",
+                label: "Jira Project Key",
+                type: "text",
+                required: true,
+                default: "MM",
+              },
+              {
+                name: "publish_mode",
+                label: "Publish Mode",
+                type: "enum",
+                required: true,
+                default: "pr_with_merge_automation",
+                options: ["pr", "pr_with_merge_automation"],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-breakdown-orchestrate" },
+    });
+
+    const presetSection = screen.getByLabelText("Task Presets");
+    const presetPublishSelect = (await within(presetSection).findByLabelText(
+      "Publish Mode",
+    )) as HTMLSelectElement;
+    expect(presetPublishSelect.value).toBe("pr_with_merge_automation");
+    expect(Array.from(presetPublishSelect.options).map((option) => option.text)).toEqual([
+      "PR",
+      "PR with Merge Automation",
+    ]);
+    expect(within(presetSection).queryByLabelText("Repository")).toBeNull();
+    expect(within(presetSection).queryByLabelText("Runtime Mode")).toBeNull();
   });
 
   it("passes a preset-selected Jira board into Jira Breakdown expansion", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5349,7 +5349,7 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
-  it("keeps parent publish controls active when selecting the Jira Breakdown and Orchestrate preset", async () => {
+  it("defaults parent publish mode to none while keeping controls active for the Jira Breakdown and Orchestrate preset", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -5399,8 +5399,14 @@ describe("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("pr");
+      ).toBe("none");
     });
+    expect((screen.getByLabelText("GitHub Repo") as HTMLInputElement).disabled).toBe(
+      false,
+    );
+    expect(
+      (screen.getByLabelText("Publish Mode") as HTMLSelectElement).disabled,
+    ).toBe(false);
   });
 
   it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1454,6 +1454,23 @@ function isMergeAutomationPublishMode(value: string): boolean {
   return value.trim().toLowerCase() === PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE;
 }
 
+function templateEnumOptionLabel(
+  definition: TaskTemplateInputDefinition,
+  option: string,
+): string {
+  const normalizedName = definition.name.trim().toLowerCase();
+  const normalizedOption = option.trim().toLowerCase();
+  if (normalizedName === "publish_mode") {
+    if (normalizedOption === "pr") {
+      return "PR";
+    }
+    if (normalizedOption === PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE) {
+      return "PR with Merge Automation";
+    }
+  }
+  return option;
+}
+
 function mapExpandedStepToState(
   index: number,
   step: ExpandedStepPayload,
@@ -3223,8 +3240,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   useEffect(() => {
     if (
       pageMode.mode === "create" &&
-      (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG ||
-        selectedPreset?.slug === JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG)
+      selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG
     ) {
       setPublishMode("none");
     }
@@ -6467,7 +6483,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           >
                             {(definition.options || []).map((option) => (
                               <option key={option} value={option}>
-                                {option}
+                                {templateEnumOptionLabel(definition, option)}
                               </option>
                             ))}
                           </select>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3240,7 +3240,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   useEffect(() => {
     if (
       pageMode.mode === "create" &&
-      selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG
+      (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG ||
+        selectedPreset?.slug === JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG)
     ) {
       setPublishMode("none");
     }

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -320,6 +320,17 @@ def _stable_idempotency_key(
     digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
     return f"jira-orchestrate:{source_issue_key}:{digest}"[:128]
 
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _downstream_task_payload(
     *,
     mapping: Mapping[str, Any],
@@ -356,8 +367,12 @@ def _downstream_task_payload(
         or publish.get("mergeAutomation")
         or publish.get("merge_automation")
     )
-    if merge_automation and _string(publish.get("mode")).lower() == "pr":
-        publish["mergeAutomation"] = merge_automation
+    if (
+        merge_automation
+        and _truthy(merge_automation.get("enabled"))
+        and _string(publish.get("mode")).lower() == "pr"
+    ):
+        publish["mergeAutomation"] = {**merge_automation, "enabled": True}
         publish.pop("merge_automation", None)
     else:
         publish.pop("mergeAutomation", None)

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -361,14 +361,15 @@ def _downstream_task_payload(
     )
     runtime = _mapping(task_payload.get("runtime"))
     publish = _mapping(task_payload.get("publish"))
-    merge_automation = _mapping(
+    merge_automation_value = (
         task_payload.get("mergeAutomation")
         or task_payload.get("merge_automation")
         or publish.get("mergeAutomation")
         or publish.get("merge_automation")
     )
     if (
-        merge_automation
+        isinstance(merge_automation_value, Mapping)
+        and (merge_automation := dict(merge_automation_value))
         and _truthy(merge_automation.get("enabled"))
         and _string(publish.get("mode")).lower() == "pr"
     ):

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -165,8 +165,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "{{ inputs.orchestration_mode }}"
         )
         assert downstream_step["jiraOrchestration"]["task"]["publish"] == {
-            "mode": "{{ inputs.publish_mode }}",
-            "mergeAutomation": {"enabled": True},
+            "mode": "pr",
+            "mergeAutomation": {
+                "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+            },
         }
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1106,11 +1106,13 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                     "jira_issue_type": "Story",
                     "jira_dependency_mode": "linear_blocker_chain",
                     "orchestration_mode": "runtime",
-                    "runtime_mode": "codex_cli",
                     "publish_mode": "pr",
                     "source_issue_key": "GAME-404",
                 },
-                context={"repository": "ExampleOrg/Game"},
+                context={
+                    "repository": "ExampleOrg/Game",
+                    "targetRuntime": "gemini_cli",
+                },
             )
 
             assert "Jira Story issue in project GAME" in expanded["steps"][1][
@@ -1129,8 +1131,16 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
             assert expanded["steps"][2]["jiraOrchestration"]["task"]["repository"] == (
                 "ExampleOrg/Game"
             )
+            assert expanded["steps"][2]["jiraOrchestration"]["task"]["runtime"] == {
+                "mode": "gemini_cli"
+            }
+            assert expanded["steps"][2]["jiraOrchestration"]["task"]["publish"] == {
+                "mode": "pr",
+                "mergeAutomation": {"enabled": False},
+            }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "GAME"
-            assert expanded["appliedTemplate"]["inputs"]["repository"] == "ExampleOrg/Game"
+            assert "repository" not in expanded["appliedTemplate"]["inputs"]
+            assert "runtime_mode" not in expanded["appliedTemplate"]["inputs"]
 
 async def test_jira_breakdown_replaces_tool_placeholder_with_single_allowed_project(
     tmp_path,
@@ -1208,18 +1218,22 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
                     "jira_project_key": "PLAT",
                     "jira_issue_type": "Story",
                     "jira_dependency_mode": "linear_blocker_chain",
-                    "repository": "ExampleOrg/Platform",
                     "orchestration_mode": "runtime",
-                    "runtime_mode": "codex_cli",
                     "publish_mode": "pr",
                     "source_issue_key": "PLAT-404",
                 },
-                context={"repository": "ExampleOrg/Game"},
+                context={
+                    "repository": "ExampleOrg/Game",
+                    "targetRuntime": "claude_code",
+                },
             )
 
             assert expanded["steps"][1]["storyOutput"]["jira"]["projectKey"] == "PLAT"
             assert expanded["steps"][2]["jiraOrchestration"]["task"]["repository"] == (
-                "ExampleOrg/Platform"
+                "ExampleOrg/Game"
+            )
+            assert expanded["steps"][2]["jiraOrchestration"]["task"]["runtime"] == (
+                {"mode": "claude_code"}
             )
 
 async def test_jira_breakdown_requires_project_when_multiple_allowed_without_repo_policy(
@@ -1411,13 +1425,14 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                     "jira_issue_type": "Story",
                     "jira_board_id": "84",
                     "jira_dependency_mode": "linear_blocker_chain",
-                    "repository": "MoonLadderStudios/MoonMind",
                     "orchestration_mode": "runtime",
-                    "runtime_mode": "codex_cli",
-                    "publish_mode": "pr",
+                    "publish_mode": "pr_with_merge_automation",
                     "source_issue_key": "MM-404",
                 },
-                context={},
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
             )
 
             assert len(expanded["steps"]) == 3

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -866,6 +866,40 @@ async def test_create_jira_orchestrate_tasks_wires_ordered_dependencies_and_trac
     assert "MM-404" in first_parameters["task"]["instructions"]
 
 @pytest.mark.asyncio
+async def test_create_jira_orchestrate_tasks_omits_disabled_merge_automation():
+    creator = _FakeExecutionCreator()
+
+    result = await create_jira_orchestrate_tasks_from_issue_mappings(
+        {
+            "jira": {
+                "issueMappings": [
+                    {
+                        "storyId": "STORY-001",
+                        "storyIndex": 1,
+                        "summary": "First",
+                        "issueKey": "MM-501",
+                    },
+                ]
+            },
+            "task": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {
+                    "mode": "pr",
+                    "mergeAutomation": {"enabled": "False"},
+                },
+                "orchestrationMode": "runtime",
+            },
+        },
+        execution_creator=creator,
+    )
+
+    assert result.status == "COMPLETED"
+    first_parameters = creator.requests[0]["initial_parameters"]
+    assert first_parameters["publishMode"] == "pr"
+    assert first_parameters["task"]["publish"] == {"mode": "pr"}
+
+@pytest.mark.asyncio
 async def test_create_jira_orchestrate_tasks_uses_previous_step_mappings_and_owner_context():
     creator = _FakeExecutionCreator()
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -900,6 +900,40 @@ async def test_create_jira_orchestrate_tasks_omits_disabled_merge_automation():
     assert first_parameters["task"]["publish"] == {"mode": "pr"}
 
 @pytest.mark.asyncio
+async def test_create_jira_orchestrate_tasks_ignores_boolean_merge_automation():
+    creator = _FakeExecutionCreator()
+
+    result = await create_jira_orchestrate_tasks_from_issue_mappings(
+        {
+            "jira": {
+                "issueMappings": [
+                    {
+                        "storyId": "STORY-001",
+                        "storyIndex": 1,
+                        "summary": "First",
+                        "issueKey": "MM-501",
+                    },
+                ]
+            },
+            "task": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {
+                    "mode": "pr",
+                    "mergeAutomation": True,
+                },
+                "orchestrationMode": "runtime",
+            },
+        },
+        execution_creator=creator,
+    )
+
+    assert result.status == "COMPLETED"
+    first_parameters = creator.requests[0]["initial_parameters"]
+    assert first_parameters["publishMode"] == "pr"
+    assert first_parameters["task"]["publish"] == {"mode": "pr"}
+
+@pytest.mark.asyncio
 async def test_create_jira_orchestrate_tasks_uses_previous_step_mappings_and_owner_context():
     creator = _FakeExecutionCreator()
 


### PR DESCRIPTION
## Summary
- Remove Repository and Runtime Mode from the Jira Breakdown and Orchestrate preset inputs so child tasks inherit the parent workflow settings.
- Limit the preset publish choice to PR and PR with Merge Automation, with merge automation selected by default.
- Preserve downstream child-task behavior by stripping disabled merge automation before creating Jira Orchestrate tasks.

## Verification
- ./tools/test_unit.sh

## Notes
- PR is intentionally ready for review, not draft.
