### PR TITLE
When Jira Orchestrate is chosen as the preset, input UI for Source Design Path and Constraints is shown. I do not want to see these input boxes in the

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,12 @@
 [
   {
-    "id": 3148978246,
+    "id": 3151679728,
     "disposition": "addressed",
-    "rationale": "Restored the Jira Breakdown and Orchestrate parent task publish default to none while keeping repository and publish controls active for child-task inheritance."
+    "rationale": "Replaced the Jira-specific hidden input set and conditional with a preset-to-hidden-input map used by isVisiblePresetInput."
   },
   {
-    "id": 3148978254,
+    "id": 4185978924,
     "disposition": "addressed",
-    "rationale": "Made mergeAutomation propagation require a mapping before reading enabled or unpacking the value, with regression coverage for boolean input."
-  },
-  {
-    "id": 4182817543,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary; the concrete referenced findings are tracked by review comments 3148978246 and 3148978254."
-  },
-  {
-    "id": 4182820069,
-    "disposition": "not-applicable",
-    "rationale": "Automated review header and metadata only; no separate actionable feedback was present."
-  },
-  {
-    "id": 3148980366,
-    "disposition": "addressed",
-    "rationale": "Restored non-publishing default behavior for the jira-breakdown-orchestrate parent execution and added focused UI regression coverage."
+    "rationale": "Summary review feedback requested the same generic hidden-input mapping, which is now implemented."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5409,6 +5409,92 @@ describe("Task Create Entrypoint", () => {
     ).toBe(false);
   });
 
+  it("hides Source Design Path and Constraints inputs for the Jira Orchestrate preset", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-orchestrate",
+                scope: "global",
+                title: "Jira Orchestrate",
+                description: "Run MoonSpec from a Jira issue.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-orchestrate",
+            scope: "global",
+            title: "Jira Orchestrate",
+            description: "Run MoonSpec from a Jira issue.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "jira_issue_key",
+                label: "Jira Issue Key",
+                type: "text",
+                required: true,
+              },
+              {
+                name: "orchestration_mode",
+                label: "Orchestration Mode",
+                type: "enum",
+                required: true,
+                default: "runtime",
+                options: ["runtime", "docs"],
+              },
+              {
+                name: "source_design_path",
+                label: "Source Design Path",
+                type: "text",
+                required: false,
+                default: "",
+              },
+              {
+                name: "constraints",
+                label: "Constraints",
+                type: "textarea",
+                required: false,
+                default: "",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSection = screen.getByLabelText("Task Presets");
+    const presetSelect = await within(presetSection).findByLabelText("Preset");
+    await waitFor(() => {
+      expect((presetSelect as HTMLSelectElement).value).toBe(
+        "global::::jira-orchestrate",
+      );
+    });
+    expect(
+      await within(presetSection).findByLabelText("Jira Issue Key"),
+    ).not.toBeNull();
+    expect(
+      within(presetSection).getByLabelText("Orchestration Mode"),
+    ).not.toBeNull();
+    expect(within(presetSection).queryByLabelText("Source Design Path")).toBeNull();
+    expect(within(presetSection).queryByLabelText("Constraints")).toBeNull();
+  });
+
   it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -28,6 +28,10 @@ const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
 const MOONSPEC_ORCHESTRATE_PRESET_SLUG = "moonspec-orchestrate";
+const JIRA_ORCHESTRATE_HIDDEN_INPUT_KEYS = new Set([
+  "sourcedesignpath",
+  "constraints",
+]);
 const PROPOSE_TASKS_PREFERENCE_KEY = "moonmind.task-create.propose-tasks";
 const JIRA_LAST_PROJECT_SESSION_KEY =
   "moonmind.task-create.jira.last-project-key";
@@ -1537,6 +1541,24 @@ function isJiraProjectInputKey(rawKey: string): boolean {
 function isRepositoryInputKey(rawKey: string): boolean {
   const normalizedKey = normalizeTemplateInputKey(rawKey);
   return normalizedKey === "repository" || normalizedKey === "repo";
+}
+
+function isVisiblePresetInput(
+  presetSlug: string | undefined,
+  definition: TaskTemplateInputDefinition,
+): boolean {
+  if (isFeatureRequestInputKey(definition.name)) {
+    return false;
+  }
+  if (
+    presetSlug === JIRA_ORCHESTRATE_PRESET_SLUG &&
+    JIRA_ORCHESTRATE_HIDDEN_INPUT_KEYS.has(
+      normalizeTemplateInputKey(definition.name),
+    )
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function resolveObjectiveInstructions(
@@ -3152,8 +3174,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     },
   });
   const selectedPresetInputs = selectedPresetDetailQuery.data?.inputs || [];
-  const visiblePresetInputs = selectedPresetInputs.filter(
-    (definition) => !isFeatureRequestInputKey(definition.name),
+  const visiblePresetInputs = selectedPresetInputs.filter((definition) =>
+    isVisiblePresetInput(selectedPreset?.slug, definition),
   );
   const presetJiraProjectInput = visiblePresetInputs.find((definition) =>
     isJiraProjectInputKey(definition.name),

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -28,10 +28,9 @@ const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
 const MOONSPEC_ORCHESTRATE_PRESET_SLUG = "moonspec-orchestrate";
-const JIRA_ORCHESTRATE_HIDDEN_INPUT_KEYS = new Set([
-  "sourcedesignpath",
-  "constraints",
-]);
+const HIDDEN_PRESET_INPUT_KEYS: Record<string, Set<string>> = {
+  [JIRA_ORCHESTRATE_PRESET_SLUG]: new Set(["sourcedesignpath", "constraints"]),
+};
 const PROPOSE_TASKS_PREFERENCE_KEY = "moonmind.task-create.propose-tasks";
 const JIRA_LAST_PROJECT_SESSION_KEY =
   "moonmind.task-create.jira.last-project-key";
@@ -1550,12 +1549,10 @@ function isVisiblePresetInput(
   if (isFeatureRequestInputKey(definition.name)) {
     return false;
   }
-  if (
-    presetSlug === JIRA_ORCHESTRATE_PRESET_SLUG &&
-    JIRA_ORCHESTRATE_HIDDEN_INPUT_KEYS.has(
-      normalizeTemplateInputKey(definition.name),
-    )
-  ) {
+  const hiddenKeys = presetSlug
+    ? HIDDEN_PRESET_INPUT_KEYS[presetSlug]
+    : undefined;
+  if (hiddenKeys?.has(normalizeTemplateInputKey(definition.name))) {
     return false;
   }
   return true;


### PR DESCRIPTION
When Jira Orchestrate is chosen as the preset, input UI for Source Design Path and Constraints is shown. I do not want to see these input boxes in the UI.