### PR TITLE
MM-538 Scoped override persistence and inheritance

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/267-settings-catalog-effective-values"
-}
+{"feature_directory":"specs/268-scoped-override-persistence"}

--- a/api_service/api/routers/settings.py
+++ b/api_service/api/routers/settings.py
@@ -50,6 +50,18 @@ def _error_response(status_code: int, error: SettingsError) -> JSONResponse:
     )
 
 
+def _settings_db_error_response(*, key: str | None = None, scope: str) -> JSONResponse:
+    return _error_response(
+        500,
+        settings_error(
+            "settings_db_unavailable",
+            "Settings persistence is unavailable.",
+            key=key,
+            scope=scope,
+        ),
+    )
+
+
 def _invalid_scope_response(scope: str) -> JSONResponse:
     return _error_response(
         400,
@@ -104,15 +116,15 @@ async def get_effective_settings(scope: Annotated[str, Query()] = "workspace"):
     resolved_scope = _coerce_scope(scope)
     if isinstance(resolved_scope, JSONResponse):
         return resolved_scope
+    if not _should_attempt_settings_db():
+        service = SettingsCatalogService()
+        return service.effective_values(scope=resolved_scope)
     try:
-        if not _should_attempt_settings_db():
-            raise SQLAlchemyError("settings DB disabled in local test mode")
         async with db_base.async_session_maker() as session:
             service = SettingsCatalogService(session=session)
             return await service.effective_values_async(scope=resolved_scope)
     except SQLAlchemyError:
-        service = SettingsCatalogService()
-        return service.effective_values(scope=resolved_scope)
+        return _settings_db_error_response(scope=resolved_scope)
 
 
 @router.get("/effective/{key}")
@@ -123,13 +135,7 @@ async def get_effective_setting(
     resolved_scope = _coerce_scope(scope)
     if isinstance(resolved_scope, JSONResponse):
         return resolved_scope
-    try:
-        if not _should_attempt_settings_db():
-            raise SQLAlchemyError("settings DB disabled in local test mode")
-        async with db_base.async_session_maker() as session:
-            service = SettingsCatalogService(session=session)
-            return await service.effective_value_async(key, scope=resolved_scope)
-    except SQLAlchemyError:
+    if not _should_attempt_settings_db():
         try:
             service = SettingsCatalogService()
             return service.effective_value(key, scope=resolved_scope)
@@ -153,6 +159,12 @@ async def get_effective_setting(
                     scope=scope,
                 ),
             )
+    try:
+        async with db_base.async_session_maker() as session:
+            service = SettingsCatalogService(session=session)
+            return await service.effective_value_async(key, scope=resolved_scope)
+    except SQLAlchemyError:
+        return _settings_db_error_response(key=key, scope=resolved_scope)
     except KeyError:
         return _error_response(
             404,

--- a/api_service/api/routers/settings.py
+++ b/api_service/api/routers/settings.py
@@ -7,7 +7,9 @@ from typing import Annotated, Any, get_args
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import SQLAlchemyError
 
+from api_service.db import base as db_base
 from api_service.services.settings_catalog import (
     SettingScope,
     SettingSection,
@@ -20,6 +22,19 @@ router = APIRouter(prefix="/settings", tags=["settings"])
 
 VALID_SETTING_SCOPES = set(get_args(SettingScope))
 VALID_SETTING_SECTIONS = set(get_args(SettingSection))
+
+
+def _should_attempt_settings_db() -> bool:
+    bind = db_base.async_session_maker.kw.get("bind")
+    drivername = getattr(getattr(bind, "url", None), "drivername", "")
+    if drivername.startswith("sqlite"):
+        return True
+    try:
+        from moonmind.config.settings import settings
+
+        return not settings.workflow.test_mode
+    except Exception:
+        return True
 
 
 class SettingsPatchRequest(BaseModel):
@@ -86,11 +101,18 @@ async def get_settings_catalog(
 
 @router.get("/effective")
 async def get_effective_settings(scope: Annotated[str, Query()] = "workspace"):
-    service = SettingsCatalogService()
     resolved_scope = _coerce_scope(scope)
     if isinstance(resolved_scope, JSONResponse):
         return resolved_scope
-    return service.effective_values(scope=resolved_scope)
+    try:
+        if not _should_attempt_settings_db():
+            raise SQLAlchemyError("settings DB disabled in local test mode")
+        async with db_base.async_session_maker() as session:
+            service = SettingsCatalogService(session=session)
+            return await service.effective_values_async(scope=resolved_scope)
+    except SQLAlchemyError:
+        service = SettingsCatalogService()
+        return service.effective_values(scope=resolved_scope)
 
 
 @router.get("/effective/{key}")
@@ -98,12 +120,39 @@ async def get_effective_setting(
     key: str,
     scope: Annotated[str, Query()] = "workspace",
 ):
-    service = SettingsCatalogService()
     resolved_scope = _coerce_scope(scope)
     if isinstance(resolved_scope, JSONResponse):
         return resolved_scope
     try:
-        return service.effective_value(key, scope=resolved_scope)
+        if not _should_attempt_settings_db():
+            raise SQLAlchemyError("settings DB disabled in local test mode")
+        async with db_base.async_session_maker() as session:
+            service = SettingsCatalogService(session=session)
+            return await service.effective_value_async(key, scope=resolved_scope)
+    except SQLAlchemyError:
+        try:
+            service = SettingsCatalogService()
+            return service.effective_value(key, scope=resolved_scope)
+        except KeyError:
+            return _error_response(
+                404,
+                settings_error(
+                    "unknown_setting",
+                    f"Unknown setting: {key}.",
+                    key=key,
+                    scope=scope,
+                ),
+            )
+        except ValueError:
+            return _error_response(
+                400,
+                settings_error(
+                    "invalid_scope",
+                    f"Setting {key} is not available at scope {scope}.",
+                    key=key,
+                    scope=scope,
+                ),
+            )
     except KeyError:
         return _error_response(
             404,
@@ -174,11 +223,94 @@ async def patch_settings(scope: str, payload: SettingsPatchRequest):
                     scope=resolved_scope,
                 ),
             )
-    return _error_response(
-        501,
-        settings_error(
-            "settings_write_unavailable",
-            "Scoped override persistence is not enabled for this story.",
-            scope=resolved_scope,
-        ),
-    )
+    try:
+        async with db_base.async_session_maker() as session:
+            write_service = SettingsCatalogService(session=session)
+            return await write_service.apply_overrides(
+                scope=resolved_scope,
+                changes=payload.changes,
+                expected_versions=payload.expected_versions,
+                reason=payload.reason,
+            )
+    except ValueError as exc:
+        if str(exc) == "version_conflict":
+            status_code = 409
+            error_code = "version_conflict"
+            message = "Expected setting version does not match current version."
+        elif str(exc) == "invalid_scope":
+            status_code = 400
+            error_code = "invalid_scope"
+            message = (
+                f"One or more settings are not available at scope {resolved_scope}."
+            )
+        else:
+            status_code = 400
+            error_code = "invalid_setting_value"
+            message = "One or more setting values are invalid."
+        return _error_response(
+            status_code,
+            settings_error(error_code, message, scope=resolved_scope),
+        )
+    except PermissionError as exc:
+        return _error_response(
+            423,
+            settings_error(
+                "read_only_setting",
+                str(exc),
+                scope=resolved_scope,
+            ),
+        )
+
+
+@router.delete("/{scope}/{key:path}")
+async def reset_setting(scope: str, key: str):
+    service = SettingsCatalogService()
+    resolved_scope = _coerce_scope(scope)
+    if isinstance(resolved_scope, JSONResponse):
+        return resolved_scope
+    try:
+        service.ensure_write_allowed(key, scope=resolved_scope)
+    except KeyError:
+        return _error_response(
+            404,
+            settings_error(
+                "setting_not_exposed",
+                f"Setting {key} is not exposed through the Settings API.",
+                key=key,
+                scope=resolved_scope,
+            ),
+        )
+    except ValueError:
+        return _error_response(
+            400,
+            settings_error(
+                "invalid_scope",
+                f"Setting {key} is not available at scope {resolved_scope}.",
+                key=key,
+                scope=resolved_scope,
+            ),
+        )
+    except PermissionError as exc:
+        return _error_response(
+            423,
+            settings_error(
+                "read_only_setting",
+                str(exc),
+                key=key,
+                scope=resolved_scope,
+            ),
+        )
+    try:
+        async with db_base.async_session_maker() as session:
+            write_service = SettingsCatalogService(session=session)
+            return await write_service.reset_override(key, scope=resolved_scope)
+    except ValueError:
+        return _error_response(
+            400,
+            settings_error(
+                "invalid_scope",
+                f"Setting {key} is not available at scope {resolved_scope}.",
+                key=key,
+                scope=resolved_scope,
+            ),
+        )

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -435,6 +435,99 @@ class ManagedSecret(Base):
         onupdate=func.now(),
     )
 
+
+_DEFAULT_SETTINGS_SUBJECT_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class SettingsOverride(Base):
+    """Sparse persisted user/workspace override for one settings key."""
+
+    __tablename__ = "settings_overrides"
+    __table_args__ = (
+        UniqueConstraint(
+            "scope",
+            "workspace_id",
+            "user_id",
+            "key",
+            name="uq_settings_overrides_scope_subject_key",
+        ),
+        CheckConstraint(
+            "scope in ('user', 'workspace')",
+            name="ck_settings_overrides_scope",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    scope: Mapped[str] = mapped_column(String(32), nullable=False)
+    workspace_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        default=lambda: UUID(_DEFAULT_SETTINGS_SUBJECT_ID),
+        server_default=text(f"'{_DEFAULT_SETTINGS_SUBJECT_ID}'"),
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        default=lambda: UUID(_DEFAULT_SETTINGS_SUBJECT_ID),
+        server_default=text(f"'{_DEFAULT_SETTINGS_SUBJECT_ID}'"),
+    )
+    key: Mapped[str] = mapped_column(String(255), nullable=False)
+    value_json: Mapped[Any | None] = mapped_column(_json_variant(), nullable=True)
+    schema_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    value_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    created_by: Mapped[UUID | None] = mapped_column(Uuid, nullable=True)
+    updated_by: Mapped[UUID | None] = mapped_column(Uuid, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class SettingsAuditEvent(Base):
+    """Durable non-secret settings change audit event."""
+
+    __tablename__ = "settings_audit_events"
+    __table_args__ = (
+        Index("ix_settings_audit_events_key_scope", "key", "scope"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    key: Mapped[str] = mapped_column(String(255), nullable=False)
+    scope: Mapped[str] = mapped_column(String(32), nullable=False)
+    workspace_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        default=lambda: UUID(_DEFAULT_SETTINGS_SUBJECT_ID),
+        server_default=text(f"'{_DEFAULT_SETTINGS_SUBJECT_ID}'"),
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        default=lambda: UUID(_DEFAULT_SETTINGS_SUBJECT_ID),
+        server_default=text(f"'{_DEFAULT_SETTINGS_SUBJECT_ID}'"),
+    )
+    actor_user_id: Mapped[UUID | None] = mapped_column(Uuid, nullable=True)
+    old_value_json: Mapped[Any | None] = mapped_column(_json_variant(), nullable=True)
+    new_value_json: Mapped[Any | None] = mapped_column(_json_variant(), nullable=True)
+    redacted: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
 class ApproverRoleListType(TypeDecorator):
     """Persist approver roles as a PostgreSQL ARRAY or JSON elsewhere."""
 

--- a/api_service/migrations/versions/268_settings_overrides.py
+++ b/api_service/migrations/versions/268_settings_overrides.py
@@ -1,0 +1,92 @@
+"""Add scoped settings overrides and audit events.
+
+Revision ID: 268_settings_overrides
+Revises: f2a3b4c5d6e7
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "268_settings_overrides"
+down_revision = "f2a3b4c5d6e7"
+branch_labels = None
+depends_on = None
+
+
+def _json_type() -> sa.types.TypeEngine:
+    return postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite")
+
+
+def upgrade() -> None:
+    default_subject = sa.text("'00000000-0000-0000-0000-000000000000'")
+    op.create_table(
+        "settings_overrides",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("scope", sa.String(length=32), nullable=False),
+        sa.Column(
+            "workspace_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=default_subject,
+        ),
+        sa.Column("user_id", sa.Uuid(), nullable=False, server_default=default_subject),
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("value_json", _json_type(), nullable=True),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("value_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_by", sa.Uuid(), nullable=True),
+        sa.Column("updated_by", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "scope in ('user', 'workspace')",
+            name="ck_settings_overrides_scope",
+        ),
+        sa.UniqueConstraint(
+            "scope",
+            "workspace_id",
+            "user_id",
+            "key",
+            name="uq_settings_overrides_scope_subject_key",
+        ),
+    )
+    op.create_table(
+        "settings_audit_events",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("scope", sa.String(length=32), nullable=False),
+        sa.Column(
+            "workspace_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=default_subject,
+        ),
+        sa.Column("user_id", sa.Uuid(), nullable=False, server_default=default_subject),
+        sa.Column("actor_user_id", sa.Uuid(), nullable=True),
+        sa.Column("old_value_json", _json_type(), nullable=True),
+        sa.Column("new_value_json", _json_type(), nullable=True),
+        sa.Column("redacted", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("request_id", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_settings_audit_events_key_scope",
+        "settings_audit_events",
+        ["key", "scope"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_settings_audit_events_key_scope",
+        table_name="settings_audit_events",
+    )
+    op.drop_table("settings_audit_events")
+    op.drop_table("settings_overrides")

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -5,13 +5,36 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api_service.db.models import SettingsAuditEvent, SettingsOverride
 from moonmind.config.settings import AppSettings, settings as app_settings
 
 SettingScope = Literal["user", "workspace", "system", "operator"]
 SettingSection = Literal["providers-secrets", "user-workspace", "operations"]
+_DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
+_PERSISTED_SCOPES: set[SettingScope] = {"user", "workspace"}
+_SECRET_PREFIXES = ("ghp_", "github_pat_", "AIza", "AKIA")
+_UNSAFE_FIELD_TOKENS = (
+    "secret",
+    "token",
+    "password",
+    "api_key",
+    "apikey",
+    "credential",
+    "private_key",
+    "refresh",
+    "oauth",
+    "workflow_payload",
+    "artifact",
+    "command_history",
+    "operational_history",
+    "decrypted",
+)
 
 
 class SettingOption(BaseModel):
@@ -124,10 +147,8 @@ class SettingRegistryEntry:
     constraints: SettingConstraints | None = None
     sensitive: bool = False
     secret_role: str | None = None
-    read_only: bool = True
-    read_only_reason: str | None = (
-        "Scoped override persistence is not enabled for this story."
-    )
+    read_only: bool = False
+    read_only_reason: str | None = None
     requires_reload: bool = False
     requires_worker_restart: bool = False
     requires_process_restart: bool = False
@@ -261,12 +282,18 @@ class SettingsCatalogService:
         settings: AppSettings | None = None,
         env: dict[str, str] | None = None,
         registry: tuple[SettingRegistryEntry, ...] = _REGISTRY,
+        session: AsyncSession | None = None,
+        workspace_id: UUID | None = None,
+        user_id: UUID | None = None,
     ) -> None:
         self._settings = settings or app_settings
         self._env = env if env is not None else os.environ
         self._registry = registry
         self._entries_by_key = {entry.key: entry for entry in registry}
         self._redacted_invalid_secret_refs: set[str] = set()
+        self._session = session
+        self._workspace_id = workspace_id or _DEFAULT_SUBJECT_ID
+        self._user_id = user_id or _DEFAULT_SUBJECT_ID
 
     def catalog(
         self,
@@ -362,6 +389,151 @@ class SettingsCatalogService:
             diagnostics=self._diagnostics(entry, value),
         )
 
+    async def effective_value_async(
+        self,
+        key: str,
+        *,
+        scope: SettingScope,
+    ) -> EffectiveSettingValue:
+        entry = self._entries_by_key.get(key)
+        if entry is None:
+            raise KeyError(key)
+        if scope not in entry.scopes:
+            raise ValueError(scope)
+        value, source, version, override_present = await self._resolve_value_async(
+            entry, scope=scope
+        )
+        return EffectiveSettingValue(
+            key=entry.key,
+            scope=scope,
+            value=value,
+            source=source,
+            source_explanation=self._source_explanation(entry, source),
+            value_version=version,
+            diagnostics=[] if override_present else self._diagnostics(entry, value),
+        )
+
+    async def effective_values_async(
+        self,
+        *,
+        scope: SettingScope,
+    ) -> EffectiveSettingsResponse:
+        values = {
+            entry.key: await self.effective_value_async(entry.key, scope=scope)
+            for entry in self._registry
+            if scope in entry.scopes
+        }
+        return EffectiveSettingsResponse(scope=scope, values=values)
+
+    async def apply_overrides(
+        self,
+        *,
+        scope: SettingScope,
+        changes: dict[str, Any],
+        expected_versions: dict[str, int] | None = None,
+        reason: str | None = None,
+    ) -> EffectiveSettingsResponse:
+        if self._session is None:
+            raise RuntimeError("settings override persistence requires a DB session")
+        if scope not in _PERSISTED_SCOPES:
+            raise ValueError("invalid_scope")
+        expected_versions = expected_versions or {}
+        entries: dict[str, SettingRegistryEntry] = {}
+        current_rows: dict[str, SettingsOverride | None] = {}
+        validated: dict[str, Any] = {}
+
+        for key, value in changes.items():
+            entry = self._entries_by_key.get(key)
+            if entry is None:
+                raise KeyError(key)
+            if scope not in entry.scopes:
+                raise ValueError("invalid_scope")
+            if entry.read_only:
+                raise PermissionError(entry.read_only_reason or "Setting is read-only.")
+            self._validate_override_value(entry, value)
+            row = await self._get_override(scope=scope, key=key)
+            current_version = row.value_version if row is not None else 1
+            expected = expected_versions.get(key)
+            if expected is not None and expected != current_version:
+                raise ValueError("version_conflict")
+            entries[key] = entry
+            current_rows[key] = row
+            validated[key] = value
+
+        for key, value in validated.items():
+            entry = entries[key]
+            row = current_rows[key]
+            old_value = row.value_json if row is not None else None
+            if row is None:
+                row = SettingsOverride(
+                    scope=scope,
+                    workspace_id=self._workspace_id,
+                    user_id=self._user_id if scope == "user" else _DEFAULT_SUBJECT_ID,
+                    key=key,
+                    value_json=value,
+                    value_version=1,
+                )
+                self._session.add(row)
+            else:
+                row.value_json = value
+                row.value_version += 1
+            self._session.add(
+                self._audit_event(
+                    entry,
+                    event_type="settings.override.updated",
+                    scope=scope,
+                    old_value=old_value,
+                    new_value=value,
+                    reason=reason,
+                )
+            )
+
+        await self._session.commit()
+        values = {
+            key: await self.effective_value_async(key, scope=scope)
+            for key in changes
+        }
+        return EffectiveSettingsResponse(scope=scope, values=values)
+
+    async def reset_override(
+        self,
+        key: str,
+        *,
+        scope: SettingScope,
+        reason: str | None = None,
+    ) -> EffectiveSettingValue:
+        if self._session is None:
+            raise RuntimeError("settings override persistence requires a DB session")
+        if scope not in _PERSISTED_SCOPES:
+            raise ValueError("invalid_scope")
+        entry = self._entries_by_key.get(key)
+        if entry is None:
+            raise KeyError(key)
+        if scope not in entry.scopes:
+            raise ValueError("invalid_scope")
+        row = await self._get_override(scope=scope, key=key)
+        if row is not None:
+            old_value = row.value_json
+            await self._session.delete(row)
+            self._session.add(
+                self._audit_event(
+                    entry,
+                    event_type="settings.override.reset",
+                    scope=scope,
+                    old_value=old_value,
+                    new_value=None,
+                    reason=reason,
+                )
+            )
+        await self._session.commit()
+        return await self.effective_value_async(key, scope=scope)
+
+    async def audit_event_count(self) -> int:
+        if self._session is None:
+            return 0
+        result = await self._session.execute(select(func.count(SettingsAuditEvent.id)))
+        return int(result.scalar_one())
+
     def _resolve_value(self, entry: SettingRegistryEntry) -> tuple[Any, str]:
         for alias in entry.env_aliases:
             if alias in self._env:
@@ -375,6 +547,65 @@ class SettingsCatalogService:
             except AttributeError:
                 return None, "missing"
         return entry.default_value, "default"
+
+    async def _resolve_value_async(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        scope: SettingScope,
+    ) -> tuple[Any, str, int, bool]:
+        if self._session is not None:
+            if scope == "user":
+                user_override = await self._get_override(scope="user", key=entry.key)
+                if user_override is not None:
+                    return (
+                        user_override.value_json,
+                        "user_override",
+                        user_override.value_version,
+                        True,
+                    )
+                workspace_override = await self._get_override(
+                    scope="workspace", key=entry.key
+                )
+                if workspace_override is not None:
+                    return (
+                        workspace_override.value_json,
+                        "workspace_override",
+                        workspace_override.value_version,
+                        True,
+                    )
+            elif scope == "workspace":
+                workspace_override = await self._get_override(
+                    scope="workspace", key=entry.key
+                )
+                if workspace_override is not None:
+                    return (
+                        workspace_override.value_json,
+                        "workspace_override",
+                        workspace_override.value_version,
+                        True,
+                    )
+        value, source = self._resolve_value(entry)
+        return value, source, 1, False
+
+    async def _get_override(
+        self,
+        *,
+        scope: SettingScope,
+        key: str,
+    ) -> SettingsOverride | None:
+        if self._session is None:
+            return None
+        user_id = self._user_id if scope == "user" else _DEFAULT_SUBJECT_ID
+        result = await self._session.execute(
+            select(SettingsOverride).where(
+                SettingsOverride.scope == scope,
+                SettingsOverride.workspace_id == self._workspace_id,
+                SettingsOverride.user_id == user_id,
+                SettingsOverride.key == key,
+            )
+        )
+        return result.scalar_one_or_none()
 
     def _parse_env_value(self, entry: SettingRegistryEntry, raw_value: str) -> Any:
         if entry.value_type == "integer":
@@ -408,7 +639,79 @@ class SettingsCatalogService:
             return "Resolved from the catalog default value."
         if source == "missing":
             return "No configured value or catalog default could be resolved."
+        if source == "workspace_override":
+            return "Resolved from a workspace override."
+        if source == "user_override":
+            return "Resolved from a user override."
         return f"Resolved from {source}."
+
+    def _validate_override_value(self, entry: SettingRegistryEntry, value: Any) -> None:
+        if self._contains_unsafe_payload(value):
+            raise ValueError("invalid_setting_value")
+        if value is None:
+            return
+        if entry.value_type == "enum":
+            allowed = {option for option, _label in entry.options}
+            if not isinstance(value, str) or value not in allowed:
+                raise ValueError("invalid_setting_value")
+        elif entry.value_type == "integer":
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError("invalid_setting_value")
+            if entry.constraints is not None:
+                if entry.constraints.minimum is not None and value < entry.constraints.minimum:
+                    raise ValueError("invalid_setting_value")
+                if entry.constraints.maximum is not None and value > entry.constraints.maximum:
+                    raise ValueError("invalid_setting_value")
+        elif entry.value_type == "boolean":
+            if not isinstance(value, bool):
+                raise ValueError("invalid_setting_value")
+        elif entry.value_type == "secret_ref":
+            if not isinstance(value, str) or "://" not in value:
+                raise ValueError("invalid_setting_value")
+            if any(value.startswith(prefix) for prefix in _SECRET_PREFIXES):
+                raise ValueError("invalid_setting_value")
+        elif entry.value_type == "string":
+            if not isinstance(value, str):
+                raise ValueError("invalid_setting_value")
+        else:
+            raise ValueError("invalid_setting_value")
+
+    def _contains_unsafe_payload(self, value: Any) -> bool:
+        if isinstance(value, str):
+            return any(value.startswith(prefix) for prefix in _SECRET_PREFIXES)
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                normalized = str(key).lower()
+                if any(token in normalized for token in _UNSAFE_FIELD_TOKENS):
+                    return True
+                if self._contains_unsafe_payload(nested):
+                    return True
+        if isinstance(value, list):
+            return any(self._contains_unsafe_payload(item) for item in value)
+        return False
+
+    def _audit_event(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        event_type: str,
+        scope: SettingScope,
+        old_value: Any,
+        new_value: Any,
+        reason: str | None,
+    ) -> SettingsAuditEvent:
+        redacted = entry.audit.redact
+        return SettingsAuditEvent(
+            event_type=event_type,
+            key=entry.key,
+            scope=scope,
+            workspace_id=self._workspace_id,
+            user_id=self._user_id if scope == "user" else _DEFAULT_SUBJECT_ID,
+            old_value_json=None if redacted or not entry.audit.store_old_value else old_value,
+            new_value_json=None if redacted or not entry.audit.store_new_value else new_value,
+            redacted=redacted,
+            reason=reason,
+        )
 
     def _diagnostics(
         self,

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Iterable, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import SettingsAuditEvent, SettingsOverride
@@ -400,8 +401,11 @@ class SettingsCatalogService:
             raise KeyError(key)
         if scope not in entry.scopes:
             raise ValueError(scope)
-        value, source, version, override_present = await self._resolve_value_async(
-            entry, scope=scope
+        overrides = await self._get_effective_overrides(scope=scope, keys=[entry.key])
+        value, source, version, override_present = self._resolve_value_from_overrides(
+            entry,
+            scope=scope,
+            overrides=overrides,
         )
         return EffectiveSettingValue(
             key=entry.key,
@@ -418,10 +422,18 @@ class SettingsCatalogService:
         *,
         scope: SettingScope,
     ) -> EffectiveSettingsResponse:
+        entries = [entry for entry in self._registry if scope in entry.scopes]
+        overrides = await self._get_effective_overrides(
+            scope=scope,
+            keys=[entry.key for entry in entries],
+        )
         values = {
-            entry.key: await self.effective_value_async(entry.key, scope=scope)
-            for entry in self._registry
-            if scope in entry.scopes
+            entry.key: self._effective_value_from_overrides(
+                entry,
+                scope=scope,
+                overrides=overrides,
+            )
+            for entry in entries
         }
         return EffectiveSettingsResponse(scope=scope, values=values)
 
@@ -439,8 +451,12 @@ class SettingsCatalogService:
             raise ValueError("invalid_scope")
         expected_versions = expected_versions or {}
         entries: dict[str, SettingRegistryEntry] = {}
-        current_rows: dict[str, SettingsOverride | None] = {}
         validated: dict[str, Any] = {}
+        current_rows = await self._get_overrides(
+            scope=scope,
+            keys=changes.keys(),
+            for_update=True,
+        )
 
         for key, value in changes.items():
             entry = self._entries_by_key.get(key)
@@ -451,18 +467,17 @@ class SettingsCatalogService:
             if entry.read_only:
                 raise PermissionError(entry.read_only_reason or "Setting is read-only.")
             self._validate_override_value(entry, value)
-            row = await self._get_override(scope=scope, key=key)
+            row = current_rows.get((scope, key))
             current_version = row.value_version if row is not None else 1
             expected = expected_versions.get(key)
             if expected is not None and expected != current_version:
                 raise ValueError("version_conflict")
             entries[key] = entry
-            current_rows[key] = row
             validated[key] = value
 
         for key, value in validated.items():
             entry = entries[key]
-            row = current_rows[key]
+            row = current_rows.get((scope, key))
             old_value = row.value_json if row is not None else None
             if row is None:
                 row = SettingsOverride(
@@ -474,6 +489,7 @@ class SettingsCatalogService:
                     value_version=1,
                 )
                 self._session.add(row)
+                current_rows[(scope, key)] = row
             else:
                 row.value_json = value
                 row.value_version += 1
@@ -488,9 +504,21 @@ class SettingsCatalogService:
                 )
             )
 
-        await self._session.commit()
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise ValueError("version_conflict") from exc
         values = {
-            key: await self.effective_value_async(key, scope=scope)
+            key: self._effective_value_from_overrides(
+                entries[key],
+                scope=scope,
+                overrides={
+                    (row_scope, changed_key): row
+                    for (row_scope, changed_key), row in current_rows.items()
+                    if row_scope == scope and changed_key in changes
+                },
+            )
             for key in changes
         }
         return EffectiveSettingsResponse(scope=scope, values=values)
@@ -588,24 +616,133 @@ class SettingsCatalogService:
         value, source = self._resolve_value(entry)
         return value, source, 1, False
 
+    def _effective_value_from_overrides(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        scope: SettingScope,
+        overrides: dict[tuple[SettingScope, str], SettingsOverride],
+    ) -> EffectiveSettingValue:
+        value, source, version, override_present = self._resolve_value_from_overrides(
+            entry,
+            scope=scope,
+            overrides=overrides,
+        )
+        return EffectiveSettingValue(
+            key=entry.key,
+            scope=scope,
+            value=value,
+            source=source,
+            source_explanation=self._source_explanation(entry, source),
+            value_version=version,
+            diagnostics=[] if override_present else self._diagnostics(entry, value),
+        )
+
+    def _resolve_value_from_overrides(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        scope: SettingScope,
+        overrides: dict[tuple[SettingScope, str], SettingsOverride],
+    ) -> tuple[Any, str, int, bool]:
+        if scope == "user":
+            user_override = overrides.get(("user", entry.key))
+            if user_override is not None:
+                return (
+                    user_override.value_json,
+                    "user_override",
+                    user_override.value_version,
+                    True,
+                )
+            workspace_override = overrides.get(("workspace", entry.key))
+            if workspace_override is not None:
+                return (
+                    workspace_override.value_json,
+                    "workspace_override",
+                    workspace_override.value_version,
+                    True,
+                )
+        elif scope == "workspace":
+            workspace_override = overrides.get(("workspace", entry.key))
+            if workspace_override is not None:
+                return (
+                    workspace_override.value_json,
+                    "workspace_override",
+                    workspace_override.value_version,
+                    True,
+                )
+        value, source = self._resolve_value(entry)
+        return value, source, 1, False
+
+    async def _get_effective_overrides(
+        self,
+        *,
+        scope: SettingScope,
+        keys: list[str],
+    ) -> dict[tuple[SettingScope, str], SettingsOverride]:
+        if self._session is None or not keys:
+            return {}
+        scopes: tuple[SettingScope, ...]
+        if scope == "user":
+            scopes = ("user", "workspace")
+        elif scope == "workspace":
+            scopes = ("workspace",)
+        else:
+            return {}
+        return await self._get_overrides(scopes=scopes, keys=keys)
+
+    async def _get_overrides(
+        self,
+        *,
+        keys: Iterable[str],
+        scope: SettingScope | None = None,
+        scopes: tuple[SettingScope, ...] | None = None,
+        for_update: bool = False,
+    ) -> dict[tuple[SettingScope, str], SettingsOverride]:
+        if self._session is None:
+            return {}
+        key_list = list(keys)
+        if not key_list:
+            return {}
+        resolved_scopes = scopes or ((scope,) if scope is not None else ())
+        if not resolved_scopes:
+            return {}
+        statement = select(SettingsOverride).where(
+            SettingsOverride.scope.in_(resolved_scopes),
+            SettingsOverride.workspace_id == self._workspace_id,
+            SettingsOverride.key.in_(key_list),
+        )
+        if "user" in resolved_scopes:
+            statement = statement.where(
+                (
+                    (SettingsOverride.scope == "user")
+                    & (SettingsOverride.user_id == self._user_id)
+                )
+                | (
+                    (SettingsOverride.scope != "user")
+                    & (SettingsOverride.user_id == _DEFAULT_SUBJECT_ID)
+                )
+            )
+        else:
+            statement = statement.where(
+                SettingsOverride.user_id == _DEFAULT_SUBJECT_ID
+            )
+        if for_update:
+            statement = statement.with_for_update()
+        result = await self._session.execute(statement)
+        return {(row.scope, row.key): row for row in result.scalars().all()}
+
     async def _get_override(
         self,
         *,
         scope: SettingScope,
         key: str,
     ) -> SettingsOverride | None:
-        if self._session is None:
-            return None
-        user_id = self._user_id if scope == "user" else _DEFAULT_SUBJECT_ID
-        result = await self._session.execute(
-            select(SettingsOverride).where(
-                SettingsOverride.scope == scope,
-                SettingsOverride.workspace_id == self._workspace_id,
-                SettingsOverride.user_id == user_id,
-                SettingsOverride.key == key,
-            )
+        rows = await self._get_overrides(
+            scope=scope,
+            keys=[key],
         )
-        return result.scalar_one_or_none()
+        return rows.get((scope, key))
 
     def _parse_env_value(self, entry: SettingRegistryEntry, raw_value: str) -> Any:
         if entry.value_type == "integer":

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,42 +1,37 @@
 [
   {
-    "id": 4185976123,
-    "disposition": "addressed",
-    "rationale": "Implemented reenter_gate derivation for remediation next steps and covered it in resolver unit tests."
-  },
-  {
-    "id": 3151677015,
-    "disposition": "addressed",
-    "rationale": "Added the reenter_gate constant, passed next_step through resolver result writers, and mapped run_fix_* next steps to reenter_gate."
-  },
-  {
-    "id": 3151717102,
-    "disposition": "addressed",
-    "rationale": "Replaced the explicit step loop with an any() expression while limiting fallback eligibility to reconstructable step instructions."
-  },
-  {
-    "id": 3151717106,
-    "disposition": "addressed",
-    "rationale": "Split child-run snapshot persistence into payload-building, artifact-write, record-update, and owner-principal helper functions with concrete type hints."
-  },
-  {
-    "id": 4186018939,
+    "id": 4186388482,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable items are tracked by the associated line comments."
+    "rationale": "Review summary only; the referenced N+1 service issues were addressed in the settings catalog changes."
   },
   {
-    "id": 4186033771,
+    "id": 3152036177,
+    "disposition": "addressed",
+    "rationale": "effective_values_async now bulk-fetches relevant user/workspace overrides and resolves values in memory instead of calling the per-key lookup path."
+  },
+  {
+    "id": 3152036185,
+    "disposition": "addressed",
+    "rationale": "apply_overrides now bulk-fetches existing override rows for all changed keys before validation and mutation."
+  },
+  {
+    "id": 3152036187,
+    "disposition": "addressed",
+    "rationale": "apply_overrides now builds the response from known mutated rows without issuing one effective-value query per changed key."
+  },
+  {
+    "id": 4186394244,
     "disposition": "not-applicable",
-    "rationale": "Automated review header/details only; no separate code action requested."
+    "rationale": "Automated review preamble only; no actionable code change requested in this comment."
   },
   {
-    "id": 3151730897,
+    "id": 3152041879,
     "disposition": "addressed",
-    "rationale": "Jira child-run snapshot artifacts are now created and completed with the execution owner principal instead of service:jira-orchestrate."
+    "rationale": "The settings effective routes now return a structured 500 when DB reads fail, keeping fallback defaults only for explicit local test mode."
   },
   {
-    "id": 3151730902,
+    "id": 3152041886,
     "disposition": "addressed",
-    "rationale": "Title-only steps no longer enable edit/rerun parameter fallback without an authoritative snapshot."
+    "rationale": "Batch writes now lock fetched rows with SELECT FOR UPDATE and translate concurrent insert conflicts into version_conflict."
   }
 ]

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -999,6 +999,23 @@ export interface paths {
         patch: operations["patch_settings_api_v1_settings__scope__patch"];
         trace?: never;
     };
+    "/api/v1/settings/{scope}/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Reset Setting */
+        delete: operations["reset_setting_api_v1_settings__scope___key__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/proxy/{provider_id}/{path}": {
         parameters: {
             query?: never;
@@ -9002,6 +9019,38 @@ export interface operations {
                 "application/json": components["schemas"]["SettingsPatchRequest"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_setting_api_v1_settings__scope___key__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                scope: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/specs/268-scoped-override-persistence/checklists/requirements.md
+++ b/specs/268-scoped-override-persistence/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Scoped Override Persistence and Inheritance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves `MM-538`, defines exactly one runtime story, and maps all in-scope source requirements to functional requirements and success criteria.

--- a/specs/268-scoped-override-persistence/contracts/settings-overrides-api.md
+++ b/specs/268-scoped-override-persistence/contracts/settings-overrides-api.md
@@ -1,0 +1,72 @@
+# Contract: Settings Overrides API
+
+Traceability: `MM-538`, FR-001 through FR-011, DESIGN-REQ-006, DESIGN-REQ-017, DESIGN-REQ-026.
+
+## PATCH `/api/v1/settings/{scope}`
+
+Persists one atomic batch of setting overrides for `scope`.
+
+Request:
+
+```json
+{
+  "changes": {
+    "workflow.default_publish_mode": "branch"
+  },
+  "expected_versions": {
+    "workflow.default_publish_mode": 1
+  },
+  "reason": "Use branch publishing for this workspace."
+}
+```
+
+Success response:
+
+```json
+{
+  "scope": "workspace",
+  "values": {
+    "workflow.default_publish_mode": {
+      "key": "workflow.default_publish_mode",
+      "scope": "workspace",
+      "value": "branch",
+      "source": "workspace_override",
+      "source_explanation": "Resolved from a workspace override.",
+      "value_version": 1,
+      "diagnostics": []
+    }
+  }
+}
+```
+
+Required failure behavior:
+
+- `setting_not_exposed` for unknown keys.
+- `invalid_scope` for unsupported scopes or keys unavailable at scope.
+- `read_only_setting` for operator-locked/read-only descriptors.
+- `invalid_setting_value` for type, option, constraint, raw secret, unsafe payload, or invalid reference failures.
+- `version_conflict` when any expected version is stale. No changes persist.
+
+## DELETE `/api/v1/settings/{scope}/{key}`
+
+Deletes the matching override row for `scope` and returns the inherited effective value.
+
+Success response:
+
+```json
+{
+  "key": "workflow.default_publish_mode",
+  "scope": "workspace",
+  "value": "pr",
+  "source": "config_or_default",
+  "source_explanation": "Resolved from application settings after config and default loading.",
+  "value_version": 1,
+  "diagnostics": []
+}
+```
+
+Required behavior:
+
+- Deleting a missing override is idempotent and still returns the current inherited effective value.
+- Reset never deletes provider profiles, managed secrets, OAuth volumes, defaults, or audit rows.
+- Reset failures use the shared structured settings error shape.

--- a/specs/268-scoped-override-persistence/data-model.md
+++ b/specs/268-scoped-override-persistence/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Scoped Override Persistence and Inheritance
+
+## SettingOverride
+
+- `id`: UUID primary key.
+- `scope`: one of `user` or `workspace` for persisted editable overrides.
+- `workspace_id`: optional UUID subject for workspace-scoped rows.
+- `user_id`: optional UUID subject for user-scoped rows.
+- `key`: stable setting key from the backend-owned registry.
+- `value_json`: JSON value. May be boolean, number, string, null, small list/object where allowed, SecretRef string, or resource reference.
+- `schema_version`: integer schema version for future migrations.
+- `value_version`: integer optimistic concurrency version; starts at 1 and increments on update.
+- `created_at` / `updated_at`: timestamps.
+- `created_by` / `updated_by`: optional actor UUIDs.
+
+Validation rules:
+
+- Unique row identity is `(scope, workspace_id, user_id, key)`.
+- Scope must be allowed by the descriptor.
+- Value must match descriptor type/options/constraints.
+- Unsafe raw secrets, OAuth state, decrypted credential files, generated credential config, large artifacts, workflow payloads, and operational history are rejected.
+- Absence of a row means inherit; a row with `value_json = null` is an intentional null override.
+
+## SettingsAuditEvent
+
+- `id`: UUID primary key.
+- `event_type`: `settings.override.updated` or `settings.override.reset`.
+- `key`: stable setting key.
+- `scope`: affected scope.
+- `workspace_id` / `user_id`: optional subject identity.
+- `actor_user_id`: optional actor UUID.
+- `old_value_json`: old value when descriptor audit policy allows it.
+- `new_value_json`: new value when descriptor audit policy allows it.
+- `redacted`: whether values were redacted according to audit policy.
+- `reason`: optional caller-provided reason.
+- `request_id`: optional request correlation ID.
+- `created_at`: timestamp.
+
+Validation rules:
+
+- Reset deletes only `SettingOverride`; audit rows remain.
+- Audit values are redacted for descriptors whose audit policy requires redaction.
+
+## EffectiveSettingValue
+
+Extends the existing read model by setting:
+
+- `value`: winning inherited or override value.
+- `source`: `user_override`, `workspace_override`, `environment`, `config_or_default`, `default`, or `missing`.
+- `override_value`: descriptor-level current override value when present.
+- `value_version`: winning override version when an override wins, otherwise `1`.
+- `diagnostics`: explicit non-secret resolver diagnostics.
+
+State transitions:
+
+```text
+no row -> create override row version 1
+override row version N -> update row version N+1 when expected version matches
+override row -> delete row on reset and write audit event
+stale expected version -> no state change
+invalid value -> no state change
+```

--- a/specs/268-scoped-override-persistence/moonspec_align_report.md
+++ b/specs/268-scoped-override-persistence/moonspec_align_report.md
@@ -1,0 +1,32 @@
+# MoonSpec Alignment Report
+
+Feature: `specs/268-scoped-override-persistence`
+Date: 2026-04-28
+
+## Verdict
+
+PASS. The artifact set is aligned for the single-story `MM-538` runtime request.
+
+## Checks
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Single story | PASS | `spec.md` has one `## User Story - Save, Inspect, and Reset Scoped Overrides` section. |
+| Original input preservation | PASS | `spec.md` preserves the trusted `MM-538` preset brief verbatim in `## Original Preset Brief`. |
+| Source requirement coverage | PASS | DESIGN-REQ-006, DESIGN-REQ-017, and DESIGN-REQ-026 map to FR rows in `spec.md`, status rows in `plan.md`, and tasks in `tasks.md`. |
+| Test-first task ordering | PASS | `tasks.md` places service/API test tasks before implementation tasks. |
+| Constitution alignment | PASS | `plan.md` records PASS for all constitution checks and no complexity violations. |
+| Prerequisite script | BLOCKED | `scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` could not run because the script is absent in this checkout. |
+
+## Key Decisions
+
+- Treated `docs/Security/SettingsSystem.md` as runtime source requirements because the Jira preset brief asks for implemented scoped persistence behavior.
+- Kept `MM-538` backend-only because the existing `MM-537` settings read contract and API route are the active boundary, and no frontend-specific requirement is present in the brief.
+- Used focused service and API tests as the integration-style boundary for this story because the settings API is the public behavior under change.
+
+## Validation
+
+- `rg -n "MM-538|DESIGN-REQ-006|DESIGN-REQ-017|DESIGN-REQ-026" specs/268-scoped-override-persistence`: PASS.
+- `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`: PASS, 22 tests.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 4117 Python tests, 16 subtests, and 445 frontend tests.
+- `./tools/test_integration.sh`: BLOCKED, Docker socket unavailable at `/var/run/docker.sock`.

--- a/specs/268-scoped-override-persistence/plan.md
+++ b/specs/268-scoped-override-persistence/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Scoped Override Persistence and Inheritance
+
+**Branch**: `268-scoped-override-persistence` | **Date**: 2026-04-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/268-scoped-override-persistence/spec.md`
+
+## Summary
+
+Implement `MM-538` by extending the existing settings catalog/effective-value backend with scoped override persistence, inheritance-aware effective resolution, reset-by-delete behavior, version conflict handling, safe value validation, and settings audit preservation. Existing `MM-537` read-side descriptors and structured error models provide the foundation, but current writes still return `settings_write_unavailable`, so this story requires code, storage, and tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `SettingsCatalogService.effective_value_async`, focused service/API tests | complete | unit + API passed |
+| FR-002 | implemented_verified | `SettingsOverride`, `apply_overrides`, PATCH route, workspace override tests | complete | unit + API passed |
+| FR-003 | implemented_verified | user-scope override and workspace inheritance tests | complete | unit + API passed |
+| FR-004 | implemented_verified | `reset_override`, DELETE route, reset tests | complete | unit + API passed |
+| FR-005 | implemented_verified | intentional null override service test | complete | unit passed |
+| FR-006 | implemented_verified | `SettingsOverride` unique constraint and migration | complete | unit table creation passed |
+| FR-007 | implemented_verified | value version increment and stale expected-version tests | complete | unit + API passed |
+| FR-008 | implemented_verified | unsafe value rejection tests | complete | unit + API passed |
+| FR-009 | implemented_verified | reset preservation tests for managed secret and audit rows | complete | unit + API passed |
+| FR-010 | implemented_verified | SecretRef reference persistence tests without plaintext resolution | complete | unit + API passed |
+| FR-011 | implemented_verified | structured write/reset error tests | complete | API passed |
+| FR-012 | implemented_verified | `spec.md`, this plan, tasks, and verification preserve `MM-538` | complete | final verify |
+| SC-001 | implemented_verified | workspace override service test | complete | unit passed |
+| SC-002 | implemented_verified | user override inheritance service/API tests | complete | unit + API passed |
+| SC-003 | implemented_verified | reset preservation API/service tests | complete | unit + API passed |
+| SC-004 | implemented_verified | stale expected-version atomicity tests | complete | unit + API passed |
+| SC-005 | implemented_verified | unsafe value and SecretRef reference tests | complete | unit + API passed |
+| SC-006 | implemented_verified | traceability command output and verification report | complete | final verify |
+| DESIGN-REQ-006 | implemented_verified | workspace/user inheritance implementation and tests | complete | unit + API passed |
+| DESIGN-REQ-017 | implemented_verified | override storage, migration, reset, and audit implementation | complete | unit + API passed |
+| DESIGN-REQ-026 | implemented_verified | persisted value safety validation and tests | complete | unit + API passed |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, Alembic, pytest, httpx ASGI test transport  
+**Storage**: Existing SQLAlchemy/Alembic database; add `settings_overrides` and `settings_audit_events` tables  
+**Unit Testing**: `pytest` through `./tools/test_unit.sh` or targeted unit commands  
+**Integration Testing**: FastAPI ASGI route tests in unit suite; hermetic integration suite through `./tools/test_integration.sh` when Docker is available  
+**Target Platform**: MoonMind API service in Linux containers  
+**Project Type**: Backend web service  
+**Performance Goals**: Settings reads and writes remain bounded to small indexed settings rows  
+**Constraints**: Do not store raw secrets or large operational payloads; do not delete provider profiles, managed secrets, OAuth rows, defaults, or audit history on reset; reject partial batch writes  
+**Scale/Scope**: Initial persistence for the existing explicit settings registry and user/workspace scopes
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS - scoped settings support existing orchestration configuration without replacing agent behavior.
+- II. One-Click Agent Deployment: PASS - uses existing local database and migrations.
+- III. Avoid Vendor Lock-In: PASS - generic settings contracts remain provider-neutral.
+- IV. Own Your Data: PASS - overrides and audits remain in operator-controlled storage.
+- V. Skills Are First-Class and Easy to Add: PASS - skill settings are persisted as metadata values, not skill source mutations.
+- VI. Evolving Scaffold: PASS - persistence is behind service/router contracts with tests.
+- VII. Runtime Configurability: PASS - implements runtime user/workspace configurability.
+- VIII. Modular and Extensible Architecture: PASS - storage models, service, and router remain isolated.
+- IX. Resilient by Default: PASS - optimistic version checks and atomic batches prevent partial or stale writes.
+- X. Facilitate Continuous Improvement: PASS - audit records and diagnostics make settings changes inspectable.
+- XI. Spec-Driven Development: PASS - this feature is driven by MoonSpec artifacts.
+- XII. Canonical Documentation Separation: PASS - implementation details stay in feature artifacts, not canonical docs.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliases; unsupported values fail fast.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/268-scoped-override-persistence/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── settings-overrides-api.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/settings.py
+├── db/models.py
+├── migrations/versions/
+└── services/settings_catalog.py
+
+tests/
+└── unit/
+    ├── api_service/api/routers/test_settings_api.py
+    └── services/test_settings_catalog.py
+```
+
+**Structure Decision**: Backend-only settings persistence story. No frontend changes are required for `MM-538`.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/268-scoped-override-persistence/quickstart.md
+++ b/specs/268-scoped-override-persistence/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Scoped Override Persistence and Inheritance
+
+## Focused Validation
+
+Run the focused settings tests:
+
+```bash
+pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q
+```
+
+Run the full unit suite before finalizing:
+
+```bash
+./tools/test_unit.sh
+```
+
+Run hermetic integration when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-to-End Scenario
+
+1. Read `/api/v1/settings/effective/workflow.default_publish_mode?scope=workspace` and confirm it inherits the configured/default value.
+2. Patch `/api/v1/settings/workspace` with `workflow.default_publish_mode=branch` and matching expected version.
+3. Confirm the effective value returns `branch`, source `workspace_override`, and value version `1`.
+4. Patch a user-scoped SecretRef setting such as `integrations.github.token_ref` with a reference value like `env://GITHUB_TOKEN`.
+5. Confirm user scope reports `user_override` while plaintext is never stored or returned.
+6. Attempt a stale expected-version patch and confirm `version_conflict` with no partial persistence.
+7. Delete the workspace override and confirm the inherited value returns while audit rows and adjacent resources remain.

--- a/specs/268-scoped-override-persistence/research.md
+++ b/specs/268-scoped-override-persistence/research.md
@@ -1,0 +1,49 @@
+# Research: Scoped Override Persistence and Inheritance
+
+## FR-001 / DESIGN-REQ-006 - Inheritance Resolution
+
+Decision: Extend the existing `SettingsCatalogService` to resolve values from config/defaults, workspace overrides, and allowed user overrides in that order.
+Evidence: `api_service/services/settings_catalog.py` currently resolves environment/config/default only and returns `config_or_default`, `environment`, `default`, or `missing`.
+Rationale: This preserves the read-side contract from `MM-537` while adding the sparse persisted layers required by `MM-538`.
+Alternatives considered: A separate resolver service was rejected for this story because the existing catalog service already owns descriptor and effective-value resolution.
+Test implications: Unit and API tests for no override, workspace override, user override, and intentional null override.
+
+## FR-002 / FR-003 / FR-006 / DESIGN-REQ-017 - Override Storage
+
+Decision: Add SQLAlchemy models and an Alembic migration for `settings_overrides` and `settings_audit_events` with unique scope/subject/key identity.
+Evidence: No current `settings_overrides` or settings audit storage exists; writes return `settings_write_unavailable`.
+Rationale: The source design requires durable sparse rows, version metadata, and reset-by-delete semantics.
+Alternatives considered: In-memory overrides were rejected because they would not satisfy persistence or reset guarantees.
+Test implications: Unit tests use an isolated async SQLite database with the SQLAlchemy models.
+
+## FR-004 / FR-009 - Reset Preservation
+
+Decision: Implement reset as a targeted delete of the matching override row plus audit event creation, returning the inherited effective value.
+Evidence: Existing provider profile and managed secret models are separate tables; reset does not need to touch them.
+Rationale: Resetting settings must not cascade into defaults, provider profiles, managed secrets, OAuth volumes, or audit history.
+Alternatives considered: Setting override value to null on reset was rejected because the design defines reset as deleting the override row and because null can be an intentional override value.
+Test implications: API reset tests check override deletion, inherited effective response, managed secret row preservation, and audit row preservation.
+
+## FR-007 - Version Conflicts And Atomicity
+
+Decision: Check every expected version before persisting a batch; if any mismatch occurs, return `version_conflict` and commit no changes.
+Evidence: Existing `SettingsPatchRequest` already includes `expected_versions`, but the route does not use them.
+Rationale: The Jira brief explicitly requires no partial change on conflicting expected versions.
+Alternatives considered: Per-key partial success was rejected because it violates the acceptance criterion.
+Test implications: Unit/API tests verify stale expected versions return `version_conflict` and leave all current override values unchanged.
+
+## FR-008 / FR-010 / DESIGN-REQ-026 - Safe Value Validation
+
+Decision: Validate override values against descriptor type/options/constraints and reject secret-like plaintext or unsafe structured payload markers. Allow SecretRef/resource reference strings as references only.
+Evidence: `SettingsCatalogService` already has non-persistent SecretRef diagnostics and invalid SecretRef redaction for environment values.
+Rationale: Override rows may store safe JSON and references but must never become a dumping ground for raw credentials, OAuth state, large artifacts, workflow payloads, or operational history.
+Alternatives considered: Accepting arbitrary JSON for object values was rejected for this story because the current registry contains no generic object settings and the security requirement is explicit.
+Test implications: Unit/API tests reject raw token-like strings for SecretRef settings and unsafe structured payload keys, while accepting `env://` or `db://` SecretRef references.
+
+## FR-011 - Structured Errors
+
+Decision: Reuse the existing `SettingsError` model and add write/reset error codes for `version_conflict`, `invalid_setting_value`, `read_only_setting`, `invalid_scope`, and `setting_not_exposed`.
+Evidence: `api_service/api/routers/settings.py` already returns structured errors for invalid reads and unsupported writes.
+Rationale: Maintaining one error shape keeps UI/API consumers stable.
+Alternatives considered: Raising HTTP exceptions with ad hoc detail payloads was rejected because it would diverge from `MM-537`.
+Test implications: API tests assert stable error shape and sanitized response content.

--- a/specs/268-scoped-override-persistence/spec.md
+++ b/specs/268-scoped-override-persistence/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Scoped Override Persistence and Inheritance
+
+**Feature Branch**: `268-scoped-override-persistence`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-538 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-538` from the trusted `jira.get_issue` response, reproduced verbatim in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-538`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-538` under `specs/`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+MM-538: Scoped override persistence and inheritance
+
+Source Reference
+Source Document: docs/Security/SettingsSystem.md
+Source Title: Settings System
+Source Sections:
+- 3. Goals
+- 4. Scoped Overrides
+- 7.3 Scope
+- 7.4 Override
+- 7.5 Effective Value
+- 11. Persistence Model
+- 16. User / Workspace Settings
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-017
+- DESIGN-REQ-026
+
+As a workspace admin or user, I can save, inspect, and reset scoped settings overrides so user and workspace configuration inherits predictably without mutating built-in defaults.
+
+Acceptance Criteria
+- Given no override, the effective value inherits from the default or higher configured source.
+- Given a workspace override, task/workspace resolution reflects the workspace value and records version metadata.
+- Given an allowed user override, user resolution wins over workspace inheritance while preserving workspace policy constraints.
+- Given reset of a user or workspace override, the override row is deleted and defaults, provider profiles, managed secrets, OAuth volumes, and audit history are not deleted.
+- Given conflicting expected versions, update returns `version_conflict` and does not persist a partial change.
+
+Requirements
+- Override storage must enforce unique scope/workspace/user/key rows.
+- Override rows may store only allowed JSON values, SecretRefs, and resource references.
+- Override rows must never store raw secrets, OAuth state blobs, decrypted files, generated credential config, large artifacts, workflow payloads, or operational history beyond audit metadata.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-538 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+```
+
+## Classification
+
+- Input type: Single-story feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable runtime story.
+- Selected mode: Runtime.
+- Source design: `docs/Security/SettingsSystem.md` is treated as runtime source requirements because the brief describes system behavior, not documentation-only work.
+- Source design path input: `.`.
+- Resume decision: No existing Moon Spec artifacts for `MM-538` were found under `specs/`; specification is the first incomplete stage.
+- Multi-spec ordering: Not applicable for `MM-538` because the trusted Jira preset brief defines one independently testable story.
+
+## User Story - Save, Inspect, and Reset Scoped Overrides
+
+**Summary**: As a workspace admin or user, I want scoped settings overrides to persist separately from defaults so workspace and user configuration inherits predictably and can be reset without deleting adjacent resources.
+
+**Goal**: MoonMind allows authorized settings clients to save workspace and user overrides for eligible settings, read effective values that explain override inheritance, reset overrides by deleting only the override row, and reject conflicting writes without partial persistence.
+
+**Independent Test**: Through the settings API, read an effective workspace value with no override, save a workspace override with the expected version, verify workspace effective resolution and version metadata, save a permitted user override that wins for user scope while workspace remains available for inheritance, reset each override, and verify defaults plus provider profiles, managed secrets, OAuth volumes, and audit history are not deleted.
+
+**Acceptance Scenarios**:
+
+1. **Given** no workspace or user override exists, **When** a settings client reads an effective value, **Then** the value inherits from the default or higher configured source and reports the inherited source.
+2. **Given** a workspace override is saved for an eligible setting, **When** task or workspace resolution reads that setting, **Then** the workspace value wins, the response reports `workspace_override`, and version metadata is incremented.
+3. **Given** a user override is saved for an eligible user-scoped setting, **When** user resolution reads that setting, **Then** the user value wins over workspace inheritance while preserving workspace policy constraints.
+4. **Given** a user or workspace override is reset, **When** the effective value is read again, **Then** only the override row is deleted and inherited defaults, provider profiles, managed secrets, OAuth volumes, and audit history remain intact.
+5. **Given** a write includes an expected version that does not match the current override version, **When** the settings API processes the update, **Then** it returns `version_conflict` and persists none of the requested changes.
+6. **Given** a proposed override contains a raw secret, OAuth state blob, credential file content, generated credential config, large artifact, workflow payload, or operational history, **When** validation runs, **Then** the update is rejected and no unsafe value is stored.
+7. **Given** MoonSpec artifacts and downstream implementation evidence are generated for this work, **When** traceability is reviewed, **Then** the preserved Jira issue key `MM-538` remains present in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Edge Cases
+
+- A workspace override exists but a user override does not; user scope must inherit the workspace value where the setting allows user scope.
+- A user override is intentionally set to `null`; the system must distinguish intentional override value from absence of an override.
+- A multi-key update contains one invalid value or version conflict; no override in the batch may be partially persisted.
+- A SecretRef override stores only the reference string and never resolves or stores plaintext.
+- Resetting an override for an unknown or disallowed key must return a structured settings error rather than deleting unrelated rows.
+
+## Assumptions
+
+- Authentication and fine-grained authorization remain outside this isolated story; disabled-mode API tests exercise the trusted backend validation and persistence behavior.
+- Workspace and user IDs may be nullable in the initial local baseline, but uniqueness must still enforce one row per scope, key, and effective subject.
+- Existing provider profiles, managed secrets, OAuth rows, and audit rows are adjacent resources that must not be cascaded or manually deleted by settings reset behavior.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | `docs/Security/SettingsSystem.md` §3, §7.3-§7.5, §10.1-§10.2, §16.4 | User and workspace settings must resolve through predictable inheritance where defaults and configured values are weaker than workspace overrides, and user overrides win only when allowed by policy. | In scope | FR-001, FR-002, FR-003, FR-005 |
+| DESIGN-REQ-017 | `docs/Security/SettingsSystem.md` §11.1-§11.4 | Scoped override persistence must store sparse user/workspace rows with unique scope/subject/key identity, version metadata, reset-by-delete semantics, and preservation of defaults, provider profiles, managed secrets, OAuth volumes, and audit history. | In scope | FR-002, FR-004, FR-006, FR-007, FR-009 |
+| DESIGN-REQ-026 | `docs/Security/SettingsSystem.md` §11.3, §14, §15, §16.3 | Override rows may store only allowed JSON values, SecretRefs, and resource references; they must not store raw secrets, OAuth state, decrypted files, generated credential config, large artifacts, workflow payloads, or operational history beyond audit metadata. | In scope | FR-008, FR-010 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST resolve effective settings with this precedence for ordinary user/workspace settings: built-in or configured default, workspace override, then allowed user override.
+- **FR-002**: The system MUST persist workspace overrides for eligible workspace-scoped settings and report the persisted value as `workspace_override` with current version metadata.
+- **FR-003**: The system MUST persist user overrides only for settings that allow user scope, and user resolution MUST preserve workspace policy constraints while allowing the user override to win when permitted.
+- **FR-004**: Resetting a user or workspace override MUST delete only the matching override row and return the inherited effective value.
+- **FR-005**: Absence of an override MUST be distinguishable from an intentionally persisted null override.
+- **FR-006**: Override storage MUST enforce unique rows by scope, workspace, user, and setting key.
+- **FR-007**: Override writes MUST increment value version metadata and reject stale expected versions with `version_conflict`.
+- **FR-008**: Override validation MUST reject raw secrets, OAuth state blobs, decrypted credential files, generated credential config, large artifacts, workflow payloads, and operational history beyond audit metadata.
+- **FR-009**: Reset behavior MUST NOT delete inherited defaults, provider profiles, managed secrets, OAuth credential volumes, or settings audit history.
+- **FR-010**: SecretRef and resource-reference overrides MUST persist only reference values and MUST never resolve or store plaintext secret material.
+- **FR-011**: Settings write and reset failures MUST use the structured settings error shape with stable error code, message, key, scope, and details.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-538`.
+
+### Key Entities
+
+- **Setting Override**: A sparse persisted value for one setting key at a user or workspace scope, including subject identity, JSON value, schema version, value version, and audit metadata.
+- **Effective Setting Value**: The resolved value for a setting at a requested scope, including whether it came from inherited configuration, workspace override, user override, or an intentional null override.
+- **Settings Audit Event**: A durable settings change record that survives override resets and stores old/new values according to the descriptor audit policy.
+- **Settings Error**: The structured error response used when an override write, reset, or read cannot be fulfilled.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Service tests prove no-override resolution inherits configured/default values and workspace overrides become effective with `workspace_override` source and incremented version.
+- **SC-002**: Service or API tests prove user overrides win only for user-scoped settings and workspace inheritance remains visible when no user override exists.
+- **SC-003**: API tests prove reset deletes only the override row, returns inherited effective values, and leaves managed secrets plus audit rows intact.
+- **SC-004**: Tests prove stale expected versions return `version_conflict` and no batch changes are partially persisted.
+- **SC-005**: Tests prove unsafe raw secret/OAuth/artifact/workflow payload values are rejected while SecretRef reference values can be persisted without plaintext resolution.
+- **SC-006**: Traceability review confirms `MM-538` and DESIGN-REQ-006, DESIGN-REQ-017, and DESIGN-REQ-026 remain preserved in MoonSpec artifacts and downstream evidence.

--- a/specs/268-scoped-override-persistence/tasks.md
+++ b/specs/268-scoped-override-persistence/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Scoped Override Persistence and Inheritance
+
+**Input**: `specs/268-scoped-override-persistence/spec.md`, `specs/268-scoped-override-persistence/plan.md`
+**Unit Test Command**: `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`
+**Integration Test Command**: `./tools/test_integration.sh` when Docker is available
+**Source Traceability**: `MM-538`; FR-001 through FR-012; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-017, DESIGN-REQ-026
+
+## Phase 1: Setup
+
+- [X] T001 Create `specs/268-scoped-override-persistence/` MoonSpec artifacts and preserve the MM-538 Jira preset brief in `spec.md`. (FR-012, SC-006)
+
+## Phase 2: Foundational
+
+- [X] T002 Add settings override and audit SQLAlchemy models plus Alembic migration in `api_service/db/models.py` and `api_service/migrations/versions/268_settings_overrides.py`. (FR-006, FR-009, DESIGN-REQ-017)
+- [X] T003 Extend settings service construction and route dependency wiring so API routes can use an async database session in `api_service/services/settings_catalog.py` and `api_service/api/routers/settings.py`. (FR-001, FR-002, FR-003, FR-004)
+
+## Phase 3: Story - Save, Inspect, and Reset Scoped Overrides
+
+**Story Summary**: Settings clients can persist workspace and user overrides, inspect inheritance and version metadata, reset overrides safely, and reject stale or unsafe writes without partial persistence.
+
+**Independent Test**: Patch workspace and user settings, verify effective inheritance and sources, reset overrides, confirm adjacent resources and audit rows remain, and validate stale version plus unsafe value failures.
+
+**Traceability IDs**: FR-001 through FR-012; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-017, DESIGN-REQ-026.
+
+### Unit Test Plan
+
+- [X] T004 [P] Add failing service tests for workspace override persistence, inherited effective values, and version metadata in `tests/unit/services/test_settings_catalog.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-006)
+- [X] T005 [P] Add failing service tests for user override precedence, workspace inheritance, and intentional null override behavior in `tests/unit/services/test_settings_catalog.py`. (FR-003, FR-005, SC-002, DESIGN-REQ-006)
+- [X] T006 [P] Add failing service tests for stale expected versions, batch atomicity, and unsafe override value rejection in `tests/unit/services/test_settings_catalog.py`. (FR-007, FR-008, FR-010, SC-004, SC-005, DESIGN-REQ-026)
+
+### API Test Plan
+
+- [X] T007 [P] Add failing API tests for PATCH workspace/user settings and DELETE reset behavior in `tests/unit/api_service/api/routers/test_settings_api.py`. (FR-002, FR-003, FR-004, FR-011, SC-003)
+- [X] T008 [P] Add failing API tests for version conflict, no partial persistence, safe SecretRef persistence, and raw secret rejection in `tests/unit/api_service/api/routers/test_settings_api.py`. (FR-007, FR-008, FR-010, FR-011, SC-004, SC-005)
+
+### Implementation
+
+- [X] T009 Implement settings override persistence, inheritance resolution, descriptor override metadata, and value validation in `api_service/services/settings_catalog.py`. (FR-001 through FR-010, DESIGN-REQ-006, DESIGN-REQ-017, DESIGN-REQ-026)
+- [X] T010 Implement PATCH and DELETE settings routes with database sessions, atomic batches, structured errors, and reset responses in `api_service/api/routers/settings.py`. (FR-002, FR-004, FR-007, FR-011)
+- [X] T011 Run focused settings tests and fix defects while preserving test intent. (SC-001 through SC-005)
+
+## Phase 4: Polish and Verification
+
+- [X] T012 Run source traceability validation for `MM-538` and DESIGN-REQ-006/DESIGN-REQ-017/DESIGN-REQ-026 across feature artifacts. (FR-012, SC-006)
+- [X] T013 Run `/moonspec-verify` and produce `verification.md` with final MoonSpec verification evidence. (FR-001 through FR-012, SC-001 through SC-006)
+
+## Dependencies and Execution Order
+
+1. T001 before all other tasks.
+2. T002 and T003 before implementation.
+3. T004 through T008 before T009 and T010.
+4. T011 after implementation.
+5. T012 and T013 after tests pass.
+
+## Parallel Examples
+
+```text
+T004, T005, and T006 can run in parallel because they add service assertions for different behavior.
+T007 and T008 can run in parallel with service tests because they cover API behavior.
+```
+
+## Implementation Strategy
+
+This story requires code and tests. Follow TDD ordering: add failing service/API tests first, confirm the targeted failures, implement storage and routes, rerun focused tests, then complete final verification.

--- a/specs/268-scoped-override-persistence/verification.md
+++ b/specs/268-scoped-override-persistence/verification.md
@@ -1,0 +1,56 @@
+# MoonSpec Verification: Scoped Override Persistence and Inheritance
+
+**Verdict**: FULLY_IMPLEMENTED
+**Feature**: `specs/268-scoped-override-persistence`
+**Original Request Source**: trusted Jira preset brief for `MM-538`, preserved in `spec.md`
+**Date**: 2026-04-28
+
+## Summary
+
+`MM-538` is implemented as scoped user/workspace settings override persistence with inheritance-aware effective resolution, reset-by-delete semantics, optimistic version checks, safe value validation, and settings audit preservation. The implementation builds on the existing `MM-537` catalog/effective-value API and adds the durable override storage required by the Jira brief.
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `SettingsCatalogService.effective_value_async` resolves config/defaults, workspace overrides, and user overrides in precedence order. |
+| FR-002 | VERIFIED | `SettingsOverride` rows and `apply_overrides` persist workspace overrides; service/API tests assert `workspace_override` source and version metadata. |
+| FR-003 | VERIFIED | user-scoped tests assert user overrides win over workspace inheritance for allowed settings. |
+| FR-004 | VERIFIED | `reset_override` and `DELETE /api/v1/settings/{scope}/{key}` delete only the override row and return inherited effective values. |
+| FR-005 | VERIFIED | service tests assert an intentional null override reports `user_override` without inherited-null diagnostics. |
+| FR-006 | VERIFIED | `SettingsOverride` model and `268_settings_overrides` migration enforce unique scope/workspace/user/key identity. |
+| FR-007 | VERIFIED | service/API tests assert version increments and stale expected versions return `version_conflict` without partial persistence. |
+| FR-008 | VERIFIED | service/API tests reject unsafe raw secret-like and workflow-payload values. |
+| FR-009 | VERIFIED | reset tests preserve managed secret rows and settings audit events. |
+| FR-010 | VERIFIED | SecretRef reference values such as `env://GITHUB_TOKEN` persist without plaintext resolution. |
+| FR-011 | VERIFIED | API tests assert structured write/reset error behavior for version conflict and invalid values. |
+| FR-012 | VERIFIED | `MM-538` is preserved across spec, plan, tasks, alignment report, and this verification report. |
+
+## Source Design Coverage
+
+| Source ID | Status | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-006 | VERIFIED | Workspace/user inheritance implementation and tests cover scoped precedence. |
+| DESIGN-REQ-017 | VERIFIED | Override table, audit table, migration, reset behavior, and preservation tests cover scoped persistence. |
+| DESIGN-REQ-026 | VERIFIED | Safe value validation rejects unsafe persisted payloads while allowing SecretRef references. |
+
+## Tests
+
+- Red-first focused run before implementation: `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q` produced the expected failures for missing settings DB session support, read-only write behavior, missing reset route, and absent override-aware effective reads. This confirmed T004 through T008 were failing before production changes.
+- `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`: PASS, 22 tests.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 4117 Python tests, 16 subtests, and 445 frontend tests.
+- `./tools/test_integration.sh`: BLOCKED. Docker socket is unavailable in this managed container: `unix:///var/run/docker.sock`.
+
+## Traceability
+
+Traceability command:
+
+```bash
+rg -n "MM-538|DESIGN-REQ-006|DESIGN-REQ-017|DESIGN-REQ-026" specs/268-scoped-override-persistence
+```
+
+Result: PASS. The Jira key and all in-scope design IDs are present across the active MoonSpec artifacts.
+
+## Residual Risk
+
+Hermetic compose-backed integration tests could not run because Docker is unavailable in this worker environment. The changed behavior is covered by focused service tests and ASGI route tests, and the full local unit wrapper passed.

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -1,7 +1,31 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from api_service.db import base as db_base
+from api_service.db.models import Base, ManagedSecret
 from api_service.main import app
+
+
+@pytest.fixture
+def settings_api_db(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/settings-api.db")
+
+    async def _setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio_run = __import__("asyncio").run
+    asyncio_run(_setup())
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    original = db_base.async_session_maker
+    db_base.async_session_maker = session_maker
+    try:
+        yield session_maker
+    finally:
+        db_base.async_session_maker = original
+        asyncio_run(engine.dispose())
 
 
 @pytest.mark.asyncio
@@ -127,3 +151,170 @@ async def test_patch_settings_invalid_scope_uses_settings_error_contract():
     body = response.json()
     assert body["error"] == "invalid_scope"
     assert body["scope"] == "organization"
+
+
+@pytest.mark.asyncio
+async def test_patch_workspace_setting_persists_override(settings_api_db):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_publish_mode": "branch"},
+                "expected_versions": {"workflow.default_publish_mode": 1},
+                "reason": "Use branch mode.",
+            },
+        )
+        effective = await client.get(
+            "/api/v1/settings/effective/workflow.default_publish_mode",
+            params={"scope": "workspace"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    value = body["values"]["workflow.default_publish_mode"]
+    assert value["value"] == "branch"
+    assert value["source"] == "workspace_override"
+    assert value["value_version"] == 1
+    assert effective.json()["source"] == "workspace_override"
+
+
+@pytest.mark.asyncio
+async def test_patch_user_setting_wins_over_workspace_inheritance(settings_api_db):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"integrations.github.token_ref": "env://WORKSPACE_TOKEN"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        inherited = await client.get(
+            "/api/v1/settings/effective/integrations.github.token_ref",
+            params={"scope": "user"},
+        )
+        await client.patch(
+            "/api/v1/settings/user",
+            json={
+                "changes": {"integrations.github.token_ref": "env://USER_TOKEN"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        user_value = await client.get(
+            "/api/v1/settings/effective/integrations.github.token_ref",
+            params={"scope": "user"},
+        )
+
+    assert inherited.json()["source"] == "workspace_override"
+    assert inherited.json()["value"] == "env://WORKSPACE_TOKEN"
+    assert user_value.json()["source"] == "user_override"
+    assert user_value.json()["value"] == "env://USER_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_delete_reset_preserves_secret_and_audit(settings_api_db):
+    async with settings_api_db() as session:
+        session.add(
+            ManagedSecret(
+                slug="github-token",
+                ciphertext="encrypted",
+                details={"label": "GitHub"},
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_publish_mode": "branch"},
+                "expected_versions": {"workflow.default_publish_mode": 1},
+            },
+        )
+        response = await client.delete(
+            "/api/v1/settings/workspace/workflow.default_publish_mode"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["source"] in {"config_or_default", "environment", "default"}
+    async with settings_api_db() as session:
+        secrets = (await session.execute(select(ManagedSecret))).scalars().all()
+        assert len(secrets) == 1
+
+
+@pytest.mark.asyncio
+async def test_version_conflict_returns_error_and_does_not_partially_persist(settings_api_db):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_publish_mode": "branch",
+                    "skills.canary_percent": 25,
+                },
+                "expected_versions": {
+                    "workflow.default_publish_mode": 1,
+                    "skills.canary_percent": 1,
+                },
+            },
+        )
+        conflict = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_publish_mode": "none",
+                    "skills.canary_percent": 50,
+                },
+                "expected_versions": {
+                    "workflow.default_publish_mode": 99,
+                    "skills.canary_percent": 1,
+                },
+            },
+        )
+        publish_mode = await client.get(
+            "/api/v1/settings/effective/workflow.default_publish_mode",
+            params={"scope": "workspace"},
+        )
+        canary = await client.get(
+            "/api/v1/settings/effective/skills.canary_percent",
+            params={"scope": "workspace"},
+        )
+
+    assert conflict.status_code == 409
+    assert conflict.json()["error"] == "version_conflict"
+    assert publish_mode.json()["value"] == "branch"
+    assert canary.json()["value"] == 25
+
+
+@pytest.mark.asyncio
+async def test_secret_ref_reference_allowed_but_raw_secret_rejected(settings_api_db):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        allowed = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"integrations.github.token_ref": "env://GITHUB_TOKEN"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        rejected = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"integrations.github.token_ref": "ghp_raw_plaintext"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+
+    assert allowed.status_code == 200
+    assert "env://GITHUB_TOKEN" in allowed.text
+    assert rejected.status_code == 400
+    assert rejected.json()["error"] == "invalid_setting_value"
+    assert "ghp_raw_plaintext" not in rejected.text

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -1,8 +1,10 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from api_service.api.routers import settings as settings_router
 from api_service.db import base as db_base
 from api_service.db.models import Base, ManagedSecret
 from api_service.main import app
@@ -113,6 +115,33 @@ async def test_effective_settings_endpoint_filters_by_scope():
     body = response.json()
     assert body["scope"] == "user"
     assert list(body["values"]) == ["integrations.github.token_ref"]
+
+
+@pytest.mark.asyncio
+async def test_effective_settings_endpoint_surfaces_db_read_failure(monkeypatch):
+    class FailingSessionMaker:
+        def __call__(self):
+            raise SQLAlchemyError("database unavailable")
+
+    monkeypatch.setattr(settings_router, "_should_attempt_settings_db", lambda: True)
+    monkeypatch.setattr(db_base, "async_session_maker", FailingSessionMaker())
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            "/api/v1/settings/effective",
+            params={"scope": "workspace"},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": "settings_db_unavailable",
+        "message": "Settings persistence is unavailable.",
+        "key": None,
+        "scope": "workspace",
+        "details": {},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -1,4 +1,24 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import Base, ManagedSecret
 from api_service.services.settings_catalog import SettingsCatalogService
+
+
+@pytest.fixture
+def settings_session_maker(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/settings.db")
+
+    async def _setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio_run = __import__("asyncio").run
+    asyncio_run(_setup())
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    yield session_maker
+    asyncio_run(engine.dispose())
 
 
 def test_catalog_returns_exposed_descriptor_metadata_and_omits_unexposed_setting():
@@ -114,3 +134,193 @@ def test_null_secret_ref_reports_inherited_null_diagnostic():
 
     assert effective.value is None
     assert effective.diagnostics[0].code == "inherited_null"
+
+
+@pytest.mark.asyncio
+async def test_workspace_override_persists_and_reports_version(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        await _workspace_override_persists_and_reports_version(settings_session)
+
+
+async def _workspace_override_persists_and_reports_version(settings_session):
+    service = SettingsCatalogService(env={}, session=settings_session)
+
+    inherited = await service.effective_value_async(
+        "workflow.default_publish_mode", scope="workspace"
+    )
+    assert inherited.source == "config_or_default"
+    assert inherited.value_version == 1
+
+    response = await service.apply_overrides(
+        scope="workspace",
+        changes={"workflow.default_publish_mode": "branch"},
+        expected_versions={"workflow.default_publish_mode": 1},
+        reason="Use branch publishing for workspace tasks.",
+    )
+
+    effective = response.values["workflow.default_publish_mode"]
+    assert effective.value == "branch"
+    assert effective.source == "workspace_override"
+    assert effective.value_version == 1
+
+    updated = await service.apply_overrides(
+        scope="workspace",
+        changes={"workflow.default_publish_mode": "none"},
+        expected_versions={"workflow.default_publish_mode": 1},
+    )
+    assert updated.values["workflow.default_publish_mode"].value == "none"
+    assert updated.values["workflow.default_publish_mode"].value_version == 2
+
+
+@pytest.mark.asyncio
+async def test_user_override_wins_and_null_override_is_intentional(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        await _user_override_wins_and_null_override_is_intentional(settings_session)
+
+
+async def _user_override_wins_and_null_override_is_intentional(settings_session):
+    service = SettingsCatalogService(env={}, session=settings_session)
+
+    await service.apply_overrides(
+        scope="workspace",
+        changes={"integrations.github.token_ref": "env://WORKSPACE_GITHUB_TOKEN"},
+        expected_versions={"integrations.github.token_ref": 1},
+    )
+    inherited_by_user = await service.effective_value_async(
+        "integrations.github.token_ref", scope="user"
+    )
+    assert inherited_by_user.value == "env://WORKSPACE_GITHUB_TOKEN"
+    assert inherited_by_user.source == "workspace_override"
+
+    await service.apply_overrides(
+        scope="user",
+        changes={"integrations.github.token_ref": "env://USER_GITHUB_TOKEN"},
+        expected_versions={"integrations.github.token_ref": 1},
+    )
+    user_effective = await service.effective_value_async(
+        "integrations.github.token_ref", scope="user"
+    )
+    assert user_effective.value == "env://USER_GITHUB_TOKEN"
+    assert user_effective.source == "user_override"
+
+    await service.apply_overrides(
+        scope="user",
+        changes={"integrations.github.token_ref": None},
+        expected_versions={"integrations.github.token_ref": 1},
+    )
+    intentional_null = await service.effective_value_async(
+        "integrations.github.token_ref", scope="user"
+    )
+    assert intentional_null.value is None
+    assert intentional_null.source == "user_override"
+    assert intentional_null.diagnostics == []
+
+
+@pytest.mark.asyncio
+async def test_version_conflict_is_atomic(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        await _version_conflict_is_atomic(settings_session)
+
+
+async def _version_conflict_is_atomic(settings_session):
+    service = SettingsCatalogService(env={}, session=settings_session)
+    await service.apply_overrides(
+        scope="workspace",
+        changes={
+            "workflow.default_publish_mode": "branch",
+            "skills.canary_percent": 25,
+        },
+        expected_versions={
+            "workflow.default_publish_mode": 1,
+            "skills.canary_percent": 1,
+        },
+    )
+
+    with pytest.raises(ValueError, match="version_conflict"):
+        await service.apply_overrides(
+            scope="workspace",
+            changes={
+                "workflow.default_publish_mode": "none",
+                "skills.canary_percent": 50,
+            },
+            expected_versions={
+                "workflow.default_publish_mode": 99,
+                "skills.canary_percent": 1,
+            },
+        )
+
+    publish_mode = await service.effective_value_async(
+        "workflow.default_publish_mode", scope="workspace"
+    )
+    canary = await service.effective_value_async(
+        "skills.canary_percent", scope="workspace"
+    )
+    assert publish_mode.value == "branch"
+    assert canary.value == 25
+
+
+@pytest.mark.asyncio
+async def test_unsafe_values_rejected_but_secret_refs_are_allowed(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        await _unsafe_values_rejected_but_secret_refs_are_allowed(settings_session)
+
+
+async def _unsafe_values_rejected_but_secret_refs_are_allowed(settings_session):
+    service = SettingsCatalogService(env={}, session=settings_session)
+
+    with pytest.raises(ValueError, match="invalid_setting_value"):
+        await service.apply_overrides(
+            scope="workspace",
+            changes={"integrations.github.token_ref": "ghp_raw_plaintext"},
+            expected_versions={"integrations.github.token_ref": 1},
+        )
+
+    with pytest.raises(ValueError, match="invalid_setting_value"):
+        await service.apply_overrides(
+            scope="workspace",
+            changes={"workflow.default_publish_mode": {"workflow_payload": {}}},
+            expected_versions={"workflow.default_publish_mode": 1},
+        )
+
+    response = await service.apply_overrides(
+        scope="workspace",
+        changes={"integrations.github.token_ref": "env://GITHUB_TOKEN"},
+        expected_versions={"integrations.github.token_ref": 1},
+    )
+    assert response.values["integrations.github.token_ref"].value == "env://GITHUB_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_reset_deletes_only_override_and_preserves_secret_and_audit(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        await _reset_deletes_only_override_and_preserves_secret_and_audit(settings_session)
+
+
+async def _reset_deletes_only_override_and_preserves_secret_and_audit(settings_session):
+    service = SettingsCatalogService(env={}, session=settings_session)
+    settings_session.add(
+        ManagedSecret(
+            slug="github-token",
+            ciphertext="encrypted",
+            details={"label": "GitHub"},
+        )
+    )
+    await settings_session.commit()
+
+    await service.apply_overrides(
+        scope="workspace",
+        changes={"workflow.default_publish_mode": "branch"},
+        expected_versions={"workflow.default_publish_mode": 1},
+        reason="temporary override",
+    )
+
+    reset = await service.reset_override(
+        "workflow.default_publish_mode", scope="workspace", reason="inherit again"
+    )
+
+    assert reset.source == "config_or_default"
+    assert reset.value != "branch"
+    secret_count = len((await settings_session.execute(select(ManagedSecret))).scalars().all())
+    audit_count = await service.audit_event_count()
+    assert secret_count == 1
+    assert audit_count >= 2

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -173,6 +173,48 @@ async def _workspace_override_persists_and_reports_version(settings_session):
 
 
 @pytest.mark.asyncio
+async def test_async_list_and_batch_write_avoid_per_key_override_queries(
+    settings_session_maker,
+):
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(env={}, session=settings_session)
+        await service.apply_overrides(
+            scope="workspace",
+            changes={
+                "workflow.default_publish_mode": "branch",
+                "skills.canary_percent": 25,
+            },
+            expected_versions={
+                "workflow.default_publish_mode": 1,
+                "skills.canary_percent": 1,
+            },
+        )
+
+        async def fail_per_key_lookup(*_args, **_kwargs):
+            raise AssertionError("per-key override lookup should not be used")
+
+        service._get_override = fail_per_key_lookup  # type: ignore[method-assign]
+
+        listed = await service.effective_values_async(scope="workspace")
+        updated = await service.apply_overrides(
+            scope="workspace",
+            changes={
+                "workflow.default_publish_mode": "none",
+                "skills.canary_percent": 50,
+            },
+            expected_versions={
+                "workflow.default_publish_mode": 1,
+                "skills.canary_percent": 1,
+            },
+        )
+
+    assert listed.values["workflow.default_publish_mode"].value == "branch"
+    assert listed.values["skills.canary_percent"].value == 25
+    assert updated.values["workflow.default_publish_mode"].value == "none"
+    assert updated.values["skills.canary_percent"].value == 50
+
+
+@pytest.mark.asyncio
 async def test_user_override_wins_and_null_override_is_intentional(settings_session_maker):
     async with settings_session_maker() as settings_session:
         await _user_override_wins_and_null_override_is_intentional(settings_session)


### PR DESCRIPTION
Jira issue key: MM-538

Active MoonSpec feature path: `specs/268-scoped-override-persistence`

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`: PASS, 22 tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 4117 Python tests, 16 subtests, 445 frontend tests
- `./tools/test_integration.sh`: BLOCKED, Docker socket unavailable at `/var/run/docker.sock`

Remaining risks:
- Hermetic compose-backed integration tests could not run in this managed container because Docker socket access is unavailable.
