### PR TITLE
MM-539 Generated User and Workspace settings UI

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory":"specs/268-scoped-override-persistence"}
+{
+  "feature_directory": "specs/269-generated-user-workspace-settings-ui"
+}

--- a/api_service/api/routers/settings.py
+++ b/api_service/api/routers/settings.py
@@ -98,7 +98,6 @@ async def get_settings_catalog(
     section: Annotated[str | None, Query()] = None,
     scope: Annotated[str | None, Query()] = None,
 ):
-    service = SettingsCatalogService()
     resolved_section = _coerce_section(section)
     if isinstance(resolved_section, JSONResponse):
         return resolved_section
@@ -108,6 +107,17 @@ async def get_settings_catalog(
         if isinstance(coerced_scope, JSONResponse):
             return coerced_scope
         resolved_scope = coerced_scope
+    if resolved_scope is not None and _should_attempt_settings_db():
+        try:
+            async with db_base.async_session_maker() as session:
+                service = SettingsCatalogService(session=session)
+                return await service.catalog_async(
+                    section=resolved_section,
+                    scope=resolved_scope,
+                )
+        except SQLAlchemyError:
+            return _settings_db_error_response(scope=resolved_scope)
+    service = SettingsCatalogService()
     return service.catalog(section=resolved_section, scope=resolved_scope)
 
 

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -316,6 +316,36 @@ class SettingsCatalogService:
             categories=categories,
         )
 
+    async def catalog_async(
+        self,
+        *,
+        section: SettingSection | None = None,
+        scope: SettingScope | None = None,
+    ) -> SettingsCatalogResponse:
+        entries = [
+            entry
+            for entry in sorted(self._registry, key=lambda item: item.order)
+            if (section is None or entry.section == section)
+            and (scope is None or scope in entry.scopes)
+        ]
+        overrides = await self._get_effective_overrides(
+            scope=scope,
+            keys=[entry.key for entry in entries],
+        )
+        categories: dict[str, list[SettingDescriptor]] = {}
+        for entry in entries:
+            descriptor = self._descriptor(
+                entry,
+                scope=scope,
+                overrides=overrides,
+            )
+            categories.setdefault(entry.category, []).append(descriptor)
+        return SettingsCatalogResponse(
+            section=section,
+            scope=scope,
+            categories=categories,
+        )
+
     def effective_values(self, *, scope: SettingScope) -> EffectiveSettingsResponse:
         values = {
             entry.key: self.effective_value(entry.key, scope=scope)
@@ -354,8 +384,23 @@ class SettingsCatalogService:
         if entry.read_only:
             raise PermissionError(entry.read_only_reason or "Setting is read-only.")
 
-    def _descriptor(self, entry: SettingRegistryEntry) -> SettingDescriptor:
-        value, source = self._resolve_value(entry)
+    def _descriptor(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        scope: SettingScope | None = None,
+        overrides: dict[tuple[SettingScope, str], SettingsOverride] | None = None,
+    ) -> SettingDescriptor:
+        if scope is not None and overrides is not None:
+            value, source, version, override_present = self._resolve_value_from_overrides(
+                entry,
+                scope=scope,
+                overrides=overrides,
+            )
+        else:
+            value, source = self._resolve_value(entry)
+            version = 1
+            override_present = False
         return SettingDescriptor(
             key=entry.key,
             title=entry.title,
@@ -387,7 +432,8 @@ class SettingsCatalogService:
             depends_on=list(entry.depends_on),
             order=entry.order,
             audit=entry.audit,
-            diagnostics=self._diagnostics(entry, value),
+            value_version=version,
+            diagnostics=[] if override_present else self._diagnostics(entry, value),
         )
 
     async def effective_value_async(
@@ -677,7 +723,7 @@ class SettingsCatalogService:
     async def _get_effective_overrides(
         self,
         *,
-        scope: SettingScope,
+        scope: SettingScope | None,
         keys: list[str],
     ) -> dict[tuple[SettingScope, str], SettingsOverride]:
         if self._session is None or not keys:

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-537",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1814"
+  "jira_issue_key": "MM-539",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1817"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,32 @@
 [
   {
-    "id": 4186388482,
+    "id": 3152319940,
+    "disposition": "addressed",
+    "rationale": "Replaced JSON.stringify comparison with order-stable recursive equality that handles arrays, objects, symbols, undefined values, and circular references without throwing."
+  },
+  {
+    "id": 3152319945,
+    "disposition": "addressed",
+    "rationale": "Moved the shared field Tailwind classes into SETTING_FIELD_CLASS_NAMES and settingFieldClassName for a reusable, readable control style helper."
+  },
+  {
+    "id": 4186702059,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; the referenced N+1 service issues were addressed in the settings catalog changes."
+    "rationale": "Summary review body only; its two concrete feedback items are tracked and addressed by comments 3152319940 and 3152319945."
   },
   {
-    "id": 3152036177,
+    "id": 3152323513,
     "disposition": "addressed",
-    "rationale": "effective_values_async now bulk-fetches relevant user/workspace overrides and resolves values in memory instead of calling the per-key lookup path."
+    "rationale": "Made the settings catalog route load persisted overrides through SettingsCatalogService.catalog_async so descriptors expose override-aware effective values and value_version."
   },
   {
-    "id": 3152036185,
+    "id": 3152323519,
     "disposition": "addressed",
-    "rationale": "apply_overrides now bulk-fetches existing override rows for all changed keys before validation and mutation."
+    "rationale": "Gated Reset visibility to overrides at the active selected scope and added frontend coverage for inherited workspace overrides in user scope."
   },
   {
-    "id": 3152036187,
-    "disposition": "addressed",
-    "rationale": "apply_overrides now builds the response from known mutated rows without issuing one effective-value query per changed key."
-  },
-  {
-    "id": 4186394244,
+    "id": 4186705950,
     "disposition": "not-applicable",
-    "rationale": "Automated review preamble only; no actionable code change requested in this comment."
-  },
-  {
-    "id": 3152041879,
-    "disposition": "addressed",
-    "rationale": "The settings effective routes now return a structured 500 when DB reads fail, keeping fallback defaults only for explicit local test mode."
-  },
-  {
-    "id": 3152041886,
-    "disposition": "addressed",
-    "rationale": "Batch writes now lock fetched rows with SELECT FOR UPDATE and translate concurrent insert conflicts into version_conflict."
+    "rationale": "Automated review wrapper text only; its concrete stale-position comments are tracked separately and addressed where they still apply."
   }
 ]

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -1,0 +1,424 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '../../utils/test-utils';
+import { renderWithClient } from '../../utils/test-utils';
+import { GeneratedSettingsSection } from './GeneratedSettingsSection';
+
+const workspaceCatalog = {
+  section: 'user-workspace',
+  scope: 'workspace',
+  categories: {
+    Workflow: [
+      {
+        key: 'workflow.default_publish_mode',
+        title: 'Default Publish Mode',
+        description: 'Fallback publish mode used when tasks omit publish mode.',
+        category: 'Workflow',
+        section: 'user-workspace',
+        type: 'enum',
+        ui: 'select',
+        scopes: ['workspace'],
+        default_value: 'pr',
+        effective_value: 'pr',
+        override_value: null,
+        source: 'config_or_default',
+        source_explanation: 'Resolved from application settings.',
+        options: [
+          { value: 'none', label: 'None' },
+          { value: 'branch', label: 'Branch' },
+          { value: 'pr', label: 'Pull Request' },
+        ],
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: true,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['task_creation', 'publishing'],
+        depends_on: [],
+        order: 10,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 3,
+        diagnostics: [],
+      },
+      {
+        key: 'live_sessions.default_enabled',
+        title: 'Live Sessions Enabled By Default',
+        description: 'Whether live task sessions are enabled by default.',
+        category: 'Workflow',
+        section: 'user-workspace',
+        type: 'boolean',
+        ui: 'toggle',
+        scopes: ['workspace'],
+        default_value: true,
+        effective_value: true,
+        override_value: null,
+        source: 'workspace_override',
+        source_explanation: 'Resolved from a workspace override.',
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: true,
+        requires_process_restart: false,
+        applies_to: ['live_sessions'],
+        depends_on: [],
+        order: 20,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [{ code: 'restart', message: 'Worker restart required.', severity: 'warning' }],
+      },
+      {
+        key: 'skills.canary_percent',
+        title: 'Skills Canary Percent',
+        description: 'Percentage of runs routed through skills-first policy.',
+        category: 'Workflow',
+        section: 'user-workspace',
+        type: 'integer',
+        ui: 'number',
+        scopes: ['workspace'],
+        default_value: 100,
+        effective_value: 25,
+        override_value: null,
+        source: 'workspace_override',
+        source_explanation: 'Resolved from a workspace override.',
+        options: null,
+        constraints: { minimum: 0, maximum: 100 },
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['skills'],
+        depends_on: [],
+        order: 30,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 2,
+        diagnostics: [],
+      },
+    ],
+    Integrations: [
+      {
+        key: 'integrations.github.token_ref',
+        title: 'GitHub Token Reference',
+        description: 'Secret reference used for GitHub API access.',
+        category: 'Integrations',
+        section: 'user-workspace',
+        type: 'secret_ref',
+        ui: 'secret_ref_picker',
+        scopes: ['user', 'workspace'],
+        default_value: null,
+        effective_value: 'env://GITHUB_TOKEN',
+        override_value: null,
+        source: 'environment',
+        source_explanation: 'Resolved from deployment environment.',
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: 'github_token',
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['github', 'integrations'],
+        depends_on: [],
+        order: 40,
+        audit: { store_old_value: true, store_new_value: true, redact: true },
+        value_version: 1,
+        diagnostics: [],
+      },
+    ],
+    Advanced: [
+      {
+        key: 'ui.density',
+        title: 'UI Density',
+        description: 'Preferred UI density.',
+        category: 'Advanced',
+        section: 'user-workspace',
+        type: 'string',
+        ui: 'text',
+        scopes: ['workspace'],
+        default_value: 'comfortable',
+        effective_value: 'comfortable',
+        override_value: null,
+        source: 'default',
+        source_explanation: 'Resolved from default.',
+        options: null,
+        constraints: { min_length: 3, max_length: 24 },
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['mission_control'],
+        depends_on: [],
+        order: 50,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [],
+      },
+      {
+        key: 'notifications.channels',
+        title: 'Notification Channels',
+        description: 'Enabled notification channels.',
+        category: 'Advanced',
+        section: 'user-workspace',
+        type: 'list',
+        ui: 'tag_editor',
+        scopes: ['workspace'],
+        default_value: [],
+        effective_value: ['email'],
+        override_value: null,
+        source: 'default',
+        source_explanation: 'Resolved from default.',
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['notifications'],
+        depends_on: [],
+        order: 60,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [],
+      },
+      {
+        key: 'git.author_defaults',
+        title: 'Git Author Defaults',
+        description: 'Default Git author metadata.',
+        category: 'Advanced',
+        section: 'user-workspace',
+        type: 'object',
+        ui: 'key_value',
+        scopes: ['workspace'],
+        default_value: {},
+        effective_value: { name: 'MoonMind' },
+        override_value: null,
+        source: 'default',
+        source_explanation: 'Resolved from default.',
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: false,
+        read_only_reason: null,
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['git'],
+        depends_on: [],
+        order: 70,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [],
+      },
+      {
+        key: 'operations.mode',
+        title: 'Operator Locked Mode',
+        description: 'Managed by operators.',
+        category: 'Advanced',
+        section: 'user-workspace',
+        type: 'string',
+        ui: 'readonly',
+        scopes: ['workspace'],
+        default_value: 'normal',
+        effective_value: 'normal',
+        override_value: null,
+        source: 'operator_locked',
+        source_explanation: 'Resolved from operator policy.',
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: true,
+        read_only_reason: 'Operator locked by workspace policy.',
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['operations'],
+        depends_on: [],
+        order: 80,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [],
+      },
+    ],
+  },
+};
+
+const userCatalog = {
+  section: 'user-workspace',
+  scope: 'user',
+  categories: {
+    Integrations: [
+      {
+        ...workspaceCatalog.categories.Integrations[0],
+        source: 'workspace_override',
+        source_explanation: 'Resolved from a workspace override.',
+        effective_value: 'env://WORKSPACE_TOKEN',
+        scopes: ['user', 'workspace'],
+      },
+    ],
+  },
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Bad Request',
+    json: async () => body,
+  } as Response;
+}
+
+describe('GeneratedSettingsSection', () => {
+  let fetchSpy: MockInstance;
+  let requests: Array<{ url: string; init: RequestInit | undefined }>;
+
+  beforeEach(() => {
+    requests = [];
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input, init) => {
+      const url = String(input);
+      requests.push({ url, init });
+
+      if (url.includes('scope=user')) {
+        return Promise.resolve(jsonResponse(userCatalog));
+      }
+      if (url.includes('/api/v1/settings/catalog')) {
+        return Promise.resolve(jsonResponse(workspaceCatalog));
+      }
+      if (url === '/api/v1/settings/workspace') {
+        return Promise.resolve(jsonResponse({ scope: 'workspace', values: {} }));
+      }
+      if (url === '/api/v1/settings/workspace/live_sessions.default_enabled') {
+        return Promise.resolve(jsonResponse({ key: 'live_sessions.default_enabled' }));
+      }
+      return Promise.resolve(jsonResponse({ error: 'not_found', message: 'not found' }, false, 404));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders descriptor rows with metadata, badges, diagnostics, and filters', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    expect(await screen.findByText('Default Publish Mode')).toBeTruthy();
+    expect(screen.getByText('Config')).toBeTruthy();
+    expect(screen.getAllByText('Workspace')).not.toHaveLength(0);
+    expect(screen.getByText('Worker restart')).toBeTruthy();
+    expect(screen.getByText('Worker restart required.')).toBeTruthy();
+    expect(screen.getByText('task_creation')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Search settings'), { target: { value: 'github' } });
+    expect(screen.getByText('GitHub Token Reference')).toBeTruthy();
+    expect(screen.queryByText('Default Publish Mode')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'Integrations' } });
+    expect(screen.getByText('GitHub Token Reference')).toBeTruthy();
+  });
+
+  it('switches scope and fetches scoped descriptors', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+    fireEvent.click(screen.getByRole('button', { name: 'User' }));
+
+    await screen.findByDisplayValue('env://WORKSPACE_TOKEN');
+    expect(requests.some((request) => request.url.includes('scope=user'))).toBe(true);
+    expect(screen.queryByText('Default Publish Mode')).toBeNull();
+  });
+
+  it('edits generated controls and previews only changed keys', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+
+    fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });
+    fireEvent.click(screen.getByLabelText('Live Sessions Enabled By Default'));
+    fireEvent.change(screen.getByLabelText('Skills Canary Percent'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('UI Density'), { target: { value: 'compact' } });
+    fireEvent.change(screen.getByLabelText('Notification Channels'), { target: { value: 'email,slack' } });
+    fireEvent.change(screen.getByLabelText('Git Author Defaults'), { target: { value: 'name=MoonMind\\nemail=dev@example.com' } });
+    fireEvent.change(screen.getByLabelText('GitHub Token Reference'), { target: { value: 'db://github-main' } });
+
+    const preview = screen.getByLabelText('Pending settings preview');
+    expect(within(preview).getByText('workflow.default_publish_mode')).toBeTruthy();
+    expect(within(preview).getByText('live_sessions.default_enabled')).toBeTruthy();
+    expect(within(preview).getByText('skills.canary_percent')).toBeTruthy();
+    expect(within(preview).getByText('ui.density')).toBeTruthy();
+    expect(within(preview).getByText('notifications.channels')).toBeTruthy();
+    expect(within(preview).getByText('git.author_defaults')).toBeTruthy();
+    expect(within(preview).getByText('integrations.github.token_ref')).toBeTruthy();
+    expect(within(preview).getAllByText('Valid')).not.toHaveLength(0);
+    expect(screen.queryByText(/plaintext/i)).toBeNull();
+  });
+
+  it('saves only changed keys with expected versions and refreshes catalog', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+    fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/settings/workspace',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({
+            changes: { 'workflow.default_publish_mode': 'branch' },
+            expected_versions: { 'workflow.default_publish_mode': 3 },
+            reason: 'Updated from Mission Control Settings.',
+          }),
+        }),
+      );
+    });
+  });
+
+  it('disables read-only descriptors and shows lock reason', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    expect(await screen.findByText('Operator Locked Mode')).toBeTruthy();
+    expect(screen.getByText('Operator locked by workspace policy.')).toBeTruthy();
+    expect((screen.getByLabelText('Operator Locked Mode') as HTMLInputElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByLabelText('Read-only only'));
+    expect(screen.getByText('Operator Locked Mode')).toBeTruthy();
+    expect(screen.queryByText('Default Publish Mode')).toBeNull();
+  });
+
+  it('resets overrides through the reset route and supports discard', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findAllByText('Live Sessions Enabled By Default');
+    fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });
+    expect(screen.getByLabelText('Pending settings preview')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(screen.queryByLabelText('Pending settings preview')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset Live Sessions Enabled By Default' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/settings/workspace/live_sessions.default_enabled',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -344,6 +344,16 @@ describe('GeneratedSettingsSection', () => {
     expect(screen.queryByText('Default Publish Mode')).toBeNull();
   });
 
+  it('does not offer reset for inherited workspace overrides in user scope', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+    fireEvent.click(screen.getByRole('button', { name: 'User' }));
+
+    await screen.findByDisplayValue('env://WORKSPACE_TOKEN');
+    expect(screen.queryByRole('button', { name: 'Reset GitHub Token Reference' })).toBeNull();
+  });
+
   it('edits generated controls and previews only changed keys', async () => {
     renderWithClient(<GeneratedSettingsSection />);
 

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -1,0 +1,688 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+type SettingScope = 'workspace' | 'user';
+
+interface SettingOption {
+  value: string;
+  label: string;
+}
+
+interface SettingConstraints {
+  minimum?: number | null;
+  maximum?: number | null;
+  min_length?: number | null;
+  max_length?: number | null;
+  pattern?: string | null;
+}
+
+interface SettingDiagnostic {
+  code: string;
+  message: string;
+  severity: 'info' | 'warning' | 'error';
+}
+
+interface SettingDescriptor {
+  key: string;
+  title: string;
+  description?: string | null;
+  category: string;
+  section: string;
+  type: string;
+  ui: string;
+  scopes: SettingScope[];
+  default_value?: unknown;
+  effective_value: unknown;
+  override_value?: unknown;
+  source: string;
+  source_explanation: string;
+  options?: SettingOption[] | null;
+  constraints?: SettingConstraints | null;
+  sensitive: boolean;
+  secret_role?: string | null;
+  read_only: boolean;
+  read_only_reason?: string | null;
+  requires_reload: boolean;
+  requires_worker_restart: boolean;
+  requires_process_restart: boolean;
+  applies_to: string[];
+  order: number;
+  value_version: number;
+  diagnostics: SettingDiagnostic[];
+}
+
+interface SettingsCatalogResponse {
+  section: string;
+  scope: SettingScope;
+  categories: Record<string, SettingDescriptor[]>;
+}
+
+interface PendingChange {
+  descriptor: SettingDescriptor;
+  value: unknown;
+  valid: boolean;
+  message?: string;
+}
+
+const SCOPE_LABELS: Record<SettingScope, string> = {
+  workspace: 'Workspace',
+  user: 'User',
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  config_or_default: 'Config',
+  default: 'Default',
+  environment: 'Environment',
+  workspace_override: 'Workspace override',
+  user_override: 'User override',
+  operator_locked: 'Operator locked',
+  provider_profile: 'Provider profile',
+  secret_reference: 'Secret reference',
+};
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source.replaceAll('_', ' ');
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'Not set';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Enabled' : 'Disabled';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return JSON.stringify(value);
+}
+
+function inputValue(value: unknown, descriptor: SettingDescriptor): string {
+  if (Array.isArray(value)) {
+    return value.join(',');
+  }
+  if (descriptor.ui === 'key_value' || descriptor.type === 'object') {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return Object.entries(value as Record<string, unknown>)
+        .map(([key, nestedValue]) => `${key}=${String(nestedValue ?? '')}`)
+        .join('\n');
+    }
+    return '';
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}
+
+function parseList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseKeyValue(raw: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const separator = line.indexOf('=');
+      if (separator === -1) {
+        parsed[line] = '';
+        return;
+      }
+      parsed[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+    });
+  return parsed;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function coerceInputValue(descriptor: SettingDescriptor, raw: string | boolean): PendingChange {
+  let value: unknown;
+  let valid = true;
+  let message: string | undefined;
+
+  if (descriptor.type === 'boolean' || descriptor.ui === 'toggle') {
+    value = Boolean(raw);
+  } else if (descriptor.type === 'integer' || descriptor.type === 'number' || descriptor.ui === 'number') {
+    const numeric = Number(raw);
+    value = Number.isInteger(numeric) ? numeric : Number(raw);
+    if (raw === '' || Number.isNaN(numeric)) {
+      valid = false;
+      message = 'Enter a number.';
+    } else if (descriptor.constraints?.minimum !== null && descriptor.constraints?.minimum !== undefined && numeric < descriptor.constraints.minimum) {
+      valid = false;
+      message = `Minimum is ${descriptor.constraints.minimum}.`;
+    } else if (descriptor.constraints?.maximum !== null && descriptor.constraints?.maximum !== undefined && numeric > descriptor.constraints.maximum) {
+      valid = false;
+      message = `Maximum is ${descriptor.constraints.maximum}.`;
+    }
+  } else if (descriptor.type === 'list' || descriptor.ui === 'tag_editor') {
+    value = parseList(String(raw));
+  } else if (descriptor.type === 'object' || descriptor.ui === 'key_value') {
+    value = parseKeyValue(String(raw));
+  } else {
+    value = String(raw);
+    if ((descriptor.type === 'secret_ref' || descriptor.ui === 'secret_ref_picker') && value && !String(value).includes('://')) {
+      valid = false;
+      message = 'Enter a SecretRef such as db://name or env://NAME.';
+    }
+  }
+
+  return message === undefined
+    ? { descriptor, value, valid }
+    : { descriptor, value, valid, message };
+}
+
+function reloadBadges(descriptor: SettingDescriptor): string[] {
+  const badges: string[] = [];
+  if (descriptor.requires_reload) {
+    badges.push('Reload');
+  }
+  if (descriptor.requires_worker_restart) {
+    badges.push('Worker restart');
+  }
+  if (descriptor.requires_process_restart) {
+    badges.push('Process restart');
+  }
+  return badges;
+}
+
+function canReset(descriptor: SettingDescriptor): boolean {
+  return descriptor.source === 'workspace_override' || descriptor.source === 'user_override';
+}
+
+async function fetchCatalog(scope: SettingScope): Promise<SettingsCatalogResponse> {
+  const response = await fetch(`/api/v1/settings/catalog?section=user-workspace&scope=${scope}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch settings catalog: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function flattenedDescriptors(catalog?: SettingsCatalogResponse): SettingDescriptor[] {
+  if (!catalog) {
+    return [];
+  }
+  return Object.values(catalog.categories)
+    .flat()
+    .sort((left, right) => left.order - right.order);
+}
+
+function sanitizeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Settings request failed.';
+}
+
+export function GeneratedSettingsSection() {
+  const queryClient = useQueryClient();
+  const [scope, setScope] = useState<SettingScope>('workspace');
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('all');
+  const [modifiedOnly, setModifiedOnly] = useState(false);
+  const [readOnlyOnly, setReadOnlyOnly] = useState(false);
+  const [pending, setPending] = useState<Record<string, PendingChange>>({});
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const catalogQuery = useQuery({
+    queryKey: ['settings-catalog', scope],
+    queryFn: () => fetchCatalog(scope),
+  });
+
+  const descriptors = useMemo(() => flattenedDescriptors(catalogQuery.data), [catalogQuery.data]);
+  const categories = useMemo(
+    () => Array.from(new Set(descriptors.map((descriptor) => descriptor.category))).sort(),
+    [descriptors],
+  );
+
+  const visibleDescriptors = descriptors.filter((descriptor) => {
+    const haystack = `${descriptor.key} ${descriptor.title} ${descriptor.description ?? ''}`.toLowerCase();
+    if (search.trim() && !haystack.includes(search.trim().toLowerCase())) {
+      return false;
+    }
+    if (category !== 'all' && descriptor.category !== category) {
+      return false;
+    }
+    if (modifiedOnly && !pending[descriptor.key]) {
+      return false;
+    }
+    if (readOnlyOnly && !descriptor.read_only) {
+      return false;
+    }
+    return true;
+  });
+
+  const visibleByCategory = visibleDescriptors.reduce<Record<string, SettingDescriptor[]>>((grouped, descriptor) => {
+    const categoryDescriptors = grouped[descriptor.category] ?? [];
+    categoryDescriptors.push(descriptor);
+    grouped[descriptor.category] = categoryDescriptors;
+    return grouped;
+  }, {});
+
+  const pendingChanges = Object.values(pending);
+  const hasInvalidChange = pendingChanges.some((change) => !change.valid);
+
+  const updatePending = (descriptor: SettingDescriptor, raw: string | boolean) => {
+    const next = coerceInputValue(descriptor, raw);
+    setPending((current) => {
+      const updated = { ...current };
+      if (valuesEqual(next.value, descriptor.effective_value)) {
+        delete updated[descriptor.key];
+      } else {
+        updated[descriptor.key] = next;
+      }
+      return updated;
+    });
+  };
+
+  const resetLocalStateForScope = (nextScope: SettingScope) => {
+    setScope(nextScope);
+    setPending({});
+    setNotice(null);
+    setCategory('all');
+    setSearch('');
+    setModifiedOnly(false);
+    setReadOnlyOnly(false);
+  };
+
+  const saveChanges = async () => {
+    if (!pendingChanges.length || hasInvalidChange) {
+      return;
+    }
+    const changes = Object.fromEntries(pendingChanges.map((change) => [change.descriptor.key, change.value]));
+    const expected_versions = Object.fromEntries(
+      pendingChanges.map((change) => [change.descriptor.key, change.descriptor.value_version]),
+    );
+    try {
+      const response = await fetch(`/api/v1/settings/${scope}`, {
+        method: 'PATCH',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          changes,
+          expected_versions,
+          reason: 'Updated from Mission Control Settings.',
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Settings save failed with status ${response.status}.`);
+      }
+      setPending({});
+      setNotice('Settings saved.');
+      await queryClient.invalidateQueries({ queryKey: ['settings-catalog', scope] });
+    } catch (error) {
+      setNotice(sanitizeError(error));
+    }
+  };
+
+  const resetOverride = async (descriptor: SettingDescriptor) => {
+    try {
+      const response = await fetch(`/api/v1/settings/${scope}/${encodeURIComponent(descriptor.key)}`, {
+        method: 'DELETE',
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Reset failed with status ${response.status}.`);
+      }
+      setPending((current) => {
+        const updated = { ...current };
+        delete updated[descriptor.key];
+        return updated;
+      });
+      setNotice(`${descriptor.title} reset.`);
+      await queryClient.invalidateQueries({ queryKey: ['settings-catalog', scope] });
+    } catch (error) {
+      setNotice(sanitizeError(error));
+    }
+  };
+
+  if (catalogQuery.isLoading) {
+    return (
+      <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 text-sm text-slate-500 shadow-sm dark:text-slate-400">
+        Loading generated settings...
+      </section>
+    );
+  }
+
+  if (catalogQuery.isError) {
+    return (
+      <section className="rounded-3xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400">
+        {sanitizeError(catalogQuery.error)}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-5" aria-label="Generated user and workspace settings">
+      <div className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">User / Workspace</h3>
+            <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
+              Configure eligible settings from backend-owned descriptors. Validation, sensitivity, and authorization remain server-side.
+            </p>
+          </div>
+          <div className="flex rounded-full border border-slate-300 p-1 dark:border-slate-700" aria-label="Settings scope">
+            {(['workspace', 'user'] as SettingScope[]).map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                className={`rounded-full px-4 py-2 text-sm font-medium ${
+                  scope === candidate
+                    ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+                    : 'text-slate-600 hover:text-slate-950 dark:text-slate-400 dark:hover:text-white'
+                }`}
+                onClick={() => resetLocalStateForScope(candidate)}
+              >
+                {SCOPE_LABELS[candidate]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {notice ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
+          {notice}
+        </div>
+      ) : null}
+
+      <div className="rounded-3xl border border-mm-border/80 bg-transparent p-5 shadow-sm">
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto_auto] md:items-end">
+          <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            Search settings
+            <input
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            Category
+            <select
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+            >
+              <option value="all">All categories</option>
+              {categories.map((candidate) => (
+                <option key={candidate} value={candidate}>
+                  {candidate}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+            <input type="checkbox" checked={modifiedOnly} onChange={(event) => setModifiedOnly(event.target.checked)} />
+            Modified only
+          </label>
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+            <input type="checkbox" checked={readOnlyOnly} onChange={(event) => setReadOnlyOnly(event.target.checked)} />
+            Read-only only
+          </label>
+        </div>
+      </div>
+
+      {pendingChanges.length ? (
+        <div
+          className="rounded-3xl border border-amber-200 bg-amber-50 p-5 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/30"
+          aria-label="Pending settings preview"
+        >
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h4 className="text-sm font-semibold text-amber-950 dark:text-amber-100">Change preview</h4>
+              <p className="text-sm text-amber-800 dark:text-amber-200">Review changed keys before saving.</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-xl border border-amber-300 px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-100 dark:border-amber-800 dark:text-amber-100 dark:hover:bg-amber-900/40"
+                onClick={() => setPending({})}
+              >
+                Discard changes
+              </button>
+              <button
+                type="button"
+                className="rounded-xl bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900"
+                disabled={hasInvalidChange}
+                onClick={saveChanges}
+              >
+                Save changes
+              </button>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3">
+            {pendingChanges.map((change) => (
+              <div key={change.descriptor.key} className="rounded-2xl border border-amber-200 bg-white/70 p-3 text-sm dark:border-amber-900/60 dark:bg-slate-950/50">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs font-semibold text-slate-900 dark:text-white">{change.descriptor.key}</span>
+                  <span className={change.valid ? 'text-emerald-700 dark:text-emerald-300' : 'text-rose-700 dark:text-rose-300'}>
+                    {change.valid ? 'Valid' : change.message ?? 'Invalid'}
+                  </span>
+                </div>
+                <div className="mt-2 grid gap-2 text-slate-700 dark:text-slate-300 md:grid-cols-2">
+                  <div>Old: {displayValue(change.descriptor.effective_value)}</div>
+                  <div>New: {displayValue(change.value)}</div>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {change.descriptor.applies_to.map((target) => (
+                    <span key={target} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                      {target}
+                    </span>
+                  ))}
+                  {reloadBadges(change.descriptor).map((badge) => (
+                    <span key={badge} className="rounded-full bg-amber-100 px-2 py-1 text-xs text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {visibleDescriptors.length === 0 ? (
+        <div className="rounded-3xl border border-mm-border/80 bg-transparent p-6 text-sm text-slate-500 shadow-sm dark:text-slate-400">
+          No settings match the current filters.
+        </div>
+      ) : null}
+
+      {Object.entries(visibleByCategory).map(([categoryName, categoryDescriptors]) => (
+        <div key={categoryName} className="rounded-3xl border border-mm-border/80 bg-transparent p-5 shadow-sm">
+          <h4 className="text-base font-semibold text-slate-900 dark:text-white">{categoryName}</h4>
+          <div className="mt-4 divide-y divide-slate-200 dark:divide-slate-800">
+            {categoryDescriptors.map((descriptor) => {
+              const pendingChange = pending[descriptor.key];
+              const currentValue = pendingChange?.value ?? descriptor.effective_value;
+              return (
+                <div key={descriptor.key} className="grid gap-4 py-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h5 className="text-sm font-semibold text-slate-950 dark:text-white">{descriptor.title}</h5>
+                      <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                        {sourceLabel(descriptor.source)}
+                      </span>
+                      <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                        {SCOPE_LABELS[scope]}
+                      </span>
+                      {reloadBadges(descriptor).map((badge) => (
+                        <span key={badge} className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                          {badge}
+                        </span>
+                      ))}
+                    </div>
+                    {descriptor.description ? (
+                      <p className="text-sm text-slate-600 dark:text-slate-400">{descriptor.description}</p>
+                    ) : null}
+                    <p className="text-xs text-slate-500 dark:text-slate-500">{descriptor.source_explanation}</p>
+                    {descriptor.read_only && descriptor.read_only_reason ? (
+                      <p className="text-sm font-medium text-amber-700 dark:text-amber-300">{descriptor.read_only_reason}</p>
+                    ) : null}
+                    {descriptor.diagnostics.map((diagnostic) => (
+                      <p key={`${descriptor.key}-${diagnostic.code}`} className="text-sm text-amber-700 dark:text-amber-300">
+                        {diagnostic.message}
+                      </p>
+                    ))}
+                    <div className="flex flex-wrap gap-2">
+                      {descriptor.applies_to.map((target) => (
+                        <span key={target} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                          {target}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    {renderControl(descriptor, currentValue, updatePending)}
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-mono text-xs text-slate-500 dark:text-slate-500">{descriptor.key}</span>
+                      {canReset(descriptor) ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+                          onClick={() => resetOverride(descriptor)}
+                          aria-label={`Reset ${descriptor.title}`}
+                        >
+                          Reset
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function renderControl(
+  descriptor: SettingDescriptor,
+  value: unknown,
+  onChange: (descriptor: SettingDescriptor, value: string | boolean) => void,
+) {
+  const disabled = descriptor.read_only;
+  const commonClassName =
+    'w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 disabled:bg-slate-100 disabled:text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:disabled:bg-slate-900 dark:disabled:text-slate-500';
+
+  if (descriptor.type === 'boolean' || descriptor.ui === 'toggle') {
+    return (
+      <label className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 p-3 text-sm font-medium text-slate-700 dark:border-slate-800 dark:text-slate-300">
+        <span>{descriptor.title}</span>
+        <input
+          aria-label={descriptor.title}
+          type="checkbox"
+          checked={Boolean(value)}
+          disabled={disabled}
+          onChange={(event) => onChange(descriptor, event.target.checked)}
+        />
+      </label>
+    );
+  }
+
+  if (descriptor.type === 'enum' || descriptor.ui === 'select') {
+    return (
+      <select
+        aria-label={descriptor.title}
+        className={commonClassName}
+        value={inputValue(value, descriptor)}
+        disabled={disabled}
+        onChange={(event) => onChange(descriptor, event.target.value)}
+      >
+        {(descriptor.options ?? []).map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  if (descriptor.type === 'integer' || descriptor.type === 'number' || descriptor.ui === 'number') {
+    return (
+      <input
+        aria-label={descriptor.title}
+        className={commonClassName}
+        type="number"
+        min={descriptor.constraints?.minimum ?? undefined}
+        max={descriptor.constraints?.maximum ?? undefined}
+        value={inputValue(value, descriptor)}
+        disabled={disabled}
+        onChange={(event) => onChange(descriptor, event.target.value)}
+      />
+    );
+  }
+
+  if (descriptor.type === 'list' || descriptor.ui === 'tag_editor') {
+    return (
+      <input
+        aria-label={descriptor.title}
+        className={commonClassName}
+        type="text"
+        value={inputValue(value, descriptor)}
+        disabled={disabled}
+        placeholder="value-a,value-b"
+        onChange={(event) => onChange(descriptor, event.target.value)}
+      />
+    );
+  }
+
+  if (descriptor.type === 'object' || descriptor.ui === 'key_value') {
+    return (
+      <textarea
+        aria-label={descriptor.title}
+        className={commonClassName}
+        rows={3}
+        value={inputValue(value, descriptor)}
+        disabled={disabled}
+        placeholder="key=value"
+        onChange={(event) => onChange(descriptor, event.target.value)}
+      />
+    );
+  }
+
+  if (descriptor.read_only || descriptor.ui === 'readonly') {
+    return (
+      <input
+        aria-label={descriptor.title}
+        className={commonClassName}
+        type="text"
+        value={displayValue(value)}
+        disabled
+        readOnly
+      />
+    );
+  }
+
+  return (
+    <input
+      aria-label={descriptor.title}
+      className={commonClassName}
+      type="text"
+      value={inputValue(value, descriptor)}
+      disabled={disabled}
+      placeholder={descriptor.type === 'secret_ref' || descriptor.ui === 'secret_ref_picker' ? 'db://secret-name or env://NAME' : undefined}
+      onChange={(event) => onChange(descriptor, event.target.value)}
+    />
+  );
+}

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -80,6 +80,29 @@ const SOURCE_LABELS: Record<string, string> = {
   secret_reference: 'Secret reference',
 };
 
+const SETTING_FIELD_CLASS_NAMES = [
+  'w-full',
+  'rounded-xl',
+  'border',
+  'border-slate-300',
+  'bg-white',
+  'px-3',
+  'py-2',
+  'text-sm',
+  'text-slate-900',
+  'disabled:bg-slate-100',
+  'disabled:text-slate-500',
+  'dark:border-slate-700',
+  'dark:bg-slate-950',
+  'dark:text-white',
+  'dark:disabled:bg-slate-900',
+  'dark:disabled:text-slate-500',
+];
+
+function settingFieldClassName(...classNames: string[]): string {
+  return [...SETTING_FIELD_CLASS_NAMES, ...classNames].filter(Boolean).join(' ');
+}
+
 function sourceLabel(source: string): string {
   return SOURCE_LABELS[source] ?? source.replaceAll('_', ' ');
 }
@@ -145,8 +168,48 @@ function parseKeyValue(raw: string): Record<string, string> {
   return parsed;
 }
 
-function valuesEqual(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+function enumerableKeys(value: object): Array<string | symbol> {
+  return Reflect.ownKeys(value)
+    .filter((key) => Object.prototype.propertyIsEnumerable.call(value, key))
+    .sort((left, right) => String(left).localeCompare(String(right)));
+}
+
+function valuesEqual(left: unknown, right: unknown, seen = new WeakMap<object, WeakSet<object>>()): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (typeof left !== 'object' || left === null || typeof right !== 'object' || right === null) {
+    return false;
+  }
+  const seenRights = seen.get(left);
+  if (seenRights?.has(right)) {
+    return true;
+  }
+  if (seenRights) {
+    seenRights.add(right);
+  } else {
+    seen.set(left, new WeakSet([right]));
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => valuesEqual(item, right[index], seen))
+    );
+  }
+  const leftKeys = enumerableKeys(left);
+  const rightKeys = enumerableKeys(right);
+  const leftRecord = left as Record<string | symbol, unknown>;
+  const rightRecord = right as Record<string | symbol, unknown>;
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) =>
+        key === rightKeys[index] &&
+        valuesEqual(leftRecord[key], rightRecord[key], seen),
+    )
+  );
 }
 
 function coerceInputValue(descriptor: SettingDescriptor, raw: string | boolean): PendingChange {
@@ -200,8 +263,11 @@ function reloadBadges(descriptor: SettingDescriptor): string[] {
   return badges;
 }
 
-function canReset(descriptor: SettingDescriptor): boolean {
-  return descriptor.source === 'workspace_override' || descriptor.source === 'user_override';
+function canReset(descriptor: SettingDescriptor, scope: SettingScope): boolean {
+  return (
+    (scope === 'workspace' && descriptor.source === 'workspace_override') ||
+    (scope === 'user' && descriptor.source === 'user_override')
+  );
 }
 
 async function fetchCatalog(scope: SettingScope): Promise<SettingsCatalogResponse> {
@@ -554,7 +620,7 @@ export function GeneratedSettingsSection() {
                     {renderControl(descriptor, currentValue, updatePending)}
                     <div className="flex items-center justify-between gap-3">
                       <span className="font-mono text-xs text-slate-500 dark:text-slate-500">{descriptor.key}</span>
-                      {canReset(descriptor) ? (
+                      {canReset(descriptor, scope) ? (
                         <button
                           type="button"
                           className="rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
@@ -582,8 +648,7 @@ function renderControl(
   onChange: (descriptor: SettingDescriptor, value: string | boolean) => void,
 ) {
   const disabled = descriptor.read_only;
-  const commonClassName =
-    'w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 disabled:bg-slate-100 disabled:text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:disabled:bg-slate-900 dark:disabled:text-slate-500';
+  const commonClassName = settingFieldClassName();
 
   if (descriptor.type === 'boolean' || descriptor.ui === 'toggle') {
     return (

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { BootPayload } from '../boot/parseBootPayload';
 import { SecretManager } from '../components/secrets/SecretManager';
+import { GeneratedSettingsSection } from '../components/settings/GeneratedSettingsSection';
 import {
   OperationsSettingsSection,
   type WorkerPauseConfig,
@@ -265,14 +266,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
 
       {section === 'user-workspace' ? (
         <div className="space-y-6">
-          <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">User / Workspace</h3>
-            <p className="mt-2 max-w-3xl text-sm text-slate-600 dark:text-slate-400">
-              This section is reserved for the broader project settings model. The
-              unified Settings tab now provides a stable home for those controls as
-              Mission Control exposes more runtime, workspace, and operator preferences.
-            </p>
-          </section>
+          <GeneratedSettingsSection />
 
           <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
             {isLoading ? (

--- a/specs/269-generated-user-workspace-settings-ui/checklists/requirements.md
+++ b/specs/269-generated-user-workspace-settings-ui/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Generated User and Workspace Settings UI
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated against the canonical MM-539 Jira preset brief preserved in `spec.md` Input.

--- a/specs/269-generated-user-workspace-settings-ui/contracts/settings-user-workspace-ui.md
+++ b/specs/269-generated-user-workspace-settings-ui/contracts/settings-user-workspace-ui.md
@@ -1,0 +1,79 @@
+# Contract: User / Workspace Generated Settings UI
+
+## Catalog Read
+
+```http
+GET /api/v1/settings/catalog?section=user-workspace&scope=workspace
+GET /api/v1/settings/catalog?section=user-workspace&scope=user
+Accept: application/json
+```
+
+Expected response shape is `SettingsCatalogResponse`:
+
+```json
+{
+  "section": "user-workspace",
+  "scope": "workspace",
+  "categories": {
+    "Workflow": [
+      {
+        "key": "workflow.default_publish_mode",
+        "title": "Default Publish Mode",
+        "type": "enum",
+        "ui": "select",
+        "source": "workspace_override",
+        "source_explanation": "Resolved from a workspace override.",
+        "effective_value": "branch",
+        "value_version": 1,
+        "read_only": false,
+        "applies_to": ["task_creation"]
+      }
+    ]
+  }
+}
+```
+
+## Save Changes
+
+```http
+PATCH /api/v1/settings/workspace
+Content-Type: application/json
+```
+
+```json
+{
+  "changes": {
+    "workflow.default_publish_mode": "branch"
+  },
+  "expected_versions": {
+    "workflow.default_publish_mode": 1
+  },
+  "reason": "Updated from Mission Control Settings."
+}
+```
+
+Rules:
+
+- The UI sends only changed keys.
+- The UI does not send raw secrets.
+- Backend validation and authorization are authoritative.
+
+## Reset Override
+
+```http
+DELETE /api/v1/settings/workspace/workflow.default_publish_mode
+Accept: application/json
+```
+
+Rules:
+
+- Show reset only for `workspace_override` or `user_override` sources.
+- Refresh catalog after reset.
+
+## UI Contract
+
+- Scope control supports `workspace` and `user`.
+- Filters include search, category, modified-only, and read-only.
+- Rows show title, description, source badge, scope badge, diagnostics, affected subsystems, reload/restart badges, lock reason, reset, and generated control.
+- Preview lists changed key, old value, new value, validation state, affected subsystems, and reload/restart requirements before save.
+- SecretRef settings are reference inputs only; plaintext secret editing stays outside this component.

--- a/specs/269-generated-user-workspace-settings-ui/data-model.md
+++ b/specs/269-generated-user-workspace-settings-ui/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Generated User and Workspace Settings UI
+
+## Setting Descriptor
+
+- `key`: Stable setting identifier used for patch and reset calls.
+- `title`: User-visible row title.
+- `description`: Optional user-visible description.
+- `category`: Category group in the User / Workspace section.
+- `section`: Must be `user-workspace` for this UI.
+- `type` and `ui`: Backend-owned value and control shape.
+- `scopes`: Scopes where the setting is available.
+- `effective_value`: Current resolved value for display and editing.
+- `source` and `source_explanation`: Current source badge and explanation.
+- `options`: Select options when applicable.
+- `constraints`: Numeric or string constraints.
+- `sensitive` and `secret_role`: SecretRef metadata; plaintext secrets are not represented.
+- `read_only` and `read_only_reason`: Lock state for ordinary editing.
+- `requires_reload`, `requires_worker_restart`, `requires_process_restart`: Runtime effect badges.
+- `applies_to`: Affected subsystems used in preview and row metadata.
+- `value_version`: Expected version used for save.
+- `diagnostics`: Backend diagnostics displayed without secret expansion.
+
+## Pending Setting Change
+
+- `key`: Descriptor key.
+- `scope`: Active user or workspace scope.
+- `oldValue`: Descriptor `effective_value`.
+- `newValue`: Local user-entered value.
+- `expectedVersion`: Descriptor `value_version`.
+- `isValid`: Client-side shape sanity for obvious UI constraints; backend remains authoritative.
+- `affectedSubsystems`: Descriptor `applies_to`.
+- `reloadRequirements`: Derived from descriptor reload/restart flags.
+
+## Settings Scope
+
+- `workspace`: Shared workspace defaults and overrides.
+- `user`: Personal settings inheriting workspace values where the backend exposes them.
+
+State transitions:
+
+1. Catalog loaded -> descriptors render by category.
+2. Descriptor edited -> pending change created.
+3. Discard -> pending changes cleared.
+4. Save -> `PATCH /settings/{scope}` -> catalog invalidated/refetched.
+5. Reset -> `DELETE /settings/{scope}/{key}` -> catalog invalidated/refetched.

--- a/specs/269-generated-user-workspace-settings-ui/plan.md
+++ b/specs/269-generated-user-workspace-settings-ui/plan.md
@@ -30,6 +30,12 @@ Implement the missing generated User / Workspace Settings UI on top of the exist
 | SCN-004 | partial | Backend read-only metadata exists | Render disabled controls and lock reason | frontend unit |
 | SCN-005 | partial | Backend reset exists | Add reset button and refresh | frontend unit |
 | SCN-006 | partial | Backend SecretRef descriptor exists | Add SecretRef reference control and tests | frontend unit |
+| SC-001 | partial | Backend catalog exists; generated frontend renderer absent at planning time | Add descriptor-driven User / Workspace UI without bespoke forms | frontend unit |
+| SC-002 | partial | Backend patch route exists; frontend changed-key submission absent at planning time | Add pending change tracking, save, and refresh behavior | frontend unit + API integration evidence |
+| SC-003 | partial | Backend read-only metadata exists; frontend lock behavior absent at planning time | Add disabled read-only controls and lock reason display | frontend unit |
+| SC-004 | partial | Backend SecretRef diagnostics and validation exist; generic reference UI absent at planning time | Add SecretRef reference control without plaintext secret handling | frontend unit |
+| SC-005 | partial | Backend reset route exists; frontend reset action absent at planning time | Add reset-to-inherited action and catalog refresh | frontend unit + API integration evidence |
+| SC-006 | implemented_verified | MM-539 and source IDs preserved in `spec.md` | Preserve through tasks and final verification | traceability review |
 | DESIGN-REQ-001 | partial | Backend catalog and scoped overrides exist; UI missing | Add UI over existing backend | frontend unit + backend tests |
 | DESIGN-REQ-004 | partial | Backend catalog section `user-workspace`; UI placeholder | Render catalog-driven section | frontend unit |
 | DESIGN-REQ-009 | partial | Descriptor metadata and server validation exist; UI missing controls/preview | Add UI controls and metadata display | frontend unit |

--- a/specs/269-generated-user-workspace-settings-ui/plan.md
+++ b/specs/269-generated-user-workspace-settings-ui/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Generated User and Workspace Settings UI
+
+**Branch**: `269-generated-user-workspace-settings-ui`
+**Date**: 2026-04-28
+**Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime spec from MM-539 Jira preset brief.
+
+## Summary
+
+Implement the missing generated User / Workspace Settings UI on top of the existing backend Settings API. The backend already exposes catalog, effective value, patch, and reset routes with descriptor metadata and server-side validation, so the primary delivery work is a React renderer that fetches descriptors by scope, renders descriptor-driven controls, tracks local intent, previews pending changes, saves changed keys with expected versions, resets overrides, and surfaces read-only, source, diagnostics, reload, and SecretRef states. Validation will use focused frontend unit tests for UI behavior plus existing backend route/service tests for API boundaries.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `api_service/api/routers/settings.py`, `api_service/services/settings_catalog.py`; frontend placeholder in `frontend/src/entrypoints/settings.tsx` | Add frontend catalog fetch and descriptor grouping for User / Workspace | frontend unit + API integration evidence |
+| FR-002 | partial | Backend descriptors support enum, integer, boolean, secret_ref; frontend renderer absent | Add generated controls for supported descriptor types, with list/key-value fallback handling | frontend unit |
+| FR-003 | partial | Backend descriptor fields exist; frontend does not display them in User / Workspace | Render row metadata, badges, diagnostics, reload indicators, affected subsystems, lock reason, reset | frontend unit |
+| FR-004 | missing | No User / Workspace filtering UI | Add search, category, scope, modified-only, and read-only filters | frontend unit |
+| FR-005 | partial | Backend `PATCH /settings/{scope}` persists overrides with expected versions | Track pending edits and submit changed keys only with expected versions | frontend unit + existing backend tests |
+| FR-006 | missing | No change preview in frontend | Add preview panel for changed keys, values, validation, affected subsystems, reload/restart | frontend unit |
+| FR-007 | partial | Backend reset route exists; frontend does not expose reset in User / Workspace | Add discard and reset-to-inherited actions | frontend unit + existing backend tests |
+| FR-008 | partial | Backend descriptor supports read-only; frontend does not render locked rows | Disable editing and show lock reasons from descriptors | frontend unit |
+| FR-009 | partial | Backend rejects unsafe secret-like values; frontend generic SecretRef UI absent | Render SecretRef as reference input/picker-style control and avoid plaintext secret copy | frontend unit |
+| FR-010 | partial | Backend returns structured errors; frontend needs sanitized display | Display API errors without dumping response payload secrets | frontend unit |
+| FR-011 | implemented_verified | MM-539 and canonical brief preserved in `spec.md` | Preserve in downstream artifacts and final verification | traceability review |
+| SCN-001 | partial | Settings page has sections, but User / Workspace is placeholder | Generated workspace descriptor view | frontend unit |
+| SCN-002 | missing | No scope switch in User / Workspace | Fetch by selected scope | frontend unit |
+| SCN-003 | missing | No pending change preview | Add pending changes and preview | frontend unit |
+| SCN-004 | partial | Backend read-only metadata exists | Render disabled controls and lock reason | frontend unit |
+| SCN-005 | partial | Backend reset exists | Add reset button and refresh | frontend unit |
+| SCN-006 | partial | Backend SecretRef descriptor exists | Add SecretRef reference control and tests | frontend unit |
+| DESIGN-REQ-001 | partial | Backend catalog and scoped overrides exist; UI missing | Add UI over existing backend | frontend unit + backend tests |
+| DESIGN-REQ-004 | partial | Backend catalog section `user-workspace`; UI placeholder | Render catalog-driven section | frontend unit |
+| DESIGN-REQ-009 | partial | Descriptor metadata and server validation exist; UI missing controls/preview | Add UI controls and metadata display | frontend unit |
+| DESIGN-REQ-023 | partial | Backend inheritance and reset behavior exist; UI missing reset/source display | Add source badges and reset-to-inherited | frontend unit |
+
+## Technical Context
+
+- **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present for existing Settings API.
+- **Primary Dependencies**: React, TanStack Query, existing FastAPI Settings routes, existing SQLAlchemy-backed Settings override service, Vitest and Testing Library.
+- **Storage**: Existing `settings_overrides` and `settings_audit_events` tables; no new persistent storage.
+- **Unit Testing**: Vitest/Testing Library for frontend; pytest for existing backend services.
+- **Integration Testing**: Existing FastAPI route tests for Settings API and focused frontend integration-style component tests with mocked fetch.
+- **Target Platform**: Mission Control browser UI served by MoonMind API.
+- **Project Type**: Web application plus existing API service.
+- **Performance Goals**: Descriptor filtering must remain client-local after one catalog fetch per scope; save/reset refreshes the affected scope.
+- **Constraints**: Frontend must not decide backend eligibility, validation, sensitivity, or authorization. SecretRef settings must not request or display plaintext secrets. Generic UI remains scoped to User / Workspace; Providers & Secrets and Operations stay specialized.
+- **Scale/Scope**: One generated renderer for current descriptor catalog, designed to handle additional eligible descriptors without bespoke forms.
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Work uses existing Settings API and Mission Control surfaces.
+- **II. One-Click Agent Deployment**: PASS. No new external dependency or setup requirement.
+- **III. Avoid Vendor Lock-In**: PASS. Generic settings metadata is internal and provider-neutral; SecretRefs remain references.
+- **IV. Own Your Data**: PASS. Settings and overrides remain operator-controlled.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime changes.
+- **VI. Replaceable Scaffolding**: PASS. Renderer uses descriptor contracts rather than bespoke forms.
+- **VII. Powerful Runtime Configurability**: PASS. Feature exposes runtime configuration through backend metadata.
+- **VIII. Modular and Extensible Architecture**: PASS. Adds a frontend component at Settings UI boundary.
+- **IX. Resilient by Default**: PASS. Errors are surfaced and backend validation remains authoritative.
+- **X. Facilitate Continuous Improvement**: PASS. UI makes validation and affected subsystems visible.
+- **XI. Spec-Driven Development**: PASS. Spec, plan, and tasks precede implementation.
+- **XII. Documentation Separation**: PASS. Runtime work remains in feature artifacts; canonical docs are read as source requirements.
+- **XIII. Pre-Release Velocity**: PASS. No compatibility aliases or legacy paths are introduced.
+
+## Project Structure
+
+```text
+frontend/src/entrypoints/settings.tsx
+frontend/src/components/settings/GeneratedSettingsSection.tsx
+frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+api_service/api/routers/settings.py
+api_service/services/settings_catalog.py
+tests/unit/api_service/api/routers/test_settings_api.py
+tests/unit/services/test_settings_catalog.py
+specs/269-generated-user-workspace-settings-ui/
+```
+
+## Phase 0 Research
+
+See [research.md](./research.md).
+
+## Phase 1 Design
+
+See [data-model.md](./data-model.md), [contracts/settings-user-workspace-ui.md](./contracts/settings-user-workspace-ui.md), and [quickstart.md](./quickstart.md).
+
+## Complexity Tracking
+
+No constitution violations or added complexity exceptions.

--- a/specs/269-generated-user-workspace-settings-ui/quickstart.md
+++ b/specs/269-generated-user-workspace-settings-ui/quickstart.md
@@ -1,0 +1,19 @@
+# Quickstart: Generated User and Workspace Settings UI
+
+1. Start Mission Control or run the frontend tests with API requests mocked.
+2. Open `/settings?section=user-workspace`.
+3. Confirm the UI requests `/api/v1/settings/catalog?section=user-workspace&scope=workspace`.
+4. Confirm eligible descriptors render by category with source and scope badges.
+5. Change an editable setting and confirm the preview lists only that changed key.
+6. Save and confirm the UI sends `PATCH /api/v1/settings/workspace` with only changed keys and expected versions.
+7. Reset an overridden setting and confirm the UI sends `DELETE /api/v1/settings/workspace/{key}` and refreshes descriptors.
+8. Switch to user scope and confirm descriptors are reloaded for `scope=user`.
+9. Confirm read-only rows are disabled with lock reasons.
+10. Confirm SecretRef rows never display or request plaintext secret values.
+
+Validation commands:
+
+```bash
+npm run ui:test -- frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+```

--- a/specs/269-generated-user-workspace-settings-ui/research.md
+++ b/specs/269-generated-user-workspace-settings-ui/research.md
@@ -1,0 +1,49 @@
+# Research: Generated User and Workspace Settings UI
+
+## FR-001 Descriptor Source
+
+Decision: Use the existing `GET /api/v1/settings/catalog?section=user-workspace&scope=<scope>` route as the sole descriptor source.
+Evidence: `api_service/api/routers/settings.py` exposes catalog filtering; `api_service/services/settings_catalog.py` builds descriptor metadata from explicit registry entries.
+Rationale: The backend is already the authority for eligibility and section/scope filtering, matching the MM-539 requirement that frontend not decide eligibility.
+Alternatives considered: Hardcoded frontend field list was rejected because it would recreate bespoke forms and drift from backend metadata.
+Test implications: Frontend unit tests should assert scoped catalog fetches and rendered descriptor data.
+
+## FR-002 Control Coverage
+
+Decision: Implement a generated renderer for `toggle`, `select`, `number`, `text`, `secret_ref_picker`, list, key/value, and read-only descriptors.
+Evidence: `SettingDescriptor` contains `type`, `ui`, `options`, `constraints`, `read_only`, and `sensitive` metadata.
+Rationale: Current registry covers enum, integer, boolean, and SecretRef; the story requires the generic renderer to support documented descriptor shapes as they are added.
+Alternatives considered: Implementing only current registry shapes was rejected because the Jira brief explicitly requires supported generic shapes.
+Test implications: Frontend unit tests should provide mock descriptors for all required UI shapes.
+
+## FR-005 Save Boundary
+
+Decision: Submit only pending changed keys to `PATCH /api/v1/settings/{scope}` with descriptor `value_version` as expected version.
+Evidence: `SettingsPatchRequest` accepts `changes` and `expected_versions`; service enforces version conflict and server-side validation.
+Rationale: This preserves local user intent while keeping validation authoritative on the backend.
+Alternatives considered: Sending the whole catalog was rejected because it would overwrite values the user did not intend to change.
+Test implications: Test request body contains only changed keys.
+
+## FR-007 Reset Boundary
+
+Decision: Use `DELETE /api/v1/settings/{scope}/{key}` only when descriptor source is `workspace_override` or `user_override`.
+Evidence: `reset_setting` route exists and `SettingsCatalogService.reset_override` returns effective inherited value after deleting override.
+Rationale: Reset-to-inherited should be visible only when there is an override to remove.
+Alternatives considered: Client-side null patch was rejected because reset semantics are already explicit in the API.
+Test implications: Test reset calls the encoded key URL and refreshes catalog.
+
+## FR-009 SecretRef Safety
+
+Decision: Treat `type: secret_ref` or `ui: secret_ref_picker` as a reference field accepting SecretRef strings only, with helper text that never asks for plaintext.
+Evidence: Backend validation rejects raw secret-like values and redacts unsafe values; docs require SecretRef pickers and no plaintext readback.
+Rationale: The generic settings UI must not become a secret editor.
+Alternatives considered: Listing managed secret metadata inside this component was deferred because Providers & Secrets already owns the specialized secret manager.
+Test implications: Test SecretRef labels and absence of plaintext-oriented language.
+
+## Existing Backend Coverage
+
+Decision: Reuse existing backend API/service tests and add frontend tests for missing UI behavior.
+Evidence: `tests/unit/api_service/api/routers/test_settings_api.py` covers catalog, effective values, patch, reset, invalid scopes, errors, and secret preservation; `tests/unit/services/test_settings_catalog.py` covers descriptor metadata, env parsing, SecretRef diagnostics, override persistence, inheritance, and conflicts.
+Rationale: The backend is already materially covered; the implementation gap is the generated frontend renderer.
+Alternatives considered: Adding duplicate backend tests was rejected unless code changes backend contracts.
+Test implications: Run focused frontend tests plus relevant existing backend tests.

--- a/specs/269-generated-user-workspace-settings-ui/spec.md
+++ b/specs/269-generated-user-workspace-settings-ui/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Generated User and Workspace Settings UI
+
+**Feature Branch**: `269-generated-user-workspace-settings-ui`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-539 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-539 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-539
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Generated User and Workspace settings UI
+- Labels: moonmind-workflow-mm-285619b3-4c87-4e03-944f-282e648fa000
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-539 from MM project
+Summary: Generated User and Workspace settings UI
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Security/SettingsSystem.md
+Source Title: Settings System
+Source Sections:
+- 3. Goals
+- 6. Settings Page Topology
+- 9. Eligibility Rules
+- 13. UI Contract
+- 16. User / Workspace Settings
+- 27. Example End-to-End Flows
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-004
+- DESIGN-REQ-009
+- DESIGN-REQ-023
+
+As a Mission Control user, I can configure eligible user and workspace settings through generated controls so local-first configuration is discoverable without bespoke forms for every setting.
+
+Acceptance Criteria
+- Given descriptors for boolean, string, bounded number, enum, list, key/value, SecretRef, and read-only settings, the UI renders the documented controls and submits only user intent.
+- Given a read-only or operator-locked descriptor, the UI displays the lock reason and does not enable ordinary editing.
+- Given a modified setting, the UI can preview validation and affected subsystem information before save.
+- Given an overridden value, the UI shows reset-to-inherited behavior and source badges using documented labels.
+- A fresh local deployment can reach Settings and configure initial non-secret settings and SecretRef bindings through Mission Control without requiring hand-edited frontend forms.
+
+Requirements
+- The frontend must not decide backend eligibility, validation, sensitivity, or authorization.
+- Ineligible, secret, or operator-only settings must remain hidden, read-only, or routed to specialized managers according to backend descriptors.
+- Generic settings UI must not allow direct environment-variable editing from the browser.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-539 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI story from `docs/Security/SettingsSystem.md`; it does not require `moonspec-breakdown`.
+
+## User Story - Generated User and Workspace Settings
+
+**Summary**: As a Mission Control user, I can configure eligible user and workspace settings through generated controls so local-first configuration is discoverable without bespoke forms for every setting.
+
+**Goal**: The Settings page exposes a usable User / Workspace section generated from backend descriptors, while preserving backend authority for eligibility, validation, sensitivity, and authorization.
+
+**Independent Test**: Load Settings with the User / Workspace section selected, serve descriptor data for workspace and user scopes, edit representative descriptor types, preview pending changes, save them through the Settings API, and reset an override while verifying read-only and SecretRef behavior does not expose plaintext or allow unauthorized editing.
+
+**Acceptance Scenarios**
+
+1. Given eligible workspace descriptors, when a user opens Settings -> User / Workspace, then controls render by descriptor type with title, description, source badge, scope badge, validation diagnostics, reload/restart badges where relevant, and affected subsystem details.
+2. Given a user switches between workspace and user scope, when the selected scope changes, then the UI fetches descriptors for that scope and only shows settings available for that scope.
+3. Given editable boolean, string, bounded number, enum, list, key/value, and SecretRef descriptors, when the user changes values, then the UI tracks only modified keys and shows a preview containing changed keys, old values, new values, validation state, affected subsystems, and reload requirements.
+4. Given a descriptor is read-only or operator locked, when it renders, then its lock reason is visible and ordinary editing and saving are disabled for that setting.
+5. Given an overridden value, when the user chooses reset, then the UI calls the reset API for that key and refreshes the descriptor so inherited source labels are visible.
+6. Given a SecretRef setting, when it renders or is edited, then the UI accepts only SecretRef-style values and does not request or display plaintext secret values.
+
+**Edge Cases**
+
+- The catalog request fails or returns no eligible settings.
+- A save request fails validation, conflicts on expected version, or is rejected by backend policy.
+- A descriptor has diagnostics before the user edits it.
+- A descriptor has no options for a select control.
+- A user discards pending edits after changing multiple settings.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The User / Workspace section MUST fetch backend-owned settings descriptors for the selected scope instead of hardcoding setting fields.
+- **FR-002**: The UI MUST render controls according to descriptor metadata for booleans, strings, bounded numbers, enums, lists, key/value mappings, SecretRef strings, and read-only values.
+- **FR-003**: Each settings row MUST display title, description when present, current control or read-only value, source badge, scope badge, validation diagnostics, reload/restart indicators when present, affected subsystem information, reset affordance when overridden, and lock reason when read-only.
+- **FR-004**: The UI MUST support search, category filtering, scope switching, modified-only filtering, and read-only filtering without bypassing backend descriptor eligibility.
+- **FR-005**: The UI MUST track local edits as explicit user intent and submit only changed keys with expected versions through the Settings API.
+- **FR-006**: The UI MUST provide a change preview before save that lists changed keys, old values, new values, validation status, affected subsystems, and reload or restart requirements.
+- **FR-007**: The UI MUST support discard for pending edits and reset-to-inherited for settings whose source is a user or workspace override.
+- **FR-008**: The UI MUST disable ordinary editing for read-only or operator-locked descriptors and show the backend-provided lock reason.
+- **FR-009**: The generic settings UI MUST represent SecretRef settings as references only and MUST NOT request or display plaintext secret values.
+- **FR-010**: Save and reset failures MUST surface actionable, sanitized errors without exposing credentials or raw secret-like values.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-539` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Setting Descriptor**: Backend-owned metadata describing one eligible setting, including key, title, description, category, section, type, UI control, scopes, current/effective value, source, options, constraints, sensitivity, read-only state, reload requirements, affected subsystems, diagnostics, and value version.
+- **Pending Setting Change**: Local UI state for one modified descriptor, carrying the user-entered value, original value, expected version, validation state, affected subsystem information, and reset/save availability.
+- **Settings Scope**: User or workspace context determining descriptor eligibility, inheritance, override source, and reset behavior.
+
+## Assumptions
+
+- The existing Settings API is the backend authority for eligibility, validation, write permission, effective values, and reset behavior.
+- The story covers the User / Workspace Settings section; Providers & Secrets and Operations remain specialized sections.
+- A descriptor with `ui: "secret_ref_picker"` or `type: "secret_ref"` is a SecretRef reference control, not a plaintext secret editor.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Security/SettingsSystem.md` section 3): Mission Control must expose a unified Settings surface with a declarative catalog, safe exhaustiveness, scoped overrides, explainable effective values, server-side validation, secret-safe behavior, local-first configuration, auditability, and documented runtime application semantics. Scope: in scope. Maps to FR-001, FR-003, FR-005, FR-006, FR-007, FR-009, and FR-010.
+- **DESIGN-REQ-004** (`docs/Security/SettingsSystem.md` section 6): The User / Workspace Settings section must be catalog-driven for user preferences, workspace defaults, non-secret integration defaults, feature flags, policy knobs, and SecretRef bindings. Scope: in scope. Maps to FR-001, FR-002, FR-004, and FR-009.
+- **DESIGN-REQ-009** (`docs/Security/SettingsSystem.md` sections 9 and 13): The generic renderer must only expose eligible settings and must render documented controls, badges, validation errors, change preview, read-only lock reasons, and SecretRef pickers without frontend-owned eligibility decisions. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-006, FR-008, and FR-009.
+- **DESIGN-REQ-023** (`docs/Security/SettingsSystem.md` sections 16 and 27): User settings must inherit workspace defaults unless overridden and the UI must make inheritance, reset-to-inherited, and workspace default changes visible in end-to-end flows. Scope: in scope. Maps to FR-003, FR-005, FR-007, and FR-010.
+
+## Success Criteria
+
+- **SC-001**: A user can open the User / Workspace section and see descriptor-driven controls for eligible settings without adding bespoke frontend forms per setting.
+- **SC-002**: Editing and saving multiple settings submits only changed keys and refreshes the displayed effective values after success.
+- **SC-003**: Read-only descriptors are visible with lock reasons and cannot be changed through ordinary controls.
+- **SC-004**: SecretRef settings are handled as references only, with no plaintext secret display or request path in the generic UI.
+- **SC-005**: Resetting an overridden setting removes the override and shows inherited source labeling after refresh.
+- **SC-006**: Verification evidence preserves `MM-539`, the canonical Jira preset brief, and DESIGN-REQ-001, DESIGN-REQ-004, DESIGN-REQ-009, and DESIGN-REQ-023 in MoonSpec artifacts.

--- a/specs/269-generated-user-workspace-settings-ui/tasks.md
+++ b/specs/269-generated-user-workspace-settings-ui/tasks.md
@@ -44,7 +44,7 @@
 
 - [X] T016 Run `npm run ui:test -- frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
 - [X] T017 Run `./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
-- [X] T018 Run `/speckit.verify` equivalent with `moonspec-verify` and preserve MM-539, source mappings, and test evidence in final verification.
+- [X] T018 Run final `/moonspec-verify` work and preserve MM-539, source mappings, and test evidence in final verification.
 
 ## Dependencies and Execution Order
 

--- a/specs/269-generated-user-workspace-settings-ui/tasks.md
+++ b/specs/269-generated-user-workspace-settings-ui/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Generated User and Workspace Settings UI
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/settings-user-workspace-ui.md](./contracts/settings-user-workspace-ui.md)
+
+**Prerequisites**: Existing Settings API routes and descriptor service remain in place.
+
+**Unit Test Command**: `npm run ui:test -- frontend/src/components/settings/GeneratedSettingsSection.test.tsx`
+
+**Integration Test Command**: `./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx`
+
+**Source Traceability**: MM-539 and the canonical Jira preset brief are preserved in `spec.md`. Tasks cover FR-001 through FR-011, SCN-001 through SCN-006, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-004, DESIGN-REQ-009, and DESIGN-REQ-023.
+
+## Phase 1: Setup
+
+- [X] T001 Create MoonSpec feature artifacts under `specs/269-generated-user-workspace-settings-ui/` preserving MM-539 and source design mappings.
+- [X] T002 Confirm `.specify/feature.json` points to `specs/269-generated-user-workspace-settings-ui`.
+
+## Phase 2: Foundational
+
+- [X] T003 [P] Add frontend test file `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` with mocked Settings API catalog, save, and reset responses for FR-001 through FR-010.
+- [X] T004 [P] Add generated settings component shell in `frontend/src/components/settings/GeneratedSettingsSection.tsx` with typed descriptor, response, and pending-change models for FR-001 and FR-002.
+
+## Phase 3: Story - Generated User and Workspace Settings
+
+**Story Summary**: As a Mission Control user, I can configure eligible user and workspace settings through generated controls so local-first configuration is discoverable without bespoke forms for every setting.
+
+**Independent Test**: Load Settings -> User / Workspace with mocked workspace and user descriptors, edit representative descriptors, preview pending changes, save changed keys only, reset an override, and verify read-only and SecretRef rows remain safe.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SCN-006, DESIGN-REQ-001, DESIGN-REQ-004, DESIGN-REQ-009, DESIGN-REQ-023.
+
+- [X] T005 Add failing frontend test that renders workspace descriptors by category, source badge, scope badge, diagnostics, affected subsystems, and reload badges in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-001, FR-003, SCN-001, DESIGN-REQ-001, and DESIGN-REQ-004.
+- [X] T006 Add failing frontend test that switches to user scope and fetches only user-scope descriptors in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-004 and SCN-002.
+- [X] T007 Add failing frontend test that edits enum, boolean, number, text, list, key/value, and SecretRef descriptors and previews only changed keys in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-002, FR-005, FR-006, and FR-009.
+- [X] T008 Add failing frontend test that save sends only changed keys with expected versions and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-005 and FR-010.
+- [X] T009 Add failing frontend test that read-only descriptors show lock reasons and disable ordinary edits in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-008 and SCN-004.
+- [X] T010 Add failing frontend test that reset-to-inherited calls the reset route only for override sources and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-007 and DESIGN-REQ-023.
+- [X] T011 Implement descriptor fetch, filters, category grouping, source/scope badges, diagnostics, and row metadata in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-001, FR-003, and FR-004.
+- [X] T012 Implement generated controls for boolean, string, bounded number, enum, list, key/value, SecretRef, and read-only settings in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-002, FR-008, and FR-009.
+- [X] T013 Implement pending change state, preview, discard, save request body, sanitized error display, and catalog refresh in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-005, FR-006, and FR-010.
+- [X] T014 Implement reset-to-inherited behavior in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-007 and DESIGN-REQ-023.
+- [X] T015 Replace the User / Workspace placeholder in `frontend/src/entrypoints/settings.tsx` with `GeneratedSettingsSection` while preserving profile display context for FR-001 and SCN-001.
+
+## Phase 4: Validation
+
+- [X] T016 Run `npm run ui:test -- frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
+- [X] T017 Run `./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
+- [X] T018 Run `/speckit.verify` equivalent with `moonspec-verify` and preserve MM-539, source mappings, and test evidence in final verification.
+
+## Dependencies and Execution Order
+
+1. T003 and T004 can run in parallel.
+2. T005 through T010 define red-first coverage before production implementation.
+3. T011 through T015 implement the story.
+4. T016 through T018 validate the implementation and traceability.
+
+## Implementation Strategy
+
+Focus implementation on the frontend renderer because backend Settings API behavior already exists and is covered. Keep the generic renderer descriptor-driven; do not add setting-specific forms. Preserve backend authority by submitting changed values to the existing API and displaying backend-provided diagnostics and errors.

--- a/specs/269-generated-user-workspace-settings-ui/tasks.md
+++ b/specs/269-generated-user-workspace-settings-ui/tasks.md
@@ -28,12 +28,12 @@
 
 **Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SCN-006, DESIGN-REQ-001, DESIGN-REQ-004, DESIGN-REQ-009, DESIGN-REQ-023.
 
-- [X] T005 Add failing frontend test that renders workspace descriptors by category, source badge, scope badge, diagnostics, affected subsystems, and reload badges in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-001, FR-003, SCN-001, DESIGN-REQ-001, and DESIGN-REQ-004.
+- [X] T005 Add failing frontend test that renders workspace descriptors by category, source badge, scope badge, diagnostics, affected subsystems, and reload badges in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-001, FR-003, SCN-001, SC-001, DESIGN-REQ-001, and DESIGN-REQ-004.
 - [X] T006 Add failing frontend test that switches to user scope and fetches only user-scope descriptors in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-004 and SCN-002.
-- [X] T007 Add failing frontend test that edits enum, boolean, number, text, list, key/value, and SecretRef descriptors and previews only changed keys in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-002, FR-005, FR-006, and FR-009.
-- [X] T008 Add failing frontend test that save sends only changed keys with expected versions and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-005 and FR-010.
-- [X] T009 Add failing frontend test that read-only descriptors show lock reasons and disable ordinary edits in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-008 and SCN-004.
-- [X] T010 Add failing frontend test that reset-to-inherited calls the reset route only for override sources and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-007 and DESIGN-REQ-023.
+- [X] T007 Add failing frontend test that edits enum, boolean, number, text, list, key/value, and SecretRef descriptors and previews only changed keys in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-002, FR-005, FR-006, FR-009, SC-002, and SC-004.
+- [X] T008 Add failing frontend test that save sends only changed keys with expected versions and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-005, FR-010, and SC-002.
+- [X] T009 Add failing frontend test that read-only descriptors show lock reasons and disable ordinary edits in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-008, SCN-004, and SC-003.
+- [X] T010 Add failing frontend test that reset-to-inherited calls the reset route only for override sources and refreshes catalog in `frontend/src/components/settings/GeneratedSettingsSection.test.tsx` for FR-007, SC-005, and DESIGN-REQ-023.
 - [X] T011 Implement descriptor fetch, filters, category grouping, source/scope badges, diagnostics, and row metadata in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-001, FR-003, and FR-004.
 - [X] T012 Implement generated controls for boolean, string, bounded number, enum, list, key/value, SecretRef, and read-only settings in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-002, FR-008, and FR-009.
 - [X] T013 Implement pending change state, preview, discard, save request body, sanitized error display, and catalog refresh in `frontend/src/components/settings/GeneratedSettingsSection.tsx` for FR-005, FR-006, and FR-010.
@@ -44,7 +44,7 @@
 
 - [X] T016 Run `npm run ui:test -- frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
 - [X] T017 Run `./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx` and record the result.
-- [X] T018 Run final `/moonspec-verify` work and preserve MM-539, source mappings, and test evidence in final verification.
+- [X] T018 Run final `/moonspec-verify` work and preserve MM-539, source mappings, SC-006, and test evidence in final verification.
 
 ## Dependencies and Execution Order
 

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -60,6 +60,41 @@ async def test_settings_catalog_endpoint_returns_grouped_descriptors():
 
 
 @pytest.mark.asyncio
+async def test_settings_catalog_endpoint_reports_persisted_override_versions(settings_api_db):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_publish_mode": "branch"},
+                "expected_versions": {"workflow.default_publish_mode": 1},
+            },
+        )
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_publish_mode": "none"},
+                "expected_versions": {"workflow.default_publish_mode": 1},
+            },
+        )
+        response = await client.get(
+            "/api/v1/settings/catalog",
+            params={"section": "user-workspace", "scope": "workspace"},
+        )
+
+    assert response.status_code == 200
+    descriptor = next(
+        item
+        for item in response.json()["categories"]["Workflow"]
+        if item["key"] == "workflow.default_publish_mode"
+    )
+    assert descriptor["effective_value"] == "none"
+    assert descriptor["source"] == "workspace_override"
+    assert descriptor["value_version"] == 2
+
+
+@pytest.mark.asyncio
 async def test_effective_setting_endpoint_returns_structured_unknown_key_error():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://testserver"


### PR DESCRIPTION
Jira issue key: MM-539

Active MoonSpec feature path: specs/269-generated-user-workspace-settings-ui

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- ./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/components/settings/GeneratedSettingsSection.tsx frontend/src/components/settings/GeneratedSettingsSection.test.tsx frontend/src/entrypoints/settings.tsx
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/GeneratedSettingsSection.test.tsx
- ./tools/test_unit.sh tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/settings/GeneratedSettingsSection.test.tsx

Remaining risks:
- Full repository unit suite was not run; affected backend and frontend coverage passed.
