### PR TITLE
I want to remove the Browse Jira images button as a separate button. However, it would be nice that if you choose a Jira issue using the Browse Jira i

### DIFF
--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -579,9 +579,9 @@ Rules:
 
 Rules:
 
-- selecting a Jira issue never mutates the draft automatically
-- text import remains explicit and supports `Replace target text` and `Append to target text`
-- image import remains explicit and supports selecting which supported images to add
+- selecting a Jira issue from the browser imports Jira text into the selected target
+- text import supports `Replace target text` and `Append to target text`
+- selecting a Jira issue also imports supported Jira images into the matching attachment target when image attachments are allowed
 - imported Jira images become structured attachments on the selected target
 - imported Jira images are not injected into instruction text as markdown, HTML, or inline data
 - when importing into a preset-bound step, text and attachment imports both count as manual customization

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -9961,7 +9961,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira images for objective attachments",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -9981,7 +9981,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira images for Step 1 attachments",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     expect(
@@ -9998,7 +9998,7 @@ describe("Task Create Entrypoint", () => {
     ).toBeTruthy();
   });
 
-  it("imports Jira images into the objective attachment target without changing text", async () => {
+  it("imports Jira text and images into the objective target from the issue browser", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -10051,12 +10051,12 @@ describe("Task Create Entrypoint", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira images for objective attachments",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     expect(
       (await screen.findByLabelText("Import target") as HTMLSelectElement).value,
-    ).toBe("preset-attachments");
+    ).toBe("preset-text");
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
     await waitFor(() => {
@@ -10064,12 +10064,12 @@ describe("Task Create Entrypoint", () => {
     });
 
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
-      "Keep objective text.",
+      "Keep objective text.\n\n---\n\nENG-202: Build browser shell\n\nLet operators browse Jira stories.",
     );
     expect(await screen.findByText("wireframe.png")).toBeTruthy();
   });
 
-  it("imports Jira images into a step attachment target", async () => {
+  it("imports Jira text and images into a step target from the issue browser", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -10120,7 +10120,7 @@ describe("Task Create Entrypoint", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira images for Step 1 attachments",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -10130,12 +10130,12 @@ describe("Task Create Entrypoint", () => {
     });
 
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
-      "Keep step text.",
+      "Keep step text.\n\n---\n\nComplete Jira issue ENG-202: Build browser shell",
     );
     expect(await screen.findByText("wireframe.png")).toBeTruthy();
   });
 
-  it("does not import Jira images when importing into text targets", async () => {
+  it("imports Jira images automatically when importing into text targets", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     let attachmentDownloads = 0;
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -10204,8 +10204,8 @@ describe("Task Create Entrypoint", () => {
       expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
     });
 
-    expect(attachmentDownloads).toBe(0);
-    expect(screen.queryByText("wireframe.png")).toBeNull();
+    expect(attachmentDownloads).toBe(2);
+    expect(await screen.findAllByText("wireframe.png")).toHaveLength(2);
     expect(
       (screen.getByLabelText(
         "Feature Request / Initial Instructions",
@@ -10285,7 +10285,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira images for Step 1 attachments",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -10216,6 +10216,82 @@ describe("Task Create Entrypoint", () => {
     );
   });
 
+  it("imports Jira images when preset target text is unchanged", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    let attachmentDownloads = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        attachmentDownloads += 1;
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["fake image"], { type: "image/png" }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    const presetInstructions = await screen.findByLabelText(
+      "Feature Request / Initial Instructions",
+    );
+    fireEvent.change(presetInstructions, {
+      target: {
+        value: "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issues for preset instructions",
+      }),
+    );
+    fireEvent.change(await screen.findByLabelText("Text import"), {
+      target: { value: "replace" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect(attachmentDownloads).toBe(1);
+    expect(await screen.findByText("wireframe.png")).toBeTruthy();
+    expect((presetInstructions as HTMLTextAreaElement).value).toBe(
+      "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+    );
+  });
+
   it("detaches template step identity and records provenance after Jira step attachment import", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3488,6 +3488,25 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setSelectedJiraIssueKey(issueKey);
   }
 
+  function resetTemplateStepIdForAttachmentChange(
+    localId: string,
+    attachments: Array<StepAttachmentRef | File>,
+  ) {
+    setSteps((current) =>
+      current.map((step) => {
+        if (
+          step.localId !== localId ||
+          !step.templateStepId ||
+          step.id !== step.templateStepId ||
+          isTemplateBoundStepForAttachments(step, attachments)
+        ) {
+          return step;
+        }
+        return { ...step, id: "" };
+      }),
+    );
+  }
+
   async function importSelectedJiraImages(
     issue: JiraIssueDetail,
     target: JiraImportTarget,
@@ -3589,21 +3608,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             nextObjectiveFiles,
           );
         } else {
-          setSteps((current) =>
-            current.map((step) => {
-              if (
-                step.localId !== target.localId ||
-                !step.templateStepId ||
-                step.id !== step.templateStepId ||
-                isTemplateBoundStepForAttachments(
-                  step,
-                  nextFilesByStep[target.localId] || [],
-                )
-              ) {
-                return step;
-              }
-              return { ...step, id: "" };
-            }),
+          resetTemplateStepIdForAttachmentChange(
+            target.localId,
+            nextFilesByStep[target.localId] || [],
           );
           setSelectedStepAttachmentFiles(nextFilesByStep);
         }
@@ -3627,6 +3634,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (messages.length > 0) {
         setSubmitMessage(messages.join(" "));
       }
+    } catch (error) {
+      const failure =
+        error instanceof Error
+          ? error
+          : new Error("Failed to download Jira images.");
+      setSubmitMessage(failure.message);
+    }
+  }
+
+  async function importSelectedJiraImagesWithReporting(
+    issue: JiraIssueDetail,
+    target: JiraImportTarget,
+    objectiveTextForReapply?: string,
+  ): Promise<void> {
+    try {
+      await importSelectedJiraImages(issue, target, objectiveTextForReapply);
     } catch (error) {
       const failure =
         error instanceof Error
@@ -3665,7 +3688,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         });
         updateStep(importTarget.localId, { id: "" });
       }
-      await importSelectedJiraImages(issue, importTarget);
+      await importSelectedJiraImagesWithReporting(issue, importTarget);
       return;
     }
     if (!selectedJiraImportText.trim()) {
@@ -3677,23 +3700,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         selectedJiraImportText,
         jiraWriteMode,
       );
-      if (nextText.trim() === templateFeatureRequest.trim()) {
-        return;
+      const provenance = createJiraProvenance(
+        issue,
+        selectedJiraBoardId,
+        jiraImportMode,
+        importTarget,
+      );
+      if (nextText.trim() !== templateFeatureRequest.trim()) {
+        setTemplateFeatureRequest(nextText);
+        updatePresetReapplyStateForObjective(
+          nextText,
+          selectedObjectiveAttachmentFiles,
+        );
       }
-      setTemplateFeatureRequest(nextText);
-      setPresetJiraProvenance(
-        createJiraProvenance(
-          issue,
-          selectedJiraBoardId,
-          jiraImportMode,
-          importTarget,
-        ),
-      );
-      updatePresetReapplyStateForObjective(
-        nextText,
-        selectedObjectiveAttachmentFiles,
-      );
-      await importSelectedJiraImages(issue, importTarget, nextText);
+      setPresetJiraProvenance(provenance);
+      await importSelectedJiraImagesWithReporting(issue, importTarget, nextText);
       return;
     }
 
@@ -3727,7 +3748,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const { [importTarget.localId]: _removed, ...rest } = current;
       return rest;
     });
-    await importSelectedJiraImages(issue, importTarget);
+    await importSelectedJiraImagesWithReporting(issue, importTarget);
   }
 
   function updatePresetReapplyStateForObjective(
@@ -3804,19 +3825,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       delete next[targetKey];
       return next;
     });
-    setSteps((current) =>
-      current.map((step) => {
-        if (
-          step.localId !== localId ||
-          !step.templateStepId ||
-          step.id !== step.templateStepId ||
-          isTemplateBoundStepForAttachments(step, mergedFilesForBinding)
-        ) {
-          return step;
-        }
-        return { ...step, id: "" };
-      }),
-    );
+    resetTemplateStepIdForAttachmentChange(localId, mergedFilesForBinding);
     setSelectedStepAttachmentFiles((current) => {
       const mergedFiles = appendDedupedAttachmentFiles(
         current[localId] || [],

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3589,6 +3589,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             nextObjectiveFiles,
           );
         } else {
+          setSteps((current) =>
+            current.map((step) => {
+              if (
+                step.localId !== target.localId ||
+                !step.templateStepId ||
+                step.id !== step.templateStepId ||
+                isTemplateBoundStepForAttachments(
+                  step,
+                  nextFilesByStep[target.localId] || [],
+                )
+              ) {
+                return step;
+              }
+              return { ...step, id: "" };
+            }),
+          );
           setSelectedStepAttachmentFiles(nextFilesByStep);
         }
       }
@@ -3677,6 +3693,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         nextText,
         selectedObjectiveAttachmentFiles,
       );
+      await importSelectedJiraImages(issue, importTarget, nextText);
       return;
     }
 
@@ -3710,6 +3727,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const { [importTarget.localId]: _removed, ...rest } = current;
       return rest;
     });
+    await importSelectedJiraImages(issue, importTarget);
   }
 
   function updatePresetReapplyStateForObjective(
@@ -6107,23 +6125,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             }}
                           />
                         </div>
-                        {jiraIntegration?.enabled ? (
-                          <button
-                            type="button"
-                            className="secondary jira-browse-button"
-                            aria-label={`Browse Jira images for Step ${index + 1} attachments`}
-                            title={`Browse Jira images for Step ${index + 1} attachments`}
-                            onClick={() =>
-                              openJiraBrowser({
-                                kind: "step",
-                                localId: step.localId,
-                                attachmentsOnly: true,
-                              })
-                            }
-                          >
-                            Browse Jira images
-                          </button>
-                        ) : null}
                         {attachmentTargetErrors[
                           attachmentTargetKey(step.localId)
                         ] ? (
@@ -6593,22 +6594,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       }}
                     />
                   </label>
-                  {jiraIntegration?.enabled ? (
-                    <button
-                      type="button"
-                      className="secondary jira-browse-button"
-                      aria-label="Browse Jira images for objective attachments"
-                      title="Browse Jira images for objective attachments"
-                      onClick={() =>
-                        openJiraBrowser({
-                          kind: "preset",
-                          attachmentsOnly: true,
-                        })
-                      }
-                    >
-                      Browse Jira images
-                    </button>
-                  ) : null}
                   {attachmentTargetErrors[attachmentTargetKey("objective")] ? (
                     <p className="notice error">
                       {attachmentTargetErrors[attachmentTargetKey("objective")]}


### PR DESCRIPTION
I want to remove the Browse Jira images button as a separate button. However, it would be nice that if you choose a Jira issue using the Browse Jira issue it automatically attaches the images to the step or preset.