### PR TITLE
The Task Detail page currently reads "Temporal Task Detail" but I would prefer for it to just say "Task Detail" instead.

### DIFF
--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -3914,7 +3914,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     <div className="stack task-detail-page">
       <div className="toolbar">
         <div>
-          <h2 className="page-title">Temporal Task Detail</h2>
+          <h2 className="page-title">Task Detail</h2>
           <div className="toolbar-identity-row">
             <p className="page-meta">Task {taskId || '—'}</p>
             {execution ? (

--- a/tests/e2e/test_task_create_submit_browser.py
+++ b/tests/e2e/test_task_create_submit_browser.py
@@ -401,7 +401,7 @@ def test_temporal_detail_resolves_source_and_fetches_latest_run_artifacts(server
         )
 
         page.goto(f"{base_url}/tasks/mm:workflow-123")
-        page.wait_for_selector("text=Temporal Task Detail")
+        page.wait_for_selector("text=Task Detail")
         assert page.url.endswith("/tasks/mm:workflow-123")
         assert ordered_calls[:3] == ["source", "detail", "artifacts"]
         browser.close()


### PR DESCRIPTION
The Task Detail page currently reads "Temporal Task Detail" but I would prefer for it to just say "Task Detail" instead.