### PR TITLE
MM-540 secret-safe settings managed secrets

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/269-generated-user-workspace-settings-ui"
+  "feature_directory": "specs/270-secret-safe-settings-managed-secrets"
 }

--- a/api_service/api/routers/secrets.py
+++ b/api_service/api/routers/secrets.py
@@ -14,6 +14,7 @@ from api_service.api.schemas import (
 )
 from api_service.db.models import SecretStatus
 from api_service.services.secrets import SecretsService
+from moonmind.utils.logging import redact_sensitive_payload
 
 logger = structlog.get_logger(__name__)
 
@@ -145,7 +146,6 @@ async def validate_secret(
     slug: str,
     db: AsyncSession = Depends(get_async_session),
     user: Any = Depends(get_current_user()),
-) -> dict[str, bool]:
-    # Check if the secret exists and is active
-    val = await SecretsService.get_secret(db, slug)
-    return {"valid": val is not None}
+) -> dict[str, Any]:
+    result = await SecretsService.validate_secret_ref(db, slug)
+    return redact_sensitive_payload(result)

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 if TYPE_CHECKING:
     pass
@@ -546,6 +546,11 @@ class SecretMetadataResponse(BaseModel):
     details: dict[str, Any]
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: Optional[datetime] = Field(None, alias="updatedAt")
+
+    @computed_field(alias="secretRef")
+    @property
+    def secret_ref(self) -> str:
+        return f"db://{self.slug}"
 
 class SecretListResponse(BaseModel):
     """Envelope for list of secret metadata."""

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -150,6 +150,59 @@ class SecretsService:
         return secret.ciphertext
 
     @classmethod
+    async def validate_secret_ref(cls, db: AsyncSession, slug: str) -> dict[str, Any]:
+        """Return redacted metadata-only validation diagnostics for a managed secret."""
+        checked_at = datetime.now(timezone.utc).isoformat()
+        result = await db.execute(select(ManagedSecret).where(ManagedSecret.slug == slug))
+        secret = result.scalar_one_or_none()
+
+        if secret is None:
+            return {
+                "valid": False,
+                "status": "missing",
+                "checkedAt": checked_at,
+                "diagnostics": [
+                    {
+                        "code": "secret_ref_unresolved",
+                        "message": "Managed secret is missing.",
+                        "severity": "error",
+                    }
+                ],
+            }
+
+        secret_status = (
+            secret.status.value
+            if isinstance(secret.status, SecretStatus)
+            else str(secret.status)
+        )
+        if secret_status == SecretStatus.ACTIVE.value:
+            return {
+                "valid": True,
+                "status": secret_status,
+                "checkedAt": checked_at,
+                "diagnostics": [
+                    {
+                        "code": "secret_ref_resolvable",
+                        "message": "Managed secret is active.",
+                        "severity": "info",
+                    }
+                ],
+            }
+
+        return {
+            "valid": False,
+            "status": secret_status,
+            "checkedAt": checked_at,
+            "diagnostics": [
+                {
+                    "code": "secret_ref_unresolved",
+                    "message": f"Managed secret is {secret_status}.",
+                    "severity": "error",
+                }
+            ],
+        }
+
+    @classmethod
     async def import_from_env(
         cls,
         db: AsyncSession,

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -153,10 +153,12 @@ class SecretsService:
     async def validate_secret_ref(cls, db: AsyncSession, slug: str) -> dict[str, Any]:
         """Return redacted metadata-only validation diagnostics for a managed secret."""
         checked_at = datetime.now(timezone.utc).isoformat()
-        result = await db.execute(select(ManagedSecret).where(ManagedSecret.slug == slug))
-        secret = result.scalar_one_or_none()
+        result = await db.execute(
+            select(ManagedSecret.status).where(ManagedSecret.slug == slug)
+        )
+        status = result.scalar_one_or_none()
 
-        if secret is None:
+        if status is None:
             return {
                 "valid": False,
                 "status": "missing",
@@ -171,9 +173,9 @@ class SecretsService:
             }
 
         secret_status = (
-            secret.status.value
-            if isinstance(secret.status, SecretStatus)
-            else str(secret.status)
+            status.value
+            if isinstance(status, SecretStatus)
+            else str(status)
         )
         if secret_status == SecretStatus.ACTIVE.value:
             return {

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -752,9 +752,9 @@ class SettingsCatalogService:
             for value in values
             if isinstance(value, str) and value.startswith("db://")
         }
-        missing = sorted(
+        missing = [
             slug for slug in slugs if slug not in self._managed_secret_status_by_slug
-        )
+        ]
         if not missing:
             return
         result = await self._session.execute(
@@ -762,15 +762,14 @@ class SettingsCatalogService:
                 ManagedSecret.slug.in_(missing)
             )
         )
-        found: set[str] = set()
-        for slug, status in result.all():
-            found.add(slug)
-            self._managed_secret_status_by_slug[slug] = (
-                status.value if isinstance(status, SecretStatus) else str(status)
-            )
+
+        statuses_from_db = {
+            slug: status.value if isinstance(status, SecretStatus) else str(status)
+            for slug, status in result.all()
+        }
+
         for slug in missing:
-            if slug not in found:
-                self._managed_secret_status_by_slug[slug] = None
+            self._managed_secret_status_by_slug[slug] = statuses_from_db.get(slug)
 
     def _resolve_value_from_overrides(
         self,

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -12,7 +12,12 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_service.db.models import SettingsAuditEvent, SettingsOverride
+from api_service.db.models import (
+    ManagedSecret,
+    SecretStatus,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
 from moonmind.config.settings import AppSettings, settings as app_settings
 
 SettingScope = Literal["user", "workspace", "system", "operator"]
@@ -295,6 +300,7 @@ class SettingsCatalogService:
         self._session = session
         self._workspace_id = workspace_id or _DEFAULT_SUBJECT_ID
         self._user_id = user_id or _DEFAULT_SUBJECT_ID
+        self._managed_secret_status_by_slug: dict[str, str | None] = {}
 
     def catalog(
         self,
@@ -331,6 +337,15 @@ class SettingsCatalogService:
         overrides = await self._get_effective_overrides(
             scope=scope,
             keys=[entry.key for entry in entries],
+        )
+        await self._prime_managed_secret_statuses(
+            self._resolve_value_from_overrides(
+                entry,
+                scope=scope,
+                overrides=overrides,
+            )[0]
+            for entry in entries
+            if scope is not None
         )
         categories: dict[str, list[SettingDescriptor]] = {}
         for entry in entries:
@@ -433,7 +448,7 @@ class SettingsCatalogService:
             order=entry.order,
             audit=entry.audit,
             value_version=version,
-            diagnostics=[] if override_present else self._diagnostics(entry, value),
+            diagnostics=self._diagnostics_for_override(entry, value, override_present),
         )
 
     async def effective_value_async(
@@ -453,6 +468,7 @@ class SettingsCatalogService:
             scope=scope,
             overrides=overrides,
         )
+        await self._prime_managed_secret_statuses([value])
         return EffectiveSettingValue(
             key=entry.key,
             scope=scope,
@@ -460,7 +476,7 @@ class SettingsCatalogService:
             source=source,
             source_explanation=self._source_explanation(entry, source),
             value_version=version,
-            diagnostics=[] if override_present else self._diagnostics(entry, value),
+            diagnostics=self._diagnostics_for_override(entry, value, override_present),
         )
 
     async def effective_values_async(
@@ -473,13 +489,31 @@ class SettingsCatalogService:
             scope=scope,
             keys=[entry.key for entry in entries],
         )
-        values = {
-            entry.key: self._effective_value_from_overrides(
+        resolved = {
+            entry.key: (
                 entry,
-                scope=scope,
-                overrides=overrides,
+                self._resolve_value_from_overrides(
+                    entry,
+                    scope=scope,
+                    overrides=overrides,
+                ),
             )
             for entry in entries
+        }
+        await self._prime_managed_secret_statuses(
+            data[0] for _entry, data in resolved.values()
+        )
+        values = {
+            key: EffectiveSettingValue(
+                key=entry.key,
+                scope=scope,
+                value=data[0],
+                source=data[1],
+                source_explanation=self._source_explanation(entry, data[1]),
+                value_version=data[2],
+                diagnostics=self._diagnostics_for_override(entry, data[0], data[3]),
+            )
+            for key, (entry, data) in resolved.items()
         }
         return EffectiveSettingsResponse(scope=scope, values=values)
 
@@ -555,17 +589,33 @@ class SettingsCatalogService:
         except IntegrityError as exc:
             await self._session.rollback()
             raise ValueError("version_conflict") from exc
-        values = {
-            key: self._effective_value_from_overrides(
+        changed_overrides = {
+            (row_scope, changed_key): row
+            for (row_scope, changed_key), row in current_rows.items()
+            if row_scope == scope and changed_key in changes
+        }
+        resolved = {
+            key: self._resolve_value_from_overrides(
                 entries[key],
                 scope=scope,
-                overrides={
-                    (row_scope, changed_key): row
-                    for (row_scope, changed_key), row in current_rows.items()
-                    if row_scope == scope and changed_key in changes
-                },
+                overrides=changed_overrides,
             )
             for key in changes
+        }
+        await self._prime_managed_secret_statuses(data[0] for data in resolved.values())
+        values = {
+            key: EffectiveSettingValue(
+                key=entries[key].key,
+                scope=scope,
+                value=data[0],
+                source=data[1],
+                source_explanation=self._source_explanation(entries[key], data[1]),
+                value_version=data[2],
+                diagnostics=self._diagnostics_for_override(
+                    entries[key], data[0], data[3]
+                ),
+            )
+            for key, data in resolved.items()
         }
         return EffectiveSettingsResponse(scope=scope, values=values)
 
@@ -681,8 +731,46 @@ class SettingsCatalogService:
             source=source,
             source_explanation=self._source_explanation(entry, source),
             value_version=version,
-            diagnostics=[] if override_present else self._diagnostics(entry, value),
+            diagnostics=self._diagnostics_for_override(entry, value, override_present),
         )
+
+    def _diagnostics_for_override(
+        self,
+        entry: SettingRegistryEntry,
+        value: Any,
+        override_present: bool,
+    ) -> list[SettingDiagnostic]:
+        if override_present and (entry.value_type != "secret_ref" or value is None):
+            return []
+        return self._diagnostics(entry, value)
+
+    async def _prime_managed_secret_statuses(self, values: Iterable[Any]) -> None:
+        if self._session is None:
+            return
+        slugs = {
+            value.removeprefix("db://")
+            for value in values
+            if isinstance(value, str) and value.startswith("db://")
+        }
+        missing = sorted(
+            slug for slug in slugs if slug not in self._managed_secret_status_by_slug
+        )
+        if not missing:
+            return
+        result = await self._session.execute(
+            select(ManagedSecret.slug, ManagedSecret.status).where(
+                ManagedSecret.slug.in_(missing)
+            )
+        )
+        found: set[str] = set()
+        for slug, status in result.all():
+            found.add(slug)
+            self._managed_secret_status_by_slug[slug] = (
+                status.value if isinstance(status, SecretStatus) else str(status)
+            )
+        for slug in missing:
+            if slug not in found:
+                self._managed_secret_status_by_slug[slug] = None
 
     def _resolve_value_from_overrides(
         self,
@@ -941,6 +1029,31 @@ class SettingsCatalogService:
                     ),
                     severity="error",
                     details={"ref_scheme": "env"},
+                )
+        elif value.startswith("db://"):
+            slug = value.removeprefix("db://")
+            if slug not in self._managed_secret_status_by_slug:
+                return None
+            status = self._managed_secret_status_by_slug.get(slug)
+            if status is None:
+                return SettingDiagnostic(
+                    code="unresolved_secret_ref",
+                    message=(
+                        f"{entry.key} references a managed secret that does "
+                        "not exist."
+                    ),
+                    severity="error",
+                    details={"ref_scheme": "db", "status": "missing"},
+                )
+            if status != SecretStatus.ACTIVE.value:
+                return SettingDiagnostic(
+                    code="unresolved_secret_ref",
+                    message=(
+                        f"{entry.key} references a managed secret that is "
+                        f"{status}."
+                    ),
+                    severity="error",
+                    details={"ref_scheme": "db", "status": status},
                 )
         elif "://" not in value:
             return SettingDiagnostic(

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-539",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1817"
+  "jira_issue_key": "MM-540",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1824"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3152319940,
+    "id": 3152883195,
     "disposition": "addressed",
-    "rationale": "Replaced JSON.stringify comparison with order-stable recursive equality that handles arrays, objects, symbols, undefined values, and circular references without throwing."
+    "rationale": "Simplified managed secret status cache priming by mapping database statuses once and filling missing slugs with null."
   },
   {
-    "id": 3152319945,
-    "disposition": "addressed",
-    "rationale": "Moved the shared field Tailwind classes into SETTING_FIELD_CLASS_NAMES and settingFieldClassName for a reusable, readable control style helper."
-  },
-  {
-    "id": 4186702059,
+    "id": 4187341440,
     "disposition": "not-applicable",
-    "rationale": "Summary review body only; its two concrete feedback items are tracked and addressed by comments 3152319940 and 3152319945."
+    "rationale": "Top-level review summary with no separate actionable request beyond inline comment 3152883195."
   },
   {
-    "id": 3152323513,
+    "id": 3152919926,
     "disposition": "addressed",
-    "rationale": "Made the settings catalog route load persisted overrides through SettingsCatalogService.catalog_async so descriptors expose override-aware effective values and value_version."
+    "rationale": "Changed validate_secret_ref to select only ManagedSecret.status and updated the unit test to assert ciphertext is not selected."
   },
   {
-    "id": 3152323519,
-    "disposition": "addressed",
-    "rationale": "Gated Reset visibility to overrides at the active selected scope and added frontend coverage for inherited workspace overrides in user scope."
-  },
-  {
-    "id": 4186705950,
+    "id": 4187391626,
     "disposition": "not-applicable",
-    "rationale": "Automated review wrapper text only; its concrete stale-position comments are tracked separately and addressed where they still apply."
+    "rationale": "Automated review wrapper; actionable content is represented by inline comment 3152919926."
   }
 ]

--- a/frontend/src/components/secrets/SecretManager.test.tsx
+++ b/frontend/src/components/secrets/SecretManager.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SecretManager } from './SecretManager';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderSecretManager() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const onNotice = vi.fn();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SecretManager
+        secrets={[
+          {
+            slug: 'github-pat-main',
+            secretRef: 'db://github-pat-main',
+            status: 'active',
+            details: {},
+            createdAt: '2026-04-28T00:00:00Z',
+            updatedAt: '2026-04-28T00:00:00Z',
+          },
+        ]}
+        onNotice={onNotice}
+        queryClient={queryClient}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onNotice };
+}
+
+describe('SecretManager', () => {
+  it('shows and copies managed SecretRefs without exposing plaintext', async () => {
+    const clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: clipboard,
+    });
+    const { onNotice } = renderSecretManager();
+
+    expect(screen.getByText('db://github-pat-main')).toBeTruthy();
+    expect(screen.queryByText(/sk-test-secret/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy SecretRef for github-pat-main' }));
+
+    await waitFor(() => {
+      expect(clipboard.writeText).toHaveBeenCalledWith('db://github-pat-main');
+    });
+    expect(onNotice).toHaveBeenCalledWith({
+      level: 'ok',
+      text: 'SecretRef copied.',
+    });
+  });
+});

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -3,6 +3,7 @@ import { QueryClient, useMutation } from '@tanstack/react-query';
 
 interface SecretMetadata {
   slug: string;
+  secretRef?: string;
   status: string;
   details: Record<string, unknown>;
   createdAt: string;
@@ -160,6 +161,15 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     return <span className="badge badge-error">{status}</span>;
   };
 
+  const copySecretRef = async (secretRef: string) => {
+    try {
+      await navigator.clipboard.writeText(secretRef);
+      onNotice({ level: 'ok', text: 'SecretRef copied.' });
+    } catch {
+      onNotice({ level: 'error', text: 'Failed to copy SecretRef.' });
+    }
+  };
+
   return (
     <div className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
       <div className="border-b border-slate-200 dark:border-slate-800 pb-4">
@@ -180,6 +190,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
               <thead>
                 <tr className="border-b border-slate-200 dark:border-slate-800">
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Secret slug</th>
+                  <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">SecretRef</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Status</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Updated</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Actions</th>
@@ -188,7 +199,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                 {secrets.length === 0 ? (
                   <tr>
-                    <td className="px-2 py-6 text-slate-500 dark:text-slate-400 italic" colSpan={4}>
+                    <td className="px-2 py-6 text-slate-500 dark:text-slate-400 italic" colSpan={5}>
                       No secrets currently stored.
                     </td>
                   </tr>
@@ -198,6 +209,11 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
                       <td className="px-2 py-4 font-mono font-bold text-slate-900 dark:text-white">
                         {secret.slug}
                       </td>
+                      <td className="px-2 py-4">
+                        <code className="rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 dark:bg-slate-900 dark:text-slate-100">
+                          {secret.secretRef ?? `db://${secret.slug}`}
+                        </code>
+                      </td>
                       <td className="px-2 py-4">{renderStatus(secret.status)}</td>
                       <td className="px-2 py-4 text-xs text-slate-500 dark:text-slate-400">
                         {secret.updatedAt
@@ -206,6 +222,14 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
                       </td>
                       <td className="px-2 py-4">
                         <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => copySecretRef(secret.secretRef ?? `db://${secret.slug}`)}
+                            className="btn btn-sm btn-outline"
+                            aria-label={`Copy SecretRef for ${secret.slug}`}
+                          >
+                            Copy
+                          </button>
                           <button
                             type="button"
                             onClick={() => {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5793,6 +5793,8 @@ export interface components {
             createdAt: string;
             /** Updatedat */
             updatedAt?: string | null;
+            /** Secretref */
+            readonly secretRef: string;
         };
         /**
          * SecretStatusUpdateRequest
@@ -8894,7 +8896,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        [key: string]: boolean;
+                        [key: string]: unknown;
                     };
                 };
             };

--- a/specs/270-secret-safe-settings-managed-secrets/checklists/requirements.md
+++ b/specs/270-secret-safe-settings-managed-secrets/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Secret-Safe Settings and Managed Secrets Workflows
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated on 2026-04-28. The spec preserves the MM-540 trusted Jira preset brief and defines one runtime story.

--- a/specs/270-secret-safe-settings-managed-secrets/contracts/secret-safe-settings-contract.md
+++ b/specs/270-secret-safe-settings-managed-secrets/contracts/secret-safe-settings-contract.md
@@ -1,0 +1,43 @@
+# Contract: Secret-Safe Settings and Managed Secrets
+
+## Managed Secret Metadata
+
+`GET /api/v1/secrets` and mutating secret endpoints return metadata items:
+
+```json
+{
+  "slug": "github-pat-main",
+  "secretRef": "db://github-pat-main",
+  "status": "active",
+  "details": {},
+  "createdAt": "2026-04-28T00:00:00Z",
+  "updatedAt": "2026-04-28T00:00:00Z"
+}
+```
+
+The response must not include `ciphertext`, `plaintext`, decrypted values, tokens, auth headers, private keys, or credential-bearing generated config.
+
+## Secret Validation
+
+`GET /api/v1/secrets/{slug}/validate` returns a redacted diagnostic envelope:
+
+```json
+{
+  "valid": true,
+  "status": "active",
+  "checkedAt": "2026-04-28T00:00:00Z",
+  "diagnostics": [
+    {
+      "code": "secret_ref_resolvable",
+      "message": "Managed secret is active.",
+      "severity": "info"
+    }
+  ]
+}
+```
+
+Missing or inactive secrets return `valid: false` with redacted diagnostics and never include plaintext.
+
+## Settings SecretRef Diagnostics
+
+Settings catalog and effective responses for `db://<slug>` values report explicit diagnostics when the backing managed secret is missing or not active. Generic settings still return the SecretRef string only.

--- a/specs/270-secret-safe-settings-managed-secrets/data-model.md
+++ b/specs/270-secret-safe-settings-managed-secrets/data-model.md
@@ -1,0 +1,28 @@
+# Data Model: Secret-Safe Settings and Managed Secrets Workflows
+
+## ManagedSecret
+
+- Existing table: `managed_secrets`.
+- Existing fields: `slug`, encrypted `ciphertext`, `status`, `details`, `created_at`, `updated_at`.
+- Browser-visible metadata derives `secretRef` as `db://<slug>`.
+- Browser-visible metadata must not include `ciphertext` or plaintext.
+
+## SecretRef
+
+- Reference string stored in settings or profile bindings.
+- `db://<slug>` references a `ManagedSecret` by slug.
+- `env://<name>` references an environment-provided secret.
+- Generic settings store the string only and do not resolve plaintext.
+
+## SecretValidationDiagnostic
+
+- `valid`: boolean result.
+- `status`: normalized non-secret result, such as `active`, `missing`, `disabled`, `rotated`, `deleted`, or `invalid`.
+- `checkedAt`: timestamp of validation.
+- `diagnostics`: list of code/message/severity objects with no plaintext.
+
+## State Rules
+
+- Active managed secret refs are valid for generic binding.
+- Missing, disabled, deleted, invalid, or rotated refs are explicit diagnostics for Settings.
+- Replacement and rotation update encrypted value but response remains metadata-only.

--- a/specs/270-secret-safe-settings-managed-secrets/moonspec-align-report.md
+++ b/specs/270-secret-safe-settings-managed-secrets/moonspec-align-report.md
@@ -1,0 +1,23 @@
+# MoonSpec Alignment Report
+
+**Date**: 2026-04-28
+**Feature**: `270-secret-safe-settings-managed-secrets`
+**Issue**: MM-540
+
+## Scope
+
+Post-task-generation alignment checked `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/secret-safe-settings-contract.md`, `quickstart.md`, `tasks.md`, and `verification.md` for drift after implementation.
+
+## Findings and Remediation
+
+| Finding | Remediation |
+| --- | --- |
+| `plan.md` still described several requirements as `partial` or `missing` even though implementation and verification evidence exists. | Updated the Requirement Status table to `implemented_verified` with implementation evidence and preservation-only planned work. |
+| `tasks.md` top-level unit command omitted `tests/unit/services/test_settings_catalog.py`, while validation tasks and quickstart included it. | Added the Settings catalog unit test file to the top-level unit command. |
+| `quickstart.md` used `npm run ui:test -- ...`, but the successful focused frontend evidence used the local Vitest binary and the repo test wrapper. | Updated quickstart to the verified local Vitest command while preserving the repo wrapper command. |
+
+## Gate Notes
+
+`.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` cannot locate the active feature because the current branch is `run-jira-orchestrate-for-mm-540-secret-s-f583acc5` rather than a numeric MoonSpec feature branch. Alignment used `.specify/feature.json`, which points at `specs/270-secret-safe-settings-managed-secrets`.
+
+No downstream artifact regeneration was required after remediation because changes were evidence/status and validation-command alignment only.

--- a/specs/270-secret-safe-settings-managed-secrets/plan.md
+++ b/specs/270-secret-safe-settings-managed-secrets/plan.md
@@ -39,7 +39,7 @@ Close the remaining secret-safety gaps in the existing Settings and Managed Secr
 - **Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, React, TanStack Query, Vitest, pytest.
 - **Storage**: Existing `managed_secrets` and settings override tables; no new persistent tables.
 - **Unit Testing**: pytest for API/service behavior; Vitest/Testing Library for frontend component behavior.
-- **Integration Testing**: Existing API route tests via FastAPI TestClient / AsyncClient and Settings API route tests.
+- **Integration Testing**: Existing FastAPI route tests via TestClient / AsyncClient, Settings API route tests, and the repo unit wrapper with `--ui-args` to execute the focused React component test alongside backend coverage.
 - **Target Platform**: Mission Control Settings page and MoonMind API.
 - **Project Type**: Web application plus API service.
 - **Performance Goals**: Secret metadata and diagnostics remain bounded list/detail responses; no plaintext is serialized.

--- a/specs/270-secret-safe-settings-managed-secrets/plan.md
+++ b/specs/270-secret-safe-settings-managed-secrets/plan.md
@@ -13,25 +13,25 @@ Close the remaining secret-safety gaps in the existing Settings and Managed Secr
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | `frontend/src/components/secrets/SecretManager.tsx` clears create/update plaintext; rotate flow closes modal | Add tests preserving one-way behavior while modifying UI | frontend unit |
-| FR-002 | partial | `SecretMetadataResponse` omits ciphertext but lacks `secretRef` | Add `secretRef` to metadata response derived from slug | API unit |
-| FR-003 | missing | Secret list shows slug/status/actions only | Add copy SecretRef action and UI test | frontend unit |
+| FR-001 | implemented_verified | `frontend/src/components/secrets/SecretManager.tsx` keeps plaintext write-only and `frontend/src/components/secrets/SecretManager.test.tsx` asserts plaintext is not rendered. | Preserve with final verification | frontend unit |
+| FR-002 | implemented_verified | `SecretMetadataResponse.secretRef` derives `db://<slug>` from metadata and API tests assert plaintext/ciphertext are absent. | Preserve with final verification | API unit |
+| FR-003 | implemented_verified | Managed Secrets UI displays and copies canonical `db://<slug>` SecretRefs. | Preserve with final verification | frontend unit |
 | FR-004 | implemented_verified | `api_service/services/settings_catalog.py`, `tests/unit/api_service/api/routers/test_settings_api.py` reject raw secret refs | Preserve with final verification | existing pytest |
 | FR-005 | implemented_verified | `integrations.github.token_ref` stores `env://` and backend returns reference only | Preserve with final verification | existing pytest |
-| FR-006 | partial | `GET /api/v1/secrets/{slug}/validate` returns only `{valid}` after plaintext lookup | Add redacted diagnostic response with status and timestamp | API unit |
-| FR-007 | partial | Settings catalog diagnoses missing `env://`; `db://` status not checked | Add `db://` managed-secret diagnostics for missing/inactive refs | service/API unit |
+| FR-006 | implemented_verified | `GET /api/v1/secrets/{slug}/validate` returns metadata-only diagnostics with status and timestamp. | Preserve with final verification | API unit |
+| FR-007 | implemented_verified | Settings catalog primes managed-secret metadata and diagnoses active, missing, and inactive `db://` refs. | Preserve with final verification | service/API unit |
 | FR-008 | implemented_verified | Registry only exposes explicit SecretRef descriptor; unsafe payload scan exists | Preserve with final verification | existing pytest |
 | FR-009 | implemented_verified | Settings PATCH uses catalog descriptors and auth dependencies | Preserve with final verification | existing pytest |
 | FR-010 | implemented_verified | MM-540 preserved in `spec.md` | Preserve in downstream artifacts and verification | traceability review |
-| SC-001 | partial | Existing metadata tests assert no ciphertext; validation response too small | Add response redaction assertions for create/list/validate | API unit |
-| SC-002 | missing | No SecretRef copy action | Add UI copy test and implementation | frontend unit |
+| SC-001 | implemented_verified | API/service tests assert `secretRef` metadata, validation diagnostics, and no plaintext/ciphertext exposure. | Preserve with final verification | API unit |
+| SC-002 | implemented_verified | Frontend test asserts SecretRef display/copy behavior and plaintext suppression. | Preserve with final verification | frontend unit |
 | SC-003 | implemented_verified | Existing test rejects `ghp_raw_plaintext` | Preserve with final verification | existing pytest |
-| SC-004 | partial | Missing `env://` diagnostics; no `db://` inactive diagnostics | Add managed secret status diagnostics | service/API unit |
+| SC-004 | implemented_verified | Settings API tests cover active, disabled, and missing `db://` diagnostics. | Preserve with final verification | service/API unit |
 | SC-005 | implemented_verified | MM-540 and source IDs present in `spec.md` | Preserve through tasks and final verification | traceability review |
-| DESIGN-REQ-002 | partial | Secrets service owns storage/resolution; Settings UI exposes workflows | Keep changes at API/UI boundary without redefining storage | API + UI unit |
+| DESIGN-REQ-002 | implemented_verified | Secrets service owns metadata validation and Settings UI exposes references without redefining storage. | Preserve with final verification | API + UI unit |
 | DESIGN-REQ-010 | implemented_verified | Generic override rejection and SecretRef storage exist | Preserve and cover `db://` diagnostics | API/service unit |
-| DESIGN-REQ-011 | partial | No plaintext readback mostly exists; validation diagnostics need redacted shape | Add redacted validation response and UI SecretRef reference | API + UI unit |
-| DESIGN-REQ-018 | partial | Most security requirements exist; validation diagnostics and db diagnostics incomplete | Add focused hardening | API/service unit |
+| DESIGN-REQ-011 | implemented_verified | Managed-secret metadata, validation, and UI display expose references and diagnostics without plaintext readback. | Preserve with final verification | API + UI unit |
+| DESIGN-REQ-018 | implemented_verified | Validation and broken-reference diagnostics are redacted and tested for `db://` SecretRefs. | Preserve with final verification | API/service unit |
 
 ## Technical Context
 

--- a/specs/270-secret-safe-settings-managed-secrets/plan.md
+++ b/specs/270-secret-safe-settings-managed-secrets/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Secret-Safe Settings and Managed Secrets Workflows
+
+**Branch**: `270-secret-safe-settings-managed-secrets`
+**Date**: 2026-04-28
+**Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime spec from MM-540 Jira preset brief.
+
+## Summary
+
+Close the remaining secret-safety gaps in the existing Settings and Managed Secrets surfaces. The backend already stores managed secrets encrypted, suppresses ciphertext in metadata responses, and rejects raw secret-like generic setting overrides. The missing runtime behavior is narrower: expose canonical `db://<slug>` references in secret metadata and UI copy actions, return redacted validation diagnostics rather than a bare boolean, and diagnose `db://` SecretRefs whose backing managed secret is missing or inactive. Validation will use focused API/service tests plus a frontend component test for copyable SecretRefs.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `frontend/src/components/secrets/SecretManager.tsx` clears create/update plaintext; rotate flow closes modal | Add tests preserving one-way behavior while modifying UI | frontend unit |
+| FR-002 | partial | `SecretMetadataResponse` omits ciphertext but lacks `secretRef` | Add `secretRef` to metadata response derived from slug | API unit |
+| FR-003 | missing | Secret list shows slug/status/actions only | Add copy SecretRef action and UI test | frontend unit |
+| FR-004 | implemented_verified | `api_service/services/settings_catalog.py`, `tests/unit/api_service/api/routers/test_settings_api.py` reject raw secret refs | Preserve with final verification | existing pytest |
+| FR-005 | implemented_verified | `integrations.github.token_ref` stores `env://` and backend returns reference only | Preserve with final verification | existing pytest |
+| FR-006 | partial | `GET /api/v1/secrets/{slug}/validate` returns only `{valid}` after plaintext lookup | Add redacted diagnostic response with status and timestamp | API unit |
+| FR-007 | partial | Settings catalog diagnoses missing `env://`; `db://` status not checked | Add `db://` managed-secret diagnostics for missing/inactive refs | service/API unit |
+| FR-008 | implemented_verified | Registry only exposes explicit SecretRef descriptor; unsafe payload scan exists | Preserve with final verification | existing pytest |
+| FR-009 | implemented_verified | Settings PATCH uses catalog descriptors and auth dependencies | Preserve with final verification | existing pytest |
+| FR-010 | implemented_verified | MM-540 preserved in `spec.md` | Preserve in downstream artifacts and verification | traceability review |
+| SC-001 | partial | Existing metadata tests assert no ciphertext; validation response too small | Add response redaction assertions for create/list/validate | API unit |
+| SC-002 | missing | No SecretRef copy action | Add UI copy test and implementation | frontend unit |
+| SC-003 | implemented_verified | Existing test rejects `ghp_raw_plaintext` | Preserve with final verification | existing pytest |
+| SC-004 | partial | Missing `env://` diagnostics; no `db://` inactive diagnostics | Add managed secret status diagnostics | service/API unit |
+| SC-005 | implemented_verified | MM-540 and source IDs present in `spec.md` | Preserve through tasks and final verification | traceability review |
+| DESIGN-REQ-002 | partial | Secrets service owns storage/resolution; Settings UI exposes workflows | Keep changes at API/UI boundary without redefining storage | API + UI unit |
+| DESIGN-REQ-010 | implemented_verified | Generic override rejection and SecretRef storage exist | Preserve and cover `db://` diagnostics | API/service unit |
+| DESIGN-REQ-011 | partial | No plaintext readback mostly exists; validation diagnostics need redacted shape | Add redacted validation response and UI SecretRef reference | API + UI unit |
+| DESIGN-REQ-018 | partial | Most security requirements exist; validation diagnostics and db diagnostics incomplete | Add focused hardening | API/service unit |
+
+## Technical Context
+
+- **Language/Version**: Python 3.12 and TypeScript/React.
+- **Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, React, TanStack Query, Vitest, pytest.
+- **Storage**: Existing `managed_secrets` and settings override tables; no new persistent tables.
+- **Unit Testing**: pytest for API/service behavior; Vitest/Testing Library for frontend component behavior.
+- **Integration Testing**: Existing API route tests via FastAPI TestClient / AsyncClient and Settings API route tests.
+- **Target Platform**: Mission Control Settings page and MoonMind API.
+- **Project Type**: Web application plus API service.
+- **Performance Goals**: Secret metadata and diagnostics remain bounded list/detail responses; no plaintext is serialized.
+- **Constraints**: Do not redefine Secrets System semantics, expose plaintext, add raw credential fields to generic settings, or trust client-supplied descriptor metadata.
+- **Scale/Scope**: One hardening story over existing managed-secret metadata, validation, and SecretRef diagnostics.
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Existing Settings and Secrets surfaces are extended at their boundaries.
+- **II. One-Click Agent Deployment**: PASS. No new dependency or setup step.
+- **III. Avoid Vendor Lock-In**: PASS. SecretRefs remain backend-neutral.
+- **IV. Own Your Data**: PASS. Managed secrets remain in operator-controlled storage.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime changes.
+- **VI. Replaceable Scaffolding**: PASS. Small boundary hardening, no broad framework.
+- **VII. Powerful Runtime Configurability**: PASS. SecretRefs remain runtime configuration references.
+- **VIII. Modular and Extensible Architecture**: PASS. API schema/service/UI component changes remain scoped.
+- **IX. Resilient by Default**: PASS. Broken SecretRefs become explicit diagnostics.
+- **X. Facilitate Continuous Improvement**: PASS. Validation results become operator-readable and redacted.
+- **XI. Spec-Driven Development**: PASS. Spec, plan, tasks, tests, implementation, and verification are ordered.
+- **XII. Documentation Separation**: PASS. Canonical docs are source requirements; runtime work stays in feature artifacts.
+- **XIII. Pre-Release Velocity**: PASS. No compatibility alias is introduced for internal contracts.
+
+## Project Structure
+
+```text
+api_service/api/schemas.py
+api_service/api/routers/secrets.py
+api_service/services/secrets.py
+api_service/services/settings_catalog.py
+frontend/src/components/secrets/SecretManager.tsx
+frontend/src/components/secrets/SecretManager.test.tsx
+tests/unit/api/test_secrets_api.py
+tests/unit/services/test_secrets.py
+tests/unit/api_service/api/routers/test_settings_api.py
+specs/270-secret-safe-settings-managed-secrets/
+```
+
+## Phase 0 Research
+
+See [research.md](./research.md).
+
+## Phase 1 Design
+
+See [data-model.md](./data-model.md), [contracts/secret-safe-settings-contract.md](./contracts/secret-safe-settings-contract.md), and [quickstart.md](./quickstart.md).
+
+## Complexity Tracking
+
+No constitution violations or added complexity exceptions.

--- a/specs/270-secret-safe-settings-managed-secrets/quickstart.md
+++ b/specs/270-secret-safe-settings-managed-secrets/quickstart.md
@@ -1,0 +1,15 @@
+# Quickstart: Secret-Safe Settings and Managed Secrets Workflows
+
+1. Create a managed secret through Settings or `POST /api/v1/secrets`.
+2. Confirm list and create responses include `secretRef: "db://<slug>"` and omit plaintext/ciphertext.
+3. Copy the SecretRef from Managed Secrets and bind it to a SecretRef setting such as `integrations.github.token_ref`.
+4. Validate the secret with `GET /api/v1/secrets/{slug}/validate` and confirm redacted diagnostics.
+5. Disable the secret and reload the Settings catalog/effective value for the bound setting; confirm an explicit inactive/broken diagnostic appears.
+
+Validation commands:
+
+```bash
+pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py -q
+npm run ui:test -- frontend/src/components/secrets/SecretManager.test.tsx
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx
+```

--- a/specs/270-secret-safe-settings-managed-secrets/quickstart.md
+++ b/specs/270-secret-safe-settings-managed-secrets/quickstart.md
@@ -10,6 +10,6 @@ Validation commands:
 
 ```bash
 pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q
-npm run ui:test -- frontend/src/components/secrets/SecretManager.test.tsx
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/secrets/SecretManager.test.tsx
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx
 ```

--- a/specs/270-secret-safe-settings-managed-secrets/quickstart.md
+++ b/specs/270-secret-safe-settings-managed-secrets/quickstart.md
@@ -9,7 +9,7 @@
 Validation commands:
 
 ```bash
-pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py -q
+pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q
 npm run ui:test -- frontend/src/components/secrets/SecretManager.test.tsx
-MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx
 ```

--- a/specs/270-secret-safe-settings-managed-secrets/research.md
+++ b/specs/270-secret-safe-settings-managed-secrets/research.md
@@ -1,0 +1,49 @@
+# Research: Secret-Safe Settings and Managed Secrets Workflows
+
+## FR-001 / One-Way Plaintext Submission
+
+Decision: Keep plaintext submission limited to existing create, update, and rotate request bodies and verify UI state clears after successful mutation.
+Evidence: `frontend/src/components/secrets/SecretManager.tsx`, `api_service/api/routers/secrets.py`.
+Rationale: The existing surface already uses password inputs and clears create/update state. The story does not require a new secret backend.
+Alternatives considered: Introducing a separate Settings-specific secret create endpoint was rejected because the Secrets System remains authoritative.
+Test implications: Frontend unit coverage.
+
+## FR-002 / Metadata Includes SecretRef
+
+Decision: Add a derived `secretRef` field to safe secret metadata responses.
+Evidence: `api_service/api/schemas.py` currently returns slug, status, details, createdAt, and updatedAt, but no canonical reference.
+Rationale: The UI should show and copy `db://<slug>` without deriving inconsistent references in multiple components.
+Alternatives considered: Deriving only in React was rejected because API consumers also need canonical metadata.
+Test implications: API unit coverage.
+
+## FR-003 / Copy SecretRef UI
+
+Decision: Add a row action in `SecretManager` that copies `db://<slug>` and reports success or failure without reading plaintext.
+Evidence: `frontend/src/components/secrets/SecretManager.tsx` currently has Edit, Rotate, and Delete actions only.
+Rationale: The brief explicitly requires showing metadata plus SecretRef after one-way submission.
+Alternatives considered: Showing only static text was rejected because the source workflow includes copying SecretRefs.
+Test implications: Vitest/Testing Library component test.
+
+## FR-004 / Raw Secret Rejection
+
+Decision: Preserve existing backend rejection of secret-shaped generic overrides.
+Evidence: `tests/unit/api_service/api/routers/test_settings_api.py::test_secret_ref_reference_allowed_but_raw_secret_rejected`.
+Rationale: Existing test evidence already covers this behavior.
+Alternatives considered: Adding duplicate validation in the frontend was rejected because the backend is authoritative.
+Test implications: Existing pytest plus final verification.
+
+## FR-006 / Redacted Validation Diagnostics
+
+Decision: Replace the bare validation response with a redacted diagnostic envelope containing `valid`, `status`, `checkedAt`, and non-secret diagnostics.
+Evidence: `api_service/api/routers/secrets.py` currently returns only `{ "valid": bool }`.
+Rationale: The story requires redacted diagnostics and a timestamp while preventing plaintext readback.
+Alternatives considered: Returning provider-specific validation detail was rejected for this story because no provider context is supplied by the endpoint.
+Test implications: API unit coverage for active and missing/inactive secrets, plus redaction assertions.
+
+## FR-007 / `db://` SecretRef Diagnostics
+
+Decision: Extend `SettingsCatalogService` to inspect managed-secret metadata for `db://` references when a session is available and report missing or inactive statuses.
+Evidence: `api_service/services/settings_catalog.py` currently diagnoses missing `env://` values and syntactically invalid references, but not `db://` managed-secret status.
+Rationale: Settings catalog/effective responses are where generic SecretRef settings surface broken-reference state.
+Alternatives considered: Resolving plaintext through `SecretsService.get_secret` was rejected because diagnostics only need metadata/status and should not decrypt values.
+Test implications: Settings API route test with active and disabled managed secret rows.

--- a/specs/270-secret-safe-settings-managed-secrets/spec.md
+++ b/specs/270-secret-safe-settings-managed-secrets/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Secret-Safe Settings and Managed Secrets Workflows
+
+**Feature Branch**: `270-secret-safe-settings-managed-secrets`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-540 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-540 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-540
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Secret-safe Settings and Managed Secrets workflows
+- Labels: moonmind-workflow-mm-285619b3-4c87-4e03-944f-282e648fa000
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-540 from MM project
+Summary: Secret-safe Settings and Managed Secrets workflows
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Security/SettingsSystem.md
+Source Title: Settings System
+Source Sections:
+- 2.2 What the Secrets System owns
+- 5.3 References Over Secrets
+- 7.9 SecretRef Setting
+- 10.4 SecretRef Resolution
+- 14. Secrets Integration
+- 22. Security Requirements
+Coverage IDs:
+- DESIGN-REQ-002
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-018
+
+As a secret manager or workspace admin, I can create and bind managed secrets from Settings while generic settings store only SecretRefs and never reveal plaintext after submission.
+
+Acceptance Criteria
+- Generic overrides reject API keys, access tokens, refresh tokens, passwords, private keys, OAuth state, and credential-bearing generated config.
+- Secret-like backend fields are hidden unless explicitly represented as SecretRef pickers or managed through the Managed Secrets creation/replacement flow.
+- Managed secret create and replace flows accept plaintext only as one-way submissions, then clear browser input and show metadata plus SecretRef.
+- Secret validation resolves plaintext only in memory at controlled execution boundaries, discards it, stores redacted metadata, and returns redacted diagnostics.
+- Broken, disabled, revoked, or missing SecretRefs are surfaced clearly and prevent affected launches where appropriate.
+
+Requirements
+- Settings must not redefine SecretRef semantics, secret storage, encryption at rest, root key custody, backend classes, resolution, rotation, revocation, audit, or plaintext redaction rules.
+- SecretRef values are security-relevant metadata and must be access controlled.
+- Settings APIs must ignore client-supplied descriptor metadata and enforce session/CSRF protections appropriate to MoonMind auth.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-540 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable Settings and Managed Secrets workflow.
+- Selected mode: Runtime.
+- Source design: `docs/Security/SettingsSystem.md` is treated as runtime source requirements.
+- Resume decision: No existing Moon Spec artifacts for `MM-540` were found under `specs/`; specification is the first incomplete stage.
+- Multi-spec ordering: Not applicable for `MM-540`.
+
+## User Story - Create and Bind SecretRefs Safely
+
+**Summary**: As a secret manager or workspace admin, I can create and bind managed secrets from Settings while generic settings store only SecretRefs and never reveal plaintext after submission.
+
+**Goal**: MoonMind lets authorized Settings users submit plaintext only through managed-secret create or replacement flows, returns secret metadata and copyable SecretRefs rather than plaintext, validates SecretRefs through controlled backend resolution, and prevents generic settings overrides from persisting raw credentials.
+
+**Independent Test**: Through Settings, create a managed secret with plaintext, verify the response and UI show metadata plus `db://<slug>` but not the plaintext, bind that SecretRef to a generic setting, validate active and disabled SecretRefs, and confirm raw credential-shaped generic overrides are rejected and redacted from responses.
+
+### Acceptance Scenarios
+
+1. **Given** a workspace admin creates a managed secret from Settings, **When** the create request succeeds, **Then** the browser-visible response and list show metadata and `db://<slug>` while never rendering the submitted plaintext.
+2. **Given** a user replaces or rotates an existing managed secret value, **When** the operation completes, **Then** plaintext input is cleared and the UI continues to show only status, timestamps, and the SecretRef.
+3. **Given** a generic SecretRef setting, **When** a user submits `db://<slug>` for an active managed secret, **Then** the setting stores only the reference and does not resolve or persist plaintext.
+4. **Given** a generic setting receives a raw API key, token, password, private key, OAuth state, or credential-bearing config value, **When** the override is submitted, **Then** the backend rejects it with a sanitized validation error and no partial override is stored.
+5. **Given** a SecretRef points at a missing, disabled, revoked, deleted, or invalid managed secret, **When** Settings resolves catalog or validation diagnostics, **Then** the UI surfaces a broken SecretRef state and affected launch checks can block rather than silently falling back.
+
+### Edge Cases
+
+- Empty plaintext create and replacement submissions are rejected before persistence.
+- SecretRef metadata is treated as security-relevant and never used to grant authorization.
+- Secret validation failures do not echo the submitted plaintext or decrypted secret.
+- Existing provider-profile secret flows remain owned by Provider Profiles and are not redefined by generic Settings.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Managed secret create, replace, and rotate flows MUST accept plaintext only as one-way submissions and clear browser-held plaintext after completion.
+- **FR-002**: Managed secret list and mutation responses MUST expose metadata and a canonical `db://<slug>` SecretRef while never exposing ciphertext or plaintext.
+- **FR-003**: The Settings UI MUST provide a copyable SecretRef affordance for managed secrets without exposing the stored secret value.
+- **FR-004**: Generic settings overrides MUST reject raw API keys, access tokens, refresh tokens, passwords, private keys, OAuth state, and credential-bearing generated config.
+- **FR-005**: Generic SecretRef settings MUST store and return only SecretRef strings, not resolved plaintext.
+- **FR-006**: Secret validation MUST resolve plaintext only in controlled backend code, discard it before responding, and return redacted diagnostics including status and timestamp.
+- **FR-007**: Missing, disabled, rotated, deleted, invalid, or otherwise unresolved `db://` SecretRefs MUST produce explicit diagnostics in Settings catalog/effective responses.
+- **FR-008**: Secret-like backend fields MUST be hidden from generic settings unless represented as SecretRef settings or handled by Managed Secrets / Provider Profile specialized flows.
+- **FR-009**: Settings APIs MUST ignore client-supplied descriptor metadata and enforce existing session/auth boundaries for secret-related settings.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-540` and this canonical Jira preset brief.
+
+### Key Entities
+
+- **ManagedSecret**: A durable encrypted secret record with slug, lifecycle status, metadata, and timestamps. Browser-visible surfaces expose only metadata plus a derived SecretRef.
+- **SecretRef**: A security-relevant reference string, such as `db://github-pat-main`, stored in settings or provider bindings instead of plaintext.
+- **SettingsOverride**: A scoped setting value that may store allowed JSON values and SecretRefs but must not store raw credentials.
+- **SecretValidationDiagnostic**: A redacted validation result for a SecretRef or managed secret, including status, timestamp, and non-secret diagnostics.
+
+## Assumptions
+
+- Existing Secrets System encryption, resolver, and provider-profile semantics remain authoritative.
+- This story extends existing Settings and Managed Secrets surfaces rather than introducing a new secret backend.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-002 | `docs/Security/SettingsSystem.md` section 2.2 | Settings may expose secret workflows and SecretRef pickers but must not redefine storage, decryption, resolution, rotation, revocation, audit, or plaintext redaction semantics owned by the Secrets System. | In scope | FR-001, FR-006, FR-008 |
+| DESIGN-REQ-010 | `docs/Security/SettingsSystem.md` sections 5.3 and 7.9 | Sensitive settings must store references, not raw values; SecretRef settings store reference strings while the referenced value remains outside the setting override. | In scope | FR-004, FR-005, FR-007 |
+| DESIGN-REQ-011 | `docs/Security/SettingsSystem.md` sections 10.4 and 14 | Plaintext resolution happens only at controlled execution or validation boundaries; Settings shows metadata, usage, validation, and broken-reference states without plaintext readback. | In scope | FR-002, FR-003, FR-006, FR-007 |
+| DESIGN-REQ-018 | `docs/Security/SettingsSystem.md` section 22 | Security requirements forbid raw secrets in generic overrides, browser plaintext readback, unmanaged secret-like fields, client-supplied descriptor trust, and unredacted validation diagnostics. | In scope | FR-001, FR-002, FR-004, FR-006, FR-008, FR-009 |
+
+## Success Criteria
+
+- **SC-001**: Secret create, update, rotate, list, and validate responses contain zero instances of submitted plaintext or decrypted secret values in tests.
+- **SC-002**: The Managed Secrets UI shows a canonical `db://<slug>` reference for each secret and copy action tests prove the copied value is the reference only.
+- **SC-003**: Settings API tests prove raw credential-shaped generic overrides fail and do not persist partial data.
+- **SC-004**: Settings catalog/effective responses report explicit diagnostics for missing and inactive `db://` SecretRefs.
+- **SC-005**: Traceability evidence preserves `MM-540`, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-018 across MoonSpec artifacts and final verification.

--- a/specs/270-secret-safe-settings-managed-secrets/tasks.md
+++ b/specs/270-secret-safe-settings-managed-secrets/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Secret-Safe Settings and Managed Secrets Workflows
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/secret-safe-settings-contract.md](./contracts/secret-safe-settings-contract.md)
+
+**Prerequisites**: Existing Settings API, Secrets API, Managed Secrets service, and Settings UI remain in place.
+
+**Unit Test Command**: `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py -q`
+
+**Integration Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx`
+
+**Source Traceability**: MM-540 and the canonical Jira preset brief are preserved in `spec.md`. Tasks cover FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-018.
+
+## Phase 1: Setup
+
+- [X] T001 Create MoonSpec feature artifacts under `specs/270-secret-safe-settings-managed-secrets/` preserving MM-540 and source design mappings. (FR-010, SC-005)
+- [X] T002 Update `.specify/feature.json` to point at `specs/270-secret-safe-settings-managed-secrets`. (FR-010)
+
+## Phase 2: Foundational
+
+- [X] T003 Add failing API tests for `secretRef` metadata and redacted validation diagnostics in `tests/unit/api/test_secrets_api.py`. (FR-002, FR-006, SC-001, DESIGN-REQ-011, DESIGN-REQ-018)
+- [X] T004 Add failing service tests for metadata-only validation results in `tests/unit/services/test_secrets.py`. (FR-006, SC-001)
+- [X] T005 Add failing Settings API test for active, disabled, and missing `db://` SecretRef diagnostics in `tests/unit/api_service/api/routers/test_settings_api.py`. (FR-005, FR-007, SC-004, DESIGN-REQ-010)
+- [X] T006 Add failing frontend test for Managed Secrets copyable `db://` refs and plaintext suppression in `frontend/src/components/secrets/SecretManager.test.tsx`. (FR-001, FR-002, FR-003, SC-002)
+
+## Phase 3: Story - Create and Bind SecretRefs Safely
+
+**Story Summary**: Secret managers and workspace admins can create managed secrets from Settings, copy and bind SecretRefs, and receive redacted validation/broken-reference diagnostics without plaintext readback.
+
+**Independent Test**: Create/list/validate managed secrets, copy `db://<slug>` in the UI, bind the reference to generic Settings, and verify raw secrets are rejected while missing/inactive refs are diagnosed.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-018.
+
+- [X] T007 Add `secretRef` to safe secret metadata response models in `api_service/api/schemas.py`. (FR-002, SC-001)
+- [X] T008 Implement redacted managed-secret validation result helpers in `api_service/services/secrets.py`. (FR-006, DESIGN-REQ-011)
+- [X] T009 Update `GET /api/v1/secrets/{slug}/validate` in `api_service/api/routers/secrets.py` to return redacted diagnostics. (FR-006, SC-001)
+- [X] T010 Implement `db://` managed-secret status diagnostics in `api_service/services/settings_catalog.py`. (FR-005, FR-007, SC-004)
+- [X] T011 Add Managed Secrets UI SecretRef display and copy action in `frontend/src/components/secrets/SecretManager.tsx`. (FR-001, FR-002, FR-003, SC-002)
+
+## Phase 4: Validation
+
+- [X] T012 Run `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q` and record the result. (SC-001, SC-003, SC-004)
+- [X] T013 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/secrets/SecretManager.test.tsx` and record the result. (SC-002)
+- [X] T014 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx` or record exact blocker. (SC-001, SC-002, SC-003, SC-004)
+- [X] T015 Run final `/moonspec-verify` work and preserve MM-540, source mappings, and test evidence in `specs/270-secret-safe-settings-managed-secrets/verification.md`. (FR-010, SC-005)
+
+## Dependencies and Execution Order
+
+1. T003 through T006 define red-first coverage before production implementation.
+2. T007 through T011 implement the story.
+3. T012 through T015 validate implementation and traceability.
+
+## Implementation Strategy
+
+Keep the change narrowly scoped to existing Secrets and Settings boundaries. Add response metadata and diagnostics without changing encryption, resolver ownership, or provider-profile semantics. Preserve backend authority for generic settings validation and keep UI behavior reference-only.

--- a/specs/270-secret-safe-settings-managed-secrets/tasks.md
+++ b/specs/270-secret-safe-settings-managed-secrets/tasks.md
@@ -4,7 +4,7 @@
 
 **Prerequisites**: Existing Settings API, Secrets API, Managed Secrets service, and Settings UI remain in place.
 
-**Unit Test Command**: `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py -q`
+**Unit Test Command**: `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q`
 
 **Integration Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx`
 

--- a/specs/270-secret-safe-settings-managed-secrets/verification.md
+++ b/specs/270-secret-safe-settings-managed-secrets/verification.md
@@ -1,0 +1,43 @@
+# Verification: Secret-Safe Settings and Managed Secrets Workflows
+
+**Verdict**: FULLY_IMPLEMENTED
+
+**Original Request Source**: trusted Jira preset brief for `MM-540`, preserved in `spec.md`.
+
+## Evidence
+
+| Area | Command / Evidence | Result |
+| --- | --- | --- |
+| Focused backend and service coverage | `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q` | PASS: 45 passed |
+| Focused frontend coverage | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/secrets/SecretManager.test.tsx` | PASS: 1 file, 1 test |
+| Repo unit runner with focused filters | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py --ui-args frontend/src/components/secrets/SecretManager.test.tsx` | PASS: 45 Python tests and 1 frontend test |
+| Full required unit suite | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS: 4132 Python tests, 1 xpassed, 16 subtests; 17 frontend files and 453 frontend tests |
+
+## Requirement Coverage
+
+| ID | Verdict | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `SecretManager` keeps plaintext in create/update/rotate inputs only and clears successful create/update; tests assert UI does not expose submitted secret text. |
+| FR-002 | VERIFIED | `SecretMetadataResponse` derives `secretRef` as `db://<slug>` and tests assert metadata omits plaintext/ciphertext. |
+| FR-003 | VERIFIED | `SecretManager` displays and copies only the canonical SecretRef. |
+| FR-004 | VERIFIED | Existing Settings API tests plus full unit suite confirm raw secret-like generic overrides are rejected and redacted. |
+| FR-005 | VERIFIED | SecretRef settings continue to store and return reference strings only. |
+| FR-006 | VERIFIED | `SecretsService.validate_secret_ref` and `GET /api/v1/secrets/{slug}/validate` return redacted status/timestamp diagnostics. |
+| FR-007 | VERIFIED | Settings catalog/effective responses diagnose missing and inactive `db://` managed-secret refs without plaintext. |
+| FR-008 | VERIFIED | Generic settings remain descriptor-driven; secret-like fields are only exposed as explicit SecretRef descriptors or specialized secret/profile flows. |
+| FR-009 | VERIFIED | Settings API still uses backend descriptors and existing auth/session dependencies; no client descriptor metadata is trusted. |
+| FR-010 | VERIFIED | `MM-540` and source design IDs are preserved across spec, plan, tasks, and this verification report. |
+
+## Source Design Coverage
+
+| Source ID | Status |
+| --- | --- |
+| DESIGN-REQ-002 | VERIFIED |
+| DESIGN-REQ-010 | VERIFIED |
+| DESIGN-REQ-011 | VERIFIED |
+| DESIGN-REQ-018 | VERIFIED |
+
+## Notes
+
+- A direct `npm run ui:test -- frontend/src/components/secrets/SecretManager.test.tsx` failed to resolve `vitest` in this shell, while the local binary and repo test runner both resolved it and passed after `npm ci --no-fund --no-audit`.
+- Full unit output includes existing warnings and one existing `xpass`; no failures remained in the final run.

--- a/tests/unit/api/test_secrets_api.py
+++ b/tests/unit/api/test_secrets_api.py
@@ -38,8 +38,10 @@ def test_create_secret(mock_secrets_service):
     assert resp.status_code == 201
     data = resp.json()
     assert data["slug"] == "NEW_KEY"
+    assert data["secretRef"] == "db://NEW_KEY"
     assert data["status"] == "active"
     assert "ciphertext" not in data
+    assert "new-secret-val" not in resp.text
 
 def test_create_secret_conflict(mock_secrets_service):
     from api_service.db.models import ManagedSecret
@@ -65,6 +67,7 @@ def test_list_secrets(mock_secrets_service):
     data = resp.json()
     assert len(data["items"]) == 1
     assert data["items"][0]["slug"] == "TEST_API_KEY"
+    assert data["items"][0]["secretRef"] == "db://TEST_API_KEY"
 
 def test_update_secret(mock_secrets_service):
     from api_service.db.models import ManagedSecret
@@ -113,11 +116,54 @@ def test_delete_secret(mock_secrets_service):
     assert resp.status_code == 204
 
 def test_validate_secret(mock_secrets_service):
-    from api_service.db.models import ManagedSecret
-    
-    mock_secret = ManagedSecret()
-    mock_secrets_service.get_secret.return_value = mock_secret
+    mock_secrets_service.validate_secret_ref.return_value = {
+        "valid": True,
+        "status": "active",
+        "checkedAt": "2026-04-28T00:00:00+00:00",
+        "diagnostics": [
+            {
+                "code": "secret_ref_resolvable",
+                "message": "Managed secret is active.",
+                "severity": "info",
+            }
+        ],
+    }
     
     resp = client.get("/api/v1/secrets/TEST_API_KEY/validate")
     assert resp.status_code == 200
-    assert resp.json()["valid"] is True
+    assert resp.json() == {
+        "valid": True,
+        "status": "active",
+        "checkedAt": "2026-04-28T00:00:00+00:00",
+        "diagnostics": [
+            {
+                "code": "secret_ref_resolvable",
+                "message": "Managed secret is active.",
+                "severity": "info",
+            }
+        ],
+    }
+
+
+def test_validate_secret_response_is_redacted(mock_secrets_service):
+    raw_secret = "sk-test-secret-value"
+    mock_secrets_service.validate_secret_ref.return_value = {
+        "valid": False,
+        "status": "missing",
+        "checkedAt": "2026-04-28T00:00:00+00:00",
+        "diagnostics": [
+            {
+                "code": "secret_ref_unresolved",
+                "message": f"Managed secret is missing; token={raw_secret}",
+                "severity": "error",
+            }
+        ],
+    }
+
+    resp = client.get("/api/v1/secrets/MISSING_SECRET/validate")
+
+    assert resp.status_code == 200
+    assert raw_secret not in resp.text
+    assert resp.json()["diagnostics"][0]["message"] == (
+        "Managed secret is missing; token=[REDACTED]"
+    )

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api_service.api.routers import settings as settings_router
 from api_service.db import base as db_base
-from api_service.db.models import Base, ManagedSecret
+from api_service.db.models import Base, ManagedSecret, SecretStatus
 from api_service.main import app
 
 
@@ -382,3 +382,89 @@ async def test_secret_ref_reference_allowed_but_raw_secret_rejected(settings_api
     assert rejected.status_code == 400
     assert rejected.json()["error"] == "invalid_setting_value"
     assert "ghp_raw_plaintext" not in rejected.text
+
+
+@pytest.mark.asyncio
+async def test_db_secret_ref_catalog_diagnostics_report_missing_and_inactive(settings_api_db):
+    async with settings_api_db() as session:
+        session.add(
+            ManagedSecret(
+                slug="active-github-token",
+                ciphertext="active-plaintext",
+                status=SecretStatus.ACTIVE,
+                details={},
+            )
+        )
+        session.add(
+            ManagedSecret(
+                slug="disabled-github-token",
+                ciphertext="disabled-plaintext",
+                status=SecretStatus.DISABLED,
+                details={},
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        active = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "integrations.github.token_ref": "db://active-github-token"
+                },
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        disabled = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "integrations.github.token_ref": "db://disabled-github-token"
+                },
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        missing = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "integrations.github.token_ref": "db://missing-github-token"
+                },
+                "expected_versions": {"integrations.github.token_ref": 2},
+            },
+        )
+
+    active_value = active.json()["values"]["integrations.github.token_ref"]
+    disabled_value = disabled.json()["values"]["integrations.github.token_ref"]
+    missing_value = missing.json()["values"]["integrations.github.token_ref"]
+
+    assert active.status_code == 200
+    assert active_value["diagnostics"] == []
+    assert "active-plaintext" not in active.text
+    assert disabled.status_code == 200
+    assert disabled_value["diagnostics"] == [
+        {
+            "code": "unresolved_secret_ref",
+            "message": (
+                "integrations.github.token_ref references a managed secret "
+                "that is disabled."
+            ),
+            "severity": "error",
+            "details": {"ref_scheme": "db", "status": "disabled"},
+        }
+    ]
+    assert "disabled-plaintext" not in disabled.text
+    assert missing.status_code == 200
+    assert missing_value["diagnostics"] == [
+        {
+            "code": "unresolved_secret_ref",
+            "message": (
+                "integrations.github.token_ref references a managed secret "
+                "that does not exist."
+            ),
+            "severity": "error",
+            "details": {"ref_scheme": "db", "status": "missing"},
+        }
+    ]

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -111,14 +111,8 @@ async def test_get_secret(mock_db_session):
 @pytest.mark.asyncio
 async def test_validate_secret_ref_returns_redacted_active_diagnostic(mock_db_session):
     slug = "test-secret"
-    existing_secret = ManagedSecret(
-        slug=slug,
-        ciphertext="sk-test-secret-value",
-        status=SecretStatus.ACTIVE,
-    )
-
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = existing_secret
+    mock_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
 
     async def mock_execute(*args, **kwargs):
         return mock_result
@@ -130,7 +124,9 @@ async def test_validate_secret_ref_returns_redacted_active_diagnostic(mock_db_se
     assert result["valid"] is True
     assert result["status"] == "active"
     assert result["diagnostics"][0]["code"] == "secret_ref_resolvable"
-    assert "sk-test-secret-value" not in str(result)
+    execute_statement = mock_db_session.execute.call_args.args[0]
+    assert "managed_secrets.status" in str(execute_statement)
+    assert "managed_secrets.ciphertext" not in str(execute_statement)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -107,6 +107,52 @@ async def test_get_secret(mock_db_session):
     fetched = await SecretsService.get_secret(mock_db_session, slug)
     assert fetched == "plntxt"
 
+
+@pytest.mark.asyncio
+async def test_validate_secret_ref_returns_redacted_active_diagnostic(mock_db_session):
+    slug = "test-secret"
+    existing_secret = ManagedSecret(
+        slug=slug,
+        ciphertext="sk-test-secret-value",
+        status=SecretStatus.ACTIVE,
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing_secret
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    result = await SecretsService.validate_secret_ref(mock_db_session, slug)
+
+    assert result["valid"] is True
+    assert result["status"] == "active"
+    assert result["diagnostics"][0]["code"] == "secret_ref_resolvable"
+    assert "sk-test-secret-value" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_validate_secret_ref_reports_missing_without_plaintext(mock_db_session):
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    result = await SecretsService.validate_secret_ref(mock_db_session, "missing-secret")
+
+    assert result["valid"] is False
+    assert result["status"] == "missing"
+    assert result["diagnostics"][0] == {
+        "code": "secret_ref_unresolved",
+        "message": "Managed secret is missing.",
+        "severity": "error",
+    }
+
 @pytest.mark.asyncio
 async def test_import_from_env(mock_db_session):
     env_dict = {


### PR DESCRIPTION
## Summary
- add canonical `db://<slug>` SecretRefs to managed secret metadata and the Managed Secrets UI
- return redacted managed-secret validation diagnostics instead of a bare boolean
- diagnose active, missing, and inactive `db://` SecretRefs in Settings responses without exposing plaintext
- preserve MM-540 MoonSpec artifacts, alignment notes, and verification evidence

## Jira Issue
MM-540

## Active MoonSpec Feature Path
`specs/270-secret-safe-settings-managed-secrets`

## Verification Verdict
FULLY_IMPLEMENTED

## Tests Run
- `pytest tests/unit/api/test_secrets_api.py tests/unit/services/test_secrets.py tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py -q`
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/secrets/SecretManager.test.tsx`
- Prior full-suite evidence is recorded in `specs/270-secret-safe-settings-managed-secrets/verification.md`: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining Risks
- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` still expects a numeric MoonSpec feature branch name; this branch is named `run-jira-orchestrate-for-mm-540-secret-s-f583acc5`.
- Direct `npm run ui:test -- frontend/src/components/secrets/SecretManager.test.tsx` could not resolve `vitest` in this shell, while the local Vitest binary and repo unit wrapper passed.