### PR TITLE
MM-541 Provider Profile management and readiness in Settings

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/270-secret-safe-settings-managed-secrets"
+  "feature_directory": "specs/271-provider-profile-readiness-settings"
 }

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -185,10 +185,23 @@ class ProviderProfileResponse(BaseModel):
     enabled: bool
     is_default: bool
     max_lease_duration_seconds: int
+    readiness: "ProviderProfileReadiness"
     created_at: Optional[str]
     updated_at: Optional[str]
 
     model_config = {"from_attributes": True}
+
+class ProviderReadinessCheck(BaseModel):
+    id: str
+    label: str
+    status: str = Field(..., pattern="^(pass|warning|error)$")
+    message: str
+
+class ProviderProfileReadiness(BaseModel):
+    status: str = Field(..., pattern="^(ready|warning|blocked)$")
+    launch_ready: bool
+    summary: str
+    checks: list[ProviderReadinessCheck]
 
 class ClaudeManualAuthCommitRequest(BaseModel):
     token: str = Field(..., min_length=1, max_length=8192)
@@ -242,7 +255,9 @@ async def list_profiles(
 
     result = await session.execute(stmt)
     rows = result.scalars().all()
-    return [_row_to_dict(r) for r in rows if _can_view_profile(r, current_user)]
+    visible_rows = [r for r in rows if _can_view_profile(r, current_user)]
+    secret_statuses = await _managed_secret_statuses_for_rows(session, visible_rows)
+    return [_row_to_dict(r, managed_secret_statuses=secret_statuses) for r in visible_rows]
 
 @router.get("/{profile_id}", response_model=ProviderProfileResponse)
 async def get_profile(
@@ -258,7 +273,8 @@ async def get_profile(
             status_code=403,
             detail="Not authorized to view this provider profile.",
         )
-    return _row_to_dict(row)
+    secret_statuses = await _managed_secret_statuses_for_rows(session, [row])
+    return _row_to_dict(row, managed_secret_statuses=secret_statuses)
 
 @router.post("", response_model=ProviderProfileResponse, status_code=201)
 async def create_profile(
@@ -311,7 +327,8 @@ async def create_profile(
 
     await sync_provider_profile_manager(session=session, runtime_id=body.runtime_id)
 
-    return _row_to_dict(profile)
+    secret_statuses = await _managed_secret_statuses_for_rows(session, [profile])
+    return _row_to_dict(profile, managed_secret_statuses=secret_statuses)
 
 @router.patch("/{profile_id}", response_model=ProviderProfileResponse)
 async def update_profile(
@@ -349,7 +366,8 @@ async def update_profile(
     await session.commit()
     await session.refresh(profile)
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
-    return _row_to_dict(profile)
+    secret_statuses = await _managed_secret_statuses_for_rows(session, [profile])
+    return _row_to_dict(profile, managed_secret_statuses=secret_statuses)
 
 @router.post(
     "/{profile_id}/manual-auth/commit",
@@ -737,7 +755,253 @@ def _get_claude_manual_validation_client() -> httpx.AsyncClient:
         _claude_manual_validation_client = httpx.AsyncClient(timeout=10.0)
     return _claude_manual_validation_client
 
-def _row_to_dict(row: ManagedAgentProviderProfile) -> dict[str, Any]:
+async def _managed_secret_statuses_for_rows(
+    session: AsyncSession,
+    rows: list[ManagedAgentProviderProfile],
+) -> dict[str, str]:
+    slugs: set[str] = set()
+    for row in rows:
+        for value in (row.secret_refs or {}).values():
+            if not isinstance(value, str):
+                continue
+            try:
+                from moonmind.auth.secret_refs import SecretBackend, parse_secret_ref
+
+                parsed = parse_secret_ref(value)
+            except Exception:
+                continue
+            if parsed.backend == SecretBackend.DB_ENCRYPTED:
+                slugs.add(parsed.locator)
+    if not slugs:
+        return {}
+
+    result = await session.execute(select(ManagedSecret).where(ManagedSecret.slug.in_(slugs)))
+    return {secret.slug: secret.status.value for secret in result.scalars().all()}
+
+
+def _readiness_check(
+    check_id: str,
+    label: str,
+    status: str,
+    message: str,
+) -> dict[str, str]:
+    return {
+        "id": check_id,
+        "label": label,
+        "status": status,
+        "message": redact_sensitive_payload(message),
+    }
+
+
+def _provider_profile_readiness(
+    row: ManagedAgentProviderProfile,
+    *,
+    managed_secret_statuses: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    managed_secret_statuses = managed_secret_statuses or {}
+    checks: list[dict[str, str]] = []
+
+    missing_required = [
+        field_name
+        for field_name, value in {
+            "profile_id": row.profile_id,
+            "runtime_id": row.runtime_id,
+            "provider_id": row.provider_id,
+            "credential_source": row.credential_source,
+            "runtime_materialization_mode": row.runtime_materialization_mode,
+        }.items()
+        if value in {None, ""}
+    ]
+    checks.append(
+        _readiness_check(
+            "required_fields",
+            "Required fields",
+            "error" if missing_required else "pass",
+            (
+                "Missing required fields: " + ", ".join(missing_required)
+                if missing_required
+                else "Required provider profile fields are present."
+            ),
+        )
+    )
+
+    checks.append(
+        _readiness_check(
+            "enabled",
+            "Enabled state",
+            "pass" if row.enabled else "error",
+            "Profile is enabled." if row.enabled else "Profile is disabled.",
+        )
+    )
+
+    credential_source = row.credential_source.value if row.credential_source else None
+    materialization_mode = (
+        row.runtime_materialization_mode.value
+        if row.runtime_materialization_mode
+        else None
+    )
+    if credential_source == "secret_ref":
+        secret_refs = row.secret_refs or {}
+        if not secret_refs:
+            checks.append(
+                _readiness_check(
+                    "secret_refs",
+                    "SecretRef bindings",
+                    "error",
+                    "credential_source secret_ref requires at least one SecretRef binding.",
+                )
+            )
+        else:
+            problems: list[str] = []
+            for role, ref in secret_refs.items():
+                try:
+                    from moonmind.auth.secret_refs import SecretBackend, parse_secret_ref
+
+                    parsed = parse_secret_ref(str(ref))
+                except Exception as exc:
+                    problems.append(f"{role}: invalid SecretRef ({exc})")
+                    continue
+                if parsed.backend == SecretBackend.DB_ENCRYPTED:
+                    status = managed_secret_statuses.get(parsed.locator)
+                    if status is None:
+                        problems.append(
+                            f"{role}: managed secret db://{parsed.locator} was not found"
+                        )
+                    elif status != SecretStatus.ACTIVE.value:
+                        problems.append(
+                            f"{role}: managed secret db://{parsed.locator} is {status}"
+                        )
+            checks.append(
+                _readiness_check(
+                    "secret_refs",
+                    "SecretRef bindings",
+                    "error" if problems else "pass",
+                    "; ".join(problems)
+                    if problems
+                    else "SecretRef bindings are syntactically valid.",
+                )
+            )
+    else:
+        checks.append(
+            _readiness_check(
+                "secret_refs",
+                "SecretRef bindings",
+                "pass",
+                "SecretRef bindings are not required for this credential source.",
+            )
+        )
+
+    oauth_required = credential_source == "oauth_volume" or materialization_mode == "oauth_home"
+    if oauth_required:
+        missing_oauth = [
+            field_name
+            for field_name, value in {
+                "volume_ref": row.volume_ref,
+                "volume_mount_path": row.volume_mount_path,
+            }.items()
+            if not value
+        ]
+        checks.append(
+            _readiness_check(
+                "oauth_volume",
+                "OAuth volume",
+                "error" if missing_oauth else "pass",
+                (
+                    "Missing OAuth volume metadata: " + ", ".join(missing_oauth)
+                    if missing_oauth
+                    else "OAuth volume metadata is present."
+                ),
+            )
+        )
+    else:
+        checks.append(
+            _readiness_check(
+                "oauth_volume",
+                "OAuth volume",
+                "pass",
+                "OAuth volume metadata is not required for this credential source.",
+            )
+        )
+
+    checks.append(
+        _readiness_check(
+            "concurrency",
+            "Concurrency",
+            "pass" if row.max_parallel_runs and row.max_parallel_runs > 0 else "error",
+            (
+                f"Profile allows {row.max_parallel_runs} parallel run(s)."
+                if row.max_parallel_runs and row.max_parallel_runs > 0
+                else "Profile has no available configured concurrency."
+            ),
+        )
+    )
+    checks.append(
+        _readiness_check(
+            "cooldown",
+            "Cooldown",
+            "pass" if row.cooldown_after_429_seconds >= 0 else "error",
+            f"Cooldown after provider rate limit is {row.cooldown_after_429_seconds}s.",
+        )
+    )
+
+    provider_readiness = (
+        row.command_behavior.get("auth_readiness")
+        if isinstance(row.command_behavior, dict)
+        else None
+    )
+    if isinstance(provider_readiness, dict):
+        launch_ready = provider_readiness.get("launch_ready")
+        if launch_ready is None:
+            launch_ready = provider_readiness.get("launchReady")
+        failure_reason = provider_readiness.get("failure_reason") or provider_readiness.get("failureReason")
+        checks.append(
+            _readiness_check(
+                "provider_validation",
+                "Provider validation",
+                "pass" if launch_ready is not False else "error",
+                (
+                    "Provider validation reports launch ready."
+                    if launch_ready is not False
+                    else f"Provider validation blocks launch: {failure_reason or 'unknown reason'}"
+                ),
+            )
+        )
+    else:
+        checks.append(
+            _readiness_check(
+                "provider_validation",
+                "Provider validation",
+                "warning",
+                "No provider-specific validation metadata is available.",
+            )
+        )
+
+    if any(check["status"] == "error" for check in checks):
+        status = "blocked"
+        launch_ready = False
+        summary = "Provider profile has launch blockers."
+    elif any(check["status"] == "warning" for check in checks):
+        status = "warning"
+        launch_ready = True
+        summary = "Provider profile is usable with readiness warnings."
+    else:
+        status = "ready"
+        launch_ready = True
+        summary = "Provider profile is ready for launch."
+
+    return {
+        "status": status,
+        "launch_ready": launch_ready,
+        "summary": summary,
+        "checks": checks,
+    }
+
+
+def _row_to_dict(
+    row: ManagedAgentProviderProfile,
+    *,
+    managed_secret_statuses: dict[str, str] | None = None,
+) -> dict[str, Any]:
     payload = {
         "profile_id": row.profile_id,
         "runtime_id": row.runtime_id,
@@ -766,6 +1030,10 @@ def _row_to_dict(row: ManagedAgentProviderProfile) -> dict[str, Any]:
         "enabled": row.enabled,
         "is_default": row.is_default,
         "max_lease_duration_seconds": row.max_lease_duration_seconds,
+        "readiness": _provider_profile_readiness(
+            row,
+            managed_secret_statuses=managed_secret_statuses,
+        ),
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
     }

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Optional
 
@@ -24,18 +25,32 @@ from api_service.db.models import (
     SecretStatus,
     User,
 )
+from moonmind.auth.secret_refs import (
+    ParsedSecretRef,
+    SecretBackend,
+    SecretReferenceError,
+    parse_secret_ref,
+)
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
-from moonmind.utils.logging import redact_profile_file_templates, redact_sensitive_payload
+from moonmind.utils.logging import (
+    redact_profile_file_templates,
+    redact_sensitive_payload,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/provider-profiles", tags=["provider-profiles"])
 _claude_manual_validation_client: httpx.AsyncClient | None = None
 
+
+@dataclass(frozen=True, slots=True)
+class _SecretRefParseResult:
+    parsed: ParsedSecretRef | None = None
+    error: str | None = None
+
 def validate_secret_refs_helper(value: dict[str, str] | None) -> dict[str, str] | None:
     if not value:
         return value
-    from moonmind.auth.secret_refs import parse_secret_ref, SecretReferenceError
     for k, v in value.items():
         if not v:
             continue
@@ -256,8 +271,20 @@ async def list_profiles(
     result = await session.execute(stmt)
     rows = result.scalars().all()
     visible_rows = [r for r in rows if _can_view_profile(r, current_user)]
-    secret_statuses = await _managed_secret_statuses_for_rows(session, visible_rows)
-    return [_row_to_dict(r, managed_secret_statuses=secret_statuses) for r in visible_rows]
+    secret_ref_results = _secret_ref_results_for_rows(visible_rows)
+    secret_statuses = await _managed_secret_statuses_for_rows(
+        session,
+        visible_rows,
+        secret_ref_results=secret_ref_results,
+    )
+    return [
+        _row_to_dict(
+            r,
+            managed_secret_statuses=secret_statuses,
+            secret_ref_results=secret_ref_results.get(r.profile_id),
+        )
+        for r in visible_rows
+    ]
 
 @router.get("/{profile_id}", response_model=ProviderProfileResponse)
 async def get_profile(
@@ -273,8 +300,17 @@ async def get_profile(
             status_code=403,
             detail="Not authorized to view this provider profile.",
         )
-    secret_statuses = await _managed_secret_statuses_for_rows(session, [row])
-    return _row_to_dict(row, managed_secret_statuses=secret_statuses)
+    secret_ref_results = _secret_ref_results_for_rows([row])
+    secret_statuses = await _managed_secret_statuses_for_rows(
+        session,
+        [row],
+        secret_ref_results=secret_ref_results,
+    )
+    return _row_to_dict(
+        row,
+        managed_secret_statuses=secret_statuses,
+        secret_ref_results=secret_ref_results.get(row.profile_id),
+    )
 
 @router.post("", response_model=ProviderProfileResponse, status_code=201)
 async def create_profile(
@@ -327,8 +363,17 @@ async def create_profile(
 
     await sync_provider_profile_manager(session=session, runtime_id=body.runtime_id)
 
-    secret_statuses = await _managed_secret_statuses_for_rows(session, [profile])
-    return _row_to_dict(profile, managed_secret_statuses=secret_statuses)
+    secret_ref_results = _secret_ref_results_for_rows([profile])
+    secret_statuses = await _managed_secret_statuses_for_rows(
+        session,
+        [profile],
+        secret_ref_results=secret_ref_results,
+    )
+    return _row_to_dict(
+        profile,
+        managed_secret_statuses=secret_statuses,
+        secret_ref_results=secret_ref_results.get(profile.profile_id),
+    )
 
 @router.patch("/{profile_id}", response_model=ProviderProfileResponse)
 async def update_profile(
@@ -366,8 +411,17 @@ async def update_profile(
     await session.commit()
     await session.refresh(profile)
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
-    secret_statuses = await _managed_secret_statuses_for_rows(session, [profile])
-    return _row_to_dict(profile, managed_secret_statuses=secret_statuses)
+    secret_ref_results = _secret_ref_results_for_rows([profile])
+    secret_statuses = await _managed_secret_statuses_for_rows(
+        session,
+        [profile],
+        secret_ref_results=secret_ref_results,
+    )
+    return _row_to_dict(
+        profile,
+        managed_secret_statuses=secret_statuses,
+        secret_ref_results=secret_ref_results.get(profile.profile_id),
+    )
 
 @router.post(
     "/{profile_id}/manual-auth/commit",
@@ -758,25 +812,39 @@ def _get_claude_manual_validation_client() -> httpx.AsyncClient:
 async def _managed_secret_statuses_for_rows(
     session: AsyncSession,
     rows: list[ManagedAgentProviderProfile],
+    *,
+    secret_ref_results: dict[str, dict[str, _SecretRefParseResult]] | None = None,
 ) -> dict[str, str]:
+    secret_ref_results = secret_ref_results or _secret_ref_results_for_rows(rows)
     slugs: set[str] = set()
     for row in rows:
-        for value in (row.secret_refs or {}).values():
-            if not isinstance(value, str):
-                continue
-            try:
-                from moonmind.auth.secret_refs import SecretBackend, parse_secret_ref
-
-                parsed = parse_secret_ref(value)
-            except Exception:
-                continue
-            if parsed.backend == SecretBackend.DB_ENCRYPTED:
-                slugs.add(parsed.locator)
+        for result in secret_ref_results.get(row.profile_id, {}).values():
+            if result.parsed and result.parsed.backend == SecretBackend.DB_ENCRYPTED:
+                slugs.add(result.parsed.locator)
     if not slugs:
         return {}
 
-    result = await session.execute(select(ManagedSecret).where(ManagedSecret.slug.in_(slugs)))
+    result = await session.execute(
+        select(ManagedSecret).where(ManagedSecret.slug.in_(slugs))
+    )
     return {secret.slug: secret.status.value for secret in result.scalars().all()}
+
+
+def _secret_ref_results_for_rows(
+    rows: list[ManagedAgentProviderProfile],
+) -> dict[str, dict[str, _SecretRefParseResult]]:
+    results: dict[str, dict[str, _SecretRefParseResult]] = {}
+    for row in rows:
+        row_results: dict[str, _SecretRefParseResult] = {}
+        for role, ref in (row.secret_refs or {}).items():
+            try:
+                row_results[str(role)] = _SecretRefParseResult(
+                    parsed=parse_secret_ref(str(ref))
+                )
+            except SecretReferenceError as exc:
+                row_results[str(role)] = _SecretRefParseResult(error=str(exc))
+        results[row.profile_id] = row_results
+    return results
 
 
 def _readiness_check(
@@ -797,41 +865,12 @@ def _provider_profile_readiness(
     row: ManagedAgentProviderProfile,
     *,
     managed_secret_statuses: dict[str, str] | None = None,
+    secret_ref_results: dict[str, _SecretRefParseResult] | None = None,
 ) -> dict[str, Any]:
     managed_secret_statuses = managed_secret_statuses or {}
-    checks: list[dict[str, str]] = []
-
-    missing_required = [
-        field_name
-        for field_name, value in {
-            "profile_id": row.profile_id,
-            "runtime_id": row.runtime_id,
-            "provider_id": row.provider_id,
-            "credential_source": row.credential_source,
-            "runtime_materialization_mode": row.runtime_materialization_mode,
-        }.items()
-        if value in {None, ""}
-    ]
-    checks.append(
-        _readiness_check(
-            "required_fields",
-            "Required fields",
-            "error" if missing_required else "pass",
-            (
-                "Missing required fields: " + ", ".join(missing_required)
-                if missing_required
-                else "Required provider profile fields are present."
-            ),
-        )
-    )
-
-    checks.append(
-        _readiness_check(
-            "enabled",
-            "Enabled state",
-            "pass" if row.enabled else "error",
-            "Profile is enabled." if row.enabled else "Profile is disabled.",
-        )
+    secret_ref_results = secret_ref_results or _secret_ref_results_for_rows([row]).get(
+        row.profile_id,
+        {},
     )
 
     credential_source = row.credential_source.value if row.credential_source else None
@@ -840,141 +879,25 @@ def _provider_profile_readiness(
         if row.runtime_materialization_mode
         else None
     )
-    if credential_source == "secret_ref":
-        secret_refs = row.secret_refs or {}
-        if not secret_refs:
-            checks.append(
-                _readiness_check(
-                    "secret_refs",
-                    "SecretRef bindings",
-                    "error",
-                    "credential_source secret_ref requires at least one SecretRef binding.",
-                )
-            )
-        else:
-            problems: list[str] = []
-            for role, ref in secret_refs.items():
-                try:
-                    from moonmind.auth.secret_refs import SecretBackend, parse_secret_ref
 
-                    parsed = parse_secret_ref(str(ref))
-                except Exception as exc:
-                    problems.append(f"{role}: invalid SecretRef ({exc})")
-                    continue
-                if parsed.backend == SecretBackend.DB_ENCRYPTED:
-                    status = managed_secret_statuses.get(parsed.locator)
-                    if status is None:
-                        problems.append(
-                            f"{role}: managed secret db://{parsed.locator} was not found"
-                        )
-                    elif status != SecretStatus.ACTIVE.value:
-                        problems.append(
-                            f"{role}: managed secret db://{parsed.locator} is {status}"
-                        )
-            checks.append(
-                _readiness_check(
-                    "secret_refs",
-                    "SecretRef bindings",
-                    "error" if problems else "pass",
-                    "; ".join(problems)
-                    if problems
-                    else "SecretRef bindings are syntactically valid.",
-                )
-            )
-    else:
-        checks.append(
-            _readiness_check(
-                "secret_refs",
-                "SecretRef bindings",
-                "pass",
-                "SecretRef bindings are not required for this credential source.",
-            )
-        )
-
-    oauth_required = credential_source == "oauth_volume" or materialization_mode == "oauth_home"
-    if oauth_required:
-        missing_oauth = [
-            field_name
-            for field_name, value in {
-                "volume_ref": row.volume_ref,
-                "volume_mount_path": row.volume_mount_path,
-            }.items()
-            if not value
-        ]
-        checks.append(
-            _readiness_check(
-                "oauth_volume",
-                "OAuth volume",
-                "error" if missing_oauth else "pass",
-                (
-                    "Missing OAuth volume metadata: " + ", ".join(missing_oauth)
-                    if missing_oauth
-                    else "OAuth volume metadata is present."
-                ),
-            )
-        )
-    else:
-        checks.append(
-            _readiness_check(
-                "oauth_volume",
-                "OAuth volume",
-                "pass",
-                "OAuth volume metadata is not required for this credential source.",
-            )
-        )
-
-    checks.append(
-        _readiness_check(
-            "concurrency",
-            "Concurrency",
-            "pass" if row.max_parallel_runs and row.max_parallel_runs > 0 else "error",
-            (
-                f"Profile allows {row.max_parallel_runs} parallel run(s)."
-                if row.max_parallel_runs and row.max_parallel_runs > 0
-                else "Profile has no available configured concurrency."
-            ),
-        )
-    )
-    checks.append(
-        _readiness_check(
-            "cooldown",
-            "Cooldown",
-            "pass" if row.cooldown_after_429_seconds >= 0 else "error",
-            f"Cooldown after provider rate limit is {row.cooldown_after_429_seconds}s.",
-        )
-    )
-
-    provider_readiness = (
-        row.command_behavior.get("auth_readiness")
-        if isinstance(row.command_behavior, dict)
-        else None
-    )
-    if isinstance(provider_readiness, dict):
-        launch_ready = provider_readiness.get("launch_ready")
-        if launch_ready is None:
-            launch_ready = provider_readiness.get("launchReady")
-        failure_reason = provider_readiness.get("failure_reason") or provider_readiness.get("failureReason")
-        checks.append(
-            _readiness_check(
-                "provider_validation",
-                "Provider validation",
-                "pass" if launch_ready is not False else "error",
-                (
-                    "Provider validation reports launch ready."
-                    if launch_ready is not False
-                    else f"Provider validation blocks launch: {failure_reason or 'unknown reason'}"
-                ),
-            )
-        )
-    else:
-        checks.append(
-            _readiness_check(
-                "provider_validation",
-                "Provider validation",
-                "warning",
-                "No provider-specific validation metadata is available.",
-            )
-        )
+    checks = [
+        _required_fields_check(row),
+        _enabled_check(row),
+        _secret_refs_check(
+            row,
+            credential_source=credential_source,
+            managed_secret_statuses=managed_secret_statuses,
+            secret_ref_results=secret_ref_results,
+        ),
+        _oauth_volume_check(
+            row,
+            credential_source=credential_source,
+            materialization_mode=materialization_mode,
+        ),
+        _concurrency_check(row),
+        _cooldown_check(row),
+        _provider_validation_check(row),
+    ]
 
     if any(check["status"] == "error" for check in checks):
         status = "blocked"
@@ -997,10 +920,190 @@ def _provider_profile_readiness(
     }
 
 
+def _required_fields_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    missing_required = [
+        field_name
+        for field_name, value in {
+            "profile_id": row.profile_id,
+            "runtime_id": row.runtime_id,
+            "provider_id": row.provider_id,
+            "credential_source": row.credential_source,
+            "runtime_materialization_mode": row.runtime_materialization_mode,
+        }.items()
+        if value in {None, ""}
+    ]
+    return _readiness_check(
+        "required_fields",
+        "Required fields",
+        "error" if missing_required else "pass",
+        (
+            "Missing required fields: " + ", ".join(missing_required)
+            if missing_required
+            else "Required provider profile fields are present."
+        ),
+    )
+
+
+def _enabled_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    return _readiness_check(
+        "enabled",
+        "Enabled state",
+        "pass" if row.enabled else "error",
+        "Profile is enabled." if row.enabled else "Profile is disabled.",
+    )
+
+
+def _secret_refs_check(
+    row: ManagedAgentProviderProfile,
+    *,
+    credential_source: str | None,
+    managed_secret_statuses: dict[str, str],
+    secret_ref_results: dict[str, _SecretRefParseResult],
+) -> dict[str, str]:
+    if credential_source != "secret_ref":
+        return _readiness_check(
+            "secret_refs",
+            "SecretRef bindings",
+            "pass",
+            "SecretRef bindings are not required for this credential source.",
+        )
+    if not row.secret_refs:
+        return _readiness_check(
+            "secret_refs",
+            "SecretRef bindings",
+            "error",
+            "credential_source secret_ref requires at least one SecretRef binding.",
+        )
+
+    problems: list[str] = []
+    for role, result in secret_ref_results.items():
+        if result.error:
+            problems.append(f"{role}: invalid SecretRef ({result.error})")
+            continue
+        if not result.parsed or result.parsed.backend != SecretBackend.DB_ENCRYPTED:
+            continue
+        status = managed_secret_statuses.get(result.parsed.locator)
+        if status is None:
+            problems.append(
+                f"{role}: managed secret db://{result.parsed.locator} was not found"
+            )
+        elif status != SecretStatus.ACTIVE.value:
+            problems.append(
+                f"{role}: managed secret db://{result.parsed.locator} is {status}"
+            )
+
+    return _readiness_check(
+        "secret_refs",
+        "SecretRef bindings",
+        "error" if problems else "pass",
+        (
+            "; ".join(problems)
+            if problems
+            else "SecretRef bindings are syntactically valid."
+        ),
+    )
+
+
+def _oauth_volume_check(
+    row: ManagedAgentProviderProfile,
+    *,
+    credential_source: str | None,
+    materialization_mode: str | None,
+) -> dict[str, str]:
+    oauth_required = (
+        credential_source == "oauth_volume" or materialization_mode == "oauth_home"
+    )
+    if not oauth_required:
+        return _readiness_check(
+            "oauth_volume",
+            "OAuth volume",
+            "pass",
+            "OAuth volume metadata is not required for this credential source.",
+        )
+
+    missing_oauth = [
+        field_name
+        for field_name, value in {
+            "volume_ref": row.volume_ref,
+            "volume_mount_path": row.volume_mount_path,
+        }.items()
+        if not value
+    ]
+    return _readiness_check(
+        "oauth_volume",
+        "OAuth volume",
+        "error" if missing_oauth else "pass",
+        (
+            "Missing OAuth volume metadata: " + ", ".join(missing_oauth)
+            if missing_oauth
+            else "OAuth volume metadata is present."
+        ),
+    )
+
+
+def _concurrency_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    has_capacity = bool(row.max_parallel_runs and row.max_parallel_runs > 0)
+    return _readiness_check(
+        "concurrency",
+        "Concurrency",
+        "pass" if has_capacity else "error",
+        (
+            f"Profile allows {row.max_parallel_runs} parallel run(s)."
+            if has_capacity
+            else "Profile has no available configured concurrency."
+        ),
+    )
+
+
+def _cooldown_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    return _readiness_check(
+        "cooldown",
+        "Cooldown",
+        "pass" if row.cooldown_after_429_seconds >= 0 else "error",
+        f"Cooldown after provider rate limit is {row.cooldown_after_429_seconds}s.",
+    )
+
+
+def _provider_validation_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    provider_readiness = (
+        row.command_behavior.get("auth_readiness")
+        if isinstance(row.command_behavior, dict)
+        else None
+    )
+    if not isinstance(provider_readiness, dict):
+        return _readiness_check(
+            "provider_validation",
+            "Provider validation",
+            "warning",
+            "No provider-specific validation metadata is available.",
+        )
+
+    launch_ready = provider_readiness.get("launch_ready")
+    if launch_ready is None:
+        launch_ready = provider_readiness.get("launchReady")
+    failure_reason = provider_readiness.get("failure_reason") or provider_readiness.get(
+        "failureReason"
+    )
+    return _readiness_check(
+        "provider_validation",
+        "Provider validation",
+        "pass" if launch_ready is not False else "error",
+        (
+            "Provider validation reports launch ready."
+            if launch_ready is not False
+            else (
+                "Provider validation blocks launch: "
+                f"{failure_reason or 'unknown reason'}"
+            )
+        ),
+    )
+
+
 def _row_to_dict(
     row: ManagedAgentProviderProfile,
     *,
     managed_secret_statuses: dict[str, str] | None = None,
+    secret_ref_results: dict[str, _SecretRefParseResult] | None = None,
 ) -> dict[str, Any]:
     payload = {
         "profile_id": row.profile_id,
@@ -1033,6 +1136,7 @@ def _row_to_dict(
         "readiness": _provider_profile_readiness(
             row,
             managed_secret_statuses=managed_secret_statuses,
+            secret_ref_results=secret_ref_results,
         ),
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import (
+    ManagedAgentProviderProfile,
     ManagedSecret,
     SecretStatus,
     SettingsAuditEvent,
@@ -276,6 +277,23 @@ _REGISTRY: tuple[SettingRegistryEntry, ...] = (
         ),
         order=60,
     ),
+    SettingRegistryEntry(
+        key="workflow.default_provider_profile_ref",
+        title="Default Provider Profile",
+        description=(
+            "Provider profile reference used when a task or runtime request does "
+            "not select a profile explicitly."
+        ),
+        category="Workflow",
+        section="user-workspace",
+        value_type="string",
+        ui="provider_profile_picker",
+        scopes=("user", "workspace"),
+        default_value=None,
+        env_aliases=("MOONMIND_DEFAULT_PROVIDER_PROFILE_REF",),
+        applies_to=("task_creation", "workflow_runtime", "provider_profiles"),
+        order=70,
+    ),
 )
 
 
@@ -301,6 +319,7 @@ class SettingsCatalogService:
         self._workspace_id = workspace_id or _DEFAULT_SUBJECT_ID
         self._user_id = user_id or _DEFAULT_SUBJECT_ID
         self._managed_secret_status_by_slug: dict[str, str | None] = {}
+        self._provider_profile_enabled_by_id: dict[str, bool | None] = {}
 
     def catalog(
         self,
@@ -346,6 +365,16 @@ class SettingsCatalogService:
             )[0]
             for entry in entries
             if scope is not None
+        )
+        await self._prime_provider_profile_statuses(
+            self._resolve_value_from_overrides(
+                entry,
+                scope=scope,
+                overrides=overrides,
+            )[0]
+            for entry in entries
+            if scope is not None
+            and entry.key == "workflow.default_provider_profile_ref"
         )
         categories: dict[str, list[SettingDescriptor]] = {}
         for entry in entries:
@@ -469,6 +498,8 @@ class SettingsCatalogService:
             overrides=overrides,
         )
         await self._prime_managed_secret_statuses([value])
+        if entry.key == "workflow.default_provider_profile_ref":
+            await self._prime_provider_profile_statuses([value])
         return EffectiveSettingValue(
             key=entry.key,
             scope=scope,
@@ -502,6 +533,11 @@ class SettingsCatalogService:
         }
         await self._prime_managed_secret_statuses(
             data[0] for _entry, data in resolved.values()
+        )
+        await self._prime_provider_profile_statuses(
+            data[0]
+            for entry, data in resolved.values()
+            if entry.key == "workflow.default_provider_profile_ref"
         )
         values = {
             key: EffectiveSettingValue(
@@ -603,6 +639,11 @@ class SettingsCatalogService:
             for key in changes
         }
         await self._prime_managed_secret_statuses(data[0] for data in resolved.values())
+        await self._prime_provider_profile_statuses(
+            data[0]
+            for key, data in resolved.items()
+            if entries[key].key == "workflow.default_provider_profile_ref"
+        )
         values = {
             key: EffectiveSettingValue(
                 key=entries[key].key,
@@ -740,7 +781,11 @@ class SettingsCatalogService:
         value: Any,
         override_present: bool,
     ) -> list[SettingDiagnostic]:
-        if override_present and (entry.value_type != "secret_ref" or value is None):
+        if (
+            override_present
+            and entry.key != "workflow.default_provider_profile_ref"
+            and (entry.value_type != "secret_ref" or value is None)
+        ):
             return []
         return self._diagnostics(entry, value)
 
@@ -770,6 +815,31 @@ class SettingsCatalogService:
 
         for slug in missing:
             self._managed_secret_status_by_slug[slug] = statuses_from_db.get(slug)
+
+    async def _prime_provider_profile_statuses(self, values: Iterable[Any]) -> None:
+        if self._session is None:
+            return
+        profile_ids = {
+            value.strip()
+            for value in values
+            if isinstance(value, str) and value.strip()
+        }
+        missing = [
+            profile_id
+            for profile_id in profile_ids
+            if profile_id not in self._provider_profile_enabled_by_id
+        ]
+        if not missing:
+            return
+        result = await self._session.execute(
+            select(
+                ManagedAgentProviderProfile.profile_id,
+                ManagedAgentProviderProfile.enabled,
+            ).where(ManagedAgentProviderProfile.profile_id.in_(missing))
+        )
+        enabled_by_id = {profile_id: bool(enabled) for profile_id, enabled in result.all()}
+        for profile_id in missing:
+            self._provider_profile_enabled_by_id[profile_id] = enabled_by_id.get(profile_id)
 
     def _resolve_value_from_overrides(
         self,
@@ -1012,7 +1082,40 @@ class SettingsCatalogService:
             diagnostic = self._secret_ref_diagnostic(entry, value)
             if diagnostic is not None:
                 diagnostics.append(diagnostic)
+        if entry.key == "workflow.default_provider_profile_ref" and isinstance(value, str):
+            diagnostic = self._provider_profile_ref_diagnostic(entry, value)
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
         return diagnostics
+
+    def _provider_profile_ref_diagnostic(
+        self, entry: SettingRegistryEntry, value: str
+    ) -> SettingDiagnostic | None:
+        profile_id = value.strip()
+        if not profile_id:
+            return None
+        if profile_id not in self._provider_profile_enabled_by_id:
+            return None
+        enabled = self._provider_profile_enabled_by_id.get(profile_id)
+        if enabled is None:
+            return SettingDiagnostic(
+                code="provider_profile_not_found",
+                message=(
+                    f"{entry.key} references a provider profile that does not exist."
+                ),
+                severity="error",
+                details={"profile_id": profile_id, "launch_blocker": True},
+            )
+        if enabled is False:
+            return SettingDiagnostic(
+                code="provider_profile_disabled",
+                message=(
+                    f"{entry.key} references a disabled provider profile."
+                ),
+                severity="error",
+                details={"profile_id": profile_id, "launch_blocker": True},
+            )
+        return None
 
     def _secret_ref_diagnostic(
         self, entry: SettingRegistryEntry, value: str

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-540",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1824"
+  "jira_issue_key": "MM-541",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1825"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": 3152883195,
+    "id": 3153651677,
     "disposition": "addressed",
-    "rationale": "Simplified managed secret status cache priming by mapping database statuses once and filling missing slugs with null."
+    "rationale": "SecretRef parsing for managed-secret status lookup now catches only SecretReferenceError and carries parse failures into readiness diagnostics instead of silently dropping them."
   },
   {
-    "id": 4187341440,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary with no separate actionable request beyond inline comment 3152883195."
-  },
-  {
-    "id": 3152919926,
+    "id": 3153651681,
     "disposition": "addressed",
-    "rationale": "Changed validate_secret_ref to select only ManagedSecret.status and updated the unit test to assert ciphertext is not selected."
+    "rationale": "Provider readiness synthesis was split into focused helper checks, and SecretRefs are parsed once per row then reused for status lookup and readiness reporting."
   },
   {
-    "id": 4187391626,
-    "disposition": "not-applicable",
-    "rationale": "Automated review wrapper; actionable content is represented by inline comment 3152919926."
+    "id": 3153651684,
+    "disposition": "addressed",
+    "rationale": "Readiness SecretRef parsing now uses the shared parser result populated from parse_secret_ref with SecretReferenceError-specific handling."
+  },
+  {
+    "id": 4188225634,
+    "disposition": "addressed",
+    "rationale": "Summary review concerns are covered by the SecretRef exception handling cleanup, readiness helper refactor, and invalid stored SecretRef regression test."
   }
 ]

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -354,6 +354,39 @@ describe('ProviderProfilesManager form controls', () => {
     },
   };
 
+  const profileWithReadiness: ProviderProfile = {
+    ...profile,
+    profile_id: 'codex-diagnostic',
+    provider_label: 'OpenAI Team',
+    default_model: 'gpt-5.4',
+    secret_refs: {
+      provider_api_key: 'db://openai-team-key',
+    },
+    max_parallel_runs: 3,
+    cooldown_after_429_seconds: 120,
+    tags: ['team', 'fast'],
+    priority: 250,
+    readiness: {
+      status: 'blocked',
+      launch_ready: false,
+      summary: 'Provider profile has launch blockers.',
+      checks: [
+        {
+          id: 'secret_refs',
+          label: 'SecretRef bindings',
+          status: 'error',
+          message: 'provider_api_key points at missing managed secret db://openai-team-key',
+        },
+        {
+          id: 'provider_validation',
+          label: 'Provider validation',
+          status: 'error',
+          message: 'Validation failed for token=[REDACTED]',
+        },
+      ],
+    },
+  };
+
   it('labels secret refs and resets create-form values', () => {
     renderProviderProfilesManager();
 
@@ -933,5 +966,43 @@ describe('ProviderProfilesManager form controls', () => {
     expect(screen.getByText('Launch readiness: Ready')).toBeTruthy();
     expect(screen.getByText(/Previous token/)).toBeTruthy();
     expect(screen.queryByText(/sk-ant-secret/)).toBeNull();
+  });
+
+  it('renders provider profile readiness and launch metadata', () => {
+    renderProviderProfilesManager([profileWithReadiness]);
+
+    expect(screen.getByText('Readiness: Blocked')).toBeTruthy();
+    expect(screen.getByText('Provider profile has launch blockers.')).toBeTruthy();
+    expect(screen.getByText('Concurrency: 3')).toBeTruthy();
+    expect(screen.getByText('Cooldown: 120s')).toBeTruthy();
+    expect(screen.getByText('Priority: 250')).toBeTruthy();
+    expect(screen.getByText('Tags: team, fast')).toBeTruthy();
+    expect(screen.getByText('provider_api_key')).toBeTruthy();
+    expect(screen.getByText('db://openai-team-key')).toBeTruthy();
+    expect(screen.getByText(/Validation failed/)).toBeTruthy();
+    expect(screen.queryByText(/sk-ant/)).toBeNull();
+  });
+
+  it('describes SecretRef role bindings without plaintext values', () => {
+    const rawSecret = 'sk-test-plaintext-never-render';
+    renderProviderProfilesManager([
+      {
+        ...profileWithReadiness,
+        secret_refs: {
+          anthropic_api_key: 'db://claude-team-key',
+        },
+        readiness: {
+          status: 'ready',
+          launch_ready: true,
+          summary: 'Provider profile is ready for launch.',
+          checks: [],
+        },
+      },
+    ]);
+
+    expect(screen.getByText('anthropic_api_key')).toBeTruthy();
+    expect(screen.getByText('db://claude-team-key')).toBeTruthy();
+    expect(screen.getByText(/Role-aware SecretRefs/)).toBeTruthy();
+    expect(screen.queryByText(rawSecret)).toBeNull();
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -7,6 +7,7 @@ export interface ProviderProfile {
   provider_id: string;
   provider_label?: string | null;
   default_model?: string | null;
+  model_overrides?: Record<string, string> | null;
   credential_source: string;
   runtime_materialization_mode: string;
   volume_ref?: string | null;
@@ -22,6 +23,21 @@ export interface ProviderProfile {
   priority?: number | null;
   clear_env_keys?: string[] | null;
   account_label?: string | null;
+  readiness?: ProviderProfileReadiness | null;
+}
+
+interface ProviderReadinessCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'warning' | 'error';
+  message: string;
+}
+
+interface ProviderProfileReadiness {
+  status: 'ready' | 'warning' | 'blocked';
+  launch_ready: boolean;
+  summary: string;
+  checks: ProviderReadinessCheck[];
 }
 
 interface Notice {
@@ -216,12 +232,22 @@ export function parseClearEnvKeys(text: string): string[] | null {
   return keys.length > 0 ? keys : null;
 }
 
-function summarizeSecretRefs(secretRefs: Record<string, string>): string {
-  const entries = Object.entries(secretRefs);
-  if (entries.length === 0) {
-    return 'No secret refs';
+function readinessLabel(status: ProviderProfileReadiness['status']): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function readinessClass(status: ProviderProfileReadiness['status']): string {
+  if (status === 'ready') {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400';
   }
-  return entries.map(([key, value]) => `${key}: ${value}`).join(', ');
+  if (status === 'warning') {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300';
+  }
+  return 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300';
+}
+
+function visibleReadinessChecks(readiness?: ProviderProfileReadiness | null): ProviderReadinessCheck[] {
+  return (readiness?.checks ?? []).filter((check) => check.status !== 'pass');
 }
 
 type ProviderAuthActionLabel =
@@ -1187,6 +1213,11 @@ export function ProviderProfilesManager({
                           : 'No model (runtime default)'}
                       </div>
                     )}
+                    {profile.model_overrides && Object.keys(profile.model_overrides).length > 0 ? (
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        Overrides: {Object.keys(profile.model_overrides).join(', ')}
+                      </div>
+                    ) : null}
                   </td>
                   <td
                     className="px-3 py-4 text-slate-700 dark:text-slate-300"
@@ -1206,6 +1237,16 @@ export function ProviderProfilesManager({
                     {profile.provider_label ? (
                       <div className="text-xs text-slate-500 dark:text-slate-400">{profile.provider_label}</div>
                     ) : null}
+                    {profile.tags && profile.tags.length > 0 ? (
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        Tags: {profile.tags.join(', ')}
+                      </div>
+                    ) : null}
+                    {profile.priority != null ? (
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        Priority: {profile.priority}
+                      </div>
+                    ) : null}
                   </td>
                   <td
                     className="px-3 py-4 text-slate-700 dark:text-slate-300"
@@ -1217,14 +1258,44 @@ export function ProviderProfilesManager({
                     <div className="text-xs text-slate-500 dark:text-slate-400">
                       {profile.runtime_materialization_mode}
                     </div>
+                    {profile.volume_ref ? (
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        OAuth volume: {profile.volume_ref}
+                      </div>
+                    ) : null}
+                    {profile.volume_mount_path ? (
+                      <div className="text-xs text-slate-500 dark:text-slate-400">
+                        Mount: {profile.volume_mount_path}
+                      </div>
+                    ) : null}
+                    <div className="text-xs text-slate-500 dark:text-slate-400">
+                      Concurrency: {profile.max_parallel_runs}
+                    </div>
+                    <div className="text-xs text-slate-500 dark:text-slate-400">
+                      Cooldown: {profile.cooldown_after_429_seconds}s
+                    </div>
                   </td>
                   <td
-                    className="px-3 py-4 font-mono text-xs text-slate-600 dark:text-slate-400"
+                    className="px-3 py-4 text-xs text-slate-600 dark:text-slate-400"
                     data-label="Secret refs"
                     headers="provider-profile-header-secret-refs"
                     role="cell"
                   >
-                    {summarizeSecretRefs(profile.secret_refs)}
+                    <div className="font-medium text-slate-700 dark:text-slate-300">
+                      Role-aware SecretRefs
+                    </div>
+                    {Object.entries(profile.secret_refs ?? {}).length === 0 ? (
+                      <div>No secret refs</div>
+                    ) : (
+                      <dl className="space-y-1">
+                        {Object.entries(profile.secret_refs ?? {}).map(([role, ref]) => (
+                          <div key={role}>
+                            <dt className="font-mono font-semibold">{role}</dt>
+                            <dd className="font-mono">{ref}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    )}
                   </td>
                   <td
                     className="px-3 py-4"
@@ -1241,6 +1312,30 @@ export function ProviderProfilesManager({
                     >
                       {profile.enabled ? 'Enabled' : 'Disabled'}
                     </span>
+                    {profile.readiness ? (
+                      <div className="mt-2 space-y-1">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${readinessClass(profile.readiness.status)}`}
+                        >
+                          Readiness: {readinessLabel(profile.readiness.status)}
+                        </span>
+                        <div className="text-xs text-slate-500 dark:text-slate-400">
+                          {profile.readiness.summary}
+                        </div>
+                        {visibleReadinessChecks(profile.readiness).map((check) => (
+                          <div
+                            key={check.id}
+                            className={
+                              check.status === 'error'
+                                ? 'text-xs text-rose-600 dark:text-rose-400'
+                                : 'text-xs text-amber-700 dark:text-amber-300'
+                            }
+                          >
+                            {check.label}: {redactClaudeSecretText(check.message)}
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
                     {oauthSession ? (
                       <div className="mt-2 text-xs font-medium text-slate-600 dark:text-slate-400">
                         OAuth: {oauthStatusLabel(oauthSession.status)}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5238,6 +5238,17 @@ export interface components {
              */
             max_lease_duration_seconds: number;
         };
+        /** ProviderProfileReadiness */
+        ProviderProfileReadiness: {
+            /** Status */
+            status: string;
+            /** Launch Ready */
+            launch_ready: boolean;
+            /** Summary */
+            summary: string;
+            /** Checks */
+            checks: components["schemas"]["ProviderReadinessCheck"][];
+        };
         /** ProviderProfileResponse */
         ProviderProfileResponse: {
             /** Profile Id */
@@ -5305,6 +5316,7 @@ export interface components {
             is_default: boolean;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds: number;
+            readiness: components["schemas"]["ProviderProfileReadiness"];
             /** Created At */
             created_at: string | null;
             /** Updated At */
@@ -5393,6 +5405,17 @@ export interface components {
             is_default?: boolean | null;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds?: number | null;
+        };
+        /** ProviderReadinessCheck */
+        ProviderReadinessCheck: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Status */
+            status: string;
+            /** Message */
+            message: string;
         };
         /**
          * RecurringTaskDefinitionListResponse

--- a/specs/271-provider-profile-readiness-settings/checklists/requirements.md
+++ b/specs/271-provider-profile-readiness-settings/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Provider Profile Management and Readiness in Settings
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Source design requirements map DESIGN-REQ-002, DESIGN-REQ-012, and DESIGN-REQ-025 to functional requirements for downstream planning and verification.

--- a/specs/271-provider-profile-readiness-settings/contracts/provider-profile-readiness-api.md
+++ b/specs/271-provider-profile-readiness-settings/contracts/provider-profile-readiness-api.md
@@ -46,6 +46,10 @@ Each provider profile response includes:
 - Readiness never includes raw credentials, API keys, OAuth state blobs, decrypted files, generated credential config, auth headers, or plaintext secret values.
 - SecretRef strings may be displayed as security-relevant metadata only when the caller is authorized to view the profile.
 
+## Related Settings Diagnostics
+
+Generic user/workspace settings may reference provider profiles only by identifier through `workflow.default_provider_profile_ref`. Effective settings responses report explicit diagnostics for missing or disabled referenced provider profiles, mark those diagnostics as launch blockers, and do not inline runtime selection, credential source class, materialization, command construction, environment shaping, generated runtime files, process launch, or capability-check semantics.
+
 ## Non-Goals
 
 - This response does not reserve, release, or inspect live Temporal slot leases.

--- a/specs/271-provider-profile-readiness-settings/contracts/provider-profile-readiness-api.md
+++ b/specs/271-provider-profile-readiness-settings/contracts/provider-profile-readiness-api.md
@@ -1,0 +1,52 @@
+# Contract: Provider Profile Readiness API
+
+## Existing Endpoints
+
+Readiness is included in existing provider profile responses:
+
+- `GET /api/v1/provider-profiles`
+- `GET /api/v1/provider-profiles/{profile_id}`
+- `POST /api/v1/provider-profiles`
+- `PATCH /api/v1/provider-profiles/{profile_id}`
+
+## Response Addition
+
+Each provider profile response includes:
+
+```json
+{
+  "profile_id": "codex_default",
+  "runtime_id": "codex_cli",
+  "provider_id": "openai",
+  "readiness": {
+    "status": "ready",
+    "launch_ready": true,
+    "summary": "Provider profile is ready for launch.",
+    "checks": [
+      {
+        "id": "enabled",
+        "label": "Enabled state",
+        "status": "pass",
+        "message": "Profile is enabled."
+      }
+    ]
+  }
+}
+```
+
+## Status Semantics
+
+- `ready`: no error or warning checks; launch-ready according to Settings-visible metadata.
+- `warning`: no error checks, but at least one warning check.
+- `blocked`: at least one error check; affected launches should not silently fall back.
+
+## Security Requirements
+
+- `message` and `summary` are sanitized.
+- Readiness never includes raw credentials, API keys, OAuth state blobs, decrypted files, generated credential config, auth headers, or plaintext secret values.
+- SecretRef strings may be displayed as security-relevant metadata only when the caller is authorized to view the profile.
+
+## Non-Goals
+
+- This response does not reserve, release, or inspect live Temporal slot leases.
+- This response does not construct commands, environment variables, generated files, process launch arguments, or runtime capability checks.

--- a/specs/271-provider-profile-readiness-settings/data-model.md
+++ b/specs/271-provider-profile-readiness-settings/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Provider Profile Management and Readiness in Settings
+
+## ProviderProfile
+
+Existing durable resource stored in `managed_agent_provider_profiles`.
+
+Relevant fields:
+- `profile_id`: stable identifier used by settings, runtime routing, and manager payloads.
+- `runtime_id`: managed runtime such as `codex_cli` or `claude_code`.
+- `provider_id` / `provider_label`: provider identity and display label.
+- `default_model` / `model_overrides`: model intent for the runtime/provider pair.
+- `credential_source`: `oauth_volume`, `secret_ref`, or `none`.
+- `runtime_materialization_mode`: `oauth_home`, `api_key_env`, `env_bundle`, `config_bundle`, or `composite`.
+- `secret_refs`: role-to-SecretRef mapping.
+- `volume_ref`, `volume_mount_path`, `account_label`: OAuth-backed credential volume metadata.
+- `max_parallel_runs`, `cooldown_after_429_seconds`, `rate_limit_policy`, `max_lease_duration_seconds`: execution policy metadata.
+- `enabled`, `is_default`, `tags`, `priority`: routing and operator-visible metadata.
+- `command_behavior`: runtime strategy metadata, including provider-specific auth/readiness diagnostics.
+
+Validation rules:
+- `profile_id`, `runtime_id`, and `provider_id` are required on create.
+- `secret_refs` values must parse as SecretRefs.
+- Codex OAuth profiles require both `volume_ref` and `volume_mount_path`.
+- Browser-visible payloads redact secret-like runtime fields.
+
+## ProviderProfileReadiness
+
+New response-only diagnostic object. It is not persisted.
+
+Fields:
+- `status`: `ready`, `warning`, or `blocked`.
+- `launch_ready`: boolean.
+- `summary`: short sanitized status.
+- `checks`: ordered list of readiness checks.
+
+Readiness checks:
+- `schema`: required profile fields and enum-valid profile shape.
+- `required_fields`: runtime/provider/materialization fields required for launch intent.
+- `secret_refs`: SecretRef syntax and managed secret existence/status when the backend can inspect it.
+- `oauth_volume`: OAuth volume metadata presence for OAuth-backed profiles.
+- `provider_validation`: provider-specific validation state, including Claude auth readiness when present.
+- `enabled`: enabled/disabled state.
+- `concurrency`: configured capacity is positive.
+- `cooldown`: cooldown policy/state metadata is known and non-negative.
+
+State transitions:
+- Any error severity check makes `status=blocked` and `launch_ready=false`.
+- Warning-only checks make `status=warning` and `launch_ready=true`.
+- All passing checks make `status=ready` and `launch_ready=true`.
+
+## ProviderReadinessCheck
+
+Fields:
+- `id`: stable check identifier.
+- `label`: operator-visible label.
+- `status`: `pass`, `warning`, or `error`.
+- `message`: sanitized operator-facing explanation.
+
+## SecretRefRoleBinding
+
+Existing JSON mapping from required role name to SecretRef.
+
+Validation rules:
+- Role names are object keys and must be strings.
+- Values must be SecretRef strings.
+- The UI may display role names and SecretRef strings but must not display plaintext.
+
+## LaunchBlockerDiagnostic
+
+Diagnostic emitted when a profile cannot be used for launch.
+
+Fields:
+- `profile_id`
+- `reason_code`
+- `message`
+- `readiness_check_id`
+
+This story models blocker causes through `ProviderProfileReadiness`; runtime strategies still own final launch behavior.

--- a/specs/271-provider-profile-readiness-settings/plan.md
+++ b/specs/271-provider-profile-readiness-settings/plan.md
@@ -16,7 +16,7 @@ Complete the Settings -> Providers & Secrets provider profile story for `MM-541`
 | FR-003 | partial | form exposes SecretRefs, OAuth volume fields, concurrency, cooldown, tags, priority; lacks normalized role/readiness guidance | add role-aware helper text and readiness diagnostics | UI |
 | FR-004 | implemented_unverified | SecretRef syntax validation exists; UI uses JSON textarea | add tests for role labels and no plaintext display in readiness/secret refs | unit + UI |
 | FR-005 | missing | Claude-specific readiness exists in `command_behavior`; no general readiness field | add `readiness` response model and synthesis from schema, required fields, SecretRefs, OAuth metadata, provider validation, enabled state, capacity, cooldown | unit + UI |
-| FR-006 | missing | no generic provider-profile reference setting diagnostics found | document as out-of-band for this slice unless existing settings reference appears during implementation; add provider-profile missing/unready launch blocker model where available | unit |
+| FR-006 | missing | no generic provider-profile reference setting diagnostics found at planning time | add `workflow.default_provider_profile_ref` as an identifier-only setting with missing/disabled provider-profile diagnostics and launch blockers, without inlining runtime launch semantics | unit |
 | FR-007 | implemented_unverified | `docs/Security/SettingsSystem.md`; generic settings search found no inline provider profile semantics | add boundary test/evidence that settings values do not carry launch semantics | unit or final verify |
 | FR-008 | implemented_unverified | runtime strategy and provider profile manager own launch payloads | preserve boundary; no generic settings launch implementation | final verify |
 | FR-009 | partial | response redaction tests exist; readiness diagnostics need sanitization tests | add redaction coverage for readiness diagnostics | unit + UI |
@@ -71,6 +71,7 @@ specs/271-provider-profile-readiness-settings/
 api_service/
 ├── api/routers/provider_profiles.py
 ├── db/models.py
+├── services/settings_catalog.py
 └── services/provider_profile_service.py
 
 frontend/src/components/settings/
@@ -78,7 +79,11 @@ frontend/src/components/settings/
 └── ProviderProfilesManager.test.tsx
 
 tests/unit/api_service/api/routers/
-└── test_provider_profiles.py
+├── test_provider_profiles.py
+└── test_settings_api.py
+
+tests/unit/services/
+└── test_settings_catalog.py
 ```
 
 **Structure Decision**: Use the existing provider profile API router, Settings component, and colocated tests. Add no new package or storage layer.

--- a/specs/271-provider-profile-readiness-settings/plan.md
+++ b/specs/271-provider-profile-readiness-settings/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Provider Profile Management and Readiness in Settings
+
+**Branch**: `run-jira-orchestrate-for-mm-541-provider-ff2c7460` | **Date**: 2026-04-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/271-provider-profile-readiness-settings/spec.md`
+
+## Summary
+
+Complete the Settings -> Providers & Secrets provider profile story for `MM-541` by adding a compact readiness contract to provider profile API responses and rendering those diagnostics in Mission Control. Current CRUD, default selection, owner authorization, SecretRef syntax validation, OAuth session actions, manual Claude API-key enrollment, and Claude-specific auth readiness exist, but readiness is not normalized for all provider profiles and the table does not expose all required launch-relevant metadata. The implementation will add backend readiness synthesis, frontend display and helpers, focused unit/UI tests, and final MoonSpec verification.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `api_service/api/routers/provider_profiles.py`; `frontend/src/components/settings/ProviderProfilesManager.tsx` expose CRUD, enable/disable, delete, default selection | preserve existing workflows and add readiness contract display | unit + UI |
+| FR-002 | partial | API response includes fields; UI table shows only a subset | expose model overrides, OAuth metadata, concurrency, cooldown, tags, priority, and readiness in list/detail display | UI |
+| FR-003 | partial | form exposes SecretRefs, OAuth volume fields, concurrency, cooldown, tags, priority; lacks normalized role/readiness guidance | add role-aware helper text and readiness diagnostics | UI |
+| FR-004 | implemented_unverified | SecretRef syntax validation exists; UI uses JSON textarea | add tests for role labels and no plaintext display in readiness/secret refs | unit + UI |
+| FR-005 | missing | Claude-specific readiness exists in `command_behavior`; no general readiness field | add `readiness` response model and synthesis from schema, required fields, SecretRefs, OAuth metadata, provider validation, enabled state, capacity, cooldown | unit + UI |
+| FR-006 | missing | no generic provider-profile reference setting diagnostics found | document as out-of-band for this slice unless existing settings reference appears during implementation; add provider-profile missing/unready launch blocker model where available | unit |
+| FR-007 | implemented_unverified | `docs/Security/SettingsSystem.md`; generic settings search found no inline provider profile semantics | add boundary test/evidence that settings values do not carry launch semantics | unit or final verify |
+| FR-008 | implemented_unverified | runtime strategy and provider profile manager own launch payloads | preserve boundary; no generic settings launch implementation | final verify |
+| FR-009 | partial | response redaction tests exist; readiness diagnostics need sanitization tests | add redaction coverage for readiness diagnostics | unit + UI |
+| FR-010 | missing | new artifacts preserve `MM-541`; final verification pending | preserve issue key in tasks, verification, commit metadata if committed | final verify |
+| DESIGN-REQ-002 | partial | ProviderProfile model and manager payload exist | preserve launch authority boundaries while adding display-only readiness | unit + verify |
+| DESIGN-REQ-012 | partial | Providers & Secrets section exists; references not inlined in settings | add readiness display and boundary evidence | UI + verify |
+| DESIGN-REQ-025 | partial | provider profile forms and Claude auth flows exist | add normalized readiness and role-aware display | unit + UI |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, React, TanStack Query, Vitest, Testing Library  
+**Storage**: Existing `managed_agent_provider_profiles`, `managed_secrets`, and `provider_profile_slot_leases`; no new tables planned  
+**Unit Testing**: `./tools/test_unit.sh` for final verification; targeted `pytest` and `npm run ui:test -- <path>` during iteration  
+**Integration Testing**: Existing hermetic integration runner `./tools/test_integration.sh`; this story expects focused API/UI unit coverage and final unit suite unless workflow boundaries change  
+**Target Platform**: Linux containers and Mission Control browser UI  
+**Project Type**: Web application with FastAPI backend and React frontend  
+**Performance Goals**: Provider profile list/readiness computation remains bounded to one query for profiles plus one best-effort query for managed secret metadata when needed  
+**Constraints**: Never expose raw credentials, decrypted secrets, OAuth state blobs, or generated credential files; preserve runtime strategy ownership of launch semantics  
+**Scale/Scope**: One Settings provider-profile story for workspace admins; no new persistent storage or new runtime launch path
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Runtime strategies and provider profile manager retain launch behavior; Settings displays and edits metadata.
+- II. One-Click Agent Deployment: PASS. No new external service dependency is introduced.
+- VII. Runtime Configurability: PASS. Provider profile behavior remains configuration/data driven.
+- IX. Resilient by Default: PASS. Readiness diagnostics fail explicitly instead of silently falling back.
+- XII. Canonical Docs vs Feature Artifacts: PASS. Implementation and rollout details stay under `specs/271-provider-profile-readiness-settings`.
+- XIII. Pre-Release Compatibility Policy: PASS. New internal response fields are added directly without compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/271-provider-profile-readiness-settings/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── provider-profile-readiness-api.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/provider_profiles.py
+├── db/models.py
+└── services/provider_profile_service.py
+
+frontend/src/components/settings/
+├── ProviderProfilesManager.tsx
+└── ProviderProfilesManager.test.tsx
+
+tests/unit/api_service/api/routers/
+└── test_provider_profiles.py
+```
+
+**Structure Decision**: Use the existing provider profile API router, Settings component, and colocated tests. Add no new package or storage layer.
+
+## Complexity Tracking
+
+No constitution violations require complexity exceptions.

--- a/specs/271-provider-profile-readiness-settings/quickstart.md
+++ b/specs/271-provider-profile-readiness-settings/quickstart.md
@@ -4,6 +4,7 @@
 
 ```bash
 pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q
+pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q
 npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx
 ```
 
@@ -22,4 +23,5 @@ npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test
 5. Disable the profile and confirm readiness becomes blocked.
 6. Configure an OAuth-backed profile without required OAuth metadata and confirm readiness explains the missing fields.
 7. Configure a profile with invalid or missing SecretRef data and confirm sanitized diagnostics appear without plaintext.
-8. Confirm runtime strategy code still owns command construction, environment shaping, generated files, process launch, and capability checks.
+8. Configure `workflow.default_provider_profile_ref` to a missing or disabled profile and confirm effective settings return explicit launch-blocker diagnostics.
+9. Confirm runtime strategy code still owns command construction, environment shaping, generated files, process launch, and capability checks.

--- a/specs/271-provider-profile-readiness-settings/quickstart.md
+++ b/specs/271-provider-profile-readiness-settings/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: Provider Profile Management and Readiness in Settings
+
+## Targeted Unit Tests
+
+```bash
+pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q
+npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx
+```
+
+## Final Unit Verification
+
+```bash
+./tools/test_unit.sh
+```
+
+## End-to-End Story Check
+
+1. Start MoonMind locally.
+2. Open Mission Control Settings -> Providers & Secrets.
+3. Create a provider profile with runtime, provider, materialization mode, default model, SecretRef role binding, concurrency, cooldown, priority, tags, and enabled state.
+4. Confirm the list displays launch-relevant profile metadata and readiness checks.
+5. Disable the profile and confirm readiness becomes blocked.
+6. Configure an OAuth-backed profile without required OAuth metadata and confirm readiness explains the missing fields.
+7. Configure a profile with invalid or missing SecretRef data and confirm sanitized diagnostics appear without plaintext.
+8. Confirm runtime strategy code still owns command construction, environment shaping, generated files, process launch, and capability checks.

--- a/specs/271-provider-profile-readiness-settings/research.md
+++ b/specs/271-provider-profile-readiness-settings/research.md
@@ -1,0 +1,57 @@
+# Research: Provider Profile Management and Readiness in Settings
+
+## FR-001 Provider Profile Workflows
+
+Decision: Partial implementation exists; preserve existing CRUD/default workflows and strengthen readiness visibility.
+Evidence: `api_service/api/routers/provider_profiles.py`; `frontend/src/components/settings/ProviderProfilesManager.tsx`; `tests/unit/api_service/api/routers/test_provider_profiles.py`.
+Rationale: Existing endpoints cover list, get, create, update, delete, enable/disable through PATCH, default normalization, owner authorization, OAuth actions, and manual Claude API-key enrollment.
+Alternatives considered: Create a separate Settings provider-profile API. Rejected because the existing router is already the public surface.
+Test implications: Add unit/UI tests only for missing readiness/display behavior; keep existing CRUD tests.
+
+## FR-002 and FR-003 Provider Profile Metadata Display
+
+Decision: Partial implementation; the API carries most fields, while the table needs denser launch-relevant display.
+Evidence: `ProviderProfileResponse` includes default model, model overrides, credential/materialization, OAuth fields, tags, priority, concurrency/cooldown; UI form exposes most but table omits several.
+Rationale: The story is best completed by rendering existing data plus readiness rather than introducing new persistence.
+Alternatives considered: Add backend descriptors for provider profile forms. Rejected for this story because the existing specialized UI already matches Provider Profiles as first-class resources.
+Test implications: UI tests for model overrides, OAuth metadata, concurrency/cooldown, tags/priority, and readiness summary.
+
+## FR-004 SecretRef Role Bindings
+
+Decision: Implemented but under-verified. Syntax validation exists; add role-aware UI copy and tests.
+Evidence: `validate_secret_refs_helper`; `parseSecretRefs`; Secret refs table summary.
+Rationale: SecretRefs are role-keyed JSON object entries. The UI should make that role/value relationship explicit without displaying plaintext.
+Alternatives considered: Replace JSON textarea with a full picker in this story. Rejected as too large and overlapping MM-540 managed secret picker work.
+Test implications: UI test for role labels and SecretRef-only display; backend test for invalid raw value already exists.
+
+## FR-005 Readiness Contract
+
+Decision: Missing for general provider profiles; add a compact synthesized readiness object to profile responses.
+Evidence: Claude auth readiness is embedded under `command_behavior.auth_readiness`, but generic rows have only `enabled`, `max_parallel_runs`, `cooldown_after_429_seconds`, SecretRefs, and OAuth fields.
+Rationale: A normalized readiness field lets the API and UI explain launch blockers without moving launch behavior into Settings.
+Alternatives considered: Query live ProviderProfileManager workflow state for every profile. Rejected for this story because it would add Temporal coupling and unstable latency to Settings list rendering.
+Test implications: Backend unit tests for disabled, missing SecretRef, missing OAuth metadata, Claude provider readiness, and redaction; UI tests for display.
+
+## FR-006 Provider Profile Reference Diagnostics
+
+Decision: No generic provider-profile reference setting exists in the current settings catalog. Cover the launch-blocker model through readiness and preserve this as final verification evidence.
+Evidence: Targeted searches in `api_service/services/settings_catalog.py` and tests found no provider-profile reference key.
+Rationale: Adding a new setting key would expand scope beyond provider profile management; the story can still ensure missing/unready profile diagnostics exist at the profile boundary.
+Alternatives considered: Add a `workflow.default_provider_profile_ref` setting now. Rejected because MM-537/MM-539 own settings catalog/effective-value surfaces.
+Test implications: Verify no generic setting inlines runtime launch semantics; test readiness blocker shape for missing metadata.
+
+## FR-007 and FR-008 Runtime Boundary
+
+Decision: Implemented_unverified; preserve existing boundary and add no launch logic to Settings.
+Evidence: `api_service/services/provider_profile_service.py` builds manager payloads; runtime strategy code lives under `moonmind/workflows`.
+Rationale: Settings should edit metadata and display readiness, while the manager and runtime strategies launch agents.
+Alternatives considered: Move command behavior validation into generic settings. Rejected by source design and security boundaries.
+Test implications: Final verification and focused tests ensure readiness is diagnostic-only.
+
+## FR-009 Sanitized Diagnostics
+
+Decision: Partial; response redaction exists but readiness messages need explicit redaction coverage.
+Evidence: `redact_sensitive_payload`, `redact_profile_file_templates`, existing redaction tests.
+Rationale: Readiness may include provider validation failure text. It must not echo tokens.
+Alternatives considered: Drop provider validation messages entirely. Rejected because actionable diagnostics are required; sanitized messages are sufficient.
+Test implications: Unit and UI tests assert token-like text is redacted from readiness diagnostics.

--- a/specs/271-provider-profile-readiness-settings/research.md
+++ b/specs/271-provider-profile-readiness-settings/research.md
@@ -34,11 +34,11 @@ Test implications: Backend unit tests for disabled, missing SecretRef, missing O
 
 ## FR-006 Provider Profile Reference Diagnostics
 
-Decision: No generic provider-profile reference setting exists in the current settings catalog. Cover the launch-blocker model through readiness and preserve this as final verification evidence.
-Evidence: Targeted searches in `api_service/services/settings_catalog.py` and tests found no provider-profile reference key.
-Rationale: Adding a new setting key would expand scope beyond provider profile management; the story can still ensure missing/unready profile diagnostics exist at the profile boundary.
-Alternatives considered: Add a `workflow.default_provider_profile_ref` setting now. Rejected because MM-537/MM-539 own settings catalog/effective-value surfaces.
-Test implications: Verify no generic setting inlines runtime launch semantics; test readiness blocker shape for missing metadata.
+Decision: Add a narrow `workflow.default_provider_profile_ref` setting that stores only a provider profile identifier and emits launch-blocker diagnostics when the referenced profile is missing or disabled.
+Evidence: `api_service/services/settings_catalog.py`; `tests/unit/services/test_settings_catalog.py`; `tests/unit/api_service/api/routers/test_settings_api.py`.
+Rationale: The spec requires user/workspace settings to reference provider profiles without inlining provider-profile launch semantics. A typed reference setting plus diagnostics satisfies the requirement while keeping runtime construction, credentials, environment shaping, generated files, process launch, and capability checks outside generic settings.
+Alternatives considered: Leave provider-profile references out of the settings catalog. Rejected during alignment because FR-006 and SC-004 explicitly require missing/disabled references to produce effective-setting diagnostics and launch blockers.
+Test implications: Unit tests for catalog exposure, missing/disabled provider profile diagnostics, and user-scope effective settings shape.
 
 ## FR-007 and FR-008 Runtime Boundary
 

--- a/specs/271-provider-profile-readiness-settings/spec.md
+++ b/specs/271-provider-profile-readiness-settings/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Provider Profile Management and Readiness in Settings
+
+**Feature Branch**: `271-provider-profile-readiness-settings`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-541 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-541 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-541
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Provider Profile management and readiness in Settings
+- Labels: moonmind-workflow-mm-285619b3-4c87-4e03-944f-282e648fa000
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-541 from MM project
+Summary: Provider Profile management and readiness in Settings
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-541 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-541: Provider Profile management and readiness in Settings
+
+Source Reference
+Source Document: docs/Security/SettingsSystem.md
+Source Title: Settings System
+Source Sections:
+- 2.3 What Provider Profiles own
+- 6.1 Providers & Secrets
+- 10.3 Provider Profile Resolution
+- 15. Provider Profiles Integration
+- 27.2 Add GitHub Token
+Coverage IDs:
+- DESIGN-REQ-002
+- DESIGN-REQ-012
+- DESIGN-REQ-025
+
+As a workspace admin, I can manage provider profiles in Settings and see readiness diagnostics while Provider Profiles remain the execution contract for runtime/provider launch semantics.
+
+Acceptance Criteria
+- Provider profile editing exposes runtime, provider, credential source class, materialization mode, default model, overrides, SecretRef role bindings, OAuth volume metadata, concurrency, cooldown, tags, priority, default status, and readiness where applicable.
+- Provider profile readiness combines schema validity, required fields, SecretRef resolvability, OAuth volume status, provider validation, enabled state, concurrency availability, and cooldown state.
+- A workspace or user setting may select a provider profile reference, but generic setting values do not inline runtime launch semantics.
+- Missing provider profile references return explicit diagnostics and launch blockers rather than silent fallback.
+- Runtime strategies still own command construction, environment shaping, generated runtime files, process launch, and capability checks.
+
+Requirements
+- Provider Profiles remain first-class resources inside Providers & Secrets.
+- Role-aware SecretRef pickers must describe what the profile needs and where the value can be resolved.
+- Readiness state must be observable before affected launches run.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-541 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Breakdown decision: `moonspec-breakdown` was not run because the Jira preset brief defines one independently testable Provider Profiles story.
+- Selected mode: Runtime.
+- Source design: `docs/Security/SettingsSystem.md` is treated as runtime source requirements.
+- Resume decision: No existing Moon Spec artifacts for `MM-541` were found under `specs/`; specification is the first incomplete stage.
+- Multi-spec ordering: Not applicable for `MM-541`.
+
+## User Story - Manage Provider Profiles and Readiness
+
+**Summary**: As a workspace admin, I can manage provider profiles in Settings and see readiness diagnostics while Provider Profiles remain the execution contract for runtime/provider launch semantics.
+
+**Goal**: MoonMind lets authorized Settings users create, inspect, edit, validate, enable, disable, and choose default provider profiles from Providers & Secrets, with actionable readiness diagnostics that explain whether a profile can launch without turning provider-profile semantics into generic settings.
+
+**Independent Test**: Open Settings -> Providers & Secrets, create or edit a provider profile with runtime/provider details, model defaults, SecretRef role bindings, OAuth volume metadata, concurrency and cooldown fields, validate readiness, select a default profile, and verify generic user/workspace settings can reference only provider profile identifiers while missing or unhealthy profiles produce explicit launch blockers.
+
+### Acceptance Scenarios
+
+1. Given a workspace admin opens Settings -> Providers & Secrets, when provider profiles are listed, then each profile shows runtime, provider, credential source class, materialization mode, default model, overrides, SecretRef binding summary, OAuth volume metadata, concurrency, cooldown, tags, priority, enabled/default state, and readiness where applicable.
+2. Given a workspace admin edits a provider profile, when required fields are missing or invalid, then the form reports schema and required-field diagnostics before the profile is used for launch.
+3. Given a provider profile requires secrets, when its SecretRef role bindings render, then each picker labels the required role and stores only the selected SecretRef location without exposing plaintext.
+4. Given a provider profile uses OAuth-backed credentials, when Settings renders readiness, then OAuth volume presence and status contribute to the readiness result.
+5. Given a profile has disabled state, exhausted concurrency, active cooldown, unresolved SecretRefs, failed provider validation, or missing required fields, when readiness is evaluated, then Settings shows explicit diagnostics and affected launches are blocked rather than silently falling back.
+6. Given a workspace or user setting selects a default provider profile, when the profile reference is missing or disabled, then the effective setting returns an explicit diagnostic and launch blocker while preserving Provider Profiles as the launch-semantics authority.
+7. Given runtime strategies launch an agent, when provider profile settings change, then command construction, environment shaping, generated runtime files, process launch, and capability checks remain owned by runtime strategies.
+
+### Edge Cases
+
+- Provider profile list or readiness fetch fails.
+- A profile references a deleted, disabled, malformed, or policy-disallowed SecretRef.
+- OAuth volume metadata exists but the backing credential state is missing or stale.
+- A default provider profile is deleted, disabled, or no longer valid for its runtime/provider.
+- Multiple profiles compete for default selection within the same runtime.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Settings MUST expose Provider Profiles as first-class resources inside Providers & Secrets with list, create, update, validate, enable, disable, delete, and default-selection workflows where authorized.
+- **FR-002**: Provider profile list and detail views MUST show runtime, provider, credential source class, materialization mode, default model, model overrides, tags, priority, enabled/default state, and readiness where applicable.
+- **FR-003**: Provider profile editing MUST expose profile-level SecretRef role bindings, OAuth volume metadata, concurrency limits, cooldown state or policy, and runtime/provider binding metadata without reducing profiles to generic key/value settings.
+- **FR-004**: Role-aware SecretRef pickers MUST describe the required credential role and store only SecretRef references without displaying plaintext secret values.
+- **FR-005**: Provider profile readiness MUST combine schema validity, required fields, SecretRef resolvability, OAuth volume status, provider-specific validation, enabled state, concurrency availability, and cooldown state where applicable.
+- **FR-006**: Missing, disabled, unhealthy, or unresolved provider profile references selected by user/workspace settings MUST return explicit diagnostics and launch blockers rather than silently falling back.
+- **FR-007**: Generic user/workspace settings MAY reference provider profile identifiers or selectors but MUST NOT inline runtime selection, credential source class, materialization, command construction, environment shaping, generated runtime files, process launch, or capability-check semantics.
+- **FR-008**: Runtime strategies MUST remain the authority for command construction, environment shaping, generated runtime files, process launch, and runtime-specific capability checks.
+- **FR-009**: Provider profile readiness and mutation failures MUST surface actionable, sanitized diagnostics without exposing raw credentials, tokens, OAuth state blobs, or decrypted files.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-541` and this canonical Jira preset brief.
+
+### Key Entities
+
+- **ProviderProfile**: A first-class resource that owns runtime/provider selection, credential source class, default model intent, materialization mode, routing metadata, SecretRef role bindings, OAuth volume references, concurrency and cooldown policy, priority, tags, enabled state, and default selection.
+- **ProviderProfileReadiness**: A diagnostic result that combines profile schema validity, required fields, SecretRef and OAuth readiness, provider validation, enabled state, concurrency availability, and cooldown state.
+- **SecretRefRoleBinding**: A mapping from a profile-required credential role to a SecretRef location, stored as metadata and never as plaintext.
+- **ProviderProfileReferenceSetting**: A user or workspace setting value that references a provider profile by stable identifier without copying provider launch semantics into generic settings.
+- **LaunchBlockerDiagnostic**: A sanitized explanation that a selected provider profile cannot be used for launch because it is missing, disabled, unhealthy, unavailable, or unresolved.
+
+## Assumptions
+
+- Existing Provider Profile data models, services, and runtime strategy boundaries remain authoritative for launch semantics.
+- This story extends the Settings Providers & Secrets surface rather than introducing a separate provider profile administration page.
+- Managed Secrets and OAuth credential storage semantics remain owned by their adjacent systems; this story only displays and binds their references for provider profiles.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-002 | `docs/Security/SettingsSystem.md` section 2.3 | Provider Profiles own runtime/provider selection, credential source class, routing metadata, default model intent, materialization strategy, launch shaping, concurrency, and cooldown policy; Settings may expose forms but must not become the execution authority. | In scope | FR-001, FR-002, FR-003, FR-007, FR-008 |
+| DESIGN-REQ-012 | `docs/Security/SettingsSystem.md` sections 6.1 and 10.3 | Providers & Secrets must expose provider-profile readiness while user/workspace settings may reference provider profiles without inlining provider profile semantics. | In scope | FR-005, FR-006, FR-007 |
+| DESIGN-REQ-025 | `docs/Security/SettingsSystem.md` sections 15 and 27.2 | Settings may manage provider profiles and role-aware SecretRef bindings; readiness combines schema validity, required fields, SecretRef resolvability, OAuth volume status, provider validation, enabled state, concurrency, and cooldown. | In scope | FR-001, FR-003, FR-004, FR-005, FR-009 |
+
+## Success Criteria
+
+- **SC-001**: A workspace admin can list and edit provider profiles from Settings -> Providers & Secrets without a separate administration surface.
+- **SC-002**: Provider profile readiness diagnostics identify at least schema, required-field, SecretRef, OAuth volume, provider validation, enabled-state, concurrency, and cooldown blockers where applicable.
+- **SC-003**: SecretRef role binding tests prove profile forms store SecretRef references only and never render submitted plaintext.
+- **SC-004**: User/workspace settings can reference provider profiles by identifier while missing or disabled references produce explicit diagnostics and launch blockers.
+- **SC-005**: Runtime strategy tests or boundary checks prove provider profile Settings changes do not move command construction, environment shaping, generated runtime files, process launch, or capability checks into generic settings.
+- **SC-006**: Verification evidence preserves `MM-541`, DESIGN-REQ-002, DESIGN-REQ-012, and DESIGN-REQ-025 across MoonSpec artifacts.

--- a/specs/271-provider-profile-readiness-settings/tasks.md
+++ b/specs/271-provider-profile-readiness-settings/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Provider Profile Management and Readiness in Settings
+
+**Input**: `specs/271-provider-profile-readiness-settings/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/provider-profile-readiness-api.md`
+**Unit test command**: `./tools/test_unit.sh`
+**Focused commands**: `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+
+## Source Traceability Summary
+
+- `MM-541`: preserved in `spec.md`, this task file, and final verification evidence.
+- `DESIGN-REQ-002`: Provider Profiles own launch semantics; Settings remains display/edit surface.
+- `DESIGN-REQ-012`: Providers & Secrets exposes readiness and generic settings do not inline provider semantics.
+- `DESIGN-REQ-025`: Provider profile editing, role-aware SecretRefs, OAuth metadata, and readiness diagnostics are visible.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature directory and existing artifact state in `specs/271-provider-profile-readiness-settings/spec.md`
+- [X] T002 Create MoonSpec plan, research, data model, contract, and quickstart artifacts in `specs/271-provider-profile-readiness-settings/`
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect existing provider profile API, service, UI, and tests in `api_service/api/routers/provider_profiles.py`, `api_service/services/provider_profile_service.py`, `frontend/src/components/settings/ProviderProfilesManager.tsx`, and existing provider profile tests
+- [X] T004 Define a response-only readiness shape without new persistent storage in `api_service/api/routers/provider_profiles.py`
+
+## Phase 3: Story - Manage Provider Profiles and Readiness
+
+**Story summary**: Workspace admins manage provider profiles in Settings and see actionable readiness diagnostics while runtime launch semantics remain owned by Provider Profiles and runtime strategies.
+
+**Independent test**: Open Settings -> Providers & Secrets, inspect and edit launch-relevant provider profile metadata, validate readiness diagnostics, and confirm diagnostics do not expose credentials.
+
+### Unit Test Plan
+
+- Backend response shape and readiness synthesis for ready, disabled, missing OAuth metadata, malformed/missing SecretRefs, provider validation state, and redaction.
+- Frontend helper/rendering tests for readiness status, metadata display, role-aware SecretRef text, and sanitized failure display.
+
+### Integration Test Plan
+
+- Existing API route tests use ASGI + SQLite and cover the real FastAPI provider profile boundary.
+- Existing React tests cover the Mission Control provider profile component boundary.
+
+### Tests First
+
+- [X] T005 [P] Add failing backend API tests for `readiness` response shape and disabled/OAuth/SecretRef blockers in `tests/unit/api_service/api/routers/test_provider_profiles.py` (FR-005, FR-006, FR-009, DESIGN-REQ-025)
+- [X] T006 [P] Add failing backend redaction test for provider readiness diagnostics in `tests/unit/api_service/api/routers/test_provider_profiles.py` (FR-009)
+- [X] T007 [P] Add failing UI tests for provider metadata and readiness display in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` (FR-002, FR-005, DESIGN-REQ-012)
+- [X] T008 [P] Add failing UI test for role-aware SecretRef display without plaintext in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` (FR-004, FR-009, DESIGN-REQ-025)
+- [X] T009 Run targeted failing tests with `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q` and `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+
+### Implementation
+
+- [X] T010 Add `ProviderReadinessCheck` and `ProviderProfileReadiness` Pydantic response models in `api_service/api/routers/provider_profiles.py` (FR-005)
+- [X] T011 Implement readiness synthesis helper in `api_service/api/routers/provider_profiles.py` using existing profile fields, managed secret metadata, and sanitized provider validation metadata (FR-005, FR-009)
+- [X] T012 Include readiness in provider profile list/get/create/update responses in `api_service/api/routers/provider_profiles.py` without adding launch behavior to Settings (FR-001, FR-005, DESIGN-REQ-002)
+- [X] T013 Extend `ProviderProfile` and render helpers in `frontend/src/components/settings/ProviderProfilesManager.tsx` for readiness and launch-relevant metadata (FR-002, FR-005)
+- [X] T014 Add role-aware SecretRef and OAuth/concurrency/cooldown display in `frontend/src/components/settings/ProviderProfilesManager.tsx` (FR-003, FR-004, DESIGN-REQ-025)
+- [X] T015 Keep runtime strategy ownership unchanged by avoiding generic settings launch code and preserving manager payload boundaries in `api_service/services/provider_profile_service.py` (FR-007, FR-008)
+
+### Story Validation
+
+- [X] T016 Run targeted backend and frontend tests and confirm pass: `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+- [X] T017 Update task checkboxes for completed story tasks in `specs/271-provider-profile-readiness-settings/tasks.md`
+
+## Final Phase: Polish And Verification
+
+- [X] T018 Run `./tools/test_unit.sh` for final unit verification
+- [X] T019 Run MoonSpec verification and write `specs/271-provider-profile-readiness-settings/verification.md`
+- [X] T020 Preserve `MM-541` in final summary and commit metadata if a commit is created
+
+## Dependencies And Execution Order
+
+1. T003-T004 before tests and implementation.
+2. T005-T009 before T010-T015.
+3. T010-T012 before backend test pass.
+4. T013-T014 before UI test pass.
+5. T016-T020 after implementation.
+
+## Parallel Examples
+
+- T005/T006 and T007/T008 can be written in parallel because they touch separate test files.
+- T010-T012 and T013-T014 can be implemented in parallel after the test expectations are known.
+
+## Implementation Strategy
+
+Keep the change response-only and diagnostic-only. Do not add persistent storage or move launch semantics into Settings. Readiness can summarize Settings-visible blockers but runtime strategies and ProviderProfileManager remain authoritative for actual launch behavior.

--- a/specs/271-provider-profile-readiness-settings/tasks.md
+++ b/specs/271-provider-profile-readiness-settings/tasks.md
@@ -2,7 +2,7 @@
 
 **Input**: `specs/271-provider-profile-readiness-settings/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/provider-profile-readiness-api.md`
 **Unit test command**: `./tools/test_unit.sh`
-**Focused commands**: `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+**Focused commands**: `pytest tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
 
 ## Source Traceability Summary
 
@@ -10,6 +10,7 @@
 - `DESIGN-REQ-002`: Provider Profiles own launch semantics; Settings remains display/edit surface.
 - `DESIGN-REQ-012`: Providers & Secrets exposes readiness and generic settings do not inline provider semantics.
 - `DESIGN-REQ-025`: Provider profile editing, role-aware SecretRefs, OAuth metadata, and readiness diagnostics are visible.
+- `FR-006`/`SC-004`: Generic settings may reference provider profile identifiers and must emit explicit launch blockers for missing or disabled referenced profiles.
 
 ## Phase 1: Setup
 
@@ -43,41 +44,43 @@
 - [X] T006 [P] Add failing backend redaction test for provider readiness diagnostics in `tests/unit/api_service/api/routers/test_provider_profiles.py` (FR-009)
 - [X] T007 [P] Add failing UI tests for provider metadata and readiness display in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` (FR-002, FR-005, DESIGN-REQ-012)
 - [X] T008 [P] Add failing UI test for role-aware SecretRef display without plaintext in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` (FR-004, FR-009, DESIGN-REQ-025)
-- [X] T009 Run targeted failing tests with `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q` and `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+- [X] T009 [P] Add failing settings catalog tests for `workflow.default_provider_profile_ref` exposure and missing/disabled provider profile diagnostics in `tests/unit/services/test_settings_catalog.py` and `tests/unit/api_service/api/routers/test_settings_api.py` (FR-006, FR-007, SC-004, DESIGN-REQ-012)
+- [X] T010 Run targeted failing tests with `pytest tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q` and `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
 
 ### Implementation
 
-- [X] T010 Add `ProviderReadinessCheck` and `ProviderProfileReadiness` Pydantic response models in `api_service/api/routers/provider_profiles.py` (FR-005)
-- [X] T011 Implement readiness synthesis helper in `api_service/api/routers/provider_profiles.py` using existing profile fields, managed secret metadata, and sanitized provider validation metadata (FR-005, FR-009)
-- [X] T012 Include readiness in provider profile list/get/create/update responses in `api_service/api/routers/provider_profiles.py` without adding launch behavior to Settings (FR-001, FR-005, DESIGN-REQ-002)
-- [X] T013 Extend `ProviderProfile` and render helpers in `frontend/src/components/settings/ProviderProfilesManager.tsx` for readiness and launch-relevant metadata (FR-002, FR-005)
-- [X] T014 Add role-aware SecretRef and OAuth/concurrency/cooldown display in `frontend/src/components/settings/ProviderProfilesManager.tsx` (FR-003, FR-004, DESIGN-REQ-025)
-- [X] T015 Keep runtime strategy ownership unchanged by avoiding generic settings launch code and preserving manager payload boundaries in `api_service/services/provider_profile_service.py` (FR-007, FR-008)
+- [X] T011 Add `ProviderReadinessCheck` and `ProviderProfileReadiness` Pydantic response models in `api_service/api/routers/provider_profiles.py` (FR-005)
+- [X] T012 Implement readiness synthesis helper in `api_service/api/routers/provider_profiles.py` using existing profile fields, managed secret metadata, and sanitized provider validation metadata (FR-005, FR-009)
+- [X] T013 Include readiness in provider profile list/get/create/update responses in `api_service/api/routers/provider_profiles.py` without adding launch behavior to Settings (FR-001, FR-005, DESIGN-REQ-002)
+- [X] T014 Extend `ProviderProfile` and render helpers in `frontend/src/components/settings/ProviderProfilesManager.tsx` for readiness and launch-relevant metadata (FR-002, FR-005)
+- [X] T015 Add role-aware SecretRef and OAuth/concurrency/cooldown display in `frontend/src/components/settings/ProviderProfilesManager.tsx` (FR-003, FR-004, DESIGN-REQ-025)
+- [X] T016 Keep runtime strategy ownership unchanged by avoiding generic settings launch code and preserving manager payload boundaries in `api_service/services/provider_profile_service.py` (FR-007, FR-008)
+- [X] T017 Add identifier-only provider profile reference setting and missing/disabled launch-blocker diagnostics in `api_service/services/settings_catalog.py` (FR-006, FR-007, SC-004, DESIGN-REQ-012)
 
 ### Story Validation
 
-- [X] T016 Run targeted backend and frontend tests and confirm pass: `pytest tests/unit/api_service/api/routers/test_provider_profiles.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
-- [X] T017 Update task checkboxes for completed story tasks in `specs/271-provider-profile-readiness-settings/tasks.md`
+- [X] T018 Run targeted backend and frontend tests and confirm pass: `pytest tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_provider_profiles.py -q`; `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+- [X] T019 Update task checkboxes for completed story tasks in `specs/271-provider-profile-readiness-settings/tasks.md`
 
 ## Final Phase: Polish And Verification
 
-- [X] T018 Run `./tools/test_unit.sh` for final unit verification
-- [X] T019 Run MoonSpec verification and write `specs/271-provider-profile-readiness-settings/verification.md`
-- [X] T020 Preserve `MM-541` in final summary and commit metadata if a commit is created
+- [X] T020 Run `./tools/test_unit.sh` for final unit verification
+- [X] T021 Run MoonSpec verification and write `specs/271-provider-profile-readiness-settings/verification.md`
+- [X] T022 Preserve `MM-541` in final summary and commit metadata if a commit is created
 
 ## Dependencies And Execution Order
 
 1. T003-T004 before tests and implementation.
-2. T005-T009 before T010-T015.
-3. T010-T012 before backend test pass.
-4. T013-T014 before UI test pass.
-5. T016-T020 after implementation.
+2. T005-T010 before T011-T017.
+3. T011-T013 and T017 before backend test pass.
+4. T014-T015 before UI test pass.
+5. T018-T022 after implementation.
 
 ## Parallel Examples
 
-- T005/T006 and T007/T008 can be written in parallel because they touch separate test files.
-- T010-T012 and T013-T014 can be implemented in parallel after the test expectations are known.
+- T005/T006/T009 and T007/T008 can be written in parallel because they touch separate test files.
+- T011-T013/T017 and T014-T015 can be implemented in parallel after the test expectations are known.
 
 ## Implementation Strategy
 
-Keep the change response-only and diagnostic-only. Do not add persistent storage or move launch semantics into Settings. Readiness can summarize Settings-visible blockers but runtime strategies and ProviderProfileManager remain authoritative for actual launch behavior.
+Keep the change response-only and diagnostic-only. Do not add persistent storage or move launch semantics into Settings. Readiness can summarize Settings-visible blockers, and generic settings can reference provider profile identifiers with launch-blocker diagnostics, but runtime strategies and ProviderProfileManager remain authoritative for actual launch behavior.

--- a/specs/271-provider-profile-readiness-settings/verification.md
+++ b/specs/271-provider-profile-readiness-settings/verification.md
@@ -1,0 +1,68 @@
+# MoonSpec Verification Report
+
+**Feature**: Provider Profile Management and Readiness in Settings  
+**Spec**: `specs/271-provider-profile-readiness-settings/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving Jira issue `MM-541`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused backend | `pytest tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_provider_profiles.py -q` | PASS | 55 passed; covers provider profile readiness API plus provider profile reference setting diagnostics. |
+| Focused frontend | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/ProviderProfilesManager.test.tsx` | PASS | 46 passed; `npm run ui:test -- ...` could not resolve `vitest` in this shell, so the same local binary was invoked directly. |
+| Full unit | `./tools/test_unit.sh` | PASS | 4137 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest suite passed with 17 files and 459 tests. |
+| Integration | `./tools/test_integration.sh` | NOT RUN | This change is covered by existing FastAPI route tests and React component tests. No Temporal workflow/activity signature or compose boundary changed. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `api_service/api/routers/provider_profiles.py`; `ProviderProfilesManager.tsx`; provider profile route tests | VERIFIED | Existing CRUD/default workflows preserved; responses now include readiness. |
+| FR-002 | `ProviderProfilesManager.tsx`; `ProviderProfilesManager.test.tsx` | VERIFIED | UI renders provider/model metadata, OAuth metadata, concurrency, cooldown, tags, priority, and readiness. |
+| FR-003 | `ProviderProfilesManager.tsx`; UI tests | VERIFIED | Provider profile form/list surfaces SecretRefs, OAuth volume metadata, concurrency/cooldown, tags, priority, and runtime/provider binding metadata. |
+| FR-004 | `validate_secret_refs_helper`; `ProviderProfilesManager.tsx`; backend/UI tests | VERIFIED | SecretRef roles are displayed as role-to-reference bindings; plaintext is not shown. |
+| FR-005 | `ProviderReadinessCheck`, `ProviderProfileReadiness`, `_provider_profile_readiness`; backend tests | VERIFIED | Readiness combines required fields, SecretRefs, OAuth metadata, provider validation, enabled state, concurrency, and cooldown. |
+| FR-006 | `SettingsCatalogService` provider profile reference setting and diagnostics; settings tests | VERIFIED | Missing and disabled provider profile references return explicit launch-blocker diagnostics. |
+| FR-007 | `SettingsCatalogService` provider profile reference setting; plan/research boundary; tests | VERIFIED | Generic settings reference profile IDs only and do not inline launch semantics. |
+| FR-008 | `api_service/services/provider_profile_service.py` unchanged launch payload boundary; provider profile router is diagnostic/edit only | VERIFIED | Runtime strategies and ProviderProfileManager remain launch authorities. |
+| FR-009 | readiness redaction helper usage; backend and UI tests | VERIFIED | Provider readiness failure text is sanitized before API/UI display. |
+| FR-010 | `spec.md`, `tasks.md`, this report | VERIFIED | `MM-541` is preserved across artifacts and final evidence. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| List displays launch metadata and readiness | `ProviderProfilesManager.test.tsx` readiness metadata test | VERIFIED | Covers runtime/provider, model, OAuth, concurrency, cooldown, tags, priority, SecretRefs, and readiness. |
+| Invalid or incomplete profile reports diagnostics | `test_provider_profile_response_includes_readiness_blockers` | VERIFIED | Disabled profile plus missing OAuth metadata blocks launch readiness. |
+| Role-aware SecretRefs | `ProviderProfilesManager.test.tsx`; `test_create_provider_profile_invalid_secret_refs` | VERIFIED | Role names and SecretRefs display without plaintext; invalid raw refs fail. |
+| OAuth metadata contributes readiness | backend readiness tests | VERIFIED | OAuth-backed profile missing `volume_ref`/`volume_mount_path` is blocked. |
+| Unhealthy profile blocks instead of fallback | backend readiness and settings reference diagnostics tests | VERIFIED | Missing/disabled refs and failed provider validation are explicit blockers. |
+| Generic settings do not inline launch semantics | settings catalog provider profile reference test | VERIFIED | The new setting is a provider profile picker/reference only. |
+| Runtime strategies remain launch authority | code inspection and unchanged manager payload boundary | VERIFIED | No launch construction moved into Settings. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-002 | provider profile API/readiness remains response-only; service launch payload boundary unchanged | VERIFIED | Settings exposes Provider Profiles without owning runtime launch semantics. |
+| DESIGN-REQ-012 | Providers & Secrets readiness display plus provider-profile reference setting diagnostics | VERIFIED | Readiness is visible; generic settings only reference profiles. |
+| DESIGN-REQ-025 | SecretRef role display, OAuth metadata, readiness checks | VERIFIED | Provider profile integration requirements are covered. |
+| Constitution IX | explicit blocked readiness and launch-blocker diagnostics | VERIFIED | No silent fallback for missing or disabled provider profile references. |
+| Constitution XII | implementation details remain under feature artifacts | VERIFIED | Canonical docs were not rewritten. |
+
+## Original Request Alignment
+
+- PASS: The Jira preset brief for `MM-541` was fetched through trusted Jira tools earlier in the run and preserved in `spec.md`.
+- PASS: The implementation is runtime mode and treats `docs/Security/SettingsSystem.md` as source requirements.
+- PASS: Existing MoonSpec artifacts were inspected; no `MM-541` artifacts existed, so the workflow started at Specify and completed through verification.
+- PASS: The story remains single-story and focused on Provider Profile management and readiness in Settings.
+
+## Gaps
+
+- None blocking.
+
+## Remaining Work
+
+- None required for `MM-541`.

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -430,6 +430,120 @@ async def test_create_provider_profile_invalid_secret_refs(client_app: AsyncClie
     assert "Invalid secret reference" in response.text
 
 @pytest.mark.asyncio
+async def test_provider_profile_response_includes_readiness_blockers(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = "oauth_missing_metadata_readiness"
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="claude_code",
+                    provider_id="anthropic",
+                    credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                    runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                    volume_ref=None,
+                    volume_mount_path=None,
+                    enabled=False,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    readiness = response.json()["readiness"]
+    assert readiness["status"] == "blocked"
+    assert readiness["launch_ready"] is False
+    checks = {check["id"]: check for check in readiness["checks"]}
+    assert checks["enabled"]["status"] == "error"
+    assert checks["oauth_volume"]["status"] == "error"
+    assert "volume_ref" in checks["oauth_volume"]["message"]
+    assert "volume_mount_path" in checks["oauth_volume"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_readiness_reports_managed_secret_status(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = "missing_db_secret_readiness"
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="codex_cli",
+                    provider_id="openai",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    secret_refs={"provider_api_key": "db://does-not-exist"},
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    readiness = response.json()["readiness"]
+    assert readiness["status"] == "blocked"
+    checks = {check["id"]: check for check in readiness["checks"]}
+    assert checks["secret_refs"]["status"] == "error"
+    assert "provider_api_key" in checks["secret_refs"]["message"]
+    assert "does-not-exist" in checks["secret_refs"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_readiness_redacts_provider_failure_text(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = "provider_failure_readiness_redaction"
+    raw_token = "sk-ant-secret-readiness-token"
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="claude_code",
+                    provider_id="anthropic",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    secret_refs={"anthropic_api_key": "env://ANTHROPIC_API_KEY"},
+                    command_behavior={
+                        "auth_readiness": {
+                            "launch_ready": False,
+                            "failure_reason": f"token={raw_token} expired",
+                        }
+                    },
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    response_text = response.text
+    assert raw_token not in response_text
+    readiness = response.json()["readiness"]
+    checks = {check["id"]: check for check in readiness["checks"]}
+    assert checks["provider_validation"]["status"] == "error"
+    assert "[REDACTED]" in checks["provider_validation"]["message"]
+
+@pytest.mark.asyncio
 async def test_create_duplicate_profile(client_app: AsyncClient, _module_db):
     """Test creating a profile that already exists returns 409."""
     sample_profile = await get_or_create_sample_profile()

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -503,6 +503,41 @@ async def test_provider_profile_readiness_reports_managed_secret_status(
 
 
 @pytest.mark.asyncio
+async def test_provider_profile_readiness_reports_invalid_stored_secret_ref(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = "invalid_stored_secret_ref_readiness"
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="codex_cli",
+                    provider_id="openai",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    secret_refs={"provider_api_key": "not-a-secret-ref"},
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    readiness = response.json()["readiness"]
+    assert readiness["status"] == "blocked"
+    checks = {check["id"]: check for check in readiness["checks"]}
+    assert checks["secret_refs"]["status"] == "error"
+    assert "provider_api_key" in checks["secret_refs"]["message"]
+    assert "invalid SecretRef" in checks["secret_refs"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_provider_profile_readiness_redacts_provider_failure_text(
     client_app: AsyncClient,
     _module_db,

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -149,7 +149,10 @@ async def test_effective_settings_endpoint_filters_by_scope():
     assert response.status_code == 200
     body = response.json()
     assert body["scope"] == "user"
-    assert list(body["values"]) == ["integrations.github.token_ref"]
+    assert list(body["values"]) == [
+        "integrations.github.token_ref",
+        "workflow.default_provider_profile_ref",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -2,7 +2,13 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from api_service.db.models import Base, ManagedSecret
+from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    ManagedSecret,
+    ProviderCredentialSource,
+    RuntimeMaterializationMode,
+)
 from api_service.services.settings_catalog import SettingsCatalogService
 
 
@@ -53,6 +59,26 @@ def test_catalog_returns_exposed_descriptor_metadata_and_omits_unexposed_setting
         for descriptor in descriptors
     }
     assert "workflow.github_token" not in all_keys
+
+
+def test_catalog_exposes_provider_profile_reference_without_launch_semantics():
+    service = SettingsCatalogService(env={})
+
+    catalog = service.catalog(section="user-workspace", scope="workspace")
+
+    workflow = catalog.categories["Workflow"]
+    provider_profile = next(
+        item for item in workflow if item.key == "workflow.default_provider_profile_ref"
+    )
+    assert provider_profile.type == "string"
+    assert provider_profile.ui == "provider_profile_picker"
+    assert provider_profile.applies_to == [
+        "task_creation",
+        "workflow_runtime",
+        "provider_profiles",
+    ]
+    assert provider_profile.effective_value is None
+    assert provider_profile.diagnostics[0].code == "inherited_null"
 
 
 def test_effective_value_reports_environment_source_and_explanation():
@@ -170,6 +196,43 @@ async def _workspace_override_persists_and_reports_version(settings_session):
     )
     assert updated.values["workflow.default_publish_mode"].value == "none"
     assert updated.values["workflow.default_publish_mode"].value_version == 2
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_reference_reports_missing_and_disabled_diagnostics(
+    settings_session_maker,
+) -> None:
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            ManagedAgentProviderProfile(
+                profile_id="disabled-profile",
+                runtime_id="codex_cli",
+                provider_id="openai",
+                credential_source=ProviderCredentialSource.SECRET_REF,
+                runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                enabled=False,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(env={}, session=settings_session)
+        missing = await service.apply_overrides(
+            scope="workspace",
+            changes={"workflow.default_provider_profile_ref": "missing-profile"},
+            expected_versions={"workflow.default_provider_profile_ref": 1},
+        )
+        missing_value = missing.values["workflow.default_provider_profile_ref"]
+        assert missing_value.diagnostics[0].code == "provider_profile_not_found"
+        assert missing_value.diagnostics[0].details["launch_blocker"] is True
+
+        disabled = await service.apply_overrides(
+            scope="workspace",
+            changes={"workflow.default_provider_profile_ref": "disabled-profile"},
+            expected_versions={"workflow.default_provider_profile_ref": 1},
+        )
+        disabled_value = disabled.values["workflow.default_provider_profile_ref"]
+        assert disabled_value.diagnostics[0].code == "provider_profile_disabled"
+        assert disabled_value.diagnostics[0].details["launch_blocker"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements MM-541 Provider Profile management and readiness in Settings.

- Adds normalized provider profile readiness to provider profile API responses.
- Displays readiness, launch-relevant profile metadata, role-aware SecretRefs, OAuth metadata, concurrency, cooldown, tags, and priority in Mission Control Settings.
- Adds identifier-only `workflow.default_provider_profile_ref` settings diagnostics for missing or disabled provider profiles without moving launch semantics into generic settings.
- Adds MoonSpec artifacts for `specs/271-provider-profile-readiness-settings`.

## Jira

- Jira issue key: MM-541

## MoonSpec

- Active feature path: `specs/271-provider-profile-readiness-settings`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests Run

- `pytest tests/unit/api_service/api/routers/test_settings_api.py tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_provider_profiles.py -q` — PASS, 55 passed
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/ProviderProfilesManager.test.tsx` — PASS, 46 passed
- `./tools/test_unit.sh` — PASS, 4137 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest suite passed with 17 files and 459 tests
- `./tools/test_integration.sh` — NOT RUN; no Temporal workflow/activity signature or compose boundary changed, and the story is covered by FastAPI route tests plus React component tests

## Remaining Risks

- The full compose-backed integration suite was not run for this UI/API-focused change.
- `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx` could not resolve `vitest` in this shell, so the same local binary was invoked directly.
