### PR TITLE
[codex] Handle pr-resolver finalOutcome disposition

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -107,6 +107,8 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
         payload.get("state"),
         payload.get("merge_outcome"),
         payload.get("outcome"),
+        payload.get("finalOutcome"),
+        payload.get("final_outcome"),
         payload.get("final_state"),
         payload.get("finalState"),
     )
@@ -120,6 +122,8 @@ def _pr_resolver_status(payload: dict[str, Any]) -> str:
             final.get("status"),
             final.get("merge_outcome"),
             final.get("outcome"),
+            final.get("finalOutcome"),
+            final.get("final_outcome"),
             final.get("final_state"),
             final.get("finalState"),
         )

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -139,6 +139,9 @@ def _pr_resolver_final_payload(payload: dict[str, Any]) -> dict[str, Any]:
     merge_outcome = payload.get("mergeOutcome")
     if isinstance(merge_outcome, dict):
         return merge_outcome
+    merge = payload.get("merge")
+    if isinstance(merge, dict):
+        return merge
     return {}
 
 

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -56,7 +56,10 @@ pytestmark = [pytest.mark.asyncio]
         ({"state": "MERGED"}, "merged"),
         ({"final": {"final_state": "MERGED"}}, "merged"),
         ({"final": {"finalState": "MERGED"}}, "merged"),
+        ({"finalOutcome": "merged"}, "merged"),
+        ({"final_outcome": "merged"}, "merged"),
         ({"mergeOutcome": {"state": "MERGED"}}, "merged"),
+        ({"mergeOutcome": {"finalOutcome": "MERGED"}}, "merged"),
     ],
 )
 async def test_pr_resolver_status_accepts_final_state_aliases(
@@ -1586,6 +1589,58 @@ async def test_fetch_result_ignores_merged_pr_resolver_artifact(tmp_path: Path):
 
     result = await adapter.fetch_result(
         "run-result-pr-merged", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+
+async def test_fetch_result_maps_final_outcome_pr_resolver_result(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "pr": 1652,\n'
+            '  "url": "https://github.com/MoonLadderStudios/Tactics/pull/1652",\n'
+            '  "actions": ["enabled auto-merge with merge method"],\n'
+            '  "finalOutcome": "merged",\n'
+            '  "mergedAt": "2026-04-28T09:03:57Z",\n'
+            '  "mergedBy": "nsticco"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-final-outcome",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-final-outcome",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-final-outcome", pr_resolver_expected=True
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "merged"

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -60,6 +60,7 @@ pytestmark = [pytest.mark.asyncio]
         ({"final_outcome": "merged"}, "merged"),
         ({"mergeOutcome": {"state": "MERGED"}}, "merged"),
         ({"mergeOutcome": {"finalOutcome": "MERGED"}}, "merged"),
+        ({"merge": {"state": "MERGED"}}, "merged"),
     ],
 )
 async def test_pr_resolver_status_accepts_final_state_aliases(
@@ -1641,6 +1642,61 @@ async def test_fetch_result_maps_final_outcome_pr_resolver_result(
 
     result = await adapter.fetch_result(
         "run-result-pr-final-outcome", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+
+async def test_fetch_result_maps_merge_object_pr_resolver_result(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "pr": 1654,\n'
+            '  "url": "https://github.com/MoonLadderStudios/Tactics/pull/1654",\n'
+            '  "branch": "149-initiative-current-cursor",\n'
+            '  "actions": ["Enabled merge via gh pr merge --auto --merge"],\n'
+            '  "merge": {\n'
+            '    "state": "MERGED",\n'
+            '    "merged_at": "2026-04-28T08:28:55Z",\n'
+            '    "merge_commit": "d56a1c93f590b7b871242f950f7b499da5887bfc"\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-merge-object",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-merge-object",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-merge-object", pr_resolver_expected=True
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "merged"


### PR DESCRIPTION
## Summary

- recognize `finalOutcome` / `final_outcome` as PR resolver terminal status fields
- derive `mergeAutomationDisposition=merged` from that artifact shape for merge automation
- add a regression test matching the failed PR resolver handoff

## Root Cause

A resolver run wrote `artifacts/pr_resolver_result.json` with `finalOutcome: "merged"` but without `mergeAutomationDisposition`. The adapter did not treat `finalOutcome` as a terminal resolver status, so merge automation received a successful child result with no disposition and failed fast.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `./tools/test_unit.sh`