### PR TITLE
MM-546 Settings migration invariants

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/274-change-application-semantics"
+  "feature_directory": "specs/275-settings-migration-invariants"
 }

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -40,6 +40,7 @@ SettingActivationState = Literal[
     "pending_restart",
     "pending_manual_operation",
 ]
+SettingMigrationState = Literal["renamed", "deprecated", "removed", "type_changed"]
 _DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
 _PERSISTED_SCOPES: set[SettingScope] = {"user", "workspace"}
 _SECRET_PREFIXES = ("ghp_", "github_pat_", "AIza", "AKIA")
@@ -122,6 +123,23 @@ class SettingDiagnostic(BaseModel):
     message: str
     severity: Literal["info", "warning", "error"] = "info"
     details: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SettingMigrationRule:
+    old_key: str
+    state: SettingMigrationState
+    message: str
+    new_key: str | None = None
+    expected_schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.old_key:
+            raise ValueError("migration rule old_key is required")
+        if self.state == "renamed" and not self.new_key:
+            raise ValueError("renamed setting migration requires new_key")
+        if self.expected_schema_version < 1:
+            raise ValueError("expected_schema_version must be positive")
 
 
 class SettingDescriptor(BaseModel):
@@ -445,6 +463,7 @@ class SettingsCatalogService:
         settings: AppSettings | None = None,
         env: dict[str, str] | None = None,
         registry: tuple[SettingRegistryEntry, ...] = _REGISTRY,
+        migration_rules: tuple[SettingMigrationRule, ...] = (),
         session: AsyncSession | None = None,
         workspace_id: UUID | None = None,
         user_id: UUID | None = None,
@@ -453,6 +472,17 @@ class SettingsCatalogService:
         self._env = env if env is not None else os.environ
         self._registry = registry
         self._entries_by_key = {entry.key: entry for entry in registry}
+        self._migration_rules = migration_rules
+        self._rules_by_old_key = {rule.old_key: rule for rule in migration_rules}
+        self._rename_rules_by_new_key = {
+            str(rule.new_key): rule
+            for rule in migration_rules
+            if rule.state == "renamed" and rule.new_key is not None
+        }
+        self._type_rules_by_key = {
+            rule.old_key: rule for rule in migration_rules if rule.state == "type_changed"
+        }
+        self._migration_diagnostics_by_key: dict[str, SettingDiagnostic] = {}
         self._redacted_invalid_secret_refs: set[str] = set()
         self._session = session
         self._workspace_id = workspace_id or _DEFAULT_SUBJECT_ID
@@ -570,6 +600,13 @@ class SettingsCatalogService:
         )
 
     def ensure_write_allowed(self, key: str, *, scope: SettingScope) -> None:
+        migration_rule = self._rules_by_old_key.get(key)
+        if migration_rule is not None and migration_rule.state in {
+            "renamed",
+            "deprecated",
+            "removed",
+        }:
+            raise PermissionError(migration_rule.message)
         entry = self._entries_by_key.get(key)
         if entry is None:
             raise KeyError(key)
@@ -728,6 +765,13 @@ class SettingsCatalogService:
         )
 
         for key, value in changes.items():
+            migration_rule = self._rules_by_old_key.get(key)
+            if migration_rule is not None and migration_rule.state in {
+                "renamed",
+                "deprecated",
+                "removed",
+            }:
+                raise PermissionError(migration_rule.message)
             entry = self._entries_by_key.get(key)
             if entry is None:
                 raise KeyError(key)
@@ -969,9 +1013,11 @@ class SettingsCatalogService:
                 diagnostics=diagnostics,
                 recent_change=recent_changes.get(entry.key),
             )
+        values.update(await self._deprecated_override_diagnostics(scope=scope))
         return SettingsDiagnosticsResponse(scope=scope, values=values)
 
     def _validate_registry(self) -> None:
+        self._validate_migration_rules()
         for entry in self._registry:
             if not entry.apply_mode:
                 raise ValueError(f"invalid_apply_mode for setting {entry.key!r}")
@@ -991,6 +1037,17 @@ class SettingsCatalogService:
                 raise ValueError(
                     f"invalid_apply_mode for setting {entry.key!r}: "
                     "non-immediate settings require affected systems"
+                )
+
+    def _validate_migration_rules(self) -> None:
+        seen: set[str] = set()
+        for rule in self._migration_rules:
+            if rule.old_key in seen:
+                raise ValueError(f"duplicate migration rule for {rule.old_key!r}")
+            seen.add(rule.old_key)
+            if rule.state == "renamed" and rule.new_key not in self._entries_by_key:
+                raise ValueError(
+                    f"renamed migration target {rule.new_key!r} is not exposed"
                 )
 
     def _activation_metadata(
@@ -1119,6 +1176,9 @@ class SettingsCatalogService:
         value: Any,
         override_present: bool,
     ) -> list[SettingDiagnostic]:
+        migration_diagnostic = self._migration_diagnostics_by_key.get(entry.key)
+        if migration_diagnostic is not None:
+            return [migration_diagnostic]
         if (
             override_present
             and entry.key != "workflow.default_provider_profile_ref"
@@ -1126,6 +1186,54 @@ class SettingsCatalogService:
         ):
             return []
         return self._diagnostics(entry, value)
+
+    async def _deprecated_override_diagnostics(
+        self,
+        *,
+        scope: SettingScope,
+    ) -> dict[str, SettingsDiagnosticRead]:
+        deprecated_rules = [
+            rule
+            for rule in self._migration_rules
+            if rule.state in {"deprecated", "removed"}
+        ]
+        if self._session is None or not deprecated_rules:
+            return {}
+        overrides = await self._get_effective_overrides(
+            scope=scope,
+            keys=[rule.old_key for rule in deprecated_rules],
+        )
+        values: dict[str, SettingsDiagnosticRead] = {}
+        for rule in deprecated_rules:
+            for row_scope in (("user", "workspace") if scope == "user" else ("workspace",)):
+                row = overrides.get((row_scope, rule.old_key))
+                if row is None:
+                    continue
+                values[rule.old_key] = SettingsDiagnosticRead(
+                    key=rule.old_key,
+                    scope=scope,
+                    source="deprecated_override",
+                    source_explanation=rule.message,
+                    apply_mode="immediate",
+                    activation_state="active",
+                    active=True,
+                    diagnostics=[
+                        SettingDiagnostic(
+                            code="setting_deprecated_override",
+                            message=rule.message,
+                            severity="warning",
+                            details={
+                                "old_key": rule.old_key,
+                                "state": rule.state,
+                                "value_version": row.value_version,
+                                "schema_version": row.schema_version,
+                            },
+                        )
+                    ],
+                    recent_change=None,
+                )
+                break
+        return values
 
     async def _prime_managed_secret_statuses(self, values: Iterable[Any]) -> None:
         if self._session is None:
@@ -1189,6 +1297,15 @@ class SettingsCatalogService:
         if scope == "user":
             user_override = overrides.get(("user", entry.key))
             if user_override is not None:
+                type_migration = self._type_migration_diagnostic(entry, user_override)
+                if type_migration is not None:
+                    self._migration_diagnostics_by_key[entry.key] = type_migration
+                    return (
+                        None,
+                        "type_migration_required",
+                        user_override.value_version,
+                        True,
+                    )
                 return (
                     user_override.value_json,
                     "user_override",
@@ -1197,6 +1314,17 @@ class SettingsCatalogService:
                 )
             workspace_override = overrides.get(("workspace", entry.key))
             if workspace_override is not None:
+                type_migration = self._type_migration_diagnostic(
+                    entry, workspace_override
+                )
+                if type_migration is not None:
+                    self._migration_diagnostics_by_key[entry.key] = type_migration
+                    return (
+                        None,
+                        "type_migration_required",
+                        workspace_override.value_version,
+                        True,
+                    )
                 return (
                     workspace_override.value_json,
                     "workspace_override",
@@ -1206,14 +1334,87 @@ class SettingsCatalogService:
         elif scope == "workspace":
             workspace_override = overrides.get(("workspace", entry.key))
             if workspace_override is not None:
+                type_migration = self._type_migration_diagnostic(
+                    entry, workspace_override
+                )
+                if type_migration is not None:
+                    self._migration_diagnostics_by_key[entry.key] = type_migration
+                    return (
+                        None,
+                        "type_migration_required",
+                        workspace_override.value_version,
+                        True,
+                    )
                 return (
                     workspace_override.value_json,
                     "workspace_override",
                     workspace_override.value_version,
                     True,
                 )
+        migrated = self._resolve_migrated_override(entry, scope=scope, overrides=overrides)
+        if migrated is not None:
+            row_scope, row, rule = migrated
+            source = (
+                "migrated_user_override"
+                if row_scope == "user"
+                else "migrated_workspace_override"
+            )
+            self._migration_diagnostics_by_key[entry.key] = SettingDiagnostic(
+                code="setting_renamed_override",
+                message=rule.message,
+                severity="warning",
+                details={
+                    "old_key": rule.old_key,
+                    "new_key": rule.new_key,
+                    "state": rule.state,
+                },
+            )
+            return row.value_json, source, row.value_version, True
         value, source = self._resolve_value(entry)
         return value, source, 1, False
+
+    def _type_migration_diagnostic(
+        self,
+        entry: SettingRegistryEntry,
+        row: SettingsOverride,
+    ) -> SettingDiagnostic | None:
+        rule = self._type_rules_by_key.get(entry.key)
+        if rule is None or row.schema_version == rule.expected_schema_version:
+            return None
+        return SettingDiagnostic(
+            code="setting_type_migration_required",
+            message=rule.message,
+            severity="error",
+            details={
+                "key": entry.key,
+                "state": rule.state,
+                "schema_version": row.schema_version,
+                "expected_schema_version": rule.expected_schema_version,
+            },
+        )
+
+    def _resolve_migrated_override(
+        self,
+        entry: SettingRegistryEntry,
+        *,
+        scope: SettingScope,
+        overrides: dict[tuple[SettingScope, str], SettingsOverride],
+    ) -> tuple[SettingScope, SettingsOverride, SettingMigrationRule] | None:
+        rule = self._rename_rules_by_new_key.get(entry.key)
+        if rule is None:
+            return None
+        if scope == "user":
+            user_override = overrides.get(("user", rule.old_key))
+            if user_override is not None:
+                return "user", user_override, rule
+            workspace_override = overrides.get(("workspace", rule.old_key))
+            if workspace_override is not None:
+                return "workspace", workspace_override, rule
+        elif scope == "workspace":
+            workspace_override = overrides.get(("workspace", rule.old_key))
+            if workspace_override is not None:
+                return "workspace", workspace_override, rule
+        return None
 
     async def _get_effective_overrides(
         self,
@@ -1230,7 +1431,15 @@ class SettingsCatalogService:
             scopes = ("workspace",)
         else:
             return {}
-        return await self._get_overrides(scopes=scopes, keys=keys)
+        expanded_keys = set(keys)
+        for key in keys:
+            rule = self._rename_rules_by_new_key.get(key)
+            if rule is not None:
+                expanded_keys.add(rule.old_key)
+        for rule in self._migration_rules:
+            if rule.state in {"deprecated", "removed"} and rule.old_key in keys:
+                expanded_keys.add(rule.old_key)
+        return await self._get_overrides(scopes=scopes, keys=expanded_keys)
 
     async def _get_overrides(
         self,
@@ -1321,6 +1530,14 @@ class SettingsCatalogService:
             return "Resolved from a workspace override."
         if source == "user_override":
             return "Resolved from a user override."
+        if source == "migrated_workspace_override":
+            return "Resolved from a workspace override migrated from a renamed setting."
+        if source == "migrated_user_override":
+            return "Resolved from a user override migrated from a renamed setting."
+        if source == "deprecated_override":
+            return "Resolved from a deprecated setting override."
+        if source == "type_migration_required":
+            return "Stored override requires an explicit type migration."
         return f"Resolved from {source}."
 
     def _validate_override_value(self, entry: SettingRegistryEntry, value: Any) -> None:

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -1013,7 +1013,8 @@ class SettingsCatalogService:
                 diagnostics=diagnostics,
                 recent_change=recent_changes.get(entry.key),
             )
-        values.update(await self._deprecated_override_diagnostics(scope=scope))
+        if key is None:
+            values.update(await self._deprecated_override_diagnostics(scope=scope))
         return SettingsDiagnosticsResponse(scope=scope, values=values)
 
     def _validate_registry(self) -> None:
@@ -1041,14 +1042,22 @@ class SettingsCatalogService:
 
     def _validate_migration_rules(self) -> None:
         seen: set[str] = set()
+        rename_targets: set[str] = set()
         for rule in self._migration_rules:
             if rule.old_key in seen:
                 raise ValueError(f"duplicate migration rule for {rule.old_key!r}")
             seen.add(rule.old_key)
-            if rule.state == "renamed" and rule.new_key not in self._entries_by_key:
-                raise ValueError(
-                    f"renamed migration target {rule.new_key!r} is not exposed"
-                )
+            if rule.state == "renamed":
+                if rule.new_key in rename_targets:
+                    raise ValueError(
+                        f"duplicate rename migration target {rule.new_key!r}"
+                    )
+                if rule.new_key is not None:
+                    rename_targets.add(rule.new_key)
+                if rule.new_key not in self._entries_by_key:
+                    raise ValueError(
+                        f"renamed migration target {rule.new_key!r} is not exposed"
+                    )
 
     def _activation_metadata(
         self,
@@ -1294,6 +1303,7 @@ class SettingsCatalogService:
         scope: SettingScope,
         overrides: dict[tuple[SettingScope, str], SettingsOverride],
     ) -> tuple[Any, str, int, bool]:
+        self._migration_diagnostics_by_key.pop(entry.key, None)
         if scope == "user":
             user_override = overrides.get(("user", entry.key))
             if user_override is not None:

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-542",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1826"
+  "jira_issue_key": "MM-546",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1831"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,27 @@
 [
   {
-    "id": 3156682613,
-    "disposition": "addressed",
-    "rationale": "Activation metadata now defaults clean catalog/effective/diagnostic reads to active and only marks newly committed non-immediate override responses as pending activation."
-  },
-  {
-    "id": 4191816834,
+    "id": 4192185054,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container with no independent actionable request beyond the inline review comment."
+    "rationale": "Positive Gemini review summary with no requested change."
   },
   {
-    "id": 3156699062,
+    "id": 3157002480,
     "disposition": "addressed",
-    "rationale": "Pending activation values now redact sensitive non-reference values while preserving safe SecretRef strings such as db:// and env:// references."
+    "rationale": "Key-scoped diagnostics now skip unrelated deprecated override diagnostics; regression test covers diagnostics(scope, key)."
   },
   {
-    "id": 3156699081,
+    "id": 3157002486,
     "disposition": "addressed",
-    "rationale": "Registry apply-mode validation errors now include the failing setting key and the specific consistency rule."
+    "rationale": "Resolution now clears cached migration diagnostics for the key before fresh override/default resolution; regression test covers reused service instances."
   },
   {
-    "id": 3156699085,
-    "disposition": "addressed",
-    "rationale": "Mission Control now renders pending values whenever a setting is inactive and pending_value is present, including explicit null resets displayed as Not set."
-  },
-  {
-    "id": 4191835297,
+    "id": 4192187854,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container; the actionable findings from the summary are tracked by the inline review comment ids."
+    "rationale": "Codex automated review container comment; actionable child review comments are tracked separately."
+  },
+  {
+    "id": 3157002490,
+    "disposition": "addressed",
+    "rationale": "Migration rule validation now rejects duplicate renamed new_key targets; regression test covers fail-fast behavior."
   }
 ]

--- a/specs/275-settings-migration-invariants/checklists/requirements.md
+++ b/specs/275-settings-migration-invariants/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Settings Migration Invariants
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves the full `MM-546` Jira preset brief in `**Input**`.
+- PASS: The spec maps every in-scope source design ID from the brief to functional requirements.
+- PASS: Runtime mode is explicit; no documentation-only output is assumed.

--- a/specs/275-settings-migration-invariants/contracts/settings-migration-invariants.md
+++ b/specs/275-settings-migration-invariants/contracts/settings-migration-invariants.md
@@ -1,0 +1,53 @@
+# Contract: Settings Migration Invariants
+
+## Service Boundary
+
+`SettingsCatalogService` must accept an explicit set of migration/deprecation rules and apply them during:
+- effective value resolution,
+- catalog descriptor diagnostics,
+- diagnostics endpoint responses,
+- write admission checks.
+
+Rules must be deterministic and fail fast. The service must not infer migrations from prompt text, environment names, or unknown keys.
+
+## API Boundary
+
+### `PATCH /api/v1/settings/{scope}`
+
+When a payload writes a removed or deprecated historical key, the response must be:
+
+```json
+{
+  "error": "read_only_setting",
+  "key": "old.setting.key",
+  "scope": "workspace"
+}
+```
+
+The response must not echo submitted raw values.
+
+### `GET /api/v1/settings/effective/{key}?scope=workspace`
+
+When a current key has a configured rename rule and only the old key has a persisted override, the response must resolve the old value under the current key and include a migration diagnostic:
+
+```json
+{
+  "key": "new.setting.key",
+  "scope": "workspace",
+  "source": "migrated_workspace_override",
+  "diagnostics": [
+    {
+      "code": "setting_renamed_override",
+      "severity": "warning"
+    }
+  ]
+}
+```
+
+### `GET /api/v1/settings/diagnostics?scope=workspace`
+
+Diagnostics must include current descriptor diagnostics and safe deprecated-key diagnostics for historical override rows known through explicit rules. Diagnostic details may include old key, new key, state, and schema version; they must not include raw override values.
+
+## Regression Gate
+
+Tests must preserve the future-integration contract that settings are exposed through descriptors, scoped overrides, server-side validation, auditability, and secret-safe diagnostics only.

--- a/specs/275-settings-migration-invariants/data-model.md
+++ b/specs/275-settings-migration-invariants/data-model.md
@@ -1,0 +1,48 @@
+# Data Model: Settings Migration Invariants
+
+## SettingMigrationRule
+
+Represents an explicit, checked-in migration or deprecation rule for one historical setting key.
+
+Fields:
+- `old_key`: historical settings key that may still exist in persisted overrides.
+- `new_key`: replacement descriptor key when the setting was renamed.
+- `state`: `renamed`, `deprecated`, `removed`, or `type_changed`.
+- `expected_schema_version`: schema version that current resolution can safely interpret.
+- `message`: redacted operator-facing explanation for diagnostics.
+
+Validation rules:
+- `renamed` rules must include `new_key`.
+- `removed` and `deprecated` rules must reject new writes to `old_key`.
+- `type_changed` rules must require explicit schema-version compatibility before resolving old persisted JSON.
+- Diagnostic messages must not include raw override values or secret-like content.
+
+## Setting Override
+
+Existing persisted override row.
+
+Relevant fields:
+- `key`
+- `scope`
+- `value_json`
+- `schema_version`
+- `value_version`
+
+State transitions:
+- Current key override resolves normally when schema version matches.
+- Old key override resolves through an explicit rename rule when no current-key override exists.
+- Removed/deprecated old key remains queryable as diagnostic evidence but cannot accept new writes.
+- Schema-version mismatch blocks normal resolution until an explicit migration is added.
+
+## Settings Diagnostic
+
+Existing read model extended by migration/deprecation evidence.
+
+New diagnostic codes:
+- `setting_renamed_override`: old key override is being used through an explicit rename rule.
+- `setting_deprecated_override`: old key override exists and requires migration/removal handling.
+- `setting_type_migration_required`: persisted override schema version is not compatible with the current descriptor.
+
+Secret safety:
+- Diagnostics may include keys, scopes, versions, and rule state.
+- Diagnostics must not include `value_json` or raw secret material.

--- a/specs/275-settings-migration-invariants/moonspec_align_report.md
+++ b/specs/275-settings-migration-invariants/moonspec_align_report.md
@@ -1,0 +1,23 @@
+# MoonSpec Alignment Report: Settings Migration Invariants
+
+**Feature**: `specs/275-settings-migration-invariants`
+**Date**: 2026-04-28
+**Source**: `MM-546`
+
+## Findings
+
+| Finding | Resolution |
+| --- | --- |
+| `plan.md` requirement statuses and summary still reflected the pre-implementation gap analysis after tasks and implementation completed. | Updated only the `## Summary` and `## Requirement Status` evidence to reflect current implementation and test evidence. |
+
+## Gate Recheck
+
+- Specify gate: PASS. `spec.md` preserves `MM-546`, contains exactly one story, has no clarification markers, and maps all source design IDs.
+- Plan gate: PASS. `plan.md`, `research.md`, `quickstart.md`, `data-model.md`, and `contracts/settings-migration-invariants.md` exist and keep unit/integration strategies explicit.
+- Tasks gate: PASS. `tasks.md` covers one story, red-first unit/API tests, implementation tasks, validation, integration command, and final `/moonspec-verify`.
+
+## Validation
+
+- Traceability inventory: PASS. Every `FR-*`, `SC-*`, and in-scope `DESIGN-REQ-*` from `spec.md` appears in both `plan.md` and `tasks.md`.
+- Placeholder scan: PASS. No unresolved `[NEEDS CLARIFICATION]`, `[FEATURE]`, `[###]`, Prompt A, or Prompt B loops remain.
+- Test evidence already recorded in `tasks.md`: focused unit/API passed, full unit passed, hermetic integration blocked by unavailable Docker socket.

--- a/specs/275-settings-migration-invariants/plan.md
+++ b/specs/275-settings-migration-invariants/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Settings Migration Invariants
+
+**Branch**: `[275-settings-migration-invariants]` | **Date**: 2026-04-28 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:be976054-2c25-4b91-8814-1aeff6eb3ee0/repo/specs/275-settings-migration-invariants/spec.md`
+
+## Summary
+
+Implement MM-546 by adding an explicit Settings System migration/deprecation rule boundary on top of the existing catalog, override, diagnostics, and audit service. Current code already enforces explicit catalog exposure, scoped writes, value validation, SecretRef redaction, source explainability, reset inheritance, audit redaction, version conflict handling, and settings permissions. The missing runtime gap is deterministic handling for renamed, removed/deprecated, and type-changed setting keys so maintainers can prove old overrides are preserved or rejected intentionally rather than silently ignored or reinterpreted. The plan is TDD-first with focused service and API tests, then final unit verification.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `SettingsCatalogService` uses an explicit `_REGISTRY`; API rejects unexposed keys; tests cover `workflow.github_token` rejection | preserve with regression tests | unit + API |
+| FR-002 | missing | no rename migration rule or old-key override resolution path found | add migration rule model and old-to-new override resolution | unit + API |
+| FR-003 | missing | unknown/removed keys are rejected but no deprecated-value diagnostics for existing rows | add removed/deprecated key write rejection plus diagnostics visibility | unit + API |
+| FR-004 | missing | `SettingsOverride.schema_version` exists but resolver does not enforce expected schema version | require explicit type migration when schema versions differ | unit |
+| FR-005 | partial | audit and diagnostics exist; migration/deprecation events do not | add redacted diagnostics and audit evidence for migrations | unit + API |
+| FR-006 | partial | existing tests cover catalog, scope, validation, constraints, version conflict, and drift partially | add catalog invariant snapshot-style test focused on exposed descriptors | unit |
+| FR-007 | implemented_verified | SecretRef and provider-profile tests prove no plaintext readback and sanitized diagnostics | preserve with final verification | unit |
+| FR-008 | implemented_verified | effective value source, user/workspace inheritance, reset, and operator/read-only patterns exist | preserve with final verification | unit |
+| FR-009 | implemented_verified | audit endpoint tests cover redaction, version conflicts, and permission checks | preserve with final verification | unit + API |
+| FR-010 | partial | future integrations receive descriptor/effective/diagnostic APIs but no explicit invariant test binds them to safe fields | add contract test for descriptor-driven, scoped, validated, audited, secret-safe surfaces | unit |
+| FR-011 | missing | new spec preserves `MM-546`; downstream artifacts and verification not complete | preserve Jira key and brief through artifacts and final report | artifact review |
+| SC-001 | missing | no rename migration test exists | add service/API tests | unit + API |
+| SC-002 | missing | no removed-key diagnostic test exists | add service/API tests | unit + API |
+| SC-003 | missing | no schema/type mismatch failure test exists | add service test | unit |
+| SC-004 | partial | broad coverage exists; no single invariant drift test for MM-546 | add invariant coverage | unit |
+| SC-005 | partial | APIs expose safe settings surfaces; no MM-546 future integration contract test | add contract/invariant test | unit |
+| SC-006 | missing | artifacts in progress | preserve traceability | artifact review |
+| DESIGN-REQ-020 | implemented_verified | explicit registry and API rejection tests enforce non-goals | preserve with invariant tests | unit + API |
+| DESIGN-REQ-021 | missing | migration/deprecation/type-change rules absent | implement rule boundary and tests | unit + API |
+| DESIGN-REQ-024 | partial | many tests exist; drift and migration gate gaps remain | add focused regression tests | unit |
+| DESIGN-REQ-027 | partial | descriptor/effective/diagnostic surfaces exist | add future integration invariant test | unit |
+| DESIGN-REQ-028 | partial | most invariants exist; migration/type-change proof missing | add migration invariant tests | unit + API |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, pytest  
+**Storage**: Existing `settings_overrides` and `settings_audit_events` tables only; no new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh` for final verification; targeted `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` during iteration  
+**Integration Testing**: Existing settings API route tests are API-boundary unit tests; full hermetic integration remains `./tools/test_integration.sh` when Docker is available  
+**Target Platform**: MoonMind API service Settings System runtime  
+**Project Type**: Web service backend  
+**Performance Goals**: Preserve current batched override reads and avoid per-key database queries for catalog/effective-value lists  
+**Constraints**: No raw secrets in diagnostics, audit, or artifacts; no compatibility aliases for internal contracts; source docs remain desired state and implementation notes stay under `specs/`  
+**Scale/Scope**: One Settings System maintenance-safety story covering migration/deprecation/type-change invariants and regression evidence
+
+## Constitution Check
+
+| Principle | Gate | Status | Evidence |
+| --- | --- | --- | --- |
+| I. Orchestrate, Don't Recreate | No agent-specific behavior | PASS | Settings service boundary only |
+| II. One-Click Agent Deployment | No new service dependency | PASS | Existing DB/test setup only |
+| III. Avoid Vendor Lock-In | No provider-specific lock-in | PASS | Generic settings rules |
+| IV. Own Your Data | Overrides/audit remain local | PASS | Existing local tables |
+| V. Skills Are First-Class | No skill runtime mutation | PASS | Out of scope |
+| VI. Replaceable Scaffolding | Behavior backed by tests | PASS | TDD tasks |
+| VII. Runtime Configurability | Improves settings evolution safety | PASS | Core story |
+| VIII. Modular Architecture | Changes stay in settings service/router tests | PASS | No cross-cutting rewrite |
+| IX. Resilient by Default | Unsafe migrations fail explicitly | PASS | Core story |
+| X. Continuous Improvement | Final report includes structured outcome | PASS | Orchestration final gate |
+| XI. Spec-Driven Development | Spec/plan/tasks drive implementation | PASS | `specs/275-settings-migration-invariants` |
+| XII. Canonical Docs Separate Desired State | Canonical docs are read-only source requirements | PASS | No docs rewrite |
+| XIII. Pre-Release Compatibility | Internal contracts fail fast instead of adding hidden aliases | PASS | Migration rules are explicit, not automatic compatibility shims |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/275-settings-migration-invariants/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── settings-migration-invariants.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/settings.py
+└── services/settings_catalog.py
+
+tests/
+└── unit/
+    ├── services/test_settings_catalog.py
+    └── api_service/api/routers/test_settings_api.py
+```
+
+**Structure Decision**: Extend the existing settings catalog service and settings API route tests. No frontend change is planned because MM-546 is a backend migration/test gate story and existing diagnostics API output is the operator-visible surface.
+
+## Complexity Tracking
+
+No constitution violations requiring complexity exceptions.

--- a/specs/275-settings-migration-invariants/plan.md
+++ b/specs/275-settings-migration-invariants/plan.md
@@ -5,34 +5,34 @@
 
 ## Summary
 
-Implement MM-546 by adding an explicit Settings System migration/deprecation rule boundary on top of the existing catalog, override, diagnostics, and audit service. Current code already enforces explicit catalog exposure, scoped writes, value validation, SecretRef redaction, source explainability, reset inheritance, audit redaction, version conflict handling, and settings permissions. The missing runtime gap is deterministic handling for renamed, removed/deprecated, and type-changed setting keys so maintainers can prove old overrides are preserved or rejected intentionally rather than silently ignored or reinterpreted. The plan is TDD-first with focused service and API tests, then final unit verification.
+Implement MM-546 by adding an explicit Settings System migration/deprecation rule boundary on top of the existing catalog, override, diagnostics, and audit service. Current code already enforces explicit catalog exposure, scoped writes, value validation, SecretRef redaction, source explainability, reset inheritance, audit redaction, version conflict handling, and settings permissions. This story adds deterministic handling for renamed, removed/deprecated, and type-changed setting keys so maintainers can prove old overrides are preserved or rejected intentionally rather than silently ignored or reinterpreted. The plan is TDD-first with focused service and API tests, then final unit verification.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
 | FR-001 | implemented_verified | `SettingsCatalogService` uses an explicit `_REGISTRY`; API rejects unexposed keys; tests cover `workflow.github_token` rejection | preserve with regression tests | unit + API |
-| FR-002 | missing | no rename migration rule or old-key override resolution path found | add migration rule model and old-to-new override resolution | unit + API |
-| FR-003 | missing | unknown/removed keys are rejected but no deprecated-value diagnostics for existing rows | add removed/deprecated key write rejection plus diagnostics visibility | unit + API |
-| FR-004 | missing | `SettingsOverride.schema_version` exists but resolver does not enforce expected schema version | require explicit type migration when schema versions differ | unit |
-| FR-005 | partial | audit and diagnostics exist; migration/deprecation events do not | add redacted diagnostics and audit evidence for migrations | unit + API |
-| FR-006 | partial | existing tests cover catalog, scope, validation, constraints, version conflict, and drift partially | add catalog invariant snapshot-style test focused on exposed descriptors | unit |
+| FR-002 | implemented_verified | `api_service/services/settings_catalog.py` defines `SettingMigrationRule` and resolves renamed old-key overrides; `tests/unit/services/test_settings_catalog.py` and `tests/unit/api_service/api/routers/test_settings_api.py` verify old override preservation | no new implementation | focused unit + API passed |
+| FR-003 | implemented_verified | removed/deprecated keys reject writes and diagnostics expose historical rows without raw values in service and API tests | no new implementation | focused unit + API passed |
+| FR-004 | implemented_verified | schema-version mismatch produces `setting_type_migration_required` instead of reinterpreting stored JSON | no new implementation | focused unit passed |
+| FR-005 | implemented_verified | migration/deprecation diagnostics provide redacted evidence; tests assert secret-like values are absent from diagnostics and API responses | no new implementation | focused unit + API passed |
+| FR-006 | implemented_verified | `test_catalog_invariant_gate_for_future_integrations` verifies descriptor exposure, safe UI type, scope, source, audit, and SecretRef invariants | no new implementation | focused unit passed |
 | FR-007 | implemented_verified | SecretRef and provider-profile tests prove no plaintext readback and sanitized diagnostics | preserve with final verification | unit |
 | FR-008 | implemented_verified | effective value source, user/workspace inheritance, reset, and operator/read-only patterns exist | preserve with final verification | unit |
 | FR-009 | implemented_verified | audit endpoint tests cover redaction, version conflicts, and permission checks | preserve with final verification | unit + API |
-| FR-010 | partial | future integrations receive descriptor/effective/diagnostic APIs but no explicit invariant test binds them to safe fields | add contract test for descriptor-driven, scoped, validated, audited, secret-safe surfaces | unit |
-| FR-011 | missing | new spec preserves `MM-546`; downstream artifacts and verification not complete | preserve Jira key and brief through artifacts and final report | artifact review |
-| SC-001 | missing | no rename migration test exists | add service/API tests | unit + API |
-| SC-002 | missing | no removed-key diagnostic test exists | add service/API tests | unit + API |
-| SC-003 | missing | no schema/type mismatch failure test exists | add service test | unit |
-| SC-004 | partial | broad coverage exists; no single invariant drift test for MM-546 | add invariant coverage | unit |
-| SC-005 | partial | APIs expose safe settings surfaces; no MM-546 future integration contract test | add contract/invariant test | unit |
-| SC-006 | missing | artifacts in progress | preserve traceability | artifact review |
+| FR-010 | implemented_verified | invariant test and `contracts/settings-migration-invariants.md` bind future settings consumers to descriptor-driven, scoped, validated, audited, secret-safe surfaces | no new implementation | focused unit passed |
+| FR-011 | implemented_verified | `spec.md`, `plan.md`, `tasks.md`, quickstart, contract, and final report preserve `MM-546` and the canonical preset brief | no new implementation | artifact review |
+| SC-001 | implemented_verified | service and API tests verify renamed old-key overrides resolve under the new key with migration diagnostics | no new implementation | focused unit + API passed |
+| SC-002 | implemented_verified | service and API tests verify removed/deprecated keys reject writes and expose safe diagnostics without raw values | no new implementation | focused unit + API passed |
+| SC-003 | implemented_verified | service test verifies schema-version mismatch blocks ambiguous type reinterpretation | no new implementation | focused unit passed |
+| SC-004 | implemented_verified | invariant gate test covers unsafe descriptor exposure, scope, validation, source, audit, and SecretRef regressions | no new implementation | focused unit passed |
+| SC-005 | implemented_verified | contract and invariant tests preserve descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior | no new implementation | focused unit passed |
+| SC-006 | implemented_verified | `rg` traceability checks and artifacts preserve `MM-546` plus DESIGN-REQ-020/021/024/027/028 | no new implementation | artifact review |
 | DESIGN-REQ-020 | implemented_verified | explicit registry and API rejection tests enforce non-goals | preserve with invariant tests | unit + API |
-| DESIGN-REQ-021 | missing | migration/deprecation/type-change rules absent | implement rule boundary and tests | unit + API |
-| DESIGN-REQ-024 | partial | many tests exist; drift and migration gate gaps remain | add focused regression tests | unit |
-| DESIGN-REQ-027 | partial | descriptor/effective/diagnostic surfaces exist | add future integration invariant test | unit |
-| DESIGN-REQ-028 | partial | most invariants exist; migration/type-change proof missing | add migration invariant tests | unit + API |
+| DESIGN-REQ-021 | implemented_verified | explicit migration rule boundary, deprecated diagnostics, write rejection, and schema-version gate implemented and tested | no new implementation | focused unit + API passed |
+| DESIGN-REQ-024 | implemented_verified | focused invariant and migration tests cover the MM-546 regression gate; full unit suite passed | no new implementation | full unit passed |
+| DESIGN-REQ-027 | implemented_verified | contract and invariant test preserve descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret safety | no new implementation | focused unit passed |
+| DESIGN-REQ-028 | implemented_verified | migration/type-change proof added while existing SecretRef, provider profile, source explainability, reset, audit, and permission tests remain passing | no new implementation | full unit passed |
 
 ## Technical Context
 

--- a/specs/275-settings-migration-invariants/quickstart.md
+++ b/specs/275-settings-migration-invariants/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Settings Migration Invariants
+
+## Focused Validation
+
+Run backend unit and API boundary coverage:
+
+```bash
+./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py
+```
+
+Expected result:
+- rename migration preserves effective values,
+- removed/deprecated keys reject new writes and surface diagnostics,
+- type/schema mismatches fail until explicitly migrated,
+- catalog invariants remain descriptor-driven and secret-safe.
+
+## Full Unit Validation
+
+```bash
+./tools/test_unit.sh
+```
+
+## Hermetic Integration Validation
+
+```bash
+./tools/test_integration.sh
+```
+
+Run when Docker is available. If Docker is unavailable in the managed runtime, record the exact blocker and rely on focused unit/API evidence for this backend-only story.
+
+## Traceability Check
+
+```bash
+rg -n "MM-546|DESIGN-REQ-020|DESIGN-REQ-021|DESIGN-REQ-024|DESIGN-REQ-027|DESIGN-REQ-028" specs/275-settings-migration-invariants
+```
+
+Expected result: the Jira key and all source design IDs remain present across MoonSpec artifacts.

--- a/specs/275-settings-migration-invariants/research.md
+++ b/specs/275-settings-migration-invariants/research.md
@@ -1,0 +1,41 @@
+# Research: Settings Migration Invariants
+
+## Input Classification
+
+Decision: `MM-546` is a single-story runtime feature request.
+Evidence: The Jira brief has one maintainer story, one source design, and a bounded acceptance set around migrations, non-goals, invariants, and tests.
+Rationale: It does not ask to split the whole Settings System design; it selects sections 4, 24, 25, 28, and 29 for one safety-gate story.
+Alternatives considered: Treating `docs/Security/SettingsSystem.md` as a broad declarative design was rejected because the Jira brief already selected one independently testable slice.
+Test implications: Unit and API boundary tests are required before implementation.
+
+## FR-002 Rename Migration
+
+Decision: Missing; add explicit migration rules that let a new descriptor resolve an old override key.
+Evidence: `SettingsCatalogService._resolve_value_from_overrides()` only checks the current descriptor key. No migration/deprecation rule type exists.
+Rationale: Without an explicit rule, a renamed setting silently loses stored operator intent.
+Alternatives considered: Automatically checking all historical keys was rejected because it would hide compatibility behavior and violate fail-fast pre-release policy.
+Test implications: Unit and API tests must prove effective value preservation and migration diagnostics/audit evidence.
+
+## FR-003 Removed Or Deprecated Settings
+
+Decision: Missing; add removed/deprecated rule handling that rejects new writes and exposes existing rows in diagnostics.
+Evidence: Unknown keys return `setting_not_exposed`; existing removed-key rows are invisible to diagnostics because only current registry entries are inspected.
+Rationale: The source design requires preserving or explaining existing values and avoiding silent loss.
+Alternatives considered: Leaving removed keys as ordinary unknown keys was rejected because it does not explain deprecated existing values.
+Test implications: API tests must prove writes are rejected without echoing submitted values and diagnostics include safe deprecated-key evidence.
+
+## FR-004 Type Changes
+
+Decision: Missing; enforce expected override schema version for persisted rows.
+Evidence: `SettingsOverride.schema_version` exists but effective-value resolution ignores it.
+Rationale: A schema version mismatch is a deterministic signal that an explicit migration is required before resolving the value.
+Alternatives considered: Revalidating old JSON against the new type was rejected because it can reinterpret values ambiguously.
+Test implications: Unit tests must prove mismatched schema versions produce an error diagnostic/pending state instead of a normal effective value.
+
+## Existing Invariant Coverage
+
+Decision: Existing behavior is strong but needs a single MM-546 invariant test.
+Evidence: Tests already cover unexposed key rejection, invalid scopes, type validation, constraints, SecretRef safety, provider profile refs, audit redaction, reset inheritance, and version conflict handling.
+Rationale: MM-546 requires these as regression-gate evidence rather than tribal knowledge.
+Alternatives considered: Rewriting all existing tests was rejected; focused invariant tests can cite existing coverage and add the missing migration gate.
+Test implications: Add a compact catalog invariant test and final targeted test run.

--- a/specs/275-settings-migration-invariants/spec.md
+++ b/specs/275-settings-migration-invariants/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Settings Migration Invariants
+
+**Feature Branch**: `[275-settings-migration-invariants]`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-546 as the canonical Moon Spec orchestration input.
+
+Canonical Jira preset brief:
+
+MM-546: Migration, non-goals, invariants, and test gate
+
+Source Reference
+Source Document: docs/Security/SettingsSystem.md
+Source Title: Settings System
+Source Sections:
+- 4. Non-Goals
+- 24. Migration and Deprecation
+- 25. Testing Requirements
+- 28. Open Integration Points
+- 29. Desired-State Invariants
+Coverage IDs:
+- DESIGN-REQ-020
+- DESIGN-REQ-021
+- DESIGN-REQ-024
+- DESIGN-REQ-027
+- DESIGN-REQ-028
+
+As a maintainer, I can evolve the Settings System safely because migrations, non-goals, future integrations, and desired-state invariants are enforced by tests and diagnostics rather than tribal knowledge.
+
+Acceptance Criteria
+- Renaming a setting uses a new descriptor key, migrates old overrides, exposes deprecation diagnostics where helpful, records audit visibility, and tests effective-value preservation.
+- Removing a setting rejects new writes, preserves or migrates existing values, explains deprecated values in diagnostics, and avoids silent loss of operator intent.
+- Changing a setting type requires explicit migration and the resolver does not ambiguously reinterpret existing JSON values.
+- Regression coverage proves catalog exposure, scope declarations, backend validation, secret safety, SecretRef validation/audit without plaintext, provider profile secret references, source explainability, reset inheritance, operator locks, operational audit, and intentional catalog changes.
+- Future integration contracts explicitly preserve descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior.
+
+Requirements
+- The Settings System must not become a generic database editor, generic secret manager, raw env editor, generic admin UI, or frontend-authoritative validation layer.
+- Catalog drift must be visible through snapshot or equivalent regression tests.
+- Non-goals and invariants must remain enforceable as the implementation evolves.
+
+Canonical source: synthesized from trusted Jira issue fields because the MCP issue response did not expose recommended preset instructions or a normalized preset brief.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-546 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata."
+
+## User Story - Settings Evolution Safety Gate
+
+**Summary**: As a maintainer, I want Settings System migration rules, non-goals, and invariants to be enforced by tests and diagnostics so that future catalog changes cannot silently weaken operator intent, validation, or secret safety.
+
+**Goal**: Maintainers can safely rename, remove, or change typed settings while receiving deterministic test and diagnostic evidence that effective values, auditability, explicit exposure, scoped overrides, and secret-safe behavior remain intact.
+
+**Independent Test**: Can be fully tested by running the Settings System unit and integration coverage for migration/deprecation behavior and catalog invariants, then confirming the suite fails on unsafe catalog changes and passes when migrations, diagnostics, and invariants are correctly preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a setting key is renamed and an old override exists, **When** effective settings are resolved after the migration, **Then** the new descriptor key is used, the old override value is preserved or migrated, audit/deprecation visibility is available, and tests prove the effective value did not change unexpectedly.
+2. **Given** a setting has been removed or deprecated, **When** a new write targets the removed key, **Then** the write is rejected, existing operator intent is preserved or migrated, diagnostics explain the deprecated value, and no generic settings path silently drops the value.
+3. **Given** a setting's type changes, **When** existing stored JSON values are evaluated, **Then** the system requires explicit migration behavior and fails rather than ambiguously reinterpreting old values.
+4. **Given** the Settings System catalog and resolution behavior are tested, **When** the regression suite runs, **Then** it proves explicit catalog exposure, scope declarations, backend validation, SecretRef safety, provider profile secret references, source explainability, reset inheritance, operator locks, operational audit, and intentional catalog changes.
+5. **Given** a future integration consumes settings data, **When** it depends on the Settings System contract, **Then** descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior remain preserved.
+
+### Edge Cases
+
+- Existing overrides may reference keys that are no longer editable but still need diagnostic visibility.
+- Secret-like or SecretRef values must never be exposed as plaintext during migration, diagnostics, audit, or tests.
+- Catalog drift may be accidental; regression evidence must distinguish intentional descriptor changes from unreviewed exposure changes.
+- Operator locks and scope declarations must still block ordinary user or workspace writes during migration and reset flows.
+- Non-goal behavior must stay excluded: raw environment editing, generic database editing, generic secret management, frontend-authoritative validation, and generic admin UI behavior.
+
+## Assumptions
+
+- Runtime mode is active; the source document is treated as runtime source requirements, not a documentation-only target.
+- The MM-546 Jira preset brief represents one independently testable Settings System maintenance-safety story.
+- Existing Settings System code and tests may already satisfy some invariants, but this story requires traceable evidence and gaps must be closed with tests or implementation.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope Status | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-020 | `docs/Security/SettingsSystem.md` section 4, Non-Goals | The Settings System must remain a typed product-specific configuration plane and must not become a generic database editor, generic secret manager, raw environment editor, generic admin UI, provider-profile replacement, or frontend-authoritative validation layer. | In scope | FR-001, FR-010 |
+| DESIGN-REQ-021 | `docs/Security/SettingsSystem.md` section 24, Migration and Deprecation | Renames, removals, and type changes must use explicit migration/deprecation behavior that preserves operator intent, rejects unsafe new writes, avoids ambiguous JSON reinterpretation, and exposes audit or diagnostic visibility. | In scope | FR-002, FR-003, FR-004, FR-005 |
+| DESIGN-REQ-024 | `docs/Security/SettingsSystem.md` section 25, Testing Requirements | Regression coverage must prove catalog exposure, sensitive-field exclusion, SecretRef behavior, key/scope/type validation, effective value inheritance, reset, audit redaction, version conflicts, provider profile references, operational authorization, and catalog drift detection. | In scope | FR-006, FR-007, FR-008, FR-009 |
+| DESIGN-REQ-027 | `docs/Security/SettingsSystem.md` section 28, Open Integration Points | Future integrations must preserve descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior. | In scope | FR-010 |
+| DESIGN-REQ-028 | `docs/Security/SettingsSystem.md` section 29, Desired-State Invariants | The Settings System must enforce explicit editability, declared scopes, backend validation, no raw secret storage or plaintext readback, SecretRef validation/audit without plaintext, provider profile secret references, source explainability, reset inheritance, operator lock protection, authorized/audited operations, and intentional catalog changes. | In scope | FR-001, FR-006, FR-007, FR-008, FR-009 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Settings System MUST enforce that only explicitly catalog-exposed settings can be edited and MUST preserve non-goal boundaries against raw environment editing, generic database editing, generic secret management, generic admin UI behavior, and frontend-authoritative validation.
+- **FR-002**: The Settings System MUST support a deterministic setting-rename migration path that maps old overrides to a new descriptor key while preserving effective values and exposing deprecation or audit visibility where helpful.
+- **FR-003**: The Settings System MUST reject new writes to removed or deprecated setting keys while preserving or migrating existing stored values and explaining deprecated values in diagnostics.
+- **FR-004**: The Settings System MUST require explicit migration behavior for setting type changes and MUST fail instead of ambiguously reinterpreting existing JSON values.
+- **FR-005**: Migration and deprecation flows MUST provide audit or diagnostic evidence sufficient for maintainers to understand what changed without exposing secrets.
+- **FR-006**: Regression coverage MUST verify catalog exposure, sensitive-field exclusion, declared scopes, unknown-key rejection, invalid-scope rejection, type validation, numeric/string constraints, and intentional catalog drift.
+- **FR-007**: Regression coverage MUST verify SecretRef safety, including no generic raw secret storage, no plaintext readback, SecretRef validation and audit without plaintext, and provider profile references to secrets without embedding them.
+- **FR-008**: Regression coverage MUST verify effective value source explainability, workspace/user override inheritance, reset-to-inheritance behavior, and operator lock enforcement.
+- **FR-009**: Regression coverage MUST verify operational audit behavior, audit redaction, version conflict handling, and authorization gating for operations controls.
+- **FR-010**: Future settings integration contracts MUST preserve descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-546` and the canonical Jira preset brief for traceability.
+
+### Key Entities
+
+- **Setting Descriptor**: Declares a setting key, type, eligible scopes, editability, validation constraints, sensitivity/SecretRef behavior, and metadata used to expose settings safely.
+- **Setting Override**: Stores operator/user/workspace intent for a setting at a declared scope and must be migrated, preserved, reset, or rejected according to descriptor rules.
+- **Effective Setting Value**: The resolved setting value with source explanation after defaults, workspace/user overrides, operator locks, migration state, and SecretRef rules are applied.
+- **Migration or Deprecation Rule**: A versioned rule that describes renames, removals, or type changes and the diagnostics/audit evidence required to preserve operator intent.
+- **Settings Diagnostic**: A safe, redacted explanation of deprecated values, rejected writes, migration outcomes, catalog drift, or invariant failures.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A rename migration test proves at least one old override resolves to the new descriptor key with the same effective value and recorded audit or deprecation evidence.
+- **SC-002**: A removal/deprecation test proves new writes to a removed key are rejected while existing intent remains visible through diagnostics or migration evidence.
+- **SC-003**: A type-change test proves ambiguous reinterpretation of existing JSON values fails without an explicit migration.
+- **SC-004**: Catalog and invariant regression coverage fails when an unsafe descriptor exposure, scope, validation, SecretRef, source explanation, reset, operator lock, audit, or operation authorization invariant is broken.
+- **SC-005**: Integration or contract evidence demonstrates future settings consumers remain bound to descriptor-driven exposure, scoped overrides, server-side validation, auditability, and secret-safe behavior.
+- **SC-006**: Traceability evidence preserves `MM-546`, the canonical Jira preset brief, and DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-024, DESIGN-REQ-027, and DESIGN-REQ-028 in MoonSpec artifacts and verification output.

--- a/specs/275-settings-migration-invariants/tasks.md
+++ b/specs/275-settings-migration-invariants/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: Settings Migration Invariants
+
+**Input**: Design documents from `/work/agent_jobs/mm:be976054-2c25-4b91-8814-1aeff6eb3ee0/repo/specs/275-settings-migration-invariants/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/settings-migration-invariants.md, quickstart.md
+
+**Tests**: Unit tests and API boundary tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Organization**: One story only: maintainers can evolve Settings System descriptors safely because migration, deprecation, type-change, and invariant behavior is enforced by deterministic tests and diagnostics.
+
+**Source Traceability**: MM-546; FR-001 through FR-011; SC-001 through SC-006; DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-024, DESIGN-REQ-027, DESIGN-REQ-028.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm active artifacts and existing settings test harness.
+
+- [X] T001 Create `specs/275-settings-migration-invariants/spec.md` and checklist preserving `MM-546` and source design IDs (FR-011, SC-006)
+- [X] T002 Create `plan.md`, `research.md`, `data-model.md`, `contracts/settings-migration-invariants.md`, `quickstart.md`, and `tasks.md` for the single story (FR-011, SC-006)
+- [X] T003 Run focused settings tests before new assertions to establish baseline: `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish test fixtures for historical override rows and migration rules.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T004 Add reusable migration-rule test fixtures in `tests/unit/services/test_settings_catalog.py` (FR-002, FR-003, FR-004, DESIGN-REQ-021)
+- [X] T005 Add reusable API test setup for historical settings override rows in `tests/unit/api_service/api/routers/test_settings_api.py` (FR-003, SC-002)
+
+**Checkpoint**: Foundation ready; story test and implementation work can start.
+
+---
+
+## Phase 3: Story - Settings Evolution Safety Gate
+
+**Summary**: As a maintainer, I want Settings System migration rules, non-goals, and invariants to be enforced by tests and diagnostics so that future catalog changes cannot silently weaken operator intent, validation, or secret safety.
+
+**Independent Test**: Run focused settings service and API tests that prove rename migrations, removed/deprecated keys, type-change schema gates, and catalog invariants behave deterministically.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-024, DESIGN-REQ-027, DESIGN-REQ-028.
+
+**Test Plan**:
+
+- Unit: migration rule validation, old-key resolution, deprecated-key diagnostics, schema mismatch failure, invariant snapshot.
+- API: write rejection for deprecated keys, effective-value migration response, diagnostics response without raw values.
+
+### Unit Tests (write first) ⚠️
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T006 [P] Add failing unit test for rename migration preserving an old workspace override under the new key in `tests/unit/services/test_settings_catalog.py` (FR-002, FR-005, SC-001, DESIGN-REQ-021)
+- [X] T007 [P] Add failing unit test for removed/deprecated old-key diagnostics without raw value exposure in `tests/unit/services/test_settings_catalog.py` (FR-003, FR-005, SC-002, DESIGN-REQ-021)
+- [X] T008 [P] Add failing unit test for schema-version mismatch requiring explicit type migration in `tests/unit/services/test_settings_catalog.py` (FR-004, SC-003)
+- [X] T009 [P] Add failing invariant regression test for descriptor exposure, declared scopes, validation, SecretRef safety, provider profile refs, source explainability, reset inheritance, operator locks/read-only behavior, audit, and intentional catalog changes in `tests/unit/services/test_settings_catalog.py` (FR-001, FR-006, FR-007, FR-008, FR-009, FR-010, SC-004, SC-005, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-027, DESIGN-REQ-028)
+- [X] T010 Run `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py` and confirm T006-T009 fail for missing MM-546 behavior, not syntax or fixture errors
+
+### API Tests (write first) ⚠️
+
+- [X] T011 [P] Add failing API test for rejected writes to deprecated keys in `tests/unit/api_service/api/routers/test_settings_api.py` (FR-003, SC-002)
+- [X] T012 [P] Add failing API test for effective-value migration response and migration diagnostic in `tests/unit/api_service/api/routers/test_settings_api.py` (FR-002, FR-005, SC-001)
+- [X] T013 [P] Add failing API test for diagnostics including deprecated historical override evidence without plaintext in `tests/unit/api_service/api/routers/test_settings_api.py` (FR-003, FR-005, FR-010, SC-002, SC-005)
+- [X] T014 Run focused API tests and confirm T011-T013 fail for missing MM-546 behavior
+
+### Implementation
+
+- [X] T015 Add `SettingMigrationRule` and migration-rule validation to `api_service/services/settings_catalog.py` (FR-002, FR-003, FR-004, DESIGN-REQ-021)
+- [X] T016 Implement old-key override resolution for explicit rename rules in `api_service/services/settings_catalog.py` (FR-002, SC-001)
+- [X] T017 Implement removed/deprecated key write rejection and safe diagnostics for historical rows in `api_service/services/settings_catalog.py` and `api_service/api/routers/settings.py` (FR-003, FR-005, SC-002)
+- [X] T018 Implement schema-version compatibility checks for type-changed persisted overrides in `api_service/services/settings_catalog.py` (FR-004, SC-003)
+- [X] T019 Add invariant helper/test coverage without weakening existing SecretRef, provider profile, reset, audit, or permission behavior in `tests/unit/services/test_settings_catalog.py` (FR-006, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-024, DESIGN-REQ-027, DESIGN-REQ-028)
+- [X] T020 Run focused validation `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` and fix story-scoped failures
+
+**Checkpoint**: The story is functional, covered by unit/API tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T021 Review `specs/275-settings-migration-invariants/spec.md`, `plan.md`, `tasks.md`, `quickstart.md`, and final evidence for `MM-546` traceability (FR-011, SC-006)
+- [X] T022 Run full unit verification with `./tools/test_unit.sh`
+- [X] T023 Run hermetic integration verification with `./tools/test_integration.sh` when Docker is available; if unavailable, record the exact blocker
+- [X] T024 Run `/moonspec-verify` for `specs/275-settings-migration-invariants/spec.md` and address any additional-work findings before final handoff
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: starts immediately.
+- **Foundational (Phase 2)**: depends on Setup and blocks story implementation.
+- **Story (Phase 3)**: depends on Foundational; tests must be written and confirmed failing before implementation.
+- **Polish (Phase 4)**: depends on focused story tests passing.
+
+### Parallel Opportunities
+
+- T006-T009 can be authored in parallel only with coordination because they share one service test file.
+- T011-T013 can be authored in parallel only with coordination because they share one API test file.
+- T015-T018 are serialized through the service contract to avoid hidden compatibility shims.
+
+## Implementation Strategy
+
+1. Preserve `MM-546` traceability in every artifact and final evidence.
+2. Write failing service and API tests for migration/deprecation/type-change behavior.
+3. Implement explicit migration rules in the settings service.
+4. Keep raw values out of diagnostics and API errors.
+5. Run focused validation, then full unit verification, then integration if Docker is available.
+
+## Verification Evidence
+
+- Baseline focused settings validation before MM-546 tests: `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` passed with 51 Python tests and 460 frontend tests.
+- Red-first run after adding MM-546 tests: `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` failed during collection because `SettingMigrationRule` was not implemented.
+- Focused story validation after implementation: `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` passed with 58 Python tests and 460 frontend tests.
+- Full unit verification: `./tools/test_unit.sh` passed with 4,187 Python tests, 16 subtests, 1 xpass, and 460 frontend tests.
+- Hermetic integration verification: `./tools/test_integration.sh` was blocked because Docker is unavailable in this managed container: `dial unix /var/run/docker.sock: connect: no such file or directory`.
+- MoonSpec helper limitation: `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` could not resolve the managed-run branch because it does not start with the numeric spec prefix; verification used the explicit feature directory `specs/275-settings-migration-invariants`.

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -10,11 +10,25 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from api_service.auth_providers import get_current_user
 from api_service.api.routers import settings as settings_router
 from api_service.db import base as db_base
-from api_service.db.models import Base, ManagedSecret, SecretStatus
+from api_service.db.models import Base, ManagedSecret, SecretStatus, SettingsOverride
 from api_service.main import app
+from api_service.services.settings_catalog import (
+    SettingMigrationRule,
+    SettingsCatalogService,
+)
 
 
 SETTINGS_USER_DEP = get_current_user()
+
+
+def _install_settings_migration_rules(monkeypatch, rules):
+    service_cls = SettingsCatalogService
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("migration_rules", rules)
+        return service_cls(*args, **kwargs)
+
+    monkeypatch.setattr(settings_router, "SettingsCatalogService", _factory)
 
 
 @pytest.fixture
@@ -167,6 +181,124 @@ async def test_settings_write_to_unexposed_key_returns_setting_not_exposed():
     assert body["key"] == "workflow.github_token"
     assert body["scope"] == "workspace"
     assert "raw-token" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_patch_deprecated_setting_key_is_rejected_without_echoing_value(
+    settings_api_db,
+    monkeypatch,
+):
+    _install_settings_migration_rules(
+        monkeypatch,
+        (
+            SettingMigrationRule(
+                old_key="test.removed_token",
+                state="removed",
+                message="test.removed_token was removed.",
+            ),
+        ),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"test.removed_token": "ghp_should_never_echo"},
+                "expected_versions": {"test.removed_token": 1},
+            },
+        )
+
+    assert response.status_code == 423
+    assert response.json()["error"] == "read_only_setting"
+    assert response.json()["key"] == "test.removed_token"
+    assert "ghp_should_never_echo" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_effective_setting_endpoint_resolves_renamed_override(
+    settings_api_db,
+    monkeypatch,
+):
+    _install_settings_migration_rules(
+        monkeypatch,
+        (
+            SettingMigrationRule(
+                old_key="workflow.legacy_publish_mode",
+                new_key="workflow.default_publish_mode",
+                state="renamed",
+                message="workflow.legacy_publish_mode was renamed.",
+            ),
+        ),
+    )
+    async with settings_api_db() as session:
+        session.add(
+            SettingsOverride(
+                scope="workspace",
+                key="workflow.legacy_publish_mode",
+                value_json="branch",
+                value_version=5,
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            "/api/v1/settings/effective/workflow.default_publish_mode",
+            params={"scope": "workspace"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["value"] == "branch"
+    assert body["source"] == "migrated_workspace_override"
+    assert body["value_version"] == 5
+    assert body["diagnostics"][0]["code"] == "setting_renamed_override"
+
+
+@pytest.mark.asyncio
+async def test_settings_diagnostics_include_deprecated_override_without_plaintext(
+    settings_api_db,
+    monkeypatch,
+):
+    _install_settings_migration_rules(
+        monkeypatch,
+        (
+            SettingMigrationRule(
+                old_key="workflow.removed_secret",
+                state="removed",
+                message="workflow.removed_secret was removed.",
+            ),
+        ),
+    )
+    async with settings_api_db() as session:
+        session.add(
+            SettingsOverride(
+                scope="workspace",
+                key="workflow.removed_secret",
+                value_json="ghp_removed_plaintext",
+                value_version=7,
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            "/api/v1/settings/diagnostics",
+            params={"scope": "workspace"},
+        )
+
+    assert response.status_code == 200
+    value = response.json()["values"]["workflow.removed_secret"]
+    assert value["source"] == "deprecated_override"
+    assert value["diagnostics"][0]["code"] == "setting_deprecated_override"
+    assert value["diagnostics"][0]["details"]["value_version"] == 7
+    assert "ghp_removed_plaintext" not in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -11,10 +11,12 @@ from api_service.db.models import (
     RuntimeMaterializationMode,
     SecretStatus,
     SettingsAuditEvent,
+    SettingsOverride,
 )
 from api_service.services.settings_catalog import (
     SETTINGS_PERMISSION_NAMES,
     SettingAuditPolicy,
+    SettingMigrationRule,
     SettingsCatalogService,
 )
 
@@ -353,6 +355,204 @@ async def _workspace_override_persists_and_reports_version(settings_session):
         updated.values["workflow.default_publish_mode"].activation_state
         == "pending_next_boundary"
     )
+
+
+@pytest.mark.asyncio
+async def test_rename_migration_preserves_old_workspace_override(settings_session_maker):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.new_runtime",
+            title="New Runtime",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default-runtime",
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+    rules = (
+        SettingMigrationRule(
+            old_key="test.old_runtime",
+            new_key="test.new_runtime",
+            state="renamed",
+            message="test.old_runtime was renamed to test.new_runtime.",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.old_runtime",
+                value_json="preserved-runtime",
+                value_version=3,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=rules,
+            session=settings_session,
+        )
+        effective = await service.effective_value_async(
+            "test.new_runtime", scope="workspace"
+        )
+
+    assert effective.value == "preserved-runtime"
+    assert effective.source == "migrated_workspace_override"
+    assert effective.value_version == 3
+    assert [diagnostic.code for diagnostic in effective.diagnostics] == [
+        "setting_renamed_override"
+    ]
+    assert effective.diagnostics[0].details == {
+        "old_key": "test.old_runtime",
+        "new_key": "test.new_runtime",
+        "state": "renamed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deprecated_override_diagnostics_do_not_expose_raw_value(
+    settings_session_maker,
+):
+    rules = (
+        SettingMigrationRule(
+            old_key="test.removed_token",
+            state="removed",
+            message="test.removed_token was removed and requires migration.",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.removed_token",
+                value_json="ghp_should_never_leak",
+                value_version=2,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(
+            env={},
+            registry=(),
+            migration_rules=rules,
+            session=settings_session,
+        )
+        diagnostics = await service.diagnostics(scope="workspace")
+
+    deprecated = diagnostics.values["test.removed_token"]
+    assert deprecated.source == "deprecated_override"
+    assert deprecated.diagnostics[0].code == "setting_deprecated_override"
+    assert deprecated.diagnostics[0].details == {
+        "old_key": "test.removed_token",
+        "state": "removed",
+        "value_version": 2,
+        "schema_version": 1,
+    }
+    assert "ghp_should_never_leak" not in deprecated.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_schema_version_mismatch_requires_explicit_type_migration(
+    settings_session_maker,
+):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.threshold",
+            title="Threshold",
+            category="Test",
+            section="user-workspace",
+            value_type="integer",
+            ui="number",
+            scopes=("workspace",),
+            default_value=10,
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+    rules = (
+        SettingMigrationRule(
+            old_key="test.threshold",
+            state="type_changed",
+            expected_schema_version=2,
+            message="test.threshold type changed and needs migration.",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.threshold",
+                value_json="10",
+                schema_version=1,
+                value_version=4,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=rules,
+            session=settings_session,
+        )
+        effective = await service.effective_value_async(
+            "test.threshold", scope="workspace"
+        )
+
+    assert effective.value is None
+    assert effective.source == "type_migration_required"
+    assert effective.value_version == 4
+    assert effective.diagnostics[0].code == "setting_type_migration_required"
+    assert effective.diagnostics[0].details == {
+        "key": "test.threshold",
+        "state": "type_changed",
+        "schema_version": 1,
+        "expected_schema_version": 2,
+    }
+
+
+def test_catalog_invariant_gate_for_future_integrations():
+    service = SettingsCatalogService(env={})
+    catalog = service.catalog(scope="workspace")
+    descriptors = [
+        descriptor
+        for values in catalog.categories.values()
+        for descriptor in values
+    ]
+
+    assert descriptors
+    for descriptor in descriptors:
+        assert descriptor.key
+        assert "workspace" in descriptor.scopes
+        assert descriptor.source_explanation
+        assert descriptor.apply_mode
+        assert descriptor.audit is not None
+        assert descriptor.ui != "raw_secret"
+        assert descriptor.type != "password"
+        assert descriptor.key not in {"workflow.github_token"}
+
+    github_ref = next(
+        item for item in descriptors if item.key == "integrations.github.token_ref"
+    )
+    assert github_ref.ui == "secret_ref_picker"
+    assert github_ref.secret_role == "github_token"
+    assert github_ref.audit.redact is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -419,6 +419,118 @@ async def test_rename_migration_preserves_old_workspace_override(settings_sessio
     }
 
 
+def test_duplicate_rename_migration_targets_are_rejected():
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.new_runtime",
+            title="New Runtime",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default-runtime",
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+    rules = (
+        SettingMigrationRule(
+            old_key="test.old_runtime_a",
+            new_key="test.new_runtime",
+            state="renamed",
+            message="test.old_runtime_a was renamed.",
+        ),
+        SettingMigrationRule(
+            old_key="test.old_runtime_b",
+            new_key="test.new_runtime",
+            state="renamed",
+            message="test.old_runtime_b was renamed.",
+        ),
+    )
+    service = SettingsCatalogService(env={}, registry=registry, migration_rules=rules)
+
+    with pytest.raises(ValueError, match="duplicate rename migration target"):
+        service.catalog(scope="workspace")
+
+
+@pytest.mark.asyncio
+async def test_migration_diagnostic_is_cleared_after_direct_override_resolution(
+    settings_session_maker,
+):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.new_runtime",
+            title="New Runtime",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default-runtime",
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+    rules = (
+        SettingMigrationRule(
+            old_key="test.old_runtime",
+            new_key="test.new_runtime",
+            state="renamed",
+            message="test.old_runtime was renamed to test.new_runtime.",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.old_runtime",
+                value_json="migrated-runtime",
+                value_version=1,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=rules,
+            session=settings_session,
+        )
+        migrated = await service.effective_value_async(
+            "test.new_runtime", scope="workspace"
+        )
+        assert [diagnostic.code for diagnostic in migrated.diagnostics] == [
+            "setting_renamed_override"
+        ]
+
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.new_runtime",
+                value_json="direct-runtime",
+                value_version=2,
+            )
+        )
+        await settings_session.commit()
+
+        direct = await service.effective_value_async(
+            "test.new_runtime", scope="workspace"
+        )
+
+    assert direct.value == "direct-runtime"
+    assert direct.source == "workspace_override"
+    assert direct.diagnostics == []
+
+
 @pytest.mark.asyncio
 async def test_deprecated_override_diagnostics_do_not_expose_raw_value(
     settings_session_maker,
@@ -461,6 +573,59 @@ async def test_deprecated_override_diagnostics_do_not_expose_raw_value(
         "schema_version": 1,
     }
     assert "ghp_should_never_leak" not in deprecated.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_key_scoped_diagnostics_exclude_unrelated_deprecated_overrides(
+    settings_session_maker,
+):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.active_runtime",
+            title="Active Runtime",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default-runtime",
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+    rules = (
+        SettingMigrationRule(
+            old_key="test.removed_token",
+            state="removed",
+            message="test.removed_token was removed and requires migration.",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=UUID("00000000-0000-0000-0000-000000000000"),
+                user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                key="test.removed_token",
+                value_json="ghp_should_never_leak",
+                value_version=2,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=rules,
+            session=settings_session,
+        )
+        diagnostics = await service.diagnostics(
+            scope="workspace", key="test.active_runtime"
+        )
+
+    assert list(diagnostics.values) == ["test.active_runtime"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements MM-546 by adding an explicit Settings System migration/deprecation rule boundary and MoonSpec artifacts for `specs/275-settings-migration-invariants`.

## Jira

- Jira issue key: MM-546

## Active MoonSpec Feature

- `specs/275-settings-migration-invariants`

## Verification Verdict

- ADDITIONAL_WORK_NEEDED: implementation and unit/API verification are complete, but hermetic integration could not run in this managed container because Docker socket access is unavailable.

## Tests Run

- `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py` - PASS; 58 backend/API tests plus 460 frontend tests via wrapper.
- `./tools/test_unit.sh` - PASS; 4,187 Python tests, 16 subtests, 1 xpass, and 460 frontend tests.
- `./tools/test_integration.sh` - NOT RUN; Docker unavailable at `/var/run/docker.sock`.
- `docker info --format '{{.ServerVersion}}'` - FAIL; Docker socket unavailable.
- `git diff --check` - PASS.

## Remaining Risks

- Hermetic integration still needs to be run in an environment with Docker available.
- No Jira Code Review transition has been performed in this step.
