### PR TITLE
[codex] Fix rerun step instruction preservation

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3560,14 +3560,14 @@ async def _create_execution_from_task_request(
         attachment_refs=attachment_index,
     )
 
-    snapshot_ref = await _persist_original_task_input_snapshot(
+    snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
         session=session,
         record=record,
         user=user,
-        payload=payload,
-        task_payload=task_payload,
+        parameters=initial_parameters,
         attachment_refs=attachment_index,
         source_kind="create",
+        input_artifact_ref=input_artifact_ref,
     )
     if snapshot_ref:
         await session.commit()

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,27 @@
 [
   {
-    "id": 3156682613,
+    "id": 3157004917,
     "disposition": "addressed",
-    "rationale": "Activation metadata now defaults clean catalog/effective/diagnostic reads to active and only marks newly committed non-immediate override responses as pending activation."
+    "rationale": "Replaced the JSON stringify/parse clone helper with structuredClone in frontend/src/entrypoints/task-create.tsx."
   },
   {
-    "id": 4191816834,
+    "id": 3157004931,
+    "disposition": "addressed",
+    "rationale": "Recovered step instructions are now explicitly converted with String(...) before being merged into the draft."
+  },
+  {
+    "id": 4192190809,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container with no independent actionable request beyond the inline review comment."
+    "rationale": "Top-level review summary; its two concrete suggestions are tracked and addressed by review comments 3157004917 and 3157004931."
   },
   {
-    "id": 3156699062,
-    "disposition": "addressed",
-    "rationale": "Pending activation values now redact sensitive non-reference values while preserving safe SecretRef strings such as db:// and env:// references."
-  },
-  {
-    "id": 3156699081,
-    "disposition": "addressed",
-    "rationale": "Registry apply-mode validation errors now include the failing setting key and the specific consistency rule."
-  },
-  {
-    "id": 3156699085,
-    "disposition": "addressed",
-    "rationale": "Mission Control now renders pending values whenever a setting is inactive and pending_value is present, including explicit null resets displayed as Not set."
-  },
-  {
-    "id": 4191835297,
+    "id": 4192213109,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container; the actionable findings from the summary are tracked by the inline review comment ids."
+    "rationale": "Informational automated review summary with no requested code change."
+  },
+  {
+    "id": 3157023149,
+    "disposition": "addressed",
+    "rationale": "Narrowed gap detection to likely degraded template steps, tolerated unavailable source artifacts, and added a regression test for valid instructionless skill steps."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1143,6 +1143,38 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Avalid-skill-rerun?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:valid-skill-rerun",
+              workflowType: "MoonMind.Run",
+              state: "completed",
+              targetRuntime: "codex_cli",
+              repository: "MoonLadderStudios/MoonMind",
+              inputArtifactRef: "expired-valid-input",
+              taskInputSnapshot: {
+                available: true,
+                artifactRef: "valid-skill-snapshot",
+                snapshotVersion: 1,
+                sourceKind: "create",
+                reconstructionMode: "authoritative",
+                disabledReasons: {},
+                fallbackEvidenceRefs: [],
+              },
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                task: {
+                  runtime: { mode: "codex_cli" },
+                },
+              },
+              actions: {
+                canUpdateInputs: false,
+                canRerun: true,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aunsupported?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -1961,6 +1993,50 @@ describe("Task Create Entrypoint", () => {
                   ],
                 },
               }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/valid-skill-snapshot/download") {
+          return Promise.resolve({
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                snapshotVersion: 1,
+                source: { kind: "create" },
+                draft: {
+                  repository: "MoonLadderStudios/MoonMind",
+                  targetRuntime: "codex_cli",
+                  taskShape: "multi_step",
+                  task: {
+                    instructions: "Run the setup step first.",
+                    runtime: { mode: "codex_cli" },
+                    steps: [
+                      {
+                        id: "setup",
+                        title: "Setup",
+                        instructions: "Run the setup step first.",
+                      },
+                      {
+                        id: "skill-only-step",
+                        title: "Run skill without free-text instructions",
+                        tool: {
+                          type: "skill",
+                          name: "moonspec-verify",
+                          version: "1.0",
+                        },
+                        skill: { id: "moonspec-verify" },
+                      },
+                    ],
+                  },
+                },
+              }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/expired-valid-input/download") {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: async () => "",
           } as Response);
         }
         if (url === "/api/artifacts/missing-input/download") {
@@ -3407,6 +3483,39 @@ describe("Task Create Entrypoint", () => {
         },
       },
     });
+  });
+
+  it("does not require source artifacts for valid instructionless skill steps", async () => {
+    window.history.pushState(
+      {},
+      "Task Rerun",
+      "/tasks/new?rerunExecutionId=mm%3Avalid-skill-rerun",
+    );
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Rerun Task" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        (screen.getAllByLabelText("Instructions")[0] as HTMLTextAreaElement)
+          .value,
+      ).toBe("Run the setup step first.");
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url]) => String(url) === "/api/artifacts/valid-skill-snapshot/download",
+      ),
+    ).toBe(true);
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url]) => String(url) === "/api/artifacts/expired-valid-input/download",
+      ),
+    ).toBe(false);
+    expect(
+      screen.queryByText(
+        "Task instructions could not be loaded from the input artifact.",
+      ),
+    ).toBeNull();
   });
 
   it("shows backend stale-state failures without redirecting from rerun mode", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1937,6 +1937,32 @@ describe("Task Create Entrypoint", () => {
               }),
           } as Response);
         }
+        if (url === "/api/artifacts/complex-input/download") {
+          return Promise.resolve({
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                repository: "MoonLadderStudios/Tactics",
+                task: {
+                  steps: [
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                      instructions: "Break down the Grid UI overlay plan.",
+                    },
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                      instructions: "Create Jira stories from recovered input.",
+                    },
+                    {
+                      id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                      instructions:
+                        "Create dependent orchestrate tasks from recovered input.",
+                    },
+                  ],
+                },
+              }),
+          } as Response);
+        }
         if (url === "/api/artifacts/missing-input/download") {
           return Promise.resolve({
             ok: false,
@@ -3291,6 +3317,11 @@ describe("Task Create Entrypoint", () => {
         ),
       ).toBeTruthy();
       expect(
+        fetchSpy.mock.calls.some(
+          ([url]) => String(url) === "/api/artifacts/complex-input/download",
+        ),
+      ).toBeTruthy();
+      expect(
         (screen.getAllByLabelText("Instructions")[0] as HTMLTextAreaElement)
           .value,
       ).toBe("Break down the Grid UI overlay plan.");
@@ -3344,6 +3375,7 @@ describe("Task Create Entrypoint", () => {
             }),
             expect.objectContaining({
               id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+              instructions: "Create Jira stories from recovered input.",
               storyOutput: {
                 mode: "jira",
                 fallback: "fail",
@@ -3356,6 +3388,8 @@ describe("Task Create Entrypoint", () => {
             }),
             expect.objectContaining({
               id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+              instructions:
+                "Create dependent orchestrate tasks from recovered input.",
               jiraOrchestration: {
                 task: {
                   repository: "MoonLadderStudios/MoonMind",

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -644,7 +644,7 @@ function nonEmptyRecordValue(value: unknown): Record<string, unknown> | undefine
 }
 
 function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
-  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  return structuredClone(value) as Record<string, unknown>;
 }
 
 function artifactInputTaskRecord(
@@ -659,16 +659,44 @@ function artifactInputTaskRecord(
 function artifactInputHasStepInstructionGaps(
   artifactInput: Record<string, unknown>,
 ): boolean {
-  const steps = artifactInputTaskRecord(artifactInput).steps;
+  const task = artifactInputTaskRecord(artifactInput);
+  const steps = task.steps;
   if (!Array.isArray(steps)) {
     return false;
   }
+  const appliedStepIds = new Set<string>();
+  const appliedTemplates = Array.isArray(task.appliedStepTemplates)
+    ? task.appliedStepTemplates
+    : [];
+  appliedTemplates.forEach((template) => {
+    const templateRecord = recordValue(template);
+    const stepIds = Array.isArray(templateRecord.stepIds)
+      ? templateRecord.stepIds
+      : [];
+    stepIds.forEach((stepId) => {
+      const normalized = String(stepId || "").trim();
+      if (normalized) {
+        appliedStepIds.add(normalized);
+      }
+    });
+  });
+  let sawInstruction = false;
   return steps.some((step) => {
     const stepRecord = recordValue(step);
-    if (Object.keys(stepRecord).length === 0) {
+    const stepId = String(stepRecord.id || "").trim();
+    if (String(stepRecord.instructions || "").trim()) {
+      sawInstruction = true;
       return false;
     }
-    return !String(stepRecord.instructions || "").trim();
+    if (!sawInstruction || !stepId || !appliedStepIds.has(stepId)) {
+      return false;
+    }
+    return (
+      stepId.startsWith("tpl:") &&
+      (Boolean(recordValue(stepRecord.tool).name) ||
+        Boolean(recordValue(stepRecord.skill).id) ||
+        Boolean(recordValue(stepRecord.skill).name))
+    );
   });
 }
 
@@ -730,7 +758,7 @@ function mergeMissingTaskInstructionsFromArtifact(
     changed = true;
     return {
       ...stepRecord,
-      instructions: sourceStep?.instructions,
+      instructions: String(sourceStep?.instructions),
     };
   });
   mergedSource.task = mergedTask;
@@ -2690,16 +2718,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             inputArtifactRef &&
             artifactInputHasStepInstructionGaps(artifactInput)
           ) {
-            const sourceArtifactInput = recordValue(
-              await readTemporalInputArtifact(
-                artifactDownloadEndpoint,
-                inputArtifactRef,
-              ),
-            );
-            artifactInput = mergeMissingTaskInstructionsFromArtifact(
-              artifactInput,
-              sourceArtifactInput,
-            );
+            try {
+              const sourceArtifactInput = recordValue(
+                await readTemporalInputArtifact(
+                  artifactDownloadEndpoint,
+                  inputArtifactRef,
+                ),
+              );
+              artifactInput = mergeMissingTaskInstructionsFromArtifact(
+                artifactInput,
+                sourceArtifactInput,
+              );
+            } catch {
+              // The authoritative snapshot remains usable if the older source
+              // input artifact has expired or is no longer accessible.
+            }
           }
         } else if (inputArtifactRef && !hasInlineTaskInstructions(inlineTask)) {
           artifactInput = recordValue(

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -643,6 +643,100 @@ function nonEmptyRecordValue(value: unknown): Record<string, unknown> | undefine
   return Object.keys(record).length > 0 ? record : undefined;
 }
 
+function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function artifactInputTaskRecord(
+  artifactInput: Record<string, unknown>,
+): Record<string, unknown> {
+  const snapshotDraft = recordValue(artifactInput.draft);
+  const source =
+    Object.keys(snapshotDraft).length > 0 ? snapshotDraft : artifactInput;
+  return recordValue(source.task);
+}
+
+function artifactInputHasStepInstructionGaps(
+  artifactInput: Record<string, unknown>,
+): boolean {
+  const steps = artifactInputTaskRecord(artifactInput).steps;
+  if (!Array.isArray(steps)) {
+    return false;
+  }
+  return steps.some((step) => {
+    const stepRecord = recordValue(step);
+    if (Object.keys(stepRecord).length === 0) {
+      return false;
+    }
+    return !String(stepRecord.instructions || "").trim();
+  });
+}
+
+function mergeMissingTaskInstructionsFromArtifact(
+  artifactInput: Record<string, unknown>,
+  sourceArtifactInput: Record<string, unknown>,
+): Record<string, unknown> {
+  const sourceTask = artifactInputTaskRecord(sourceArtifactInput);
+  const sourceSteps = Array.isArray(sourceTask.steps) ? sourceTask.steps : [];
+  if (sourceSteps.length === 0) {
+    return artifactInput;
+  }
+
+  const merged = cloneJsonRecord(artifactInput);
+  const mergedDraft = recordValue(merged.draft);
+  const mergedSource =
+    Object.keys(mergedDraft).length > 0 ? mergedDraft : merged;
+  const mergedTask = recordValue(mergedSource.task);
+  const mergedSteps = Array.isArray(mergedTask.steps) ? mergedTask.steps : [];
+  if (mergedSteps.length === 0) {
+    return artifactInput;
+  }
+
+  let changed = false;
+  const sourceStepsById = new Map<string, Record<string, unknown>>();
+  sourceSteps.forEach((step) => {
+    const stepRecord = recordValue(step);
+    const stepId = String(stepRecord.id || "").trim();
+    if (stepId) {
+      sourceStepsById.set(stepId, stepRecord);
+    }
+  });
+
+  const sourceTaskInstructions = String(sourceTask.instructions || "").trim();
+  if (
+    sourceTaskInstructions &&
+    !String(mergedTask.instructions || "").trim()
+  ) {
+    mergedTask.instructions = sourceTask.instructions;
+    changed = true;
+  }
+
+  mergedTask.steps = mergedSteps.map((step, index) => {
+    const stepRecord = recordValue(step);
+    if (Object.keys(stepRecord).length === 0) {
+      return step;
+    }
+    if (String(stepRecord.instructions || "").trim()) {
+      return step;
+    }
+    const stepId = String(stepRecord.id || "").trim();
+    const sourceStep = stepId
+      ? sourceStepsById.get(stepId)
+      : recordValue(sourceSteps[index]);
+    const sourceInstructions = String(sourceStep?.instructions || "").trim();
+    if (!sourceInstructions) {
+      return step;
+    }
+    changed = true;
+    return {
+      ...stepRecord,
+      instructions: sourceStep?.instructions,
+    };
+  });
+  mergedSource.task = mergedTask;
+  return changed ? merged : artifactInput;
+}
+
 function mergeRecordValues(
   base: Record<string, unknown>,
   overlay: Record<string, unknown>,
@@ -2592,6 +2686,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               snapshotArtifactRef,
             ),
           );
+          if (
+            inputArtifactRef &&
+            artifactInputHasStepInstructionGaps(artifactInput)
+          ) {
+            const sourceArtifactInput = recordValue(
+              await readTemporalInputArtifact(
+                artifactDownloadEndpoint,
+                inputArtifactRef,
+              ),
+            );
+            artifactInput = mergeMissingTaskInstructionsFromArtifact(
+              artifactInput,
+              sourceArtifactInput,
+            );
+          }
         } else if (inputArtifactRef && !hasInlineTaskInstructions(inlineTask)) {
           artifactInput = recordValue(
             await readTemporalInputArtifact(

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -477,6 +477,8 @@ function selectDraftSteps(
   taskSteps: TemporalSubmissionDraft['steps'],
   artifactTaskSteps: TemporalSubmissionDraft['steps'],
 ): TemporalSubmissionDraft['steps'] {
+  const instructionCount = (steps: TemporalSubmissionDraft['steps']) =>
+    steps.filter((step) => stringValue(step.instructions)).length;
   const artifactHasAttachments = artifactTaskSteps.some(
     (step) =>
       (step.inputAttachments || []).length > 0 ||
@@ -491,6 +493,9 @@ function selectDraftSteps(
     return artifactTaskSteps;
   }
   if (artifactTaskSteps.length > taskSteps.length) {
+    return artifactTaskSteps;
+  }
+  if (instructionCount(artifactTaskSteps) > instructionCount(taskSteps)) {
     return artifactTaskSteps;
   }
   return taskSteps.length > 0 ? taskSteps : artifactTaskSteps;

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2265,6 +2265,79 @@ def test_create_execution_persists_task_input_snapshot_for_direct_run_submission
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(record)
 
+
+def test_task_submission_snapshot_uses_input_artifact_for_stripped_step_instructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    record = _build_execution_record(has_task_input_snapshot=False)
+    service.create_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=False)
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard, "temporal_task_editing_enabled", True
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _persist_snapshot(**kwargs) -> str:
+        captured.update(kwargs)
+        target_record = kwargs["record"]
+        target_record.memo = {
+            **dict(target_record.memo or {}),
+            "task_input_snapshot_ref": "art_snapshot_hydrated_create",
+            "task_input_snapshot_version": 1,
+            "task_input_snapshot_source_kind": "create",
+        }
+        return "art_snapshot_hydrated_create"
+
+    persist_mock = AsyncMock(side_effect=_persist_snapshot)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._persist_original_task_input_snapshot_from_parameters",
+        persist_mock,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex_cli",
+                    "inputArtifactRef": "art-full-input",
+                    "task": {
+                        "instructions": "Top level stays inline.",
+                        "runtime": {"mode": "codex_cli"},
+                        "steps": [
+                            {
+                                "id": "step-1",
+                                "instructions": "Top level stays inline.",
+                            },
+                            {"id": "step-2", "title": "Stripped later step"},
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    persist_mock.assert_awaited_once()
+    assert captured["parameters"]["task"]["steps"][1] == {
+        "id": "step-2",
+        "title": "Stripped later step",
+    }
+    assert captured["input_artifact_ref"] == "art-full-input"
+    assert captured["source_kind"] == "create"
+    session.commit.assert_awaited_once()
+
+
 def test_create_execution_enforces_idempotency(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:


### PR DESCRIPTION
## Summary
- Persist task input snapshots from hydrated parameters so oversized step instructions stored only in input artifacts are retained.
- Repair rerun draft loading for older degraded snapshots by pulling missing step instructions from the original input artifact.
- Prefer draft step sources with more instruction bodies when reconstructing edit/rerun forms.

## Root Cause
The original input artifact for a multi-step workflow could contain all step instructions while the authoritative task input snapshot only retained the inline subset after the frontend stripped oversized later step instructions. Rerun mode trusted that degraded snapshot first, so later steps were reconstructed as title/skill-only.

## Validation
- npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh

## Impact
Rerunning workflows like mm:b6f70e3c-8ae3-4f21-b5b1-be5807ebabc8 now preserves later step instructions instead of silently submitting a degraded rerun draft.