### PR TITLE
[codex] Fix Claude model label reconciliation

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -7,6 +7,11 @@ from moonmind.config.logging import configure_logging
 configure_logging()
 logger = logging.getLogger(__name__)  # Get logger after configuration
 
+_CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES = {
+    "Sonnet 4.6": "claude-sonnet-4-6",
+    "Opus 4.7": "claude-opus-4-7",
+}
+
 import os  # For path operations
 import time
 from contextlib import asynccontextmanager
@@ -828,13 +833,35 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         profile_id == "codex_openrouter_qwen36_plus"
                         and current_model_text == legacy_openrouter_model
                     )
-                    if desired_default_model is not None and (
-                        not current_model_text or should_reconcile_deprecated_model
+                    reconciled_model = desired_default_model
+                    if profile_id == "claude_anthropic":
+                        reconciled_model = (
+                            _CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES.get(
+                                current_model_text,
+                                desired_default_model,
+                            )
+                        )
+                    should_reconcile_claude_display_model = (
+                        profile_id == "claude_anthropic"
+                        and reconciled_model is not None
+                        and current_model_text
+                        in _CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES
+                    )
+                    should_reconcile_default_model = (
+                        desired_default_model is not None
+                        and (
+                            not current_model_text
+                            or should_reconcile_deprecated_model
+                        )
+                    )
+                    if (
+                        should_reconcile_default_model
+                        or should_reconcile_claude_display_model
                     ):
                         stmt = (
                             update(ManagedAgentProviderProfile)
                             .where(ManagedAgentProviderProfile.profile_id == profile_id)
-                            .values(default_model=desired_default_model)
+                            .values(default_model=reconciled_model)
                         )
                         await session.execute(stmt)
                         needs_commit = True

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -7,11 +7,6 @@ from moonmind.config.logging import configure_logging
 configure_logging()
 logger = logging.getLogger(__name__)  # Get logger after configuration
 
-_CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES = {
-    "Sonnet 4.6": "claude-sonnet-4-6",
-    "Opus 4.7": "claude-opus-4-7",
-}
-
 import os  # For path operations
 import time
 from contextlib import asynccontextmanager
@@ -530,6 +525,10 @@ async def add_request_id(request: Request, call_next):
 
 _CODEX_OPENROUTER_QWEN36_PLUS_MODEL = "qwen/qwen3.6-plus"
 _LEGACY_CODEX_OPENROUTER_QWEN36_PLUS_FREE_MODEL = "qwen/qwen3.6-plus:free"
+_CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES = {
+    "Sonnet 4.6": "claude-sonnet-4-6",
+    "Opus 4.7": "claude-opus-4-7",
+}
 
 def _codex_openrouter_qwen36_plus_file_templates(
     model: str,
@@ -833,19 +832,17 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         profile_id == "codex_openrouter_qwen36_plus"
                         and current_model_text == legacy_openrouter_model
                     )
-                    reconciled_model = desired_default_model
-                    if profile_id == "claude_anthropic":
-                        reconciled_model = (
-                            _CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES.get(
-                                current_model_text,
-                                desired_default_model,
-                            )
-                        )
-                    should_reconcile_claude_display_model = (
+                    is_legacy_claude_display_model = (
                         profile_id == "claude_anthropic"
-                        and reconciled_model is not None
                         and current_model_text
                         in _CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES
+                    )
+                    reconciled_model = (
+                        _CLAUDE_ANTHROPIC_LEGACY_DISPLAY_MODEL_ALIASES[
+                            current_model_text
+                        ]
+                        if is_legacy_claude_display_model
+                        else desired_default_model
                     )
                     should_reconcile_default_model = (
                         desired_default_model is not None
@@ -856,7 +853,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                     )
                     if (
                         should_reconcile_default_model
-                        or should_reconcile_claude_display_model
+                        or is_legacy_claude_display_model
                     ):
                         stmt = (
                             update(ManagedAgentProviderProfile)

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,17 @@
 [
   {
-    "id": 4192185054,
+    "id": 4192598542,
     "disposition": "not-applicable",
-    "rationale": "Positive Gemini review summary with no requested change."
+    "rationale": "Summary review comment only; the two concrete inline comments were classified separately."
   },
   {
-    "id": 3157002480,
+    "id": 3157353680,
     "disposition": "addressed",
-    "rationale": "Key-scoped diagnostics now skip unrelated deprecated override diagnostics; regression test covers diagnostics(scope, key)."
+    "rationale": "Simplified the Claude display-label reconciliation branch by using a single legacy-label predicate and direct mapping lookup."
   },
   {
-    "id": 3157002486,
+    "id": 3157353686,
     "disposition": "addressed",
-    "rationale": "Resolution now clears cached migration diagnostics for the key before fresh override/default resolution; regression test covers reused service instances."
-  },
-  {
-    "id": 4192187854,
-    "disposition": "not-applicable",
-    "rationale": "Codex automated review container comment; actionable child review comments are tracked separately."
-  },
-  {
-    "id": 3157002490,
-    "disposition": "addressed",
-    "rationale": "Migration rule validation now rejects duplicate renamed new_key targets; regression test covers fail-fast behavior."
+    "rationale": "Moved the Claude legacy model alias constant out of the import/logging block and next to related provider-profile constants."
   }
 ]

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -215,6 +215,31 @@ async def test_auto_seed_reconcile_does_not_overwrite_user_default_model(_module
         assert profile.default_model == "gpt-user-custom"
 
 @pytest.mark.asyncio
+async def test_auto_seed_reconciles_claude_display_default_model(
+    _module_db, monkeypatch
+):
+    """Known stale Claude display labels should be rewritten to CLI model IDs."""
+    from api_service.main import _auto_seed_provider_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    await _auto_seed_provider_profiles()
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, "claude_anthropic")
+        assert profile is not None
+        profile.default_model = "Sonnet 4.6"
+        await session.commit()
+
+    seeded = await _auto_seed_provider_profiles()
+    assert seeded == []
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, "claude_anthropic")
+        assert profile is not None
+        assert profile.default_model == "claude-sonnet-4-6"
+
+@pytest.mark.asyncio
 async def test_auto_seed_reconciles_legacy_codex_default_provider(
     _module_db, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Fixes Claude Anthropic provider profiles that still store display model labels such as `Sonnet 4.6` by reconciling them to Claude Code CLI model IDs during startup seed reconciliation.

## Root Cause

Claude Code rejects display labels passed through as `--model`; the failed workflow used `Sonnet 4.6`, which caused every managed Claude attempt to exit before doing work.

## Changes

- Add reconciliation for known stale Claude display labels on `claude_anthropic`.
- Preserve user-set custom model values that are not known stale labels.
- Add unit coverage for the stale-label reconciliation path.

## Validation

- `./tools/test_unit.sh tests/unit/api_service/test_provider_profile_auto_seed.py`
- `./tools/test_unit.sh`
