### PR TITLE
[codex] Preserve managed session report text

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,22 @@
 [
   {
-    "id": 4192185054,
+    "id": 3157549495,
+    "disposition": "addressed",
+    "rationale": "Refactored fetch-result enrichment to compute operator_summary once with explicit precedence: collected stdout/result summary first, completed-session assistant text only as fallback."
+  },
+  {
+    "id": 4192865071,
     "disposition": "not-applicable",
-    "rationale": "Positive Gemini review summary with no requested change."
+    "rationale": "Review summary only; the actionable child comment is tracked separately."
   },
   {
-    "id": 3157002480,
+    "id": 3157551082,
     "disposition": "addressed",
-    "rationale": "Key-scoped diagnostics now skip unrelated deprecated override diagnostics; regression test covers diagnostics(scope, key)."
+    "rationale": "Gated managed-session lastAssistantText enrichment to completed successful runs and added a failed-run regression test proving stale assistant text is not copied."
   },
   {
-    "id": 3157002486,
-    "disposition": "addressed",
-    "rationale": "Resolution now clears cached migration diagnostics for the key before fresh override/default resolution; regression test covers reused service instances."
-  },
-  {
-    "id": 4192187854,
+    "id": 4192866795,
     "disposition": "not-applicable",
-    "rationale": "Codex automated review container comment; actionable child review comments are tracked separately."
-  },
-  {
-    "id": 3157002490,
-    "disposition": "addressed",
-    "rationale": "Migration rule validation now rejects duplicate renamed new_key targets; regression test covers fail-fast behavior."
+    "rationale": "Automated review wrapper only; the actionable child comment is tracked separately."
   }
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4519,6 +4519,20 @@ class TemporalAgentRuntimeActivities:
                     )
                 if record.diagnostics_ref:
                     meta.setdefault("diagnosticsRef", record.diagnostics_ref)
+                session_metadata = await self._managed_session_summary_metadata(record)
+                if session_metadata:
+                    for key in (
+                        "lastAssistantText",
+                        "lastAssistantTextTruncated",
+                        "lastAssistantTextOriginalChars",
+                    ):
+                        if key in session_metadata:
+                            meta.setdefault(key, session_metadata[key])
+                    assistant_text = self._assistant_text_from_session_metadata(
+                        session_metadata
+                    )
+                    if assistant_text:
+                        meta.setdefault("operator_summary", assistant_text)
                 operator_summary = await self._collect_operator_summary(
                     record=record,
                     result=result,
@@ -4565,6 +4579,60 @@ class TemporalAgentRuntimeActivities:
             return result
         finally:
             await self._cleanup_managed_run_publish_support_best_effort(run_id)
+
+    async def _managed_session_summary_metadata(
+        self,
+        record: ManagedRunRecord,
+    ) -> Mapping[str, Any]:
+        if self._session_controller is None:
+            return {}
+        if (
+            not record.session_id
+            or record.session_epoch is None
+            or not record.container_id
+            or not record.thread_id
+        ):
+            return {}
+
+        try:
+            summary = await self._session_controller.fetch_session_summary(
+                FetchCodexManagedSessionSummaryRequest(
+                    sessionId=record.session_id,
+                    sessionEpoch=record.session_epoch,
+                    containerId=record.container_id,
+                    threadId=record.thread_id,
+                )
+            )
+            summary_model = (
+                summary
+                if isinstance(summary, CodexManagedSessionSummary)
+                else CodexManagedSessionSummary.model_validate(summary)
+            )
+            return (
+                summary_model.metadata
+                if isinstance(summary_model.metadata, Mapping)
+                else {}
+            )
+        except Exception:
+            logger.debug(
+                "Failed to fetch managed-session summary metadata for run %s",
+                record.run_id,
+                exc_info=True,
+            )
+            return {}
+
+    def _assistant_text_from_session_metadata(
+        self,
+        metadata: Mapping[str, Any],
+    ) -> str | None:
+        for key in ("assistantText", "lastAssistantText"):
+            value = metadata.get(key)
+            if not isinstance(value, str) or not value.strip():
+                continue
+            summary = self._sanitize_operator_summary(value)
+            if summary and not is_generic_completion_summary(summary):
+                return summary
+        return None
 
     async def _collect_operator_summary(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4519,26 +4519,27 @@ class TemporalAgentRuntimeActivities:
                     )
                 if record.diagnostics_ref:
                     meta.setdefault("diagnosticsRef", record.diagnostics_ref)
-                session_metadata = await self._managed_session_summary_metadata(record)
-                if session_metadata:
-                    for key in (
-                        "lastAssistantText",
-                        "lastAssistantTextTruncated",
-                        "lastAssistantTextOriginalChars",
-                    ):
-                        if key in session_metadata:
-                            meta.setdefault(key, session_metadata[key])
-                    assistant_text = self._assistant_text_from_session_metadata(
-                        session_metadata
-                    )
-                    if assistant_text:
-                        meta.setdefault("operator_summary", assistant_text)
                 operator_summary = await self._collect_operator_summary(
                     record=record,
                     result=result,
                 )
-                if operator_summary:
-                    meta["operator_summary"] = operator_summary
+                assistant_text = None
+                if record.status == "completed" and result.failure_class is None:
+                    session_metadata = await self._managed_session_summary_metadata(record)
+                    if session_metadata:
+                        for key in (
+                            "lastAssistantText",
+                            "lastAssistantTextTruncated",
+                            "lastAssistantTextOriginalChars",
+                        ):
+                            if key in session_metadata:
+                                meta.setdefault(key, session_metadata[key])
+                        assistant_text = self._assistant_text_from_session_metadata(
+                            session_metadata
+                        )
+                final_operator_summary = operator_summary or assistant_text
+                if final_operator_summary:
+                    meta["operator_summary"] = final_operator_summary
 
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
@@ -4645,7 +4646,7 @@ class TemporalAgentRuntimeActivities:
             return stdout_summary
 
         summary = self._sanitize_operator_summary(result.summary)
-        if summary and summary != "Completed with status completed":
+        if summary and not is_generic_completion_summary(summary):
             return summary
         return None
 

--- a/specs/276-managed-session-report-body/checklists/requirements.md
+++ b/specs/276-managed-session-report-body/checklists/requirements.md
@@ -1,0 +1,6 @@
+# Specification Quality Checklist: Managed Session Report Body
+
+- [X] Requirements describe user-visible behavior rather than implementation-only mechanics.
+- [X] The investigation evidence identifies why the referenced task produced a content-poor report.
+- [X] Tests are defined at the fetch-result and report-publication boundaries.
+- [X] No new storage system or report-specific persistence model is introduced.

--- a/specs/276-managed-session-report-body/plan.md
+++ b/specs/276-managed-session-report-body/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan: Managed Session Report Body
+
+## Technical Context
+
+**Language/Runtime**: Python 3.12, Pydantic v2, Temporal activity boundaries
+**Primary Files**: `moonmind/workflows/temporal/activity_runtime.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, `tests/unit/workflows/temporal/test_activity_runtime.py`
+**Storage**: Existing artifact store and managed-session metadata only; no new storage.
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The fix carries provider-authored final text; it does not synthesize an alternate report.
+- **IV. Own Your Data**: PASS. Text remains in local MoonMind artifact/metadata paths.
+- **IX. Resilient by Default**: PASS. Session-summary enrichment is best-effort and does not fail terminal runs.
+- **X. Facilitate Continuous Improvement**: PASS. Report artifacts become meaningful terminal evidence.
+- **XI. Spec-Driven Development**: PASS. This feature directory records the runtime change and verification.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. This implementation plan stays feature-local.
+- **XIII. Pre-release Compatibility Policy**: PASS. No compatibility alias or semantic fallback is introduced; the existing report body precedence is completed.
+
+## Implementation
+
+1. Add a small activity-runtime helper that, for managed-session run records, calls `fetch_session_summary` through the configured session controller and extracts bounded `lastAssistantText` metadata.
+2. Merge meaningful assistant text into fetch-result metadata as `lastAssistantText` and `operator_summary` before `agent_runtime.publish_artifacts` runs.
+3. Keep failures to load session metadata as debug-only best-effort behavior.
+4. Add tests for fetch-result enrichment and report bundle publication from `lastAssistantText`.
+
+## Verification
+
+- Focused unit tests for the changed activities.
+- Full `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` before publishing.

--- a/specs/276-managed-session-report-body/spec.md
+++ b/specs/276-managed-session-report-body/spec.md
@@ -1,0 +1,35 @@
+# Feature Specification: Managed Session Report Body
+
+**Feature Branch**: `276-managed-session-report-body`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User request: "I want to be able to check Report for a task, provide instructions like the ones provided with this MoonMind task, and then get a report artifact which contains meaningful text (NOT \"workflow completed successfully\" with no detail). Task mm:e5fc42e2-de42-497a-bc90-67075dc5f1cc. Investigate what is missing for this to work properly and then implement a plan to fix it. Create a non-draft PR when done and tests are passing."
+
+## User Story - Preserve Managed Session Final Text in Reports
+
+**Summary**: As a MoonMind operator, I want a report-enabled Codex managed-session task to publish a `report.primary` artifact containing the agent's final answer, so report views are meaningful and not just generic workflow completion text.
+
+**Goal**: When report output is enabled and a managed session records final assistant text, the fetch-result and report-publication boundary carries that text into the report artifact body.
+
+**Independent Test**: Run the fetch-result and publish-artifacts activities with a completed managed-session record whose terminal result is generic but whose session summary contains `lastAssistantText`; verify the resulting metadata and `report.primary` body use the assistant text instead of generic completion wording.
+
+## Investigation Evidence
+
+- Task `mm:e5fc42e2-de42-497a-bc90-67075dc5f1cc` completed with `reportProjection.hasReport=true`, so report artifact publication and projection are wired.
+- Its primary report preview contains only `# Final report` and `Completed with status completed`.
+- Its `output.agent_result` artifact includes stdout/stderr/diagnostics/session refs, but no `operator_summary`, `assistantText`, or `lastAssistantText`.
+- The Codex managed-session runtime records `lastAssistantText` in session summary metadata, and the report publisher already knows how to use `assistantText` / `lastAssistantText`; the missing bridge is fetch-result metadata enrichment for managed sessions.
+
+## Requirements
+
+- **FR-001**: `agent_runtime.fetch_result` MUST enrich completed managed-session results with the session summary's `lastAssistantText` when available.
+- **FR-002**: Generic completion summaries such as `Completed with status completed` MUST NOT replace meaningful managed-session assistant text in report-producing paths.
+- **FR-003**: `agent_runtime.publish_artifacts` MUST publish `report.primary` content from `assistantText`, `lastAssistantText`, or a non-generic operator summary before falling back to generic summaries.
+- **FR-004**: Enrichment MUST remain best-effort and must not fail a completed task when session summary metadata cannot be loaded.
+- **FR-005**: The final text carried through metadata MUST remain bounded and sanitized by existing summary redaction behavior.
+
+## Success Criteria
+
+- **SC-001**: Unit tests prove fetch-result metadata includes `lastAssistantText` and `operator_summary` when the managed session summary has meaningful assistant text and the terminal result is generic.
+- **SC-002**: Unit tests prove report publication writes a `report.primary` body containing the assistant text and not only generic completion text.
+- **SC-003**: Existing report projection and artifact contract tests continue to pass.

--- a/specs/276-managed-session-report-body/tasks.md
+++ b/specs/276-managed-session-report-body/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Managed Session Report Body
+
+- [X] T001 Inspect task `mm:e5fc42e2-de42-497a-bc90-67075dc5f1cc` execution and report artifacts to identify the missing metadata bridge.
+- [X] T002 Create MoonSpec feature artifacts for the managed-session report body fix.
+- [X] T003 Add fetch-result unit coverage for managed-session `lastAssistantText` enrichment.
+- [X] T004 Add report publication unit coverage for `lastAssistantText` report body content.
+- [X] T005 Implement activity-runtime managed-session summary metadata enrichment.
+- [X] T006 Run focused tests for activity-runtime report publication and fetch-result enrichment.
+- [X] T007 Run full unit test suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T008 Commit, push, and open a non-draft PR.

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2040,6 +2040,71 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
             body = path.read_bytes()
             assert body.decode("utf-8") == "# Integration test report\n\nAll tests passed.\n"
 
+async def test_agent_runtime_publish_artifacts_uses_last_assistant_text_for_report_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(artifact_service=service)
+
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:node-1",
+                    workflow_run_id="child-run-1",
+                ),
+            )
+
+            await activities.agent_runtime_publish_artifacts(
+                AgentRunResult(
+                    summary="Completed with status completed",
+                    metadata={
+                        "lastAssistantText": (
+                            "# Docker Compose Update System Report\n\n"
+                            "The implementation is missing report handoff coverage."
+                        ),
+                        "moonmind": {
+                            "reportOutput": {
+                                "enabled": True,
+                                "required": True,
+                                "reportType": "agent_run_report",
+                                "executionRef": {
+                                    "namespace": "default",
+                                    "workflow_id": "parent-wf",
+                                    "run_id": "parent-run-1",
+                                },
+                            }
+                        },
+                    },
+                )
+            )
+
+            reports = await service.list_for_execution(
+                namespace="default",
+                workflow_id="parent-wf",
+                run_id="parent-run-1",
+                principal="system:agent_runtime",
+                link_type="report.primary",
+                latest_only=True,
+            )
+
+            assert len(reports) == 1
+            _artifact, path = await service.read_path(
+                artifact_id=reports[0].artifact_id,
+                principal="system:agent_runtime",
+            )
+            rendered = path.read_text(encoding="utf-8")
+            assert rendered.startswith("# Docker Compose Update System Report")
+            assert "missing report handoff coverage" in rendered
+            assert "Completed with status completed" not in rendered
+
 async def test_agent_runtime_publish_artifacts_fails_required_report_on_publish_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1447,6 +1447,54 @@ async def test_fetch_result_adds_managed_session_assistant_text_to_metadata(
     assert result.metadata["operator_summary"].startswith("# Implementation check")
     controller.fetch_session_summary.assert_awaited_once()
 
+async def test_fetch_result_does_not_use_stale_session_text_for_failed_runs(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    store.save(
+        ManagedRunRecord(
+            runId="fr-session-failed",
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="failed",
+            startedAt=datetime.now(tz=UTC),
+            errorMessage="Process exited with code 1",
+            failureClass="execution_error",
+            sessionId="sess:fr-session-failed:codex_cli",
+            sessionEpoch=1,
+            containerId="ctr-session-failed",
+            threadId="thread-session-failed",
+        )
+    )
+    controller = AsyncMock()
+    controller.fetch_session_summary = AsyncMock(
+        return_value=CodexManagedSessionSummary(
+            sessionState={
+                "sessionId": "sess:fr-session-failed:codex_cli",
+                "sessionEpoch": 1,
+                "containerId": "ctr-session-failed",
+                "threadId": "thread-session-failed",
+            },
+            metadata={
+                "lastAssistantText": "# Stale success report\n\nThis should not be used."
+            },
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store,
+        session_controller=controller,
+    )
+    result = await activities.agent_runtime_fetch_result(
+        {"run_id": "fr-session-failed", "agent_id": "codex_cli"}
+    )
+
+    assert result.summary == "Process exited with code 1"
+    assert result.failure_class == "execution_error"
+    assert "lastAssistantText" not in result.metadata
+    assert "operator_summary" not in result.metadata
+    controller.fetch_session_summary.assert_not_awaited()
+
 async def test_fetch_result_failed_returns_typed_model(tmp_path: Path) -> None:
     """T5.2 — failed run returns typed AgentRunResult with correct failure_class."""
     store = _make_store(tmp_path)

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1399,6 +1399,54 @@ async def test_fetch_result_completed_returns_typed_model(tmp_path: Path) -> Non
     assert isinstance(result, AgentRunResult), f"Expected AgentRunResult, got {type(result)}"
     assert result.failure_class is None
 
+async def test_fetch_result_adds_managed_session_assistant_text_to_metadata(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    store.save(
+        ManagedRunRecord(
+            runId="fr-session-report",
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=datetime.now(tz=UTC),
+            sessionId="sess:fr-session-report:codex_cli",
+            sessionEpoch=1,
+            containerId="ctr-session-report",
+            threadId="thread-session-report",
+        )
+    )
+    controller = AsyncMock()
+    controller.fetch_session_summary = AsyncMock(
+        return_value=CodexManagedSessionSummary(
+            sessionState={
+                "sessionId": "sess:fr-session-report:codex_cli",
+                "sessionEpoch": 1,
+                "containerId": "ctr-session-report",
+                "threadId": "thread-session-report",
+            },
+            metadata={
+                "lastAssistantText": (
+                    "# Implementation check\n\n"
+                    "The requested Docker Compose update behavior is partially implemented."
+                )
+            },
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store,
+        session_controller=controller,
+    )
+    result = await activities.agent_runtime_fetch_result(
+        {"run_id": "fr-session-report", "agent_id": "codex_cli"}
+    )
+
+    assert result.summary == "Completed with status completed"
+    assert result.metadata["lastAssistantText"].startswith("# Implementation check")
+    assert result.metadata["operator_summary"].startswith("# Implementation check")
+    controller.fetch_session_summary.assert_awaited_once()
+
 async def test_fetch_result_failed_returns_typed_model(tmp_path: Path) -> None:
     """T5.2 — failed run returns typed AgentRunResult with correct failure_class."""
     store = _make_store(tmp_path)


### PR DESCRIPTION
## Summary
- Fetch managed-session summary metadata during `agent_runtime.fetch_result` when a completed run has a session locator.
- Carry sanitized `lastAssistantText` into result metadata so report-enabled tasks publish meaningful `report.primary` bodies instead of generic completion text.
- Add MoonSpec artifacts for feature 276 and unit coverage for fetch-result enrichment plus report publication precedence.

## Root Cause
Task `mm:e5fc42e2-de42-497a-bc90-67075dc5f1cc` produced a valid report artifact, but the artifact body only contained `Completed with status completed` because fetch-result metadata did not include the Codex managed session final assistant text. The report publisher already preferred `assistantText` / `lastAssistantText`; that text just was not bridged from the session summary.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -k managed_session_assistant_text`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py -k last_assistant_text_for_report_body`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/test_activity_runtime.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`