### PR TITLE
MM-556: Unify Step Type authoring controls

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/275-settings-migration-invariants"
+  "feature_directory": "specs/276-step-type-authoring-controls"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-546",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1831"
+  "jira_issue_key": "MM-556",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1837"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,37 @@
 [
   {
-    "id": 4192598542,
+    "id": 4192954412,
+    "disposition": "addressed",
+    "rationale": "Summary review covered by the concrete fixes for per-step preset state, non-destructive Step Type switching, Tool submission blocking, and spec alignment."
+  },
+  {
+    "id": 3157632598,
+    "disposition": "addressed",
+    "rationale": "Preset selector and status state now live on each StepState, with regression coverage for independent Preset selections across multiple steps."
+  },
+  {
+    "id": 3157632604,
+    "disposition": "addressed",
+    "rationale": "Step Type changes no longer clear hidden Skill fields; submission still filters them when Step Type is not Skill, and tests verify preserved values."
+  },
+  {
+    "id": 3157632608,
+    "disposition": "addressed",
+    "rationale": "Updated SC-004 and assumptions to reflect that step-editor Preset use is canonical while the remaining Task Presets section is temporary management/advanced-input UI."
+  },
+  {
+    "id": 3157641194,
+    "disposition": "addressed",
+    "rationale": "Tool Step Type submissions now fail fast until a typed Tool is selected, preventing accidental default skill execution."
+  },
+  {
+    "id": 3157641196,
+    "disposition": "addressed",
+    "rationale": "Preset selection is scoped per step instead of using the component-level selectedPresetKey, with a regression test covering two Preset steps."
+  },
+  {
+    "id": 4192965003,
     "disposition": "not-applicable",
-    "rationale": "Summary review comment only; the two concrete inline comments were classified separately."
-  },
-  {
-    "id": 3157353680,
-    "disposition": "addressed",
-    "rationale": "Simplified the Claude display-label reconciliation branch by using a single legacy-label predicate and direct mapping lookup."
-  },
-  {
-    "id": 3157353686,
-    "disposition": "addressed",
-    "rationale": "Moved the Claude legacy model alias constant out of the import/logging block and next to related provider-profile constants."
+    "rationale": "Informational automated review container with no separate actionable request beyond the individual review comments."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2464,7 +2464,7 @@ describe("Task Create Entrypoint", () => {
     expect(screen.getByLabelText("Runtime")).toBeTruthy();
     expect(screen.getByLabelText("Publish Mode")).toBeTruthy();
     expect(canonicalCreateSections()).toEqual(
-      expect.arrayContaining(["Task Presets", "Dependencies"]),
+      expect.arrayContaining(["Steps", "Dependencies"]),
     );
     expect(
       screen.getByRole("button", {
@@ -6687,7 +6687,6 @@ describe("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Task Presets",
       "Dependencies",
       "Execution context",
       "Execution controls",
@@ -6703,7 +6702,6 @@ describe("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Task Presets",
       "Dependencies",
       "Execution context",
       "Execution controls",
@@ -6722,12 +6720,121 @@ describe("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Task Presets",
       "Dependencies",
       "Execution context",
       "Execution controls",
       "Submit",
     ]);
+  });
+
+  it("offers one Step Type control with Tool Skill and Preset choices", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+
+    const stepType = within(primaryStep as HTMLElement).getByLabelText(
+      "Step Type",
+    ) as HTMLSelectElement;
+    expect(
+      Array.from(stepType.options).map((option) => option.textContent),
+    ).toEqual(["Tool", "Skill", "Preset"]);
+    expect(stepType.value).toBe("skill");
+    expect(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+    ).toBeTruthy();
+  });
+
+  it("switches Step Type configuration areas while preserving instructions", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    const step = primaryStep as HTMLElement;
+    const instructions = within(step).getByLabelText("Instructions") as HTMLTextAreaElement;
+    const stepType = within(step).getByLabelText("Step Type") as HTMLSelectElement;
+
+    fireEvent.change(instructions, {
+      target: { value: "Keep this Step Type instruction." },
+    });
+    fireEvent.change(stepType, { target: { value: "tool" } });
+
+    expect(instructions.value).toBe("Keep this Step Type instruction.");
+    expect(within(step).getByLabelText("Tool")).toBeTruthy();
+    expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    expect(within(step).queryByLabelText("Preset")).toBeNull();
+
+    fireEvent.change(stepType, { target: { value: "preset" } });
+
+    expect(instructions.value).toBe("Keep this Step Type instruction.");
+    expect(within(step).getByLabelText("Preset")).toBeTruthy();
+    expect(within(step).getByRole("button", { name: "Apply" })).toBeTruthy();
+    expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    expect(within(step).queryByLabelText("Tool")).toBeNull();
+  });
+
+  it("does not submit hidden Skill fields after switching Step Type away from Skill", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    const step = primaryStep as HTMLElement;
+
+    fireEvent.click(screen.getByLabelText("Show advanced step options"));
+    fireEvent.change(within(step).getByLabelText(/Skill \(optional\)/), {
+      target: { value: "custom-skill" },
+    });
+    fireEvent.change(
+      within(step).getByLabelText("Step 1 Skill Args (optional JSON object)"),
+      {
+        target: { value: '{"hidden":true}' },
+      },
+    );
+    fireEvent.change(
+      within(step).getByLabelText(
+        /Step 1 Skill Required Capabilities \(optional CSV\)/,
+      ),
+      {
+        target: { value: "docker, qdrant" },
+      },
+    );
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "tool" },
+    });
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Run a tool Step Type submission." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+    const request = latestCreateRequest();
+    expect(request.payload).toMatchObject({
+      requiredCapabilities: ["codex_cli", "git", "gh"],
+    });
+    const payload = request.payload as {
+      task: {
+        tool?: Record<string, unknown>;
+        skill?: Record<string, unknown>;
+        inputs?: Record<string, unknown>;
+      };
+    };
+    expect(payload.task.tool?.name).toBe("auto");
+    expect(payload.task.skill?.id).toBe("auto");
+    expect(payload.task.inputs).toBeUndefined();
   });
 
   it("keeps manual authoring available without optional presets Jira or image upload", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6777,7 +6777,52 @@ describe("Task Create Entrypoint", () => {
     expect(within(step).queryByLabelText("Tool")).toBeNull();
   });
 
-  it("does not submit hidden Skill fields after switching Step Type away from Skill", async () => {
+  it("keeps Preset selections scoped to each step", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add Step" }));
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    const secondStep = (await screen.findByText("Step 2")).closest(
+      "section",
+    ) as HTMLElement;
+
+    fireEvent.change(within(primaryStep).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    fireEvent.change(within(secondStep).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+
+    const firstPreset = within(primaryStep).getByLabelText(
+      "Preset",
+    ) as HTMLSelectElement;
+    const secondPreset = within(secondStep).getByLabelText(
+      "Preset",
+    ) as HTMLSelectElement;
+
+    await waitFor(() => {
+      expect(firstPreset.options.length).toBeGreaterThan(2);
+    });
+    const firstValue = firstPreset.options[1]?.value || "";
+    const secondValue = firstPreset.options[2]?.value || "";
+    expect(firstValue).not.toBe("");
+    expect(secondValue).not.toBe("");
+
+    fireEvent.change(firstPreset, { target: { value: firstValue } });
+    fireEvent.change(secondPreset, { target: { value: secondValue } });
+
+    expect(firstPreset.value).toBe(firstValue);
+    expect(secondPreset.value).toBe(secondValue);
+
+    fireEvent.change(firstPreset, { target: { value: secondValue } });
+
+    expect(firstPreset.value).toBe(secondValue);
+    expect(secondPreset.value).toBe(secondValue);
+  });
+
+  it("preserves hidden Skill fields but blocks Tool submissions without a selected Tool", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
@@ -6807,34 +6852,43 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Step Type"), {
       target: { value: "tool" },
     });
+    expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "skill" },
+    });
+    expect(
+      (within(step).getByLabelText(/Skill \(optional\)/) as HTMLInputElement)
+        .value,
+    ).toBe("custom-skill");
+    expect(
+      (
+        within(step).getByLabelText(
+          "Step 1 Skill Args (optional JSON object)",
+        ) as HTMLTextAreaElement
+      ).value,
+    ).toBe('{"hidden":true}');
+    expect(
+      (
+        within(step).getByLabelText(
+          /Step 1 Skill Required Capabilities \(optional CSV\)/,
+        ) as HTMLInputElement
+      ).value,
+    ).toBe("docker, qdrant");
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "tool" },
+    });
     fireEvent.change(screen.getByLabelText("Instructions"), {
       target: { value: "Run a tool Step Type submission." },
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "/api/executions",
-        expect.objectContaining({
-          method: "POST",
-        }),
-      );
-    });
-    const request = latestCreateRequest();
-    expect(request.payload).toMatchObject({
-      requiredCapabilities: ["codex_cli", "git", "gh"],
-    });
-    const payload = request.payload as {
-      task: {
-        tool?: Record<string, unknown>;
-        skill?: Record<string, unknown>;
-        inputs?: Record<string, unknown>;
-      };
-    };
-    expect(payload.task.tool?.name).toBe("auto");
-    expect(payload.task.skill?.id).toBe("auto");
-    expect(payload.task.inputs).toBeUndefined();
+    expect(
+      await screen.findByText("Select a Tool before submitting a Tool step."),
+    ).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+    ).toBe(false);
   });
 
   it("keeps manual authoring available without optional presets Jira or image upload", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -516,10 +516,13 @@ interface StepAttachmentRef {
   sizeBytes: number;
 }
 
+type StepType = "tool" | "skill" | "preset";
+
 interface StepState {
   localId: string;
   id: string;
   title: string;
+  stepType: StepType;
   instructions: string;
   skillId: string;
   skillArgs: string;
@@ -1097,6 +1100,7 @@ function createStepStateEntry(
     localId: `step-${index}`,
     id: "",
     title: "",
+    stepType: "skill",
     instructions: "",
     skillId: "",
     skillArgs: "",
@@ -4391,6 +4395,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         }
         const nextStep = { ...step, ...updates };
         if (
+          Object.prototype.hasOwnProperty.call(updates, "stepType") &&
+          nextStep.stepType !== "skill"
+        ) {
+          nextStep.skillId = "";
+          nextStep.skillArgs = "";
+          nextStep.skillRequiredCapabilities = "";
+        }
+        if (
           Object.prototype.hasOwnProperty.call(updates, "instructions") &&
           nextStep.templateStepId &&
           nextStep.id === nextStep.templateStepId &&
@@ -4418,6 +4430,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const { [localId]: _removed, ...rest } = current;
       return rest;
     });
+  }
+
+  function handleStepTypeChange(localId: string, value: string) {
+    const nextType: StepType =
+      value === "tool" || value === "preset" ? value : "skill";
+    updateStep(localId, { stepType: nextType });
   }
 
   function addStep() {
@@ -5105,7 +5123,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    const primarySkillId = primaryValidation.value.skillId.trim() || "auto";
+    const primaryStepIsSkill = primaryStep?.stepType === "skill";
+    const primarySkillId = primaryStepIsSkill
+      ? primaryValidation.value.skillId.trim() || "auto"
+      : "auto";
     const effectiveSubmissionSkillId = resolveEffectiveSkillId(
       primarySkillId,
       appliedTemplates,
@@ -5114,10 +5135,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       isResolverSkill(effectiveSubmissionSkillId) && isMergeAutomationPublishMode(publishMode)
         ? "none"
         : normalizedPublishMode;
-    const primarySkillArgsRaw = showAdvancedStepOptions
+    const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions
       ? String(primaryStep?.skillArgs || "").trim()
       : "";
-    const taskSkillRequiredCapabilities = showAdvancedStepOptions
+    const taskSkillRequiredCapabilities = primaryStepIsSkill && showAdvancedStepOptions
       ? parseCapabilitiesCsv(String(primaryStep?.skillRequiredCapabilities || ""))
       : [];
 
@@ -5174,11 +5195,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (!step) {
         continue;
       }
-      const stepSkillId = step.skillId.trim();
-      const stepSkillArgsRaw = showAdvancedStepOptions
+      const stepIsSkill = step.stepType === "skill";
+      const stepSkillId = stepIsSkill ? step.skillId.trim() : "";
+      const stepSkillArgsRaw = stepIsSkill && showAdvancedStepOptions
         ? step.skillArgs.trim()
         : "";
-      const stepSkillCaps = showAdvancedStepOptions
+      const stepSkillCaps = stepIsSkill && showAdvancedStepOptions
         ? parseCapabilitiesCsv(step.skillRequiredCapabilities)
         : [];
       const stepAttachmentFiles = selectedStepAttachmentFiles[step.localId] || [];
@@ -6252,6 +6274,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     </div>
                   </div>
 
+                  <label className="queue-step-type-field">
+                    Step Type
+                    <select
+                      data-step-field="stepType"
+                      data-step-index={String(index)}
+                      value={step.stepType}
+                      onChange={(event) =>
+                        handleStepTypeChange(step.localId, event.target.value)
+                      }
+                    >
+                      <option value="tool">Tool</option>
+                      <option value="skill">Skill</option>
+                      <option value="preset">Preset</option>
+                    </select>
+                  </label>
+
                   <div className="stack">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
@@ -6492,66 +6530,130 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     ) : null}
                   </div>
 
-                  <label>
-                    Skill (optional)
-                    <input
-                      data-step-field="skillId"
-                      data-step-index={String(index)}
-                      list={SKILL_OPTIONS_DATALIST_ID}
-                      value={step.skillId}
-                      placeholder={
-                        isPrimaryStep
-                          ? "auto (default), moonspec-orchestrate, ..."
-                          : "inherit primary step skill"
-                      }
-                      onChange={(event) =>
-                        updateStep(step.localId, {
-                          skillId: event.target.value,
-                        })
-                      }
-                    />
-                    {isPrimaryStep ? null : (
-                      <span className="small">
-                        Leave skill blank to inherit primary step defaults.
-                      </span>
-                    )}
-                  </label>
-
-                  {showSkillArgsField ? (
-                    <label
-                      className="queue-step-skill-args-field"
-                      data-skill-args-index={String(index)}
-                    >
-                      {`Step ${index + 1} Skill Args (optional JSON object)`}
-                      <textarea
-                        className="queue-step-skill-args"
-                        data-step-field="skillArgs"
-                        data-step-index={String(index)}
-                        placeholder='{"notes":"optional context"}'
-                        value={step.skillArgs}
-                        onChange={(event) =>
-                          updateStep(step.localId, {
-                            skillArgs: event.target.value,
-                          })
-                        }
-                      />
-                    </label>
+                  {step.stepType === "tool" ? (
+                    <div className="stack queue-step-type-panel">
+                      <label>
+                        Tool
+                        <input
+                          data-step-field="toolId"
+                          data-step-index={String(index)}
+                          placeholder="Select a typed operation"
+                          value=""
+                          readOnly
+                        />
+                      </label>
+                      <p className="small">
+                        Tool steps run a typed integration or system operation.
+                      </p>
+                    </div>
                   ) : null}
-                  {showAdvancedStepOptions ? (
-                    <label>
-                      {`Step ${index + 1} Skill Required Capabilities (optional CSV)`}
-                      <input
-                        data-step-field="skillRequiredCapabilities"
-                        data-step-index={String(index)}
-                        value={step.skillRequiredCapabilities}
-                        placeholder="docker,qdrant,unity"
-                        onChange={(event) =>
-                          updateStep(step.localId, {
-                            skillRequiredCapabilities: event.target.value,
-                          })
-                        }
-                      />
-                    </label>
+
+                  {step.stepType === "skill" ? (
+                    <>
+                      <label>
+                        Skill (optional)
+                        <input
+                          data-step-field="skillId"
+                          data-step-index={String(index)}
+                          list={SKILL_OPTIONS_DATALIST_ID}
+                          value={step.skillId}
+                          placeholder={
+                            isPrimaryStep
+                              ? "auto (default), moonspec-orchestrate, ..."
+                              : "inherit primary step skill"
+                          }
+                          onChange={(event) =>
+                            updateStep(step.localId, {
+                              skillId: event.target.value,
+                            })
+                          }
+                        />
+                        {isPrimaryStep ? null : (
+                          <span className="small">
+                            Leave skill blank to inherit primary step defaults.
+                          </span>
+                        )}
+                      </label>
+
+                      {showSkillArgsField ? (
+                        <label
+                          className="queue-step-skill-args-field"
+                          data-skill-args-index={String(index)}
+                        >
+                          {`Step ${index + 1} Skill Args (optional JSON object)`}
+                          <textarea
+                            className="queue-step-skill-args"
+                            data-step-field="skillArgs"
+                            data-step-index={String(index)}
+                            placeholder='{"notes":"optional context"}'
+                            value={step.skillArgs}
+                            onChange={(event) =>
+                              updateStep(step.localId, {
+                                skillArgs: event.target.value,
+                              })
+                            }
+                          />
+                        </label>
+                      ) : null}
+                      {showAdvancedStepOptions ? (
+                        <label>
+                          {`Step ${index + 1} Skill Required Capabilities (optional CSV)`}
+                          <input
+                            data-step-field="skillRequiredCapabilities"
+                            data-step-index={String(index)}
+                            value={step.skillRequiredCapabilities}
+                            placeholder="docker,qdrant,unity"
+                            onChange={(event) =>
+                              updateStep(step.localId, {
+                                skillRequiredCapabilities: event.target.value,
+                              })
+                            }
+                          />
+                        </label>
+                      ) : null}
+                    </>
+                  ) : null}
+
+                  {step.stepType === "preset" ? (
+                    <div
+                      className="stack queue-step-type-panel"
+                      aria-label="Step Preset"
+                    >
+                      <label>
+                        Preset
+                        <select
+                          value={selectedPresetKey}
+                          onChange={(event) => {
+                            setSelectedPresetKey(event.target.value);
+                            setTemplateInputValues({});
+                            templateInputMemoryRef.current = {};
+                            setTemplateMessage(null);
+                            setPresetReapplyNeeded(false);
+                          }}
+                        >
+                          <option value="">Select preset...</option>
+                          {templateItems.map((item) => (
+                            <option key={item.key} value={item.key}>
+                              {`${item.title} (${scopeLabel(item.scope)})`}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <button
+                        type="button"
+                        className="secondary"
+                        aria-disabled={applyPresetDisabled}
+                        aria-busy={isApplyingPreset}
+                        title={applyPresetTooltip}
+                        disabled={applyPresetDisabled}
+                        onClick={handleApplyPreset}
+                      >
+                        Apply
+                      </button>
+                      {presetStatusText ? (
+                        <p className="small">{presetStatusText}</p>
+                      ) : null}
+                    </div>
                   ) : null}
                 </section>
               );
@@ -6578,7 +6680,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         {taskTemplateCatalogEnabled ? (
           <section
             className="card stack"
-            data-canonical-create-section="Task Presets"
             aria-label="Task Presets"
           >
             <div className="actions">

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -527,6 +527,9 @@ interface StepState {
   skillId: string;
   skillArgs: string;
   skillRequiredCapabilities: string;
+  presetKey: string;
+  presetMessage: string | null;
+  presetReapplyNeeded: boolean;
   templateStepId: string;
   templateInstructions: string;
   inputAttachments: StepAttachmentRef[];
@@ -1105,6 +1108,9 @@ function createStepStateEntry(
     skillId: "",
     skillArgs: "",
     skillRequiredCapabilities: "",
+    presetKey: "",
+    presetMessage: null,
+    presetReapplyNeeded: false,
     templateStepId: "",
     templateInstructions: "",
     inputAttachments: [],
@@ -1255,6 +1261,7 @@ function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
     !step.skillId.trim() &&
     !step.skillArgs.trim() &&
     !step.skillRequiredCapabilities.trim() &&
+    !step.presetKey.trim() &&
     !step.templateStepId.trim() &&
     !step.templateInstructions.trim() &&
     step.inputAttachments.length === 0 &&
@@ -1313,6 +1320,12 @@ function validatePrimaryStepSubmission(
   | { ok: false; error: string } {
   if (!primaryStep) {
     return { ok: false, error: "Add at least one step before submitting." };
+  }
+  if (primaryStep.stepType === "tool") {
+    return {
+      ok: false,
+      error: "Select a Tool before submitting a Tool step.",
+    };
   }
   const instructions = primaryStep.instructions.trim();
   const skillId = primaryStep.skillId.trim();
@@ -4387,6 +4400,33 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     templateOptionsQuery.isLoading,
   ]);
 
+  function stepPresetStatusText(step: StepState): string {
+    if (step.presetReapplyNeeded) {
+      return PRESET_REAPPLY_REQUIRED_MESSAGE;
+    }
+    if (step.presetMessage) {
+      return step.presetMessage;
+    }
+    if (templateOptionsQuery.isLoading) {
+      return "Loading presets...";
+    }
+    if (templateOptionsQuery.isError) {
+      return "Failed to load presets.";
+    }
+    if (templateItems.length === 0) {
+      return "No presets available for your account.";
+    }
+    return "";
+  }
+
+  function updateStepPreset(localId: string, presetKey: string) {
+    updateStep(localId, {
+      presetKey,
+      presetMessage: null,
+      presetReapplyNeeded: false,
+    });
+  }
+
   function updateStep(localId: string, updates: Partial<StepState>) {
     setSteps((current) =>
       current.map((step) => {
@@ -4394,14 +4434,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           return step;
         }
         const nextStep = { ...step, ...updates };
-        if (
-          Object.prototype.hasOwnProperty.call(updates, "stepType") &&
-          nextStep.stepType !== "skill"
-        ) {
-          nextStep.skillId = "";
-          nextStep.skillArgs = "";
-          nextStep.skillRequiredCapabilities = "";
-        }
         if (
           Object.prototype.hasOwnProperty.call(updates, "instructions") &&
           nextStep.templateStepId &&
@@ -4489,7 +4521,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
   }
 
-  function resolveTemplateInputs(inputs: TaskTemplateInputDefinition[]): {
+  function resolveTemplateInputs(
+    inputs: TaskTemplateInputDefinition[],
+    explicitInputValues: Record<string, unknown> = templateInputValues,
+  ): {
     values: Record<string, unknown>;
     assumptions: string[];
   } {
@@ -4521,7 +4556,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       let valueSource = "";
       const remembered = templateInputMemoryRef.current[name];
       const defaultValue = definition.default;
-      const explicitInputValue = templateInputValues[name];
+      const explicitInputValue = explicitInputValues[name];
 
       if (isFeatureRequestKey && explicitFeatureRequest) {
         value = explicitFeatureRequest;
@@ -4665,6 +4700,144 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
   }
 
+  async function loadPresetDetail(
+    preset: TemplateOption,
+  ): Promise<TaskTemplateDetail> {
+    const response = await fetch(
+      withQueryParams(
+        interpolatePath(taskTemplateDetailEndpoint, {
+          slug: preset.slug,
+        }),
+        {
+          scope: preset.scope,
+          scopeRef: preset.scopeRef || undefined,
+        },
+      ),
+      { headers: { Accept: "application/json" } },
+    );
+    if (!response.ok) {
+      throw new Error(
+        await responseErrorMessage(response, "Failed to load preset details."),
+      );
+    }
+    return (await response.json()) as TaskTemplateDetail;
+  }
+
+  async function applyPresetToDraft({
+    preset,
+    detail,
+    inputValues,
+    setMessage,
+  }: {
+    preset: TemplateOption;
+    detail: TaskTemplateDetail;
+    inputValues: Record<string, unknown>;
+    setMessage: (message: string) => void;
+  }) {
+    const scopeParams = {
+      scope: preset.scope,
+      scopeRef: preset.scopeRef || undefined,
+    };
+    const { values: inputs, assumptions } = resolveTemplateInputs(
+      detail.inputs || [],
+      inputValues,
+    );
+    const presetRuntime = runtime.trim().toLowerCase();
+    const expandResponse = await fetch(
+      withQueryParams(
+        interpolatePath(taskTemplateExpandEndpoint, {
+          slug: preset.slug,
+        }),
+        scopeParams,
+      ),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          version:
+            detail.version ||
+            detail.latestVersion ||
+            preset.latestVersion ||
+            "1.0.0",
+          inputs,
+          context: {
+            repository: repository.trim() || defaultRepository,
+            repo: repository.trim() || defaultRepository,
+            targetRuntime: presetRuntime,
+          },
+          options: { enforceStepLimit: true },
+        }),
+      },
+    );
+    if (!expandResponse.ok) {
+      throw new Error(
+        await responseErrorMessage(expandResponse, "Failed to apply preset."),
+      );
+    }
+    const expanded = (await expandResponse.json()) as TaskTemplateExpandResponse;
+    const expandedSteps = (expanded.steps || []).map((step, index) =>
+      mapExpandedStepToState(nextStepNumber + index, step),
+    );
+    if (hasAdvancedStepOptionValues(expandedSteps)) {
+      setShowAdvancedStepOptions(true);
+    }
+    const replaceEmptyDefault =
+      steps.length === 1 && isEmptyStepStateEntry(steps[0]);
+
+    setSteps((current) => {
+      if (replaceEmptyDefault) {
+        return expandedSteps.length > 0
+          ? expandedSteps
+          : [createStepStateEntry(nextStepNumber)];
+      }
+      return [...current, ...expandedSteps];
+    });
+    setNextStepNumber((current) => current + Math.max(expandedSteps.length, 1));
+    setAppliedTemplateFeatureRequest(templateFeatureRequest.trim());
+    setAppliedTemplateObjectiveAttachmentSignature(
+      attachmentSignature(selectedObjectiveAttachmentFiles),
+    );
+    if (expandedSteps.length > 0) {
+      const appliedTemplate = expanded.appliedTemplate || {};
+      setAppliedTemplates((current) => [
+        ...current,
+        {
+          slug: String(appliedTemplate.slug || preset.slug),
+          version: String(
+            appliedTemplate.version ||
+              detail.version ||
+              preset.latestVersion ||
+              "1.0.0",
+          ),
+          inputs:
+            appliedTemplate.inputs &&
+            typeof appliedTemplate.inputs === "object"
+              ? appliedTemplate.inputs
+              : inputs,
+          stepIds: Array.isArray(appliedTemplate.stepIds)
+            ? appliedTemplate.stepIds
+            : expandedSteps.map((step) => step.id).filter(Boolean),
+          appliedAt:
+            String(appliedTemplate.appliedAt || "").trim() ||
+            new Date().toISOString(),
+          capabilities: Array.isArray(expanded.capabilities)
+            ? expanded.capabilities
+            : [],
+        },
+      ]);
+    }
+    const autoFillSuffix =
+      assumptions.length > 0
+        ? ` Auto-filled ${assumptions.length} input(s): ${assumptions.join(", ")}.`
+        : "";
+    setMessage(
+      `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`,
+    );
+  }
+
   async function handleApplyPreset() {
     if (isApplyingPreset) return;
     if (!selectedPreset) {
@@ -4685,115 +4858,52 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setTemplateMessage("Applying preset...");
 
     try {
-      const scopeParams = {
-        scope: selectedPreset.scope,
-        scopeRef: selectedPreset.scopeRef || undefined,
-      };
-      const { values: inputs, assumptions } = resolveTemplateInputs(
-        detail.inputs || [],
-      );
-      const presetRuntime = runtime.trim().toLowerCase();
-      const expandResponse = await fetch(
-        withQueryParams(
-          interpolatePath(taskTemplateExpandEndpoint, {
-            slug: selectedPreset.slug,
-          }),
-          scopeParams,
-        ),
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-          body: JSON.stringify({
-            version:
-              detail.version ||
-              detail.latestVersion ||
-              selectedPreset.latestVersion ||
-              "1.0.0",
-            inputs,
-            context: {
-              repository: repository.trim() || defaultRepository,
-              repo: repository.trim() || defaultRepository,
-              targetRuntime: presetRuntime,
-            },
-            options: { enforceStepLimit: true },
-          }),
-        },
-      );
-      if (!expandResponse.ok) {
-        throw new Error(
-          await responseErrorMessage(expandResponse, "Failed to apply preset."),
-        );
-      }
-      const expanded =
-        (await expandResponse.json()) as TaskTemplateExpandResponse;
-      const expandedSteps = (expanded.steps || []).map((step, index) =>
-        mapExpandedStepToState(nextStepNumber + index, step),
-      );
-      if (hasAdvancedStepOptionValues(expandedSteps)) {
-        setShowAdvancedStepOptions(true);
-      }
-      const replaceEmptyDefault =
-        steps.length === 1 && isEmptyStepStateEntry(steps[0]);
-
-      setSteps((current) => {
-        if (replaceEmptyDefault) {
-          return expandedSteps.length > 0
-            ? expandedSteps
-            : [createStepStateEntry(nextStepNumber)];
-        }
-        return [...current, ...expandedSteps];
+      await applyPresetToDraft({
+        preset: selectedPreset,
+        detail,
+        inputValues: templateInputValues,
+        setMessage: setTemplateMessage,
       });
-      setNextStepNumber(
-        (current) => current + Math.max(expandedSteps.length, 1),
-      );
-      setAppliedTemplateFeatureRequest(templateFeatureRequest.trim());
-      setAppliedTemplateObjectiveAttachmentSignature(
-        attachmentSignature(selectedObjectiveAttachmentFiles),
-      );
       setPresetReapplyNeeded(false);
-      if (expandedSteps.length > 0) {
-        const appliedTemplate = expanded.appliedTemplate || {};
-        setAppliedTemplates((current) => [
-          ...current,
-          {
-            slug: String(appliedTemplate.slug || selectedPreset.slug),
-            version: String(
-              appliedTemplate.version ||
-                detail.version ||
-                selectedPreset.latestVersion ||
-                "1.0.0",
-            ),
-            inputs:
-              appliedTemplate.inputs &&
-              typeof appliedTemplate.inputs === "object"
-                ? appliedTemplate.inputs
-                : inputs,
-            stepIds: Array.isArray(appliedTemplate.stepIds)
-              ? appliedTemplate.stepIds
-              : expandedSteps.map((step) => step.id).filter(Boolean),
-            appliedAt:
-              String(appliedTemplate.appliedAt || "").trim() ||
-              new Date().toISOString(),
-            capabilities: Array.isArray(expanded.capabilities)
-              ? expanded.capabilities
-              : [],
-          },
-        ]);
-      }
-      const autoFillSuffix =
-        assumptions.length > 0
-          ? ` Auto-filled ${assumptions.length} input(s): ${assumptions.join(", ")}.`
-          : "";
-      setTemplateMessage(
-        `Applied preset '${selectedPreset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`,
-      );
     } catch (error) {
       const failure =
         error instanceof Error ? error : new Error("Failed to apply preset.");
       setTemplateMessage(`Failed to apply preset: ${failure.message}`);
+    } finally {
+      setIsApplyingPreset(false);
+    }
+  }
+
+  async function handleApplyStepPreset(localId: string) {
+    if (isApplyingPreset) return;
+    const step = steps.find((candidate) => candidate.localId === localId);
+    const preset = templateItems.find((item) => item.key === step?.presetKey);
+    if (!step || !preset) {
+      updateStep(localId, { presetMessage: "Choose a preset first." });
+      return;
+    }
+    setIsApplyingPreset(true);
+    updateStep(localId, {
+      presetMessage: "Applying preset...",
+      presetReapplyNeeded: false,
+    });
+    try {
+      const detail =
+        selectedPreset?.key === preset.key && selectedPresetDetailQuery.data
+          ? selectedPresetDetailQuery.data
+          : await loadPresetDetail(preset);
+      await applyPresetToDraft({
+        preset,
+        detail,
+        inputValues: {},
+        setMessage: (message) => updateStep(localId, { presetMessage: message }),
+      });
+    } catch (error) {
+      const failure =
+        error instanceof Error ? error : new Error("Failed to apply preset.");
+      updateStep(localId, {
+        presetMessage: `Failed to apply preset: ${failure.message}`,
+      });
     } finally {
       setIsApplyingPreset(false);
     }
@@ -6622,13 +6732,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       <label>
                         Preset
                         <select
-                          value={selectedPresetKey}
+                          value={step.presetKey}
                           onChange={(event) => {
-                            setSelectedPresetKey(event.target.value);
-                            setTemplateInputValues({});
-                            templateInputMemoryRef.current = {};
-                            setTemplateMessage(null);
-                            setPresetReapplyNeeded(false);
+                            updateStepPreset(step.localId, event.target.value);
                           }}
                         >
                           <option value="">Select preset...</option>
@@ -6642,16 +6748,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       <button
                         type="button"
                         className="secondary"
-                        aria-disabled={applyPresetDisabled}
+                        aria-disabled={isApplyingPreset || !step.presetKey}
                         aria-busy={isApplyingPreset}
                         title={applyPresetTooltip}
-                        disabled={applyPresetDisabled}
-                        onClick={handleApplyPreset}
+                        disabled={isApplyingPreset || !step.presetKey}
+                        onClick={() => handleApplyStepPreset(step.localId)}
                       >
                         Apply
                       </button>
-                      {presetStatusText ? (
-                        <p className="small">{presetStatusText}</p>
+                      {stepPresetStatusText(step) ? (
+                        <p className="small">{stepPresetStatusText(step)}</p>
                       ) : null}
                     </div>
                   ) : null}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2507,6 +2507,17 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   padding: 0;
 }
 
+.queue-step-type-field select {
+  max-width: 16rem;
+}
+
+.queue-step-type-panel {
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgb(var(--mm-panel) / 0.58);
+}
+
 .queue-step-extension {
   margin: 0.25rem 0 0.4rem;
 }

--- a/specs/276-step-type-authoring-controls/checklists/requirements.md
+++ b/specs/276-step-type-authoring-controls/checklists/requirements.md
@@ -36,4 +36,4 @@
 
 ## Notes
 
-- MM-556 is preserved in the Input field for downstream traceability.
+- MM-556 is preserved in the Input field and `## Original Preset Brief` section for downstream traceability.

--- a/specs/276-step-type-authoring-controls/checklists/requirements.md
+++ b/specs/276-step-type-authoring-controls/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Step Type Authoring Controls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- MM-556 is preserved in the Input field for downstream traceability.

--- a/specs/276-step-type-authoring-controls/contracts/create-page-step-type-ui.md
+++ b/specs/276-step-type-authoring-controls/contracts/create-page-step-type-ui.md
@@ -1,0 +1,47 @@
+# UI Contract: Create Page Step Type Authoring
+
+## Step Type Control
+
+Each step editor exposes one accessible control named `Step Type` with exactly these user-facing options:
+
+- `Tool`
+- `Skill`
+- `Preset`
+
+Default selection: `Skill` for newly created steps.
+
+## Skill Configuration Area
+
+Visible only when `Step Type = Skill`.
+
+Contains:
+
+- Existing Skill selector.
+- Existing Skill Args advanced field when advanced step options are enabled.
+- Existing Skill Required Capabilities advanced field when advanced step options are enabled.
+
+## Tool Configuration Area
+
+Visible only when `Step Type = Tool`.
+
+Contains Tool-specific authoring copy and controls/placeholders that do not present Skill, Preset, Capability, Activity, Invocation, Command, or Script as the step discriminator.
+
+## Preset Configuration Area
+
+Visible only when `Step Type = Preset`.
+
+Contains existing preset-use controls:
+
+- Preset selection.
+- Feature Request / Initial Instructions.
+- Visible preset inputs.
+- Apply action.
+- Preset status/error message.
+
+Preset use must appear in the step editor, not as a separate canonical Create page section.
+
+## Submission Compatibility
+
+- Skill-specific fields are submitted only for Skill steps.
+- Hidden advanced Skill fields are not submitted after switching away from Skill.
+- Existing preset expansion endpoint and applied template metadata remain the source of concrete executable steps.

--- a/specs/276-step-type-authoring-controls/data-model.md
+++ b/specs/276-step-type-authoring-controls/data-model.md
@@ -1,0 +1,31 @@
+# Data Model: Step Type Authoring Controls
+
+## Step Draft
+
+Represents one authored step in the Create page.
+
+Fields relevant to this story:
+
+- `stepType`: one of `skill`, `tool`, or `preset`.
+- `instructions`: compatible freeform step instructions retained when Step Type changes.
+- `skillId`: Skill-specific selector value; used only when `stepType = skill`.
+- `skillArgs`: Skill-specific advanced JSON; used only when `stepType = skill` and advanced options are visible.
+- `skillRequiredCapabilities`: Skill-specific advanced CSV; used only when `stepType = skill` and advanced options are visible.
+- Existing attachment, provenance, template, story output, and Jira orchestration fields remain unchanged.
+
+## Step Type
+
+User-facing discriminator for an authored step.
+
+Allowed values:
+
+- `tool`: shows Tool-specific configuration area.
+- `skill`: shows Skill-specific configuration area.
+- `preset`: shows Preset-specific configuration area.
+
+State transitions:
+
+- Any Step Type can change to any other Step Type.
+- Instructions persist across transitions.
+- Hidden incompatible Skill-specific values are cleared or excluded before submission when leaving Skill.
+- Preset application continues to expand through the existing preset expansion flow.

--- a/specs/276-step-type-authoring-controls/plan.md
+++ b/specs/276-step-type-authoring-controls/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Step Type Authoring Controls
+
+**Branch**: `276-step-type-authoring-controls` | **Date**: 2026-04-28 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/276-step-type-authoring-controls/spec.md`
+
+## Summary
+
+MM-556 requires the Create page step editor to expose one Step Type discriminator for Tool, Skill, and Preset. Current evidence shows per-step Skill controls and a separate Task Presets authoring section in `frontend/src/entrypoints/task-create.tsx`, so the implementation will add per-step Step Type state, conditionally render type-specific configuration, move preset-use controls into the step editor, and update frontend tests. The validation strategy is Vitest/Testing Library coverage for the Step Type control, type switching, hidden field submission, and canonical section order.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | Step editor shows `Skill (optional)` but no Step Type control | Add one Step Type control per step | frontend unit |
+| FR-002 | missing | Type-specific areas are not keyed by a Step Type state | Add conditional Skill/Tool/Preset areas | frontend unit |
+| FR-003 | partial | Skill selector and advanced fields exist but are always the default authoring model | Gate Skill controls behind Skill Step Type | frontend unit |
+| FR-004 | partial | Preset use exists in separate `Task Presets` section | Render preset selection/apply controls from Preset Step Type in step editor | frontend unit |
+| FR-005 | partial | Some copy uses Skill and Task Presets as authoring discriminators | Normalize primary discriminator copy to Step Type | frontend unit |
+| FR-006 | partial | Hidden advanced fields are cleared only by advanced toggle, not Step Type | Preserve instructions and clear hidden incompatible fields on type changes/submission | frontend unit |
+| SCN-001..006 | missing | No scenario tests for Step Type switching | Add Create page tests for all scenarios | frontend unit |
+| DESIGN-REQ-001 | missing | Source model not reflected by Create page | Implement one Step Type per authored step | frontend unit |
+| DESIGN-REQ-002 | missing | Preset use is separate from step editor | Move preset use into Step Type area | frontend unit |
+| DESIGN-REQ-015 | partial | Internal terms may remain in advanced capability copy but not as discriminator | Ensure discriminator labels use Step Type and canonical values | frontend unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React; Python 3.12 remains present but is not expected for this UI story  
+**Primary Dependencies**: React, TanStack Query, existing Create page helpers, existing Mission Control stylesheet, Vitest and Testing Library  
+**Storage**: Existing task draft state only; no new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` for focused frontend unit coverage, then `./tools/test_unit.sh` for final unit verification when feasible  
+**Integration Testing**: Existing frontend render/submission tests are the integration boundary for this Create page slice; compose integration is not required because no backend behavior changes  
+**Target Platform**: Mission Control web UI  
+**Project Type**: Web application frontend  
+**Performance Goals**: Step Type switching should be synchronous and avoid extra network requests except existing preset detail/expand calls  
+**Constraints**: Preserve existing submission payload behavior for executable Skill steps; do not introduce docs-only behavior; keep preset expansion deterministic through existing preset endpoint  
+**Scale/Scope**: One Create page step-authoring story for MM-556
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Reuses existing preset expansion and task submission surfaces.
+- II. One-Click Agent Deployment: PASS. No deployment prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. UI terminology is provider-neutral.
+- IV. Own Your Data: PASS. Uses existing local draft state and preset APIs.
+- V. Skills Are First-Class and Easy to Add: PASS. Skill remains a first-class Step Type.
+- VI. Scientific Method: PASS. Test-first frontend validation is planned.
+- VII. Runtime Configurability: PASS. No hardcoded provider behavior added.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay within the Create page authoring boundary.
+- IX. Resilient by Default: PASS. No workflow/activity contract changes.
+- X. Facilitate Continuous Improvement: PASS. Tests and MoonSpec verification document evidence.
+- XI. Spec-Driven Development: PASS. Spec, plan, and tasks precede implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime work stays in specs and code, not canonical docs migration notes.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden semantic transforms added.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/276-step-type-authoring-controls/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-step-type-ui.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create.test.tsx
+frontend/src/styles/mission-control.css
+```
+
+**Structure Decision**: This is a frontend Create page story. Existing backend task submission and preset expansion contracts are reused.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/276-step-type-authoring-controls/quickstart.md
+++ b/specs/276-step-type-authoring-controls/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: Step Type Authoring Controls
+
+## Focused frontend validation
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx
+```
+
+## Managed unit validation
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+## Full unit validation
+
+```bash
+./tools/test_unit.sh
+```
+
+## Manual verification
+
+1. Open the Create page.
+2. Confirm Step 1 shows one `Step Type` control with Tool, Skill, and Preset.
+3. Select Skill and confirm the Skill selector is visible.
+4. Select Tool and confirm Skill and Preset controls are hidden while instructions remain.
+5. Select Preset and confirm preset selection and Apply controls are shown inside the step editor.
+6. Confirm the canonical Create page authoring sections no longer include a separate Task Presets section.

--- a/specs/276-step-type-authoring-controls/research.md
+++ b/specs/276-step-type-authoring-controls/research.md
@@ -1,0 +1,49 @@
+# Research: Step Type Authoring Controls
+
+## FR-001 / DESIGN-REQ-001
+
+Decision: Add a `Step Type` control to each rendered step with Tool, Skill, and Preset choices.
+Evidence: `frontend/src/entrypoints/task-create.tsx` currently renders per-step instructions and `Skill (optional)` without a Step Type discriminator.
+Rationale: The source design requires one user-facing discriminator per authored step.
+Alternatives considered: Keep the separate Task Presets section and Skill field as-is; rejected because the user must learn separate authoring concepts.
+Test implications: Frontend unit tests must assert accessible Step Type options.
+
+## FR-002 / DESIGN-REQ-002
+
+Decision: Store selected Step Type in step draft state and use it to render one type-specific configuration area.
+Evidence: Existing `StepState` carries skill fields and preset state is page-level, not step-selected.
+Rationale: Conditional rendering directly satisfies the selected-type-controls-fields invariant.
+Alternatives considered: Infer type from non-empty fields; rejected because it creates hidden state and ambiguous authoring.
+Test implications: Tests must switch Tool, Skill, and Preset and assert only relevant controls are visible.
+
+## FR-003
+
+Decision: Keep existing Skill selector and advanced Skill fields, but show and submit them only while Step Type is Skill.
+Evidence: Existing tests already validate advanced Skill fields and hidden advanced-field submission.
+Rationale: This preserves current Skill behavior while making Skill one Step Type rather than the implicit default.
+Alternatives considered: Rename Skill to Tool internally; rejected because Tool and Skill are distinct product concepts.
+Test implications: Update existing tests to select Skill when needed and add a regression for switching away from Skill.
+
+## FR-004
+
+Decision: Render the existing preset selection, inputs, and Apply action inside the primary step when Step Type is Preset, and remove the separate canonical Task Presets authoring section.
+Evidence: Existing Task Presets section is a separate authoring surface in `task-create.tsx`.
+Rationale: Preset use belongs inside step authoring; preset management can remain separate elsewhere.
+Alternatives considered: Duplicate preset controls in both places; rejected because it would violate exactly-one authoring control.
+Test implications: Canonical Create page section order should omit `Task Presets`; preset tests should scope to the step editor.
+
+## FR-005 / DESIGN-REQ-015
+
+Decision: Use `Step Type` as the discriminator label and Tool, Skill, Preset as option labels. Keep `requiredCapabilities` terminology only in advanced technical fields if necessary, not as the step discriminator.
+Evidence: `Skill (optional)` and `Task Presets` currently act as authoring concepts.
+Rationale: The source design only forbids internal terms as the Step Type label; capability remains a technical advanced field.
+Alternatives considered: Rename all capability fields globally; rejected as broader than MM-556.
+Test implications: Assert Step Type label is present and forbidden terms are not option labels.
+
+## FR-006
+
+Decision: Preserve instructions across Step Type changes and ignore/clear hidden Skill fields when the selected Step Type is not Skill.
+Evidence: `updateStep` already clears Skill args when advanced options are hidden, but submission still derives primary skill defaults.
+Rationale: Instructions are compatible across types; Skill args/capabilities are not compatible when the step is Tool or Preset.
+Alternatives considered: Prompt before every Step Type change; rejected because the current scope can safely clear hidden incompatible fields.
+Test implications: Test that instructions persist and hidden Skill args/capabilities are not submitted after switching to Tool.

--- a/specs/276-step-type-authoring-controls/spec.md
+++ b/specs/276-step-type-authoring-controls/spec.md
@@ -38,6 +38,7 @@ As a task author, I want one Step Type control in the step editor so I can choos
 
 - Runtime mode applies: this story changes the Create page task-authoring behavior and validates it with frontend tests.
 - The first delivered slice may keep the existing execution payload semantics for executable Skill steps while moving preset use into the step-authoring surface.
+- The legacy `Task Presets` section may remain temporarily for preset management actions such as save/delete and existing advanced preset inputs; it is not the canonical Step Type discriminator surface for choosing Preset while authoring a step.
 
 ## Source Design Requirements
 
@@ -70,4 +71,4 @@ As a task author, I want one Step Type control in the step editor so I can choos
 - **SC-001**: A rendered step has one accessible control named Step Type with exactly Tool, Skill, and Preset options.
 - **SC-002**: Switching among Tool, Skill, and Preset changes the visible configuration area without removing existing instructions.
 - **SC-003**: Frontend tests cover Skill, Tool, and Preset Step Type rendering and hidden Skill field submission behavior.
-- **SC-004**: The Create page no longer presents preset use as a separate canonical authoring section outside the step editor.
+- **SC-004**: The Create page presents preset use inside the step editor when Step Type is Preset; any remaining `Task Presets` section is temporary management/advanced-input UI and is not the canonical Step Type authoring surface.

--- a/specs/276-step-type-authoring-controls/spec.md
+++ b/specs/276-step-type-authoring-controls/spec.md
@@ -1,0 +1,67 @@
+# Feature Specification: Step Type Authoring Controls
+
+**Feature Branch**: `276-step-type-authoring-controls`
+**Created**: 2026-04-28
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-556 as the canonical Moon Spec orchestration input. Implement MM-556: Unify Step Type authoring controls. Build the task authoring experience so the step editor has exactly one user-facing Step Type control covering Tool, Skill, and Preset. The selected Step Type must determine which type-specific configuration UI is shown. When the user changes Step Type, preserve compatible fields where possible and clearly handle incompatible fields before data is lost. User-facing copy must consistently use Step Type for the discriminator and avoid exposing internal runtime terminology such as Capability, Activity, Invocation, Command, or Script as the step type label. Preserve MM-556 in generated spec artifacts and pull request references. Source Reference: docs/Steps/StepTypes.md sections 1, 2, 3, 4, 6.1, 6.2, and 10. Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-015."
+
+## User Story - Unified Step Type Selection
+
+**Summary**: As a task author, I want one Step Type control in the step editor so I can choose Tool, Skill, or Preset without learning MoonMind internal runtime terminology.
+
+**Goal**: Task authors can choose the kind of work a step represents from a single Step Type discriminator and see only the configuration controls relevant to that selected type.
+
+**Independent Test**: Render the task Create page, inspect the primary step editor, switch between Tool, Skill, and Preset, and verify that exactly one Step Type control drives the visible configuration area while preserving compatible step instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Create page step editor is visible, **When** the user inspects a step, **Then** the step exposes one Step Type control with Tool, Skill, and Preset choices.
+2. **Given** Step Type is Skill, **When** the user views the step configuration, **Then** Skill-specific controls are visible and Tool/Preset-specific controls are hidden.
+3. **Given** Step Type is Tool, **When** the user views the step configuration, **Then** Tool-specific controls are visible and Skill/Preset-specific controls are hidden.
+4. **Given** Step Type is Preset, **When** the user views the step configuration, **Then** Preset-specific selection and apply controls are visible in the step editor and Skill/Tool-specific controls are hidden.
+5. **Given** a user has entered step instructions, **When** the user changes Step Type, **Then** compatible instructions remain available and incompatible type-specific fields are not silently submitted while hidden.
+6. **Given** the step editor is visible, **When** labels and primary helper copy are inspected, **Then** the discriminator is called Step Type and does not use Capability, Activity, Invocation, Command, or Script as the step type label.
+
+### Edge Cases
+
+- A newly added step defaults to a valid Step Type and remains independently editable.
+- Hidden advanced Skill fields are not submitted after switching away from Skill.
+- A Preset step can use the existing preset expansion flow without requiring a separate authoring section outside the step editor.
+
+## Assumptions
+
+- Runtime mode applies: this story changes the Create page task-authoring behavior and validates it with frontend tests.
+- The first delivered slice may keep the existing execution payload semantics for executable Skill steps while moving preset use into the step-authoring surface.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | docs/Steps/StepTypes.md sections 1, 2, 4 | Every authored step has exactly one Step Type and the selected type controls what the step represents and which fields are shown. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-002 | docs/Steps/StepTypes.md sections 2, 6.1, 6.2 | The step editor must expose Tool, Skill, and Preset through one Step Type picker and render type-specific configuration below it. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-015 | docs/Steps/StepTypes.md section 10 | UI copy must use Step Type and avoid internal discriminator terms such as Capability, Activity, Invocation, Command, and Script. | In scope | FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The step editor MUST expose exactly one user-facing Step Type control per step with Tool, Skill, and Preset options.
+- **FR-002**: The selected Step Type MUST determine which type-specific configuration area is visible for that step.
+- **FR-003**: Users MUST be able to choose Skill and configure the existing skill selector and advanced skill fields only while Skill is the selected Step Type.
+- **FR-004**: Users MUST be able to choose Preset from the step editor and access preset selection/application controls without relying on a separate preset-use section.
+- **FR-005**: Primary step-discriminator UI copy MUST use Step Type and MUST NOT use Capability, Activity, Invocation, Command, or Script as the step type label.
+- **FR-006**: Changing Step Type MUST preserve compatible instructions and MUST prevent hidden incompatible type-specific fields from being submitted silently.
+
+### Key Entities
+
+- **Step Draft**: A user-authored step in the Create page, including instructions, selected Step Type, and any type-specific draft fields.
+- **Step Type**: The user-facing discriminator with Tool, Skill, and Preset values.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A rendered step has one accessible control named Step Type with exactly Tool, Skill, and Preset options.
+- **SC-002**: Switching among Tool, Skill, and Preset changes the visible configuration area without removing existing instructions.
+- **SC-003**: Frontend tests cover Skill, Tool, and Preset Step Type rendering and hidden Skill field submission behavior.
+- **SC-004**: The Create page no longer presents preset use as a separate canonical authoring section outside the step editor.

--- a/specs/276-step-type-authoring-controls/spec.md
+++ b/specs/276-step-type-authoring-controls/spec.md
@@ -5,6 +5,12 @@
 **Status**: Draft
 **Input**: User description: "Use the Jira preset brief for MM-556 as the canonical Moon Spec orchestration input. Implement MM-556: Unify Step Type authoring controls. Build the task authoring experience so the step editor has exactly one user-facing Step Type control covering Tool, Skill, and Preset. The selected Step Type must determine which type-specific configuration UI is shown. When the user changes Step Type, preserve compatible fields where possible and clearly handle incompatible fields before data is lost. User-facing copy must consistently use Step Type for the discriminator and avoid exposing internal runtime terminology such as Capability, Activity, Invocation, Command, or Script as the step type label. Preserve MM-556 in generated spec artifacts and pull request references. Source Reference: docs/Steps/StepTypes.md sections 1, 2, 3, 4, 6.1, 6.2, and 10. Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-015."
 
+## Original Preset Brief
+
+Jira issue: MM-556
+
+As a task author, I want one Step Type control in the step editor so I can choose Tool, Skill, or Preset without learning MoonMind internal runtime terminology.
+
 ## User Story - Unified Step Type Selection
 
 **Summary**: As a task author, I want one Step Type control in the step editor so I can choose Tool, Skill, or Preset without learning MoonMind internal runtime terminology.

--- a/specs/276-step-type-authoring-controls/tasks.md
+++ b/specs/276-step-type-authoring-controls/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
 - Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -73,7 +73,7 @@
 - [X] T013 Add Tool-specific configuration area in `frontend/src/entrypoints/task-create.tsx` (FR-002)
 - [X] T014 Move preset-use controls into the Preset Step Type area in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-004)
 - [X] T015 Update Mission Control styles for Step Type controls in `frontend/src/styles/mission-control.css` (FR-001, FR-002)
-- [X] T016 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and fix failures until the story tests pass
+- [X] T016 Story validation: Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and fix failures until the story tests pass
 
 **Checkpoint**: The story is functional, covered by focused frontend tests, and testable independently
 
@@ -84,7 +84,7 @@
 **Purpose**: Validate without adding hidden scope.
 
 - [X] T017 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
-- [X] T018 Run `/speckit.verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-556
+- [X] T018 Run `/moonspec-verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-556
 
 ---
 

--- a/specs/276-step-type-authoring-controls/tasks.md
+++ b/specs/276-step-type-authoring-controls/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: Step Type Authoring Controls
+
+**Input**: Design documents from `/specs/276-step-type-authoring-controls/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around MM-556's single user story.
+
+**Source Traceability**: FR-001..FR-006, SC-001..SC-004, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-015.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing Create page frontend test harness and no new project structure is required.
+
+- [X] T001 Confirm existing Create page implementation and test files in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`
+- [X] T002 Create MoonSpec artifacts for MM-556 in `specs/276-step-type-authoring-controls/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new backend, schema, or service foundation is required; this story reuses existing preset and task submission surfaces.
+
+- [X] T003 Verify existing preset expansion endpoint usage remains in `frontend/src/entrypoints/task-create.tsx`
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Unified Step Type Selection
+
+**Summary**: As a task author, I want one Step Type control in the step editor so I can choose Tool, Skill, or Preset without learning MoonMind internal runtime terminology.
+
+**Independent Test**: Render the Create page, switch Step Type among Skill, Tool, and Preset, and verify only the relevant configuration area appears while compatible instructions persist.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, SC-001, SC-002, SC-003, SC-004, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-015
+
+**Test Plan**:
+
+- Unit: Step Type state, conditional rendering, hidden Skill field submission, canonical section order.
+- Integration: Create page render/submission tests exercise the UI contract and existing task submission boundary.
+
+### Unit Tests (write first) ⚠️
+
+- [X] T004 [P] Add failing test for one Step Type control with Tool, Skill, and Preset in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, SC-001, DESIGN-REQ-001)
+- [X] T005 [P] Add failing test for switching Skill/Tool/Preset configuration areas and preserving instructions in `frontend/src/entrypoints/task-create.test.tsx` (FR-002, FR-003, FR-004, FR-006, SC-002, DESIGN-REQ-002)
+- [X] T006 [P] Add failing test that hidden Skill advanced fields are not submitted after switching away from Skill in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, SC-003)
+- [X] T007 [P] Update canonical section-order test to omit separate Task Presets authoring section in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, SC-004)
+- [X] T008 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` to confirm new tests fail for expected Step Type gaps
+
+### Integration Tests (write first) ⚠️
+
+- [X] T009 Treat focused Create page Vitest render/submission coverage as the story integration boundary and confirm failures from T008 cover the public UI contract in `frontend/src/entrypoints/task-create.test.tsx`
+
+### Implementation
+
+- [X] T010 Add Step Type draft state and type-change handling in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-006)
+- [X] T011 Render one Step Type control per step in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-005)
+- [X] T012 Gate Skill controls and advanced Skill fields behind Skill Step Type in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-003, FR-006)
+- [X] T013 Add Tool-specific configuration area in `frontend/src/entrypoints/task-create.tsx` (FR-002)
+- [X] T014 Move preset-use controls into the Preset Step Type area in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-004)
+- [X] T015 Update Mission Control styles for Step Type controls in `frontend/src/styles/mission-control.css` (FR-001, FR-002)
+- [X] T016 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and fix failures until the story tests pass
+
+**Checkpoint**: The story is functional, covered by focused frontend tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate without adding hidden scope.
+
+- [X] T017 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- [X] T018 Run `/speckit.verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-556
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 and Phase 2 are complete.
+- T004-T007 must be written before implementation.
+- T010-T015 follow red-first confirmation.
+- T016 validates focused frontend behavior.
+- T017-T018 are final validation.
+
+## Implementation Strategy
+
+1. Add failing frontend tests for the MM-556 UI contract.
+2. Implement Step Type state and conditional rendering in the Create page.
+3. Reuse existing preset expansion behavior inside the Preset Step Type area.
+4. Run focused UI tests and managed unit validation.
+5. Verify artifacts and implementation against MM-556.


### PR DESCRIPTION
## Jira

- Jira issue key: MM-556
- Active MoonSpec feature path: `specs/276-step-type-authoring-controls`

## Verification Verdict

- MoonSpec verification verdict: ADDITIONAL_WORK_NEEDED

## Tests Run

- PASS: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` (206 tests)
- PASS: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (4192 Python tests + 206 UI tests)
- PASS: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
- PASS: `git diff --check`

## Remaining Risks

- Final MoonSpec verification found ADDITIONAL_WORK_NEEDED because the legacy visible `Task Presets (optional)` authoring section still exists alongside the new Step Type path. A bounded hide/removal probe caused 68 focused Create-page UI failures in existing preset/Jira flows and was reverted; completing that convergence requires a follow-up migration of those legacy flows.
