### PR TITLE
MM-557: Validate Tool and Skill executable steps

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/276-step-type-authoring-controls"
+  "feature_directory": "specs/277-validate-tool-skill-executable-steps"
 }

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -365,6 +365,29 @@ class TaskTemplateStepSkillSchema(BaseModel):
     required_capabilities: list[str] = Field(
         default_factory=list, alias="requiredCapabilities"
     )
+    context: dict[str, Any] = Field(default_factory=dict)
+    permissions: dict[str, Any] = Field(default_factory=dict)
+    autonomy: dict[str, Any] = Field(default_factory=dict)
+    runtime: dict[str, Any] = Field(default_factory=dict)
+
+class TaskTemplateStepToolSchema(BaseModel):
+    """Tool payload attached to a template step."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: Optional[str] = None
+    name: Optional[str] = None
+    version: Optional[str] = None
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    args: dict[str, Any] = Field(default_factory=dict)
+    required_authorization: Any = Field(None, alias="requiredAuthorization")
+    required_capabilities: list[str] = Field(
+        default_factory=list, alias="requiredCapabilities"
+    )
+    side_effect_policy: Any = Field(None, alias="sideEffectPolicy")
+    retry_policy: Any = Field(None, alias="retryPolicy")
+    execution: dict[str, Any] = Field(default_factory=dict)
+    validation: dict[str, Any] = Field(default_factory=dict)
 
 class TaskTemplateStepBlueprintSchema(BaseModel):
     """Template step blueprint definition."""
@@ -372,6 +395,7 @@ class TaskTemplateStepBlueprintSchema(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     kind: Optional[Literal["step", "include"]] = None
+    type: Optional[Literal["tool", "skill"]] = None
     slug: Optional[str] = None
     title: Optional[str] = None
     instructions: Optional[str] = None
@@ -379,6 +403,7 @@ class TaskTemplateStepBlueprintSchema(BaseModel):
     alias: Optional[str] = None
     scope: Optional[Literal["global", "personal"]] = None
     input_mapping: dict[str, Any] = Field(default_factory=dict, alias="inputMapping")
+    tool: Optional[TaskTemplateStepToolSchema] = None
     skill: Optional[TaskTemplateStepSkillSchema] = None
     annotations: dict[str, Any] = Field(default_factory=dict)
 

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -282,6 +282,16 @@ def _normalize_step_type(raw_step: Mapping[str, Any], *, index: int) -> str:
         )
     return step_type
 
+
+def _has_substantive_tool_metadata(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, Mapping | list | tuple | set):
+        return bool(value)
+    return True
+
 def _normalize_tool_payload(raw_tool: Any, *, index: int) -> dict[str, Any]:
     if not isinstance(raw_tool, Mapping):
         raise TaskTemplateValidationError(
@@ -293,7 +303,10 @@ def _normalize_tool_payload(raw_tool: Any, *, index: int) -> dict[str, Any]:
             f"Step {index} tool.id or tool.name is required."
         )
     inputs = raw_tool.get("inputs")
-    if inputs is None:
+    args = raw_tool.get("args")
+    if inputs is None or (
+        isinstance(inputs, Mapping) and not inputs and args is not None
+    ):
         inputs = raw_tool.get("args")
     if inputs is None:
         inputs = {}
@@ -319,9 +332,11 @@ def _normalize_tool_payload(raw_tool: Any, *, index: int) -> dict[str, Any]:
         if value is not None:
             tool_payload[key] = value
     if any(marker in tool_id.lower() for marker in _COMMAND_TOOL_MARKERS):
-        if not tool_payload["inputs"] or not any(
-            key in tool_payload for key in ("sideEffectPolicy", "validation")
-        ):
+        has_policy_metadata = any(
+            _has_substantive_tool_metadata(tool_payload.get(key))
+            for key in ("sideEffectPolicy", "validation")
+        )
+        if not tool_payload["inputs"] or not has_policy_metadata:
             raise TaskTemplateValidationError(
                 f"Step {index} command-like Tool steps require bounded inputs and policy metadata."
             )

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -35,6 +35,7 @@ from moonmind.config.settings import settings
 
 _FORBIDDEN_STEP_KEYS = frozenset(
     {
+        "bash",
         "runtime",
         "targetRuntime",
         "target_runtime",
@@ -45,6 +46,10 @@ _FORBIDDEN_STEP_KEYS = frozenset(
         "git",
         "publish",
         "container",
+        "command",
+        "cmd",
+        "script",
+        "shell",
     }
 )
 _SUPPORTED_INPUT_TYPES = frozenset(
@@ -73,6 +78,7 @@ _STEP_RESERVED_KEYS = frozenset(
     {
         "id",
         "kind",
+        "type",
         "title",
         "slug",
         "version",
@@ -81,6 +87,7 @@ _STEP_RESERVED_KEYS = frozenset(
         "inputMapping",
         "input_mapping",
         "instructions",
+        "tool",
         "skill",
         "skills",
         "annotations",
@@ -100,6 +107,22 @@ _INCLUDE_STEP_KEYS = frozenset(
 )
 _STEP_KIND = "step"
 _INCLUDE_KIND = "include"
+_STEP_TYPE_TOOL = "tool"
+_STEP_TYPE_SKILL = "skill"
+_SKILL_METADATA_KEYS = frozenset(
+    {"context", "permissions", "autonomy", "runtime", "allowedTools"}
+)
+_TOOL_METADATA_KEYS = frozenset(
+    {
+        "requiredAuthorization",
+        "requiredCapabilities",
+        "sideEffectPolicy",
+        "retryPolicy",
+        "execution",
+        "validation",
+    }
+)
+_COMMAND_TOOL_MARKERS = ("command", "shell", "bash")
 logger = logging.getLogger(__name__)
 
 class _StatsdEmitter:
@@ -247,6 +270,102 @@ def _extract_step_capabilities(step: dict[str, Any]) -> list[str]:
     if not isinstance(caps, list):
         return []
     return _normalize_capabilities(caps)
+
+def _normalize_step_type(raw_step: Mapping[str, Any], *, index: int) -> str:
+    raw_type = raw_step.get("type")
+    if raw_type is None or str(raw_type).strip() == "":
+        return _STEP_TYPE_SKILL
+    step_type = str(raw_type).strip().lower()
+    if step_type not in {_STEP_TYPE_TOOL, _STEP_TYPE_SKILL}:
+        raise TaskTemplateValidationError(
+            f"Step {index} type must be one of: tool, skill."
+        )
+    return step_type
+
+def _normalize_tool_payload(raw_tool: Any, *, index: int) -> dict[str, Any]:
+    if not isinstance(raw_tool, Mapping):
+        raise TaskTemplateValidationError(
+            f"Step {index} Tool step requires a tool payload object."
+        )
+    tool_id = str(raw_tool.get("id") or raw_tool.get("name") or "").strip()
+    if not tool_id:
+        raise TaskTemplateValidationError(
+            f"Step {index} tool.id or tool.name is required."
+        )
+    inputs = raw_tool.get("inputs")
+    if inputs is None:
+        inputs = raw_tool.get("args")
+    if inputs is None:
+        inputs = {}
+    if not isinstance(inputs, Mapping):
+        raise TaskTemplateValidationError(
+            f"Step {index} tool.inputs must be an object when provided."
+        )
+    tool_payload: dict[str, Any] = {"id": tool_id, "inputs": dict(inputs)}
+    version = str(raw_tool.get("version") or "").strip()
+    if version:
+        tool_payload["version"] = version
+    caps = raw_tool.get("requiredCapabilities")
+    if caps is not None:
+        if not isinstance(caps, list):
+            raise TaskTemplateValidationError(
+                f"Step {index} tool.requiredCapabilities must be a list."
+            )
+        normalized_caps = _normalize_capabilities(caps)
+        if normalized_caps:
+            tool_payload["requiredCapabilities"] = normalized_caps
+    for key in _TOOL_METADATA_KEYS - {"requiredCapabilities"}:
+        value = raw_tool.get(key)
+        if value is not None:
+            tool_payload[key] = value
+    if any(marker in tool_id.lower() for marker in _COMMAND_TOOL_MARKERS):
+        if not tool_payload["inputs"] or not any(
+            key in tool_payload for key in ("sideEffectPolicy", "validation")
+        ):
+            raise TaskTemplateValidationError(
+                f"Step {index} command-like Tool steps require bounded inputs and policy metadata."
+            )
+    return tool_payload
+
+def _normalize_skill_payload(raw_skill: Any, *, index: int) -> dict[str, Any]:
+    if raw_skill is None:
+        return {"id": "auto", "args": {}}
+    if not isinstance(raw_skill, Mapping):
+        raise TaskTemplateValidationError(
+            f"Step {index} skill must be an object when provided."
+        )
+    skill_id = str(raw_skill.get("id") or "auto").strip() or "auto"
+    skill_args = raw_skill.get("args")
+    if skill_args is None:
+        skill_args = {}
+    if not isinstance(skill_args, Mapping):
+        raise TaskTemplateValidationError(
+            f"Step {index} skill.args must be an object when provided."
+        )
+    skill_payload: dict[str, Any] = {"id": skill_id, "args": dict(skill_args)}
+    caps = raw_skill.get("requiredCapabilities")
+    if caps is not None:
+        if not isinstance(caps, list):
+            raise TaskTemplateValidationError(
+                f"Step {index} skill.requiredCapabilities must be a list."
+            )
+        normalized_caps = _normalize_capabilities(caps)
+        if normalized_caps:
+            skill_payload["requiredCapabilities"] = normalized_caps
+    for key in _SKILL_METADATA_KEYS:
+        value = raw_skill.get(key)
+        if value is not None:
+            if not isinstance(value, Mapping) and key in {
+                "context",
+                "permissions",
+                "autonomy",
+                "runtime",
+            }:
+                raise TaskTemplateValidationError(
+                    f"Step {index} skill.{key} must be an object when provided."
+                )
+            skill_payload[key] = dict(value) if isinstance(value, Mapping) else value
+    return skill_payload
 
 def _slugify_from_title(title: str) -> str:
     return _normalize_slug(title)
@@ -938,37 +1057,32 @@ class TaskTemplateCatalogService:
                 raise TaskTemplateValidationError(
                     f"Step {index} requires non-empty instructions."
                 )
-            step_payload: dict[str, Any] = {"instructions": instructions}
+            step_type = _normalize_step_type(raw_step, index=index)
+            step_payload: dict[str, Any] = {
+                "type": step_type,
+                "instructions": instructions,
+            }
             title = str(raw_step.get("title") or "").strip()
             if title:
                 step_payload["title"] = title
             if "slug" in raw_step and str(raw_step.get("slug") or "").strip():
                 step_payload["slug"] = str(raw_step.get("slug")).strip()
-            skill = raw_step.get("skill")
-            if skill is not None:
-                if not isinstance(skill, dict):
+            if step_type == _STEP_TYPE_TOOL:
+                if raw_step.get("skill") is not None:
                     raise TaskTemplateValidationError(
-                        f"Step {index} skill must be an object when provided."
+                        f"Step {index} Tool step must not include a skill payload."
                     )
-                skill_id = str(skill.get("id") or "auto").strip() or "auto"
-                skill_args = skill.get("args")
-                if skill_args is None:
-                    skill_args = {}
-                if not isinstance(skill_args, dict):
+                step_payload["tool"] = _normalize_tool_payload(
+                    raw_step.get("tool"), index=index
+                )
+            else:
+                if raw_step.get("tool") is not None:
                     raise TaskTemplateValidationError(
-                        f"Step {index} skill.args must be an object when provided."
+                        f"Step {index} Skill step must not include a tool payload."
                     )
-                skill_payload = {"id": skill_id, "args": dict(skill_args)}
-                caps = skill.get("requiredCapabilities")
-                if caps is not None:
-                    if not isinstance(caps, list):
-                        raise TaskTemplateValidationError(
-                            f"Step {index} skill.requiredCapabilities must be a list."
-                        )
-                    normalized_caps = _normalize_capabilities(caps)
-                    if normalized_caps:
-                        skill_payload["requiredCapabilities"] = normalized_caps
-                step_payload["skill"] = skill_payload
+                step_payload["skill"] = _normalize_skill_payload(
+                    raw_step.get("skill"), index=index
+                )
             annotations = raw_step.get("annotations")
             if annotations is not None:
                 if not isinstance(annotations, dict):
@@ -1158,6 +1272,7 @@ class TaskTemplateCatalogService:
                     f"Expanded instructions still contain unresolved template "
                     f"placeholders at {_format_include_path(path)}."
                 )
+            step_type = _normalize_step_type(rendered, index=source_index)
             next_index = len(resolved_steps) + 1
             if enforce_limit and next_index > root_max_step_count:
                 raise TaskTemplateValidationError(
@@ -1171,6 +1286,7 @@ class TaskTemplateCatalogService:
                     index=next_index,
                     inputs=root_inputs,
                 ),
+                "type": step_type,
                 "instructions": instructions,
                 "presetProvenance": {
                     "root": {"slug": root_slug, "version": root_version},
@@ -1188,8 +1304,24 @@ class TaskTemplateCatalogService:
             title = str(rendered.get("title") or "").strip()
             if title:
                 step_payload["title"] = title
-            if isinstance(rendered.get("skill"), dict):
-                step_payload["skill"] = rendered["skill"]
+            if step_type == _STEP_TYPE_TOOL:
+                if rendered.get("skill") is not None:
+                    raise TaskTemplateValidationError(
+                        f"Expanded Tool step must not include a skill payload at "
+                        f"{_format_include_path(path)}."
+                    )
+                step_payload["tool"] = _normalize_tool_payload(
+                    rendered.get("tool"), index=source_index
+                )
+            else:
+                if rendered.get("tool") is not None:
+                    raise TaskTemplateValidationError(
+                        f"Expanded Skill step must not include a tool payload at "
+                        f"{_format_include_path(path)}."
+                    )
+                step_payload["skill"] = _normalize_skill_payload(
+                    rendered.get("skill"), index=source_index
+                )
             step_payload.update(
                 {
                     str(key).strip(): value

--- a/api_service/services/task_templates/save.py
+++ b/api_service/services/task_templates/save.py
@@ -29,7 +29,7 @@ _SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(token|password|secret)\s*=\s*[^\s]+", re.IGNORECASE),
 )
 _ALLOWED_STEP_KEYS = frozenset(
-    {"slug", "title", "instructions", "skill", "annotations"}
+    {"slug", "title", "type", "instructions", "tool", "skill", "annotations"}
 )
 logger = logging.getLogger(__name__)
 
@@ -101,11 +101,31 @@ class TaskTemplateSaveService:
                 cleaned["title"] = title
             else:
                 cleaned.pop("title", None)
-            skill = cleaned.get("skill")
-            if skill is not None and not isinstance(skill, dict):
+            step_type = str(cleaned.get("type") or "skill").strip().lower()
+            if step_type not in {"tool", "skill"}:
                 raise TaskTemplateValidationError(
-                    f"step {index} skill must be an object"
+                    f"step {index} type must be one of: tool, skill"
                 )
+            cleaned["type"] = step_type
+            tool = cleaned.get("tool")
+            if step_type == "tool":
+                if not isinstance(tool, dict):
+                    raise TaskTemplateValidationError(
+                        f"step {index} tool must be an object"
+                    )
+                cleaned.pop("skill", None)
+            elif tool is not None:
+                raise TaskTemplateValidationError(
+                    f"step {index} skill step must not include tool"
+                )
+            skill = cleaned.get("skill")
+            if step_type == "skill":
+                if skill is not None and not isinstance(skill, dict):
+                    raise TaskTemplateValidationError(
+                        f"step {index} skill must be an object"
+                    )
+            else:
+                cleaned.pop("skill", None)
             sanitized.append(cleaned)
         return sanitized
 

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,22 @@
 [
   {
-    "id": 4192954412,
+    "id": 3158058337,
     "disposition": "addressed",
-    "rationale": "Summary review covered by the concrete fixes for per-step preset state, non-destructive Step Type switching, Tool submission blocking, and spec alignment."
+    "rationale": "Updated tool payload normalization so non-empty tool.args is preserved when schema-provided tool.inputs is an empty object, with unit coverage."
   },
   {
-    "id": 3157632598,
+    "id": 3158058340,
     "disposition": "addressed",
-    "rationale": "Preset selector and status state now live on each StepState, with regression coverage for independent Preset selections across multiple steps."
+    "rationale": "Command-like tool validation now requires substantive sideEffectPolicy or validation metadata instead of accepting empty default objects, with unit coverage."
   },
   {
-    "id": 3157632604,
-    "disposition": "addressed",
-    "rationale": "Step Type changes no longer clear hidden Skill fields; submission still filters them when Step Type is not Skill, and tests verify preserved values."
-  },
-  {
-    "id": 3157632608,
-    "disposition": "addressed",
-    "rationale": "Updated SC-004 and assumptions to reflect that step-editor Preset use is canonical while the remaining Task Presets section is temporary management/advanced-input UI."
-  },
-  {
-    "id": 3157641194,
-    "disposition": "addressed",
-    "rationale": "Tool Step Type submissions now fail fast until a typed Tool is selected, preventing accidental default skill execution."
-  },
-  {
-    "id": 3157641196,
-    "disposition": "addressed",
-    "rationale": "Preset selection is scoped per step instead of using the component-level selectedPresetKey, with a regression test covering two Preset steps."
-  },
-  {
-    "id": 4192965003,
+    "id": 4193474718,
     "disposition": "not-applicable",
-    "rationale": "Informational automated review container with no separate actionable request beyond the individual review comments."
+    "rationale": "Automated review summary container; actionable inline comments from this review are tracked separately."
+  },
+  {
+    "id": 4193481160,
+    "disposition": "not-applicable",
+    "rationale": "Review body explicitly states there is no feedback to address."
   }
 ]

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6662,6 +6662,8 @@ export interface components {
         TaskTemplateStepBlueprintSchema: {
             /** Kind */
             kind?: ("step" | "include") | null;
+            /** Type */
+            type?: ("tool" | "skill") | null;
             /** Slug */
             slug?: string | null;
             /** Title */
@@ -6678,6 +6680,7 @@ export interface components {
             inputMapping?: {
                 [key: string]: unknown;
             };
+            tool?: components["schemas"]["TaskTemplateStepToolSchema"] | null;
             skill?: components["schemas"]["TaskTemplateStepSkillSchema"] | null;
             /** Annotations */
             annotations?: {
@@ -6700,6 +6703,58 @@ export interface components {
             };
             /** Requiredcapabilities */
             requiredCapabilities?: string[];
+            /** Context */
+            context?: {
+                [key: string]: unknown;
+            };
+            /** Permissions */
+            permissions?: {
+                [key: string]: unknown;
+            };
+            /** Autonomy */
+            autonomy?: {
+                [key: string]: unknown;
+            };
+            /** Runtime */
+            runtime?: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * TaskTemplateStepToolSchema
+         * @description Tool payload attached to a template step.
+         */
+        TaskTemplateStepToolSchema: {
+            /** Id */
+            id?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Version */
+            version?: string | null;
+            /** Inputs */
+            inputs?: {
+                [key: string]: unknown;
+            };
+            /** Args */
+            args?: {
+                [key: string]: unknown;
+            };
+            /** Requiredauthorization */
+            requiredAuthorization?: unknown;
+            /** Requiredcapabilities */
+            requiredCapabilities?: string[];
+            /** Sideeffectpolicy */
+            sideEffectPolicy?: unknown;
+            /** Retrypolicy */
+            retryPolicy?: unknown;
+            /** Execution */
+            execution?: {
+                [key: string]: unknown;
+            };
+            /** Validation */
+            validation?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * TaskTemplateSummarySchema

--- a/specs/277-validate-tool-skill-executable-steps/checklists/requirements.md
+++ b/specs/277-validate-tool-skill-executable-steps/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Validate Tool and Skill Executable Steps
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: MM-557 is preserved in the original preset brief and source traceability.

--- a/specs/277-validate-tool-skill-executable-steps/contracts/executable-step-validation.md
+++ b/specs/277-validate-tool-skill-executable-steps/contracts/executable-step-validation.md
@@ -1,0 +1,66 @@
+# Contract: Executable Step Validation
+
+## Accepted Tool Step
+
+```json
+{
+  "type": "tool",
+  "title": "Move Jira issue to In Progress",
+  "instructions": "Move MM-557 to In Progress after blocker checks pass.",
+  "tool": {
+    "id": "jira.transition_issue",
+    "version": "1.0.0",
+    "inputs": {
+      "issueKey": "MM-557",
+      "targetStatus": "In Progress"
+    },
+    "requiredAuthorization": "jira",
+    "requiredCapabilities": ["jira"],
+    "sideEffectPolicy": "idempotent-by-transition-target"
+  }
+}
+```
+
+Expected result: accepted and persisted/expanded with `type: tool` and normalized `tool.inputs`.
+
+## Accepted Skill Step
+
+```json
+{
+  "type": "skill",
+  "title": "Triage Jira issue",
+  "instructions": "Read MM-557 and decide whether it needs clarification.",
+  "skill": {
+    "id": "jira-triage",
+    "args": {"issueKey": "MM-557"},
+    "requiredCapabilities": ["jira"],
+    "autonomy": {"mode": "bounded"}
+  }
+}
+```
+
+Expected result: accepted and persisted/expanded with `type: skill` and Skill metadata.
+
+## Rejected Mixed Step
+
+```json
+{
+  "type": "tool",
+  "instructions": "Implement MM-557.",
+  "skill": {"id": "jira-implement", "args": {"issueKey": "MM-557"}}
+}
+```
+
+Expected result: validation error before persistence or expansion.
+
+## Rejected Shell Step
+
+```json
+{
+  "type": "skill",
+  "instructions": "Run deployment script.",
+  "command": "bash deploy.sh"
+}
+```
+
+Expected result: validation error before persistence or expansion.

--- a/specs/277-validate-tool-skill-executable-steps/data-model.md
+++ b/specs/277-validate-tool-skill-executable-steps/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Validate Tool and Skill Executable Steps
+
+## Executable Step Blueprint
+
+Represents one authored executable step inside a task template version or saved task preset.
+
+Fields:
+- `type`: optional Step Type discriminator for executable steps. Allowed values: `tool`, `skill`. Omitted values are treated as the existing Skill-shaped default only when no Tool payload is present.
+- `instructions`: non-empty operator-facing instructions or description.
+- `title`: optional display label.
+- `tool`: Tool Step Payload, required when `type = tool`.
+- `skill`: Skill Step Payload, allowed when `type = skill` or omitted legacy Skill-shaped data.
+- `annotations`: optional metadata object.
+
+Validation rules:
+- Unsupported `type` values fail validation.
+- `type = tool` requires `tool` and rejects `skill`.
+- `type = skill` rejects Tool-only payloads.
+- Top-level arbitrary shell fields fail validation.
+
+## Tool Step Payload
+
+Fields:
+- `id` or `name`: required non-empty typed tool identifier.
+- `version`: optional version string.
+- `inputs` or `args`: optional object; normalized to `inputs`.
+- `requiredAuthorization`, `requiredCapabilities`, `sideEffectPolicy`, `retryPolicy`, `execution`, `validation`: optional metadata preserved when present.
+
+Validation rules:
+- `inputs`/`args` must be an object when supplied.
+- `requiredCapabilities` must be a list when supplied.
+- Command-like tools are accepted only as typed Tool payloads with object inputs and policy metadata.
+
+## Skill Step Payload
+
+Fields:
+- `id`: optional skill selector; defaults to `auto` for documented auto semantics.
+- `args`: optional object; defaults to `{}`.
+- `requiredCapabilities`: optional list.
+- `context`, `permissions`, `autonomy`, `runtime`: optional metadata preserved when present.
+
+Validation rules:
+- `args` must be an object when supplied.
+- `requiredCapabilities` must be a list when supplied.
+- Tool-only payload fields are rejected for Skill steps.

--- a/specs/277-validate-tool-skill-executable-steps/moonspec_align_report.md
+++ b/specs/277-validate-tool-skill-executable-steps/moonspec_align_report.md
@@ -1,0 +1,37 @@
+# MoonSpec Alignment Report
+
+**Feature**: `277-validate-tool-skill-executable-steps`  
+**Date**: 2026-04-29  
+**Source**: MM-557 Jira preset brief preserved in `spec.md`  
+**Result**: PASS - no artifact remediation required
+
+## Findings
+
+| Finding | Severity | Resolution |
+| --- | --- | --- |
+| `spec.md` preserves MM-557, the original preset brief, exactly one user story, source mappings, functional requirements, and measurable success criteria. | None | No spec changes required. |
+| `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/executable-step-validation.md` exist and remain aligned to the task-template validation boundary. | None | No planning artifact regeneration required. |
+| `tasks.md` covers one story and includes red-first unit tests, service integration-boundary coverage, implementation tasks, story validation, and final `/moonspec-verify` work. | None | No task regeneration required. |
+| MoonSpec prerequisite script is branch-name gated and rejects the managed branch `run-jira-orchestrate-for-mm-557-validate-e5aa5a6f`. | Low | Manual artifact inventory was used for this alignment pass; no feature artifact change required. |
+
+## Key Decisions
+
+- `moonspec-breakdown` remains skipped because MM-557 is a single independently testable story.
+- `moonspec-specify`, `moonspec-plan`, and `moonspec-tasks` outputs remain current; no downstream artifact is stale.
+- No Prompt A/Prompt B loop, scripted approval, or manual analyze prompt was used.
+
+## Gate Recheck
+
+- Specify gate: PASS.
+- Plan gate: PASS.
+- Tasks gate: PASS.
+- Align gate: PASS.
+
+## Validation
+
+- `rg` artifact inventory: PASS, no unresolved `NEEDS CLARIFICATION`, legacy `/speckit.verify`, Prompt A, or Prompt B markers found in active artifacts.
+- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: NOT RUN to completion because the script rejects the managed branch name before artifact evaluation.
+
+## Remaining Risks
+
+- None blocking.

--- a/specs/277-validate-tool-skill-executable-steps/plan.md
+++ b/specs/277-validate-tool-skill-executable-steps/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Validate Tool and Skill Executable Steps
+
+**Branch**: `277-validate-tool-skill-executable-steps` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/277-validate-tool-skill-executable-steps/spec.md`
+
+## Summary
+
+MM-557 requires executable step blueprints to validate Tool and Skill steps against distinct contracts before task templates are persisted or expanded. Current repo evidence shows `TaskTemplateCatalogService` validates instructions, includes, and skill payloads, while API schemas and save-from-task sanitization do not preserve explicit `type: tool` plus `tool` payloads. The implementation will extend the task template boundary to parse explicit Step Type, validate and normalize Tool payloads, preserve Skill metadata, reject mixed or shell-shaped executable steps, and add unit coverage using the existing async task template service tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | `TaskTemplateStepBlueprintSchema` has no `type` or `tool`; catalog ignores explicit Step Type | Add `type`/`tool` schema and catalog validation | unit + integration-boundary |
+| FR-002 | missing | No Tool payload identifier validation | Require `tool.id` or `tool.name` | unit |
+| FR-003 | missing | No Tool input object validation | Validate `tool.inputs`/`tool.args` object shape | unit |
+| FR-004 | missing | Tool metadata is not preserved by schema/create/save paths | Preserve normalized Tool payload metadata | unit + integration-boundary |
+| FR-005 | partial | Legacy Skill steps and `skill` payload validation exist | Add explicit `type: skill` validation and reject Tool-only fields | unit |
+| FR-006 | implemented_unverified | `skill.args` and `requiredCapabilities` validation exists in catalog; save path only checks skill object | Add save-path coverage and keep validation evidence | unit |
+| FR-007 | partial | Existing catalog preserves `id`, `args`, and `requiredCapabilities`; not context/permissions/autonomy metadata | Preserve allowed Skill metadata fields | unit |
+| FR-008 | missing | Unsupported `type` values are ignored by schema/catalog | Reject unsupported Step Type values | unit |
+| FR-009 | missing | Mixed Tool/Skill payloads are not detected | Reject selected-type payload mismatches | unit |
+| FR-010 | partial | Template validation errors already surface, but not for Tool/Skill distinctions | Use existing `TaskTemplateValidationError` messages | unit |
+| FR-011 | missing | No Tool example validation exists | Add Jira transition Tool acceptance test | unit |
+| FR-012 | implemented_unverified | Skill-shaped examples are accepted | Add explicit Jira triage Skill acceptance test | unit |
+| FR-013 | missing | Swapped/mixed Jira variants are not rejected | Add rejection tests | unit |
+| FR-014 | partial | Some top-level forbidden keys exist, but `command`/`script` are not rejected and Tool policy exception is absent | Reject shell-shaped fields unless bounded Tool payload declares policy metadata | unit |
+| SC-001..005 | missing | No MM-557 tests exist | Add targeted service tests and run focused/full unit suite | unit + final verify |
+| DESIGN-REQ-003 | missing | Tool contract not represented in template validation | Add Tool step contract validation | unit |
+| DESIGN-REQ-004 | partial | Skill contract partially represented | Preserve broader Skill metadata and explicit Step Type | unit |
+| DESIGN-REQ-005 | partial | Existing errors surface, but Step Type-specific errors missing | Add Step Type-specific validation errors | unit |
+| DESIGN-REQ-013 | missing | Jira Tool/Skill examples are not distinguished | Add Jira example tests | unit |
+| DESIGN-REQ-017 | partial | Top-level forbidden keys exist but shell fields are incomplete | Add shell field rejection | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React remains present but not expected for this backend validation story  
+**Primary Dependencies**: Pydantic v2, FastAPI request models, SQLAlchemy async test fixtures, existing task template catalog/save services, pytest  
+**Storage**: Existing task step template tables only; no new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py` for focused service coverage, then `./tools/test_unit.sh` for final verification when feasible  
+**Integration Testing**: Existing async service tests cover the API/service boundary for create/save/expand without compose; hermetic compose integration is not required because no external services or workflow contracts change  
+**Target Platform**: MoonMind API service and Mission Control task template persistence boundary  
+**Project Type**: Backend service with API schema boundary  
+**Performance Goals**: Validation remains linear in number of template steps and does not introduce network calls  
+**Constraints**: Preserve checked-in seed template compatibility; do not introduce hidden fallbacks for Tool semantics; reject unsupported Step Type values fail-fast  
+**Scale/Scope**: One executable step validation story for MM-557
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Reuses task template service boundaries and typed tool concepts.
+- II. One-Click Agent Deployment: PASS. No deployment changes.
+- III. Avoid Vendor Lock-In: PASS. Step validation is provider-neutral.
+- IV. Own Your Data: PASS. Uses existing local template persistence.
+- V. Skills Are First-Class and Easy to Add: PASS. Skill remains a first-class executable Step Type.
+- VI. Scientific Method: PASS. Test-first validation is planned.
+- VII. Runtime Configurability: PASS. No hardcoded provider configuration added.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay within task template schema/service boundaries.
+- IX. Resilient by Default: PASS. Invalid executable steps fail before execution.
+- X. Facilitate Continuous Improvement: PASS. Tests and verification preserve evidence.
+- XI. Spec-Driven Development: PASS. Spec, plan, and tasks precede implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime work remains in specs/code/tests.
+- XIII. Pre-release Compatibility Policy: PASS. Unsupported explicit Step Type values fail fast; legacy skill-shaped templates remain validated as existing Skill data rather than translated into Tool semantics.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/277-validate-tool-skill-executable-steps/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── executable-step-validation.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/api/schemas.py
+api_service/services/task_templates/catalog.py
+api_service/services/task_templates/save.py
+tests/unit/api/test_task_step_templates_service.py
+```
+
+**Structure Decision**: The task template API/service boundary is the narrowest runtime surface where authored executable steps are persisted, saved from drafts, expanded from presets, and validated before execution.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/277-validate-tool-skill-executable-steps/quickstart.md
+++ b/specs/277-validate-tool-skill-executable-steps/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Validate Tool and Skill Executable Steps
+
+## Focused Test-First Loop
+
+1. Add service tests for MM-557 validation behavior:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py
+   ```
+
+2. Confirm the new tests fail before implementation for missing Tool/Skill validation.
+
+3. Implement schema and service validation in:
+
+   ```text
+   api_service/api/schemas.py
+   api_service/services/task_templates/catalog.py
+   api_service/services/task_templates/save.py
+   ```
+
+4. Re-run the focused test command until it passes.
+
+## Final Verification
+
+Run the managed unit suite when feasible:
+
+```bash
+./tools/test_unit.sh
+```
+
+Then run `/moonspec-verify` equivalent by checking `spec.md`, `plan.md`, `tasks.md`, changed code, and test evidence against MM-557.

--- a/specs/277-validate-tool-skill-executable-steps/research.md
+++ b/specs/277-validate-tool-skill-executable-steps/research.md
@@ -1,0 +1,41 @@
+# Research: Validate Tool and Skill Executable Steps
+
+## FR-001..FR-004 Tool step contract
+
+Decision: Missing. Add explicit `type: tool` and `tool` payload support to API schema, catalog validation, save-from-task sanitization, and expansion preservation.
+Evidence: `api_service/api/schemas.py` lacks `type` and `tool` fields for `TaskTemplateStepBlueprintSchema`; `api_service/services/task_templates/catalog.py` only validates `skill`; `api_service/services/task_templates/save.py` only allows `slug`, `title`, `instructions`, `skill`, and `annotations`.
+Rationale: Tool steps must be deterministic typed operations and cannot be represented as generic skill steps.
+Alternatives considered: Reusing `skill` for Tool operations was rejected because MM-557 requires Tool and Skill not to be interchangeable.
+Test implications: Unit tests for create, save, and expand boundaries.
+
+## FR-005..FR-007 Skill step contract
+
+Decision: Partial. Keep existing skill-shaped validation, add explicit `type: skill`, preserve context/permissions/autonomy metadata in the Skill payload, and reject Tool-only fields for Skill steps.
+Evidence: `catalog.py` validates `skill.id`, `skill.args`, and `skill.requiredCapabilities`; it drops other Skill contract metadata.
+Rationale: Skill steps represent agentic work and need their own metadata without being forced through Tool semantics.
+Alternatives considered: Allowing arbitrary Skill payload fields was rejected because executable steps should have bounded validation.
+Test implications: Unit tests for explicit Skill acceptance and invalid Skill args/capabilities in create/save paths.
+
+## FR-008..FR-010 Common Step Type validation
+
+Decision: Missing. Add common Step Type normalization and fail-fast errors for unsupported Step Type or payload mismatch.
+Evidence: Existing template validation validates `kind` for step/include but does not validate authored executable Step Type.
+Rationale: The Step Type discriminator controls the expected type-specific payload.
+Alternatives considered: Inferring Step Type from any payload was rejected except for existing skill-shaped templates, which remain Skill by default.
+Test implications: Unit tests for unsupported type and mixed payload rejection.
+
+## FR-011..FR-013 Jira examples
+
+Decision: Missing. Add validation tests using Jira transition as Tool and Jira triage/implementation as Skill.
+Evidence: `docs/Steps/StepTypes.md` section 9 defines this distinction; no service tests assert it.
+Rationale: Jira examples are the acceptance proof that deterministic and agentic work remain separate.
+Alternatives considered: Testing only generic tool names was rejected because the source design explicitly calls out Jira.
+Test implications: Unit tests for accepted and rejected Jira-shaped examples.
+
+## FR-014 Shell snippet rejection
+
+Decision: Partial. Existing forbidden top-level keys reject runtime/repo/container fields, but command/script snippets are not forbidden.
+Evidence: `_FORBIDDEN_STEP_KEYS` in `catalog.py` omits command/script/shell/bash fields; save service does not scan them because it drops unknown keys.
+Rationale: Arbitrary shell snippets are not a Step Type. A typed Tool may represent command execution only when bounded inputs and policy metadata are present.
+Alternatives considered: Rejecting every Tool with command-like input text was rejected because approved typed command tools can accept bounded inputs.
+Test implications: Unit tests for top-level shell field rejection and accepted typed Tool policy metadata.

--- a/specs/277-validate-tool-skill-executable-steps/spec.md
+++ b/specs/277-validate-tool-skill-executable-steps/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Validate Tool and Skill Executable Steps
+
+**Feature Branch**: `277-validate-tool-skill-executable-steps`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-557 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-557` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-557` and local artifact `artifacts/moonspec-inputs/MM-557-canonical-moonspec-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-557` under `specs/`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-557 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-557
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Validate Tool and Skill executable steps
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`; potentially related custom fields `Implementation plan` and `Source` were present but empty.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-557 from MM project
+Summary: Validate Tool and Skill executable steps
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-557 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-557: Validate Tool and Skill executable steps
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 5.1 `tool`
+- 5.2 `skill`
+- 8.1 Common validation
+- 8.2 Tool validation
+- 8.3 Skill validation
+- 9. Jira Example
+- 15. Non-Goals
+
+Coverage IDs:
+- DESIGN-REQ-003
+- DESIGN-REQ-004
+- DESIGN-REQ-005
+- DESIGN-REQ-013
+- DESIGN-REQ-017
+
+As an operator, I want Tool and Skill steps validated against their distinct contracts so deterministic operations and agentic work are configured safely before execution.
+
+Acceptance Criteria
+- Tool validation requires an existing resolvable tool, schema-valid inputs, required authorization, worker capabilities, known side-effect policy, and no forbidden fields.
+- Skill validation requires a resolvable skill or documented auto semantics, contract-valid inputs, known runtime compatibility, required context, allowed permissions, and enforceable autonomy controls.
+- Common validation requires stable local identity, title or generated display label, Step Type, type-specific payload, and visible errors before submission.
+- Arbitrary shell snippets are rejected unless the selected Tool is an approved typed command tool with bounded inputs and policy.
+- Jira transition examples validate as Tool steps while Jira triage or implementation examples validate as Skill steps.
+
+Requirements
+- Tool steps are deterministic typed operations, not scripts.
+- Skill steps represent agentic work even when they may use tools internally.
+- Executable steps are validated before submission.
+- Tool and Skill are not treated as interchangeable merely because both may map into plan nodes.
+```
+
+## User Story - Validate Executable Step Contracts
+
+**Summary**: As an operator, I want Tool and Skill executable steps validated against distinct contracts so deterministic operations and agentic work are configured safely before execution.
+
+**Goal**: Task template and preset submission paths reject malformed executable steps early, keep Tool and Skill semantics distinct, and preserve deterministic Jira operations as Tool steps while agentic Jira work remains Skill steps.
+
+**Independent Test**: Create and save task step templates containing Tool and Skill steps, then verify valid examples persist and expand with their declared Step Type while mixed, malformed, forbidden, or arbitrary shell-shaped steps fail with visible validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template step declares Step Type `tool`, **When** the template is created or expanded, **Then** the step is accepted only if it declares a resolvable typed tool identifier, object inputs, known authorization/capability/policy metadata where supplied, and no forbidden fields.
+2. **Given** a template step declares Step Type `skill`, **When** the template is created or saved from a task, **Then** the step is accepted only if it declares a resolvable skill selector or documented `auto` selector, object arguments, runtime/context metadata where supplied, allowed permissions/capabilities, and enforceable autonomy metadata when present.
+3. **Given** a step omits explicit Step Type but otherwise matches the current Skill shape, **When** existing templates are loaded, **Then** the system treats the authored executable step as Skill and validates it through the Skill contract without accepting Tool-only fields.
+4. **Given** a step mixes Tool and Skill payloads or selects Tool without a Tool payload, **When** the template is created, saved, or expanded, **Then** validation fails before the template can be used.
+5. **Given** a step includes arbitrary shell snippets as command/script fields, **When** the step is validated, **Then** validation rejects it unless it is represented as an approved typed Tool with bounded object inputs and policy metadata.
+6. **Given** Jira examples are authored, **When** Jira transition is represented as a Tool step and Jira triage/implementation is represented as a Skill step, **Then** validation accepts the correctly typed examples and rejects the swapped or mixed variants.
+
+### Edge Cases
+
+- A legacy skill-shaped template has no explicit `type`; it must remain valid only as Skill-shaped data and must not silently gain Tool semantics.
+- A Tool step uses `tool.name` instead of `tool.id`; the identifier is still resolvable if non-empty and its inputs remain an object.
+- A Tool step uses `tool.args`; it is normalized as Tool inputs only when the value is an object.
+- A Skill step includes empty `requiredCapabilities`; empty values are ignored, but non-list values are rejected.
+- A template include remains a Preset expansion mechanism and is not treated as a Tool or Skill executable step.
+
+## Assumptions
+
+- Runtime mode applies: this story changes executable step validation behavior, not only documentation.
+- The first implementation slice targets task step template create/save/expand boundaries because those are the current persisted preset authoring paths where executable step blueprints enter the system.
+- Existing Create page Step Type UI from MM-556 is treated as input to this backend validation story rather than reimplemented here.
+- Full live registry authorization checks can be added behind provider-specific registries later; this story requires deterministic structural and metadata validation at the template service boundary.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-003 | docs/Steps/StepTypes.md section 5.1 | Tool steps are typed executable operations with name/version, schemas, authorization, capabilities, retry policy, execution binding, and validation/error model. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-004 | docs/Steps/StepTypes.md section 5.2 | Skill steps represent agent-facing behavior with selector, instructions, context, runtime preferences, allowed tools/capabilities, and autonomy controls. | In scope | FR-005, FR-006, FR-007 |
+| DESIGN-REQ-005 | docs/Steps/StepTypes.md section 8.1 | Common validation requires stable identity or display label, Step Type, type-specific payload, and surfaced validation errors before submission. | In scope | FR-008, FR-009, FR-010 |
+| DESIGN-REQ-013 | docs/Steps/StepTypes.md sections 8.2, 8.3, and 9 | Tool and Skill validation must stay distinct; Jira transitions are Tool steps while Jira triage/implementation is Skill work. | In scope | FR-011, FR-012, FR-013 |
+| DESIGN-REQ-017 | docs/Steps/StepTypes.md section 15 | Arbitrary shell scripts must not become a first-class Step Type. | In scope | FR-014 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept an authored Tool step only when `type` is `tool` and a Tool payload object is present.
+- **FR-002**: System MUST require Tool steps to declare a non-empty tool identifier through `tool.id` or `tool.name`.
+- **FR-003**: System MUST require Tool step inputs, when present through `tool.inputs` or `tool.args`, to be an object.
+- **FR-004**: System MUST preserve Tool step identifier, version, object inputs, and declared metadata needed for authorization, capabilities, side-effect, retry, execution, and validation policy.
+- **FR-005**: System MUST accept an authored Skill step only when it has an explicit `type: skill` or uses the existing skill-shaped default and a Skill payload object or documented `auto` selector.
+- **FR-006**: System MUST require Skill step args, when present, to be an object and Skill required capabilities, when present, to be a list.
+- **FR-007**: System MUST preserve Skill selector, args, required capabilities, context, permissions, and autonomy metadata when supplied in the allowed Skill payload.
+- **FR-008**: System MUST reject executable steps with unsupported Step Type values.
+- **FR-009**: System MUST reject steps that mix Tool and Skill payloads contrary to the selected Step Type.
+- **FR-010**: System MUST surface validation failures through existing task template validation errors before templates are persisted or expanded.
+- **FR-011**: System MUST accept a Jira transition example authored as a Tool step with typed inputs.
+- **FR-012**: System MUST accept a Jira triage or implementation example authored as a Skill step.
+- **FR-013**: System MUST reject Jira transition examples authored as Skill steps when the payload declares a deterministic Tool operation, and reject Jira agentic examples authored as Tool steps when they use Skill-only fields.
+- **FR-014**: System MUST reject arbitrary shell command/script snippets unless represented as an approved typed Tool payload with bounded object inputs and policy metadata.
+
+### Key Entities
+
+- **Executable Step Blueprint**: A task template step definition with common step fields and one selected Step Type.
+- **Tool Step Payload**: Typed deterministic operation metadata including identifier, version, object inputs, and optional policy metadata.
+- **Skill Step Payload**: Agentic work metadata including selector, object args, capabilities, context, permissions, and autonomy controls.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests cover valid Tool, valid Skill, and legacy Skill-shaped executable step validation.
+- **SC-002**: Unit tests cover mixed Tool/Skill payload rejection and unsupported Step Type rejection.
+- **SC-003**: Unit tests cover arbitrary shell-shaped step rejection.
+- **SC-004**: Template expansion preserves valid Tool and Skill Step Type payloads after rendering.
+- **SC-005**: Existing seeded template tests continue to pass without requiring checked-in seed template rewrites.

--- a/specs/277-validate-tool-skill-executable-steps/tasks.md
+++ b/specs/277-validate-tool-skill-executable-steps/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Validate Tool and Skill Executable Steps
+
+**Input**: Design documents from `/specs/277-validate-tool-skill-executable-steps/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Organization**: Tasks are grouped by phase around MM-557's single user story.
+
+**Source Traceability**: FR-001..FR-014, SC-001..SC-005, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-013, DESIGN-REQ-017.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py`
+- Integration tests: focused async task template service tests in `tests/unit/api/test_task_step_templates_service.py` exercise create/save/expand service boundaries without compose
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create MM-557 MoonSpec artifacts and confirm the service boundary.
+
+- [X] T001 Create MoonSpec artifacts for MM-557 in `specs/277-validate-tool-skill-executable-steps/`
+- [X] T002 Confirm executable step validation currently lives at task template schema/service boundaries in `api_service/api/schemas.py`, `api_service/services/task_templates/catalog.py`, and `api_service/services/task_templates/save.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new persistence or external services are required; validation will reuse existing task template errors.
+
+- [X] T003 Verify no database migration or external registry dependency is required for structural executable step validation in `api_service/services/task_templates/catalog.py`
+
+**Checkpoint**: Foundation ready - story test and implementation work can begin
+
+---
+
+## Phase 3: Story - Validate Executable Step Contracts
+
+**Summary**: As an operator, I want Tool and Skill executable steps validated against distinct contracts so deterministic operations and agentic work are configured safely before execution.
+
+**Independent Test**: Create/save/expand task step templates containing Tool and Skill steps and verify valid examples persist while mixed, malformed, forbidden, or shell-shaped steps fail with validation errors.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013, FR-014, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-013, DESIGN-REQ-017
+
+**Test Plan**:
+
+- Unit: task template catalog/save service validation for Tool and Skill payloads.
+- Integration boundary: async service tests persist and expand templates through the same service paths used by API routes.
+
+### Unit Tests (write first)
+
+- [X] T004 [P] Add failing test for valid Jira transition Tool step persistence and expansion in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-002, FR-003, FR-004, FR-011, SC-001, SC-004, DESIGN-REQ-003, DESIGN-REQ-013)
+- [X] T005 [P] Add failing test for explicit Jira triage Skill step and legacy Skill-shaped step validation in `tests/unit/api/test_task_step_templates_service.py` (FR-005, FR-006, FR-007, FR-012, SC-001, DESIGN-REQ-004)
+- [X] T006 [P] Add failing tests for unsupported Step Type and mixed Tool/Skill payload rejection in `tests/unit/api/test_task_step_templates_service.py` (FR-008, FR-009, FR-010, FR-013, SC-002, DESIGN-REQ-005, DESIGN-REQ-013)
+- [X] T007 [P] Add failing tests for arbitrary shell field rejection and bounded typed command Tool acceptance in `tests/unit/api/test_task_step_templates_service.py` (FR-014, SC-003, DESIGN-REQ-017)
+- [X] T008 Run `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py` to confirm new tests fail for expected validation gaps
+
+### Integration Tests (write first)
+
+- [X] T009 Treat async create/save/expand tests in `tests/unit/api/test_task_step_templates_service.py` as the service integration boundary for MM-557 because they exercise persistence and expansion without external dependencies
+
+### Implementation
+
+- [X] T010 Add Step Type, Tool payload, and Skill metadata request/response schema fields in `api_service/api/schemas.py` (FR-001, FR-004, FR-005, FR-007)
+- [X] T011 Add common executable Step Type normalization and shell-field rejection in `api_service/services/task_templates/catalog.py` (FR-008, FR-010, FR-014)
+- [X] T012 Add Tool step validation and normalization in `api_service/services/task_templates/catalog.py` (FR-001, FR-002, FR-003, FR-004, FR-011)
+- [X] T013 Add explicit Skill step validation, broader Skill metadata preservation, and mixed payload rejection in `api_service/services/task_templates/catalog.py` (FR-005, FR-006, FR-007, FR-009, FR-012, FR-013)
+- [X] T014 Preserve and validate Tool/Skill step payloads in save-from-task sanitization in `api_service/services/task_templates/save.py` (FR-001, FR-004, FR-005, FR-007, FR-010)
+- [X] T015 Preserve normalized Tool and Skill Step Type payloads during expansion in `api_service/services/task_templates/catalog.py` (FR-004, FR-007, SC-004)
+- [X] T016 Story validation: Run `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py` and fix failures until MM-557 tests pass
+
+**Checkpoint**: The story is functional, covered by focused service tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate without adding hidden scope.
+
+- [X] T017 Run `./tools/test_unit.sh`
+- [X] T018 Run `/moonspec-verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-557
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 and Phase 2 are complete.
+- T004-T007 must be written before implementation.
+- T010-T015 follow red-first confirmation.
+- T016 validates focused backend behavior.
+- T017-T018 are final validation.
+
+## Implementation Strategy
+
+1. Add failing task template service tests for the MM-557 Tool/Skill validation contract.
+2. Extend API schemas and service sanitization to preserve explicit Step Type payloads.
+3. Implement common, Tool-specific, Skill-specific, and shell-snippet validation.
+4. Reuse existing template validation error paths so failures surface before persistence or expansion.
+5. Run focused unit tests, then the managed unit suite when feasible.
+6. Verify artifacts and implementation against MM-557.

--- a/specs/277-validate-tool-skill-executable-steps/verification.md
+++ b/specs/277-validate-tool-skill-executable-steps/verification.md
@@ -1,0 +1,73 @@
+# MoonSpec Verification Report
+
+**Feature**: Validate Tool and Skill Executable Steps  
+**Spec**: `/work/agent_jobs/mm:ac3fde5a-c2b2-4b8a-8d49-5b1cf87e4d91/repo/specs/277-validate-tool-skill-executable-steps/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving canonical Jira preset brief for `MM-557`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused Unit | `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py` | PASS | 36 backend task-template tests passed; the script also ran 17 frontend Vitest files with 465 tests passed. |
+| Full Unit | `./tools/test_unit.sh` | PASS | 4196 Python tests passed, 1 xpassed, 16 subtests passed; 17 frontend Vitest files with 465 tests passed. Existing warnings only. |
+| Formatting | `python -m black ...` | NOT RUN | `black` is not installed in the managed environment. Syntax and behavior were covered by the passing unit suite. |
+| Hermetic Compose Integration | `./tools/test_integration.sh` | NOT RUN | Docker socket is unavailable in this managed container (`/var/run/docker.sock` missing), so compose-backed integration could not be started. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `TaskTemplateStepBlueprintSchema.type`, `TaskTemplateStepBlueprintSchema.tool`; `catalog._normalize_step_type`; `test_mm557_accepts_and_expands_jira_transition_tool_step` | VERIFIED | Tool steps require `type: tool` and a Tool payload. |
+| FR-002 | `catalog._normalize_tool_payload`; Jira transition Tool test | VERIFIED | Requires non-empty `tool.id` or `tool.name`. |
+| FR-003 | `catalog._normalize_tool_payload`; Tool tests | VERIFIED | Requires `tool.inputs`/`tool.args` to be objects. |
+| FR-004 | `catalog._normalize_tool_payload`; expansion preservation in `_expand_version_steps`; Tool expansion test | VERIFIED | Tool identifier, version, inputs, capabilities, auth, side-effect, retry, execution, and validation metadata are preserved when supplied. |
+| FR-005 | `catalog._normalize_skill_payload`; explicit and legacy Skill tests | VERIFIED | Explicit `type: skill` and legacy skill-shaped default validate as Skill. |
+| FR-006 | `catalog._normalize_skill_payload`; explicit Skill test | VERIFIED | Skill args must be an object and required capabilities must be a list. |
+| FR-007 | `TaskTemplateStepSkillSchema`; `catalog._normalize_skill_payload`; explicit Skill metadata test | VERIFIED | Skill context, permissions, autonomy, runtime, and allowedTools metadata are preserved. |
+| FR-008 | `catalog._normalize_step_type`; unsupported type test | VERIFIED | Unsupported Step Type values fail fast. |
+| FR-009 | catalog Tool/Skill mismatch checks; mixed payload tests | VERIFIED | Mixed Tool/Skill payloads are rejected. |
+| FR-010 | Existing `TaskTemplateValidationError` paths plus MM-557 rejection tests | VERIFIED | Validation failures surface before persistence or expansion. |
+| FR-011 | Jira transition Tool test | VERIFIED | Deterministic Jira transition validates as Tool. |
+| FR-012 | Jira triage Skill test | VERIFIED | Agentic Jira triage validates as Skill. |
+| FR-013 | Mixed Jira payload rejection tests | VERIFIED | Swapped/mixed Jira examples fail. |
+| FR-014 | `_FORBIDDEN_STEP_KEYS`; command-like typed Tool policy check; shell rejection test | VERIFIED | Top-level shell snippets are rejected; bounded typed command Tool is accepted only with object inputs and policy metadata. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Tool step accepted only with typed contract | `test_mm557_accepts_and_expands_jira_transition_tool_step` | VERIFIED | Covers identifier, inputs, metadata, persistence, and expansion. |
+| Skill step accepted only with Skill contract | `test_mm557_accepts_explicit_and_legacy_skill_steps` | VERIFIED | Covers explicit Skill, legacy Skill-shaped data, args, capabilities, and metadata. |
+| Legacy omitted Step Type remains Skill-shaped only | `test_mm557_accepts_explicit_and_legacy_skill_steps` | VERIFIED | Legacy step is normalized as Skill and does not gain Tool semantics. |
+| Mixed/missing payloads rejected | `test_mm557_rejects_unsupported_or_mixed_step_type_payloads` | VERIFIED | Covers unsupported type and Tool/Skill payload mismatch. |
+| Arbitrary shell snippets rejected | `test_mm557_rejects_shell_snippets_unless_bounded_typed_tool` | VERIFIED | Covers top-level `command` rejection and typed bounded command Tool acceptance. |
+| Jira examples stay distinct | Tool and Skill Jira tests plus mixed rejection tests | VERIFIED | Jira transition is Tool; Jira triage/implementation is Skill. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-003 | Tool schema/service validation and Tool tests | VERIFIED | Tool steps are typed executable operations with bounded metadata. |
+| DESIGN-REQ-004 | Skill schema/service validation and Skill tests | VERIFIED | Skill steps preserve agent-facing selector and control metadata. |
+| DESIGN-REQ-005 | Step Type validation and `TaskTemplateValidationError` tests | VERIFIED | Common validation catches unsupported or malformed executable steps before use. |
+| DESIGN-REQ-013 | Jira Tool/Skill acceptance and rejection tests | VERIFIED | Deterministic Jira operations and agentic Jira work are not interchangeable. |
+| DESIGN-REQ-017 | Shell field rejection and command-like Tool policy check | VERIFIED | Arbitrary shell scripts are not a first-class Step Type. |
+| Constitution XI | `spec.md`, `plan.md`, `tasks.md`, `verification.md` | VERIFIED | Spec-driven artifacts preserve MM-557 and precede implementation evidence. |
+| Constitution XIII | fail-fast unsupported Step Type validation | VERIFIED | No hidden compatibility transform gives unsupported explicit values new semantics. |
+
+## Original Request Alignment
+
+- PASS. The implementation uses the MM-557 Jira preset brief as the canonical MoonSpec input and preserves `MM-557` in spec artifacts and tests.
+- PASS. Runtime mode was used; the implementation changes executable step validation behavior.
+- PASS. The input was classified as a single-story feature request, and no prior MM-557 spec artifacts existed under `specs/`.
+- PASS. Tool and Skill executable steps are validated through distinct contracts before template persistence/expansion.
+
+## Gaps
+
+- None blocking.
+
+## Remaining Work
+
+- None for MM-557.

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1954,3 +1954,71 @@ async def test_mm557_rejects_shell_snippets_unless_bounded_typed_tool(tmp_path):
 
     assert created["steps"][0]["tool"]["id"] == "command.run_typed"
     assert created["steps"][0]["tool"]["inputs"] == {"commandId": "unit-tests"}
+
+
+async def test_mm557_tool_args_survive_empty_schema_inputs(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            created = await service.create_template(
+                slug="tool-args-fallback",
+                title="Tool Args Fallback",
+                description="Tool args from API request payload",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "type": "tool",
+                        "instructions": "Fetch Jira issue.",
+                        "tool": {
+                            "name": "jira.get_issue",
+                            "inputs": {},
+                            "args": {"issueKey": "MM-557"},
+                        },
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+    assert created["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-557"}
+
+
+async def test_mm557_command_tool_rejects_empty_policy_metadata(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="command-like Tool steps require bounded inputs and policy metadata",
+            ):
+                await service.create_template(
+                    slug="empty-command-policy",
+                    title="Empty Command Policy",
+                    description="Command tool with default schema metadata",
+                    scope="personal",
+                    scope_ref=str(user_id),
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "type": "tool",
+                            "instructions": "Run a bounded test command.",
+                            "tool": {
+                                "name": "command.run_typed",
+                                "inputs": {"commandId": "unit-tests"},
+                                "validation": {},
+                            },
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=user_id,
+                )

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1732,3 +1732,225 @@ async def test_sync_seed_templates_updates_existing_seed(tmp_path):
             assert len(template.latest_version.steps) == 2
             assert template.latest_version.steps[0]["skill"]["id"] == "moonspec-specify"
             assert template.latest_version.annotations["sourceSkill"] == "moonspec-orchestrate"
+
+async def test_mm557_accepts_and_expands_jira_transition_tool_step(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            created = await service.create_template(
+                slug="jira-transition-tool",
+                title="Jira Transition Tool",
+                description="Typed Jira transition",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=["jira"],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "type": "tool",
+                        "title": "Move Jira issue",
+                        "instructions": "Move MM-557 to In Progress.",
+                        "tool": {
+                            "id": "jira.transition_issue",
+                            "version": "1.0.0",
+                            "inputs": {
+                                "issueKey": "MM-557",
+                                "targetStatus": "In Progress",
+                            },
+                            "requiredAuthorization": "jira",
+                            "requiredCapabilities": ["jira"],
+                            "sideEffectPolicy": "idempotent-by-transition-target",
+                        },
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+            expanded = await service.expand_template(
+                slug="jira-transition-tool",
+                scope="personal",
+                scope_ref=str(user_id),
+                version="1.0.0",
+                inputs={},
+                context={},
+                options=ExpandOptions(should_enforce_step_limit=True),
+                user_id=user_id,
+            )
+
+    step = created["steps"][0]
+    assert step["type"] == "tool"
+    assert step["tool"]["id"] == "jira.transition_issue"
+    assert step["tool"]["inputs"]["issueKey"] == "MM-557"
+    assert step["tool"]["requiredCapabilities"] == ["jira"]
+    assert expanded["steps"][0]["type"] == "tool"
+    assert expanded["steps"][0]["tool"]["id"] == "jira.transition_issue"
+
+async def test_mm557_accepts_explicit_and_legacy_skill_steps(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            created = await service.create_template(
+                slug="jira-skill-steps",
+                title="Jira Skill Steps",
+                description="Agentic Jira steps",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=["jira"],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "type": "skill",
+                        "title": "Triage Jira issue",
+                        "instructions": "Read MM-557 and decide next action.",
+                        "skill": {
+                            "id": "jira-triage",
+                            "args": {"issueKey": "MM-557"},
+                            "requiredCapabilities": ["jira"],
+                            "context": {"repository": "MoonLadderStudios/MoonMind"},
+                            "permissions": {"jira": "read"},
+                            "autonomy": {"mode": "bounded"},
+                        },
+                    },
+                    {
+                        "title": "Legacy implementation step",
+                        "instructions": "Implement MM-557.",
+                        "skill": {"id": "jira-implement", "args": {"issueKey": "MM-557"}},
+                    },
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+    explicit, legacy = created["steps"]
+    assert explicit["type"] == "skill"
+    assert explicit["skill"]["id"] == "jira-triage"
+    assert explicit["skill"]["context"]["repository"] == "MoonLadderStudios/MoonMind"
+    assert explicit["skill"]["permissions"] == {"jira": "read"}
+    assert explicit["skill"]["autonomy"] == {"mode": "bounded"}
+    assert legacy["type"] == "skill"
+    assert legacy["skill"]["id"] == "jira-implement"
+
+async def test_mm557_rejects_unsupported_or_mixed_step_type_payloads(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            with pytest.raises(TaskTemplateValidationError, match="Step 1 type must be one of: tool, skill"):
+                await service.create_template(
+                    slug="bad-type",
+                    title="Bad Type",
+                    description="Bad type",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[{"type": "command", "instructions": "Run something"}],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+            with pytest.raises(TaskTemplateValidationError, match="Step 1 Tool step must not include a skill payload"):
+                await service.create_template(
+                    slug="tool-with-skill",
+                    title="Tool With Skill",
+                    description="Bad tool",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "type": "tool",
+                            "instructions": "Implement MM-557.",
+                            "skill": {"id": "jira-implement", "args": {"issueKey": "MM-557"}},
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+            with pytest.raises(TaskTemplateValidationError, match="Step 1 Skill step must not include a tool payload"):
+                await service.create_template(
+                    slug="skill-with-tool",
+                    title="Skill With Tool",
+                    description="Bad skill",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "type": "skill",
+                            "instructions": "Move MM-557.",
+                            "tool": {
+                                "id": "jira.transition_issue",
+                                "inputs": {"issueKey": "MM-557"},
+                            },
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+async def test_mm557_rejects_shell_snippets_unless_bounded_typed_tool(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            with pytest.raises(TaskTemplateValidationError, match="forbidden keys: command"):
+                await service.create_template(
+                    slug="shell-snippet",
+                    title="Shell Snippet",
+                    description="Bad shell",
+                    scope="personal",
+                    scope_ref=str(user_id),
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "type": "skill",
+                            "instructions": "Run a shell snippet.",
+                            "command": "bash deploy.sh",
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=user_id,
+                )
+
+            created = await service.create_template(
+                slug="bounded-command-tool",
+                title="Bounded Command Tool",
+                description="Approved typed command",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "type": "tool",
+                        "instructions": "Run a bounded test command.",
+                        "tool": {
+                            "name": "command.run_typed",
+                            "inputs": {"commandId": "unit-tests"},
+                            "requiredCapabilities": ["command-runner"],
+                            "sideEffectPolicy": "bounded",
+                            "validation": {"schema": "registered"},
+                        },
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+    assert created["steps"][0]["tool"]["id"] == "command.run_typed"
+    assert created["steps"][0]["tool"]["inputs"] == {"commandId": "unit-tests"}


### PR DESCRIPTION
## Summary

- Validate Tool and Skill executable step contracts for task templates.
- Preserve the MM-557 MoonSpec feature artifacts under `specs/277-validate-tool-skill-executable-steps/`.
- Add service-boundary regression coverage for valid Tool/Skill steps, mixed payload rejection, unsupported Step Type rejection, and shell-snippet rejection.

## Jira

- MM-557

## Active MoonSpec Feature Path

- `specs/277-validate-tool-skill-executable-steps/`

## Verification Verdict

- FULLY_IMPLEMENTED

## Tests Run

- `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py` - PASS
- `./tools/test_unit.sh` - PASS
- `./tools/test_integration.sh` - NOT RUN; Docker socket unavailable in the managed container

## Remaining Risks

- None blocking.
