### PR TITLE
MM-558: Preview and apply Preset steps

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/277-validate-tool-skill-executable-steps"
+  "feature_directory": "specs/278-preview-apply-preset-steps"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-556",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1837"
+  "jira_issue_key": "MM-558",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1840"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": 3158058337,
-    "disposition": "addressed",
-    "rationale": "Updated tool payload normalization so non-empty tool.args is preserved when schema-provided tool.inputs is an empty object, with unit coverage."
-  },
-  {
-    "id": 3158058340,
-    "disposition": "addressed",
-    "rationale": "Command-like tool validation now requires substantive sideEffectPolicy or validation metadata instead of accepting empty default objects, with unit coverage."
-  },
-  {
-    "id": 4193474718,
+    "id": 4340312586,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary container; actionable inline comments from this review are tracked separately."
+    "rationale": "Quota warning from gemini-code-assist; no code feedback to address."
   },
   {
-    "id": 4193481160,
+    "id": 4340316442,
     "disposition": "not-applicable",
-    "rationale": "Review body explicitly states there is no feedback to address."
+    "rationale": "Duplicate quota warning from gemini-code-assist; no code feedback to address."
+  },
+  {
+    "id": 3158201200,
+    "disposition": "addressed",
+    "rationale": "Preset-generated Tool steps now preserve and submit their executable tool binding after Apply preview, with regression coverage."
+  },
+  {
+    "id": 4193618593,
+    "disposition": "not-applicable",
+    "rationale": "Review summary container for the actionable inline comment; no separate code change requested."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7000,7 +7000,9 @@ describe("Task Create Entrypoint", () => {
       );
     });
 
-    const request = latestCreateRequest();
+    const request = latestCreateRequest() as {
+      payload: { task: { steps: Array<Record<string, unknown>> } };
+    };
     expect(request.payload.task.steps[0]).toEqual({
       id: "tpl:speckit-demo:1.2.3:01",
       title: "Fetch Jira issue",
@@ -7011,7 +7013,7 @@ describe("Task Create Entrypoint", () => {
         inputs: { issueKey: "MM-558" },
       },
     });
-    expect(request.payload.task.steps[0].skill).toBeUndefined();
+    expect(request.payload.task.steps[0]?.["skill"]).toBeUndefined();
   });
 
   it("keeps the draft unchanged when step preset preview expansion fails", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6760,7 +6760,10 @@ describe("Task Create Entrypoint", () => {
 
     expect(instructions.value).toBe("Keep this Step Type instruction.");
     expect(within(step).getByLabelText("Preset")).toBeTruthy();
-    expect(within(step).getByRole("button", { name: "Apply" })).toBeTruthy();
+    expect(within(step).getByRole("button", { name: "Preview" })).toBeTruthy();
+    expect(
+      within(step).getByRole("button", { name: "Apply preview" }),
+    ).toBeTruthy();
     expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
     expect(within(step).queryByLabelText("Tool")).toBeNull();
   });
@@ -6808,6 +6811,225 @@ describe("Task Create Entrypoint", () => {
 
     expect(firstPreset.value).toBe(secondValue);
     expect(secondPreset.value).toBe(secondValue);
+  });
+
+  it("previews step preset generated steps and warnings without mutating the draft", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:speckit-demo:1.2.3:01",
+                title: "Fetch Jira issue",
+                instructions: "Fetch MM-558.",
+                tool: {
+                  type: "tool",
+                  id: "jira.get_issue",
+                  inputs: { issueKey: "MM-558" },
+                },
+                source: {
+                  kind: "preset-derived",
+                  presetId: "speckit-demo",
+                },
+              },
+              {
+                id: "tpl:speckit-demo:1.2.3:02",
+                title: "Implement issue",
+                instructions: "Implement MM-558.",
+                skill: {
+                  id: "moonspec-orchestrate",
+                  args: { issueKey: "MM-558" },
+                },
+              },
+            ],
+            appliedTemplate: {
+              slug: "speckit-demo",
+              version: "1.2.3",
+            },
+            warnings: ["Auto-filled Feature Name."],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Keep authored placeholder." },
+    });
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+
+    expect(await within(step).findByText("Preset preview")).toBeTruthy();
+    expect(within(step).getByText("Fetch Jira issue")).toBeTruthy();
+    expect(within(step).getAllByText("Tool").length).toBeGreaterThan(0);
+    expect(within(step).getByText("Implement issue")).toBeTruthy();
+    expect(within(step).getAllByText("Skill").length).toBeGreaterThan(0);
+    expect(within(step).getByText("Auto-filled Feature Name.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Keep authored placeholder.")).toBeTruthy();
+    expect(screen.queryByDisplayValue("Fetch MM-558.")).toBeNull();
+  });
+
+  it("applies a step preset preview by replacing the selected preset step with editable generated steps", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+    expect(await within(step).findByText("Clarify spec")).toBeTruthy();
+    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+
+    expect(await screen.findByDisplayValue("Clarify the {{ inputs.feature_name }} scope.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Write a plan for the task builder recovery.")).toBeTruthy();
+    expect(screen.queryByLabelText("Step Preset")).toBeNull();
+
+    const firstGeneratedStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(firstGeneratedStep).getByLabelText("Instructions"), {
+      target: { value: "Edited generated step." },
+    });
+    expect(screen.getByDisplayValue("Edited generated step.")).toBeTruthy();
+  });
+
+  it("keeps the draft unchanged when step preset preview expansion fails", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: false,
+          text: async () => "Generated step validation failed.",
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Keep authored preset step." },
+    });
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+
+    expect(
+      await within(step).findByText(
+        "Failed to preview preset: Generated step validation failed.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue("Keep authored preset step.")).toBeTruthy();
+    expect(screen.queryByDisplayValue("Clarify the {{ inputs.feature_name }} scope.")).toBeNull();
+  });
+
+  it("blocks submission while unresolved preset steps remain", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Do not submit unresolved preset." },
+    });
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText(
+        "Preview and apply Preset steps before submitting.",
+      ),
+    ).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+    ).toBe(false);
+  });
+
+  it("previews and applies a step preset from the step editor without using Task Presets", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const taskPresetsSection = await screen.findByLabelText("Task Presets");
+    expect(within(taskPresetsSection).getByRole("button", { name: "Apply" })).toBeTruthy();
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+    expect(await within(step).findByText("Clarify spec")).toBeTruthy();
+    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+
+    expect(await screen.findByDisplayValue("Clarify the {{ inputs.feature_name }} scope.")).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("preserves hidden Skill fields but blocks Tool submissions without a selected Tool", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6926,6 +6926,94 @@ describe("Task Create Entrypoint", () => {
     expect(screen.getByDisplayValue("Edited generated step.")).toBeTruthy();
   });
 
+  it("submits preset-generated tool steps with their executable tool binding after apply", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:speckit-demo:1.2.3:01",
+                title: "Fetch Jira issue",
+                instructions: "Fetch MM-558.",
+                tool: {
+                  type: "tool",
+                  id: "jira.get_issue",
+                  inputs: { issueKey: "MM-558" },
+                },
+              },
+              {
+                id: "tpl:speckit-demo:1.2.3:02",
+                title: "Implement issue",
+                instructions: "Implement MM-558.",
+                skill: {
+                  id: "moonspec-orchestrate",
+                  args: { issueKey: "MM-558" },
+                },
+              },
+            ],
+            appliedTemplate: {
+              slug: "speckit-demo",
+              version: "1.2.3",
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Step Type"), {
+      target: { value: "preset" },
+    });
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+    expect(await within(step).findByText("Fetch Jira issue")).toBeTruthy();
+    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+
+    expect(await screen.findByDisplayValue("Fetch MM-558.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const request = latestCreateRequest();
+    expect(request.payload.task.steps[0]).toEqual({
+      id: "tpl:speckit-demo:1.2.3:01",
+      title: "Fetch Jira issue",
+      instructions: "Fetch MM-558.",
+      tool: {
+        type: "tool",
+        id: "jira.get_issue",
+        inputs: { issueKey: "MM-558" },
+      },
+    });
+    expect(request.payload.task.steps[0].skill).toBeUndefined();
+  });
+
   it("keeps the draft unchanged when step preset preview expansion fails", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -464,6 +464,7 @@ interface TaskTemplateListResponse {
 interface TaskTemplateStepSkill {
   id?: string;
   name?: string;
+  type?: string;
   args?: Record<string, unknown>;
   inputs?: Record<string, unknown>;
   requiredCapabilities?: string[];
@@ -541,6 +542,8 @@ interface StepState {
   templateInstructions: string;
   inputAttachments: StepAttachmentRef[];
   templateAttachments: StepAttachmentRef[];
+  generatedTool?: TaskTemplateStepSkill;
+  generatedSkill?: TaskTemplateStepSkill;
   storyOutput?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
 }
@@ -1339,6 +1342,21 @@ function isTemplateBoundStepForAttachments(
   );
 }
 
+function executableGeneratedToolPayload(
+  step: StepState | null | undefined,
+): TaskTemplateStepSkill | null {
+  if (step?.stepType !== "tool" || !step.generatedTool) {
+    return null;
+  }
+  const toolId = String(
+    step.generatedTool.id || step.generatedTool.name || "",
+  ).trim();
+  if (!toolId) {
+    return null;
+  }
+  return step.generatedTool;
+}
+
 function validatePrimaryStepSubmission(
   primaryStep: StepState | null,
   options: { additionalStepsCount?: number } = {},
@@ -1349,6 +1367,15 @@ function validatePrimaryStepSubmission(
     return { ok: false, error: "Add at least one step before submitting." };
   }
   if (primaryStep.stepType === "tool") {
+    if (executableGeneratedToolPayload(primaryStep)) {
+      return {
+        ok: true,
+        value: {
+          instructions: primaryStep.instructions.trim(),
+          skillId: "",
+        },
+      };
+    }
     return {
       ok: false,
       error: "Select a Tool before submitting a Tool step.",
@@ -1759,6 +1786,8 @@ function mapExpandedStepToState(
     templateStepId: stepId,
     templateInstructions: instructions,
     templateAttachments,
+    ...(step.tool ? { generatedTool: step.tool } : {}),
+    ...(step.skill ? { generatedSkill: step.skill } : {}),
     ...(storyOutput ? { storyOutput } : {}),
     ...(jiraOrchestration ? { jiraOrchestration } : {}),
   });
@@ -5489,6 +5518,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         return;
       }
       const stepIsSkill = step.stepType === "skill";
+      const generatedToolPayload = executableGeneratedToolPayload(step);
       const stepSkillId = stepIsSkill ? step.skillId.trim() : "";
       const stepSkillArgsRaw = stepIsSkill && showAdvancedStepOptions
         ? step.skillArgs.trim()
@@ -5503,7 +5533,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         step.inputAttachments.length > 0 ||
         Boolean(stepSkillId) ||
         Boolean(stepSkillArgsRaw) ||
-        stepSkillCaps.length > 0;
+        stepSkillCaps.length > 0 ||
+        Boolean(generatedToolPayload);
       let stepSkillArgs: Record<string, unknown> = {};
       if (stepSkillArgsRaw) {
         try {
@@ -5776,7 +5807,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (step.title.trim()) {
         stepPayload.title = step.title.trim();
       }
-      if (stepSkillId || stepSkillArgsRaw || stepSkillCaps.length > 0) {
+      const generatedToolPayload = executableGeneratedToolPayload(step);
+      if (generatedToolPayload) {
+        stepPayload.tool = generatedToolPayload;
+      } else if (stepSkillId || stepSkillArgsRaw || stepSkillCaps.length > 0) {
         stepPayload.tool = {
           type: "skill",
           name: stepSkillId || primarySkillId,
@@ -5802,6 +5836,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       Boolean(primaryInstructionsForSubmit) &&
       objectiveInstructionsForSubmit !== primaryInstructionsForSubmit;
     const hasTemplateBoundStep = steps.some((step) => Boolean(step.id.trim()));
+    const primaryGeneratedToolPayload =
+      executableGeneratedToolPayload(primaryStep);
     const includeExplicitSteps =
       additionalSteps.length > 0 ||
       includePrimaryStepForObjectiveOverride ||
@@ -5821,7 +5857,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 : pageMode.mode !== "create"
                   ? { inputAttachments: [] }
                 : {}),
-              ...(primaryStepHasSkillOverride
+              ...(primaryGeneratedToolPayload
+                ? { tool: primaryGeneratedToolPayload }
+                : primaryStepHasSkillOverride
                 ? { tool: primaryStepTool, skill: primaryStepSkill }
                 : {}),
             },

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -475,6 +475,8 @@ interface ExpandedStepPayload {
   instructions?: string;
   skill?: TaskTemplateStepSkill;
   tool?: TaskTemplateStepSkill;
+  type?: string;
+  source?: Record<string, unknown>;
   inputAttachments?: StepAttachmentRef[];
   attachments?: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
@@ -493,6 +495,7 @@ interface TaskTemplateExpandResponse {
     appliedAt?: string;
   };
   capabilities?: string[];
+  warnings?: string[];
 }
 
 interface TemplateOption extends TaskTemplateSummary {
@@ -533,12 +536,32 @@ interface StepState {
   presetKey: string;
   presetMessage: string | null;
   presetReapplyNeeded: boolean;
+  presetPreview: PresetPreviewState | null;
   templateStepId: string;
   templateInstructions: string;
   inputAttachments: StepAttachmentRef[];
   templateAttachments: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
+}
+
+interface PresetPreviewStep {
+  title: string;
+  stepType: StepType;
+  sourceLabel: string;
+}
+
+interface PresetPreviewState {
+  presetKey: string;
+  presetTitle: string;
+  version: string;
+  expandedSteps: ExpandedStepPayload[];
+  previewSteps: PresetPreviewStep[];
+  warnings: string[];
+  inputs: Record<string, unknown>;
+  assumptions: string[];
+  capabilities: string[];
+  appliedTemplate?: TaskTemplateExpandResponse["appliedTemplate"];
 }
 
 interface AppliedTemplateState {
@@ -1114,6 +1137,7 @@ function createStepStateEntry(
     presetKey: "",
     presetMessage: null,
     presetReapplyNeeded: false,
+    presetPreview: null,
     templateStepId: "",
     templateInstructions: "",
     inputAttachments: [],
@@ -1328,6 +1352,12 @@ function validatePrimaryStepSubmission(
     return {
       ok: false,
       error: "Select a Tool before submitting a Tool step.",
+    };
+  }
+  if (primaryStep.stepType === "preset") {
+    return {
+      ok: false,
+      error: "Preview and apply Preset steps before submitting.",
     };
   }
   const instructions = primaryStep.instructions.trim();
@@ -1690,6 +1720,11 @@ function mapExpandedStepToState(
   index: number,
   step: ExpandedStepPayload,
 ): StepState {
+  const rawType = String(step.type || "").trim().toLowerCase();
+  const isToolStep =
+    rawType === "tool" ||
+    Boolean(step.tool && !step.skill) ||
+    String(step.tool?.type || "").trim().toLowerCase() === "tool";
   const tool = step.tool || step.skill || {};
   const inlineInputs =
     tool.inputs && typeof tool.inputs === "object"
@@ -1716,6 +1751,7 @@ function mapExpandedStepToState(
   return createStepStateEntry(index, {
     id: stepId,
     title: String(step.title || "").trim(),
+    stepType: isToolStep ? "tool" : "skill",
     instructions,
     skillId: String(tool.name || tool.id || "").trim(),
     skillArgs: stringifySkillArgs(inlineInputs),
@@ -4427,6 +4463,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       presetKey,
       presetMessage: null,
       presetReapplyNeeded: false,
+      presetPreview: null,
     });
   }
 
@@ -4470,7 +4507,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function handleStepTypeChange(localId: string, value: string) {
     const nextType: StepType =
       value === "tool" || value === "preset" ? value : "skill";
-    updateStep(localId, { stepType: nextType });
+    updateStep(localId, { stepType: nextType, presetPreview: null });
   }
 
   function addStep() {
@@ -4726,17 +4763,42 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     return (await response.json()) as TaskTemplateDetail;
   }
 
-  async function applyPresetToDraft({
+  function previewStepType(step: ExpandedStepPayload): StepType {
+    const rawType = String(step.type || "").trim().toLowerCase();
+    if (
+      rawType === "tool" ||
+      Boolean(step.tool && !step.skill) ||
+      String(step.tool?.type || "").trim().toLowerCase() === "tool"
+    ) {
+      return "tool";
+    }
+    return "skill";
+  }
+
+  function previewSourceLabel(step: ExpandedStepPayload): string {
+    const source = step.source;
+    if (!source || typeof source !== "object") {
+      return "";
+    }
+    const presetId = String(source.presetId || source.presetSlug || "").trim();
+    const originalStepId = String(source.originalStepId || "").trim();
+    return [
+      presetId ? `origin ${presetId}` : "",
+      originalStepId ? `step ${originalStepId}` : "",
+    ]
+      .filter(Boolean)
+      .join(" / ");
+  }
+
+  async function expandPresetForDraft({
     preset,
     detail,
     inputValues,
-    setMessage,
   }: {
     preset: TemplateOption;
     detail: TaskTemplateDetail;
     inputValues: Record<string, unknown>;
-    setMessage: (message: string) => void;
-  }) {
+  }): Promise<PresetPreviewState> {
     const scopeParams = {
       scope: preset.scope,
       scopeRef: preset.scopeRef || undefined,
@@ -4745,6 +4807,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       detail.inputs || [],
       inputValues,
     );
+    const version =
+      detail.version || detail.latestVersion || preset.latestVersion || "1.0.0";
     const presetRuntime = runtime.trim().toLowerCase();
     const expandResponse = await fetch(
       withQueryParams(
@@ -4760,11 +4824,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           Accept: "application/json",
         },
         body: JSON.stringify({
-          version:
-            detail.version ||
-            detail.latestVersion ||
-            preset.latestVersion ||
-            "1.0.0",
+          version,
           inputs,
           context: {
             repository: repository.trim() || defaultRepository,
@@ -4777,11 +4837,83 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
     if (!expandResponse.ok) {
       throw new Error(
-        await responseErrorMessage(expandResponse, "Failed to apply preset."),
+        await responseErrorMessage(expandResponse, "Failed to preview preset."),
       );
     }
     const expanded = (await expandResponse.json()) as TaskTemplateExpandResponse;
-    const expandedSteps = (expanded.steps || []).map((step, index) =>
+    const expandedSteps = expanded.steps || [];
+    return {
+      presetKey: preset.key,
+      presetTitle: preset.title,
+      version,
+      expandedSteps,
+      previewSteps: expandedSteps.map((step, index) => ({
+        title: String(step.title || step.id || `Step ${index + 1}`).trim(),
+        stepType: previewStepType(step),
+        sourceLabel: previewSourceLabel(step),
+      })),
+      warnings: Array.isArray(expanded.warnings)
+        ? expanded.warnings.map((warning) => String(warning)).filter(Boolean)
+        : [],
+      inputs,
+      assumptions,
+      capabilities: Array.isArray(expanded.capabilities)
+        ? expanded.capabilities
+        : [],
+      appliedTemplate: expanded.appliedTemplate,
+    };
+  }
+
+  function recordAppliedPreset(
+    preset: TemplateOption,
+    detail: TaskTemplateDetail,
+    preview: PresetPreviewState,
+    expandedSteps: StepState[],
+  ) {
+    if (expandedSteps.length === 0) {
+      return;
+    }
+    const appliedTemplate = preview.appliedTemplate || {};
+    setAppliedTemplates((current) => [
+      ...current,
+      {
+        slug: String(appliedTemplate.slug || preset.slug),
+        version: String(
+          appliedTemplate.version ||
+            detail.version ||
+            preset.latestVersion ||
+            "1.0.0",
+        ),
+        inputs:
+          appliedTemplate.inputs &&
+          typeof appliedTemplate.inputs === "object"
+            ? appliedTemplate.inputs
+            : preview.inputs,
+        stepIds: Array.isArray(appliedTemplate.stepIds)
+          ? appliedTemplate.stepIds
+          : expandedSteps.map((step) => step.id).filter(Boolean),
+        appliedAt:
+          String(appliedTemplate.appliedAt || "").trim() ||
+          new Date().toISOString(),
+        capabilities: preview.capabilities,
+      },
+    ]);
+  }
+
+  function applyPresetPreviewToDraft({
+    preset,
+    detail,
+    preview,
+    setMessage,
+    replaceLocalId,
+  }: {
+    preset: TemplateOption;
+    detail: TaskTemplateDetail;
+    preview: PresetPreviewState;
+    setMessage: (message: string) => void;
+    replaceLocalId?: string;
+  }) {
+    const expandedSteps = preview.expandedSteps.map((step, index) =>
       mapExpandedStepToState(nextStepNumber + index, step),
     );
     if (hasAdvancedStepOptionValues(expandedSteps)) {
@@ -4791,6 +4923,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       steps.length === 1 && isEmptyStepStateEntry(steps[0]);
 
     setSteps((current) => {
+      if (replaceLocalId) {
+        const targetIndex = current.findIndex(
+          (step) => step.localId === replaceLocalId,
+        );
+        if (targetIndex >= 0) {
+          const next = current.slice();
+          next.splice(targetIndex, 1, ...expandedSteps);
+          return next.length > 0 ? next : [createStepStateEntry(nextStepNumber)];
+        }
+      }
       if (replaceEmptyDefault) {
         return expandedSteps.length > 0
           ? expandedSteps
@@ -4803,42 +4945,29 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setAppliedTemplateObjectiveAttachmentSignature(
       attachmentSignature(selectedObjectiveAttachmentFiles),
     );
-    if (expandedSteps.length > 0) {
-      const appliedTemplate = expanded.appliedTemplate || {};
-      setAppliedTemplates((current) => [
-        ...current,
-        {
-          slug: String(appliedTemplate.slug || preset.slug),
-          version: String(
-            appliedTemplate.version ||
-              detail.version ||
-              preset.latestVersion ||
-              "1.0.0",
-          ),
-          inputs:
-            appliedTemplate.inputs &&
-            typeof appliedTemplate.inputs === "object"
-              ? appliedTemplate.inputs
-              : inputs,
-          stepIds: Array.isArray(appliedTemplate.stepIds)
-            ? appliedTemplate.stepIds
-            : expandedSteps.map((step) => step.id).filter(Boolean),
-          appliedAt:
-            String(appliedTemplate.appliedAt || "").trim() ||
-            new Date().toISOString(),
-          capabilities: Array.isArray(expanded.capabilities)
-            ? expanded.capabilities
-            : [],
-        },
-      ]);
-    }
+    recordAppliedPreset(preset, detail, preview, expandedSteps);
     const autoFillSuffix =
-      assumptions.length > 0
-        ? ` Auto-filled ${assumptions.length} input(s): ${assumptions.join(", ")}.`
+      preview.assumptions.length > 0
+        ? ` Auto-filled ${preview.assumptions.length} input(s): ${preview.assumptions.join(", ")}.`
         : "";
     setMessage(
       `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`,
     );
+  }
+
+  async function applyPresetToDraft({
+    preset,
+    detail,
+    inputValues,
+    setMessage,
+  }: {
+    preset: TemplateOption;
+    detail: TaskTemplateDetail;
+    inputValues: Record<string, unknown>;
+    setMessage: (message: string) => void;
+  }) {
+    const preview = await expandPresetForDraft({ preset, detail, inputValues });
+    applyPresetPreviewToDraft({ preset, detail, preview, setMessage });
   }
 
   async function handleApplyPreset() {
@@ -4877,7 +5006,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
   }
 
-  async function handleApplyStepPreset(localId: string) {
+  async function handlePreviewStepPreset(localId: string) {
     if (isApplyingPreset) return;
     const step = steps.find((candidate) => candidate.localId === localId);
     const preset = templateItems.find((item) => item.key === step?.presetKey);
@@ -4887,7 +5016,53 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
     setIsApplyingPreset(true);
     updateStep(localId, {
-      presetMessage: "Applying preset...",
+      presetMessage: "Previewing preset...",
+      presetReapplyNeeded: false,
+      presetPreview: null,
+    });
+    try {
+      const detail =
+        selectedPreset?.key === preset.key && selectedPresetDetailQuery.data
+          ? selectedPresetDetailQuery.data
+          : await loadPresetDetail(preset);
+      const preview = await expandPresetForDraft({
+        preset,
+        detail,
+        inputValues: {},
+      });
+      updateStep(localId, {
+        presetPreview: preview,
+        presetMessage: `Previewed preset '${preset.title}' (${preview.previewSteps.length} steps).`,
+      });
+    } catch (error) {
+      const failure =
+        error instanceof Error ? error : new Error("Failed to preview preset.");
+      updateStep(localId, {
+        presetMessage: `Failed to preview preset: ${failure.message}`,
+        presetPreview: null,
+      });
+    } finally {
+      setIsApplyingPreset(false);
+    }
+  }
+
+  async function handleApplyStepPreset(localId: string) {
+    if (isApplyingPreset) return;
+    const step = steps.find((candidate) => candidate.localId === localId);
+    const preset = templateItems.find((item) => item.key === step?.presetKey);
+    if (!step || !preset) {
+      updateStep(localId, { presetMessage: "Choose a preset first." });
+      return;
+    }
+    if (!step.presetPreview || step.presetPreview.presetKey !== preset.key) {
+      updateStep(localId, {
+        presetMessage: "Preview the selected preset before applying.",
+      });
+      return;
+    }
+    setIsApplyingPreset(true);
+    updateStep(localId, {
+      presetMessage: "Applying preset preview...",
       presetReapplyNeeded: false,
     });
     try {
@@ -4895,10 +5070,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         selectedPreset?.key === preset.key && selectedPresetDetailQuery.data
           ? selectedPresetDetailQuery.data
           : await loadPresetDetail(preset);
-      await applyPresetToDraft({
+      applyPresetPreviewToDraft({
         preset,
         detail,
-        inputValues: {},
+        preview: step.presetPreview,
+        replaceLocalId: localId,
         setMessage: (message) => updateStep(localId, { presetMessage: message }),
       });
     } catch (error) {
@@ -5307,6 +5483,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const step = steps[index];
       if (!step) {
         continue;
+      }
+      if (step.stepType === "preset") {
+        setSubmitMessage("Preview and apply Preset steps before submitting.");
+        return;
       }
       const stepIsSkill = step.stepType === "skill";
       const stepSkillId = stepIsSkill ? step.skillId.trim() : "";
@@ -6753,12 +6933,74 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         className="secondary"
                         aria-disabled={isApplyingPreset || !step.presetKey}
                         aria-busy={isApplyingPreset}
-                        title={applyPresetTooltip}
+                        title="Preview the selected preset expansion"
                         disabled={isApplyingPreset || !step.presetKey}
+                        onClick={() => handlePreviewStepPreset(step.localId)}
+                      >
+                        Preview
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary"
+                        aria-disabled={
+                          isApplyingPreset ||
+                          !step.presetKey ||
+                          !step.presetPreview
+                        }
+                        aria-busy={isApplyingPreset}
+                        title={applyPresetTooltip}
+                        disabled={
+                          isApplyingPreset ||
+                          !step.presetKey ||
+                          !step.presetPreview
+                        }
                         onClick={() => handleApplyStepPreset(step.localId)}
                       >
-                        Apply
+                        Apply preview
                       </button>
+                      {step.presetPreview ? (
+                        <div
+                          className="queue-step-preset-preview"
+                          aria-label="Preset preview"
+                        >
+                          <strong>Preset preview</strong>
+                          <ol>
+                            {step.presetPreview.previewSteps.map(
+                              (previewStep, previewIndex) => (
+                                <li
+                                  key={`${step.localId}-preview-${previewIndex}`}
+                                >
+                                  <span>{previewStep.title}</span>{" "}
+                                  <span className="queue-step-preview-type">
+                                    {previewStep.stepType === "tool"
+                                      ? "Tool"
+                                      : "Skill"}
+                                  </span>
+                                  {previewStep.sourceLabel ? (
+                                    <span className="small">
+                                      {` ${previewStep.sourceLabel}`}
+                                    </span>
+                                  ) : null}
+                                </li>
+                              ),
+                            )}
+                          </ol>
+                          {step.presetPreview.warnings.length > 0 ? (
+                            <ul className="list">
+                              {step.presetPreview.warnings.map(
+                                (warning, warningIndex) => (
+                                  <li
+                                    key={`${step.localId}-warning-${warningIndex}`}
+                                    className="notice warning"
+                                  >
+                                    {warning}
+                                  </li>
+                                ),
+                              )}
+                            </ul>
+                          ) : null}
+                        </div>
+                      ) : null}
                       {stepPresetStatusText(step) ? (
                         <p className="small">{stepPresetStatusText(step)}</p>
                       ) : null}

--- a/specs/278-preview-apply-preset-steps/checklists/requirements.md
+++ b/specs/278-preview-apply-preset-steps/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Preview and Apply Preset Steps
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Classification: single-story runtime feature request.
+- Existing artifact scan found no `MM-558` spec under `specs/`, so this feature starts at Specify.

--- a/specs/278-preview-apply-preset-steps/contracts/create-page-preset-preview.md
+++ b/specs/278-preview-apply-preset-steps/contracts/create-page-preset-preview.md
@@ -1,0 +1,38 @@
+# UI Contract: Create Page Preset Preview and Apply
+
+## Preset Authoring Area
+
+When `Step Type = Preset`, the step editor shows:
+
+- Preset selector.
+- Preview action.
+- Apply action enabled only after a current successful preview.
+- Status/error text.
+
+## Preview Behavior
+
+Preview calls the existing preset expansion path using the selected preset version, normalized inputs, repository context, runtime context, and enforced step limits.
+
+On success, the UI shows:
+
+- Generated step count.
+- Each generated step title.
+- Each generated step Step Type.
+- Expansion warnings, if returned.
+
+Preview must not mutate the task draft's step list.
+
+On failure, the UI shows the failure and leaves the draft unchanged.
+
+## Apply Behavior
+
+Apply uses the latest successful preview for that Preset step.
+
+- The selected temporary Preset step is replaced by generated Tool and/or Skill steps.
+- Generated steps remain editable through ordinary step controls.
+- Source provenance from expansion is preserved when available.
+- Applying without a current preview first triggers preview or is blocked with visible guidance.
+
+## Submission Behavior
+
+Submitting a task with any unresolved `Step Type = Preset` step is blocked unless a future linked-preset mode is explicitly present. This story does not add linked-preset mode.

--- a/specs/278-preview-apply-preset-steps/data-model.md
+++ b/specs/278-preview-apply-preset-steps/data-model.md
@@ -1,0 +1,55 @@
+# Data Model: Preview and Apply Preset Steps
+
+## Preset Step Draft
+
+Temporary task-authoring step selected by the user.
+
+Fields:
+- `localId`: stable local step identity.
+- `stepType`: `preset`.
+- `presetKey`: selected preset catalog key.
+- `instructions`: optional user-authored context preserved while editing.
+- `presetMessage`: status or validation message.
+- `presetPreview`: latest successful preview, if any.
+
+Validation:
+- `presetKey` is required before preview.
+- A Preset Step Draft is not executable by default and cannot be submitted unresolved.
+
+## Preset Expansion Preview
+
+Deterministic preview generated from the selected preset and current inputs.
+
+Fields:
+- `presetKey`: catalog key used to produce the preview.
+- `version`: preset version used for expansion.
+- `steps`: generated step previews with title and Step Type.
+- `warnings`: non-blocking warnings returned by expansion.
+- `inputValues`: normalized preset inputs used for preview.
+
+Validation:
+- Preview is replaced when preset selection or inputs change.
+- Apply is enabled only for a current successful preview.
+- Expansion errors do not mutate the draft.
+
+## Preset-Derived Step
+
+Concrete Tool or Skill step inserted by applying a preview.
+
+Fields:
+- Existing editable step state fields.
+- `stepType`: `tool` or `skill` after mapping.
+- `source`: optional preset provenance from expansion.
+
+Validation:
+- Must pass generated Tool or Skill validation before submission.
+- Must remain editable like ordinary steps.
+
+## State Transitions
+
+```text
+empty/manual step -> Preset Step Draft -> Preview Ready -> Applied Preset-Derived Step(s)
+                         |                    |
+                         |                    -> Preview Failed (draft unchanged)
+                         -> Unresolved Submit Blocked
+```

--- a/specs/278-preview-apply-preset-steps/plan.md
+++ b/specs/278-preview-apply-preset-steps/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Preview and Apply Preset Steps
+
+**Branch**: `278-preview-apply-preset-steps` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/278-preview-apply-preset-steps/spec.md`
+
+## Summary
+
+MM-558 requires Preset steps to be configured inside the step editor, previewed before application, and then applied into editable Tool and Skill steps with visible warnings and provenance. Current repo evidence shows Step Type `Preset`, per-step preset selection, and direct apply already exist in `frontend/src/entrypoints/task-create.tsx`, while preset expansion happens through the existing task-template expand endpoint. The missing slice is a first-class preview action/state that lists generated steps and warnings before apply, applies exactly the previewed expansion into the selected step position, and blocks unresolved Preset submission. Implementation will add focused frontend state and tests first, then reuse existing expand and mapping helpers for preview/apply.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `task-create.tsx` renders Step Type `Preset` in each step editor | Add focused MM-558 preview/apply tests to lock behavior | frontend unit |
+| FR-002 | partial | Detail loading and expand failures surface messages; previewable version is inferred through current detail/expand flow | Verify missing/inactive/unavailable preset errors on preview before apply | frontend unit |
+| FR-003 | partial | `resolveTemplateInputs` prepares inputs; expand endpoint validates server-side | Add preview test for invalid preset input failure without draft mutation | frontend unit |
+| FR-004 | missing | Current `handleApplyStepPreset` expands and applies in one action; no preview list/warnings before apply | Add preview action/state that calls expand and renders generated steps/warnings | frontend unit |
+| FR-005 | missing | No generated-step preview UI exists before apply | Render preview titles and Step Types before apply | frontend unit |
+| FR-006 | partial | Direct apply appends generated steps; per-step apply does not replace the temporary Preset step with previewed steps | Apply previewed expansion by replacing selected Preset step | frontend unit |
+| FR-007 | implemented_unverified | `mapExpandedStepToState` creates editable step state used by existing apply flow | Verify applied preview steps are editable after apply | frontend unit |
+| FR-008 | partial | Applied template metadata exists; per-step visible origin/preview provenance is limited | Preserve existing source/provenance metadata and expose origin text where available | frontend unit |
+| FR-009 | partial | Backend expansion validates preset includes and generated steps; frontend handles expand errors | Add tests for generated-step validation failure and warning display | frontend unit |
+| FR-010 | partial | Tool step submission is blocked without a selected tool; unresolved Preset submission behavior needs explicit coverage | Block submit while unresolved Preset steps remain | frontend unit |
+| FR-011 | implemented_unverified | Preset selection already appears in the step editor; separate Task Presets section still exists for optional management/global apply | Verify step-editor preset use does not require Task Presets section | frontend unit |
+| SCN-001..006 | partial | Existing tests cover Step Type and direct preset apply; no preview-before-apply scenarios | Add scenario tests for preview, warnings, apply, unresolved submit block, and no mutation before apply | frontend unit |
+| DESIGN-REQ-006 | partial | Preset step is a temporary authoring state but direct apply bypasses preview | Add preview state and default unresolved-blocking behavior | frontend unit |
+| DESIGN-REQ-007 | implemented_unverified | Step editor includes Preset controls | Verify in MM-558 tests | frontend unit |
+| DESIGN-REQ-009 | missing | No preview step list before apply | Implement preview list and apply-from-preview | frontend unit |
+| DESIGN-REQ-010 | partial | Reapply/dirty state exists; undo/detach/compare/origin are not fully visible for per-step preview | Preserve provenance and expose supported origin/warning text; defer unsupported actions from UI | frontend unit |
+| DESIGN-REQ-017 | partial | Expand endpoint enforces deterministic expansion and limits; warnings are not rendered before apply | Render warnings in preview and prevent apply on expansion failure | frontend unit |
+| DESIGN-REQ-019 | partial | Linked preset mode is not presented, but unresolved Preset submit block needs explicit coverage | Add unresolved Preset submit blocker | frontend unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present for backend validation but is not expected to change for the primary slice  
+**Primary Dependencies**: React, TanStack Query, existing task-template catalog/expand endpoints, existing Create page helpers, Vitest and Testing Library  
+**Storage**: Existing task draft state only; no new persistent storage  
+**Unit Testing**: Focused frontend run via `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`; final unit suite via `./tools/test_unit.sh` when feasible  
+**Integration Testing**: Existing frontend render/submission tests act as the Create page integration boundary; compose integration is not required unless backend expansion contracts change  
+**Target Platform**: Mission Control web UI  
+**Project Type**: Web application frontend with existing FastAPI-backed task-template expand API  
+**Performance Goals**: Preview/apply should reuse existing one expand request per explicit preview and avoid background expansion on selection  
+**Constraints**: Preserve existing task-template expansion endpoint, generated step mapping, and optional Task Presets management behavior; unresolved Preset steps must not reach task submission by default  
+**Scale/Scope**: One task-authoring story for MM-558 focused on Create page Preset preview/apply behavior
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Reuses existing preset expansion and step authoring contracts.
+- II. One-Click Agent Deployment: PASS. No deployment prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. Preset behavior is provider-neutral.
+- IV. Own Your Data: PASS. Uses local draft state and MoonMind-owned preset APIs.
+- V. Skills Are First-Class and Easy to Add: PASS. Generated Skill steps remain first-class editable steps.
+- VI. Scientific Method: PASS. TDD with focused frontend tests is planned before implementation.
+- VII. Runtime Configurability: PASS. No hardcoded provider/runtime behavior added.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay within existing Create page and task-template expansion boundaries.
+- IX. Resilient by Default: PASS. Unresolved preset submission is blocked before workflow execution.
+- X. Facilitate Continuous Improvement: PASS. Artifacts and tests capture verification evidence.
+- XI. Spec-Driven Development: PASS. Spec and plan precede implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime implementation details stay under `specs/` and code.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden semantic transforms planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/278-preview-apply-preset-steps/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-preset-preview.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create.test.tsx
+frontend/src/styles/mission-control.css
+```
+
+**Structure Decision**: This is primarily a frontend Create page story. Existing backend task-template detail/expand services are reused; backend tests are only needed if frontend implementation exposes a backend contract gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/278-preview-apply-preset-steps/quickstart.md
+++ b/specs/278-preview-apply-preset-steps/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Preview and Apply Preset Steps
+
+## Focused Unit Verification
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected coverage:
+- Select Step Type `Preset` inside a step editor.
+- Preview generated steps without mutating the draft.
+- Render generated step titles, Step Types, and warnings.
+- Apply the preview and replace the temporary Preset step with editable generated steps.
+- Show preview failures without draft mutation.
+- Block submission while unresolved Preset steps remain.
+
+## Full Unit Verification
+
+```bash
+./tools/test_unit.sh
+```
+
+## Manual Scenario
+
+1. Open Mission Control Create page.
+2. Add or edit a step and choose `Step Type = Preset`.
+3. Select a preset.
+4. Preview the expansion and confirm generated step titles, Step Types, and warnings are visible.
+5. Apply the preview.
+6. Confirm the Preset placeholder is gone and generated steps are editable.
+7. Try submitting another unresolved Preset step and confirm submission is blocked.

--- a/specs/278-preview-apply-preset-steps/research.md
+++ b/specs/278-preview-apply-preset-steps/research.md
@@ -1,0 +1,57 @@
+# Research: Preview and Apply Preset Steps
+
+## FR-001 / DESIGN-REQ-007
+
+Decision: Existing Step Type `Preset` controls are implementation evidence but require MM-558-specific verification.
+Evidence: `frontend/src/entrypoints/task-create.tsx` renders a Step Type select with Tool, Skill, and Preset; existing tests around Step Type selection live in `frontend/src/entrypoints/task-create.test.tsx`.
+Rationale: The core authoring surface from MM-556 is present, so MM-558 should not rebuild it.
+Alternatives considered: Replacing the Task Presets area entirely; rejected because this story only requires preset use inside step authoring and existing management/global apply behavior may remain temporarily.
+Test implications: Frontend unit tests.
+
+## FR-004 / FR-005 / DESIGN-REQ-009
+
+Decision: Preview-before-apply is missing and must be added.
+Evidence: `handleApplyStepPreset` calls `applyPresetToDraft` directly; `applyPresetToDraft` immediately maps expanded steps and updates draft state. No preview state or generated-step list is rendered before apply.
+Rationale: The acceptance criteria require a visible generated-step preview before apply, not just selecting and applying a preset.
+Alternatives considered: Treat existing direct apply as preview because it uses the expand endpoint; rejected because it mutates the draft immediately.
+Test implications: Red-first frontend tests for preview list, warnings, no draft mutation before apply, and apply from preview.
+
+## FR-002 / FR-003 / FR-009 / DESIGN-REQ-017
+
+Decision: Reuse existing task-template detail and expand API for validation; surface failures and warnings at preview time.
+Evidence: `loadPresetDetail`, `resolveTemplateInputs`, and `applyPresetToDraft` already prepare inputs and call the expand endpoint with `enforceStepLimit`. Backend preset include validation exists in `api_service/services/task_templates/catalog.py`.
+Rationale: Preview can use the same deterministic expansion path as apply, avoiding a second expansion semantics path.
+Alternatives considered: Client-side expansion from template details; rejected because backend expansion is authoritative and already validates includes and limits.
+Test implications: Frontend unit tests mocking expand success, warnings, and failure.
+
+## FR-006 / FR-007
+
+Decision: Applying a previewed per-step preset should replace the selected temporary Preset step with the generated steps, then those steps should remain editable through existing `StepState` controls.
+Evidence: Existing global apply appends or replaces an empty default draft; existing per-step apply calls the same append-oriented helper, so it does not specifically replace the selected Preset step.
+Rationale: Source design says applying a preset replaces the temporary Preset step.
+Alternatives considered: Continue appending generated steps after the Preset step; rejected because it leaves unresolved authoring placeholders and makes provenance unclear.
+Test implications: Frontend unit test for replacing the selected step and editing generated instructions.
+
+## FR-008 / DESIGN-REQ-010
+
+Decision: Preserve existing source/provenance data and expose available origin/warning information; do not invent unsupported detach/compare/update actions.
+Evidence: Expanded steps can carry source metadata and applied template state exists, but current per-step UI has only status text.
+Rationale: The spec says supported provenance actions are conditional on source data.
+Alternatives considered: Implementing full compare/detach/update workflows now; rejected as larger than the preview/apply slice and not backed by existing source data contracts.
+Test implications: Frontend unit tests for visible origin/provenance when source metadata is present.
+
+## FR-010 / DESIGN-REQ-019
+
+Decision: Block task submission when unresolved Preset steps remain.
+Evidence: Tool submissions without selected Tool are already blocked; Preset unresolved submission needs equivalent coverage.
+Rationale: Presets are authoring-time placeholders by default and linked-preset mode is not present.
+Alternatives considered: Auto-apply presets during submit; rejected because the requirement says preview/apply must be explicit and transparent.
+Test implications: Frontend unit submission test.
+
+## Test Strategy
+
+Decision: Use frontend unit tests as the primary TDD boundary.
+Evidence: `frontend/src/entrypoints/task-create.test.tsx` already mocks task-template catalog/detail/expand and verifies submission payloads.
+Rationale: The story is a Create page authoring behavior slice, and backend expansion remains unchanged.
+Alternatives considered: Compose-backed integration tests; rejected unless backend contract changes become necessary.
+Test implications: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`, then full `./tools/test_unit.sh` when feasible.

--- a/specs/278-preview-apply-preset-steps/spec.md
+++ b/specs/278-preview-apply-preset-steps/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Preview and Apply Preset Steps
+
+**Feature Branch**: `278-preview-apply-preset-steps`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-558 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-558` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-558` and local artifact `artifacts/moonspec-inputs/MM-558-canonical-moonspec-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-558` under `specs/`, so `Specify` was the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-558 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-558
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Preview and apply Preset steps
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-558-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-558 from MM project
+Summary: Preview and apply Preset steps
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-558 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-558: Preview and apply Preset steps
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 5.3 `preset`
+- 6.5 Preset picker
+- 6.6 Preset preview and apply
+- 8.4 Preset validation
+- 9. Jira Example
+- 12. Preset Management vs Preset Use
+- 16. Open Design Decisions
+
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-017
+- DESIGN-REQ-019
+
+As a task author, I want to configure a Preset step, preview its generated steps, and apply it into executable Tool and Skill steps so reusable workflows stay transparent and editable.
+
+Acceptance Criteria
+- Preset use is available inside the step editor and there is no separate Presets section for choosing and applying a preset to the current task.
+- Preview lists the generated steps before apply and exposes expansion warnings.
+- Apply replaces the temporary Preset step with concrete Tool and/or Skill steps that pass their own validation.
+- Undo, show origin, detach provenance, compare, and explicit update actions are available where supported by source data.
+- Unresolved Preset steps cannot be submitted unless a future linked-preset mode is explicitly introduced and visibly different.
+
+Requirements
+- Preset steps are authoring-time placeholders by default.
+- Expansion is deterministic and validated before execution.
+- Generated steps are editable like ordinary steps after apply.
+- Linked presets remain outside the default behavior.
+```
+
+## User Story - Preview and Apply Preset Steps
+
+**Summary**: As a task author, I want to configure a Preset step, preview its generated steps, and apply it into executable Tool and Skill steps so reusable workflows stay transparent and editable.
+
+**Goal**: Task authors can choose a Preset while editing a task step, review the deterministic expansion before accepting it, and replace the temporary Preset step with editable executable steps that retain visible preset provenance.
+
+**Independent Test**: Render the task authoring experience, choose Step Type `Preset`, select and configure an available preset, preview the generated Tool and Skill steps with warnings, apply the preset, and verify the draft contains editable executable steps instead of an unresolved Preset step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author is editing a step, **When** they choose Step Type `Preset`, **Then** the step editor lets them select and configure a preset from the same authoring surface used for Tool and Skill steps.
+2. **Given** a configured Preset step, **When** the author requests preview, **Then** the system shows the generated step list before application and includes any expansion warnings that affect the draft.
+3. **Given** the previewed expansion is valid, **When** the author applies the preset, **Then** the temporary Preset step is replaced by concrete Tool and/or Skill steps that are editable like ordinary steps.
+4. **Given** generated steps come from a preset, **When** the author inspects them after application, **Then** the UI exposes preset origin and supports supported provenance actions such as undo, detach, compare, or explicit update when source data is available.
+5. **Given** a Preset step remains unresolved, **When** the author submits the task, **Then** submission is blocked unless an explicit future linked-preset mode is available and visibly different from default preset application.
+6. **Given** the Presets section is visible elsewhere, **When** the author is choosing a preset for the current task, **Then** preset use happens inside the step editor and the separate Presets section is not required for applying a preset to the draft.
+
+### Edge Cases
+
+- A selected preset is missing, inactive, or not previewable; preview and apply are blocked with visible errors.
+- Preset inputs fail the preset input schema; the author sees input-level validation before expansion.
+- Expansion succeeds but one or more generated steps fail Tool or Skill validation; apply is blocked and the failing generated steps are identified.
+- Expansion returns warnings without hard validation failures; warnings remain visible before apply and after apply where relevant.
+- The author cancels or undoes an expansion; the draft returns to the prior Preset step state when the prior state is still available.
+- A future linked-preset mode exists; it must be explicitly labeled and must not be confused with default authoring-time expansion.
+
+## Assumptions
+
+- Runtime mode applies: this story changes task authoring behavior and validation, not only documentation.
+- MM-556 Step Type authoring controls and MM-557 executable step validation are treated as prerequisites or adjacent behavior; this story focuses on Preset preview/application.
+- Preset management remains separate from preset use. This story does not require building the preset catalog management experience.
+- Supported provenance actions may be conditionally available based on source data; unsupported actions should not be presented as available.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | docs/Steps/StepTypes.md section 5.3 | Preset steps select reusable templates, configure inputs, and are temporary authoring states for preview and application rather than normally executable runtime steps. | In scope | FR-001, FR-002, FR-003, FR-010 |
+| DESIGN-REQ-007 | docs/Steps/StepTypes.md section 6.5 | Preset selection for use belongs in the same step-authoring surface as Tool and Skill, not in a separate Presets section. | In scope | FR-001, FR-011 |
+| DESIGN-REQ-009 | docs/Steps/StepTypes.md section 6.6 | The UI must preview generated steps before apply and replace the temporary Preset step with editable ordinary steps on apply. | In scope | FR-004, FR-005, FR-006 |
+| DESIGN-REQ-010 | docs/Steps/StepTypes.md section 6.6 | Preset application should support undo, show origin, detach provenance, compare generated steps, and update to newer preset versions only as explicit user actions where supported. | In scope | FR-007, FR-008 |
+| DESIGN-REQ-017 | docs/Steps/StepTypes.md section 8.4 | Preset validation requires existing/previewable preset versions, schema-valid inputs, deterministic expansion, valid generated Tool/Skill steps, policy limits, and visible warnings. | In scope | FR-002, FR-003, FR-004, FR-009 |
+| DESIGN-REQ-019 | docs/Steps/StepTypes.md section 16 | Linked presets are not the default; any future linked-preset mode must be explicit and visibly different from ordinary preset application. | In scope | FR-010 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The step editor MUST allow authors to select Step Type `Preset` and choose a preset from the same step-authoring surface used for Tool and Skill steps.
+- **FR-002**: The system MUST validate that the selected preset exists and that its version is active or explicitly previewable before preview or apply can succeed.
+- **FR-003**: The system MUST validate Preset inputs against the preset input schema before expansion.
+- **FR-004**: The system MUST expand configured Preset steps deterministically for preview and MUST surface expansion warnings before application.
+- **FR-005**: The preview MUST list the generated steps before apply, including their user-visible titles and Step Types.
+- **FR-006**: Applying a valid Preset expansion MUST replace the temporary Preset step with concrete Tool and/or Skill steps in the draft.
+- **FR-007**: Generated steps MUST remain editable like ordinary steps after application.
+- **FR-008**: Preset-derived generated steps MUST expose source provenance sufficient for supported origin, detach, compare, undo, and explicit update actions.
+- **FR-009**: The system MUST validate generated steps under their own Tool or Skill rules before allowing application or submission.
+- **FR-010**: The system MUST block task submission when unresolved Preset steps remain unless an explicit future linked-preset mode is available and visibly different from default preset application.
+- **FR-011**: The Presets management section MUST NOT be required for choosing and applying a preset to the current task draft.
+
+### Key Entities
+
+- **Preset Step Draft**: A temporary authored step with Step Type `Preset`, selected preset identity/version, and preset input values.
+- **Preset Expansion Preview**: The deterministic generated step list and warnings produced from a configured Preset step before application.
+- **Preset-Derived Step**: A concrete Tool or Skill step inserted by applying a preset, including optional source provenance.
+- **Preset Provenance**: Metadata that connects generated steps back to the preset, version, include path, or original step when source data is available.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests cover selecting Step Type `Preset`, configuring a preset, previewing generated steps, and applying the expansion into the draft.
+- **SC-002**: Validation tests cover missing preset, invalid preset inputs, generated step validation failure, and unresolved Preset submission blocking.
+- **SC-003**: Preview shows generated step titles, Step Types, and expansion warnings before apply.
+- **SC-004**: Applied preset-derived steps are editable as ordinary Tool and Skill steps and preserve visible origin/provenance where source data exists.
+- **SC-005**: The task author can apply a preset from the step editor without using a separate Presets management section.

--- a/specs/278-preview-apply-preset-steps/tasks.md
+++ b/specs/278-preview-apply-preset-steps/tasks.md
@@ -1,0 +1,115 @@
+# Tasks: Preview and Apply Preset Steps
+
+**Input**: Design documents from `/specs/278-preview-apply-preset-steps/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around MM-558's single user story.
+
+**Source Traceability**: FR-001..FR-011, SC-001..SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-019.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing Create page preset and test harness boundaries.
+
+- [X] T001 Confirm active MM-558 feature artifacts in `specs/278-preview-apply-preset-steps/spec.md`, `specs/278-preview-apply-preset-steps/plan.md`, `specs/278-preview-apply-preset-steps/research.md`, `specs/278-preview-apply-preset-steps/data-model.md`, `specs/278-preview-apply-preset-steps/contracts/create-page-preset-preview.md`, and `specs/278-preview-apply-preset-steps/quickstart.md`
+- [X] T002 Confirm existing Create page implementation and test files in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Reuse existing preset catalog/detail/expand surfaces; no backend schema or service foundation is required unless red tests expose a contract gap.
+
+- [X] T003 Verify existing task-template detail and expand calls in `frontend/src/entrypoints/task-create.tsx` are the authoritative preview/apply source (FR-002, FR-003, FR-004, DESIGN-REQ-017)
+- [X] T004 Verify existing generated step mapping in `frontend/src/entrypoints/task-create.tsx` produces editable step state (FR-007)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Preview and Apply Preset Steps
+
+**Summary**: As a task author, I want to configure a Preset step, preview its generated steps, and apply it into executable Tool and Skill steps so reusable workflows stay transparent and editable.
+
+**Independent Test**: Render the Create page, choose Step Type `Preset`, select a preset, preview the generated Tool/Skill steps and warnings, apply the preview, and verify the Preset placeholder is replaced by editable concrete steps.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-017, DESIGN-REQ-019
+
+**Test Plan**:
+
+- Unit: preview state, generated step list/warnings, no mutation before apply, apply replacement, unresolved submit block, preview failure handling.
+- Integration: Create page Vitest render/submission coverage acts as the story integration boundary because it exercises UI state and mocked task-template API calls.
+
+### Unit Tests (write first) ⚠️
+
+- [X] T005 [P] Add failing test that Step Type `Preset` can preview generated step titles, Step Types, and expansion warnings without mutating the draft in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, FR-005, SC-001, SC-003, DESIGN-REQ-009, DESIGN-REQ-017)
+- [X] T006 [P] Add failing test that applying a preview replaces the selected Preset step with editable generated steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, FR-007, SC-004, DESIGN-REQ-006, DESIGN-REQ-009)
+- [X] T007 [P] Add failing test that preview expansion failure or generated-step validation failure leaves the draft unchanged and shows a visible error in `frontend/src/entrypoints/task-create.test.tsx` (FR-002, FR-003, FR-009, SC-002, DESIGN-REQ-017)
+- [X] T008 [P] Add failing test that unresolved Preset steps block task submission by default in `frontend/src/entrypoints/task-create.test.tsx` (FR-010, DESIGN-REQ-019)
+- [X] T009 [P] Add failing test that step-editor preset preview/apply works without using the separate Task Presets management section in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-011, SC-005, DESIGN-REQ-007)
+- [X] T010 Run focused Vitest for `frontend/src/entrypoints/task-create.test.tsx` to confirm new MM-558 tests fail for expected preview/apply gaps
+
+### Integration Tests (write first) ⚠️
+
+- [X] T011 Treat focused Create page Vitest render/submission coverage as the story integration boundary and confirm failures from T010 cover the public UI contract in `frontend/src/entrypoints/task-create.test.tsx`
+
+### Implementation
+
+- [X] T012 Add per-step preset preview state and stale-preview invalidation in `frontend/src/entrypoints/task-create.tsx` (FR-004, FR-005)
+- [X] T013 Refactor preset expansion helper in `frontend/src/entrypoints/task-create.tsx` so preview can fetch expansion without mutating the draft and apply can reuse the previewed expansion (FR-004, FR-006, DESIGN-REQ-017)
+- [X] T014 Render preview results with generated step titles, Step Types, source/origin text when available, and warnings in `frontend/src/entrypoints/task-create.tsx` (FR-005, FR-008, SC-003, DESIGN-REQ-010)
+- [X] T015 Replace the selected temporary Preset step with previewed generated steps on apply in `frontend/src/entrypoints/task-create.tsx` (FR-006, FR-007)
+- [X] T016 Block submission of unresolved Preset steps in `frontend/src/entrypoints/task-create.tsx` (FR-010, DESIGN-REQ-019)
+- [X] T017 Verify existing Mission Control list, small-text, and notice styles are sufficient for preset preview and warning/error states without changing `frontend/src/styles/mission-control.css` (FR-005, FR-008)
+- [X] T018 Story validation: Run focused Vitest for `frontend/src/entrypoints/task-create.test.tsx` and fix failures until MM-558 focused tests pass
+
+**Checkpoint**: The story is functional, covered by focused frontend tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate without adding hidden scope.
+
+- [X] T019 Run focused Vitest for `frontend/src/entrypoints/task-create.test.tsx`
+- [X] T020 Run full `./tools/test_unit.sh` when feasible, or record exact blocker in `specs/278-preview-apply-preset-steps/verification.md`
+- [X] T021 Run `/moonspec-verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-558 in `specs/278-preview-apply-preset-steps/verification.md`
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 and Phase 2 are complete.
+- T005-T009 must be written before implementation.
+- T010-T011 confirm red-first behavior.
+- T012-T017 implement only after red-first confirmation.
+- T018 validates focused frontend behavior.
+- T019-T021 are final validation.
+
+## Parallel Example
+
+```text
+T005, T006, T007, T008, and T009 can be drafted in parallel because they touch the same test file but cover independent test cases; merge them before T010.
+```
+
+## Implementation Strategy
+
+1. Add failing frontend tests for preview-before-apply, warnings, no draft mutation, apply replacement, unresolved submit blocking, and step-editor-only preset use.
+2. Add preview state and expansion helper reuse in the Create page.
+3. Render preview details and apply from current preview.
+4. Block unresolved Preset submission.
+5. Run focused UI tests, managed unit validation, and MoonSpec verification.

--- a/specs/278-preview-apply-preset-steps/verification.md
+++ b/specs/278-preview-apply-preset-steps/verification.md
@@ -1,0 +1,27 @@
+# Verification: Preview and Apply Preset Steps
+
+**Feature**: `278-preview-apply-preset-steps`  
+**Jira**: `MM-558`  
+**Date**: 2026-04-29  
+**Verdict**: FULLY_IMPLEMENTED with full-suite test gap
+
+## Coverage
+
+| Requirement | Result | Evidence |
+| --- | --- | --- |
+| FR-001, FR-011, DESIGN-REQ-007 | PASS | Step editor keeps Step Type `Preset` and tests verify step-editor preset preview/apply without relying on Task Presets management. |
+| FR-002, FR-003, FR-009, DESIGN-REQ-017 | PASS | Preview uses the existing expand path and surfaces expansion failures without mutating the draft. |
+| FR-004, FR-005, DESIGN-REQ-009 | PASS | Preview action renders generated step titles, Step Types, and warnings before apply. |
+| FR-006, FR-007 | PASS | Apply preview replaces the selected temporary Preset step with editable generated steps. |
+| FR-008, DESIGN-REQ-010 | PASS | Preview exposes available source/origin text when expansion source metadata is present; unsupported provenance actions are not invented. |
+| FR-010, DESIGN-REQ-019 | PASS | Submission is blocked while unresolved Preset steps remain. |
+
+## Test Evidence
+
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`: PASS, 212 tests.
+- `git diff --check`: PASS.
+
+## Full-Suite Gap
+
+- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` was attempted, but the wrapper began the full Python unit suite first and was still in unrelated Python tests at roughly 20% after several minutes. The run was stopped for focused iteration.
+- Full `./tools/test_unit.sh` was not completed for the same runtime cost reason. Focused frontend coverage for the changed file passed.


### PR DESCRIPTION
## Summary

- Implements MM-558 Preview and apply Preset steps for the Mission Control Create page.
- Adds per-step Preset preview state, preview rendering for generated Tool/Skill steps and warnings, apply-from-preview replacement, provenance recording, and unresolved Preset submission blocking.
- Preserves the MoonSpec artifacts under specs/278-preview-apply-preset-steps with verification evidence.

## Validation

- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` PASS, 212 tests.
- `git diff --check` PASS, documented in `specs/278-preview-apply-preset-steps/verification.md`.

## Notes

- Full `./tools/test_unit.sh` remains a documented runtime-cost gap: the wrapper entered unrelated Python tests and was stopped after several minutes during focused iteration.
