### PR TITLE
MM-559: Submit discriminated executable payloads

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/278-preview-apply-preset-steps"
+  "feature_directory": "specs/279-submit-discriminated-executable-payloads"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-558",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1840"
+  "jira_issue_key": "MM-559",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1841"
 }

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7006,6 +7006,7 @@ describe("Task Create Entrypoint", () => {
     expect(request.payload.task.steps[0]).toEqual({
       id: "tpl:speckit-demo:1.2.3:01",
       title: "Fetch Jira issue",
+      type: "tool",
       instructions: "Fetch MM-558.",
       tool: {
         type: "tool",
@@ -8275,6 +8276,7 @@ describe("Task Create Entrypoint", () => {
     expect(request.payload.task.steps).toEqual([
       {
         instructions: "Primary objective",
+        type: "skill",
       },
       {},
     ]);
@@ -8420,6 +8422,7 @@ describe("Task Create Entrypoint", () => {
       {
         id: "tpl:speckit-demo:1.2.3:01",
         title: "Clarify spec",
+        type: "skill",
         instructions: "Clarify the {{ inputs.feature_name }} scope.",
         tool: {
           type: "skill",
@@ -8435,6 +8438,7 @@ describe("Task Create Entrypoint", () => {
       {
         id: "tpl:speckit-demo:1.2.3:02",
         title: "Plan implementation",
+        type: "skill",
         instructions: "Write a plan for the task builder recovery.",
         storyOutput: {
           mode: "jira",

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2302,6 +2302,26 @@ function stripOversizedInlineInstructions(
   const fitsInlineLimit = () =>
     utf8ByteLength(JSON.stringify(requestBody)) <=
     INLINE_TASK_INPUT_LIMIT_BYTES;
+  const removeTypeOnlyStep = (step: Record<string, unknown>) => {
+    const nonTypeKeys = Object.entries(step).filter(([key, value]) => {
+      if (key === "type" || value === undefined || value === null) {
+        return false;
+      }
+      if (typeof value === "string") {
+        return value.trim().length > 0;
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      if (typeof value === "object") {
+        return Object.keys(value).length > 0;
+      }
+      return true;
+    });
+    if (nonTypeKeys.length === 0) {
+      delete step.type;
+    }
+  };
   if (fitsInlineLimit()) {
     return;
   }
@@ -2316,7 +2336,9 @@ function stripOversizedInlineInstructions(
     ) {
       continue;
     }
-    delete (step as Record<string, unknown>).instructions;
+    const stepRecord = step as Record<string, unknown>;
+    delete stepRecord.instructions;
+    removeTypeOnlyStep(stepRecord);
     if (fitsInlineLimit()) {
       return;
     }
@@ -2339,7 +2361,9 @@ function stripOversizedInlineInstructions(
     ) {
       continue;
     }
-    delete (step as Record<string, unknown>).instructions;
+    const stepRecord = step as Record<string, unknown>;
+    delete stepRecord.instructions;
+    removeTypeOnlyStep(stepRecord);
     if (fitsInlineLimit()) {
       return;
     }
@@ -5890,13 +5914,33 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 sourceStep,
                 effectivePayloadAttachments,
               ));
-          return {
+          const submittedStepType: Exclude<StepType, "preset"> =
+            sourceStep.stepType === "tool" ? "tool" : "skill";
+          const hasPayloadContent = Object.entries(entry.payload).some(
+            ([key, value]) =>
+              !(
+                key === "inputAttachments" &&
+                Array.isArray(value) &&
+                value.length === 0
+              ),
+          );
+          const hasSubmittedStepShape =
+            hasPayloadContent ||
+            Boolean(sourceStep.id.trim()) ||
+            Boolean(sourceStep.title.trim()) ||
+            Boolean(sourceStep.storyOutput) ||
+            Boolean(
+              sourceStep.jiraOrchestration &&
+                Object.keys(sourceStep.jiraOrchestration).length > 0,
+            );
+          const submittedStep = {
             ...(shouldPreserveStepId && sourceStep.id.trim()
               ? { id: sourceStep.id.trim() }
               : {}),
             ...(sourceStep.title.trim()
               ? { title: sourceStep.title.trim() }
               : {}),
+            ...(hasSubmittedStepShape ? { type: submittedStepType } : {}),
             ...(sourceStep.storyOutput
               ? { storyOutput: sourceStep.storyOutput }
               : {}),
@@ -5906,6 +5950,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               : {}),
             ...entry.payload,
           };
+          const hasNonTypeContent = Object.entries(submittedStep).some(
+            ([key, value]) => {
+              if (key === "type" || value === undefined || value === null) {
+                return false;
+              }
+              if (typeof value === "string") {
+                return value.trim().length > 0;
+              }
+              if (Array.isArray(value)) {
+                return value.length > 0;
+              }
+              if (typeof value === "object") {
+                return Object.keys(value).length > 0;
+              }
+              return true;
+            },
+          );
+          if (!hasNonTypeContent) {
+            return {};
+          }
+          return submittedStep;
         })
       : [];
 

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -1000,6 +1000,36 @@ class TaskStepSpec(BaseModel):
         if not isinstance(value, Mapping):
             return value
         payload = dict(value)
+        raw_type = _clean_optional_str(payload.get("type"))
+        if raw_type is not None:
+            step_type = raw_type.lower()
+            if step_type not in {"tool", "skill"}:
+                raise TaskContractError("task.steps[].type must be one of: tool, skill")
+            tool_payload = payload.get("tool")
+            skill_payload = payload.get("skill")
+            if step_type == "tool":
+                if not isinstance(tool_payload, Mapping):
+                    raise TaskContractError("Tool steps require a tool payload")
+                tool_id = _clean_optional_str(
+                    tool_payload.get("id") or tool_payload.get("name")
+                )
+                if not tool_id:
+                    raise TaskContractError("Tool steps require tool.id or tool.name")
+                if skill_payload is not None:
+                    raise TaskContractError(
+                        "Tool steps must not include a skill payload"
+                    )
+            if step_type == "skill":
+                legacy_skill_tool = False
+                if isinstance(tool_payload, Mapping):
+                    tool_type = str(
+                        tool_payload.get("type") or tool_payload.get("kind") or ""
+                    ).strip().lower()
+                    legacy_skill_tool = tool_type in {"", "skill"}
+                    if not legacy_skill_tool:
+                        raise TaskContractError(
+                            "Skill steps must not include a non-skill tool payload"
+                        )
         if "inputAttachments" in payload:
             _validate_input_attachment_payloads(
                 payload.get("inputAttachments"),

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -616,7 +616,18 @@ def _selected_step_tool_name(step_entry: Mapping[str, Any]) -> str:
     )
     return str(step_tool.get("name") or step_tool.get("id") or "").strip()
 
-def _selected_step_tool_type(tool_name: str) -> str:
+def _selected_step_type(step_entry: Mapping[str, Any]) -> str:
+    return str(step_entry.get("type") or "").strip().lower()
+
+def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
+    step_tool = _coerce_mapping(step_entry.get("tool")) or _coerce_mapping(
+        step_entry.get("skill")
+    )
+    return str(step_tool.get("version") or "1.0").strip() or "1.0"
+
+def _selected_step_tool_type(step_entry: Mapping[str, Any], tool_name: str) -> str:
+    if _selected_step_type(step_entry) == "tool":
+        return "skill"
     if tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS:
         return "skill"
     return "agent_runtime"
@@ -934,9 +945,13 @@ def _build_runtime_planner():
         creates_story_breakdown_artifact = False
 
         # --- Expand task.steps[] or stepCount into multiple plan nodes ---
+        has_explicit_step_types = (
+            isinstance(raw_steps, list)
+            and any(isinstance(s, Mapping) and _selected_step_type(s) for s in raw_steps)
+        )
         has_multi_steps = (
             isinstance(raw_steps, list)
-            and len(raw_steps) > 1
+            and (len(raw_steps) > 1 or has_explicit_step_types)
             and all(isinstance(s, Mapping) for s in raw_steps)
         )
         if has_multi_steps:
@@ -1036,10 +1051,12 @@ def _build_runtime_planner():
                 # Per-step tool/skill override
                 step_tool_name = _selected_step_tool_name(step_entry)
                 step_runtime = runtime_mode
-                tool_type = _selected_step_tool_type(step_tool_name)
+                tool_type = _selected_step_tool_type(step_entry, step_tool_name)
+                tool_version = _selected_step_tool_version(step_entry)
                 effective_step_skill_name = step_tool_name or selected_skill_name
                 if step_tool_name:
-                    step_runtime = step_tool_name
+                    if tool_type == "skill" or not _selected_step_type(step_entry):
+                        step_runtime = step_tool_name
                     step_node_inputs["selectedSkill"] = step_tool_name
                     if _jira_agent_skill_selected(step_tool_name):
                         step_node_inputs["publishMode"] = "none"
@@ -1075,7 +1092,7 @@ def _build_runtime_planner():
                     "tool": {
                         "type": tool_type,
                         "name": step_runtime,
-                        "version": "1.0",
+                        "version": tool_version if tool_type == "skill" else "1.0",
                     },
                     "inputs": step_node_inputs,
                 })

--- a/specs/279-submit-discriminated-executable-payloads/checklists/requirements.md
+++ b/specs/279-submit-discriminated-executable-payloads/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Submit Discriminated Executable Payloads
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves the `MM-559` Jira preset brief, defines one runtime story, and maps all in-scope source design requirements.

--- a/specs/279-submit-discriminated-executable-payloads/contracts/executable-step-payload.md
+++ b/specs/279-submit-discriminated-executable-payloads/contracts/executable-step-payload.md
@@ -1,0 +1,94 @@
+# Contract: Executable Step Payload
+
+Source story: `MM-559` Submit discriminated executable payloads.
+
+## Accepted executable submitted steps
+
+```json
+{
+  "id": "fetch-jira-issue",
+  "title": "Fetch Jira issue",
+  "type": "tool",
+  "tool": {
+    "id": "jira.get_issue",
+    "version": "1.0.0",
+    "inputs": {
+      "issueKey": "MM-559"
+    }
+  },
+  "source": {
+    "kind": "preset-derived",
+    "presetId": "jira.implementation_flow",
+    "version": "2026-04-28",
+    "originalStepId": "fetch-issue"
+  }
+}
+```
+
+```json
+{
+  "id": "implement-issue",
+  "title": "Implement issue",
+  "type": "skill",
+  "skill": {
+    "id": "moonspec-implement",
+    "args": {
+      "issueKey": "MM-559"
+    }
+  }
+}
+```
+
+## Rejected executable submitted steps
+
+Unresolved Preset step:
+
+```json
+{
+  "type": "preset",
+  "preset": {
+    "id": "jira.implementation_flow",
+    "inputs": {
+      "issueKey": "MM-559"
+    }
+  }
+}
+```
+
+Temporal implementation label:
+
+```json
+{
+  "type": "activity",
+  "activity": {
+    "name": "mm.skill.execute"
+  }
+}
+```
+
+Conflicting executable payload:
+
+```json
+{
+  "type": "tool",
+  "tool": {
+    "id": "jira.get_issue",
+    "inputs": {
+      "issueKey": "MM-559"
+    }
+  },
+  "skill": {
+    "id": "moonspec-implement",
+    "args": {}
+  }
+}
+```
+
+## Runtime mapping
+
+| Submitted Step Type | Runtime materialization |
+| --- | --- |
+| `tool` | Plan node invoking the typed tool id/name from `tool` |
+| `skill` | Plan node invoking the selected agent-facing skill |
+| `preset` | No runtime node; rejected before materialization |
+| `activity` | No runtime node; rejected before materialization |

--- a/specs/279-submit-discriminated-executable-payloads/data-model.md
+++ b/specs/279-submit-discriminated-executable-payloads/data-model.md
@@ -1,0 +1,48 @@
+# Data Model: Submit Discriminated Executable Payloads
+
+## Executable Step
+
+Represents a submitted task step that can enter runtime materialization.
+
+Fields:
+- `id`: optional stable local identity.
+- `title`: optional display title.
+- `instructions`: optional step instructions.
+- `type`: optional during migration, but when present must be `tool` or `skill` for executable submission.
+- `tool`: required for explicit Tool steps; contains `id` or `name`, optional `version`, and `inputs`.
+- `skill`: required for explicit Skill steps when the step selects a skill directly; contains `id` and `args`.
+- `source`: optional provenance metadata for audit and reconstruction.
+
+Validation:
+- `type: "tool"` requires a Tool sub-payload and forbids a Skill sub-payload.
+- `type: "skill"` forbids a Tool sub-payload unless it is the legacy mirrored `tool.type: "skill"` selector currently used by the runtime.
+- `type: "preset"` is not executable and is rejected at submission.
+- `type: "activity"` and any other values are rejected.
+
+## Preset Step
+
+Represents an authoring-time placeholder.
+
+Fields:
+- `type: "preset"`
+- `preset`: preset id/version/inputs
+
+Validation:
+- Valid only for preview/apply authoring flows.
+- Rejected from executable task submission.
+
+## Step Provenance
+
+Represents optional audit metadata.
+
+Fields:
+- `kind`
+- `presetId` or `presetSlug`
+- `version`
+- `includePath`
+- `originalStepId`
+- existing `presetProvenance` expansion metadata
+
+Validation:
+- Preserved when present.
+- Not required for runtime materialization.

--- a/specs/279-submit-discriminated-executable-payloads/plan.md
+++ b/specs/279-submit-discriminated-executable-payloads/plan.md
@@ -35,7 +35,7 @@ Task submissions must preserve explicit Step Type intent for executable Tool and
 **Primary Dependencies**: Pydantic v2, Temporal Python SDK runtime materializer, FastAPI task submission router, React/Vitest test harness  
 **Storage**: No new persistent storage; uses existing task payloads and artifact-backed execution inputs  
 **Unit Testing**: `./tools/test_unit.sh`; focused Python pytest and Vitest commands during iteration
-**Integration Testing**: Hermetic integration not required for this narrow contract story; runtime materialization covered by existing Python unit tests  
+**Integration Testing**: Hermetic `integration_ci` coverage is not required for this narrow payload-contract story; integration-boundary evidence comes from Create-page submitted payload tests plus worker runtime materialization tests  
 **Target Platform**: MoonMind API service, Temporal worker runtime, Mission Control Create page  
 **Project Type**: Web service plus frontend application  
 **Performance Goals**: Validation remains synchronous and bounded to submitted step count; no additional network calls  

--- a/specs/279-submit-discriminated-executable-payloads/plan.md
+++ b/specs/279-submit-discriminated-executable-payloads/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Submit Discriminated Executable Payloads
+
+**Branch**: `279-submit-discriminated-executable-payloads` | **Date**: 2026-04-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/279-submit-discriminated-executable-payloads/spec.md`
+
+## Summary
+
+Task submissions must preserve explicit Step Type intent for executable Tool and Skill steps, reject unresolved Preset or Activity-labeled steps at the executable submission boundary, and materialize Tool and Skill steps into distinct runtime plan node types without requiring preset provenance. The implementation will extend the existing task payload contract and runtime materializer, then update Create-page submission serialization so preset-applied steps are submitted as flattened discriminated executable steps. Verification will use focused Python unit tests for backend validation and runtime materialization plus Vitest coverage for Create-page submission payloads.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | Template catalog accepts explicit `type: tool/skill`; task submission contract does not validate step discriminators. | Add task step discriminator validation and tests. | unit |
+| FR-002 | partial | Runtime materializer maps multi-step entries by selected tool name and defaults non-Jira tools to `agent_runtime`. | Use explicit `step.type` to materialize Tool steps as typed tool nodes and Skill steps as agent-runtime/skill nodes. | unit |
+| FR-003 | partial | Create page and template catalog have Step Type UI/model; submitted explicit steps omit `type` in several paths. | Serialize explicit step `type` for generated Tool and Skill submissions. | frontend unit |
+| FR-004 | missing | Preset UI blocks preset submission, but backend contract does not reject `type: preset` if submitted directly. | Reject unresolved Preset steps in task payload validation. | unit |
+| FR-005 | missing | No backend Step Type validation rejects `activity`. | Reject non-canonical Step Type values including `activity`. | unit |
+| FR-006 | implemented_unverified | `source` and template provenance fields are preserved by permissive step models and expansion output. | Add regression coverage that provenance does not affect runtime mapping. | unit |
+| FR-007 | partial | Template catalog rejects Tool/Skill conflicts; task submission contract does not. | Reject submitted executable steps that carry conflicting Tool and Skill sub-payloads. | unit |
+| SCN-001 | partial | Tool template expansion exists; runtime plan mapping does not honor explicit submitted Tool Step Type. | Add materialization test and implementation. | unit |
+| SCN-002 | partial | Skill steps materialize today through legacy `tool.type: skill`; explicit `type: skill` is not validated. | Add validation and materialization test. | unit |
+| SCN-003 | missing | Backend direct submission can carry `type: preset`. | Add rejection test and validator. | unit |
+| SCN-004 | implemented_unverified | `source` extra metadata survives Pydantic model validation by design. | Add runtime mapping test with provenance present. | unit |
+| SCN-005 | missing | No direct Step Type rejection for `activity`. | Add rejection test and validator. | unit |
+| DESIGN-REQ-008 | partial | Frontend blocks Preset steps; backend direct payload does not. | Enforce executable-only step types at submission boundary. | unit + frontend unit |
+| DESIGN-REQ-011 | partial | Runtime plan nodes are generated but do not use submitted Step Type discriminator. | Map Tool and Skill by explicit type. | unit |
+| DESIGN-REQ-012 | missing | Activity label is not explicitly rejected. | Reject Activity as a Step Type. | unit |
+| DESIGN-REQ-016 | partial | API shape exists in source docs and UI types; submitted payload omits explicit type in key paths. | Preserve submitted discriminators and validate sub-payloads. | unit + frontend unit |
+| DESIGN-REQ-019 | partial | Preset expansion flattens steps, but direct preset submission lacks backend guard. | Reject preset runtime nodes and keep provenance audit-only. | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Create page behavior  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK runtime materializer, FastAPI task submission router, React/Vitest test harness  
+**Storage**: No new persistent storage; uses existing task payloads and artifact-backed execution inputs  
+**Unit Testing**: `./tools/test_unit.sh`; focused Python pytest and Vitest commands during iteration
+**Integration Testing**: Hermetic integration not required for this narrow contract story; runtime materialization covered by existing Python unit tests  
+**Target Platform**: MoonMind API service, Temporal worker runtime, Mission Control Create page  
+**Project Type**: Web service plus frontend application  
+**Performance Goals**: Validation remains synchronous and bounded to submitted step count; no additional network calls  
+**Constraints**: Preserve MM-559 traceability; do not expose Temporal Activity as Step Type; do not require preset provenance for runtime correctness  
+**Scale/Scope**: Existing task step limit of 50 submitted steps
+
+## Constitution Check
+
+- Orchestrate, Don't Recreate: PASS. The change preserves typed tool/skill orchestration and does not rebuild agent cognition.
+- Thin Scaffolding, Thick Contracts: PASS. The work strengthens task payload and runtime plan contracts.
+- Tests are the Anchor: PASS. Unit and frontend tests are required before implementation.
+- Resilient by Default: PASS. Invalid runtime payloads fail fast before plan execution.
+- Canonical Documentation Separates Desired State from Migration Backlog: PASS. Canonical docs remain unchanged; implementation notes stay in this feature artifact.
+- Compatibility Policy: PASS. Unsupported submitted Step Type values fail fast instead of hidden fallback behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/279-submit-discriminated-executable-payloads/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── executable-step-payload.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── workflows/
+│   ├── tasks/task_contract.py
+│   └── temporal/worker_runtime.py
+
+frontend/
+└── src/entrypoints/
+    ├── task-create.tsx
+    └── task-create.test.tsx
+
+tests/
+└── unit/workflows/
+    ├── tasks/test_task_contract.py
+    └── temporal/test_temporal_worker_runtime.py
+```
+
+**Structure Decision**: Update the existing task contract and runtime materializer where submitted task steps are validated and compiled. Update the existing Create page entrypoint and its Vitest tests for submitted payload shape.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/279-submit-discriminated-executable-payloads/quickstart.md
+++ b/specs/279-submit-discriminated-executable-payloads/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Submit Discriminated Executable Payloads
+
+## Focused Validation
+
+Run backend validation tests:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+```
+
+Run focused Create page tests:
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx
+```
+
+Run final unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Manual Payload Checks
+
+1. Submit or validate a task with a step shaped as `type: "tool"` and a `tool` sub-payload.
+2. Confirm the runtime plan node uses the typed tool id/name and does not expose Activity as the Step Type.
+3. Submit or validate a task with a step shaped as `type: "skill"` and a `skill` sub-payload.
+4. Confirm the runtime plan node uses the selected agent-facing skill.
+5. Submit or validate a task with `type: "preset"` and confirm it is rejected before runtime materialization.
+6. Confirm preset-applied Create-page submissions include flattened steps with `type: "tool"` or `type: "skill"` and retain optional provenance metadata when present.

--- a/specs/279-submit-discriminated-executable-payloads/research.md
+++ b/specs/279-submit-discriminated-executable-payloads/research.md
@@ -26,7 +26,7 @@ Decision: Preserve `source` and existing `presetProvenance` metadata in step inp
 
 Rationale: The source design treats provenance as audit and reconstruction metadata, not hidden runtime work.
 
-## Decision 5: Focus integration evidence on materializer unit tests
+## Decision 5: Focus integration evidence on deterministic boundary tests
 
 Decision: Use Python unit tests for payload validation and materialization plus Vitest for browser submission payloads. Do not add compose-backed integration tests for this story.
 

--- a/specs/279-submit-discriminated-executable-payloads/research.md
+++ b/specs/279-submit-discriminated-executable-payloads/research.md
@@ -1,0 +1,33 @@
+# Research: Submit Discriminated Executable Payloads
+
+## Decision 1: Validate Step Type at the task contract boundary
+
+Decision: Add explicit submitted-step validation in `moonmind/workflows/tasks/task_contract.py`.
+
+Rationale: The task contract is the earliest shared backend boundary for task-shaped execution payloads. It can reject unresolved Preset steps, Activity labels, and conflicting Tool/Skill payloads before any workflow history or runtime plan nodes are produced.
+
+Alternatives considered: Only relying on the Create-page UI was rejected because API and automation callers can submit task payloads directly.
+
+## Decision 2: Preserve legacy step fields only when no explicit Step Type is supplied
+
+Decision: Explicit `type` values are validated strictly. Existing steps without `type` continue through current selection rules while new submitted payloads include `type`.
+
+Rationale: The source design acknowledges migration readers, but unsupported explicit runtime values must fail fast. This keeps existing stored drafts readable without accepting ambiguous new discriminators.
+
+## Decision 3: Use explicit Step Type for runtime plan node selection
+
+Decision: In `worker_runtime.py`, explicit Tool steps materialize as typed tool plan nodes using the submitted tool id/name; explicit Skill steps materialize through the existing agent-runtime or Jira skill path.
+
+Rationale: This directly satisfies runtime mapping semantics without changing the plan executor's Temporal Activity internals.
+
+## Decision 4: Keep preset provenance audit-only
+
+Decision: Preserve `source` and existing `presetProvenance` metadata in step inputs, but do not require either to choose the runtime node.
+
+Rationale: The source design treats provenance as audit and reconstruction metadata, not hidden runtime work.
+
+## Decision 5: Focus integration evidence on materializer unit tests
+
+Decision: Use Python unit tests for payload validation and materialization plus Vitest for browser submission payloads. Do not add compose-backed integration tests for this story.
+
+Rationale: No database, external service, or worker-topology behavior changes are needed. The contract boundary can be exercised deterministically in unit tests.

--- a/specs/279-submit-discriminated-executable-payloads/spec.md
+++ b/specs/279-submit-discriminated-executable-payloads/spec.md
@@ -77,11 +77,11 @@ Classification: single-story runtime feature request. Existing artifact inspecti
 
 **Acceptance Scenarios**:
 
-1. **Given** a task submission contains a Tool step with `type: "tool"` and a tool sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Tool step and maps to a typed tool plan node.
-2. **Given** a task submission contains a Skill step with `type: "skill"` and a skill sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Skill step and maps to an agent-facing skill plan node.
-3. **Given** a task submission contains an unresolved Preset step with `type: "preset"`, **When** executable submission validation runs, **Then** the submission is rejected before runtime materialization.
-4. **Given** preset-expanded executable steps include source provenance metadata, **When** the task payload is validated and materialized, **Then** provenance is preserved for audit and reconstruction but is not required to choose the runtime plan node.
-5. **Given** a submitted step uses Temporal Activity terminology as its Step Type, **When** executable submission validation runs, **Then** the submission is rejected and no Activity Step Type enters the runtime plan.
+1. **SCN-001 - Tool step materialization**: **Given** a task submission contains a Tool step with `type: "tool"` and a tool sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Tool step and maps to a typed tool plan node.
+2. **SCN-002 - Skill step materialization**: **Given** a task submission contains a Skill step with `type: "skill"` and a skill sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Skill step and maps to an agent-facing skill plan node.
+3. **SCN-003 - Preset rejection**: **Given** a task submission contains an unresolved Preset step with `type: "preset"`, **When** executable submission validation runs, **Then** the submission is rejected before runtime materialization.
+4. **SCN-004 - Provenance preservation**: **Given** preset-expanded executable steps include source provenance metadata, **When** the task payload is validated and materialized, **Then** provenance is preserved for audit and reconstruction but is not required to choose the runtime plan node.
+5. **SCN-005 - Activity label rejection**: **Given** a submitted step uses Temporal Activity terminology as its Step Type, **When** executable submission validation runs, **Then** the submission is rejected and no Activity Step Type enters the runtime plan.
 
 ### Edge Cases
 

--- a/specs/279-submit-discriminated-executable-payloads/spec.md
+++ b/specs/279-submit-discriminated-executable-payloads/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Submit Discriminated Executable Payloads
+
+**Feature Branch**: `279-submit-discriminated-executable-payloads`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**:
+
+```text
+# MM-559 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-559
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Submit discriminated executable payloads
+- Labels: moonmind-workflow-mm-b197665d-a0b9-489d-a38a-9723a9d469c1
+- Trusted fetch tool: jira.get_issue
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose recommended preset instructions or a normalized preset brief.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-559 from MM project
+Summary: Submit discriminated executable payloads
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-559 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-559: Submit discriminated executable payloads
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 7.1 Authoring payload
+- 7.2 Runtime plan mapping
+- 10.3 Keep `Activity` Temporal-specific
+- 11. API Shape
+- 15. Non-Goals
+- 16. Open Design Decisions
+
+Coverage IDs:
+- DESIGN-REQ-008
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-016
+- DESIGN-REQ-019
+
+As a workflow maintainer, I want task submissions to use explicit discriminated Step payloads that compile into runtime plans without exposing Temporal implementation details to authors.
+
+Acceptance Criteria
+- The API shape exposes StepType values tool, skill, and preset with distinct sub-payloads.
+- Executable submission normally accepts only ToolStep or SkillStep.
+- Preset-derived source metadata can be present but is not required for runtime correctness.
+- Runtime materialization maps Tool and Skill into plan nodes and does not materialize Preset as a runtime node by default.
+- Temporal Activity remains an implementation detail and is not used as a Step Type label.
+
+Requirements
+- Step payloads are explicit and discriminated.
+- Preset expansion produces executable payloads before submission.
+- Provenance metadata is durable enough for audit and reconstruction but not hidden work.
+- Internal alternatives such as step.action.kind cannot change the user-facing Step Type terminology.
+```
+
+Classification: single-story runtime feature request. Existing artifact inspection found no prior `MM-559` spec under `specs/`, so `Specify` is the first incomplete MoonSpec stage.
+
+## User Story - Submit Executable Step Payloads
+
+**Summary**: As a workflow maintainer, I want task submissions to carry explicit Tool and Skill step discriminators so runtime plans can be materialized without exposing Temporal implementation details or unresolved preset placeholders.
+
+**Goal**: Draft and preset-expanded task submissions preserve clear user-facing Step Type intent through submission validation and runtime materialization.
+
+**Independent Test**: Can be fully tested by submitting or validating task payloads with Tool, Skill, and Preset step shapes and confirming that only executable Tool and Skill steps enter runtime plans while preset provenance remains audit metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task submission contains a Tool step with `type: "tool"` and a tool sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Tool step and maps to a typed tool plan node.
+2. **Given** a task submission contains a Skill step with `type: "skill"` and a skill sub-payload, **When** the task payload is validated and materialized, **Then** the step remains classified as a Skill step and maps to an agent-facing skill plan node.
+3. **Given** a task submission contains an unresolved Preset step with `type: "preset"`, **When** executable submission validation runs, **Then** the submission is rejected before runtime materialization.
+4. **Given** preset-expanded executable steps include source provenance metadata, **When** the task payload is validated and materialized, **Then** provenance is preserved for audit and reconstruction but is not required to choose the runtime plan node.
+5. **Given** a submitted step uses Temporal Activity terminology as its Step Type, **When** executable submission validation runs, **Then** the submission is rejected and no Activity Step Type enters the runtime plan.
+
+### Edge Cases
+
+- A step includes both Tool and Skill sub-payloads.
+- A step omits `type` while carrying legacy skill or tool-shaped fields.
+- A command-like Tool step has unbounded inputs or lacks required policy metadata.
+- A preset-derived step has missing or partial provenance metadata.
+- A runtime plan is generated from a single explicit step or multiple explicit steps.
+
+## Assumptions
+
+- Existing legacy readers may continue to accept older task shapes during migration, but new executable authoring and submitted payloads should prefer explicit `type`, `tool`, and `skill` fields.
+- Preset preview and apply flows are responsible for expanding Preset steps before submission; this story enforces the executable submission boundary.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Functional Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-008 | `docs/Steps/StepTypes.md` section 7.1 | Executable task submission should contain only executable Tool and Skill steps by default. | In scope | FR-001, FR-004 |
+| DESIGN-REQ-011 | `docs/Steps/StepTypes.md` section 7.2 | Runtime materialization maps Tool and Skill steps into plan nodes and does not materialize Preset as a runtime node by default. | In scope | FR-002, FR-004 |
+| DESIGN-REQ-012 | `docs/Steps/StepTypes.md` section 10.3 | Temporal Activity remains an implementation detail and must not be used as the Step Type label. | In scope | FR-005 |
+| DESIGN-REQ-016 | `docs/Steps/StepTypes.md` section 11 | Step API shape is explicit and discriminated with `tool`, `skill`, and `preset` values and distinct sub-payloads. | In scope | FR-001, FR-003 |
+| DESIGN-REQ-019 | `docs/Steps/StepTypes.md` sections 15 and 16 | Presets are not hidden runtime work, and internal alternatives must not change user-facing Step Type terminology. | In scope | FR-004, FR-006 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept executable submitted steps with explicit `type: "tool"` plus a Tool sub-payload or `type: "skill"` plus a Skill sub-payload.
+- **FR-002**: System MUST materialize Tool steps and Skill steps into runtime plan nodes using their explicit Step Type intent rather than Temporal Activity terminology.
+- **FR-003**: System MUST expose or preserve Step Type values `tool`, `skill`, and `preset` in authoring and template-derived payload contracts with distinct sub-payloads.
+- **FR-004**: System MUST reject unresolved Preset steps at the executable submission boundary unless a future linked-preset execution mode is explicitly implemented.
+- **FR-005**: System MUST reject Activity or other Temporal implementation labels as submitted Step Type values.
+- **FR-006**: System MUST preserve preset-derived source or provenance metadata when present without requiring it for runtime correctness.
+- **FR-007**: System MUST reject steps with conflicting discriminators, such as Tool and Skill sub-payloads on the same executable step.
+
+### Key Entities
+
+- **Executable Step**: A submitted task step whose Step Type is `tool` or `skill` and whose type-specific sub-payload is valid.
+- **Preset Step**: An authoring-time placeholder that must be expanded before executable submission.
+- **Step Provenance**: Optional metadata describing preset origin, include path, original step identity, or related reconstruction details.
+- **Runtime Plan Node**: The internal execution unit produced from an executable step.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Validation tests cover Tool, Skill, Preset rejection, Activity rejection, conflicting payloads, and provenance-preservation cases.
+- **SC-002**: Runtime materialization tests prove Tool and Skill submitted steps produce executable plan nodes and Preset steps do not.
+- **SC-003**: UI or template expansion tests prove preset-applied submissions send flattened executable steps with explicit Step Type values.
+- **SC-004**: Traceability evidence preserves `MM-559` and all in-scope `DESIGN-REQ-*` mappings in MoonSpec artifacts and final verification output.

--- a/specs/279-submit-discriminated-executable-payloads/tasks.md
+++ b/specs/279-submit-discriminated-executable-payloads/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Submit Discriminated Executable Payloads
+
+**Input**: `specs/279-submit-discriminated-executable-payloads/spec.md` and `specs/279-submit-discriminated-executable-payloads/plan.md`
+
+**Prerequisites**: spec, plan, research, data model, contract, and quickstart complete.
+
+**Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+
+**Frontend Test Command**: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+
+**Final Verification Command**: `./tools/test_unit.sh`
+
+**Source Traceability**: MM-559 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-007, SC-001 through SC-004, and DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-016, and DESIGN-REQ-019.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm `.specify/feature.json` points to `specs/279-submit-discriminated-executable-payloads` and the requirements checklist is complete.
+- [X] T002 Inspect existing task contract, runtime materializer, and Create-page submission tests in `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `frontend/src/entrypoints/task-create.test.tsx`.
+
+## Phase 2: Foundational Tests
+
+- [X] T003 [P] Add failing task contract unit tests for explicit Tool, Skill, Preset rejection, Activity rejection, conflicting payloads, and provenance preservation in `tests/unit/workflows/tasks/test_task_contract.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-008, DESIGN-REQ-012, DESIGN-REQ-016, and DESIGN-REQ-019.
+- [X] T004 [P] Add failing runtime materialization unit tests for explicit Tool and Skill mapping and provenance-agnostic mapping in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` for FR-002, FR-006, SCN-001, SCN-002, SCN-004, and DESIGN-REQ-011.
+- [X] T005 [P] Add failing Create-page submission expectations that applied preset steps include explicit `type` values in `frontend/src/entrypoints/task-create.test.tsx` for FR-003, SC-003, and DESIGN-REQ-016.
+- [X] T006 Run the focused failing tests and record the expected red result in `specs/279-submit-discriminated-executable-payloads/tasks.md`.
+
+## Phase 3: Story Implementation
+
+**Story**: Submitted task steps use explicit executable Tool/Skill discriminators and reject unresolved Preset or Activity labels.
+
+**Independent Test**: Validate task payloads and materialize runtime plans for Tool, Skill, Preset, Activity, conflicting payloads, and preset provenance cases.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SC-001, SC-002, SC-003, SC-004, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-016, DESIGN-REQ-019.
+
+- [X] T007 Implement submitted step discriminator validation in `moonmind/workflows/tasks/task_contract.py` for FR-001, FR-004, FR-005, and FR-007.
+- [X] T008 Implement explicit Step Type aware runtime plan mapping in `moonmind/workflows/temporal/worker_runtime.py` for FR-002, FR-006, and DESIGN-REQ-011.
+- [X] T009 Implement explicit `type` serialization for Create-page submitted Tool and Skill steps in `frontend/src/entrypoints/task-create.tsx` for FR-003 and DESIGN-REQ-016.
+- [X] T010 Run focused backend and frontend tests and fix implementation defects.
+
+## Phase 4: Polish
+
+- [X] T011 Update `specs/279-submit-discriminated-executable-payloads/tasks.md` checkboxes and red/green evidence.
+- [X] T012 Review changed code for MM-559 traceability, no raw credentials, and no Temporal Activity Step Type leakage.
+
+## Phase 5: Final Verification
+
+- [X] T013 Run `./tools/test_unit.sh` for final unit verification or record the exact blocker.
+- [X] T014 Run `/speckit.verify` equivalent by comparing implementation, tests, and artifacts against `specs/279-submit-discriminated-executable-payloads/spec.md`, then write `specs/279-submit-discriminated-executable-payloads/verification.md`.
+
+## Execution Evidence
+
+- Red-first backend run: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` initially failed on missing submitted Step Type validation and explicit Tool/Skill runtime mapping.
+- Focused backend green run: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` passed with 69 Python tests.
+- Focused frontend green run: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed with 213 tests.
+- TypeScript check: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` passed.
+- Final full unit run: `./tools/test_unit.sh` passed with 4215 Python tests, 16 subtests, and 471 frontend tests.

--- a/specs/279-submit-discriminated-executable-payloads/tasks.md
+++ b/specs/279-submit-discriminated-executable-payloads/tasks.md
@@ -8,6 +8,8 @@
 
 **Frontend Test Command**: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
 
+**Integration Test Strategy**: No compose-backed `integration_ci` test is required for this narrow payload-contract story because there is no new database, external service, or worker-topology behavior. Integration-boundary coverage is provided by the Create-page submission test in `frontend/src/entrypoints/task-create.test.tsx`, which exercises preset expansion through submitted task payload shape, and by runtime materialization tests at the worker boundary.
+
 **Final Verification Command**: `./tools/test_unit.sh`
 
 **Source Traceability**: MM-559 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-007, SC-001 through SC-004, and DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-016, and DESIGN-REQ-019.
@@ -21,8 +23,9 @@
 
 - [X] T003 [P] Add failing task contract unit tests for explicit Tool, Skill, Preset rejection, Activity rejection, conflicting payloads, and provenance preservation in `tests/unit/workflows/tasks/test_task_contract.py` for FR-001, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-008, DESIGN-REQ-012, DESIGN-REQ-016, and DESIGN-REQ-019.
 - [X] T004 [P] Add failing runtime materialization unit tests for explicit Tool and Skill mapping and provenance-agnostic mapping in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` for FR-002, FR-006, SCN-001, SCN-002, SCN-004, and DESIGN-REQ-011.
-- [X] T005 [P] Add failing Create-page submission expectations that applied preset steps include explicit `type` values in `frontend/src/entrypoints/task-create.test.tsx` for FR-003, SC-003, and DESIGN-REQ-016.
-- [X] T006 Run the focused failing tests and record the expected red result in `specs/279-submit-discriminated-executable-payloads/tasks.md`.
+- [X] T005 [P] Add failing Create-page integration-boundary submission expectations that applied preset steps include explicit `type` values in `frontend/src/entrypoints/task-create.test.tsx` for FR-003, SC-003, and DESIGN-REQ-016.
+- [X] T006 [P] Confirm compose-backed integration is not required and record integration-boundary coverage in `specs/279-submit-discriminated-executable-payloads/tasks.md`.
+- [X] T007 Run the focused failing tests and record the expected red result in `specs/279-submit-discriminated-executable-payloads/tasks.md`.
 
 ## Phase 3: Story Implementation
 
@@ -32,25 +35,26 @@
 
 **Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SC-001, SC-002, SC-003, SC-004, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-016, DESIGN-REQ-019.
 
-- [X] T007 Implement submitted step discriminator validation in `moonmind/workflows/tasks/task_contract.py` for FR-001, FR-004, FR-005, and FR-007.
-- [X] T008 Implement explicit Step Type aware runtime plan mapping in `moonmind/workflows/temporal/worker_runtime.py` for FR-002, FR-006, and DESIGN-REQ-011.
-- [X] T009 Implement explicit `type` serialization for Create-page submitted Tool and Skill steps in `frontend/src/entrypoints/task-create.tsx` for FR-003 and DESIGN-REQ-016.
-- [X] T010 Run focused backend and frontend tests and fix implementation defects.
+- [X] T008 Implement submitted step discriminator validation in `moonmind/workflows/tasks/task_contract.py` for FR-001, FR-004, FR-005, and FR-007.
+- [X] T009 Implement explicit Step Type aware runtime plan mapping in `moonmind/workflows/temporal/worker_runtime.py` for FR-002, FR-006, and DESIGN-REQ-011.
+- [X] T010 Implement explicit `type` serialization for Create-page submitted Tool and Skill steps in `frontend/src/entrypoints/task-create.tsx` for FR-003 and DESIGN-REQ-016.
+- [X] T011 Run focused backend and frontend tests and fix implementation defects.
 
-## Phase 4: Polish
+## Phase 4: Story Validation And Polish
 
-- [X] T011 Update `specs/279-submit-discriminated-executable-payloads/tasks.md` checkboxes and red/green evidence.
-- [X] T012 Review changed code for MM-559 traceability, no raw credentials, and no Temporal Activity Step Type leakage.
+- [X] T012 Validate the single story end-to-end against Tool, Skill, Preset rejection, Activity rejection, provenance, and Create-page submission scenarios in `specs/279-submit-discriminated-executable-payloads/verification.md`.
+- [X] T013 Update `specs/279-submit-discriminated-executable-payloads/tasks.md` checkboxes and red/green evidence.
+- [X] T014 Review changed code for MM-559 traceability, no raw credentials, and no Temporal Activity Step Type leakage.
 
 ## Phase 5: Final Verification
 
-- [X] T013 Run `./tools/test_unit.sh` for final unit verification or record the exact blocker.
-- [X] T014 Run `/speckit.verify` equivalent by comparing implementation, tests, and artifacts against `specs/279-submit-discriminated-executable-payloads/spec.md`, then write `specs/279-submit-discriminated-executable-payloads/verification.md`.
+- [X] T015 Run `./tools/test_unit.sh` for final unit verification or record the exact blocker.
+- [X] T016 Run `/moonspec-verify` equivalent by comparing implementation, tests, and artifacts against `specs/279-submit-discriminated-executable-payloads/spec.md`, then write `specs/279-submit-discriminated-executable-payloads/verification.md`.
 
 ## Execution Evidence
 
 - Red-first backend run: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` initially failed on missing submitted Step Type validation and explicit Tool/Skill runtime mapping.
 - Focused backend green run: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` passed with 69 Python tests.
-- Focused frontend green run: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed with 213 tests.
+- Focused frontend integration-boundary green run: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed with 213 tests.
 - TypeScript check: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` passed.
 - Final full unit run: `./tools/test_unit.sh` passed with 4215 Python tests, 16 subtests, and 471 frontend tests.

--- a/specs/279-submit-discriminated-executable-payloads/verification.md
+++ b/specs/279-submit-discriminated-executable-payloads/verification.md
@@ -1,0 +1,35 @@
+# Verification: Submit Discriminated Executable Payloads
+
+**Feature**: `specs/279-submit-discriminated-executable-payloads/spec.md`  
+**Original Request Source**: MM-559 Jira preset brief preserved in `spec.md` Input  
+**Verdict**: FULLY_IMPLEMENTED
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `TaskStepSpec` validates explicit `type: "tool"` and `type: "skill"` submitted steps; `test_task_steps_accept_explicit_tool_and_skill_discriminators` covers both. |
+| FR-002 | VERIFIED | `_build_runtime_planner` maps explicit Tool steps to typed tool plan nodes and explicit Skill steps to agent-runtime nodes; covered by `test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node` and `test_runtime_planner_maps_explicit_skill_step_to_agent_runtime_node`. |
+| FR-003 | VERIFIED | Create-page submitted preset-derived Tool and Skill steps include `type` values; covered by updated `task-create.test.tsx` expectations. |
+| FR-004 | VERIFIED | `type: "preset"` is rejected at the task contract boundary; covered by `test_task_steps_reject_non_executable_step_types`. |
+| FR-005 | VERIFIED | `activity` and `Activity` Step Type labels are rejected; covered by `test_task_steps_reject_non_executable_step_types`. |
+| FR-006 | VERIFIED | Provenance metadata remains preserved in task contract dumps and runtime node inputs while mapping is chosen from explicit Step Type; covered by contract and runtime tests. |
+| FR-007 | VERIFIED | Conflicting Tool and Skill executable payloads are rejected; covered by `test_task_steps_reject_conflicting_executable_payloads` and `test_task_steps_reject_skill_step_with_non_skill_tool_payload`. |
+| DESIGN-REQ-008 | VERIFIED | Executable submission boundary accepts Tool/Skill and rejects Preset. |
+| DESIGN-REQ-011 | VERIFIED | Runtime materialization distinguishes explicit Tool and Skill submitted steps. |
+| DESIGN-REQ-012 | VERIFIED | Activity remains rejected as a Step Type label. |
+| DESIGN-REQ-016 | VERIFIED | Submitted payloads preserve explicit discriminators and distinct sub-payload validation. |
+| DESIGN-REQ-019 | VERIFIED | Preset provenance is audit metadata and unresolved Preset steps do not materialize. |
+
+## Test Evidence
+
+- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`: PASS, 69 tests.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`: PASS, 213 tests.
+- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`: PASS.
+- `./tools/test_unit.sh`: PASS, 4215 Python tests, 16 subtests, and 471 frontend tests.
+
+## Notes
+
+- The implementation preserves existing legacy step behavior when no explicit `type` is supplied, while strict validation applies once a submitted Step Type is present.
+- Oversized inline instruction stripping removes type-only step remnants so artifact-backed payload slimming does not create fake executable steps.
+- No raw credentials or external Jira data were committed.

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -84,6 +84,109 @@ def test_task_step_spec_with_step_skills() -> None:
     assert spec.skills.exclude == ["bad-skill"]
     assert spec.skills.materialization_mode == "none"
 
+def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
+    spec = TaskExecutionSpec.model_validate(
+        {
+            "instructions": "Run explicit steps.",
+            "steps": [
+                {
+                    "id": "fetch-issue",
+                    "type": "tool",
+                    "instructions": "Fetch issue.",
+                    "tool": {
+                        "id": "jira.get_issue",
+                        "version": "1.0.0",
+                        "inputs": {"issueKey": "MM-559"},
+                    },
+                    "source": {
+                        "kind": "preset-derived",
+                        "presetId": "jira-flow",
+                    },
+                },
+                {
+                    "id": "implement",
+                    "type": "skill",
+                    "instructions": "Implement issue.",
+                    "skill": {
+                        "id": "moonspec-implement",
+                        "args": {"issueKey": "MM-559"},
+                    },
+                },
+            ],
+        }
+    )
+
+    dumped_steps = [step.model_dump(by_alias=True) for step in spec.steps]
+    assert dumped_steps[0]["type"] == "tool"
+    assert dumped_steps[0]["tool"]["id"] == "jira.get_issue"
+    assert dumped_steps[0]["source"]["presetId"] == "jira-flow"
+    assert dumped_steps[1]["type"] == "skill"
+    assert dumped_steps[1]["skill"]["id"] == "moonspec-implement"
+
+@pytest.mark.parametrize("step_type", ["preset", "activity", "Activity"])
+def test_task_steps_reject_non_executable_step_types(step_type: str) -> None:
+    with pytest.raises(ValidationError, match="task\\.steps\\[\\]\\.type"):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Run explicit steps.",
+                "steps": [
+                    {
+                        "type": step_type,
+                        "instructions": "This must not execute.",
+                        "preset": {
+                            "id": "jira.implementation_flow",
+                            "inputs": {"issueKey": "MM-559"},
+                        },
+                    }
+                ],
+            }
+        )
+
+def test_task_steps_reject_conflicting_executable_payloads() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Tool steps must not include a skill payload",
+    ):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Run explicit steps.",
+                "steps": [
+                    {
+                        "type": "tool",
+                        "instructions": "Fetch issue.",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "inputs": {"issueKey": "MM-559"},
+                        },
+                        "skill": {"id": "moonspec-implement", "args": {}},
+                    }
+                ],
+            }
+        )
+
+def test_task_steps_reject_skill_step_with_non_skill_tool_payload() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Skill steps must not include a non-skill tool payload",
+    ):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Run explicit steps.",
+                "steps": [
+                    {
+                        "type": "skill",
+                        "instructions": "Implement issue.",
+                        "tool": {
+                            "type": "tool",
+                            "id": "jira.get_issue",
+                            "inputs": {"issueKey": "MM-559"},
+                        },
+                        "skill": {"id": "moonspec-implement", "args": {}},
+                    }
+                ],
+            }
+        )
+
 def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> None:
     task_skills = TaskExecutionSpec.model_validate(
         {

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -236,6 +236,86 @@ def test_runtime_planner_promotes_profile_id_to_runtime_node():
     assert runtime_node["profileId"] == "codex-provider-profile"
     assert runtime_node["providerProfile"] == "codex-provider-profile"
 
+def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run explicit tool step.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "fetch-issue",
+                        "type": "tool",
+                        "instructions": "Fetch MM-559.",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-559"},
+                        },
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetId": "jira-flow",
+                        },
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["tool"] == {
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
+    }
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
+    assert plan["nodes"][0]["inputs"]["type"] == "tool"
+    assert plan["nodes"][0]["inputs"]["source"]["presetId"] == "jira-flow"
+
+def test_runtime_planner_maps_explicit_skill_step_to_agent_runtime_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run explicit skill step.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "implement",
+                        "type": "skill",
+                        "instructions": "Implement MM-559.",
+                        "skill": {
+                            "id": "moonspec-implement",
+                            "args": {"issueKey": "MM-559"},
+                        },
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "moonspec-implement"
+    assert plan["nodes"][0]["inputs"]["type"] == "skill"
+
 def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
Jira issue key: MM-559

Active MoonSpec feature path: specs/279-submit-discriminated-executable-payloads

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py: PASS, 69 Python tests plus frontend phase with 471 tests
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx: PASS, 213 tests
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json: PASS
- ./tools/test_unit.sh: PASS, 4215 Python tests, 16 subtests, and 471 frontend tests

Remaining risks:
- The MoonSpec prerequisite helper rejects this managed branch name because it does not match the numeric feature-branch pattern; feature resolution and gates were verified directly from .specify/feature.json and artifacts.
- Push succeeded through gh credential fallback because the configured MoonMind git credential helper failed to import api_service in this environment.