### PR TITLE
MM-560 prevent proposal promotion drift

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/279-submit-discriminated-executable-payloads"
+  "feature_directory": "specs/280-promote-proposals-no-drift"
 }

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -323,14 +323,10 @@ async def promote_proposal(
     user: User = Depends(get_current_user()),
 ) -> TaskProposalPromoteResponse:
     try:
-        # Build the override: explicit taskCreateRequestOverride takes
-        # precedence; runtimeMode is a lightweight shortcut that
-        # constructs one on-the-fly when the full override is absent.
-        if payload.task_create_request_override is not None:
-            override_payload = payload.task_create_request_override
-        elif payload.runtime_mode:
-            runtime_mode = payload.runtime_mode.strip()
-            if not runtime_mode:
+        runtime_mode_override = None
+        if payload.runtime_mode:
+            runtime_mode_override = payload.runtime_mode.strip()
+            if not runtime_mode_override:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail={
@@ -338,23 +334,6 @@ async def promote_proposal(
                         "message": "runtimeMode must be a non-empty string",
                     },
                 )
-            # Fetch the stored proposal to extract the repository for
-            # the override envelope that the service expects.
-            stored = await service.get_proposal(proposal_id)
-            stored_request = stored.task_create_request or {}
-            stored_payload = stored_request.get("payload") or {}
-            repo = stored_payload.get("repository", "")
-            override_payload = {
-                "type": "task",
-                "priority": stored_request.get("priority", 0),
-                "maxAttempts": stored_request.get("maxAttempts", 3),
-                "payload": {
-                    "repository": repo,
-                    "task": {"runtime": {"mode": runtime_mode}},
-                },
-            }
-        else:
-            override_payload = None
 
         proposal, final_request = await service.promote_proposal(
             proposal_id=proposal_id,
@@ -362,7 +341,7 @@ async def promote_proposal(
             priority_override=payload.priority,
             max_attempts_override=payload.max_attempts,
             note=payload.note,
-            task_create_request_override=override_payload,
+            runtime_mode_override=runtime_mode_override,
         )
 
         initial_parameters = dict(final_request.get("payload") or {})

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-559",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1841"
+  "jira_issue_key": "MM-560",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1842"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,17 @@
 [
   {
-    "id": 4340312586,
+    "id": 4340704945,
     "disposition": "not-applicable",
-    "rationale": "Quota warning from gemini-code-assist; no code feedback to address."
+    "rationale": "Automated quota warning with no requested code change."
   },
   {
-    "id": 4340316442,
-    "disposition": "not-applicable",
-    "rationale": "Duplicate quota warning from gemini-code-assist; no code feedback to address."
-  },
-  {
-    "id": 3158201200,
+    "id": 3158511680,
     "disposition": "addressed",
-    "rationale": "Preset-generated Tool steps now preserve and submit their executable tool binding after Apply preview, with regression coverage."
+    "rationale": "Runtime promotion override now updates top-level targetRuntime alongside task.runtime.mode, with a regression test covering stored payloads that already include targetRuntime."
   },
   {
-    "id": 4193618593,
+    "id": 4193967441,
     "disposition": "not-applicable",
-    "rationale": "Review summary container for the actionable inline comment; no separate code change requested."
+    "rationale": "Codex review wrapper summary; the actionable child review comment is tracked separately."
   }
 ]

--- a/docs/Tasks/TaskProposalSystem.md
+++ b/docs/Tasks/TaskProposalSystem.md
@@ -414,16 +414,19 @@ Promotion must follow this algorithm:
 
 1. load the stored proposal
 2. verify the proposal is still `open`
-3. merge `taskCreateRequestOverride` into the stored `taskCreateRequest`
-4. apply shortcut `runtimeMode` only by constructing that override
-5. validate the merged payload against the canonical task contract, including verification of any agent-skill selectors
-6. preserve explicit skill-selection intent from the stored proposal unless the operator intentionally overrides it, ensuring promotion-time overrides do not silently drop or corrupt skill fields
-7. preserve `task.authoredPresets` and per-step `source` provenance from the stored proposal unless the operator intentionally overrides those fields through the merged payload
-8. submit the merged task through the same Temporal-backed create path used by
+3. apply bounded promotion controls such as `priority`, `maxAttempts`, `note`, and `runtimeMode`
+4. validate the stored payload against the canonical task contract, including verification of any agent-skill selectors and executable step types
+5. preserve explicit skill-selection intent from the stored proposal
+6. preserve `task.authoredPresets` and per-step `source` provenance from the stored proposal
+7. submit the reviewed task through the same Temporal-backed create path used by
    `/api/executions`
-9. create a new `MoonMind.Run` through `TemporalExecutionService.create_execution()`
-10. store the promoted workflow or execution identifier on the proposal record
-11. return both the updated proposal and the new execution metadata
+8. create a new `MoonMind.Run` through `TemporalExecutionService.create_execution()`
+9. store the promoted workflow or execution identifier on the proposal record
+10. return both the updated proposal and the new execution metadata
+
+Promotion does not accept a full task payload replacement. If a future proposal
+refresh or preset re-expansion flow is introduced, it must be an explicit
+preview-and-validate action before promotion.
 
 Promotion is therefore a control-plane-to-Temporal bridge, not a proposal-local
 mutation only.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6339,13 +6339,9 @@ export interface components {
             note?: string | null;
             /**
              * Runtimemode
-             * @description Shortcut to override the agent runtime mode (e.g. gemini_cli, jules, codex). Ignored when taskCreateRequestOverride is provided.
+             * @description Shortcut to override only the agent runtime mode (e.g. gemini_cli, jules, codex) while preserving the reviewed proposal payload.
              */
             runtimeMode?: string | null;
-            /** Taskcreaterequestoverride */
-            taskCreateRequestOverride?: {
-                [key: string]: unknown;
-            } | null;
         };
         /**
          * TaskProposalPromoteResponse

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -110,7 +110,7 @@ class TaskProposalListResponse(BaseModel):
 class TaskProposalPromoteRequest(BaseModel):
     """Optional overrides supplied during promotion."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     priority: Optional[int] = Field(None, alias="priority")
     max_attempts: Optional[int] = Field(None, alias="maxAttempts")
@@ -119,12 +119,9 @@ class TaskProposalPromoteRequest(BaseModel):
         None,
         alias="runtimeMode",
         description=(
-            "Shortcut to override the agent runtime mode (e.g. gemini_cli, "
-            "jules, codex). Ignored when taskCreateRequestOverride is provided."
+            "Shortcut to override only the agent runtime mode (e.g. gemini_cli, "
+            "jules, codex) while preserving the reviewed proposal payload."
         ),
-    )
-    task_create_request_override: Optional[dict[str, Any]] = Field(
-        None, alias="taskCreateRequestOverride"
     )
 
 class TaskProposalDismissRequest(BaseModel):

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -761,6 +761,7 @@ class TaskProposalService:
             runtime["mode"] = normalized_runtime_mode
             task["runtime"] = runtime
             payload["task"] = task
+            payload["targetRuntime"] = normalized_runtime_mode
             try:
                 parsed = CanonicalTaskPayload.model_validate(payload)
                 payload = parsed.model_dump(by_alias=True, exclude_none=True)

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -725,15 +725,15 @@ class TaskProposalService:
         priority_override: int | None = None,
         max_attempts_override: int | None = None,
         note: str | None = None,
-        task_create_request_override: dict[str, Any] | None = None,
+        runtime_mode_override: str | None = None,
     ) -> tuple[TaskProposal, dict[str, Any]]:
         """Validate and finalize a proposal for execution promotion.
 
         Returns the updated TaskProposal and the finalized taskCreateRequest
         envelope (suitable for use as ``initial_parameters``) ready to execute.
-        The returned envelope may differ from the stored proposal record when
-        an override is provided; the stored ``task_create_request`` is not
-        mutated by this method.
+        Runtime mode may be overridden as a bounded promotion control; reviewed
+        task steps, instructions, and provenance are always loaded from the
+        stored proposal payload.
         """
         proposal = await self._repository.get_proposal_for_update(proposal_id)
         if proposal.status is not TaskProposalStatus.OPEN:
@@ -741,14 +741,7 @@ class TaskProposalService:
                 f"proposal status {proposal.status.value} cannot be promoted"
             )
 
-        if task_create_request_override:
-            override_envelope, _ = self._prepare_task_create_request(
-                task_create_request_override,
-                apply_runtime_defaults=True,
-            )
-            request = override_envelope
-        else:
-            request = dict(proposal.task_create_request or {})
+        request = dict(proposal.task_create_request or {})
         payload = dict(request.get("payload") or {})
         try:
             parsed = CanonicalTaskPayload.model_validate(payload)
@@ -757,6 +750,24 @@ class TaskProposalService:
             raise TaskProposalValidationError(
                 f"stored task payload is invalid: {exc}"
             ) from exc
+        if runtime_mode_override is not None:
+            normalized_runtime_mode = self._normalize_proposal_runtime_mode(
+                runtime_mode_override
+            )
+            task_node = payload.get("task")
+            task = dict(task_node) if isinstance(task_node, Mapping) else {}
+            runtime_node = task.get("runtime")
+            runtime = dict(runtime_node) if isinstance(runtime_node, Mapping) else {}
+            runtime["mode"] = normalized_runtime_mode
+            task["runtime"] = runtime
+            payload["task"] = task
+            try:
+                parsed = CanonicalTaskPayload.model_validate(payload)
+                payload = parsed.model_dump(by_alias=True, exclude_none=True)
+            except ValidationError as exc:
+                raise TaskProposalValidationError(
+                    f"runtimeMode override is invalid: {exc}"
+                ) from exc
         payload = self._enforce_proposal_pr_publish_mode(payload)
         request["payload"] = payload
 

--- a/specs/029-task-proposal-phase2/contracts/task_proposals_phase2.yaml
+++ b/specs/029-task-proposal-phase2/contracts/task_proposals_phase2.yaml
@@ -36,8 +36,9 @@ paths:
                   type: integer
                 note:
                   type: string
-                taskCreateRequestOverride:
-                  $ref: '#/components/schemas/CreateJobRequest'
+                runtimeMode:
+                  type: string
+                  description: Bounded runtime override applied to the stored reviewed payload.
       responses:
         '200':
           description: Promotion result with queue job.

--- a/specs/029-task-proposal-phase2/research.md
+++ b/specs/029-task-proposal-phase2/research.md
@@ -12,10 +12,10 @@
 - **Rationale**: Avoids complex fuzzy matching while still grouping near-duplicates; stable and index-friendly.
 - **Alternatives Considered**: Cosine similarity on embeddings (would add heavy dependencies) and naive title substring search (slow, inconsistent).
 
-## Edit-Before-Promote Flow
-- **Decision**: Extend promote endpoint with optional `taskCreateRequestOverride` payload; UI will open modal pre-populated with stored request allowing edits.
-- **Rationale**: Keeps single endpoint, leverages existing validation path, ensures audit data stays centralized.
-- **Alternatives Considered**: Separate `PUT /api/proposals/{id}` editing route (adds concurrency issues), manual queue job creation page (duplicates logic already in proposals).
+## Reviewed-Payload Promotion Flow
+- **Decision**: Promotion uses the stored reviewed proposal payload and accepts only bounded controls such as runtime mode, priority, max attempts, and note. Full task payload replacement is superseded by MM-560.
+- **Rationale**: Keeps promotion deterministic and prevents reviewed proposals from drifting by replacing flattened steps or re-expanding live preset catalog entries.
+- **Alternatives Considered**: Full edit-before-promote payload override (rejected by MM-560 because it can bypass reviewed content), separate proposal-refresh flow (left to explicit preview-and-validation work).
 
 ## Snooze + Priority Mechanics
 - **Decision**: Add `review_priority` ENUM + `snoozed_until` timestamp persisted on proposals plus optional `snooze_note`. Provide API to snooze/unsnooze and background job to auto-unsnooze.

--- a/specs/029-task-proposal-phase2/spec.md
+++ b/specs/029-task-proposal-phase2/spec.md
@@ -76,8 +76,8 @@ As a platform owner, I want Slack/webhook alerts whenever new security or tests 
 - **FR-001**: The backend MUST compute and persist a deterministic deduplication key (`dedup_key`) and opaque hash (`dedup_hash`) derived from repository + normalized title for every proposal.
 - **FR-002**: The API MUST expose a `similar` collection per proposal listing up to 10 other open proposals sharing the same dedup key ordered by recency.
 - **FR-003**: The dashboard list and detail views MUST surface the dedup hash and similar proposal links without trusting raw user input.
-- **FR-004**: Reviewers MUST be able to launch an "Edit & Promote" UI affordance that loads the stored task payload, allows edits to instructions, publish settings, priority, attempts, affinity key, and tags, and submits the modified payload to the backend promote endpoint.
-- **FR-005**: Promotion API MUST accept an optional `taskCreateRequestOverride` object (parallel to stored envelope) and validate it using the canonical Task contract before enqueuing.
+- **FR-004**: Reviewers MUST be able to inspect the stored task payload before promotion and apply bounded promotion controls such as runtime mode, priority, max attempts, and note without replacing the reviewed payload.
+- **FR-005**: Promotion API MUST validate the stored reviewed Task payload using the canonical Task contract before enqueuing and MUST NOT accept full task payload replacement during promotion.
 - **FR-006**: The system MUST track reviewer-defined triage priority (`low`, `normal`, `high`, `urgent`) per proposal and display it in API/UI responses.
 - **FR-007**: Reviewers MUST be able to snooze a proposal until a timestamp (`snoozed_until`), during which it is excluded from default `status=open` listings but retrievable via `status=snoozed` or `includeSnoozed=true` filter.
 - **FR-008**: Snoozed proposals MUST automatically revert to `open` status when the snooze timestamp passes, without manual intervention.

--- a/specs/029-task-proposal-phase2/tasks.md
+++ b/specs/029-task-proposal-phase2/tasks.md
@@ -36,14 +36,14 @@ Independent Test: Create proposals with similar titles + repo, hit `/api/proposa
 
 ## Phase 4: User Story 2 – Edit Before Promote (Priority: P1)
 
-Goal: Allow reviewers to modify the stored canonical payload before enqueuing while keeping existing one-click promote.
+Goal: Allow reviewers to inspect the stored canonical payload and apply bounded promotion controls before enqueuing while keeping existing one-click promote.
 
-Independent Test: Use dashboard modal to edit instructions/priority, promote, and verify queue job uses overrides + audit note.
+Independent Test: Use dashboard controls to adjust runtime/priority, promote, and verify the queue job uses the stored reviewed payload plus bounded controls.
 
-- [X] T013 [US2] Expand promotion service (`moonmind/workflows/task_proposals/service.py`) to accept `taskCreateRequestOverride` merged with stored envelope plus audit logging.
-- [X] T014 [US2] Update request/response schemas + router handling (`moonmind/schemas/task_proposal_models.py`, `api_service/api/routers/task_proposals.py`) to validate override payload.
-- [X] T015 [US2] Implement dashboard "Edit & Promote" modal with form editing instructions/git/publish/priority/attempts and call promote endpoint with overrides (`api_service/static/task_dashboard/dashboard.js`).
-- [X] T016 [US2] Add backend + UI tests validating override behavior (pytest updates in `tests/unit/api/routers/test_task_proposals.py` and new frontend smoke coverage via lint-friendly JS unit or manual instrumentation comment) plus existing worker tests unaffected.
+- [X] T013 [US2] Expand promotion service (`moonmind/workflows/task_proposals/service.py`) to validate the stored reviewed envelope and apply bounded runtime/priority controls.
+- [X] T014 [US2] Update request/response schemas + router handling (`moonmind/schemas/task_proposal_models.py`, `api_service/api/routers/task_proposals.py`) to reject full task payload replacement.
+- [X] T015 [US2] Keep dashboard promotion controls bounded to reviewed-payload promotion (`frontend/src/entrypoints/proposals.tsx`).
+- [X] T016 [US2] Add backend tests validating reviewed-payload promotion behavior and bounded runtime controls.
 
 ---
 

--- a/specs/280-promote-proposals-no-drift/checklists/requirements.md
+++ b/specs/280-promote-proposals-no-drift/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Promote Proposals Without Live Preset Drift
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass for the selected single-story runtime scope.

--- a/specs/280-promote-proposals-no-drift/contracts/proposal-promotion.md
+++ b/specs/280-promote-proposals-no-drift/contracts/proposal-promotion.md
@@ -1,0 +1,38 @@
+# Contract: Proposal Promotion
+
+## Endpoint
+
+`POST /api/proposals/{proposal_id}/promote`
+
+## Accepted Request Controls
+
+```json
+{
+  "priority": 0,
+  "maxAttempts": 3,
+  "note": "optional reviewer note",
+  "runtimeMode": "codex"
+}
+```
+
+## Rejected Request Controls
+
+```json
+{
+  "taskCreateRequestOverride": {
+    "type": "task",
+    "payload": {}
+  }
+}
+```
+
+Promotion must reject full task payload replacement before creating an execution.
+
+## Promotion Semantics
+
+1. Load the stored proposal.
+2. Validate the stored `taskCreateRequest.payload` through the canonical task contract.
+3. Reject unresolved `type: "preset"` submitted steps.
+4. Preserve `task.authoredPresets` and `task.steps[].source` in the final payload.
+5. Apply only bounded promotion controls.
+6. Create the execution from the final validated payload.

--- a/specs/280-promote-proposals-no-drift/moonspec_align_report.md
+++ b/specs/280-promote-proposals-no-drift/moonspec_align_report.md
@@ -1,0 +1,18 @@
+# MoonSpec Align Report: Promote Proposals Without Live Preset Drift
+
+**Date**: 2026-04-29
+**Feature**: `specs/280-promote-proposals-no-drift`
+**Result**: PASS
+
+## Checks
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Prerequisites | PASS | `SPECIFY_FEATURE=280-promote-proposals-no-drift .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` returned the feature directory and available docs. |
+| Original input preservation | PASS | `spec.md` preserves the trusted `MM-560` preset brief in `## Original Preset Brief`. |
+| Single-story scope | PASS | `spec.md` contains exactly one user story: Reviewed Proposal Promotion. |
+| Source mapping | PASS | `DESIGN-REQ-014`, `DESIGN-REQ-018`, and `DESIGN-REQ-019` are mapped to FRs. |
+| Task coverage | PASS | `tasks.md` covers unit tests, API boundary tests, implementation, OpenAPI alignment, traceability, and final verification. |
+| Verification evidence | PASS | `verification.md` records targeted and full unit verification with a `FULLY_IMPLEMENTED` verdict. |
+
+No artifact remediations were required during the align pass.

--- a/specs/280-promote-proposals-no-drift/plan.md
+++ b/specs/280-promote-proposals-no-drift/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Promote Proposals Without Live Preset Drift
+
+**Branch**: `280-promote-proposals-no-drift`
+**Date**: 2026-04-29
+**Spec**: `specs/280-promote-proposals-no-drift/spec.md`
+**Input**: Single-story runtime feature request from MM-560.
+
+## Summary
+
+Task proposal creation and service-level promotion already validate canonical task payloads and preserve preset provenance metadata. The remaining gap is the promotion API and service allowing a full `taskCreateRequestOverride`, which can replace the reviewed proposal payload at promotion time. This plan removes full replacement promotion, keeps bounded controls (`runtimeMode`, `priority`, `maxAttempts`, `note`), validates the stored flat payload, and adds unit plus API boundary tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `CanonicalTaskPayload` rejects `type: "preset"` in task steps; no explicit proposal promotion regression test | add unit regression test for unresolved preset rejection | unit |
+| FR-002 | implemented_verified | `tests/unit/workflows/task_proposals/test_service.py::test_promote_proposal_preserves_preset_provenance` | keep existing behavior | unit |
+| FR-003 | partial | service uses stored payload by default but accepts full override | remove full override path | unit + API |
+| FR-004 | partial | `runtimeMode` currently works by constructing a full override | make runtime override bounded and service-owned | unit + API |
+| FR-005 | missing | `taskCreateRequestOverride` is accepted by schema/router/service | reject/remove full replacement override | API |
+| FR-006 | implemented_verified | `TaskProposalTaskPreview` exposes `presetProvenance`, `authoredPresetCount`, and `stepSourceKinds` | preserve behavior | API |
+| SC-001 | partial | provenance test exists, preset rejection test missing | add unit test | unit |
+| SC-002 | missing | API accepts override | update API test to reject override | API |
+| SC-003 | partial | runtime shortcut API test exists but uses full override internally | update assertion to bounded service argument | API |
+| SC-004 | implemented_unverified | spec artifacts preserve IDs | run traceability check | traceability |
+| DESIGN-REQ-014 | implemented_verified | task contract rejects ambiguous `preset` step submission; preview uses preset provenance terminology | keep validation and preview terminology | unit/API |
+| DESIGN-REQ-018 | partial | provenance preserved; reviewed flat payload can be replaced by override | remove replacement override | unit + API |
+| DESIGN-REQ-019 | missing | full override can be used as an implicit refresh path | reject full override | API |
+
+## Technical Context
+
+- Language/version: Python 3.12
+- Primary dependencies: FastAPI, Pydantic v2, SQLAlchemy async ORM, existing task contract models
+- Storage: existing `task_proposals` table only; no schema changes
+- Unit testing: pytest through `./tools/test_unit.sh`
+- Integration testing: FastAPI router tests mounted in-process; no Docker required
+- Target platform: MoonMind API and Temporal execution submission path
+- Project type: backend API/service change with generated frontend OpenAPI type alignment
+- Performance goals: no additional external calls or catalog lookups during promotion
+- Constraints: no raw Jira credentials; do not add compatibility aliases for removed internal contract behavior
+- Scale/scope: one proposal promotion request at a time
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The change preserves existing orchestration and validation surfaces.
+- II. One-Click Agent Deployment: PASS. No new deployment dependencies.
+- III. Avoid Vendor Lock-In: PASS. Proposal behavior is provider-neutral.
+- IV. Own Your Data: PASS. Uses stored proposal payloads, not external live catalog state.
+- V. Skills Are First-Class: PASS. Preserves skill/tool distinctions in reviewed payloads.
+- VI. Replaceable Scaffolding: PASS. Removes a drift-prone override path and relies on existing contracts.
+- VII. Runtime Configurability: PASS. No hardcoded deployment configuration.
+- VIII. Modular Architecture: PASS. Changes stay within proposal schema, router, and service boundaries.
+- IX. Resilient by Default: PASS. Promotion remains deterministic and validation-first.
+- X. Continuous Improvement: PASS. Adds regression tests.
+- XI. Spec-Driven Development: PASS. This plan follows the MM-560 spec.
+- XII. Canonical Docs Separation: PASS. No canonical docs are changed for implementation notes.
+- XIII. Pre-Release Compatibility: PASS. Removes the superseded internal full-override promotion path rather than adding aliases.
+
+## Project Structure
+
+```text
+moonmind/
+  schemas/task_proposal_models.py
+  workflows/task_proposals/service.py
+tests/
+  unit/api/routers/test_task_proposals.py
+  unit/workflows/task_proposals/test_service.py
+frontend/src/generated/openapi.ts
+specs/280-promote-proposals-no-drift/
+```
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions.

--- a/specs/280-promote-proposals-no-drift/quickstart.md
+++ b/specs/280-promote-proposals-no-drift/quickstart.md
@@ -1,0 +1,19 @@
+# Quickstart: Promote Proposals Without Live Preset Drift
+
+1. Run targeted service and API tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py
+```
+
+2. Run the final unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+3. Verify traceability:
+
+```bash
+rg -n "MM-560|DESIGN-REQ-014|DESIGN-REQ-018|DESIGN-REQ-019" specs/280-promote-proposals-no-drift
+```

--- a/specs/280-promote-proposals-no-drift/research.md
+++ b/specs/280-promote-proposals-no-drift/research.md
@@ -1,0 +1,24 @@
+# Research: Promote Proposals Without Live Preset Drift
+
+## Decision 1: Remove full task payload replacement from proposal promotion
+
+**Decision**: Stop accepting `taskCreateRequestOverride` in promotion requests and service calls.
+
+**Rationale**: The reviewed proposal payload is the artifact the operator approved. A full override can replace steps, instructions, authored preset bindings, or provenance at promotion time, creating the live-preset drift MM-560 forbids.
+
+**Alternatives considered**:
+
+- Deep-compare override to stored payload: rejected because it would preserve a complex compatibility path and still invite hidden semantic changes.
+- Allow only matching overrides: rejected because bounded first-class promotion controls are clearer.
+
+## Decision 2: Keep `runtimeMode` as a bounded promotion control
+
+**Decision**: Keep runtime selection as an explicit bounded promotion option and apply it inside the service after loading the stored payload.
+
+**Rationale**: Runtime selection changes execution placement, not the reviewed task content. Applying it service-side avoids constructing a replacement envelope in the router.
+
+## Decision 3: Rely on `CanonicalTaskPayload` for unresolved Preset rejection
+
+**Decision**: Use existing task contract validation to reject unresolved `type: "preset"` steps during promotion.
+
+**Rationale**: The task contract already defines executable submission as Tool or Skill steps. Adding a targeted regression test is enough to prove the story behavior without duplicating validation logic.

--- a/specs/280-promote-proposals-no-drift/spec.md
+++ b/specs/280-promote-proposals-no-drift/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Promote Proposals Without Live Preset Drift
+
+**Feature Branch**: `280-promote-proposals-no-drift`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-560 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-560` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-560` and local artifact `artifacts/moonspec-inputs/MM-560-canonical-moonspec-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-560` under `specs/`, so `Specify` was the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-560 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-560
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Promote proposals without live preset drift
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-560-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-560 from MM project
+Summary: Promote proposals without live preset drift
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-560 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-560: Promote proposals without live preset drift
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 7.3 Backward compatibility
+- 13. Proposal and Promotion Semantics
+- 14. Migration Guidance
+- 15. Non-Goals
+- 16. Open Design Decisions
+Coverage IDs:
+- DESIGN-REQ-014
+- DESIGN-REQ-018
+- DESIGN-REQ-019
+
+As an operator reviewing task proposals, I want promotable payloads to preserve executable intent so promotion validates reviewed steps and cannot silently re-expand changed preset catalog entries.
+
+Acceptance Criteria
+- Stored proposals contain executable Tool and Skill steps by default.
+- Preset provenance can be preserved without causing live catalog lookup during promotion.
+- Promotion validates the reviewed flat payload.
+- Refreshing from the preset catalog is an explicit action with preview and validation.
+- Legacy payload readers do not reintroduce ambiguous umbrella terminology into new UI or docs.
+
+Requirements
+- Task proposals preserve executable intent.
+- Migration may read legacy shapes but new authoring surfaces converge on Step Type.
+- Compatibility readers must not undermine terminology or payload convergence.
+- Future linked-preset behavior requires separate explicit rules.
+```
+
+## User Story - Reviewed Proposal Promotion
+
+**Summary**: As an operator reviewing task proposals, I want promotion to execute the reviewed flat Tool and Skill payload so preset-derived proposals cannot silently drift by re-expanding live catalog entries.
+
+**Goal**: Promotion starts an execution from the stored reviewed proposal payload, preserves preset provenance metadata, validates the flat executable payload, and rejects promotion-time replacement payloads that could bypass the reviewed content.
+
+**Independent Test**: Create or load a proposal containing flattened executable steps and preset provenance, promote it, and verify the promoted execution parameters are derived from the stored proposal payload without any live preset lookup or full payload replacement.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open proposal with stored executable Tool and Skill steps and preset provenance metadata, **When** the operator promotes it, **Then** the system validates and executes the stored flat payload and preserves the provenance metadata.
+2. **Given** an open proposal, **When** a promotion request includes only bounded promotion controls such as runtime mode, priority, max attempts, or note, **Then** the system applies those controls without replacing the reviewed steps.
+3. **Given** an open proposal, **When** a promotion request includes a full task payload override, **Then** the system rejects the request before creating an execution.
+4. **Given** a stored proposal payload contains an unresolved Preset step, **When** promotion validates the payload, **Then** promotion fails because submitted task steps must be executable Tool or Skill steps.
+
+### Edge Cases
+
+- Stored proposal payloads may include legacy-compatible step shapes, but new validation must not allow unresolved `type: "preset"` submission.
+- Promotion-time runtime changes must not remove `authoredPresets`, step `source`, or executable steps from the stored payload.
+- Existing preset provenance metadata is audit metadata only and must not trigger catalog refresh or lookup during promotion.
+
+## Assumptions
+
+- Runtime selection is a bounded promotion control because it changes where the reviewed task runs, not what reviewed steps execute.
+- Explicit preset refresh and preview behavior is out of scope for this story except that promotion must not perform it implicitly.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Maps To |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-014 | `docs/Steps/StepTypes.md` section 7.3 | Compatibility readers may read legacy shapes during migration, but new surfaces must normalize toward Step Type and must not reintroduce ambiguous umbrella terminology. | In scope | FR-001, FR-006 |
+| DESIGN-REQ-018 | `docs/Steps/StepTypes.md` sections 13 and 14 | Stored proposals should contain executable Tool and Skill steps, may carry preset provenance as metadata, and promotion must validate the reviewed flat payload without requiring live preset lookup. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-019 | `docs/Steps/StepTypes.md` sections 15 and 16 | Hidden runtime preset work is a non-goal; any future linked-preset or refresh behavior must be explicit and visibly different from ordinary promotion. | In scope | FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST validate stored proposal task steps as executable Tool or Skill steps before creating a promoted execution.
+- **FR-002**: System MUST preserve stored `authoredPresets` and step `source` provenance metadata in the final promoted task payload when present.
+- **FR-003**: System MUST derive promoted execution parameters from the stored reviewed proposal payload by default.
+- **FR-004**: System MAY apply bounded promotion controls such as runtime mode, priority, max attempts, and note without replacing the reviewed payload.
+- **FR-005**: System MUST reject promotion requests that attempt to replace the reviewed proposal with a full task payload override.
+- **FR-006**: User-visible proposal preview and API response terminology MUST expose preset provenance without using ambiguous umbrella terminology for Tool, Skill, and Preset.
+
+### Key Entities
+
+- **Task Proposal**: A reviewed candidate task with status, repository, provenance, and a stored `taskCreateRequest` envelope.
+- **Promoted Execution Payload**: The canonical task payload used to start the execution after promotion.
+- **Preset Provenance Metadata**: Optional audit metadata such as `authoredPresets` and step `source` that explains preset-derived origins without requiring runtime catalog lookup.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests verify promotion preserves preset provenance and rejects unresolved Preset steps.
+- **SC-002**: API tests verify full task payload overrides are rejected before execution creation.
+- **SC-003**: API tests verify runtime-only promotion still creates an execution using stored reviewed task content.
+- **SC-004**: Traceability checks preserve `MM-560`, `DESIGN-REQ-014`, `DESIGN-REQ-018`, and `DESIGN-REQ-019` in Moon Spec artifacts.

--- a/specs/280-promote-proposals-no-drift/tasks.md
+++ b/specs/280-promote-proposals-no-drift/tasks.md
@@ -3,6 +3,7 @@
 **Input**: `specs/280-promote-proposals-no-drift/spec.md`
 **Plan**: `specs/280-promote-proposals-no-drift/plan.md`
 **Unit command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py`
+**Integration/API boundary command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_proposals.py`
 **Final command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 
 ## Source Traceability
@@ -17,12 +18,12 @@ Promotion must execute the reviewed flat proposal payload, preserve preset prove
 
 - [X] T001 Add a unit regression test in `tests/unit/workflows/task_proposals/test_service.py` proving promotion rejects a stored unresolved `type: "preset"` step. (FR-001, SC-001, DESIGN-REQ-014)
 - [X] T002 Add a unit regression test in `tests/unit/workflows/task_proposals/test_service.py` proving `runtime_mode_override` changes runtime while preserving stored steps and preset provenance. (FR-002, FR-003, FR-004, DESIGN-REQ-018)
-- [X] T003 Update API router tests in `tests/unit/api/routers/test_task_proposals.py` to reject `taskCreateRequestOverride` and to assert `runtimeMode` is passed as a bounded runtime override. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-019)
+- [X] T003 Update integration-style API router boundary tests in `tests/unit/api/routers/test_task_proposals.py` to reject `taskCreateRequestOverride` and to assert `runtimeMode` is passed as a bounded runtime override. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-019)
 - [X] T004 Run targeted tests and confirm the new tests fail before implementation. (TDD)
 - [X] T005 Remove `taskCreateRequestOverride` from `moonmind/schemas/task_proposal_models.py` and update runtime mode description. (FR-005)
 - [X] T006 Update `moonmind/workflows/task_proposals/service.py` so promotion accepts only a bounded `runtime_mode_override` and applies it to the stored validated payload. (FR-003, FR-004)
 - [X] T007 Update `api_service/api/routers/task_proposals.py` so the router no longer builds a full override envelope for runtime selection. (FR-004, FR-005)
 - [X] T008 Update generated OpenAPI TypeScript in `frontend/src/generated/openapi.ts` to remove `taskCreateRequestOverride` from the promote request model. (FR-005)
 - [X] T009 Run targeted tests and fix any failures. (SC-001, SC-002, SC-003)
-- [X] T010 Run traceability check for `MM-560`, `DESIGN-REQ-014`, `DESIGN-REQ-018`, and `DESIGN-REQ-019`. (SC-004)
-- [X] T011 Run final unit verification or record the exact blocker. (Final verification)
+- [X] T010 Run story validation and traceability check for `MM-560`, `DESIGN-REQ-014`, `DESIGN-REQ-018`, and `DESIGN-REQ-019`. (SC-004)
+- [X] T011 Run final `/moonspec-verify` work by producing `verification.md`, then run final unit verification or record the exact blocker. (Final verification)

--- a/specs/280-promote-proposals-no-drift/tasks.md
+++ b/specs/280-promote-proposals-no-drift/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Promote Proposals Without Live Preset Drift
+
+**Input**: `specs/280-promote-proposals-no-drift/spec.md`
+**Plan**: `specs/280-promote-proposals-no-drift/plan.md`
+**Unit command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py`
+**Final command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+
+## Source Traceability
+
+MM-560; FR-001 through FR-006; SC-001 through SC-004; DESIGN-REQ-014, DESIGN-REQ-018, DESIGN-REQ-019.
+
+## Story Summary
+
+Promotion must execute the reviewed flat proposal payload, preserve preset provenance, reject unresolved Preset steps, and reject full promotion-time task payload replacement.
+
+## Tasks
+
+- [X] T001 Add a unit regression test in `tests/unit/workflows/task_proposals/test_service.py` proving promotion rejects a stored unresolved `type: "preset"` step. (FR-001, SC-001, DESIGN-REQ-014)
+- [X] T002 Add a unit regression test in `tests/unit/workflows/task_proposals/test_service.py` proving `runtime_mode_override` changes runtime while preserving stored steps and preset provenance. (FR-002, FR-003, FR-004, DESIGN-REQ-018)
+- [X] T003 Update API router tests in `tests/unit/api/routers/test_task_proposals.py` to reject `taskCreateRequestOverride` and to assert `runtimeMode` is passed as a bounded runtime override. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-019)
+- [X] T004 Run targeted tests and confirm the new tests fail before implementation. (TDD)
+- [X] T005 Remove `taskCreateRequestOverride` from `moonmind/schemas/task_proposal_models.py` and update runtime mode description. (FR-005)
+- [X] T006 Update `moonmind/workflows/task_proposals/service.py` so promotion accepts only a bounded `runtime_mode_override` and applies it to the stored validated payload. (FR-003, FR-004)
+- [X] T007 Update `api_service/api/routers/task_proposals.py` so the router no longer builds a full override envelope for runtime selection. (FR-004, FR-005)
+- [X] T008 Update generated OpenAPI TypeScript in `frontend/src/generated/openapi.ts` to remove `taskCreateRequestOverride` from the promote request model. (FR-005)
+- [X] T009 Run targeted tests and fix any failures. (SC-001, SC-002, SC-003)
+- [X] T010 Run traceability check for `MM-560`, `DESIGN-REQ-014`, `DESIGN-REQ-018`, and `DESIGN-REQ-019`. (SC-004)
+- [X] T011 Run final unit verification or record the exact blocker. (Final verification)

--- a/specs/280-promote-proposals-no-drift/verification.md
+++ b/specs/280-promote-proposals-no-drift/verification.md
@@ -1,0 +1,31 @@
+# Verification: Promote Proposals Without Live Preset Drift
+
+**Date**: 2026-04-29
+**Verdict**: FULLY_IMPLEMENTED
+
+## Evidence
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `TaskProposalService.promote_proposal` validates the stored proposal payload through `CanonicalTaskPayload`; `tests/unit/workflows/task_proposals/test_service.py::test_promote_proposal_rejects_unresolved_preset_steps` proves unresolved `type: "preset"` steps fail before commit. |
+| FR-002 | VERIFIED | `test_promote_proposal_preserves_preset_provenance` and `test_promote_proposal_applies_runtime_override` verify `authoredPresets` and step `source` metadata survive promotion. |
+| FR-003 | VERIFIED | Full task payload replacement was removed from the schema, router, and service. Promotion derives the final task from `proposal.task_create_request`. |
+| FR-004 | VERIFIED | `runtimeMode` is passed as `runtime_mode_override` and applied service-side without replacing reviewed steps. |
+| FR-005 | VERIFIED | `TaskProposalPromoteRequest` forbids extra fields; API test `test_promote_proposal_rejects_task_create_request_override` verifies `taskCreateRequestOverride` is rejected before execution creation. |
+| FR-006 | VERIFIED | Existing preview model continues to expose `presetProvenance`, `authoredPresetCount`, and `stepSourceKinds`; no ambiguous umbrella terminology was introduced. |
+| DESIGN-REQ-014 | VERIFIED | New promotion validation preserves Step Type convergence and rejects unresolved Preset submission. |
+| DESIGN-REQ-018 | VERIFIED | Stored proposals execute as reviewed flat payloads; preset provenance remains metadata. |
+| DESIGN-REQ-019 | VERIFIED | Hidden promotion-time refresh or live preset replacement is blocked by removing full payload overrides. |
+
+## Commands
+
+| Command | Result |
+| --- | --- |
+| `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py` | PASS: Python `26 passed`; frontend unit suite invoked by runner `17 passed`, `471 passed`. |
+| `rg -n "MM-560\|DESIGN-REQ-014\|DESIGN-REQ-018\|DESIGN-REQ-019" specs/280-promote-proposals-no-drift` | PASS: Traceability IDs preserved in spec, plan, quickstart, and tasks. |
+| `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS: Python `4213 passed, 1 xpassed, 100 warnings, 16 subtests passed`; frontend `17 passed`, `471 passed`. |
+| `./tools/test_integration.sh` | NOT RUN: Docker socket unavailable in the managed workspace (`/var/run/docker.sock` missing). |
+
+## Residual Risk
+
+No known implementation gaps remain for MM-560. The full unit run emitted pre-existing warnings unrelated to this change. Compose-backed integration could not run because Docker is unavailable in this managed workspace.

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -209,18 +209,11 @@ def test_promote_proposal_uses_first_non_empty_instruction_line_for_title(
     call_kwargs = execution_service.create_execution.await_args.kwargs
     assert call_kwargs["title"] == "First line with spaces"
 
-def test_promote_proposal_accepts_override_payload(
+def test_promote_proposal_rejects_task_create_request_override(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
     test_client, service, execution_service = client
     proposal = _build_proposal()
-    final_request = {
-        "payload": {
-            "repository": "Moon/Repo",
-            "task": {"instructions": "edit"}
-        }
-    }
-    service.promote_proposal.return_value = (proposal, final_request)
 
     response = test_client.post(
         f"/api/proposals/{proposal.id}/promote",
@@ -237,14 +230,9 @@ def test_promote_proposal_accepts_override_payload(
         },
     )
 
-    assert response.status_code == 200
-    kwargs = service.promote_proposal.await_args.kwargs
-    assert (
-        kwargs["task_create_request_override"]["payload"]["task"]["instructions"]
-        == "edit"
-    )
-    call_kwargs = execution_service.create_execution.await_args.kwargs
-    assert call_kwargs["title"] == "edit"
+    assert response.status_code == 422
+    service.promote_proposal.assert_not_awaited()
+    execution_service.create_execution.assert_not_awaited()
 
 def test_promote_proposal_rejects_invalid_state(
     client: tuple[TestClient, AsyncMock, AsyncMock],
@@ -344,7 +332,7 @@ def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock, AsyncMock
 def test_promote_proposal_with_runtime_mode_shortcut(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
-    """runtimeMode shortcut builds a task_create_request_override for the service."""
+    """runtimeMode shortcut is passed as a bounded promotion control."""
     test_client, service, execution_service = client
     proposal = _build_proposal()
     proposal.task_create_request = {
@@ -368,7 +356,6 @@ def test_promote_proposal_with_runtime_mode_shortcut(
             }
         }
     }
-    service.get_proposal.return_value = proposal
     service.promote_proposal.return_value = (proposal, final_request)
 
     response = test_client.post(
@@ -378,10 +365,7 @@ def test_promote_proposal_with_runtime_mode_shortcut(
 
     assert response.status_code == 200
     kwargs = service.promote_proposal.await_args.kwargs
-    override = kwargs["task_create_request_override"]
-    assert override is not None
-    assert override["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
-    assert override["payload"]["repository"] == "Moon/Repo"
+    assert kwargs["runtime_mode_override"] == "gemini_cli"
     execution_service.create_execution.assert_awaited_once()
     call_kwargs = execution_service.create_execution.await_args.kwargs
     assert call_kwargs["idempotency_key"] == f"proposal-promote-{proposal.id}"

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -444,6 +444,23 @@ async def test_promote_proposal_applies_runtime_override() -> None:
                 "task": {
                     "instructions": "Refactor logic",
                     "runtime": {"mode": "gemini_cli"},
+                    "authoredPresets": [
+                        {
+                            "presetId": "runtime-quality-followup",
+                            "version": "2026-04-17",
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "type": "skill",
+                            "title": "Refactor logic",
+                            "skill": {"id": "code.implementation"},
+                            "source": {
+                                "kind": "preset-derived",
+                                "presetId": "runtime-quality-followup",
+                            },
+                        }
+                    ],
                 }
             }
         },
@@ -451,27 +468,26 @@ async def test_promote_proposal_applies_runtime_override() -> None:
     repo.get_proposal_for_update.return_value = proposal
     service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
 
-    override_request = {
-        "type": "task",
-        "payload": {
-            "repository": "Moon/Repo",
-            "task": {
-                "instructions": "Refactor logic",
-                "runtime": {"mode": "claude"},
-            }
-        }
-    }
-
     updated_proposal, final_request = await service.promote_proposal(
         proposal_id=proposal.id,
         promoted_by_user_id=uuid4(),
-        task_create_request_override=override_request,
+        runtime_mode_override="claude_code",
     )
 
     repo.commit.assert_awaited()
     assert updated_proposal.status is TaskProposalStatus.PROMOTED
     
     assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
+    assert final_request["payload"]["task"]["authoredPresets"] == [
+        {
+            "presetId": "runtime-quality-followup",
+            "version": "2026-04-17",
+        }
+    ]
+    assert final_request["payload"]["task"]["steps"][0]["source"] == {
+        "kind": "preset-derived",
+        "presetId": "runtime-quality-followup",
+    }
     assert updated_proposal.task_create_request["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
 
 @pytest.mark.asyncio
@@ -539,7 +555,7 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
     }
 
 @pytest.mark.asyncio
-async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> None:
+async def test_promote_proposal_rejects_unresolved_preset_steps() -> None:
     repo = AsyncMock()
     proposal = SimpleNamespace(
         id=uuid4(),
@@ -553,8 +569,17 @@ async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> Non
             "payload": {
                 "repository": "Moon/Repo",
                 "task": {
-                    "instructions": "Refactor logic",
-                    "runtime": {"mode": "gemini_cli"},
+                    "instructions": "Apply preset later",
+                    "steps": [
+                        {
+                            "type": "preset",
+                            "title": "Runtime quality follow-up",
+                            "preset": {
+                                "id": "runtime-quality-followup",
+                                "inputs": {},
+                            },
+                        }
+                    ],
                 }
             }
         },
@@ -562,74 +587,10 @@ async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> Non
     repo.get_proposal_for_update.return_value = proposal
     service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
 
-    override_request = {
-        "type": "task",
-        "payload": {
-            "repository": "Moon/Repo",
-            "targetRuntime": "codex_cli",
-            "task": {
-                "instructions": "Refactor logic",
-                "runtime": {"mode": "claude_code"},
-            },
-        },
-    }
+    with pytest.raises(TaskProposalValidationError, match="stored task payload is invalid"):
+        await service.promote_proposal(
+            proposal_id=proposal.id,
+            promoted_by_user_id=uuid4(),
+        )
 
-    updated_proposal, final_request = await service.promote_proposal(
-        proposal_id=proposal.id,
-        promoted_by_user_id=uuid4(),
-        task_create_request_override=override_request,
-    )
-
-    repo.commit.assert_awaited()
-    assert updated_proposal.status is TaskProposalStatus.PROMOTED
-    assert final_request["payload"]["targetRuntime"] == "codex"
-    assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("runtime_mode_field", ["targetRuntime", "target_runtime"])
-async def test_promote_proposal_override_normalizes_runtime_mapping_aliases(
-    runtime_mode_field: str,
-) -> None:
-    repo = AsyncMock()
-    proposal = SimpleNamespace(
-        id=uuid4(),
-        status=TaskProposalStatus.OPEN,
-        repository="Moon/Repo",
-        promoted_at=None,
-        promoted_by_user_id=None,
-        decided_by_user_id=None,
-        decision_note=None,
-        task_create_request={
-            "payload": {
-                "repository": "Moon/Repo",
-                "task": {
-                    "instructions": "Refactor logic",
-                    "runtime": {"mode": "gemini_cli"},
-                }
-            }
-        },
-    )
-    repo.get_proposal_for_update.return_value = proposal
-    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
-
-    override_request = {
-        "type": "task",
-        "payload": {
-            "repository": "Moon/Repo",
-            "task": {
-                "instructions": "Refactor logic",
-                "runtime": {runtime_mode_field: "claude_code"},
-            },
-        },
-    }
-
-    updated_proposal, final_request = await service.promote_proposal(
-        proposal_id=proposal.id,
-        promoted_by_user_id=uuid4(),
-        task_create_request_override=override_request,
-    )
-
-    repo.commit.assert_awaited()
-    assert updated_proposal.status is TaskProposalStatus.PROMOTED
-    assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
-
+    repo.commit.assert_not_awaited()

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -441,6 +441,7 @@ async def test_promote_proposal_applies_runtime_override() -> None:
         task_create_request={
             "payload": {
                 "repository": "Moon/Repo",
+                "targetRuntime": "gemini_cli",
                 "task": {
                     "instructions": "Refactor logic",
                     "runtime": {"mode": "gemini_cli"},
@@ -476,7 +477,8 @@ async def test_promote_proposal_applies_runtime_override() -> None:
 
     repo.commit.assert_awaited()
     assert updated_proposal.status is TaskProposalStatus.PROMOTED
-    
+
+    assert final_request["payload"]["targetRuntime"] == "claude"
     assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
     assert final_request["payload"]["task"]["authoredPresets"] == [
         {
@@ -488,7 +490,12 @@ async def test_promote_proposal_applies_runtime_override() -> None:
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
     }
-    assert updated_proposal.task_create_request["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
+    assert (
+        updated_proposal.task_create_request["payload"]["task"]["runtime"]["mode"]
+        == "gemini_cli"
+    )
+    assert updated_proposal.task_create_request["payload"]["targetRuntime"] == "gemini_cli"
+
 
 @pytest.mark.asyncio
 async def test_promote_proposal_preserves_preset_provenance() -> None:


### PR DESCRIPTION
## Jira Issue
- MM-560

## Active MoonSpec Feature
- specs/280-promote-proposals-no-drift

## Summary
- Remove full task payload replacement during proposal promotion.
- Preserve reviewed flat proposal payloads and preset provenance while allowing bounded runtime and priority controls.
- Add MoonSpec artifacts, verification, and regression coverage.

## Verification Verdict
- FULLY_IMPLEMENTED

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `./tools/test_integration.sh`: blocked because Docker socket was unavailable in the managed workspace.

## Remaining Risks
- Compose-backed integration was not run because Docker was unavailable in the managed workspace.
