### PR TITLE
[codex] Fix launch session activity heartbeats

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3867,7 +3867,16 @@ class TemporalAgentRuntimeActivities:
             profile=profile,
         )
         try:
-            response = await controller.launch_session(validated)
+            response = await _await_with_activity_heartbeats(
+                controller.launch_session(validated),
+                heartbeat_payload={
+                    "activityType": "agent_runtime.launch_session",
+                    "taskRunId": validated.task_run_id,
+                    "runtimeFamily": validated.runtime_family,
+                    "sessionId": validated.session_id,
+                    "threadId": validated.thread_id,
+                },
+            )
         except Exception as exc:
             from moonmind.utils.logging import redact_sensitive_text
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -414,6 +414,67 @@ async def test_launch_session_delegates_to_remote_session_controller() -> None:
     assert result.session_state.container_id == "ctr-1"
     controller.launch_session.assert_awaited_once()
 
+async def test_launch_session_heartbeats_while_waiting_for_remote_session_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from temporalio import activity as temporal_activity
+
+    heartbeats: list[dict[str, Any]] = []
+
+    async def _slow_launch_session(
+        _request: Any,
+    ) -> CodexManagedSessionHandle:
+        await asyncio.sleep(0.03)
+        return CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+        )
+
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(temporal_activity, "in_activity", lambda: True)
+    monkeypatch.setattr(temporal_activity, "heartbeat", heartbeats.append)
+
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(side_effect=_slow_launch_session)
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    result = await activities.agent_runtime_launch_session(
+        {
+            "taskRunId": "task-1",
+            "sessionId": "sess-1",
+            "threadId": "thread-1",
+            "workspacePath": "/work/task/repo",
+            "sessionWorkspacePath": "/work/task/session",
+            "artifactSpoolPath": "/work/task/artifacts",
+            "codexHomePath": "/work/task/codex-home",
+            "imageRef": "moonmind:latest",
+        }
+    )
+
+    assert isinstance(result, CodexManagedSessionHandle)
+    assert result.status == "ready"
+    assert heartbeats
+    assert all(
+        heartbeat == {
+            "activityType": "agent_runtime.launch_session",
+            "taskRunId": "task-1",
+            "runtimeFamily": "codex",
+            "sessionId": "sess-1",
+            "threadId": "thread-1",
+        }
+        for heartbeat in heartbeats
+    )
+
 async def test_launch_session_uses_github_descriptor_from_activity_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes managed Codex session launch failures caused by `agent_runtime.launch_session` timing out its Temporal heartbeat while waiting for the session controller to finish container launch. The activity now uses the same bounded heartbeat wrapper as the other blocking managed-session controls.

## Root Cause

`agent_runtime.launch_session` declared a 30 second heartbeat timeout but awaited `controller.launch_session()` directly. Slow Docker startup or readiness checks could exceed that window, causing Temporal heartbeat timeouts and retries even when the session container eventually started.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Python unit suite: 4216 passed. Frontend Vitest suite: 471 passed.