### PR TITLE
[codex] Fix duplicate preset step planning

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -616,6 +616,40 @@ def _selected_step_tool_name(step_entry: Mapping[str, Any]) -> str:
     )
     return str(step_tool.get("name") or step_tool.get("id") or "").strip()
 
+def _canonical_step_fingerprint(step_entry: Mapping[str, Any]) -> str:
+    try:
+        return json.dumps(step_entry, sort_keys=True, separators=(",", ":"))
+    except TypeError:
+        return repr(sorted(step_entry.items(), key=lambda item: str(item[0])))
+
+
+def _dedupe_repeated_step_entries(
+    raw_steps: list[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    deduped: list[Mapping[str, Any]] = []
+    fingerprints_by_id: dict[str, str] = {}
+
+    for step_entry in raw_steps:
+        step_id = str(step_entry.get("id") or "").strip()
+        if not step_id:
+            deduped.append(step_entry)
+            continue
+
+        fingerprint = _canonical_step_fingerprint(step_entry)
+        existing_fingerprint = fingerprints_by_id.get(step_id)
+        if existing_fingerprint is None:
+            fingerprints_by_id[step_id] = fingerprint
+            deduped.append(step_entry)
+            continue
+        if existing_fingerprint == fingerprint:
+            continue
+        raise RuntimeError(
+            f"task step id {step_id!r} is duplicated with different payloads; "
+            "step ids must be unique"
+        )
+
+    return deduped
+
 def _selected_step_type(step_entry: Mapping[str, Any]) -> str:
     return str(step_entry.get("type") or "").strip().lower()
 
@@ -861,6 +895,12 @@ def _build_runtime_planner():
             node_inputs["selectedSkill"] = selected_skill_name
 
         raw_steps = task_payload.get("steps")
+        if (
+            isinstance(raw_steps, list)
+            and len(raw_steps) > 1
+            and all(isinstance(s, Mapping) for s in raw_steps)
+        ):
+            raw_steps = _dedupe_repeated_step_entries(raw_steps)
         publish_uses_git = not _task_uses_only_jira_agent_skill(
             selected_skill_name=selected_skill_name,
             raw_steps=raw_steps,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -648,6 +648,127 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
         "sourceIssueKey": "MM-404"
     }
 
+
+def test_runtime_planner_dedupes_repeated_identical_preset_steps():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+    breakdown_step = {
+        "id": "tpl:jira-breakdown-orchestrate:1.0.0:01:6bfb1360",
+        "title": "Break down declarative design",
+        "type": "skill",
+        "skill": {"id": "moonspec-breakdown", "requiredCapabilities": ["git"]},
+        "instructions": "Extract MoonSpec stories.",
+    }
+    jira_step = {
+        "id": "tpl:jira-breakdown-orchestrate:1.0.0:02:6bfb1360",
+        "title": "Create Jira stories",
+        "type": "skill",
+        "skill": {"id": "story.create_jira_issues"},
+        "instructions": "Create Jira issues from the generated breakdown.",
+        "storyOutput": {
+            "mode": "jira",
+            "fallback": "fail",
+            "jira": {
+                "projectKey": "MM",
+                "issueTypeName": "Story",
+                "boardId": "15",
+                "dependencyMode": "linear_blocker_chain",
+            },
+        },
+    }
+    orchestrate_step = {
+        "id": "tpl:jira-breakdown-orchestrate:1.0.0:03:6bfb1360",
+        "title": "Create dependent Jira Orchestrate tasks",
+        "type": "skill",
+        "skill": {"id": "story.create_jira_orchestrate_tasks"},
+        "instructions": "Create dependent Jira Orchestrate tasks.",
+        "jiraOrchestration": {
+            "task": {
+                "repository": "MoonLadderStudios/Tactics",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+                "orchestrationMode": "runtime",
+            },
+            "traceability": {"sourceIssueKey": ""},
+        },
+    }
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "docs\\Steps\\StepTypes.md",
+                "instructions": "docs\\Steps\\StepTypes.md",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    breakdown_step,
+                    jira_step,
+                    orchestrate_step,
+                    dict(breakdown_step),
+                    dict(jira_step),
+                    dict(orchestrate_step),
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert [node["id"] for node in plan["nodes"]] == [
+        "tpl:jira-breakdown-orchestrate:1.0.0:01:6bfb1360",
+        "tpl:jira-breakdown-orchestrate:1.0.0:02:6bfb1360",
+        "tpl:jira-breakdown-orchestrate:1.0.0:03:6bfb1360",
+    ]
+    assert plan["edges"] == [
+        {
+            "from": "tpl:jira-breakdown-orchestrate:1.0.0:01:6bfb1360",
+            "to": "tpl:jira-breakdown-orchestrate:1.0.0:02:6bfb1360",
+        },
+        {
+            "from": "tpl:jira-breakdown-orchestrate:1.0.0:02:6bfb1360",
+            "to": "tpl:jira-breakdown-orchestrate:1.0.0:03:6bfb1360",
+        },
+    ]
+
+
+def test_runtime_planner_rejects_conflicting_duplicate_step_ids():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    with pytest.raises(RuntimeError, match="duplicated with different payloads"):
+        planner(
+            inputs={
+                "task": {
+                    "title": "Conflicting step ids",
+                    "instructions": "Run conflicting steps.",
+                    "runtime": {"mode": "codex_cli"},
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                            "instructions": "Extract MoonSpec stories.",
+                        },
+                        {
+                            "id": "step-1",
+                            "tool": {
+                                "type": "skill",
+                                "name": "story.create_jira_issues",
+                            },
+                            "instructions": "Create Jira issues.",
+                        },
+                    ],
+                }
+            },
+            parameters={},
+            snapshot=snapshot,
+        )
+
 @pytest.mark.asyncio
 async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path):
     async with _template_db(tmp_path) as session_maker:


### PR DESCRIPTION
## Summary

Fixes the Jira Breakdown and Orchestrate failure where a submitted task contained the same three preset steps twice. The runtime planner now collapses repeated identical step entries by ID before generating plan edges, preventing a duplicate preset application from turning a linear sequence into a cyclic DAG.

Conflicting duplicate step IDs still fail clearly with an explicit duplicate-step error instead of producing an ambiguous plan cycle.

## Root Cause

Workflow `mm:5ff4e137-b3a5-4120-9e6f-32e7cfe42fe6` started with six task steps: `01, 02, 03, 01, 02, 03`. The planner chained raw steps in order, so the second `01` produced an edge from `03 -> 01`, yielding `01 -> 02 -> 03 -> 01` and failing with `plan edges contain at least one cycle`.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'dedupes_repeated_identical_preset_steps or rejects_conflicting_duplicate_step_ids or jira_orchestrate_task_creator'`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Full unit runner results: Python `4215 passed`, one xpass; frontend Vitest `471 passed`.