### PR TITLE
MM-562 Present Step Type authoring in the task step editor

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/280-promote-proposals-no-drift"
+  "feature_directory": "specs/281-step-type-authoring"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-560",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1842"
+  "jira_issue_key": "MM-562",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1845"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,17 @@
 [
   {
-    "id": 4340704945,
-    "disposition": "not-applicable",
-    "rationale": "Automated quota warning with no requested code change."
-  },
-  {
-    "id": 3158511680,
+    "id": 3159416583,
     "disposition": "addressed",
-    "rationale": "Runtime promotion override now updates top-level targetRuntime alongside task.runtime.mode, with a regression test covering stored payloads that already include targetRuntime."
+    "rationale": "Added aria-describedby on the Step Type select so screen readers announce the helper text."
   },
   {
-    "id": 4193967441,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper summary; the actionable child review comment is tracked separately."
+    "id": 3159416593,
+    "disposition": "addressed",
+    "rationale": "Added a unique helper-text id matching the Step Type select aria-describedby value."
+  },
+  {
+    "id": 4195075109,
+    "disposition": "addressed",
+    "rationale": "Review summary covered the same Step Type helper-text accessibility issue, which is now implemented and tested."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6744,12 +6744,18 @@ describe("Task Create Entrypoint", () => {
     expect(primaryStep).not.toBeNull();
     const step = primaryStep as HTMLElement;
     const stepType = within(step).getByLabelText("Step Type") as HTMLSelectElement;
+    const helpId = stepType.getAttribute("aria-describedby");
+
+    expect(helpId).toBeTruthy();
 
     expect(
       within(step).getByText(
         "Skill asks an agent to perform work using reusable behavior.",
       ),
     ).toBeTruthy();
+    expect(document.getElementById(helpId as string)?.textContent).toBe(
+      "Skill asks an agent to perform work using reusable behavior.",
+    );
 
     fireEvent.change(stepType, { target: { value: "tool" } });
     expect(

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6735,6 +6735,39 @@ describe("Task Create Entrypoint", () => {
     ).toBeTruthy();
   });
 
+  it("presents concise Step Type helper copy for Tool Skill and Preset", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    const step = primaryStep as HTMLElement;
+    const stepType = within(step).getByLabelText("Step Type") as HTMLSelectElement;
+
+    expect(
+      within(step).getByText(
+        "Skill asks an agent to perform work using reusable behavior.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.change(stepType, { target: { value: "tool" } });
+    expect(
+      within(step).getByText(
+        "Tool runs a typed integration or system operation directly.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.change(stepType, { target: { value: "preset" } });
+    expect(
+      within(step).getByText(
+        "Preset inserts a reusable set of configured steps.",
+      ),
+    ).toBeTruthy();
+    expect(within(step).queryByText(/Temporal Activity/)).toBeNull();
+    expect(within(step).queryByText(/Capability/)).toBeNull();
+  });
+
   it("switches Step Type configuration areas while preserving instructions", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -525,6 +525,12 @@ interface StepAttachmentRef {
 
 type StepType = "tool" | "skill" | "preset";
 
+const STEP_TYPE_HELP_TEXT: Record<StepType, string> = {
+  tool: "Tool runs a typed integration or system operation directly.",
+  skill: "Skill asks an agent to perform work using reusable behavior.",
+  preset: "Preset inserts a reusable set of configured steps.",
+};
+
 interface StepState {
   localId: string;
   id: string;
@@ -6673,6 +6679,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <label className="queue-step-type-field">
                     Step Type
                     <select
+                      aria-label="Step Type"
                       data-step-field="stepType"
                       data-step-index={String(index)}
                       value={step.stepType}
@@ -6684,6 +6691,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       <option value="skill">Skill</option>
                       <option value="preset">Preset</option>
                     </select>
+                    <span className="small">
+                      {STEP_TYPE_HELP_TEXT[step.stepType]}
+                    </span>
                   </label>
 
                   <div className="stack">

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -6680,6 +6680,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     Step Type
                     <select
                       aria-label="Step Type"
+                      aria-describedby={`queue-step-type-help-${index}`}
                       data-step-field="stepType"
                       data-step-index={String(index)}
                       value={step.stepType}
@@ -6691,7 +6692,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       <option value="skill">Skill</option>
                       <option value="preset">Preset</option>
                     </select>
-                    <span className="small">
+                    <span id={`queue-step-type-help-${index}`} className="small">
                       {STEP_TYPE_HELP_TEXT[step.stepType]}
                     </span>
                   </label>

--- a/specs/281-step-type-authoring/checklists/requirements.md
+++ b/specs/281-step-type-authoring/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Present Step Type Authoring
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves `MM-562`, the trusted Jira preset brief, and one runtime Create page story.

--- a/specs/281-step-type-authoring/contracts/create-page-step-type-presentation.md
+++ b/specs/281-step-type-authoring/contracts/create-page-step-type-presentation.md
@@ -1,0 +1,35 @@
+# UI Contract: Create Page Step Type Presentation
+
+## Step Type Selector
+
+Each ordinary step editor exposes exactly one accessible selector named `Step Type`.
+
+Options:
+
+- `Tool`
+- `Skill`
+- `Preset`
+
+Default selection: `Skill` for newly created steps.
+
+## Helper Copy
+
+The Step Type area exposes concise copy for each choice:
+
+- Tool: runs a typed integration or system operation directly.
+- Skill: asks an agent to perform work using reusable behavior.
+- Preset: inserts a reusable set of configured steps.
+
+The helper copy must not present `Capability`, `Activity`, `Invocation`, `Command`, or `Script` as the primary Step Type discriminator.
+
+## Type-Specific Presentation
+
+- When `Step Type = Tool`, Tool-specific controls are visible and Skill/Preset controls are hidden.
+- When `Step Type = Skill`, Skill-specific controls are visible and Tool/Preset controls are hidden.
+- When `Step Type = Preset`, Preset-specific controls are visible and Tool/Skill controls are hidden.
+
+## Data Preservation
+
+- Instructions remain visible and preserved when Step Type changes.
+- Hidden Skill fields are not submitted for Tool or Preset steps.
+- Step Type and Preset selections remain scoped to each individual step.

--- a/specs/281-step-type-authoring/data-model.md
+++ b/specs/281-step-type-authoring/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Present Step Type Authoring
+
+## Step Draft
+
+Represents one user-authored task step in the Create page.
+
+Fields relevant to this story:
+
+- `localId`: stable local identity for the draft step.
+- `instructions`: compatible freeform instructions retained across Step Type changes.
+- `stepType`: selected Step Type value.
+- `skillId`, `skillArgs`, `skillRequiredCapabilities`: Skill-specific draft values.
+- `presetKey`, `presetPreview`: Preset-specific draft values.
+
+## Step Type
+
+User-facing discriminator for step authoring.
+
+Allowed values:
+
+- `tool`
+- `skill`
+- `preset`
+
+Display labels:
+
+- Tool
+- Skill
+- Preset
+
+Validation rules:
+
+- Every authored step has exactly one selected Step Type.
+- Tool, Skill, and Preset each expose concise helper copy.
+- The selected Step Type controls the visible type-specific controls.
+- Hidden type-specific values may remain in draft state for recovery, but they are not submitted as active configuration for unrelated Step Types.
+
+## Type-Specific Controls
+
+Visible controls determined by `stepType`.
+
+- Tool: typed-operation controls or placeholder validation surface.
+- Skill: skill selector and Skill advanced fields.
+- Preset: preset selection, preview, and apply controls.

--- a/specs/281-step-type-authoring/plan.md
+++ b/specs/281-step-type-authoring/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Present Step Type Authoring
+
+**Branch**: `281-step-type-authoring` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/281-step-type-authoring/spec.md`
+
+## Summary
+
+MM-562 requires the Create page step editor to present Tool, Skill, and Preset through one Step Type selector, show type-specific controls, preserve compatible authoring data, and avoid internal runtime vocabulary in the primary selector. Current repo evidence from MM-556/MM-558 already implements the selector, switching behavior, preset scoping, preview/apply, and hidden Skill-field submission safeguards in `frontend/src/entrypoints/task-create.tsx` with Vitest coverage in `frontend/src/entrypoints/task-create.test.tsx`. The remaining MM-562-specific gap is concise helper copy for the Step Type choices, so the implementation will add focused frontend coverage and a small UI helper text addition.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `task-create.tsx` renders one `Step Type` select per step; `task-create.test.tsx` verifies Tool/Skill/Preset options | no code work | focused frontend unit |
+| FR-002 | partial | Options exist, but no concise helper copy is rendered with the Step Type selector | add helper copy for Tool, Skill, and Preset choices | focused frontend unit |
+| FR-003 | implemented_verified | Conditional Tool/Skill/Preset panels render from `step.stepType`; tests cover switching | no code work | focused frontend unit |
+| FR-004 | implemented_verified | Instructions persist across switching and hidden Skill fields are blocked for Tool submission; tests cover both | no code work | focused frontend unit |
+| FR-005 | implemented_unverified | Selector label/options use Step Type, Tool, Skill, Preset; helper copy must avoid internal discriminator terms | verify in helper-copy test | focused frontend unit |
+| FR-006 | implemented_verified | Preset selections are scoped to each step; tests cover independent step state | no code work | focused frontend unit |
+| SCN-001 | implemented_verified | Existing Step Type selector test | no code work | focused frontend unit |
+| SCN-002 | partial | Helper copy absent | add test and UI copy | focused frontend unit |
+| SCN-003 | implemented_verified | Existing switching test | no code work | focused frontend unit |
+| SCN-004 | implemented_verified | Existing hidden Skill field submission test | no code work | focused frontend unit |
+| SCN-005 | implemented_unverified | Existing copy likely passes; helper copy must be checked | add assertions to focused test | focused frontend unit |
+| DESIGN-REQ-001 | implemented_verified | Step Type selector and conditional panels exist | no code work | focused frontend unit |
+| DESIGN-REQ-002 | partial | Step Type picker exists; helper copy gap remains | add helper copy | focused frontend unit |
+| DESIGN-REQ-009 | implemented_verified | Switching preserves instructions and hidden fields are not submitted | no code work | focused frontend unit |
+| DESIGN-REQ-018 | implemented_unverified | Primary selector avoids internal labels; new helper copy must preserve that | add assertions | focused frontend unit |
+| SC-001 | implemented_verified | Existing options test | no code work | focused frontend unit |
+| SC-002 | missing | No helper-copy test | add test | focused frontend unit |
+| SC-003 | implemented_verified | Existing switching test | no code work | focused frontend unit |
+| SC-004 | implemented_verified | Existing hidden Skill submission test | no code work | focused frontend unit |
+| SC-005 | implemented_verified | Existing per-step Preset scoping test | no code work | focused frontend unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected for this UI story  
+**Primary Dependencies**: React, TanStack Query, existing Create page state helpers, Vitest, Testing Library  
+**Storage**: Existing task draft state only; no new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: Focused Create page render/submission Vitest coverage is the integration boundary for this frontend-only story; compose-backed integration is not required because backend behavior does not change  
+**Target Platform**: Mission Control web UI  
+**Project Type**: Web application frontend  
+**Performance Goals**: Step Type switching and helper rendering remain synchronous with no new network requests  
+**Constraints**: Preserve MM-562 traceability; do not expose Temporal Activity or capability terminology as the primary Step Type discriminator; do not change executable submission semantics  
+**Scale/Scope**: One Create page Step Type authoring presentation story
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Reuses existing Create page and preset expansion surfaces.
+- II. One-Click Agent Deployment: PASS. No deployment prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. Step Type labels are provider-neutral.
+- IV. Own Your Data: PASS. Uses existing local draft state only.
+- V. Skills Are First-Class and Easy to Add: PASS. Skill remains a first-class Step Type.
+- VI. Scientific Method: PASS. The remaining gap is covered test-first.
+- VII. Runtime Configurability: PASS. No hardcoded provider runtime behavior is added.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay within the Create page authoring boundary.
+- IX. Resilient by Default: PASS. No workflow or activity contract changes.
+- X. Facilitate Continuous Improvement: PASS. Verification records exact evidence.
+- XI. Spec-Driven Development: PASS. Spec, plan, and tasks preserve MM-562 before implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime work is captured in feature artifacts and code.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden semantic transforms are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/281-step-type-authoring/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-step-type-presentation.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create.test.tsx
+```
+
+**Structure Decision**: This is a frontend Create page story. Existing backend task submission, preset expansion, and runtime contracts are reused without changes.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/281-step-type-authoring/quickstart.md
+++ b/specs/281-step-type-authoring/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: Present Step Type Authoring
+
+## Focused Verification
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected result:
+
+- Create page tests pass.
+- A rendered step exposes one `Step Type` selector with Tool, Skill, and Preset.
+- Helper copy for Tool, Skill, and Preset is visible.
+- Switching Step Type changes visible controls and preserves instructions.
+- Hidden Skill fields are not submitted for Tool steps.
+
+## Manual Smoke Scenario
+
+1. Open Mission Control Create.
+2. Inspect Step 1.
+3. Confirm `Step Type` has Tool, Skill, and Preset options.
+4. Confirm the Step Type area explains Tool, Skill, and Preset with concise copy.
+5. Enter instructions, switch among Tool, Skill, and Preset, and confirm instructions remain.
+6. Confirm Tool, Skill, and Preset controls appear only for their selected Step Type.

--- a/specs/281-step-type-authoring/research.md
+++ b/specs/281-step-type-authoring/research.md
@@ -1,0 +1,25 @@
+# Research: Present Step Type Authoring
+
+## Decision 1: Reuse Existing Step Type Draft State
+
+Decision: Treat the current `step.stepType` Create page draft state as the implementation foundation for MM-562.
+
+Rationale: The current code already renders one Step Type selector per step and switches Tool, Skill, and Preset configuration areas from that value.
+
+Evidence: `frontend/src/entrypoints/task-create.tsx` renders the `Step Type` select and conditional panels; `frontend/src/entrypoints/task-create.test.tsx` covers selector options and switching.
+
+## Decision 2: Add Helper Copy Beside the Selector
+
+Decision: Add concise helper copy under the Step Type selector describing Tool, Skill, and Preset choices.
+
+Rationale: MM-562 specifically requires documented helper text or equivalent concise copy. Adding one dynamic helper preserves the compact editor while satisfying the acceptance criterion.
+
+Alternatives considered: Expanding every option label with long text was rejected because native select options should remain short and scannable.
+
+## Decision 3: Keep Existing Hidden Field Behavior
+
+Decision: Preserve existing type-specific draft values when switching types, but submit only fields relevant to the selected Step Type.
+
+Rationale: This satisfies the source design rule to preserve compatible fields and avoid silently submitting incompatible hidden fields.
+
+Evidence: Existing tests cover instruction preservation and hidden Skill field handling when switching to Tool.

--- a/specs/281-step-type-authoring/spec.md
+++ b/specs/281-step-type-authoring/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Present Step Type Authoring
+
+**Feature Branch**: `281-step-type-authoring`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-562 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-562` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-562`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-562` under `specs/`, so `Specify` was the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-562 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-562
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Present Step Type authoring in the task step editor
+- Trusted fetch tool: jira.get_issue
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the response did not expose recommended preset instructions or a normalized preset brief.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-562 from MM project
+Summary: Present Step Type authoring in the task step editor
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-562 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-562: Present Step Type authoring in the task step editor
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 1. Purpose
+- 2. Desired-State Summary
+- 3. Terminology
+- 4. Core Invariants
+- 6. User Experience Contract
+- 10. Naming Policy
+
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-009
+- DESIGN-REQ-018
+
+User Story
+As a task author, I can choose Tool, Skill, or Preset from a single Step Type control so the editor shows the right fields without requiring internal runtime vocabulary.
+
+Acceptance Criteria
+- The step editor exposes exactly one user-facing Step Type selector for ordinary step authoring.
+- The selector offers Tool, Skill, and Preset using the documented helper text or equivalent concise copy.
+- Changing Step Type changes the type-specific controls below the selector.
+- Meaningful incompatible data is not silently lost when the user changes Step Type.
+- Temporal Activity and capability terminology remain absent from the primary user-facing Step Type selector.
+
+Requirements
+- Every authored step in the editor has one selected Step Type.
+- The selected Step Type controls available sub-options and validation surface.
+- UI copy consistently uses Step Type, Tool, Skill, and Preset for the authoring model.
+```
+
+## User Story - Step Type Authoring Presentation
+
+**Summary**: As a task author, I can choose Tool, Skill, or Preset from a single Step Type control so the editor shows the right fields without requiring internal runtime vocabulary.
+
+**Goal**: Ordinary task authoring presents one clear Step Type choice per step, explains the available choices with concise product copy, and updates the configuration area without exposing Temporal or capability terminology as the primary discriminator.
+
+**Independent Test**: Render the Create page step editor, inspect the Step Type selector, switch among Tool, Skill, and Preset, and verify the selector choices, helper copy, visible configuration controls, instruction preservation, and absence of internal discriminator labels.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author opens the step editor, **When** they inspect an authored step, **Then** the step exposes exactly one user-facing control named Step Type.
+2. **Given** the Step Type selector is visible, **When** the author inspects its choices, **Then** Tool, Skill, and Preset are available with concise helper copy that describes each choice.
+3. **Given** the author changes Step Type, **When** the selected value becomes Tool, Skill, or Preset, **Then** only the matching type-specific controls are shown below the selector.
+4. **Given** the author has entered step instructions and type-specific values, **When** the author changes Step Type, **Then** compatible instructions remain available and incompatible hidden fields are not silently submitted.
+5. **Given** the primary Step Type selector is visible, **When** its label, options, and helper copy are inspected, **Then** it uses Step Type, Tool, Skill, and Preset rather than Temporal Activity or capability terminology.
+
+### Edge Cases
+
+- A newly added step has one valid selected Step Type and can be changed independently from other steps.
+- Preset selection remains scoped to the step where Step Type is Preset.
+- Advanced Skill fields that become hidden after a Step Type change are not submitted as active configuration for non-Skill steps.
+- The separate Task Presets management area, if present, is not the canonical Step Type selector for ordinary step authoring.
+
+## Assumptions
+
+- Runtime mode applies: this story verifies and completes Create page task-authoring behavior, not documentation-only wording.
+- Existing MM-556 and MM-558 Step Type implementation work may satisfy most behavior, but MM-562 must preserve its own Jira traceability and verify the specific helper-copy acceptance criterion.
+- The current Tool implementation may remain a typed-operation placeholder when no concrete tool picker is available, as long as the Step Type authoring model and validation surface remain clear.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | docs/Steps/StepTypes.md sections 1, 2, 4 | Every authored step has exactly one Step Type that determines what the step represents and which fields are shown. | In scope | FR-001, FR-003, FR-006 |
+| DESIGN-REQ-002 | docs/Steps/StepTypes.md sections 2, 3, 6.1, 6.2 | The Step Type control offers Tool, Skill, and Preset and renders type-specific configuration below the selector. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-009 | docs/Steps/StepTypes.md section 6.1 | Changing Step Type preserves compatible fields and prevents meaningful incompatible data from being silently lost or submitted. | In scope | FR-004 |
+| DESIGN-REQ-018 | docs/Steps/StepTypes.md section 10 | Primary authoring copy uses Step Type, Tool, Skill, and Preset and avoids Temporal Activity or capability terminology as the step discriminator. | In scope | FR-002, FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The step editor MUST expose exactly one user-facing Step Type selector for each ordinary authored step.
+- **FR-002**: The Step Type selector MUST offer Tool, Skill, and Preset with documented helper text or equivalent concise copy for the choices.
+- **FR-003**: The selected Step Type MUST determine which type-specific controls appear below the selector.
+- **FR-004**: Changing Step Type MUST preserve compatible instructions and MUST prevent hidden incompatible type-specific fields from being silently submitted.
+- **FR-005**: Primary Step Type selector copy MUST use Step Type, Tool, Skill, and Preset and MUST NOT use Temporal Activity or capability terminology as the primary discriminator.
+- **FR-006**: Each authored step MUST maintain its own selected Step Type and type-specific draft state independently from other steps.
+
+### Key Entities
+
+- **Step Draft**: A user-authored task step with instructions, selected Step Type, and type-specific draft state.
+- **Step Type**: The user-facing discriminator with values Tool, Skill, and Preset.
+- **Type-Specific Controls**: The visible configuration controls controlled by the selected Step Type.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests verify a rendered step has one accessible Step Type selector with exactly Tool, Skill, and Preset options.
+- **SC-002**: Frontend tests verify the Step Type choices expose concise helper copy for Tool, Skill, and Preset.
+- **SC-003**: Frontend tests verify switching among Tool, Skill, and Preset changes visible configuration without removing existing instructions.
+- **SC-004**: Frontend tests verify hidden Skill fields are not submitted for non-Skill Step Types.
+- **SC-005**: Frontend tests verify independent step-scoped Step Type and Preset state.

--- a/specs/281-step-type-authoring/tasks.md
+++ b/specs/281-step-type-authoring/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: Present Step Type Authoring
+
+**Input**: Design documents from `/specs/281-step-type-authoring/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around MM-562's single user story.
+
+**Source Traceability**: FR-001..FR-006, SC-001..SC-005, SCN-001..SCN-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-009, DESIGN-REQ-018.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm MM-562 artifacts and existing Create page Step Type implementation baseline.
+
+- [X] T001 Create MoonSpec artifacts for MM-562 in `specs/281-step-type-authoring/`
+- [X] T002 Confirm existing Create page implementation and tests in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: No new backend, schema, service, or runtime foundation is required; this story refines existing Create page Step Type presentation.
+
+- [X] T003 Verify existing Step Type selector, type switching, preset scoping, and hidden Skill field behavior are already implemented in `frontend/src/entrypoints/task-create.tsx`
+
+**Checkpoint**: Foundation ready - remaining MM-562 work is helper-copy verification and UI presentation.
+
+---
+
+## Phase 3: Story - Step Type Authoring Presentation
+
+**Summary**: As a task author, I can choose Tool, Skill, or Preset from a single Step Type control so the editor shows the right fields without requiring internal runtime vocabulary.
+
+**Independent Test**: Render the Create page step editor, inspect the Step Type selector, switch among Tool, Skill, and Preset, and verify the selector choices, helper copy, visible configuration controls, instruction preservation, and absence of internal discriminator labels.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-009, DESIGN-REQ-018
+
+**Test Plan**:
+
+- Unit: Step Type helper copy, selector options, switching behavior, hidden field submission behavior.
+- Integration: Create page render/submission tests exercise the public UI contract and task submission boundary.
+
+### Unit Tests (write first)
+
+- [X] T004 Add failing test for Tool, Skill, and Preset helper copy in `frontend/src/entrypoints/task-create.test.tsx` (FR-002, FR-005, SC-002, DESIGN-REQ-002, DESIGN-REQ-018)
+- [X] T005 Confirm existing test for one Step Type control with Tool, Skill, and Preset choices in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, SC-001, DESIGN-REQ-001)
+- [X] T006 Confirm existing test for switching Tool/Skill/Preset configuration areas and preserving instructions in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SC-003, DESIGN-REQ-009)
+- [X] T007 Confirm existing test that hidden Skill fields are not submitted for Tool steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, SC-004)
+- [X] T008 Confirm existing test for independent per-step Preset state in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, SC-005)
+- [X] T009 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` to confirm the helper-copy test fails before implementation
+
+### Implementation
+
+- [X] T010 Add Step Type helper copy in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-005, DESIGN-REQ-002, DESIGN-REQ-018)
+- [X] T011 Story validation: Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and fix failures until focused frontend tests pass
+
+**Checkpoint**: The story is functional and covered by focused Create page tests.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Validate without adding hidden scope.
+
+- [X] T012 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- [X] T013 Run `/moonspec-verify` equivalent by checking spec, plan, tasks, changed code, and test evidence against MM-562
+
+---
+
+## Dependencies & Execution Order
+
+- T004 must be written before T010.
+- T009 confirms red-first behavior before implementation.
+- T011 validates focused behavior after implementation.
+- T012-T013 are final validation.
+
+## Implementation Strategy
+
+1. Preserve MM-562 traceability in MoonSpec artifacts.
+2. Add a failing focused frontend test for Step Type helper copy.
+3. Add concise helper copy to the existing Step Type selector.
+4. Run focused frontend and managed unit verification.
+5. Verify artifacts and implementation against MM-562.

--- a/specs/281-step-type-authoring/verification.md
+++ b/specs/281-step-type-authoring/verification.md
@@ -1,0 +1,27 @@
+# Verification: Present Step Type Authoring
+
+**Feature**: `281-step-type-authoring`  
+**Jira**: `MM-562`  
+**Date**: 2026-04-29  
+**Verdict**: FULLY_IMPLEMENTED
+
+## Coverage
+
+| Requirement | Result | Evidence |
+| --- | --- | --- |
+| FR-001, SC-001, DESIGN-REQ-001 | PASS | `frontend/src/entrypoints/task-create.tsx` renders one accessible `Step Type` selector per step; `task-create.test.tsx` verifies exactly Tool, Skill, and Preset options. |
+| FR-002, SC-002, DESIGN-REQ-002 | PASS | `STEP_TYPE_HELP_TEXT` provides concise Tool, Skill, and Preset helper copy beside the selector; the new focused test verifies all three strings. |
+| FR-003, SC-003 | PASS | Existing conditional rendering shows Tool, Skill, or Preset controls from `step.stepType`; focused tests verify switching changes visible controls. |
+| FR-004, SC-004, DESIGN-REQ-009 | PASS | Existing tests verify instructions survive Step Type changes and hidden Skill fields are not submitted for Tool steps. |
+| FR-005, DESIGN-REQ-018 | PASS | Selector label/options and helper copy use Step Type, Tool, Skill, and Preset; the new focused test asserts Temporal Activity and Capability are not present in the selector area. |
+| FR-006, SC-005 | PASS | Existing per-step Preset selection test verifies independent step-scoped state. |
+
+## Test Evidence
+
+- Red-first: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` failed with 1 failing helper-copy test before implementation.
+- Focused UI: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed, 214 tests.
+- Managed unit wrapper: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` passed, 4216 Python tests, 1 xpassed, 16 subtests, then 214 focused UI tests.
+
+## Residual Risk
+
+- The Tool-specific panel remains a placeholder until a full typed tool picker is delivered by adjacent Step Type stories; MM-562 only requires presentation, switching, helper copy, and terminology behavior.


### PR DESCRIPTION
## Summary
- Adds concise Step Type helper copy for Tool, Skill, and Preset in the Create page step editor.
- Preserves the accessible Step Type selector name while keeping existing Tool/Skill/Preset switching behavior.
- Adds MM-562 MoonSpec artifacts for `specs/281-step-type-authoring`.

## Jira
- MM-562

## MoonSpec
- Active feature path: `specs/281-step-type-authoring`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests run
- Red-first: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` failed with 1 failing helper-copy test before implementation.
- Focused UI: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed, 214 tests.
- Managed unit wrapper: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` passed, 4216 Python tests, 1 xpassed, 16 subtests, then 214 focused UI tests.

## Remaining risks
- The Tool-specific panel remains a placeholder until the adjacent typed tool picker work lands; MM-562 only covers Step Type presentation, helper copy, switching, and terminology behavior.