### PR TITLE
MM-566 Normalize Step Type API payloads

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/284-preview-apply-preset-executable-steps"
+  "feature_directory": "specs/285-normalize-step-type-api"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-563",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1846"
+  "jira_issue_key": "MM-566",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1849"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,32 @@
 [
   {
-    "id": 4343068831,
+    "id": 4343518614,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and does not identify a code or documentation change for this PR."
+    "rationale": "Qodo free-tier limit notification is informational and contains no code feedback to address."
   },
   {
-    "id": 3160438952,
+    "id": 3160855192,
     "disposition": "addressed",
-    "rationale": "Updated moonspec_align_report.md so validation no longer contradicts the PASS result; it records the passing SPECIFY_FEATURE prerequisite command for the automation branch."
+    "rationale": "Replaced generic draft step payload records with specific Tool, Skill, and Preset payload interfaces with flexible index signatures."
   },
   {
-    "id": 3160438958,
-    "disposition": "addressed",
-    "rationale": "Ran the managed unit wrapper to completion and updated verification.md with the passing wrapper evidence."
+    "id": 4196785865,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; its actionable type-safety feedback is tracked by review comment 3160855192."
   },
   {
-    "id": 4196289541,
+    "id": 3160875256,
     "disposition": "addressed",
-    "rationale": "Resolved both review findings by recording passing prerequisite validation and completed managed-wrapper test evidence."
+    "rationale": "Draft reconstruction now reads step.stepType before falling back to legacy step.type."
+  },
+  {
+    "id": 3160875268,
+    "disposition": "addressed",
+    "rationale": "Preset draft hydration now preserves preset inputs in step preview state and reuses them when previewing the preset expansion."
+  },
+  {
+    "id": 4196808307,
+    "disposition": "not-applicable",
+    "rationale": "Codex review body is informational; its actionable findings are tracked by review comments 3160875256 and 3160875268."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -881,6 +881,43 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (
+          url === "/api/executions/mm%3Apreset-step-input-edit?source=temporal"
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:preset-step-input-edit",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                task: {
+                  instructions: "Edit a preset step.",
+                  steps: [
+                    {
+                      id: "preset-step",
+                      title: "Preset",
+                      stepType: "preset",
+                      instructions: "Preview the configured preset.",
+                      preset: {
+                        id: "global::::speckit-demo",
+                        slug: "speckit-demo",
+                        version: "1.2.3",
+                        inputs: { feature_name: "MM-566" },
+                      },
+                    },
+                  ],
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aauto-primary-skill?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -3309,6 +3346,42 @@ describe("Task Create Entrypoint", () => {
       expect(screen.getByText("Step 1 (Primary)")).toBeTruthy();
       expect(screen.getByText("Step 2")).toBeTruthy();
       expect(screen.getByText("Step 3")).toBeTruthy();
+    });
+  });
+
+  it("preserves reconstructed preset inputs when previewing an edit draft", async () => {
+    renderForEdit("mm:preset-step-input-edit");
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    await waitFor(() => {
+      expect(
+        (within(step).getByLabelText("Step Type") as HTMLSelectElement).value,
+      ).toBe("preset");
+      expect(
+        (within(step).getByLabelText("Preset") as HTMLSelectElement).value,
+      ).toBe("global::::speckit-demo");
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url, init]) => {
+          if (
+            !String(url).startsWith(
+              "/api/task-step-templates/speckit-demo:expand?scope=global",
+            )
+          ) {
+            return false;
+          }
+          const body = JSON.parse(String(init?.body || "{}")) as {
+            inputs?: Record<string, unknown>;
+          };
+          return body.inputs?.feature_name === "MM-566";
+        }),
+      ).toBe(true);
     });
   });
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2950,6 +2950,12 @@ describe("Task Create Entrypoint", () => {
         id: "step-primary",
         title: "Primary",
         instructions: "Primary operator objective.",
+        stepType: "skill",
+        skill: {
+          id: "moonspec-orchestrate",
+          args: { mode: "runtime" },
+          requiredCapabilities: ["git"],
+        },
         skillId: "moonspec-orchestrate",
         skillArgs: { mode: "runtime" },
         skillRequiredCapabilities: ["git"],
@@ -2960,6 +2966,11 @@ describe("Task Create Entrypoint", () => {
         id: "step-second",
         title: "Second",
         instructions: "Second step instructions.",
+        stepType: "tool",
+        tool: {
+          name: "pr-resolver",
+          inputs: { merge: false },
+        },
         skillId: "pr-resolver",
         skillArgs: { merge: false },
         skillRequiredCapabilities: [],
@@ -2974,6 +2985,101 @@ describe("Task Create Entrypoint", () => {
           },
         },
       },
+    ]);
+  });
+
+  it("reconstructs explicit Step Type draft payloads for editing", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:step-types",
+      workflowType: "MoonMind.Run",
+      inputParameters: {
+        task: {
+          instructions: "Edit explicit Step Type payloads.",
+          steps: [
+            {
+              id: "tool-step",
+              title: "Fetch issue",
+              type: "tool",
+              instructions: "Fetch Jira issue.",
+              tool: {
+                id: "jira.get_issue",
+                inputs: { issueKey: "MM-566" },
+              },
+            },
+            {
+              id: "skill-step",
+              title: "Implement",
+              type: "skill",
+              instructions: "Implement the issue.",
+              skill: {
+                id: "moonspec-implement",
+                args: { issueKey: "MM-566" },
+                requiredCapabilities: ["git"],
+              },
+            },
+            {
+              id: "preset-step",
+              title: "Jira flow",
+              type: "preset",
+              instructions: "Configure Jira orchestration.",
+              preset: {
+                id: "jira-orchestrate",
+                version: "2026-04-29",
+                inputs: { issueKey: "MM-566" },
+              },
+            },
+            {
+              id: "legacy-skill",
+              instructions: "Read an old skill-shaped tool.",
+              tool: {
+                type: "skill",
+                id: "legacy-skill",
+                inputs: { mode: "runtime" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps).toEqual([
+      expect.objectContaining({
+        id: "tool-step",
+        stepType: "tool",
+        tool: {
+          id: "jira.get_issue",
+          inputs: { issueKey: "MM-566" },
+        },
+        skillId: "jira.get_issue",
+        skillArgs: { issueKey: "MM-566" },
+      }),
+      expect.objectContaining({
+        id: "skill-step",
+        stepType: "skill",
+        skill: {
+          id: "moonspec-implement",
+          args: { issueKey: "MM-566" },
+          requiredCapabilities: ["git"],
+        },
+        skillId: "moonspec-implement",
+        skillArgs: { issueKey: "MM-566" },
+        skillRequiredCapabilities: ["git"],
+      }),
+      expect.objectContaining({
+        id: "preset-step",
+        stepType: "preset",
+        preset: {
+          id: "jira-orchestrate",
+          version: "2026-04-29",
+          inputs: { issueKey: "MM-566" },
+        },
+      }),
+      expect.objectContaining({
+        id: "legacy-skill",
+        stepType: "skill",
+        skillId: "legacy-skill",
+        skillArgs: { mode: "runtime" },
+      }),
     ]);
   });
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1177,19 +1177,50 @@ function createStepStateEntriesFromTemporalDraft(
     const primarySkill = draft.primarySkill || "";
     const shouldUsePrimarySkill =
       index === 0 &&
+      step.stepType === "skill" &&
       primarySkill !== "" &&
       !hasExplicitSkillSelection(step.skillId);
     const hasJiraOrchestration =
       step.jiraOrchestration &&
       Object.keys(step.jiraOrchestration).length > 0;
+    const toolPayload = step.tool || {};
+    const presetPayload = step.preset || {};
 
     return createStepStateEntry(index + 1, {
       id: step.id,
       title: step.title,
+      stepType: step.stepType,
       instructions: step.instructions,
-      skillId: shouldUsePrimarySkill ? primarySkill : step.skillId,
-      skillArgs: stringifySkillArgs(step.skillArgs),
+      skillId:
+        step.stepType === "skill"
+          ? shouldUsePrimarySkill
+            ? primarySkill
+            : step.skillId
+          : "",
+      skillArgs:
+        step.stepType === "skill" ? stringifySkillArgs(step.skillArgs) : "",
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
+      toolId:
+        step.stepType === "tool"
+          ? String(toolPayload.id || toolPayload.name || step.skillId || "").trim()
+          : "",
+      toolVersion:
+        step.stepType === "tool"
+          ? String(toolPayload.version || "").trim()
+          : "",
+      toolInputs:
+        step.stepType === "tool"
+          ? JSON.stringify(toolPayload.inputs || step.skillArgs || {}, null, 2)
+          : "{}",
+      presetKey:
+        step.stepType === "preset"
+          ? String(
+              presetPayload.id ||
+                presetPayload.slug ||
+                presetPayload.name ||
+                "",
+            ).trim()
+          : "",
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
       inputAttachments: (step.inputAttachments || []).map(

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1185,6 +1185,15 @@ function createStepStateEntriesFromTemporalDraft(
       Object.keys(step.jiraOrchestration).length > 0;
     const toolPayload = step.tool || {};
     const presetPayload = step.preset || {};
+    const presetKey =
+      step.stepType === "preset"
+        ? String(
+            presetPayload.id ||
+              presetPayload.slug ||
+              presetPayload.name ||
+              "",
+          ).trim()
+        : "";
 
     return createStepStateEntry(index + 1, {
       id: step.id,
@@ -1212,15 +1221,11 @@ function createStepStateEntriesFromTemporalDraft(
         step.stepType === "tool"
           ? JSON.stringify(toolPayload.inputs || step.skillArgs || {}, null, 2)
           : "{}",
-      presetKey:
+      presetKey,
+      presetPreview:
         step.stepType === "preset"
-          ? String(
-              presetPayload.id ||
-                presetPayload.slug ||
-                presetPayload.name ||
-                "",
-            ).trim()
-          : "",
+          ? presetPreviewStateFromDraftPayload(presetKey, presetPayload)
+          : null,
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
       inputAttachments: (step.inputAttachments || []).map(
@@ -1261,6 +1266,34 @@ function stepAttachmentRefFromTemporal(
 function hasExplicitSkillSelection(skillId: string): boolean {
   const normalized = skillId.trim().toLowerCase();
   return normalized !== "" && normalized !== "auto";
+}
+
+function presetPreviewStateFromDraftPayload(
+  presetKey: string,
+  presetPayload: Record<string, unknown>,
+): PresetPreviewState | null {
+  const inputs = presetPayload.inputs;
+  if (!inputs || typeof inputs !== "object" || Array.isArray(inputs)) {
+    return null;
+  }
+  const version = String(presetPayload.version || "").trim();
+  return {
+    presetKey,
+    presetTitle: String(
+      presetPayload.title ||
+        presetPayload.name ||
+        presetPayload.slug ||
+        presetPayload.id ||
+        "",
+    ).trim(),
+    version,
+    expandedSteps: [],
+    previewSteps: [],
+    warnings: [],
+    inputs: inputs as Record<string, unknown>,
+    assumptions: [],
+    capabilities: [],
+  };
 }
 
 function isResolverSkill(skillId: string): boolean {
@@ -5168,7 +5201,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const preview = await expandPresetForDraft({
         preset,
         detail,
-        inputValues: {},
+        inputValues:
+          step.presetPreview?.presetKey === preset.key
+            ? step.presetPreview.inputs
+            : {},
       });
       updateStep(localId, {
         presetPreview: preview,

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -59,6 +59,38 @@ export type TemporalTaskInputAttachmentRef = {
   sizeBytes: number;
 };
 
+export type TemporalSubmissionDraftStepType = 'tool' | 'skill' | 'preset';
+
+export type TemporalSubmissionDraftToolPayload = {
+  id?: string;
+  name?: string;
+  version?: string;
+  type?: string;
+  kind?: string;
+  inputs?: Record<string, unknown>;
+  args?: Record<string, unknown>;
+  requiredCapabilities?: unknown;
+  [key: string]: unknown;
+};
+
+export type TemporalSubmissionDraftSkillPayload = {
+  id?: string;
+  name?: string;
+  inputs?: Record<string, unknown>;
+  args?: Record<string, unknown>;
+  requiredCapabilities?: unknown;
+  [key: string]: unknown;
+};
+
+export type TemporalSubmissionDraftPresetPayload = {
+  id?: string;
+  slug?: string;
+  name?: string;
+  version?: string;
+  inputs?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
 export type TemporalSubmissionDraft = {
   runtime: string | null;
   providerProfile: string | null;
@@ -77,10 +109,10 @@ export type TemporalSubmissionDraft = {
     id: string;
     title: string;
     instructions: string;
-    stepType: 'tool' | 'skill' | 'preset';
-    tool?: Record<string, unknown>;
-    skill?: Record<string, unknown>;
-    preset?: Record<string, unknown>;
+    stepType: TemporalSubmissionDraftStepType;
+    tool?: TemporalSubmissionDraftToolPayload;
+    skill?: TemporalSubmissionDraftSkillPayload;
+    preset?: TemporalSubmissionDraftPresetPayload;
     skillId: string;
     skillArgs: Record<string, unknown>;
     skillRequiredCapabilities: string[];
@@ -404,9 +436,9 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
   const tool = objectValue(step.tool);
   const skill = objectValue(step.skill);
   const preset = objectValue(step.preset);
-  const rawStepType = stringValue(step.type).toLowerCase();
+  const rawStepType = stringValue(step.stepType, step.type).toLowerCase();
   const legacyToolType = stringValue(tool.type, tool.kind).toLowerCase();
-  const stepType: 'tool' | 'skill' | 'preset' =
+  const stepType: TemporalSubmissionDraftStepType =
     rawStepType === 'tool' || rawStepType === 'skill' || rawStepType === 'preset'
       ? rawStepType
       : Object.keys(preset).length > 0

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -77,6 +77,10 @@ export type TemporalSubmissionDraft = {
     id: string;
     title: string;
     instructions: string;
+    stepType: 'tool' | 'skill' | 'preset';
+    tool?: Record<string, unknown>;
+    skill?: Record<string, unknown>;
+    preset?: Record<string, unknown>;
     skillId: string;
     skillArgs: Record<string, unknown>;
     skillRequiredCapabilities: string[];
@@ -399,6 +403,17 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
 
   const tool = objectValue(step.tool);
   const skill = objectValue(step.skill);
+  const preset = objectValue(step.preset);
+  const rawStepType = stringValue(step.type).toLowerCase();
+  const legacyToolType = stringValue(tool.type, tool.kind).toLowerCase();
+  const stepType: 'tool' | 'skill' | 'preset' =
+    rawStepType === 'tool' || rawStepType === 'skill' || rawStepType === 'preset'
+      ? rawStepType
+      : Object.keys(preset).length > 0
+        ? 'preset'
+        : Object.keys(tool).length > 0 && legacyToolType !== 'skill'
+          ? 'tool'
+          : 'skill';
   const instructions = stringValue(step.instructions);
   const id = stringValue(step.id);
   const templateStepId = stringValue(
@@ -423,6 +438,10 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     id,
     title: stringValue(step.title),
     instructions,
+    stepType,
+    ...(Object.keys(tool).length > 0 ? { tool } : {}),
+    ...(Object.keys(skill).length > 0 ? { skill } : {}),
+    ...(Object.keys(preset).length > 0 ? { preset } : {}),
     skillId: stringValue(tool.name, tool.id, skill.id, skill.name),
     skillArgs: firstObjectValue(tool.inputs, tool.args, skill.inputs, skill.args),
     skillRequiredCapabilities: stringArrayValue(
@@ -445,6 +464,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     result.id ||
     result.title ||
     result.instructions ||
+    result.stepType !== 'skill' ||
     result.skillId ||
     Object.keys(result.skillArgs).length > 0 ||
     result.skillRequiredCapabilities.length > 0 ||

--- a/specs/285-normalize-step-type-api/checklists/requirements.md
+++ b/specs/285-normalize-step-type-api/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Normalize Step Type API and Executable Submission Payloads
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- MM-566 is treated as a runtime implementation workflow.
+- Related MM-559 artifacts are implementation evidence only; they are not reused as the active MM-566 feature because they preserve a different Jira issue key.

--- a/specs/285-normalize-step-type-api/contracts/step-type-payloads.md
+++ b/specs/285-normalize-step-type-api/contracts/step-type-payloads.md
@@ -1,0 +1,49 @@
+# Contract: Step Type Payloads
+
+## Draft-Oriented Payload
+
+Draft and edit reconstruction surfaces must preserve explicit Step Type intent:
+
+```ts
+type DraftStepType = "tool" | "skill" | "preset";
+
+type DraftStep = {
+  id: string;
+  title: string;
+  instructions: string;
+  stepType: DraftStepType;
+  tool?: {
+    id?: string;
+    name?: string;
+    inputs?: Record<string, unknown>;
+  };
+  skill?: {
+    id?: string;
+    name?: string;
+    inputs?: Record<string, unknown>;
+    args?: Record<string, unknown>;
+  };
+  preset?: {
+    id?: string;
+    slug?: string;
+    version?: string;
+    inputs?: Record<string, unknown>;
+  };
+};
+```
+
+Legacy readers may infer `stepType` from older `tool` or `skill` fields when no explicit type is present, but new reconstructed draft output should expose the inferred `stepType`.
+
+## Executable Submission Payload
+
+Executable submission accepts only:
+
+```ts
+type ExecutableStep = ToolStep | SkillStep;
+```
+
+Unresolved `PresetStep` payloads, Temporal Activity labels, and mixed Tool/Skill payloads must fail validation before runtime materialization.
+
+## Compatibility Boundary
+
+Compatibility belongs in reconstruction/read paths only. It must not make Preset an executable runtime node or make Activity a user-facing Step Type.

--- a/specs/285-normalize-step-type-api/data-model.md
+++ b/specs/285-normalize-step-type-api/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Normalize Step Type API and Executable Submission Payloads
+
+## Step Type
+
+- Values: `tool`, `skill`, `preset`.
+- Validation:
+  - Draft/edit reconstruction may represent all three values.
+  - Executable submission accepts `tool` and `skill` only by default.
+  - `activity`, `script`, and `command` are not valid Step Type values.
+
+## Draft Step
+
+- Fields:
+  - `id`: stable local identity when available.
+  - `title`: optional display title.
+  - `instructions`: optional authoring or execution instructions.
+  - `stepType`: explicit Step Type discriminator.
+  - `tool`: optional Tool payload for Tool steps.
+  - `skill`: optional Skill payload for Skill steps.
+  - `preset`: optional Preset payload for Preset steps.
+  - `source`: optional provenance metadata.
+  - `inputAttachments`: optional step attachment refs.
+- Validation:
+  - `stepType=tool` may carry `tool`.
+  - `stepType=skill` may carry `skill`.
+  - `stepType=preset` may carry `preset`.
+  - Legacy readers may infer `stepType` from older `tool` or `skill` fields only for reconstruction.
+
+## Executable Step
+
+- Fields:
+  - `type`: `tool` or `skill`.
+  - Matching type-specific payload.
+  - Optional source/provenance metadata.
+- Validation:
+  - Preset steps are rejected before runtime materialization.
+  - Activity labels are rejected before runtime materialization.
+  - Conflicting Tool/Skill payloads are rejected.
+
+## State Transitions
+
+1. Draft authoring may hold Tool, Skill, or Preset steps.
+2. Preset preview/apply expands Preset steps into executable Tool and Skill steps.
+3. Executable submission validates only Tool and Skill steps.
+4. Runtime materialization consumes executable steps only.

--- a/specs/285-normalize-step-type-api/moonspec_align_report.md
+++ b/specs/285-normalize-step-type-api/moonspec_align_report.md
@@ -1,0 +1,46 @@
+# MoonSpec Alignment Report: Normalize Step Type API and Executable Submission Payloads
+
+**Feature**: `specs/285-normalize-step-type-api`
+**Jira**: `MM-566`
+**Date**: 2026-04-29
+
+## Scope
+
+Ran the MoonSpec alignment workflow after task generation for the active MM-566 feature artifacts:
+
+- `spec.md`
+- `plan.md`
+- `research.md`
+- `data-model.md`
+- `contracts/step-type-payloads.md`
+- `quickstart.md`
+- `tasks.md`
+
+The standard helper path documented by the skill, `scripts/bash/check-prerequisites.sh`, is not present in this checkout. The repo-local helper `.specify/scripts/bash/check-prerequisites.sh` exists but rejects the managed branch name `run-jira-orchestrate-for-mm-566-normaliz-5fe1e6ca` because it is not in `NNN-feature-name` format. Alignment therefore used `.specify/feature.json`, which points to `specs/285-normalize-step-type-api`, and validated the same artifact gates directly.
+
+## Findings
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Original request preservation | PASS | `spec.md` preserves `MM-566` and the full canonical Jira preset brief in `**Input**`. |
+| Story isolation | PASS | `spec.md` contains exactly one `## User Story - ...` section; `tasks.md` contains exactly one story phase. |
+| Functional requirement coverage | PASS | FR-001 through FR-007 all appear in `tasks.md`. |
+| Acceptance scenario coverage | PASS | SCN-001 through SCN-006 all appear in `tasks.md`. |
+| Success criterion coverage | PASS | SC-001 through SC-005 all appear in `tasks.md`. |
+| Source design coverage | PASS | DESIGN-REQ-012, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-019 all appear in `tasks.md`. |
+| Unit strategy | PASS | `plan.md` and `tasks.md` identify unit validation through `./tools/test_unit.sh` and focused task-contract coverage. |
+| Integration strategy | PASS | `plan.md` and `tasks.md` explicitly document no compose-backed `integration_ci` requirement and use frontend edit/rerun reconstruction tests as the integration-boundary coverage. |
+| Red-first ordering | PASS | `tasks.md` records the red-first frontend run before implementation and green evidence afterward. |
+| Implementation work | PASS | `tasks.md` includes implementation work for draft Step Type preservation. |
+| Story validation | PASS | `tasks.md` includes story evidence validation against executable-boundary tests. |
+| Final verify | PASS | `tasks.md` includes `/moonspec-verify` equivalent work and `verification.md` exists. |
+
+## Remediation
+
+No spec, plan, design artifact, or task edits were required. No downstream artifact regeneration was triggered.
+
+## Validation
+
+- Direct artifact coverage check: PASS.
+- No unresolved placeholders such as `[NEEDS CLARIFICATION]` or `TODO` were found in the active spec, plan, or tasks.
+- No constitution or source-request conflict was identified.

--- a/specs/285-normalize-step-type-api/plan.md
+++ b/specs/285-normalize-step-type-api/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Normalize Step Type API and Executable Submission Payloads
+
+**Branch**: `285-normalize-step-type-api` | **Date**: 2026-04-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/285-normalize-step-type-api/spec.md`
+
+## Summary
+
+MM-566 requires Step Type payloads to remain explicit across draft reconstruction and executable submission. Repo inspection shows the executable submission boundary is largely implemented by `specs/279-submit-discriminated-executable-payloads`, including backend validation for Tool and Skill steps and rejection of Preset, Activity, and mixed payloads. The remaining gap is draft reconstruction for editable Temporal task inputs: explicit `type: "preset"` draft steps are currently inferred as Skill because the frontend draft model does not preserve Step Type. The plan adds focused draft reconstruction coverage and a narrow frontend model update, then verifies existing backend submission tests and the canonical Step Type documentation.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `TaskStepSpec` validates explicit executable `type`; `frontend/src/lib/temporalTaskEditing.ts` does not preserve explicit draft Step Type. | Add draft Step Type fields and reconstruction logic. | frontend unit |
+| FR-002 | implemented_verified | `TaskStepSpec._reject_forbidden_step_overrides` accepts `tool` and `skill`; `tests/unit/workflows/tasks/test_task_contract.py` covers executable Tool and Skill. | No new implementation. | final unit |
+| FR-003 | implemented_verified | Backend tests reject `preset`, `activity`, and `Activity` Step Types. | No new implementation. | final unit |
+| FR-004 | missing | `draftStepFrom` infers Skill when a draft step is not a tool step. | Preserve `type: "preset"` and preset payload during draft reconstruction. | frontend unit |
+| FR-005 | implemented_verified | Backend tests reject Tool steps with Skill payloads and Skill steps with non-skill Tool payloads. | No new implementation. | final unit |
+| FR-006 | partial | Legacy draft reconstruction keeps old Tool/Skill fields readable but lacks explicit Step Type output. | Keep legacy inference while adding explicit discriminator preservation. | frontend unit |
+| FR-007 | partial | `docs/Steps/StepTypes.md` uses Step Type terminology but contains a duplicated migration bullet. | Fix the contradictory duplicate and verify no new output uses Activity as primary Step Type. | docs check + final unit |
+| SCN-001 | partial | Draft Tool reconstruction derives `skillId` from `tool`, but no explicit Step Type assertion. | Add Tool draft reconstruction assertion. | frontend unit |
+| SCN-002 | partial | Draft Skill reconstruction derives `skillId` from `skill`, but no explicit Step Type assertion. | Add Skill draft reconstruction assertion. | frontend unit |
+| SCN-003 | missing | Preset draft steps are not represented in `TemporalSubmissionDraft`. | Add Preset draft reconstruction test and implementation. | frontend unit |
+| SCN-004 | implemented_verified | Backend task contract tests reject non-executable Step Types. | No new implementation. | final unit |
+| SCN-005 | implemented_verified | Backend task contract tests reject conflicting payloads. | No new implementation. | final unit |
+| SCN-006 | partial | Legacy reconstruction is supported, but explicit Step Type output is not asserted. | Add regression assertion for legacy skill inference. | frontend unit |
+| DESIGN-REQ-012 | partial | Executable boundary implemented; draft Preset representation missing. | Implement draft Preset reconstruction. | frontend unit |
+| DESIGN-REQ-014 | implemented_verified | Existing task contract validation covers mixed payload rejection. | No new implementation. | final unit |
+| DESIGN-REQ-015 | partial | Existing model preserves identity/title/instructions; explicit draft discriminator missing. | Add `stepType` and `preset` draft fields. | frontend unit |
+| DESIGN-REQ-019 | partial | Compatibility readers exist; doc duplicate needs cleanup. | Keep legacy inference and fix doc duplicate. | frontend unit + docs check |
+| SC-001 | missing | No draft reconstruction test covers all three Step Types. | Add frontend unit test. | frontend unit |
+| SC-002 | implemented_verified | Backend tests cover executable validation matrix. | No new implementation. | final unit |
+| SC-003 | partial | Legacy tests cover edit reconstruction but not Step Type inference. | Add legacy inference assertion. | frontend unit |
+| SC-004 | partial | Docs mostly converge, but duplicate migration bullet exists. | Fix duplicate and verify terminology. | docs check |
+| SC-005 | missing | MM-566 verification artifact not yet written. | Write final verification. | moonspec verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control task draft editing
+**Primary Dependencies**: Pydantic v2 task contract models, React/Vitest test harness, existing Temporal task editing helpers
+**Storage**: No new persistent storage; existing task input snapshots and execution parameters only
+**Unit Testing**: `./tools/test_unit.sh`; focused Vitest command through `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+**Integration Testing**: No compose-backed integration test is required for this narrow draft/contract story; integration-boundary evidence comes from frontend task reconstruction and existing backend executable submission validation
+**Target Platform**: MoonMind API task contract and Mission Control Create/Edit task surfaces
+**Project Type**: Web service plus frontend application
+**Performance Goals**: Draft reconstruction remains synchronous and linear in submitted step count
+**Constraints**: Preserve MM-566 traceability; do not make Preset steps executable by default; do not use Activity as a user-facing Step Type
+**Scale/Scope**: Existing task step limits and draft reconstruction paths only
+
+## Constitution Check
+
+- Orchestrate, Don't Recreate: PASS. The change preserves MoonMind's typed task orchestration boundary.
+- One-Click Agent Deployment: PASS. No new required external dependency or deployment prerequisite.
+- Avoid Vendor Lock-In: PASS. Step Type semantics are provider-neutral.
+- Own Your Data: PASS. Existing task snapshots remain portable JSON-like payloads.
+- Skills Are First-Class and Easy to Add: PASS. Skill steps remain explicit and separate from Tool and Preset steps.
+- Thin Scaffolding, Thick Contracts: PASS. The work strengthens discriminated payload contracts rather than adding orchestration scaffolding.
+- Powerful Runtime Configurability: PASS. No hardcoded runtime mode or model behavior changes.
+- Modular and Extensible Architecture: PASS. Changes stay in task draft reconstruction and task contract boundaries.
+- Resilient by Default: PASS. Invalid executable payloads continue to fail before runtime materialization.
+- Facilitate Continuous Improvement: PASS. Final verification records the outcome and evidence.
+- Spec-Driven Development: PASS. MM-566 artifacts precede the narrow code/doc changes.
+- Canonical Documentation Separation: PASS. Desired-state docs are adjusted only to remove contradiction; migration notes stay in this spec.
+- Compatibility Policy: PASS. No new compatibility alias is introduced; legacy readability remains scoped to existing reader behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/285-normalize-step-type-api/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/
+│   └── step-type-payloads.md
+├── checklists/
+│   └── requirements.md
+├── quickstart.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/lib/temporalTaskEditing.ts
+frontend/src/entrypoints/task-create.test.tsx
+docs/Steps/StepTypes.md
+tests/unit/workflows/tasks/test_task_contract.py
+```
+
+**Structure Decision**: Update frontend draft reconstruction for authoring/editing behavior, reuse existing backend executable submission validation, and clean the canonical Step Types doc contradiction.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/285-normalize-step-type-api/quickstart.md
+++ b/specs/285-normalize-step-type-api/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: Normalize Step Type API and Executable Submission Payloads
+
+## Focused Frontend Verification
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected result: Temporal task editing tests pass, including explicit Tool, Skill, and Preset draft reconstruction.
+
+## Focused Backend Verification
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
+```
+
+Expected result: executable submission validation accepts Tool/Skill and rejects Preset, Activity, and mixed payloads.
+
+## Final Verification
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected result: full unit suite passes, or the exact environmental blocker is recorded in `verification.md`.

--- a/specs/285-normalize-step-type-api/research.md
+++ b/specs/285-normalize-step-type-api/research.md
@@ -1,0 +1,41 @@
+# Research: Normalize Step Type API and Executable Submission Payloads
+
+## Input Classification
+
+Decision: MM-566 is a single-story runtime feature request.
+Evidence: The preserved Jira brief identifies one API consumer story with one cohesive boundary: draft payloads may contain Tool, Skill, and Preset, while executable submissions normally contain Tool and Skill only.
+Rationale: The source design sections cover a single Step Type payload normalization path rather than multiple independent product stories.
+Alternatives considered: Reusing `specs/279-submit-discriminated-executable-payloads` was rejected because that spec preserves MM-559, not MM-566.
+Test implications: The new feature must preserve MM-566 in artifacts and final verification even when implementation evidence comes from MM-559-era code.
+
+## Executable Submission Boundary
+
+Decision: Treat FR-002, FR-003, FR-005, DESIGN-REQ-014, SCN-004, SCN-005, and SC-002 as implemented and verified by existing task contract tests.
+Evidence: `moonmind/workflows/tasks/task_contract.py` validates explicit executable step types and rejects Preset, Activity, and conflicting payloads. `tests/unit/workflows/tasks/test_task_contract.py` covers accepted Tool/Skill payloads, rejected non-executable Step Types, and mixed payload errors.
+Rationale: The acceptance behavior is already enforced at the executable payload boundary and should not be reimplemented for MM-566.
+Alternatives considered: Duplicating backend validators was rejected because it would increase contract surface without changing behavior.
+Test implications: Rerun the focused backend task contract tests and full unit suite for final evidence.
+
+## Draft Reconstruction Gap
+
+Decision: Implement explicit Step Type preservation in `frontend/src/lib/temporalTaskEditing.ts`.
+Evidence: `TemporalSubmissionDraft.steps` currently stores `skillId` and `skillArgs` but not `stepType`, `tool`, or `preset`; `draftStepFrom` derives all non-tool steps as Skill-like editable rows.
+Rationale: MM-566 requires draft APIs to represent ToolStep, SkillStep, and PresetStep explicitly. Executable submission validation alone does not satisfy draft-oriented Preset representation.
+Alternatives considered: Modeling Preset only in Create-page local state was rejected because Temporal edit/rerun reconstruction is the API consumer boundary for stored drafts.
+Test implications: Add frontend unit coverage for explicit Tool, Skill, Preset draft reconstruction and legacy Skill readability.
+
+## Legacy Readability
+
+Decision: Preserve existing legacy inference while adding explicit discriminators for new output.
+Evidence: Existing tests reconstruct older steps from `tool`, `skill`, and template fields; the source design allows migration phases and legacy readers where necessary.
+Rationale: Removing legacy readability would break edit/rerun of already-stored task inputs and exceed MM-566 scope.
+Alternatives considered: Rejecting legacy steps during draft reconstruction was rejected because the Jira brief explicitly allows migration phases.
+Test implications: Add assertions that legacy Skill-shaped steps still reconstruct as editable Skill steps.
+
+## Documentation Convergence
+
+Decision: Fix the duplicated runtime migration bullet in `docs/Steps/StepTypes.md` and verify the doc keeps Step Type terminology as the primary discriminator.
+Evidence: Section 14 repeats "Compile executable steps into the canonical plan format" twice.
+Rationale: The duplicate is minor but contradicts the "new API outputs and docs converge" acceptance criterion because the migration guidance is visibly inconsistent.
+Alternatives considered: Leaving docs untouched was rejected because MM-566 explicitly includes docs convergence.
+Test implications: Use targeted text inspection plus final review.

--- a/specs/285-normalize-step-type-api/spec.md
+++ b/specs/285-normalize-step-type-api/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Normalize Step Type API and Executable Submission Payloads
+
+**Feature Branch**: `285-normalize-step-type-api`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-566 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-566 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-566
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Normalize Step Type API and executable submission payloads
+- Trusted fetch tool: `jira.get_issue` through MoonMind MCP `/mcp/tools/call`
+- Canonical source: synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-566 from MM project
+Summary: Normalize Step Type API and executable submission payloads
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-566 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-566: Normalize Step Type API and executable submission payloads
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 7. Runtime and Payload Contract
+- 8. Validation Rules
+- 11. API Shape
+- 14. Migration Guidance
+Coverage IDs:
+- DESIGN-REQ-012
+- DESIGN-REQ-014
+- DESIGN-REQ-015
+- DESIGN-REQ-019
+
+As an API consumer, I can submit explicit discriminated Step Type payloads where drafts may contain Preset steps but executable submissions normally contain only Tool and Skill steps.
+
+Acceptance Criteria
+- Draft APIs can represent ToolStep, SkillStep, and PresetStep as explicit discriminated shapes.
+- Executable submission normally accepts only ToolStep and SkillStep.
+- Invalid mixed payloads fail fast with validation errors.
+- Legacy shapes remain readable only where migration requires them.
+- New API outputs and docs converge on Step Type terminology and shapes.
+
+Requirements
+- Step payloads include stable local identity, optional/generated title, type discriminator, and matching type-specific payload.
+- Compatibility readers do not reintroduce ambiguous UI or docs terminology.
+- Migration can proceed in phases while preserving desired-state API direction."
+
+Preserved source Jira preset brief: `MM-566` from the trusted `jira.get_issue` response, reproduced in the `**Input**` field above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-566` and local artifact `artifacts/moonspec/mm-566-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: related feature `specs/279-submit-discriminated-executable-payloads` preserves Jira source `MM-559`; no existing Moon Spec feature directory preserved `MM-566`, so `Specify` is the first incomplete MM-566 stage.
+
+## User Story - Normalize Step Type Payload Boundaries
+
+**Summary**: As an API consumer, I can work with explicit Tool, Skill, and Preset step shapes in draft-oriented payloads while executable submissions accept only Tool and Skill steps.
+
+**Goal**: Step Type payloads should be unambiguous across authoring, draft reconstruction, executable submission, and documentation so invalid mixed shapes fail fast and legacy readers do not erase the desired Step Type model.
+
+**Independent Test**: Reconstruct or validate payloads containing ToolStep, SkillStep, PresetStep, invalid mixed steps, and legacy step shapes; then confirm draft-oriented surfaces preserve the explicit discriminator, executable submission rejects unresolved Preset or invalid Activity labels, and docs describe the same Step Type terminology.
+
+**Acceptance Scenarios**:
+
+1. **SCN-001 - Draft Tool shape**: **Given** a draft or editable task payload contains `type: "tool"` with a matching Tool payload, **When** the draft is reconstructed for editing, **Then** the step remains a Tool step with stable identity, title, instructions, and Tool inputs preserved.
+2. **SCN-002 - Draft Skill shape**: **Given** a draft or editable task payload contains `type: "skill"` with a matching Skill payload, **When** the draft is reconstructed for editing, **Then** the step remains a Skill step with stable identity, title, instructions, and Skill inputs preserved.
+3. **SCN-003 - Draft Preset shape**: **Given** a draft or editable task payload contains `type: "preset"` with a matching Preset payload, **When** the draft is reconstructed for editing, **Then** the step remains a Preset step and is not silently coerced to Skill.
+4. **SCN-004 - Executable boundary**: **Given** a submitted executable task contains an unresolved Preset step or Activity-labeled step, **When** executable payload validation runs, **Then** validation fails before runtime materialization.
+5. **SCN-005 - Mixed payload rejection**: **Given** a submitted executable step combines conflicting Step Type payloads, **When** validation runs, **Then** validation fails with an actionable error.
+6. **SCN-006 - Legacy readability**: **Given** an older task shape lacks an explicit Step Type but still carries recognizable legacy Tool or Skill fields, **When** compatibility readers reconstruct it, **Then** the reader preserves existing editability without promoting ambiguous terminology into new API output.
+
+### Edge Cases
+
+- A draft Preset step has preset inputs but no executable instructions yet.
+- A Step Type discriminator differs in case, such as `Activity`.
+- A legacy Skill step is represented through older `tool.type = "skill"` fields.
+- A Tool step includes a Skill payload, or a Skill step includes a non-skill Tool payload.
+- A doc or UI-facing output uses `Activity`, `Script`, or `Command` as the primary Step Type label.
+
+## Assumptions
+
+- MM-559 already delivered much of the executable submission boundary; this MM-566 story may reuse that implementation as evidence but must preserve the newer Jira source request in its own artifacts.
+- Preset steps remain authoring-time draft placeholders by default and are not executable runtime plan nodes.
+- Legacy readers may remain permissive only to preserve editability for already-stored task inputs.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Functional Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-012 | `docs/Steps/StepTypes.md` section 7 | Draft authoring may temporarily contain Preset steps, while executable task submission should normally contain only Tool and Skill steps. | In scope | FR-001, FR-002, FR-004 |
+| DESIGN-REQ-014 | `docs/Steps/StepTypes.md` section 8 | Invalid mixed Step Type payloads must fail validation. | In scope | FR-003, FR-005 |
+| DESIGN-REQ-015 | `docs/Steps/StepTypes.md` section 11 | Step payloads use stable local identity, optional title, explicit type discriminator, and matching type-specific payloads. | In scope | FR-001, FR-002, FR-006 |
+| DESIGN-REQ-019 | `docs/Steps/StepTypes.md` section 14 | Migration may proceed in phases while preserving legacy readability only where necessary and converging new outputs on Step Type terminology. | In scope | FR-006, FR-007 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Draft-oriented APIs and edit reconstruction MUST represent `ToolStep`, `SkillStep`, and `PresetStep` as explicit discriminated shapes.
+- **FR-002**: Executable task submission MUST accept only `type: "tool"` and `type: "skill"` step payloads by default.
+- **FR-003**: Executable task submission MUST reject unresolved `type: "preset"` steps and Temporal `Activity` labels before runtime materialization.
+- **FR-004**: Draft Preset steps MUST remain Preset steps during reconstruction and MUST NOT be silently coerced to Skill.
+- **FR-005**: Step validation MUST reject conflicting or mixed type-specific payloads with actionable validation errors.
+- **FR-006**: Compatibility readers MUST keep legacy Tool and Skill shapes readable only where needed for migration and editing.
+- **FR-007**: New API outputs, UI-facing labels, and canonical docs MUST converge on Tool, Skill, Preset, and Step Type terminology rather than Activity, Script, or Command as the primary discriminator.
+
+### Key Entities
+
+- **Step Type**: The user-facing discriminator for a task step: Tool, Skill, or Preset.
+- **ToolStep**: An executable step with `type: "tool"` and a matching typed Tool payload.
+- **SkillStep**: An executable step with `type: "skill"` and a matching Skill payload.
+- **PresetStep**: A draft-only authoring placeholder with `type: "preset"` and a matching Preset payload.
+- **Executable Submission**: The task payload boundary that can be materialized into runtime execution and normally accepts only ToolStep and SkillStep.
+- **Legacy Reader**: Compatibility code that reconstructs older task shapes for editing without changing the desired-state API.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Draft reconstruction tests cover explicit Tool, Skill, and Preset step payloads and preserve their Step Type discriminators.
+- **SC-002**: Executable submission tests cover accepted Tool and Skill payloads plus rejected Preset, Activity, and conflicting mixed payloads.
+- **SC-003**: Legacy reconstruction tests prove older Tool and Skill-shaped payloads remain editable without introducing Preset execution behavior.
+- **SC-004**: Documentation verification confirms the Step Type API shape is not internally contradictory and uses Step Type terminology for the primary discriminator.
+- **SC-005**: Final verification preserves Jira issue key `MM-566` and the original Jira preset brief in active MoonSpec artifacts and delivery metadata.

--- a/specs/285-normalize-step-type-api/tasks.md
+++ b/specs/285-normalize-step-type-api/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: Normalize Step Type API and Executable Submission Payloads
+
+**Input**: `specs/285-normalize-step-type-api/spec.md` and `specs/285-normalize-step-type-api/plan.md`
+
+**Prerequisites**: spec, plan, research, data model, contract, and quickstart complete.
+
+**Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py`
+**Frontend Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+**Integration Test Strategy**: No compose-backed `integration_ci` test is required because this story changes draft reconstruction and executable validation contracts without new storage, service topology, or external provider behavior. Frontend edit/rerun reconstruction tests serve as the integration-boundary coverage for draft APIs.
+**Final Verification Command**: `./tools/test_unit.sh`
+
+**Source Traceability**: MM-566 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-007, SCN-001 through SCN-006, SC-001 through SC-005, and DESIGN-REQ-012, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-019.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active MM-566 artifacts under `specs/285-normalize-step-type-api/` and `.specify/feature.json`.
+- [X] T002 Inspect existing MM-559 task contract implementation and Step Type source doc in `moonmind/workflows/tasks/task_contract.py`, `tests/unit/workflows/tasks/test_task_contract.py`, and `docs/Steps/StepTypes.md`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm no database migration, service dependency, or compose integration harness is required for MM-566 in `specs/285-normalize-step-type-api/plan.md`.
+
+## Phase 3: Story
+
+**Story**: Draft APIs represent Tool, Skill, and Preset Step Types explicitly while executable submissions accept only Tool and Skill.
+
+**Independent Test**: Reconstruct explicit Tool, Skill, Preset, and legacy step payloads; validate executable submission rejects Preset, Activity, and mixed payloads.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SCN-006, SC-001, SC-002, SC-003, SC-004, DESIGN-REQ-012, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-019.
+
+- [X] T004 [P] Add failing frontend draft reconstruction tests for explicit Tool, Skill, Preset, and legacy Skill shapes in `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-004, FR-006, SCN-001, SCN-002, SCN-003, and SCN-006.
+- [X] T005 Run focused frontend test command and record the red result in `specs/285-normalize-step-type-api/tasks.md`.
+- [X] T006 Implement explicit draft Step Type preservation in `frontend/src/lib/temporalTaskEditing.ts` for FR-001, FR-004, FR-006, DESIGN-REQ-012, and DESIGN-REQ-015.
+- [X] T007 Verify Step Type documentation convergence in `docs/Steps/StepTypes.md` for FR-007, SC-004, and DESIGN-REQ-019.
+- [X] T008 Run focused frontend and backend validation commands and fix defects.
+- [X] T009 Validate story evidence against executable boundary tests in `tests/unit/workflows/tasks/test_task_contract.py` for FR-002, FR-003, FR-005, SCN-004, SCN-005, and DESIGN-REQ-014.
+
+## Final Phase: Polish And Verification
+
+- [X] T010 Run final `./tools/test_unit.sh` or record the exact blocker.
+- [X] T011 Run `/moonspec-verify` equivalent and write `specs/285-normalize-step-type-api/verification.md`.
+
+## Execution Evidence
+
+- Red-first frontend run: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` initially failed in `reconstructs ordered editable steps from Temporal execution fields` because draft reconstruction now preserved the original `skill` payload and the pre-existing expectation did not account for it.
+- Focused frontend green run: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed with 219 tests.
+- Focused backend validation: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py` passed the focused 25 Python task-contract tests and the wrapper's 477 frontend tests.
+- TypeScript check: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` passed.
+- Final full unit run: `./tools/test_unit.sh` passed with 4221 Python tests, 1 xpass, 16 subtests, and 477 frontend tests.

--- a/specs/285-normalize-step-type-api/verification.md
+++ b/specs/285-normalize-step-type-api/verification.md
@@ -1,0 +1,39 @@
+# MoonSpec Verification: Normalize Step Type API and Executable Submission Payloads
+
+**Feature**: `specs/285-normalize-step-type-api`
+**Jira**: `MM-566`
+**Original Request Source**: `spec.md` `**Input**` preserving the trusted Jira preset brief
+**Verified**: 2026-04-29
+
+## Verdict
+
+`FULLY_IMPLEMENTED`
+
+## Requirement Coverage
+
+| Requirement | Result | Evidence |
+| --- | --- | --- |
+| FR-001 | PASS | `frontend/src/lib/temporalTaskEditing.ts` now reconstructs draft steps with explicit `stepType` plus optional `tool`, `skill`, or `preset` payloads. |
+| FR-002 | PASS | `moonmind/workflows/tasks/task_contract.py` accepts executable `tool` and `skill` types; focused backend task-contract tests passed. |
+| FR-003 | PASS | Existing task-contract tests reject unresolved `preset`, `activity`, and `Activity` submitted step types. |
+| FR-004 | PASS | `frontend/src/entrypoints/task-create.test.tsx` covers explicit Preset draft reconstruction without coercion to Skill. |
+| FR-005 | PASS | Existing task-contract tests reject conflicting Tool/Skill payloads. |
+| FR-006 | PASS | Draft reconstruction preserves legacy skill-shaped Tool payload readability while exposing inferred `stepType: "skill"`. |
+| FR-007 | PASS | `docs/Steps/StepTypes.md` already uses Step Type terminology for Tool, Skill, Preset, and executable submission; no contradictory duplicate remained in the current checkout. |
+| DESIGN-REQ-012 | PASS | Draft Preset representation and executable-only submission boundary are both covered. |
+| DESIGN-REQ-014 | PASS | Mixed payload validation is covered by backend task-contract tests. |
+| DESIGN-REQ-015 | PASS | Draft reconstruction preserves identity, title, instructions, discriminator, and type-specific payloads. |
+| DESIGN-REQ-019 | PASS | Legacy readability remains scoped to reconstruction; new draft output converges on explicit Step Type. |
+
+## Test Evidence
+
+- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`: initial red-first run failed on an expectation that did not include the newly preserved `skill` payload.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`: PASS, 219 tests.
+- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py`: PASS, 25 focused Python task-contract tests plus 477 frontend tests from the wrapper.
+- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`: PASS.
+- Final `./tools/test_unit.sh`: PASS, 4221 Python tests, 1 xpass, 16 subtests, and 477 frontend tests.
+
+## Notes
+
+- The related `specs/279-submit-discriminated-executable-payloads` implementation remains valid supporting evidence but is not the active MM-566 feature artifact because it preserves Jira key `MM-559`.
+- No database, external provider, or compose-backed integration changes were required.


### PR DESCRIPTION
## Jira

- MM-566

## MoonSpec

- Active feature path: `specs/285-normalize-step-type-api`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary

- Preserves explicit draft Step Type payloads for Tool, Skill, and Preset task steps during Temporal edit/rerun reconstruction.
- Maps reconstructed Tool and Preset steps back into the correct Create page authoring controls.
- Adds MM-566 MoonSpec artifacts, alignment report, task evidence, and verification report.

## Tests run

- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (red-first evidence recorded in tasks.md)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`
- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py`
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
- `./tools/test_unit.sh`

## Remaining risks

- None known. No database, external provider, or compose-backed integration changes were required.
