### PR TITLE
[codex] Fix Tactics PR resolver disposition

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 4343518614,
+    "id": 4346762893,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier limit notification is informational and contains no code feedback to address."
+    "rationale": "Qodo free-tier limit notice; no implementation feedback to address."
   },
   {
-    "id": 3160855192,
-    "disposition": "addressed",
-    "rationale": "Replaced generic draft step payload records with specific Tool, Skill, and Preset payload interfaces with flexible index signatures."
-  },
-  {
-    "id": 4196785865,
+    "id": 4199997533,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable type-safety feedback is tracked by review comment 3160855192."
+    "rationale": "Gemini review summary explicitly reported no further feedback."
   },
   {
-    "id": 3160875256,
+    "id": 3163560523,
     "disposition": "addressed",
-    "rationale": "Draft reconstruction now reads step.stepType before falling back to legacy step.type."
+    "rationale": "Constrained selected-skill snapshot materialization to MoonMind-managed job workspaces under MOONMIND_AGENT_RUNTIME_STORE/<run_id>/repo and added regression coverage for external workspace paths."
   },
   {
-    "id": 3160875268,
-    "disposition": "addressed",
-    "rationale": "Preset draft hydration now preserves preset inputs in step preview state and reuses them when previewing the preset expansion."
-  },
-  {
-    "id": 4196808307,
+    "id": 4200010279,
     "disposition": "not-applicable",
-    "rationale": "Codex review body is informational; its actionable findings are tracked by review comments 3160875256 and 3160875268."
+    "rationale": "Codex review summary container; the actionable inline review comment is tracked and addressed separately."
   }
 ]

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -83,6 +83,8 @@ _PR_RESOLVER_RESULT_PATH_LIST = ", ".join(
 def _normalize_pr_resolver_text(value: Any) -> str:
     """Return one normalized resolver status candidate."""
 
+    if isinstance(value, Mapping):
+        return ""
     return str(value or "").strip().lower()
 
 
@@ -136,6 +138,12 @@ def _pr_resolver_final_payload(payload: dict[str, Any]) -> dict[str, Any]:
     final = payload.get("final")
     if isinstance(final, dict):
         return final
+    final_state = payload.get("final_state")
+    if isinstance(final_state, dict):
+        return final_state
+    final_state = payload.get("finalState")
+    if isinstance(final_state, dict):
+        return final_state
     merge_outcome = payload.get("mergeOutcome")
     if isinstance(merge_outcome, dict):
         return merge_outcome

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -62,6 +62,14 @@ from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as C
 from moonmind.codex_cloud.settings import build_codex_cloud_gate, CODEX_CLOUD_DISABLED_MESSAGE
 from moonmind.workflows.adapters.jules_client import JulesClient
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
+from moonmind.workflows.skills.materializer import (
+    SkillMaterializationError,
+    materialize_run_skill_workspace,
+)
+from moonmind.workflows.skills.resolver import (
+    SkillResolutionError,
+    resolve_run_skill_selection,
+)
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     build_deployment_update_tool_definition_payload,
@@ -3953,7 +3961,7 @@ class TemporalAgentRuntimeActivities:
         self,
         payload: Mapping[str, Any],
         /,
-    ) -> str:
+    ) -> Any:
         request_raw = payload.get("request")
         if not isinstance(request_raw, Mapping):
             raise TemporalActivityRuntimeError(
@@ -3963,6 +3971,10 @@ class TemporalAgentRuntimeActivities:
         workspace_path_raw = str(
             payload.get("workspace_path") or payload.get("workspacePath") or ""
         ).strip()
+        self._materialize_selected_agent_skill_for_turn(
+            request=request,
+            workspace_path=workspace_path_raw,
+        )
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
             if not workspace_path_raw:
@@ -4010,6 +4022,89 @@ class TemporalAgentRuntimeActivities:
         )
 
     @classmethod
+    def _materialize_selected_agent_skill_for_turn(
+        cls,
+        *,
+        request: AgentExecutionRequest,
+        workspace_path: str,
+    ) -> None:
+        """Materialize the selected active skill for a managed-session turn."""
+
+        params = request.parameters if isinstance(request.parameters, Mapping) else {}
+        selected_skill = selected_agent_skill(params)
+        if not selected_skill or not workspace_path:
+            return
+
+        workspace = Path(workspace_path).expanduser().resolve()
+        run_root = workspace.parent
+        cache_root = cls._managed_session_skill_cache_root(run_root)
+        try:
+            selection = resolve_run_skill_selection(
+                run_id=str(request.idempotency_key or run_root.name),
+                context={"skill_selection": [selected_skill]},
+            )
+            materialize_run_skill_workspace(
+                selection=selection,
+                run_root=run_root,
+                cache_root=cache_root,
+                verify_signatures=settings.workflow.skills_verify_signatures,
+            )
+        except (SkillMaterializationError, SkillResolutionError, OSError) as exc:
+            raise TemporalActivityRuntimeError(
+                f"selected skill materialization failed for '{selected_skill}': {exc}"
+            ) from exc
+
+        cls._ensure_managed_session_skill_shortcuts(
+            workspace=workspace,
+            skills_active_path=run_root / "skills_active",
+        )
+
+    @staticmethod
+    def _managed_session_skill_cache_root(run_root: Path) -> Path:
+        raw_cache_root = Path(settings.workflow.skills_cache_root).expanduser()
+        if raw_cache_root.is_absolute():
+            cache_root = raw_cache_root.resolve()
+        else:
+            cache_root = (run_root.parent / raw_cache_root).resolve()
+        cache_root.mkdir(parents=True, exist_ok=True)
+        return cache_root
+
+    @classmethod
+    def _ensure_managed_session_skill_shortcuts(
+        cls,
+        *,
+        workspace: Path,
+        skills_active_path: Path,
+    ) -> None:
+        """Expose non-invasive repo-local shortcuts to the active skill set."""
+
+        active_link = workspace / ".agents" / "skills" / "active"
+        if active_link.parent.is_symlink():
+            return
+        cls._replace_relative_symlink_if_possible(
+            active_link,
+            target=skills_active_path,
+        )
+
+    @staticmethod
+    def _replace_relative_symlink_if_possible(path: Path, *, target: Path) -> None:
+        if path.exists() or path.is_symlink():
+            if not path.is_symlink():
+                return
+            current = path.resolve(strict=False)
+            if current == target.resolve(strict=False):
+                return
+            try:
+                path.unlink()
+            except OSError:
+                return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.symlink_to(Path(os.path.relpath(target, path.parent)))
+        except OSError:
+            return
+
+    @classmethod
     def _prepare_managed_codex_turn_text(
         cls,
         instructions: str,
@@ -4020,7 +4115,31 @@ class TemporalAgentRuntimeActivities:
             instructions,
             parameters=parameters,
         )
+        prepared = cls._prepend_selected_skill_activation(
+            prepared,
+            parameters=parameters,
+        )
         return append_managed_codex_runtime_note(prepared)
+
+    @staticmethod
+    def _prepend_selected_skill_activation(
+        instructions: str,
+        *,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        selected_skill = selected_agent_skill(parameters)
+        if not selected_skill:
+            return instructions
+        if "Active MoonMind skill snapshot:" in instructions:
+            return instructions
+        block = (
+            "Active MoonMind skill snapshot:\n"
+            f"- Selected skill: {selected_skill}\n"
+            f"- Read `../skills_active/{selected_skill}/SKILL.md` first and follow that active snapshot.\n"
+            f"- If needed, `.agents/skills/active/{selected_skill}/SKILL.md` points to the same active snapshot.\n"
+            f"- Do not use repo-local `.agents/skills/{selected_skill}/SKILL.md` for this managed step; it may be stale source input.\n\n"
+        )
+        return block + instructions
 
     @staticmethod
     def _append_selected_jira_tool_hint(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3971,7 +3971,7 @@ class TemporalAgentRuntimeActivities:
         workspace_path_raw = str(
             payload.get("workspace_path") or payload.get("workspacePath") or ""
         ).strip()
-        self._materialize_selected_agent_skill_for_turn(
+        skill_snapshot_materialized = self._materialize_selected_agent_skill_for_turn(
             request=request,
             workspace_path=workspace_path_raw,
         )
@@ -3993,6 +3993,7 @@ class TemporalAgentRuntimeActivities:
                 prepared = self._prepare_managed_codex_turn_text(
                     instruction_ref,
                     parameters=request.parameters,
+                    skill_snapshot_materialized=skill_snapshot_materialized,
                 )
                 if payload.get("includePreparedRequestMetadata"):
                     return {
@@ -4008,6 +4009,7 @@ class TemporalAgentRuntimeActivities:
             prepared = self._prepare_managed_codex_turn_text(
                 instructions,
                 parameters=parameters,
+                skill_snapshot_materialized=skill_snapshot_materialized,
             )
             if payload.get("includePreparedRequestMetadata"):
                 return {
@@ -4027,16 +4029,19 @@ class TemporalAgentRuntimeActivities:
         *,
         request: AgentExecutionRequest,
         workspace_path: str,
-    ) -> None:
+    ) -> bool:
         """Materialize the selected active skill for a managed-session turn."""
 
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
         if not selected_skill or not workspace_path:
-            return
+            return False
 
         workspace = Path(workspace_path).expanduser().resolve()
-        run_root = workspace.parent
+        run_root = cls._managed_session_run_root_for_workspace(workspace)
+        if run_root is None:
+            return False
+
         cache_root = cls._managed_session_skill_cache_root(run_root)
         try:
             selection = resolve_run_skill_selection(
@@ -4058,6 +4063,25 @@ class TemporalAgentRuntimeActivities:
             workspace=workspace,
             skills_active_path=run_root / "skills_active",
         )
+        return True
+
+    @staticmethod
+    def _managed_session_run_root_for_workspace(workspace: Path) -> Path | None:
+        """Return a run root only for MoonMind-managed job workspaces."""
+
+        store_root = Path(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+        ).expanduser().resolve()
+        try:
+            relative = workspace.relative_to(store_root)
+        except ValueError:
+            return None
+        if len(relative.parts) != 2 or relative.parts[1] != "repo":
+            return None
+        run_id = str(relative.parts[0]).strip()
+        if not run_id:
+            return None
+        return store_root / run_id
 
     @staticmethod
     def _managed_session_skill_cache_root(run_root: Path) -> Path:
@@ -4110,6 +4134,7 @@ class TemporalAgentRuntimeActivities:
         instructions: str,
         *,
         parameters: Mapping[str, Any] | None,
+        skill_snapshot_materialized: bool = False,
     ) -> str:
         prepared = cls._append_selected_jira_tool_hint(
             instructions,
@@ -4118,6 +4143,7 @@ class TemporalAgentRuntimeActivities:
         prepared = cls._prepend_selected_skill_activation(
             prepared,
             parameters=parameters,
+            skill_snapshot_materialized=skill_snapshot_materialized,
         )
         return append_managed_codex_runtime_note(prepared)
 
@@ -4126,9 +4152,10 @@ class TemporalAgentRuntimeActivities:
         instructions: str,
         *,
         parameters: Mapping[str, Any] | None,
+        skill_snapshot_materialized: bool = False,
     ) -> str:
         selected_skill = selected_agent_skill(parameters)
-        if not selected_skill:
+        if not selected_skill or not skill_snapshot_materialized:
             return instructions
         if "Active MoonMind skill snapshot:" in instructions:
             return instructions

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -56,6 +56,8 @@ pytestmark = [pytest.mark.asyncio]
         ({"state": "MERGED"}, "merged"),
         ({"final": {"final_state": "MERGED"}}, "merged"),
         ({"final": {"finalState": "MERGED"}}, "merged"),
+        ({"final_state": {"state": "MERGED"}}, "merged"),
+        ({"finalState": {"state": "MERGED"}}, "merged"),
         ({"finalOutcome": "merged"}, "merged"),
         ({"final_outcome": "merged"}, "merged"),
         ({"mergeOutcome": {"state": "MERGED"}}, "merged"),
@@ -1843,6 +1845,61 @@ async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadat
     assert (
         result.metadata["headSha"]
         == "49061ed20f6b2260ba9564e71f4f896e3f96d3df"
+    )
+
+
+async def test_fetch_result_maps_tactics_final_state_object_pr_resolver_metadata(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "pr_resolver_result.json").write_text(
+        (
+            "{\n"
+            '  "final_state": {\n'
+            '    "state": "MERGED",\n'
+            '    "head_commit": "ac70bf9e3350ea728a1cd1332081160ae25390c3"\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-tactics-final-state",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-tactics-final-state",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-tactics-final-state", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert (
+        result.metadata["headSha"]
+        == "ac70bf9e3350ea728a1cd1332081160ae25390c3"
     )
 
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2535,6 +2535,76 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_verify_tool_hin
     assert "Verify KANDY-3607 against this branch." in result
     assert "Managed Codex CLI note:" in result
 
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_materializes_selected_skill_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    skill_root = tmp_path / "moonmind_skills"
+    active_skill = skill_root / "pr-resolver"
+    active_skill.mkdir(parents=True)
+    (active_skill / "SKILL.md").write_text(
+        "---\nname: pr-resolver\ndescription: active\n---\nactive resolver body\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.workflow,
+        "skills_cache_root",
+        str(tmp_path / "skill_cache"),
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_local_mirror_root",
+        str(tmp_path / "unused_local"),
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_legacy_mirror_root",
+        str(skill_root),
+    )
+
+    job_root = tmp_path / "job-1"
+    workspace = job_root / "repo"
+    stale_repo_skill = workspace / ".agents" / "skills" / "pr-resolver"
+    stale_repo_skill.mkdir(parents=True)
+    (stale_repo_skill / "SKILL.md").write_text(
+        "stale repo-local resolver body\n",
+        encoding="utf-8",
+    )
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Resolve the PR.",
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "pr-resolver",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+        }
+    )
+
+    assert result.startswith("Active MoonMind skill snapshot:")
+    assert "../skills_active/pr-resolver/SKILL.md" in result
+    assert "Do not use repo-local `.agents/skills/pr-resolver/SKILL.md`" in result
+    assert (job_root / "skills_active" / "pr-resolver" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ).endswith("active resolver body\n")
+    assert (workspace / ".agents" / "skills" / "active").is_symlink()
+    assert not (workspace / "skills_active").exists()
+    assert (
+        stale_repo_skill / "SKILL.md"
+    ).read_text(encoding="utf-8") == "stale repo-local resolver body\n"
+
 @pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_includes_context_artifact_reference(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2561,8 +2561,10 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
         "moonmind.workflows.skills.resolver.settings.workflow.skills_legacy_mirror_root",
         str(skill_root),
     )
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
 
-    job_root = tmp_path / "job-1"
+    job_root = managed_root / "job-1"
     workspace = job_root / "repo"
     stale_repo_skill = workspace / ".agents" / "skills" / "pr-resolver"
     stale_repo_skill.mkdir(parents=True)
@@ -2604,6 +2606,46 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
     assert (
         stale_repo_skill / "SKILL.md"
     ).read_text(encoding="utf-8") == "stale repo-local resolver body\n"
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_skips_skill_snapshot_for_external_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+    workspace = tmp_path / "external" / "repo"
+    workspace.mkdir(parents=True)
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Resolve the PR.",
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "pr-resolver",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+        }
+    )
+
+    assert not result.startswith("Active MoonMind skill snapshot:")
+    assert "../skills_active/pr-resolver/SKILL.md" not in result
+    assert not (workspace.parent / "skills_active").exists()
+    assert not (workspace / "skills_active").exists()
+    assert not (workspace / ".agents" / "skills" / "active").exists()
+
 
 @pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_includes_context_artifact_reference(


### PR DESCRIPTION
## Summary

- derive merge automation disposition from legacy Tactics pr-resolver result shapes
- materialize selected managed-session skill snapshots before Codex turns
- add adapter and activity regressions for stale repo-local skill bundles

## Root Cause

Tactics workspaces can carry stale repo-local `.agents/skills/pr-resolver` bundles. The resolver still merged the PR, but wrote a legacy `artifacts/pr_resolver_result.json` without `mergeAutomationDisposition`, causing merge automation to fail fast after the PR was already merged.

## Validation

- `git diff --check`
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- Full `./tools/test_unit.sh` before moving the diff to the fresh branch: Python `4219 passed`, UI `471 passed`
