### PR TITLE
[codex] Fix terminal dependency fanout

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,32 @@
 [
   {
-    "id": 4340704945,
+    "id": 4346976767,
     "disposition": "not-applicable",
-    "rationale": "Automated quota warning with no requested code change."
+    "rationale": "Qodo account free-tier notice; no code action required."
   },
   {
-    "id": 3158511680,
+    "id": 3163732225,
     "disposition": "addressed",
-    "rationale": "Runtime promotion override now updates top-level targetRuntime alongside task.runtime.mode, with a regression test covering stored payloads that already include targetRuntime."
+    "rationale": "Shielded the terminal-state activity, used ABANDON cancellation policy, and waits for the shielded activity when cancellation is received."
   },
   {
-    "id": 4193967441,
+    "id": 4200206564,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper summary; the actionable child review comment is tracked separately."
+    "rationale": "Review summary; its actionable shielding feedback is tracked and addressed by review comment 3163732225."
+  },
+  {
+    "id": 3163747010,
+    "disposition": "addressed",
+    "rationale": "Added RUN_TERMINAL_STATE_ACTIVITY_PATCH and skipped the new activity on histories where workflow.patched returns false."
+  },
+  {
+    "id": 3163747015,
+    "disposition": "addressed",
+    "rationale": "Changed record_terminal_state to preserve existing same-state terminal summaries while still fanning out dependency resolution."
+  },
+  {
+    "id": 4200225292,
+    "disposition": "not-applicable",
+    "rationale": "Codex review wrapper comment; no standalone actionable request beyond the inline findings."
   }
 ]

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -160,6 +160,30 @@ class DependencyStatusSnapshotInput(BaseModel):
 
     workflow_ids: list[str] = Field(default_factory=list, alias="workflowIds")
 
+
+class ExecutionTerminalStateInput(BaseModel):
+    """Input parameters for execution.record_terminal_state."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    workflow_id: str = Field(..., alias="workflowId", min_length=1)
+    state: Literal["completed", "failed", "canceled"] = Field(..., alias="state")
+    close_status: Literal[
+        "completed",
+        "failed",
+        "canceled",
+        "terminated",
+        "timed_out",
+    ] | None = Field(None, alias="closeStatus")
+    summary: str | None = Field(None, alias="summary")
+    error_category: Literal[
+        "user_error",
+        "integration_error",
+        "execution_error",
+        "system_error",
+    ] | None = Field(None, alias="errorCategory")
+
+
 class ExternalAgentRunInput(BaseModel):
     """Public input for external provider run status/fetch/cancel activities."""
 

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -337,6 +337,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="execution.record_terminal_state",
+            family="execution",
+            capability_class="artifacts",
+            task_queue=cfg.activity_artifacts_task_queue,
+            fleet=ARTIFACTS_FLEET,
+            timeouts=TemporalActivityTimeouts(30, 60),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="artifact.list_for_execution",
             family="artifact",
             capability_class="artifacts",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -411,6 +411,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "artifacts",
         "execution_dependency_status_snapshot",
     ),
+    "execution.record_terminal_state": (
+        "artifacts",
+        "execution_record_terminal_state",
+    ),
     "artifact.list_for_execution": ("artifacts", "artifact_list_for_execution"),
     "artifact.compute_preview": ("artifacts", "artifact_compute_preview"),
     "artifact.link": ("artifacts", "artifact_link"),

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2489,6 +2489,38 @@ class TemporalArtifactActivities:
             for workflow_id, item in snapshot.items()
         }
 
+    async def execution_record_terminal_state(
+        self,
+        request: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from api_service.db.base import get_async_session_context
+        from moonmind.schemas.temporal_activity_models import (
+            ExecutionTerminalStateInput,
+        )
+        from moonmind.workflows.temporal.service import TemporalExecutionService
+
+        model = ExecutionTerminalStateInput.model_validate(request or {})
+
+        async with get_async_session_context() as session:
+            service = TemporalExecutionService(session)
+            record = await service.record_terminal_state(
+                workflow_id=model.workflow_id,
+                state=model.state,
+                close_status=model.close_status,
+                summary=model.summary,
+                error_category=model.error_category,
+            )
+
+        return {
+            "workflowId": record.workflow_id,
+            "state": getattr(getattr(record, "state", None), "value", record.state),
+            "closeStatus": getattr(
+                getattr(record, "close_status", None),
+                "value",
+                record.close_status,
+            ),
+        }
+
     async def artifact_list_for_execution(
         self,
         *,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2007,6 +2007,59 @@ class TemporalExecutionService:
         await self._fan_out_dependency_resolution(record)
         return await self._sync_projection_best_effort(record)
 
+    async def record_terminal_state(
+        self,
+        *,
+        workflow_id: str,
+        state: str,
+        close_status: str | None = None,
+        summary: str | None = None,
+        error_category: str | None = None,
+    ) -> TemporalExecutionRecord | TemporalExecutionCanonicalRecord:
+        normalized_state = str(state or "").strip().lower()
+        state_by_value = {item.value: item for item in MoonMindWorkflowState}
+        target_state = state_by_value.get(normalized_state)
+        if target_state not in TERMINAL_STATES:
+            raise TemporalExecutionValidationError(
+                f"Unsupported terminal state '{state}'."
+            )
+
+        normalized_close_status = str(close_status or "").strip().lower()
+        close_status_by_value = {item.value: item for item in TemporalExecutionCloseStatus}
+        target_close_status = close_status_by_value.get(normalized_close_status)
+        if target_close_status is None:
+            target_close_status = {
+                MoonMindWorkflowState.COMPLETED: TemporalExecutionCloseStatus.COMPLETED,
+                MoonMindWorkflowState.FAILED: TemporalExecutionCloseStatus.FAILED,
+                MoonMindWorkflowState.CANCELED: TemporalExecutionCloseStatus.CANCELED,
+            }[target_state]
+
+        record = await self._require_source_execution(workflow_id)
+        if record.state in TERMINAL_STATES and record.state is not target_state:
+            raise TemporalExecutionValidationError(
+                f"Execution already terminal as {record.state.value}."
+            )
+
+        self._set_state(record, target_state, close_status=target_close_status)
+        if summary:
+            if target_state is MoonMindWorkflowState.FAILED:
+                category = str(error_category or "execution_error").strip()
+                if category not in ALLOWED_ERROR_CATEGORIES:
+                    category = "execution_error"
+                self._update_summary(
+                    record,
+                    f"{category}: {summary}",
+                    error_category=category,
+                )
+            else:
+                self._update_summary(record, summary)
+
+        await self._sync_integration_correlation_record(record)
+        await self._session.commit()
+        await self._session.refresh(record)
+        await self._fan_out_dependency_resolution(record)
+        return await self._sync_projection_best_effort(record)
+
     async def mark_execution_planning(
         self,
         *,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2039,6 +2039,14 @@ class TemporalExecutionService:
             raise TemporalExecutionValidationError(
                 f"Execution already terminal as {record.state.value}."
             )
+        if record.state in TERMINAL_STATES:
+            if record.close_status is None:
+                self._set_state(record, target_state, close_status=target_close_status)
+                await self._sync_integration_correlation_record(record)
+                await self._session.commit()
+                await self._session.refresh(record)
+            await self._fan_out_dependency_resolution(record)
+            return await self._sync_projection_best_effort(record)
 
         self._set_state(record, target_state, close_status=target_close_status)
         if summary:

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
-ACTIVE_STEP_STATUSES = ("running", "reviewing", "awaiting_external", "ready")
+ACTIVE_STEP_STATUSES = ("running", "reviewing", "awaiting_external")
 TERMINAL_STEP_STATUSES = {"succeeded", "failed", "skipped", "canceled"}
 READY_DEPENDENCY_STATUSES = {"succeeded", "skipped"}
 _UNSET = object()

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -178,6 +178,7 @@ NATIVE_PR_PUSH_STATUS_GATE_PATCH = "native-pr-push-status-gate-v1"
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
+RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
@@ -5007,21 +5008,43 @@ class MoonMindRunWorkflow:
         summary: str | None,
         error_category: str | None = None,
     ) -> None:
+        if not workflow.patched(RUN_TERMINAL_STATE_ACTIVITY_PATCH):
+            return
+
+        activity_task: asyncio.Task[Any] | None = None
         try:
             terminal_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
                 "execution.record_terminal_state"
             )
-            await execute_typed_activity(
-                "execution.record_terminal_state",
-                ExecutionTerminalStateInput(
-                    workflowId=workflow.info().workflow_id,
-                    state=state,
-                    closeStatus=close_status,
-                    summary=summary,
-                    errorCategory=error_category,
-                ),
-                **self._execute_kwargs_for_route(terminal_route),
+            activity_task = asyncio.create_task(
+                execute_typed_activity(
+                    "execution.record_terminal_state",
+                    ExecutionTerminalStateInput(
+                        workflowId=workflow.info().workflow_id,
+                        state=state,
+                        closeStatus=close_status,
+                        summary=summary,
+                        errorCategory=error_category,
+                    ),
+                    cancellation_type=ActivityCancellationType.ABANDON,
+                    **self._execute_kwargs_for_route(terminal_route),
+                )
             )
+            await asyncio.shield(activity_task)
+        except (CancelledError, asyncio.CancelledError):
+            self._get_logger().warning(
+                "Cancellation received while recording terminal execution state; "
+                "waiting for shielded activity to finish."
+            )
+            try:
+                if activity_task is not None:
+                    await activity_task
+            except Exception as exc:
+                self._get_logger().warning(
+                    "Failed to record terminal execution state after cancellation: %s",
+                    exc,
+                )
+            raise
         except Exception as exc:
             self._get_logger().warning(
                 "Failed to record terminal execution state: %s", exc

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -27,6 +27,7 @@ with workflow.unsafe.imports_passed_through():
         ArtifactReadInput,
         ArtifactWriteCompleteInput,
         DependencyStatusSnapshotInput,
+        ExecutionTerminalStateInput,
         PlanGenerateInput,
     )
     from moonmind.workflows.temporal.jules_bundle import (
@@ -1417,6 +1418,13 @@ class MoonMindRunWorkflow:
             await self._run_finalizing_stage(
                 parameters=parameters, status="canceled", error=None
             )
+            self._close_status = CLOSE_STATUS_CANCELED
+            self._set_state(STATE_CANCELED, summary="Execution canceled.")
+            await self._record_terminal_state(
+                state=STATE_CANCELED,
+                close_status=CLOSE_STATUS_CANCELED,
+                summary="Execution canceled.",
+            )
             return {"status": "canceled"}
 
         self._set_state(STATE_INITIALIZING, summary="Execution initialized.")
@@ -1428,6 +1436,13 @@ class MoonMindRunWorkflow:
                     await self._run_finalizing_stage(
                         parameters=parameters, status="canceled", error=None
                     )
+                    self._close_status = CLOSE_STATUS_CANCELED
+                    self._set_state(STATE_CANCELED, summary="Execution canceled.")
+                    await self._record_terminal_state(
+                        state=STATE_CANCELED,
+                        close_status=CLOSE_STATUS_CANCELED,
+                        summary="Execution canceled.",
+                    )
                     return {"status": "canceled"}
         except ValueError as exc:
             await self._run_finalizing_stage(
@@ -1435,6 +1450,12 @@ class MoonMindRunWorkflow:
             )
             self._close_status = CLOSE_STATUS_FAILED
             self._set_state(STATE_FAILED, summary=str(exc))
+            await self._record_terminal_state(
+                state=STATE_FAILED,
+                close_status=CLOSE_STATUS_FAILED,
+                summary=str(exc),
+                error_category="execution_error",
+            )
             raise exceptions.ApplicationError(
                 str(exc),
                 non_retryable=True,
@@ -1446,6 +1467,13 @@ class MoonMindRunWorkflow:
         if self._cancel_requested:
             await self._run_finalizing_stage(
                 parameters=parameters, status="canceled", error=None
+            )
+            self._close_status = CLOSE_STATUS_CANCELED
+            self._set_state(STATE_CANCELED, summary="Execution canceled.")
+            await self._record_terminal_state(
+                state=STATE_CANCELED,
+                close_status=CLOSE_STATUS_CANCELED,
+                summary="Execution canceled.",
             )
             return {"status": "canceled"}
 
@@ -1465,6 +1493,12 @@ class MoonMindRunWorkflow:
             )
             self._close_status = CLOSE_STATUS_FAILED
             self._set_state(STATE_FAILED, summary=str(exc))
+            await self._record_terminal_state(
+                state=STATE_FAILED,
+                close_status=CLOSE_STATUS_FAILED,
+                summary=str(exc),
+                error_category="execution_error",
+            )
             raise exceptions.ApplicationError(
                 str(exc),
                 non_retryable=True,
@@ -1473,11 +1507,26 @@ class MoonMindRunWorkflow:
             await self._run_finalizing_stage(
                 parameters=parameters, status="failed", error=str(exc)
             )
+            self._close_status = CLOSE_STATUS_FAILED
+            self._set_state(STATE_FAILED, summary=str(exc))
+            await self._record_terminal_state(
+                state=STATE_FAILED,
+                close_status=CLOSE_STATUS_FAILED,
+                summary=str(exc),
+                error_category="execution_error",
+            )
             raise
 
         if self._cancel_requested:
             await self._run_finalizing_stage(
                 parameters=parameters, status="canceled", error=None
+            )
+            self._close_status = CLOSE_STATUS_CANCELED
+            self._set_state(STATE_CANCELED, summary="Execution canceled.")
+            await self._record_terminal_state(
+                state=STATE_CANCELED,
+                close_status=CLOSE_STATUS_CANCELED,
+                summary="Execution canceled.",
             )
             return {"status": "canceled"}
 
@@ -1508,6 +1557,12 @@ class MoonMindRunWorkflow:
         if publish_failure:
             self._close_status = CLOSE_STATUS_FAILED
             self._set_state(STATE_FAILED, summary=output_message)
+            await self._record_terminal_state(
+                state=STATE_FAILED,
+                close_status=CLOSE_STATUS_FAILED,
+                summary=output_message,
+                error_category="execution_error",
+            )
             raise exceptions.ApplicationError(
                 output_message,
                 non_retryable=True,
@@ -1515,6 +1570,11 @@ class MoonMindRunWorkflow:
 
         self._close_status = CLOSE_STATUS_COMPLETED
         self._set_state(STATE_COMPLETED, summary=output_message)
+        await self._record_terminal_state(
+            state=STATE_COMPLETED,
+            close_status=CLOSE_STATUS_COMPLETED,
+            summary=output_message,
+        )
 
         output: RunWorkflowOutput = {
             "status": output_status,
@@ -4938,6 +4998,34 @@ class MoonMindRunWorkflow:
             self._summary_ref = resolved_artifact_id
         except Exception as exc:
             self._get_logger().warning(f"Failed to generate finish summary: {exc}")
+
+    async def _record_terminal_state(
+        self,
+        *,
+        state: str,
+        close_status: str,
+        summary: str | None,
+        error_category: str | None = None,
+    ) -> None:
+        try:
+            terminal_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                "execution.record_terminal_state"
+            )
+            await execute_typed_activity(
+                "execution.record_terminal_state",
+                ExecutionTerminalStateInput(
+                    workflowId=workflow.info().workflow_id,
+                    state=state,
+                    closeStatus=close_status,
+                    summary=summary,
+                    errorCategory=error_category,
+                ),
+                **self._execute_kwargs_for_route(terminal_route),
+            )
+        except Exception as exc:
+            self._get_logger().warning(
+                "Failed to record terminal execution state: %s", exc
+            )
 
     def _set_state(self, state: str, summary: Optional[str] = None) -> None:
 

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -82,6 +82,14 @@ def test_default_catalog_exposes_canonical_queues_and_fleets():
         catalog.resolve_activity("workload.run").task_queue
         == AGENT_RUNTIME_TASK_QUEUE
     )
+    assert (
+        catalog.resolve_activity("execution.record_terminal_state").task_queue
+        == ARTIFACTS_TASK_QUEUE
+    )
+    assert (
+        catalog.resolve_activity("execution.record_terminal_state").fleet
+        == ARTIFACTS_FLEET
+    )
     assert catalog.resolve_activity("workload.run").fleet == AGENT_RUNTIME_FLEET
     assert catalog.resolve_activity("workload.run").capability_class == "docker_workload"
     assert (

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1534,8 +1534,15 @@ async def test_build_activity_bindings_filters_to_requested_fleet(tmp_path: Path
             assert "artifact.lifecycle_sweep" in {
                 binding.activity_type for binding in bindings
             }
+            assert "execution.record_terminal_state" in {
+                binding.activity_type for binding in bindings
+            }
             assert any(
                 binding.handler.__name__ == "artifact_lifecycle_sweep"
+                for binding in bindings
+            )
+            assert any(
+                binding.handler.__name__ == "execution_record_terminal_state"
                 for binding in bindings
             )
 

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -143,6 +143,30 @@ def test_progress_summary_prefers_active_step_title_and_counts_statuses() -> Non
         "updatedAt": updated_at.isoformat(),
     }
 
+def test_progress_summary_does_not_treat_ready_step_as_current() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 6, tzinfo=UTC)
+    progress = build_progress_summary(
+        [
+            {
+                "logicalStepId": "step-1",
+                "status": "ready",
+                "title": "Move Jira issue to In Progress",
+                "updatedAt": updated_at.isoformat(),
+            },
+            {
+                "logicalStepId": "step-2",
+                "status": "pending",
+                "title": "Run implementation",
+                "updatedAt": updated_at.isoformat(),
+            },
+        ],
+        updated_at=updated_at,
+    )
+
+    assert progress["ready"] == 1
+    assert progress["pending"] == 1
+    assert progress["currentStepTitle"] is None
+
 def test_contract_models_accept_representative_rows_and_progress() -> None:
     updated_at = datetime(2026, 4, 7, 12, 10, tzinfo=UTC)
 

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1417,6 +1417,63 @@ async def test_mark_execution_succeeded_fans_out_dependency_resolution_signals(
         assert payload["failureCategory"] is None
 
 @pytest.mark.asyncio
+async def test_record_terminal_state_fans_out_dependency_resolution_signals(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        prerequisite = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Prerequisite",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        dependent = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Dependent",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={"task": {"dependsOn": [prerequisite.workflow_id]}},
+            idempotency_key=None,
+        )
+
+        mock_client_adapter.signal_workflow.reset_mock()
+        await service.record_terminal_state(
+            workflow_id=prerequisite.workflow_id,
+            state="completed",
+            close_status="completed",
+            summary="Prerequisite completed from workflow terminal path.",
+        )
+
+        source = await session.get(
+            TemporalExecutionCanonicalRecord, prerequisite.workflow_id
+        )
+        assert source is not None
+        assert source.state is MoonMindWorkflowState.COMPLETED
+        assert source.close_status is TemporalExecutionCloseStatus.COMPLETED
+        mock_client_adapter.signal_workflow.assert_awaited_once()
+        assert mock_client_adapter.signal_workflow.await_args.args[0] == (
+            dependent.workflow_id
+        )
+        assert mock_client_adapter.signal_workflow.await_args.args[1] == (
+            "DependencyResolved"
+        )
+        payload = mock_client_adapter.signal_workflow.await_args.args[2]
+        assert payload["prerequisiteWorkflowId"] == prerequisite.workflow_id
+        assert payload["terminalState"] == "completed"
+        assert payload["closeStatus"] == "completed"
+
+@pytest.mark.asyncio
 async def test_dependency_status_snapshot_repairs_stale_terminal_prerequisite(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1473,6 +1473,47 @@ async def test_record_terminal_state_fans_out_dependency_resolution_signals(
         assert payload["terminalState"] == "completed"
         assert payload["closeStatus"] == "completed"
 
+
+@pytest.mark.asyncio
+async def test_record_terminal_state_preserves_existing_terminal_summary(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="Cancelable run",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="operator requested cancellation",
+            graceful=True,
+        )
+
+        await service.record_terminal_state(
+            workflow_id=created.workflow_id,
+            state="canceled",
+            close_status="canceled",
+            summary="Execution canceled.",
+        )
+
+        canceled = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert canceled is not None
+        assert canceled.state is MoonMindWorkflowState.CANCELED
+        assert canceled.close_status is TemporalExecutionCloseStatus.CANCELED
+        assert canceled.memo["summary"] == "operator requested cancellation"
+
+
 @pytest.mark.asyncio
 async def test_dependency_status_snapshot_repairs_stale_terminal_prerequisite(
     tmp_path, mock_client_adapter

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -8,6 +8,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
+from temporalio.workflow import ActivityCancellationType
 from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_TASK_QUEUE
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.run import (
@@ -389,6 +390,7 @@ async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatc
         },
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info())
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(
         run_workflow_module,
         "execute_typed_activity",
@@ -410,6 +412,28 @@ async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatc
         "errorCategory": None,
     }
     assert captured["kwargs"]["task_queue"] == ARTIFACTS_TASK_QUEUE
+    assert captured["kwargs"]["cancellation_type"] == ActivityCancellationType.ABANDON
+
+
+@pytest.mark.asyncio
+async def test_record_terminal_state_skips_activity_without_patch(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+
+    async def fake_execute_typed_activity(activity_type, payload, **kwargs):
+        raise AssertionError("terminal state activity should be patch-gated")
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+
+    await workflow_instance._record_terminal_state(
+        state="completed",
+        close_status="completed",
+        summary="Workflow completed successfully",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -8,6 +8,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
+from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_TASK_QUEUE
+from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.run import (
     DEPENDENCY_RECONCILE_INTERVAL,
     DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
@@ -359,6 +361,56 @@ def test_update_inputs_extracts_clarification_message_from_parameters_patch():
     )
 
     assert message == "Use the Workers page copy for now."
+
+
+@pytest.mark.asyncio
+async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    captured = {}
+
+    async def fake_execute_typed_activity(activity_type, payload, **kwargs):
+        captured["activity_type"] = activity_type
+        captured["payload"] = payload.model_dump(by_alias=True)
+        captured["kwargs"] = kwargs
+        return {
+            "workflowId": "wf-terminal",
+            "state": "completed",
+            "closeStatus": "completed",
+        }
+
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-terminal",
+            "run_id": "run-terminal",
+            "search_attributes": {},
+        },
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info())
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+
+    await workflow_instance._record_terminal_state(
+        state="completed",
+        close_status="completed",
+        summary="Workflow completed successfully",
+    )
+
+    assert captured["activity_type"] == "execution.record_terminal_state"
+    assert captured["payload"] == {
+        "workflowId": "wf-terminal",
+        "state": "completed",
+        "closeStatus": "completed",
+        "summary": "Workflow completed successfully",
+        "errorCategory": None,
+    }
+    assert captured["kwargs"]["task_queue"] == ARTIFACTS_TASK_QUEUE
+
 
 @pytest.mark.asyncio
 async def test_wait_for_dependencies_records_dependency_metadata(monkeypatch):


### PR DESCRIPTION
## Summary

- add a workflow terminal-state activity that persists completed/failed/canceled execution state and fans out dependency resolution immediately
- wire the activity through the catalog/runtime/artifacts worker path and call it from `MoonMindRunWorkflow` terminal branches
- stop reporting `ready` steps as the current active step, so dependency waits do not look like a Jira step is still running

## Root Cause

The task details endpoint enriched dependency summaries on read. That read path could repair stale terminal dependency projections and emit `DependencyResolved`, which meant opening task details could genuinely unblock dependent workflows.

## Impact

Dependent workflows should now advance when a prerequisite workflow reaches terminal state, without relying on task-details polling or manual UI inspection to trigger repair.

## Validation

- `git diff --check`
- targeted `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_catalog.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py`
- full `./tools/test_unit.sh`
