### PR TITLE
[codex] fix auto skill materialization

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 4346976767,
+    "id": 4347927664,
     "disposition": "not-applicable",
-    "rationale": "Qodo account free-tier notice; no code action required."
+    "rationale": "Qodo free-tier quota notice is informational and does not request a code change."
   },
   {
-    "id": 3163732225,
+    "id": 3164517105,
     "disposition": "addressed",
-    "rationale": "Shielded the terminal-state activity, used ABANDON cancellation policy, and waits for the shielded activity when cancellation is received."
+    "rationale": "Added _AUTO_SKILL_SENTINEL and used it for the managed-session materialization guard."
   },
   {
-    "id": 4200206564,
-    "disposition": "not-applicable",
-    "rationale": "Review summary; its actionable shielding feedback is tracked and addressed by review comment 3163732225."
-  },
-  {
-    "id": 3163747010,
+    "id": 3164517135,
     "disposition": "addressed",
-    "rationale": "Added RUN_TERMINAL_STATE_ACTIVITY_PATCH and skipped the new activity on histories where workflow.patched returns false."
+    "rationale": "Reused _AUTO_SKILL_SENTINEL for the selected-skill activation guard."
   },
   {
-    "id": 3163747015,
+    "id": 4201130280,
     "disposition": "addressed",
-    "rationale": "Changed record_terminal_state to preserve existing same-state terminal summaries while still fanning out dependency resolution."
-  },
-  {
-    "id": 4200225292,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment; no standalone actionable request beyond the inline findings."
+    "rationale": "Summary review requested replacing the magic auto string with a module-level constant, which is now implemented."
   }
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -170,6 +170,7 @@ async def _run_command(cmd, **kwargs):
     return CmdRes(stdout)
 
 logger = getLogger(__name__)
+_AUTO_SKILL_SENTINEL = "auto"
 _NON_SECRET_MANAGED_SESSION_ENV_KEYS: tuple[str, ...] = ("MOONMIND_URL",)
 _MANAGED_SESSION_TELEMETRY_KEYS: tuple[str, ...] = (
     "activityType",
@@ -1017,7 +1018,7 @@ def _default_registry_skill_payload(*, name: str, version: str) -> dict[str, Any
 
     description = (
         "Execute generic runtime CLI instructions."
-        if name == "auto"
+        if name == _AUTO_SKILL_SENTINEL
         else f"Execute '{name}' via the generic runtime CLI handler."
     )
     # 3600s gives the sandbox worker enough headroom to exhaust the full
@@ -1116,7 +1117,7 @@ def _iter_requested_registry_tools(
     # 'auto' is a placeholder meaning "no explicit skill selected". It should
     # not be included in the registry as a dispatchable skill — when only 'auto'
     # is present, the runtime should be used directly without skill dispatch.
-    if selected and all(name == "auto" for name, _ in selected):
+    if selected and all(name == _AUTO_SKILL_SENTINEL for name, _ in selected):
         selected = []
 
     return tuple(selected)
@@ -4038,7 +4039,11 @@ class TemporalAgentRuntimeActivities:
 
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
-        if not selected_skill or selected_skill == "auto" or not workspace_path:
+        if (
+            not selected_skill
+            or selected_skill == _AUTO_SKILL_SENTINEL
+            or not workspace_path
+        ):
             return False
 
         workspace = Path(workspace_path).expanduser().resolve()
@@ -4161,7 +4166,7 @@ class TemporalAgentRuntimeActivities:
         selected_skill = selected_agent_skill(parameters)
         if (
             not selected_skill
-            or selected_skill == "auto"
+            or selected_skill == _AUTO_SKILL_SENTINEL
             or not skill_snapshot_materialized
         ):
             return instructions

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4038,7 +4038,7 @@ class TemporalAgentRuntimeActivities:
 
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
-        if not selected_skill or not workspace_path:
+        if not selected_skill or selected_skill == "auto" or not workspace_path:
             return False
 
         workspace = Path(workspace_path).expanduser().resolve()
@@ -4159,7 +4159,11 @@ class TemporalAgentRuntimeActivities:
         skill_snapshot_materialized: bool = False,
     ) -> str:
         selected_skill = selected_agent_skill(parameters)
-        if not selected_skill or not skill_snapshot_materialized:
+        if (
+            not selected_skill
+            or selected_skill == "auto"
+            or not skill_snapshot_materialized
+        ):
             return instructions
         if "Active MoonMind skill snapshot:" in instructions:
             return instructions

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2648,6 +2648,56 @@ async def test_agent_runtime_prepare_turn_instructions_skips_skill_snapshot_for_
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_treats_auto_skill_as_no_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    empty_skill_root = tmp_path / "empty_skills"
+    empty_skill_root.mkdir()
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_local_mirror_root",
+        str(empty_skill_root),
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_legacy_mirror_root",
+        str(empty_skill_root),
+    )
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+
+    job_root = managed_root / "job-1"
+    workspace = job_root / "repo"
+    workspace.mkdir(parents=True)
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Use the default runtime behavior.",
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "auto",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+        }
+    )
+
+    assert result.startswith("Use the default runtime behavior.")
+    assert "Active MoonMind skill snapshot:" not in result
+    assert not (job_root / "skills_active").exists()
+    assert not (workspace / ".agents" / "skills" / "active").exists()
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_includes_context_artifact_reference(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Treat `selectedSkill: auto` as the selector sentinel during managed-session turn preparation.
- Skip active skill snapshot materialization and activation hints for `auto`.
- Add regression coverage for managed workspaces with empty skill mirrors.

## Root Cause
Managed Codex task setup treated `auto` as a concrete agent skill and attempted to resolve `auto:local`. Deployments without an `auto` skill mirror failed in `agent_runtime.prepare_turn_instructions` before the agent could start.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -q`
- Restarted `temporal-worker-agent-runtime`; health check returned healthy and no new `auto:local` materialization errors appeared after restart.