### PR TITLE
[codex] Fix artifact-backed skill snapshot materialization

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -329,6 +329,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY moonmind /app/moonmind/
 COPY api_service /app/api_service/
 COPY config /app/config/
+COPY .agents /app/.agents/
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --disable-pip-version-check --no-deps .
 

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,47 @@
 [
   {
-    "id": 4347927664,
+    "id": 4349829261,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier quota notice is informational and does not request a code change."
+    "rationale": "Qodo free-tier notice is informational and does not request a code change."
   },
   {
-    "id": 3164517105,
+    "id": 4202559225,
     "disposition": "addressed",
-    "rationale": "Added _AUTO_SKILL_SENTINEL and used it for the managed-session materialization guard."
+    "rationale": "Review summary concerns were handled through the specific inline comments below."
   },
   {
-    "id": 3164517135,
+    "id": 3165750067,
     "disposition": "addressed",
-    "rationale": "Reused _AUTO_SKILL_SENTINEL for the selected-skill activation guard."
+    "rationale": "Normalized selected-skill exclusions from both string and object-shaped entries before comparison."
   },
   {
-    "id": 4201130280,
+    "id": 3165750070,
     "disposition": "addressed",
-    "rationale": "Summary review requested replacing the magic auto string with a module-level constant, which is now implemented."
+    "rationale": "Built-in skill discovery now checks packaged /app/.agents/skills before local development fallbacks."
+  },
+  {
+    "id": 3165750073,
+    "disposition": "not-applicable",
+    "rationale": "ValidationError is already imported in activity_runtime.py on the current branch."
+  },
+  {
+    "id": 3165750076,
+    "disposition": "addressed",
+    "rationale": "Workflow skill resolution now imports a workflow-safe Mapping alias and uses it for object-shaped selector checks."
+  },
+  {
+    "id": 3165758894,
+    "disposition": "addressed",
+    "rationale": "File-backed skills are now persisted as full tar.gz bundles and materialized with companion files intact."
+  },
+  {
+    "id": 3165758896,
+    "disposition": "addressed",
+    "rationale": "Publish filtering now skips .agents/skills only when it is the generated projection symlink, preserving checked-in skill edits."
+  },
+  {
+    "id": 4202568151,
+    "disposition": "not-applicable",
+    "rationale": "Codex review wrapper comment is informational; its actionable inline comments were classified separately."
   }
 ]

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import shutil
 from pathlib import Path
 from typing import Any
@@ -14,16 +13,20 @@ from moonmind.workflows.skills.workspace_links import (
     ensure_shared_skill_links,
 )
 
-logger = logging.getLogger(__name__)
-
 class AgentSkillMaterializer:
     """Materializes a ResolvedSkillSet into a run-scoped directory."""
 
-    def __init__(self, workspace_root: str, artifact_service: Any | None = None) -> None:
+    def __init__(
+        self,
+        workspace_root: str,
+        artifact_service: Any | None = None,
+        backing_root: str | None = None,
+    ) -> None:
         if not workspace_root:
             raise ValueError("workspace_root must be provided")
         self.workspace_root = Path(workspace_root).resolve()
         self._artifact_service = artifact_service
+        self.backing_root = Path(backing_root).resolve() if backing_root else None
 
     async def materialize(
         self,
@@ -42,7 +45,7 @@ class AgentSkillMaterializer:
             RuntimeMaterializationMode.WORKSPACE_MOUNTED,
             RuntimeMaterializationMode.HYBRID,
         ):
-            active_dir = self.workspace_root / "skills_active"
+            active_dir = self.backing_root or self.workspace_root / "skills_active"
             visible_dir = self.workspace_root / ".agents" / "skills"
             manifest_path = active_dir / "_manifest.json"
 
@@ -55,22 +58,29 @@ class AgentSkillMaterializer:
                 raise RuntimeError(f"Failed to prepare skills_active directory: {ex}") from ex
 
             for skill in resolved_skillset.skills:
-                if skill.content_ref and self._artifact_service:
-                    try:
-                        _artifact, payload = await self._artifact_service.read(
-                            artifact_id=skill.content_ref,
-                            principal="system",
-                            allow_restricted_raw=True,
-                        )
-                        skill_dir = active_dir / skill.skill_name
-                        skill_dir.mkdir(parents=True, exist_ok=True)
-                        (skill_dir / "SKILL.md").write_bytes(payload)
-                    except Exception as ex:
-                        logger.warning(
-                            "Failed to materialize content for skill %s: %s",
-                            skill.skill_name,
-                            ex,
-                        )
+                if not skill.content_ref:
+                    raise RuntimeError(
+                        "resolved skill snapshot cannot be materialized: "
+                        f"skill '{skill.skill_name}' has no content_ref"
+                    )
+                if not self._artifact_service:
+                    raise RuntimeError(
+                        "resolved skill snapshot cannot be materialized: "
+                        "artifact service is required for skill content refs"
+                    )
+                try:
+                    _artifact, payload = await self._artifact_service.read(
+                        artifact_id=skill.content_ref,
+                        principal="system",
+                        allow_restricted_raw=True,
+                    )
+                    skill_dir = active_dir / skill.skill_name
+                    skill_dir.mkdir(parents=True, exist_ok=True)
+                    (skill_dir / "SKILL.md").write_bytes(payload)
+                except Exception as ex:
+                    raise RuntimeError(
+                        f"Failed to materialize content for skill {skill.skill_name}: {ex}"
+                    ) from ex
 
             manifest_content = {
                 "backing_path": str(active_dir),

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -1,9 +1,12 @@
+import io
 import json
 import shutil
+import tarfile
 from pathlib import Path
 from typing import Any
 
 from moonmind.schemas.agent_skill_models import (
+    AgentSkillFormat,
     ResolvedSkillSet,
     RuntimeMaterializationMode,
     RuntimeSkillMaterialization,
@@ -76,7 +79,10 @@ class AgentSkillMaterializer:
                     )
                     skill_dir = active_dir / skill.skill_name
                     skill_dir.mkdir(parents=True, exist_ok=True)
-                    (skill_dir / "SKILL.md").write_bytes(payload)
+                    if skill.format == AgentSkillFormat.BUNDLE:
+                        self._extract_skill_bundle(payload, skill_dir)
+                    else:
+                        (skill_dir / "SKILL.md").write_bytes(payload)
                 except Exception as ex:
                     raise RuntimeError(
                         f"Failed to materialize content for skill {skill.skill_name}: {ex}"
@@ -156,6 +162,29 @@ class AgentSkillMaterializer:
                 shutil.rmtree(child)
             else:
                 child.unlink()
+
+    @staticmethod
+    def _extract_skill_bundle(payload: bytes, skill_dir: Path) -> None:
+        root = skill_dir.resolve()
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+            for member in archive.getmembers():
+                member_path = Path(member.name)
+                if member_path.is_absolute() or ".." in member_path.parts:
+                    raise RuntimeError(
+                        f"skill bundle contains unsafe path: {member.name}"
+                    )
+                target = (root / member_path).resolve()
+                if target != root and root not in target.parents:
+                    raise RuntimeError(
+                        f"skill bundle extracts outside skill directory: {member.name}"
+                    )
+                if not member.isfile() and not member.isdir():
+                    raise RuntimeError(
+                        f"skill bundle contains unsupported entry: {member.name}"
+                    )
+            archive.extractall(root, filter="data")
+        if not (skill_dir / "SKILL.md").is_file():
+            raise RuntimeError("skill bundle did not contain SKILL.md")
 
     def _validate_projection_path(self, visible_dir: Path) -> None:
         agents_dir = visible_dir.parent

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -46,13 +46,29 @@ class SkillLoader(abc.ABC):
         """Return resolved skill entries from this source that match the selector."""
         raise NotImplementedError
 
+
 class BuiltInSkillLoader(SkillLoader):
     """Loads embedded capabilities shipped directly with the system."""
+
+    def __init__(self, skills_root: Path | None = None) -> None:
+        self._skills_root = skills_root
+
+    @property
+    def skills_root(self) -> Path:
+        if self._skills_root is not None:
+            return self._skills_root
+        return Path(__file__).resolve().parents[2] / ".agents" / "skills"
 
     async def load_skills(
         self, selector: SkillSelector, context: SkillResolutionContext
     ) -> list[ResolvedSkillEntry]:
-        results = []
+        results = _scan_for_skills(
+            self.skills_root,
+            AgentSkillSourceKind.BUILT_IN,
+            version="1.0.0",
+            skip_names={"local"},
+        )
+        discovered = {entry.skill_name for entry in results}
         for name in [
             "moonmind-doc-writer",
             "moonmind-default-reviewer",
@@ -63,6 +79,8 @@ class BuiltInSkillLoader(SkillLoader):
             "fix-merge-conflicts",
             "auto",
         ]:
+            if name in discovered:
+                continue
             results.append(
                 ResolvedSkillEntry(
                     skill_name=name,
@@ -71,8 +89,9 @@ class BuiltInSkillLoader(SkillLoader):
                         source_kind=AgentSkillSourceKind.BUILT_IN
                     ),
                 )
-            )
+        )
         return results
+
 
 class DeploymentSkillLoader(SkillLoader):
     """Loads authoritative skills administered through the central DB/API."""
@@ -92,10 +111,12 @@ class DeploymentSkillLoader(SkillLoader):
             stmt = select(AgentSkillDefinition).options(
                 selectinload(AgentSkillDefinition.versions)
             )
-            
+
             if selector.include:
-                stmt = stmt.where(AgentSkillDefinition.slug.in_([e.name for e in selector.include]))
-                
+                stmt = stmt.where(
+                    AgentSkillDefinition.slug.in_([e.name for e in selector.include])
+                )
+
             res = await session.execute(stmt)
             defs = res.scalars().all()
 
@@ -118,18 +139,26 @@ class DeploymentSkillLoader(SkillLoader):
 
         return results
 
+
 def _scan_for_skills(
-    skills_dir: Path, source_kind: AgentSkillSourceKind
+    skills_dir: Path,
+    source_kind: AgentSkillSourceKind,
+    *,
+    version: str = "latest",
+    skip_names: set[str] | None = None,
 ) -> list[ResolvedSkillEntry]:
     results = []
     if not skills_dir.is_dir():
         return results
-    for item in skills_dir.iterdir():
+    skip_names = skip_names or set()
+    for item in sorted(skills_dir.iterdir(), key=lambda path: path.name):
+        if item.name in skip_names:
+            continue
         if item.is_dir() and (item / "SKILL.md").exists():
             results.append(
                 ResolvedSkillEntry(
                     skill_name=item.name,
-                    version="latest",
+                    version=version,
                     provenance=AgentSkillProvenance(
                         source_kind=source_kind,
                         source_path=str(item),
@@ -137,6 +166,7 @@ def _scan_for_skills(
                 )
             )
     return results
+
 
 class RepoSkillLoader(SkillLoader):
     """Loads skills from the canonical `.agents/skills` repository path."""

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from moonmind.config.settings import settings
 from moonmind.schemas.agent_skill_models import (
     AgentSkillFormat,
     AgentSkillProvenance,
@@ -57,7 +58,17 @@ class BuiltInSkillLoader(SkillLoader):
     def skills_root(self) -> Path:
         if self._skills_root is not None:
             return self._skills_root
-        return Path(__file__).resolve().parents[2] / ".agents" / "skills"
+        candidates = [
+            Path("/app/.agents/skills"),
+            Path.cwd() / ".agents" / "skills",
+            Path(settings.workflow.skills_legacy_mirror_root).expanduser(),
+            Path(__file__).resolve().parents[2] / ".agents" / "skills",
+        ]
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if (resolved / "pr-resolver" / "SKILL.md").exists():
+                return resolved
+        return candidates[0]
 
     async def load_skills(
         self, selector: SkillSelector, context: SkillResolutionContext

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -1,11 +1,14 @@
 import hashlib
+import io
 import json
+import tarfile
 from pathlib import Path
 from typing import Any
 
 from temporalio import activity
 
 from moonmind.schemas.agent_skill_models import (
+    AgentSkillFormat,
     ResolvedSkillSet,
     SkillSelector,
     RuntimeSkillMaterialization,
@@ -87,12 +90,12 @@ class AgentSkillsActivities:
                 updated_skills.append(skill)
                 continue
 
-            skill_file = Path(skill.provenance.source_path) / "SKILL.md"
+            skill_dir = Path(skill.provenance.source_path)
             try:
-                payload = skill_file.read_bytes()
+                payload = self._build_skill_bundle_payload(skill_dir)
             except OSError as exc:
                 raise RuntimeError(
-                    f"failed to persist selected skill '{skill.skill_name}' from {skill_file}: {exc}"
+                    f"failed to persist selected skill '{skill.skill_name}' from {skill_dir}: {exc}"
                 ) from exc
 
             digest = "sha256:" + hashlib.sha256(payload).hexdigest()
@@ -104,9 +107,10 @@ class AgentSkillsActivities:
             )
             artifact, _ = await self._artifact_service.create(
                 principal="agent_workflow",
-                content_type="text/markdown",
+                content_type="application/gzip",
                 metadata_json={
                     "contentDigest": digest,
+                    "contentFormat": AgentSkillFormat.BUNDLE.value,
                     "producer": "agent_skill.resolve",
                     "skillName": skill.skill_name,
                     "sourceKind": skill.provenance.source_kind.value,
@@ -119,18 +123,34 @@ class AgentSkillsActivities:
                 artifact_id=artifact.artifact_id,
                 principal="agent_workflow",
                 payload=payload,
-                content_type="text/markdown",
+                content_type="application/gzip",
             )
             updated_skills.append(
                 skill.model_copy(
                     update={
                         "content_digest": digest,
                         "content_ref": artifact.artifact_id,
+                        "format": AgentSkillFormat.BUNDLE,
                     }
                 )
             )
 
         return resolved_set.model_copy(update={"skills": updated_skills})
+
+    @staticmethod
+    def _build_skill_bundle_payload(skill_dir: Path) -> bytes:
+        if not skill_dir.is_dir():
+            raise OSError(f"skill source path is not a directory: {skill_dir}")
+        if not (skill_dir / "SKILL.md").is_file():
+            raise OSError(f"skill source path is missing SKILL.md: {skill_dir}")
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+            for path in sorted(skill_dir.rglob("*")):
+                if path.is_symlink() or not path.is_file():
+                    continue
+                archive.add(path, arcname=str(path.relative_to(skill_dir)))
+        return buffer.getvalue()
 
     async def _persist_resolved_skillset_manifest(
         self,

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -1,3 +1,8 @@
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
 from temporalio import activity
 
 from moonmind.schemas.agent_skill_models import (
@@ -10,8 +15,8 @@ from moonmind.services.skill_resolution import (
     AgentSkillResolver,
     SkillResolutionContext,
 )
-from typing import Any
 from moonmind.services.skill_materialization import AgentSkillMaterializer
+
 
 class AgentSkillsActivities:
     """Temporal activities for managing agent skill resolution and materialization."""
@@ -34,11 +39,11 @@ class AgentSkillsActivities:
         allow_repo_skills: bool = False,
     ) -> ResolvedSkillSet:
         """Resolve a SkillSelector intent into a canonical ResolvedSkillSet."""
-        
+
         # Instantiate the proper context bounds
         info = activity.info()
         snapshot_id = f"skillset_{info.workflow_id}_{info.activity_id}"
-        
+
         context = SkillResolutionContext(
             snapshot_id=snapshot_id,
             deployment_id=run_id,
@@ -52,57 +57,135 @@ class AgentSkillsActivities:
         resolved_set = await resolver.resolve(selector, context)
 
         if self._artifact_service:
-            import json
-            try:
-                from moonmind.workflows.temporal.artifacts import ExecutionRef
-                from moonmind.core.artifacts import TemporalArtifactRetentionClass, TemporalArtifactRedactionLevel
-                
-                link = ExecutionRef(
-                    namespace=info.namespace,
-                    workflow_id=info.workflow_id,
-                    run_id=info.workflow_run_id,
-                    link_type="input.skill_snapshot",
-                )
-                
-                payload = resolved_set.model_dump(mode="json")
-                artifact, _ = await self._artifact_service.create(
-                    principal="agent_workflow",
-                    content_type="application/json",
-                    metadata_json={"producer": "agent_skill.resolve", "snapshot_id": snapshot_id},
-                    link=link,
-                    retention_class=TemporalArtifactRetentionClass.LONG,
-                    redaction_level=TemporalArtifactRedactionLevel.NONE,
-                )
-                
-                await self._artifact_service.write_complete(
-                    artifact_id=artifact.artifact_id,
-                    principal="agent_workflow",
-                    payload=json.dumps(payload, sort_keys=True, indent=2).encode("utf-8"),
-                    content_type="application/json",
-                )
-                
-                # Link the artifact to the payload
-                resolved_set.manifest_ref = artifact.artifact_id
-            except Exception as e:
-                activity.logger.warning(f"Failed to persist ResolvedSkillSet artifact: {e}")
+            resolved_set = await self._persist_file_backed_skill_content(
+                resolved_set=resolved_set,
+                activity_info=info,
+            )
+            resolved_set = await self._persist_resolved_skillset_manifest(
+                resolved_set=resolved_set,
+                snapshot_id=snapshot_id,
+                activity_info=info,
+            )
 
         return resolved_set
+
+    async def _persist_file_backed_skill_content(
+        self,
+        *,
+        resolved_set: ResolvedSkillSet,
+        activity_info: Any,
+    ) -> ResolvedSkillSet:
+        from moonmind.workflows.temporal.artifacts import ExecutionRef
+        from moonmind.core.artifacts import (
+            TemporalArtifactRedactionLevel,
+            TemporalArtifactRetentionClass,
+        )
+
+        updated_skills = []
+        for skill in resolved_set.skills:
+            if skill.content_ref or not skill.provenance.source_path:
+                updated_skills.append(skill)
+                continue
+
+            skill_file = Path(skill.provenance.source_path) / "SKILL.md"
+            try:
+                payload = skill_file.read_bytes()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"failed to persist selected skill '{skill.skill_name}' from {skill_file}: {exc}"
+                ) from exc
+
+            digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+            link = ExecutionRef(
+                namespace=activity_info.namespace,
+                workflow_id=activity_info.workflow_id,
+                run_id=activity_info.workflow_run_id,
+                link_type="input.agent_skill_body",
+            )
+            artifact, _ = await self._artifact_service.create(
+                principal="agent_workflow",
+                content_type="text/markdown",
+                metadata_json={
+                    "contentDigest": digest,
+                    "producer": "agent_skill.resolve",
+                    "skillName": skill.skill_name,
+                    "sourceKind": skill.provenance.source_kind.value,
+                },
+                link=link,
+                retention_class=TemporalArtifactRetentionClass.LONG,
+                redaction_level=TemporalArtifactRedactionLevel.NONE,
+            )
+            await self._artifact_service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal="agent_workflow",
+                payload=payload,
+                content_type="text/markdown",
+            )
+            updated_skills.append(
+                skill.model_copy(
+                    update={
+                        "content_digest": digest,
+                        "content_ref": artifact.artifact_id,
+                    }
+                )
+            )
+
+        return resolved_set.model_copy(update={"skills": updated_skills})
+
+    async def _persist_resolved_skillset_manifest(
+        self,
+        *,
+        resolved_set: ResolvedSkillSet,
+        snapshot_id: str,
+        activity_info: Any,
+    ) -> ResolvedSkillSet:
+        from moonmind.workflows.temporal.artifacts import ExecutionRef
+        from moonmind.core.artifacts import (
+            TemporalArtifactRedactionLevel,
+            TemporalArtifactRetentionClass,
+        )
+
+        link = ExecutionRef(
+            namespace=activity_info.namespace,
+            workflow_id=activity_info.workflow_id,
+            run_id=activity_info.workflow_run_id,
+            link_type="input.skill_snapshot",
+        )
+        payload = resolved_set.model_dump(mode="json")
+        artifact, _ = await self._artifact_service.create(
+            principal="agent_workflow",
+            content_type="application/json",
+            metadata_json={
+                "producer": "agent_skill.resolve",
+                "snapshot_id": snapshot_id,
+            },
+            link=link,
+            retention_class=TemporalArtifactRetentionClass.LONG,
+            redaction_level=TemporalArtifactRedactionLevel.NONE,
+        )
+        await self._artifact_service.write_complete(
+            artifact_id=artifact.artifact_id,
+            principal="agent_workflow",
+            payload=json.dumps(payload, sort_keys=True, indent=2).encode("utf-8"),
+            content_type="application/json",
+        )
+        return resolved_set.model_copy(update={"manifest_ref": artifact.artifact_id})
 
     @activity.defn(name="agent_skill.build_prompt_index")
     async def build_prompt_index(
         self, resolved_skillset: ResolvedSkillSet
     ) -> str:
         """Render a ResolvedSkillSet into a prompt-injectable payload."""
-        
+
         lines = []
         lines.append(f"# Active Agent Skills (Snapshot: {resolved_skillset.snapshot_id})")
         lines.append(f"Resolved At: {resolved_skillset.resolved_at.isoformat()}")
         lines.append("---")
-        
+
         if not resolved_skillset.skills:
             lines.append("No specialized agent skills active.")
             return "\n".join(lines)
-            
+
         for skill in resolved_skillset.skills:
             lines.append(f"## Skill: {skill.skill_name}")
             if skill.version:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -261,7 +261,6 @@ _OPERATOR_SUMMARY_TAIL_BYTES = 64 * 1024
 _PUBLISH_GIT_EXCLUDED_PATHS: tuple[str, ...] = (
     "CLAUDE.md",
     "live_streams.spool",
-    ".agents/skills",
 )
 _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
 
@@ -5176,13 +5175,24 @@ class TemporalAgentRuntimeActivities:
         return tuple(dict.fromkeys(paths))
 
     @staticmethod
-    def _should_exclude_publish_path(path_text: str) -> bool:
+    def _should_exclude_publish_path(
+        path_text: str,
+        *,
+        workspace: Path | None = None,
+    ) -> bool:
         """Skip runtime scaffolding paths that should never be published."""
         normalized = str(path_text or "").strip().rstrip("/")
         if not normalized:
             return True
         for excluded in _PUBLISH_GIT_EXCLUDED_PATHS:
             if normalized == excluded or normalized.startswith(f"{excluded}/"):
+                return True
+        if workspace is not None and (
+            normalized == ".agents/skills"
+            or normalized.startswith(".agents/skills/")
+        ):
+            projection = workspace / ".agents" / "skills"
+            if projection.is_symlink():
                 return True
         return False
 
@@ -5437,7 +5447,7 @@ class TemporalAgentRuntimeActivities:
             changed_paths = tuple(
                 path
                 for path in self._parse_git_status_paths(status_stdout)
-                if not self._should_exclude_publish_path(path)
+                if not self._should_exclude_publish_path(path, workspace=workspace)
             )
         except ValueError as exc:
             return {

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -62,14 +62,11 @@ from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as C
 from moonmind.codex_cloud.settings import build_codex_cloud_gate, CODEX_CLOUD_DISABLED_MESSAGE
 from moonmind.workflows.adapters.jules_client import JulesClient
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
-from moonmind.workflows.skills.materializer import (
-    SkillMaterializationError,
-    materialize_run_skill_workspace,
+from moonmind.schemas.agent_skill_models import (
+    ResolvedSkillSet,
+    RuntimeMaterializationMode,
 )
-from moonmind.workflows.skills.resolver import (
-    SkillResolutionError,
-    resolve_run_skill_selection,
-)
+from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     build_deployment_update_tool_definition_payload,
@@ -264,7 +261,7 @@ _OPERATOR_SUMMARY_TAIL_BYTES = 64 * 1024
 _PUBLISH_GIT_EXCLUDED_PATHS: tuple[str, ...] = (
     "CLAUDE.md",
     "live_streams.spool",
-    ".agents/skills/active",
+    ".agents/skills",
 )
 _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
 
@@ -3976,7 +3973,7 @@ class TemporalAgentRuntimeActivities:
         workspace_path_raw = str(
             payload.get("workspace_path") or payload.get("workspacePath") or ""
         ).strip()
-        skill_snapshot_materialized = self._materialize_selected_agent_skill_for_turn(
+        skill_snapshot_materialized = await self._materialize_selected_agent_skill_for_turn(
             request=request,
             workspace_path=workspace_path_raw,
         )
@@ -4028,14 +4025,13 @@ class TemporalAgentRuntimeActivities:
             "request.instructionRef or request.parameters.instructions is required"
         )
 
-    @classmethod
-    def _materialize_selected_agent_skill_for_turn(
-        cls,
+    async def _materialize_selected_agent_skill_for_turn(
+        self,
         *,
         request: AgentExecutionRequest,
         workspace_path: str,
     ) -> bool:
-        """Materialize the selected active skill for a managed-session turn."""
+        """Materialize the resolved active skill snapshot for a managed-session turn."""
 
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
@@ -4047,32 +4043,70 @@ class TemporalAgentRuntimeActivities:
             return False
 
         workspace = Path(workspace_path).expanduser().resolve()
-        run_root = cls._managed_session_run_root_for_workspace(workspace)
+        run_root = self._managed_session_run_root_for_workspace(workspace)
         if run_root is None:
             return False
 
-        cache_root = cls._managed_session_skill_cache_root(run_root)
+        skillset_ref = str(request.resolved_skillset_ref or "").strip()
+        if not skillset_ref:
+            raise TemporalActivityRuntimeError(
+                "selected skill materialization failed before runtime launch: "
+                f"selected skill '{selected_skill}' requires request.resolvedSkillsetRef"
+            )
+
         try:
-            selection = resolve_run_skill_selection(
-                run_id=str(request.idempotency_key or run_root.name),
-                context={"skill_selection": [selected_skill]},
+            resolved_skillset = await self._load_resolved_skillset(skillset_ref)
+            resolved_names = {entry.skill_name for entry in resolved_skillset.skills}
+            if selected_skill not in resolved_names:
+                raise TemporalActivityRuntimeError(
+                    "selected skill materialization failed before runtime launch: "
+                    f"selected skill '{selected_skill}' is not present in resolvedSkillsetRef {skillset_ref}"
+                )
+            skills_backing_root = (
+                run_root
+                / "runtime"
+                / "skills_active"
+                / resolved_skillset.snapshot_id
             )
-            materialize_run_skill_workspace(
-                selection=selection,
-                run_root=run_root,
-                cache_root=cache_root,
-                verify_signatures=settings.workflow.skills_verify_signatures,
+            materializer = AgentSkillMaterializer(
+                workspace_root=str(workspace),
+                artifact_service=self._artifact_service,
+                backing_root=str(skills_backing_root),
             )
-        except (SkillMaterializationError, SkillResolutionError, OSError) as exc:
+            await materializer.materialize(
+                resolved_skillset=resolved_skillset,
+                runtime_id=str(request.agent_id or "managed-runtime"),
+                mode=RuntimeMaterializationMode.HYBRID,
+            )
+        except TemporalActivityRuntimeError:
+            raise
+        except (RuntimeError, OSError, ValueError, ValidationError) as exc:
             raise TemporalActivityRuntimeError(
                 f"selected skill materialization failed for '{selected_skill}': {exc}"
             ) from exc
 
-        cls._ensure_managed_session_skill_shortcuts(
-            workspace=workspace,
-            skills_active_path=run_root / "skills_active",
-        )
         return True
+
+    async def _load_resolved_skillset(self, skillset_ref: str) -> ResolvedSkillSet:
+        if self._artifact_service is None:
+            raise TemporalActivityRuntimeError(
+                "selected skill materialization failed before runtime launch: "
+                "artifact service is required to read request.resolvedSkillsetRef"
+            )
+        try:
+            _artifact, payload = await self._artifact_service.read(
+                artifact_id=skillset_ref,
+                principal="agent_runtime",
+                allow_restricted_raw=True,
+            )
+            data = json.loads(payload.decode("utf-8"))
+            return ResolvedSkillSet.model_validate(data)
+        except TemporalActivityRuntimeError:
+            raise
+        except (OSError, TypeError, ValueError, ValidationError) as exc:
+            raise TemporalActivityRuntimeError(
+                f"failed to read resolvedSkillsetRef {skillset_ref}: {exc}"
+            ) from exc
 
     @staticmethod
     def _managed_session_run_root_for_workspace(workspace: Path) -> Path | None:
@@ -4091,51 +4125,6 @@ class TemporalAgentRuntimeActivities:
         if not run_id:
             return None
         return store_root / run_id
-
-    @staticmethod
-    def _managed_session_skill_cache_root(run_root: Path) -> Path:
-        raw_cache_root = Path(settings.workflow.skills_cache_root).expanduser()
-        if raw_cache_root.is_absolute():
-            cache_root = raw_cache_root.resolve()
-        else:
-            cache_root = (run_root.parent / raw_cache_root).resolve()
-        cache_root.mkdir(parents=True, exist_ok=True)
-        return cache_root
-
-    @classmethod
-    def _ensure_managed_session_skill_shortcuts(
-        cls,
-        *,
-        workspace: Path,
-        skills_active_path: Path,
-    ) -> None:
-        """Expose non-invasive repo-local shortcuts to the active skill set."""
-
-        active_link = workspace / ".agents" / "skills" / "active"
-        if active_link.parent.is_symlink():
-            return
-        cls._replace_relative_symlink_if_possible(
-            active_link,
-            target=skills_active_path,
-        )
-
-    @staticmethod
-    def _replace_relative_symlink_if_possible(path: Path, *, target: Path) -> None:
-        if path.exists() or path.is_symlink():
-            if not path.is_symlink():
-                return
-            current = path.resolve(strict=False)
-            if current == target.resolve(strict=False):
-                return
-            try:
-                path.unlink()
-            except OSError:
-                return
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.symlink_to(Path(os.path.relpath(target, path.parent)))
-        except OSError:
-            return
 
     @classmethod
     def _prepare_managed_codex_turn_text(
@@ -4175,9 +4164,9 @@ class TemporalAgentRuntimeActivities:
         block = (
             "Active MoonMind skill snapshot:\n"
             f"- Selected skill: {selected_skill}\n"
-            f"- Read `../skills_active/{selected_skill}/SKILL.md` first and follow that active snapshot.\n"
-            f"- If needed, `.agents/skills/active/{selected_skill}/SKILL.md` points to the same active snapshot.\n"
-            f"- Do not use repo-local `.agents/skills/{selected_skill}/SKILL.md` for this managed step; it may be stale source input.\n\n"
+            f"- Read `.agents/skills/{selected_skill}/SKILL.md` first and follow that active snapshot.\n"
+            "- `.agents/skills` is the resolved active skill projection for this managed step.\n"
+            "- Do not discover skills from repo-local or local-only source folders during execution.\n\n"
         )
         return block + instructions
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -36,6 +36,7 @@ with workflow.unsafe.imports_passed_through():
         is_jules_agent_runtime_node,
     )
     from moonmind.workflows.tasks.routing import _coerce_bool
+    from moonmind.workflows.agent_skills.selection import selected_agent_skill
     from moonmind.config.settings import settings
     from moonmind.utils.logging import scrub_github_tokens
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
@@ -3875,12 +3876,34 @@ class MoonMindRunWorkflow:
             task_skills,
             node_skills if node_skills is not None else node_inputs.get("skills"),
         )
-        if effective is None:
+        selected_skill = selected_agent_skill(node_inputs)
+        if selected_skill == "auto":
+            selected_skill = ""
+        if effective is None and not selected_skill:
             return None
 
-        selector = SkillSelector.model_validate(
+        effective_payload = (
             effective.model_dump(mode="json", exclude_none=True)
+            if effective is not None
+            else {}
         )
+        if selected_skill:
+            excluded = set(effective_payload.get("exclude") or [])
+            if selected_skill in excluded:
+                raise ValueError(
+                    f"selected skill '{selected_skill}' cannot also be excluded"
+                )
+            include = list(effective_payload.get("include") or [])
+            included_names = {
+                str(item.get("name") or "").strip().lower()
+                for item in include
+                if isinstance(item, Mapping)
+            }
+            if selected_skill not in included_names:
+                include.append({"name": selected_skill})
+                effective_payload["include"] = include
+
+        selector = SkillSelector.model_validate(effective_payload)
         if not selector.sets and not selector.include and not selector.exclude:
             return None
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -12,6 +12,8 @@ from temporalio.exceptions import CancelledError
 from temporalio.workflow import ActivityCancellationType, ChildWorkflowCancellationType
 
 with workflow.unsafe.imports_passed_through():
+    from collections.abc import Mapping as WorkflowMapping
+
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
     )
@@ -3888,8 +3890,14 @@ class MoonMindRunWorkflow:
             else {}
         )
         if selected_skill:
-            excluded = set(effective_payload.get("exclude") or [])
-            if selected_skill in excluded:
+            excluded_names = {
+                str(item.get("name") or "").strip().lower()
+                if isinstance(item, WorkflowMapping)
+                else str(item or "").strip().lower()
+                for item in (effective_payload.get("exclude") or [])
+            }
+            excluded_names.discard("")
+            if selected_skill in excluded_names:
                 raise ValueError(
                     f"selected skill '{selected_skill}' cannot also be excluded"
                 )
@@ -3897,7 +3905,7 @@ class MoonMindRunWorkflow:
             included_names = {
                 str(item.get("name") or "").strip().lower()
                 for item in include
-                if isinstance(item, Mapping)
+                if isinstance(item, WorkflowMapping)
             }
             if selected_skill not in included_names:
                 include.append({"name": selected_skill})

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -121,3 +121,11 @@ def test_runtime_services_receive_temporal_namespace_and_address():
         == "${TEMPORAL_ADDRESS:-temporal-internal:7233}"
     )
     assert namespace_init_env["TEMPORAL_NAMESPACE"] == "${TEMPORAL_NAMESPACE:-default}"
+
+
+def test_runtime_image_includes_agent_skill_sources():
+    dockerfile = (REPO_ROOT / "api_service" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert "COPY .agents /app/.agents/" in dockerfile

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -1,10 +1,13 @@
 import json
+import io
+import tarfile
 from datetime import datetime, UTC
 from pathlib import Path
 
 import pytest
 
 from moonmind.schemas.agent_skill_models import (
+    AgentSkillFormat,
     AgentSkillSourceKind,
     AgentSkillProvenance,
     ResolvedSkillEntry,
@@ -122,6 +125,53 @@ async def test_materializer_projects_only_selected_skills(tmp_path: Path):
     assert not (visible_dir / "unselected_skill").exists()
 
 @pytest.mark.asyncio
+async def test_materializer_extracts_skill_bundle_with_companion_files(
+    tmp_path: Path,
+):
+    artifact_service = _StaticArtifactService(
+        {
+            "artifact-bundle": _skill_bundle_payload(
+                {
+                    "SKILL.md": b"# Bundle Skill\n",
+                    "bin/run.py": b"print('run')\n",
+                }
+            )
+        }
+    )
+    materializer = AgentSkillMaterializer(
+        str(tmp_path), artifact_service=artifact_service
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="bundle_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="bundle_skill",
+                version="1.0.0",
+                format=AgentSkillFormat.BUNDLE,
+                content_ref="artifact-bundle",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            )
+        ],
+    )
+
+    await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
+
+    visible_dir = tmp_path / ".agents" / "skills"
+    assert (visible_dir / "bundle_skill" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == "# Bundle Skill\n"
+    assert (visible_dir / "bundle_skill" / "bin" / "run.py").read_text(
+        encoding="utf-8"
+    ) == "print('run')\n"
+
+@pytest.mark.asyncio
 async def test_materializer_rejects_incompatible_agents_skills_path(tmp_path: Path):
     source_dir = tmp_path / ".agents" / "skills"
     source_dir.mkdir(parents=True)
@@ -233,6 +283,15 @@ def _skill(name: str, content_ref: str) -> ResolvedSkillEntry:
         content_ref=content_ref,
         provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT),
     )
+
+def _skill_bundle_payload(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, payload in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
 
 class _StaticArtifactService:
     def __init__(self, payloads: dict[str, bytes]) -> None:

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -57,6 +57,19 @@ async def test_resolver_resolves_built_in_skills():
     skill = result.skills[0]
     assert skill.skill_name == "read_file"
     assert skill.provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+
+async def test_built_in_loader_discovers_packaged_agent_skills():
+    loader = BuiltInSkillLoader()
+    context = SkillResolutionContext(snapshot_id="snap-123")
+    selector = SkillSelector(include=[{"name": "moonspec-breakdown"}])
+
+    results = await loader.load_skills(selector, context)
+
+    discovered = {entry.skill_name: entry for entry in results}
+    assert "moonspec-breakdown" in discovered
+    assert discovered["moonspec-breakdown"].content_ref is None
+    assert discovered["moonspec-breakdown"].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+    assert discovered["moonspec-breakdown"].provenance.source_path
     
 async def test_resolver_resolves_local_skills_when_allowed():
     loader = LocalSkillLoader()

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -73,6 +74,53 @@ async def test_resolve_skills_activity_passes_repo_and_local_policy():
     assert result.policy_summary["repo_skills_allowed"] is False
     assert result.policy_summary["local_skills_allowed"] is True
 
+async def test_resolve_skills_activity_persists_file_backed_skill_content(
+    tmp_path,
+):
+    skill_dir = tmp_path / "skills" / "pr-resolver"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("# PR Resolver\n\nUse the resolved body.\n", encoding="utf-8")
+
+    artifact_service = _RecordingArtifactService()
+    activities = AgentSkillsActivities(artifact_service=artifact_service)
+    env = ActivityEnvironment()
+    selector = SkillSelector(include=[{"name": "pr-resolver"}])
+
+    with patch(
+        "moonmind.workflows.agent_skills.agent_skills_activities.AgentSkillResolver.resolve"
+    ) as mock_resolve:
+        mock_resolve.return_value = ResolvedSkillSet(
+            snapshot_id="skillset_test_abc123",
+            resolved_at=datetime.now(UTC),
+            skills=[
+                ResolvedSkillEntry(
+                    skill_name="pr-resolver",
+                    version="1.0.0",
+                    provenance=AgentSkillProvenance(
+                        source_kind=AgentSkillSourceKind.BUILT_IN,
+                        source_path=str(skill_dir),
+                    ),
+                )
+            ],
+        )
+
+        result = await env.run(
+            activities.resolve_skills,
+            selector,
+            "run-1",
+            None,
+            False,
+            False,
+        )
+
+    assert result.skills[0].content_ref == "art-1"
+    assert result.skills[0].content_digest.startswith("sha256:")
+    assert result.manifest_ref == "art-2"
+    assert artifact_service.payloads["art-1"] == skill_file.read_bytes()
+    manifest = artifact_service.payloads["art-2"].decode("utf-8")
+    assert '"content_ref": "art-1"' in manifest
+
 async def test_build_prompt_index_activity_returns_bundle():
     activities = AgentSkillsActivities()
     ActivityEnvironment()
@@ -122,7 +170,11 @@ async def test_materialize_activity_returns_materialization():
 async def test_materialize_activity_returns_canonical_agents_skills_metadata(
     tmp_path,
 ):
-    activities = AgentSkillsActivities()
+    activities = AgentSkillsActivities(
+        artifact_service=_RecordingArtifactService(
+            initial_payloads={"artifact-read-file": b"# Read File\n"}
+        )
+    )
     env = ActivityEnvironment()
     snapshot = ResolvedSkillSet(
         snapshot_id="snap-canonical",
@@ -130,6 +182,7 @@ async def test_materialize_activity_returns_canonical_agents_skills_metadata(
         skills=[
             ResolvedSkillEntry(
                 skill_name="read_file",
+                content_ref="artifact-read-file",
                 provenance=AgentSkillProvenance(
                     source_kind=AgentSkillSourceKind.BUILT_IN
                 ),
@@ -150,3 +203,36 @@ async def test_materialize_activity_returns_canonical_agents_skills_metadata(
     assert result.metadata["visiblePath"] == str(visible_path)
     assert result.metadata["manifestPath"] == str(visible_path / "_manifest.json")
     assert result.metadata["activeSkills"] == ["read_file"]
+
+
+class _RecordingArtifactService:
+    def __init__(self, initial_payloads: dict[str, bytes] | None = None) -> None:
+        self.payloads: dict[str, bytes] = dict(initial_payloads or {})
+        self.created: list[dict[str, object]] = []
+
+    async def create(self, **kwargs):
+        artifact_id = f"art-{len(self.created) + 1}"
+        self.created.append(kwargs)
+        return SimpleNamespace(artifact_id=artifact_id), None
+
+    async def write_complete(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        payload: bytes,
+        content_type: str,
+    ):
+        del principal, content_type
+        self.payloads[artifact_id] = payload
+        return SimpleNamespace(artifact_id=artifact_id)
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ):
+        del principal, allow_restricted_raw
+        return SimpleNamespace(artifact_id=artifact_id), self.payloads[artifact_id]

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -1,4 +1,6 @@
 from datetime import UTC, datetime
+import io
+import tarfile
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -81,6 +83,9 @@ async def test_resolve_skills_activity_persists_file_backed_skill_content(
     skill_dir.mkdir(parents=True)
     skill_file = skill_dir / "SKILL.md"
     skill_file.write_text("# PR Resolver\n\nUse the resolved body.\n", encoding="utf-8")
+    helper = skill_dir / "bin" / "resolve.py"
+    helper.parent.mkdir()
+    helper.write_text("print('resolve')\n", encoding="utf-8")
 
     artifact_service = _RecordingArtifactService()
     activities = AgentSkillsActivities(artifact_service=artifact_service)
@@ -116,8 +121,16 @@ async def test_resolve_skills_activity_persists_file_backed_skill_content(
 
     assert result.skills[0].content_ref == "art-1"
     assert result.skills[0].content_digest.startswith("sha256:")
+    assert result.skills[0].format == "bundle"
     assert result.manifest_ref == "art-2"
-    assert artifact_service.payloads["art-1"] == skill_file.read_bytes()
+    with tarfile.open(
+        fileobj=io.BytesIO(artifact_service.payloads["art-1"]),
+        mode="r:gz",
+    ) as archive:
+        assert sorted(member.name for member in archive.getmembers()) == [
+            "SKILL.md",
+            "bin/resolve.py",
+        ]
     manifest = artifact_service.payloads["art-2"].decode("utf-8")
     assert '"content_ref": "art-1"' in manifest
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2830,6 +2830,36 @@ async def test_agent_runtime_prepare_turn_instructions_treats_auto_skill_as_no_s
     assert not (workspace / ".agents" / "skills").exists()
 
 
+async def test_publish_path_filter_excludes_generated_skill_projection_symlink(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    backing = tmp_path / "runtime" / "skills_active"
+    backing.mkdir(parents=True)
+    projection = workspace / ".agents" / "skills"
+    projection.parent.mkdir(parents=True)
+    projection.symlink_to(backing, target_is_directory=True)
+
+    assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        ".agents/skills",
+        workspace=workspace,
+    )
+
+
+async def test_publish_path_filter_allows_checked_in_skill_directory(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    skill_file = workspace / ".agents" / "skills" / "pr-resolver" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.write_text("# Repo Skill\n", encoding="utf-8")
+
+    assert not TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        ".agents/skills/pr-resolver/SKILL.md",
+        workspace=workspace,
+    )
+
+
 @pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_includes_context_artifact_reference(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -24,6 +24,12 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunStatus,
     ManagedRunRecord,
 )
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
+)
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionBinding,
@@ -55,6 +61,22 @@ pytestmark = [pytest.mark.asyncio]
 
 def _make_store(tmp_path: Path) -> ManagedRunStore:
     return ManagedRunStore(tmp_path / "run_store")
+
+
+class _StaticArtifactService:
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ) -> tuple[SimpleNamespace, bytes]:
+        del principal, allow_restricted_raw
+        return SimpleNamespace(artifact_id=artifact_id), self._payloads[artifact_id]
+
 
 def _save_record(
     store: ManagedRunStore,
@@ -2541,39 +2563,37 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    skill_root = tmp_path / "moonmind_skills"
-    active_skill = skill_root / "pr-resolver"
-    active_skill.mkdir(parents=True)
-    (active_skill / "SKILL.md").write_text(
-        "---\nname: pr-resolver\ndescription: active\n---\nactive resolver body\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(
-        activity_runtime_module.settings.workflow,
-        "skills_cache_root",
-        str(tmp_path / "skill_cache"),
-    )
-    monkeypatch.setattr(
-        "moonmind.workflows.skills.resolver.settings.workflow.skills_local_mirror_root",
-        str(tmp_path / "unused_local"),
-    )
-    monkeypatch.setattr(
-        "moonmind.workflows.skills.resolver.settings.workflow.skills_legacy_mirror_root",
-        str(skill_root),
-    )
     managed_root = tmp_path / "agent_jobs"
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
 
     job_root = managed_root / "job-1"
     workspace = job_root / "repo"
-    stale_repo_skill = workspace / ".agents" / "skills" / "pr-resolver"
-    stale_repo_skill.mkdir(parents=True)
-    (stale_repo_skill / "SKILL.md").write_text(
-        "stale repo-local resolver body\n",
-        encoding="utf-8",
+    workspace.mkdir(parents=True)
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-pr-resolver",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="pr-resolver",
+                version="1.0.0",
+                content_ref="art-pr-resolver-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            )
+        ],
+    )
+    artifact_service = _StaticArtifactService(
+        {
+            "art-pr-resolver-snapshot": resolved_skillset.model_dump_json().encode(
+                "utf-8"
+            ),
+            "art-pr-resolver-body": b"---\nname: pr-resolver\ndescription: active\n---\nactive resolver body\n",
+        }
     )
 
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
     result = await activities.agent_runtime_prepare_turn_instructions(
         {
             "request": {
@@ -2581,6 +2601,7 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
                 "agentId": "codex",
                 "correlationId": "corr-1",
                 "idempotencyKey": "idem-1",
+                "resolvedSkillsetRef": "art-pr-resolver-snapshot",
                 "parameters": {
                     "instructions": "Resolve the PR.",
                     "publishMode": "none",
@@ -2596,16 +2617,128 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
     )
 
     assert result.startswith("Active MoonMind skill snapshot:")
-    assert "../skills_active/pr-resolver/SKILL.md" in result
-    assert "Do not use repo-local `.agents/skills/pr-resolver/SKILL.md`" in result
-    assert (job_root / "skills_active" / "pr-resolver" / "SKILL.md").read_text(
+    assert ".agents/skills/pr-resolver/SKILL.md" in result
+    assert "resolved active skill projection" in result
+    backing_skill = (
+        job_root
+        / "runtime"
+        / "skills_active"
+        / "skillset-pr-resolver"
+        / "pr-resolver"
+        / "SKILL.md"
+    )
+    assert backing_skill.read_text(encoding="utf-8").endswith("active resolver body\n")
+    visible_skills = workspace / ".agents" / "skills"
+    assert visible_skills.is_symlink()
+    assert (visible_skills / "pr-resolver" / "SKILL.md").read_text(
         encoding="utf-8"
     ).endswith("active resolver body\n")
-    assert (workspace / ".agents" / "skills" / "active").is_symlink()
     assert not (workspace / "skills_active").exists()
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_fails_when_active_projection_collides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+    workspace = managed_root / "job-1" / "repo"
+    checked_in_skill = workspace / ".agents" / "skills" / "pr-resolver"
+    checked_in_skill.mkdir(parents=True)
+    (checked_in_skill / "SKILL.md").write_text(
+        "checked-in source input\n",
+        encoding="utf-8",
+    )
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-pr-resolver",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="pr-resolver",
+                version="1.0.0",
+                content_ref="art-pr-resolver-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            )
+        ],
+    )
+    artifact_service = _StaticArtifactService(
+        {
+            "art-pr-resolver-snapshot": resolved_skillset.model_dump_json().encode(
+                "utf-8"
+            ),
+            "art-pr-resolver-body": b"resolved active body\n",
+        }
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.agent_runtime_prepare_turn_instructions(
+            {
+                "request": {
+                    "agentKind": "managed",
+                    "agentId": "codex",
+                    "correlationId": "corr-1",
+                    "idempotencyKey": "idem-1",
+                    "resolvedSkillsetRef": "art-pr-resolver-snapshot",
+                    "parameters": {
+                        "instructions": "Resolve the PR.",
+                        "metadata": {
+                            "moonmind": {
+                                "selectedSkill": "pr-resolver",
+                            },
+                        },
+                    },
+                },
+                "workspacePath": str(workspace),
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "skill projection failed before runtime launch" in message
+    assert "object kind: directory" in message
     assert (
-        stale_repo_skill / "SKILL.md"
-    ).read_text(encoding="utf-8") == "stale repo-local resolver body\n"
+        checked_in_skill / "SKILL.md"
+    ).read_text(encoding="utf-8") == "checked-in source input\n"
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_requires_skillset_ref_for_selected_skill(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+    workspace = managed_root / "job-1" / "repo"
+    workspace.mkdir(parents=True)
+
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.agent_runtime_prepare_turn_instructions(
+            {
+                "request": {
+                    "agentKind": "managed",
+                    "agentId": "codex",
+                    "correlationId": "corr-1",
+                    "idempotencyKey": "idem-1",
+                    "parameters": {
+                        "instructions": "Resolve the PR.",
+                        "metadata": {
+                            "moonmind": {
+                                "selectedSkill": "pr-resolver",
+                            },
+                        },
+                    },
+                },
+                "workspacePath": str(workspace),
+            }
+        )
+
+    assert "requires request.resolvedSkillsetRef" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -2641,10 +2774,10 @@ async def test_agent_runtime_prepare_turn_instructions_skips_skill_snapshot_for_
     )
 
     assert not result.startswith("Active MoonMind skill snapshot:")
-    assert "../skills_active/pr-resolver/SKILL.md" not in result
-    assert not (workspace.parent / "skills_active").exists()
+    assert ".agents/skills/pr-resolver/SKILL.md" not in result
+    assert not (workspace.parent / "runtime" / "skills_active").exists()
     assert not (workspace / "skills_active").exists()
-    assert not (workspace / ".agents" / "skills" / "active").exists()
+    assert not (workspace / ".agents" / "skills").exists()
 
 
 @pytest.mark.asyncio
@@ -2693,8 +2826,8 @@ async def test_agent_runtime_prepare_turn_instructions_treats_auto_skill_as_no_s
 
     assert result.startswith("Use the default runtime behavior.")
     assert "Active MoonMind skill snapshot:" not in result
-    assert not (job_root / "skills_active").exists()
-    assert not (workspace / ".agents" / "skills" / "active").exists()
+    assert not (job_root / "runtime" / "skills_active").exists()
+    assert not (workspace / ".agents" / "skills").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -282,6 +282,37 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         execute_activity.assert_not_called()
 
+    async def test_agent_node_rejects_selected_skill_excluded_by_object_selector(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+
+        class EffectiveSelector:
+            def model_dump(self, **_kwargs):
+                return {"exclude": [{"name": "pr-resolver"}]}
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(),
+        ) as execute_activity, patch(
+            "moonmind.workflows.temporal.workflows.run.build_effective_task_skill_selectors",
+            return_value=EffectiveSelector(),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "selected skill 'pr-resolver' cannot also be excluded",
+            ):
+                await wf._resolve_agent_node_skillset_ref(
+                    task_skills=None,
+                    node_inputs={
+                        "skills": {"exclude": [{"name": "pr-resolver"}]},
+                        "selectedSkill": "pr-resolver",
+                    },
+                    node_id="step-1",
+                    existing_skillset_ref=None,
+                )
+
+        execute_activity.assert_not_called()
+
     async def test_agent_node_pinned_resolution_failure_happens_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -227,6 +227,61 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         activity_args = calls[0][1]
         self.assertEqual(activity_args[1:], ["owner-1", "/workspace/repo", False, False])
 
+    async def test_agent_node_resolves_selected_skill_before_launch(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/selected-skill",
+            skills=[],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={
+                    "selectedSkill": "moonspec-breakdown",
+                    "workspaceRoot": "/workspace/repo",
+                },
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/selected-skill")
+        args, kwargs = execute_activity.call_args
+        self.assertEqual(args, ("agent_skill.resolve",))
+        selector = kwargs["args"][0]
+        self.assertEqual(
+            [(entry.name, entry.version) for entry in selector.include],
+            [("moonspec-breakdown", None)],
+        )
+        self.assertEqual(kwargs["args"][1:], ["owner-1", "/workspace/repo", False, False])
+
+    async def test_agent_node_rejects_selected_skill_excluded_by_selector(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(),
+        ) as execute_activity:
+            with self.assertRaisesRegex(
+                ValueError,
+                "selected skill 'pr-resolver' cannot also be excluded",
+            ):
+                await wf._resolve_agent_node_skillset_ref(
+                    task_skills={"exclude": ["pr-resolver"]},
+                    node_inputs={"selectedSkill": "pr-resolver"},
+                    node_id="step-1",
+                    existing_skillset_ref=None,
+                )
+
+        execute_activity.assert_not_called()
+
     async def test_agent_node_pinned_resolution_failure_happens_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"


### PR DESCRIPTION
## Summary

- Resolve selected agent skills before managed runtime launch and pass compact resolved snapshot refs into runtime requests.
- Persist file-backed skill bodies as artifacts, then materialize the runtime-visible active tree from artifact-backed `content_ref` values.
- Align managed runtime projection with `docs/Steps/SkillSystem.md`: `.agents/skills` is the active resolved projection, with backing content in a run-scoped store.
- Package built-in `.agents` skill sources into the runtime image instead of requiring worker bind mounts.

## Root Cause

A workflow selected `moonspec-breakdown` through `selectedSkill`, but that value was not included in pre-launch skill resolution. The managed-session turn-prep activity then tried to rediscover the skill from local mirror paths, which violated the desired Skill System contract and failed when workers did not have those paths mounted.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Focused skill/runtime suite: `173 passed`
- `docker compose config --services`
- Recreated Temporal workers locally and verified they were healthy after the change.
