### PR TITLE
[codex] Fix skillset ref propagation for mapping results

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,17 @@
 [
   {
-    "id": 4349829261,
+    "id": 4350220583,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and does not request a code change."
+    "rationale": "Qodo free-tier quota notice; no code action requested."
   },
   {
-    "id": 4202559225,
+    "id": 3166079083,
     "disposition": "addressed",
-    "rationale": "Review summary concerns were handled through the specific inline comments below."
+    "rationale": "Updated _resolved_skillset_field to explicitly handle None and use shared mapping/object key iteration, with regression coverage for missing results."
   },
   {
-    "id": 3165750067,
-    "disposition": "addressed",
-    "rationale": "Normalized selected-skill exclusions from both string and object-shaped entries before comparison."
-  },
-  {
-    "id": 3165750070,
-    "disposition": "addressed",
-    "rationale": "Built-in skill discovery now checks packaged /app/.agents/skills before local development fallbacks."
-  },
-  {
-    "id": 3165750073,
+    "id": 4202935592,
     "disposition": "not-applicable",
-    "rationale": "ValidationError is already imported in activity_runtime.py on the current branch."
-  },
-  {
-    "id": 3165750076,
-    "disposition": "addressed",
-    "rationale": "Workflow skill resolution now imports a workflow-safe Mapping alias and uses it for object-shaped selector checks."
-  },
-  {
-    "id": 3165758894,
-    "disposition": "addressed",
-    "rationale": "File-backed skills are now persisted as full tar.gz bundles and materialized with companion files intact."
-  },
-  {
-    "id": 3165758896,
-    "disposition": "addressed",
-    "rationale": "Publish filtering now skips .agents/skills only when it is the generated projection symlink, preserving checked-in skill edits."
-  },
-  {
-    "id": 4202568151,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment is informational; its actionable inline comments were classified separately."
+    "rationale": "Review summary that duplicates the actionable inline comment handled under comment 3166079083."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3943,14 +3943,11 @@ class MoonMindRunWorkflow:
 
     @staticmethod
     def _resolved_skillset_field(resolved: Any, *keys: str) -> Any:
-        if isinstance(resolved, WorkflowMapping):
-            for key in keys:
-                value = resolved.get(key)
-                if value:
-                    return value
+        if resolved is None:
             return None
+        is_mapping = isinstance(resolved, WorkflowMapping)
         for key in keys:
-            value = getattr(resolved, key, None)
+            value = resolved.get(key) if is_mapping else getattr(resolved, key, None)
             if value:
                 return value
         return None

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3927,11 +3927,33 @@ class MoonMindRunWorkflow:
             ],
             **self._execute_kwargs_for_route(route),
         )
-        manifest_ref = getattr(resolved, "manifest_ref", None)
+        manifest_ref = self._resolved_skillset_field(
+            resolved,
+            "manifest_ref",
+            "manifestRef",
+        )
         if manifest_ref:
             return str(manifest_ref)
-        snapshot_id = getattr(resolved, "snapshot_id", None)
+        snapshot_id = self._resolved_skillset_field(
+            resolved,
+            "snapshot_id",
+            "snapshotId",
+        )
         return str(snapshot_id) if snapshot_id else None
+
+    @staticmethod
+    def _resolved_skillset_field(resolved: Any, *keys: str) -> Any:
+        if isinstance(resolved, WorkflowMapping):
+            for key in keys:
+                value = resolved.get(key)
+                if value:
+                    return value
+            return None
+        for key in keys:
+            value = getattr(resolved, key, None)
+            if value:
+                return value
+        return None
 
     @staticmethod
     def _existing_agent_skillset_ref(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -287,6 +287,15 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ref, "artifact://skillsets/selected-skill")
         execute_activity.assert_awaited_once()
 
+    def test_resolved_skillset_field_accepts_missing_result(self) -> None:
+        self.assertIsNone(
+            MoonMindRunWorkflow._resolved_skillset_field(
+                None,
+                "manifest_ref",
+                "manifestRef",
+            )
+        )
+
     async def test_agent_node_rejects_selected_skill_excluded_by_selector(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -261,6 +261,32 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(kwargs["args"][1:], ["owner-1", "/workspace/repo", False, False])
 
+    async def test_agent_node_accepts_mapping_skill_resolution_result(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = {
+            "snapshotId": "skillset-wf-step-1",
+            "manifestRef": "artifact://skillsets/selected-skill",
+            "skills": [],
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={
+                    "selectedSkill": "moonspec-breakdown",
+                    "workspaceRoot": "/workspace/repo",
+                },
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/selected-skill")
+        execute_activity.assert_awaited_once()
+
     async def test_agent_node_rejects_selected_skill_excluded_by_selector(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"


### PR DESCRIPTION
## Summary
- Preserve resolved agent skill snapshot refs when `agent_skill.resolve` returns mapping-shaped payloads.
- Add unit coverage for the selected-skill boundary that previously dropped `manifestRef`.

## Root Cause
`MoonMind.Run` only read Pydantic-style attributes from the skill resolution result. When Temporal delivered a dict/camelCase result, the workflow lost `manifestRef`, so Codex session preparation failed before launch because `resolvedSkillsetRef` was missing.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
- `./tools/test_unit.sh`

Opened ready for review per request.