### PR TITLE
There are a number of issues with the new step type selector that I want to improve:

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,47 @@
 [
   {
-    "id": 4349829261,
+    "id": 4350228343,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and does not request a code change."
+    "rationale": "Qodo free-tier notification is informational and contains no requested code change."
   },
   {
-    "id": 4202559225,
+    "id": 3166086006,
     "disposition": "addressed",
-    "rationale": "Review summary concerns were handled through the specific inline comments below."
+    "rationale": "Preset Management now derives selection from React state instead of reading the input ref during render."
   },
   {
-    "id": 3165750067,
+    "id": 3166086011,
     "disposition": "addressed",
-    "rationale": "Normalized selected-skill exclusions from both string and object-shaped entries before comparison."
+    "rationale": "Step preset input updates now use a functional setSteps update so rapid edits merge against the latest step state."
   },
   {
-    "id": 3165750070,
+    "id": 3166086013,
     "disposition": "addressed",
-    "rationale": "Built-in skill discovery now checks packaged /app/.agents/skills before local development fallbacks."
+    "rationale": "Step type radio options now use label wrappers with native click-anywhere behavior and no wrapper onClick."
   },
   {
-    "id": 3165750073,
+    "id": 3166086015,
+    "disposition": "addressed",
+    "rationale": "Preset Management text input now uses only onChange and removed the duplicate onInput handler."
+  },
+  {
+    "id": 4202945045,
     "disposition": "not-applicable",
-    "rationale": "ValidationError is already imported in activity_runtime.py on the current branch."
+    "rationale": "Review body summarizes the inline comments and has no separate actionable request."
   },
   {
-    "id": 3165750076,
+    "id": 3166103261,
     "disposition": "addressed",
-    "rationale": "Workflow skill resolution now imports a workflow-safe Mapping alias and uses it for object-shaped selector checks."
+    "rationale": "Preset Management selection now resolves existing presets by unique template key rather than title, with duplicate-title test coverage."
   },
   {
-    "id": 3165758894,
-    "disposition": "addressed",
-    "rationale": "File-backed skills are now persisted as full tar.gz bundles and materialized with companion files intact."
-  },
-  {
-    "id": 3165758896,
-    "disposition": "addressed",
-    "rationale": "Publish filtering now skips .agents/skills only when it is the generated projection symlink, preserving checked-in skill edits."
-  },
-  {
-    "id": 4202568151,
+    "id": 4202965932,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment is informational; its actionable inline comments were classified separately."
+    "rationale": "Codex review body is informational; the actionable inline comments are tracked separately."
+  },
+  {
+    "id": 3166103264,
+    "disposition": "addressed",
+    "rationale": "Step preset jira_board inputs now render as Jira board selectors backed by Jira board data, with regression test coverage."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6219,6 +6219,121 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("renders Jira board selectors for step preset inputs", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown",
+                scope: "global",
+                title: "Jira Breakdown",
+                description: "Create Jira stories from a breakdown.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/jira-breakdown?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-breakdown",
+            scope: "global",
+            title: "Jira Breakdown",
+            description: "Create Jira stories from a breakdown.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Declarative Design Path or Text",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "jira_board_id",
+                label: "Jira Board",
+                type: "jira_board",
+                required: false,
+                default: "42",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith("/api/task-step-templates/jira-breakdown:expand?scope=global")
+      ) {
+        const body = JSON.parse(String(init?.body || "{}"));
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-breakdown:1.0.0:01",
+                title: "Create Jira stories",
+                instructions: `Selected Jira board ID: ${body.inputs.jira_board_id}`,
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-breakdown",
+              version: "1.0.0",
+              inputs: body.inputs,
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = await within(step).findByLabelText("Preset");
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-breakdown" },
+    });
+
+    const boardSelect = (await within(step).findByLabelText(
+      "Jira Board",
+    )) as HTMLSelectElement;
+    expect(boardSelect.tagName).toBe("SELECT");
+    await waitFor(() => {
+      expect(
+        Array.from(boardSelect.options).some((option) => option.value === "7"),
+      ).toBe(true);
+    });
+    fireEvent.change(boardSelect, { target: { value: "7" } });
+    fireEvent.change(
+      within(step).getByLabelText("Feature Request / Initial Instructions"),
+      { target: { value: "docs/Design.md" } },
+    );
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+
+    await waitFor(() => {
+      const expandCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).startsWith(
+          "/api/task-step-templates/jira-breakdown:expand?scope=global",
+        ),
+      );
+      expect(expandCall).toBeTruthy();
+      const body = JSON.parse(String(expandCall?.[1]?.body || "{}"));
+      expect(body.inputs.jira_board_id).toBe("7");
+    });
+  });
+
   it("preserves typed preset text spacing and submits unchecked boolean inputs", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -6851,7 +6966,7 @@ describe("Task Create Entrypoint", () => {
 
     const presetsSection = await screen.findByLabelText("Preset Management");
     fireEvent.change(within(presetsSection).getByLabelText("Preset Name"), {
-      target: { value: "Spec Kit Demo" },
+      target: { value: "global::::speckit-demo" },
     });
 
     const deleteButton = within(presetsSection).getByRole("button", {
@@ -6881,8 +6996,17 @@ describe("Task Create Entrypoint", () => {
 
     const presetsSection = await screen.findByLabelText("Preset Management");
     const presetName = within(presetsSection).getByLabelText("Preset Name");
-    fireEvent.input(presetName, {
-      target: { value: "Personal Demo" },
+    await waitFor(() => {
+      expect(
+        Array.from(
+          document.querySelectorAll<HTMLOptionElement>(
+            "#queue-template-name-options option",
+          ),
+        ).some((option) => option.value === "personal::::personal-demo"),
+      ).toBe(true);
+    });
+    fireEvent.change(presetName, {
+      target: { value: "personal::::personal-demo" },
     });
     await waitFor(() => {
       expect(
@@ -6907,6 +7031,106 @@ describe("Task Create Entrypoint", () => {
       "Delete preset 'Personal Demo'? This cannot be undone.",
     );
     expect(await screen.findByText("Deleted preset 'Personal Demo'.")).toBeTruthy();
+
+    confirmSpy.mockRestore();
+  });
+
+  it("resolves Preset Management selections by template key when titles collide", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "shared-global",
+                scope: "global",
+                title: "Shared Demo",
+                description: "Global preset with a duplicate title.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates?scope=personal")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "shared-personal",
+                scope: "personal",
+                title: "Shared Demo",
+                description: "Personal preset with a duplicate title.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        path === "/api/task-step-templates/shared-personal" &&
+        init?.method === "DELETE"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 204,
+          text: async () => "",
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetsSection = await screen.findByLabelText("Preset Management");
+    const presetName = within(presetsSection).getByLabelText("Preset Name");
+    await waitFor(() => {
+      expect(
+        Array.from(
+          document.querySelectorAll<HTMLOptionElement>(
+            "#queue-template-name-options option",
+          ),
+        ).some((option) => option.value === "personal::::shared-personal"),
+      ).toBe(true);
+    });
+    fireEvent.change(presetName, {
+      target: { value: "personal::::shared-personal" },
+    });
+    await waitFor(() => {
+      expect(
+        within(presetsSection)
+          .getByRole("button", { name: "Delete preset" })
+          .getAttribute("title"),
+      ).toBe("Delete the selected preset");
+    });
+
+    fireEvent.click(
+      within(presetsSection).getByRole("button", { name: "Delete preset" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/task-step-templates/shared-personal?scope=personal",
+        expect.objectContaining({
+          method: "DELETE",
+        }),
+      );
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url).startsWith("/api/task-step-templates/shared-global") &&
+          init?.method === "DELETE",
+      ),
+    ).toBe(false);
 
     confirmSpy.mockRestore();
   });
@@ -7052,7 +7276,12 @@ describe("Task Create Entrypoint", () => {
       { name: "Step Type" },
     );
     expect(
-      within(stepType).getAllByRole("radio").map((option) => option.nextSibling?.textContent),
+      within(stepType)
+        .getAllByRole("radio")
+        .map(
+          (option) =>
+            (option.nextSibling as HTMLElement | null)?.dataset.label || "",
+        ),
     ).toEqual(["Skill", "Tool", "Preset"]);
     expect(
       (within(stepType).getByLabelText("Step Type Skill") as HTMLInputElement)

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -401,6 +401,10 @@ describe("Task Create Entrypoint", () => {
     ).map((element) => element.dataset.canonicalCreateSection || "");
   }
 
+  function selectStepType(step: HTMLElement, type: "Skill" | "Tool" | "Preset") {
+    fireEvent.click(within(step).getByLabelText(`Step Type ${type}`));
+  }
+
   function expectAllButtonsHaveTitles(container: ParentNode = document): void {
     const missingTitles = Array.from(
       container.querySelectorAll<HTMLButtonElement>("button"),
@@ -3357,8 +3361,9 @@ describe("Task Create Entrypoint", () => {
     ) as HTMLElement;
     await waitFor(() => {
       expect(
-        (within(step).getByLabelText("Step Type") as HTMLSelectElement).value,
-      ).toBe("preset");
+        (within(step).getByLabelText("Step Type Preset") as HTMLInputElement)
+          .checked,
+      ).toBe(true);
       expect(
         (within(step).getByLabelText("Preset") as HTMLSelectElement).value,
       ).toBe("global::::speckit-demo");
@@ -5992,19 +5997,20 @@ describe("Task Create Entrypoint", () => {
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetSection = screen.getByLabelText("Task Presets");
-    const presetSelect = await within(presetSection).findByLabelText("Preset");
-    await waitFor(() => {
-      expect((presetSelect as HTMLSelectElement).value).toBe(
-        "global::::jira-orchestrate",
-      );
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = await within(step).findByLabelText("Preset");
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-orchestrate" },
     });
     expect(
-      await within(presetSection).findByLabelText("Jira Issue Key"),
+      await within(step).findByLabelText("Jira Issue Key"),
     ).not.toBeNull();
-    expect(within(presetSection).queryByLabelText("Orchestration Mode")).toBeNull();
-    expect(within(presetSection).queryByLabelText("Source Design Path")).toBeNull();
-    expect(within(presetSection).queryByLabelText("Constraints")).toBeNull();
+    expect(within(step).queryByLabelText("Orchestration Mode")).toBeNull();
+    expect(within(step).queryByLabelText("Source Design Path")).toBeNull();
+    expect(within(step).queryByLabelText("Constraints")).toBeNull();
   });
 
   it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {
@@ -6073,13 +6079,16 @@ describe("Task Create Entrypoint", () => {
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetSelect = await screen.findByLabelText("Preset");
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = await within(step).findByLabelText("Preset");
     fireEvent.change(presetSelect, {
       target: { value: "global::::jira-breakdown-orchestrate" },
     });
 
-    const presetSection = screen.getByLabelText("Task Presets");
-    const presetPublishSelect = (await within(presetSection).findByLabelText(
+    const presetPublishSelect = (await within(step).findByLabelText(
       "Publish Mode",
     )) as HTMLSelectElement;
     expect(presetPublishSelect.value).toBe("pr_with_merge_automation");
@@ -6087,8 +6096,8 @@ describe("Task Create Entrypoint", () => {
       "PR",
       "PR with Merge Automation",
     ]);
-    expect(within(presetSection).queryByLabelText("Repository")).toBeNull();
-    expect(within(presetSection).queryByLabelText("Runtime Mode")).toBeNull();
+    expect(within(step).queryByLabelText("Repository")).toBeNull();
+    expect(within(step).queryByLabelText("Runtime Mode")).toBeNull();
   });
 
   it("passes a preset-selected Jira board into Jira Breakdown expansion", async () => {
@@ -6782,36 +6791,25 @@ describe("Task Create Entrypoint", () => {
     expect(await screen.findByLabelText("Branch")).not.toBeNull();
     expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
     expect(await screen.findByDisplayValue("3")).not.toBeNull();
-    expect(screen.getByText("Task Presets (optional)")).not.toBeNull();
+    expect(screen.getByText("Preset Management")).not.toBeNull();
     expect(screen.getByText("Schedule (optional)")).not.toBeNull();
   });
 
-  it("right-aligns Task Presets actions with Apply last", async () => {
+  it("right-aligns Preset Management save and delete actions", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetsSection = await screen.findByLabelText("Task Presets");
+    const presetsSection = await screen.findByLabelText("Preset Management");
     const saveButton = within(presetsSection).getByRole("button", {
       name: "Save preset",
     });
     const deleteButton = within(presetsSection).getByRole("button", {
       name: "Delete preset",
     });
-    const applyButton = within(presetsSection).getByRole("button", {
-      name: "Apply",
-    });
-    const actionRow = applyButton.closest(".actions");
+    const actionRow = saveButton.closest(".actions");
 
     expect(actionRow?.classList.contains("queue-template-actions")).toBe(true);
     expect(
-      saveButton.compareDocumentPosition(applyButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
       saveButton.compareDocumentPosition(deleteButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      deleteButton.compareDocumentPosition(applyButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(saveButton.getAttribute("title")).toBe(
@@ -6837,26 +6835,23 @@ describe("Task Create Entrypoint", () => {
 
     renderWithClient(<TaskCreatePage payload={disabledPayload} />);
 
-    const presetsSection = await screen.findByLabelText("Task Presets");
+    const presetsSection = await screen.findByLabelText("Preset Management");
     expect(
       within(presetsSection).queryByRole("button", { name: "Save preset" }),
     ).toBeNull();
     expect(
       within(presetsSection).queryByRole("button", { name: "Delete preset" }),
     ).toBeNull();
-    expect(within(presetsSection).getByRole("button", { name: "Apply" }))
-      .toBeTruthy();
+    expect(within(presetsSection).queryByRole("button", { name: "Apply" }))
+      .toBeNull();
   });
 
   it("disables preset deletion for global presets", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetsSection = await screen.findByLabelText("Task Presets");
-    await within(presetsSection).findByRole("option", {
-      name: "Spec Kit Demo (Global)",
-    });
-    fireEvent.change(within(presetsSection).getByLabelText("Preset"), {
-      target: { value: "global::::speckit-demo" },
+    const presetsSection = await screen.findByLabelText("Preset Management");
+    fireEvent.change(within(presetsSection).getByLabelText("Preset Name"), {
+      target: { value: "Spec Kit Demo" },
     });
 
     const deleteButton = within(presetsSection).getByRole("button", {
@@ -6879,17 +6874,15 @@ describe("Task Create Entrypoint", () => {
     ).toBe(false);
   });
 
-  it("deletes the selected preset from the Task Presets actions", async () => {
+  it("deletes the selected preset from Preset Management actions", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetsSection = await screen.findByLabelText("Task Presets");
-    await within(presetsSection).findByRole("option", {
-      name: "Personal Demo (Personal)",
-    });
-    fireEvent.change(within(presetsSection).getByLabelText("Preset"), {
-      target: { value: "personal::::personal-demo" },
+    const presetsSection = await screen.findByLabelText("Preset Management");
+    const presetName = within(presetsSection).getByLabelText("Preset Name");
+    fireEvent.input(presetName, {
+      target: { value: "Personal Demo" },
     });
     await waitFor(() => {
       expect(
@@ -7054,19 +7047,23 @@ describe("Task Create Entrypoint", () => {
     );
     expect(primaryStep).not.toBeNull();
 
-    const stepType = within(primaryStep as HTMLElement).getByLabelText(
-      "Step Type",
-    ) as HTMLSelectElement;
+    const stepType = within(primaryStep as HTMLElement).getByRole(
+      "radiogroup",
+      { name: "Step Type" },
+    );
     expect(
-      Array.from(stepType.options).map((option) => option.textContent),
-    ).toEqual(["Tool", "Skill", "Preset"]);
-    expect(stepType.value).toBe("skill");
+      within(stepType).getAllByRole("radio").map((option) => option.nextSibling?.textContent),
+    ).toEqual(["Skill", "Tool", "Preset"]);
+    expect(
+      (within(stepType).getByLabelText("Step Type Skill") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
     expect(
       within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
     ).toBeTruthy();
   });
 
-  it("presents concise Step Type helper copy for Tool Skill and Preset", async () => {
+  it("presents concise Step Type helper copy as tooltips for Tool Skill and Preset", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
@@ -7074,33 +7071,26 @@ describe("Task Create Entrypoint", () => {
     );
     expect(primaryStep).not.toBeNull();
     const step = primaryStep as HTMLElement;
-    const stepType = within(step).getByLabelText("Step Type") as HTMLSelectElement;
-    const helpId = stepType.getAttribute("aria-describedby");
-
-    expect(helpId).toBeTruthy();
-
     expect(
-      within(step).getByText(
+      within(step)
+        .getByLabelText("Step Type Skill")
+        .closest(".queue-step-type-option")?.getAttribute("title"),
+    ).toBe("Skill asks an agent to perform work using reusable behavior.");
+    expect(
+      within(step)
+        .getByLabelText("Step Type Tool")
+        .closest(".queue-step-type-option")?.getAttribute("title"),
+    ).toBe("Tool runs a typed integration or system operation directly.");
+    expect(
+      within(step)
+        .getByLabelText("Step Type Preset")
+        .closest(".queue-step-type-option")?.getAttribute("title"),
+    ).toBe("Preset inserts a reusable set of configured steps.");
+    expect(
+      within(step).queryByText(
         "Skill asks an agent to perform work using reusable behavior.",
       ),
-    ).toBeTruthy();
-    expect(document.getElementById(helpId as string)?.textContent).toBe(
-      "Skill asks an agent to perform work using reusable behavior.",
-    );
-
-    fireEvent.change(stepType, { target: { value: "tool" } });
-    expect(
-      within(step).getByText(
-        "Tool runs a typed integration or system operation directly.",
-      ),
-    ).toBeTruthy();
-
-    fireEvent.change(stepType, { target: { value: "preset" } });
-    expect(
-      within(step).getByText(
-        "Preset inserts a reusable set of configured steps.",
-      ),
-    ).toBeTruthy();
+    ).toBeNull();
     expect(within(step).queryByText(/Temporal Activity/)).toBeNull();
     expect(within(step).queryByText(/Capability/)).toBeNull();
   });
@@ -7114,19 +7104,18 @@ describe("Task Create Entrypoint", () => {
     expect(primaryStep).not.toBeNull();
     const step = primaryStep as HTMLElement;
     const instructions = within(step).getByLabelText("Instructions") as HTMLTextAreaElement;
-    const stepType = within(step).getByLabelText("Step Type") as HTMLSelectElement;
 
     fireEvent.change(instructions, {
       target: { value: "Keep this Step Type instruction." },
     });
-    fireEvent.change(stepType, { target: { value: "tool" } });
+    selectStepType(step, "Tool");
 
     expect(instructions.value).toBe("Keep this Step Type instruction.");
     expect(within(step).getByLabelText("Tool")).toBeTruthy();
     expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
     expect(within(step).queryByLabelText("Preset")).toBeNull();
 
-    fireEvent.change(stepType, { target: { value: "preset" } });
+    selectStepType(step, "Preset");
 
     expect(instructions.value).toBe("Keep this Step Type instruction.");
     expect(within(step).getByLabelText("Preset")).toBeTruthy();
@@ -7149,12 +7138,8 @@ describe("Task Create Entrypoint", () => {
       "section",
     ) as HTMLElement;
 
-    fireEvent.change(within(primaryStep).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
-    fireEvent.change(within(secondStep).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(primaryStep, "Preset");
+    selectStepType(secondStep, "Preset");
 
     const firstPreset = within(primaryStep).getByLabelText(
       "Preset",
@@ -7239,9 +7224,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Keep authored placeholder." },
     });
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
     const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
     await waitFor(() => {
       expect(presetSelect.options.length).toBeGreaterThan(1);
@@ -7268,9 +7251,7 @@ describe("Task Create Entrypoint", () => {
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
     const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
     await waitFor(() => {
       expect(presetSelect.options.length).toBeGreaterThan(1);
@@ -7345,9 +7326,7 @@ describe("Task Create Entrypoint", () => {
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
     const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
     await waitFor(() => {
       expect(presetSelect.options.length).toBeGreaterThan(1);
@@ -7412,9 +7391,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Keep authored preset step." },
     });
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
     const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
     await waitFor(() => {
       expect(presetSelect.options.length).toBeGreaterThan(1);
@@ -7443,9 +7420,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Do not submit unresolved preset." },
     });
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -7462,15 +7437,15 @@ describe("Task Create Entrypoint", () => {
   it("previews and applies a step preset from the step editor without using Task Presets", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const taskPresetsSection = await screen.findByLabelText("Task Presets");
-    expect(within(taskPresetsSection).getByRole("button", { name: "Apply" })).toBeTruthy();
+    const presetManagementSection = await screen.findByLabelText("Preset Management");
+    expect(
+      within(presetManagementSection).queryByRole("button", { name: "Apply" }),
+    ).toBeNull();
 
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "preset" },
-    });
+    selectStepType(step, "Preset");
     const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
     await waitFor(() => {
       expect(presetSelect.options.length).toBeGreaterThan(1);
@@ -7520,13 +7495,9 @@ describe("Task Create Entrypoint", () => {
         target: { value: "docker, qdrant" },
       },
     );
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "tool" },
-    });
+    selectStepType(step, "Tool");
     expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "skill" },
-    });
+    selectStepType(step, "Skill");
     expect(
       (within(step).getByLabelText(/Skill \(optional\)/) as HTMLInputElement)
         .value,
@@ -7545,9 +7516,7 @@ describe("Task Create Entrypoint", () => {
         ) as HTMLInputElement
       ).value,
     ).toBe("docker, qdrant");
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "tool" },
-    });
+    selectStepType(step, "Tool");
     fireEvent.change(screen.getByLabelText("Instructions"), {
       target: { value: "Run a tool Step Type submission." },
     });
@@ -7572,9 +7541,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Fetch MM-563 through the trusted Jira tool." },
     });
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "tool" },
-    });
+    selectStepType(step, "Tool");
     fireEvent.change(within(step).getByLabelText("Tool"), {
       target: { value: "jira.get_issue" },
     });
@@ -7621,9 +7588,7 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Do not submit invalid tool inputs." },
     });
-    fireEvent.change(within(step).getByLabelText("Step Type"), {
-      target: { value: "tool" },
-    });
+    selectStepType(step, "Tool");
     fireEvent.change(within(step).getByLabelText("Tool"), {
       target: { value: "jira.get_issue" },
     });

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2841,7 +2841,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [templateInputValues, setTemplateInputValues] = useState<
     Record<string, string | boolean>
   >({});
-  const presetManagementInputRef = useRef<HTMLInputElement | null>(null);
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
   const [presetReapplyNeeded, setPresetReapplyNeeded] = useState(false);
   const [appliedTemplateFeatureRequest, setAppliedTemplateFeatureRequest] =
@@ -3336,21 +3335,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     },
   });
 
+  const jiraBoardProjectKey =
+    selectedJiraProjectKey || jiraIntegration?.defaultProjectKey || "";
   const jiraBoardsQuery = useQuery({
     queryKey: [
       "task-create",
       "jira",
       "boards",
       jiraIntegration?.endpoints.boards,
-      selectedJiraProjectKey,
+      jiraBoardProjectKey,
     ],
-    enabled: Boolean(
-      jiraIntegration?.enabled && jiraBrowserOpen && selectedJiraProjectKey,
-    ),
+    enabled: Boolean(jiraIntegration?.enabled && jiraBoardProjectKey),
     queryFn: async (): Promise<JiraBoard[]> => {
       const endpoint = interpolatePath(
         jiraIntegration?.endpoints.boards || "",
-        { projectKey: selectedJiraProjectKey },
+        { projectKey: jiraBoardProjectKey },
       );
       const response = await fetch(endpoint, {
         headers: { Accept: "application/json" },
@@ -3611,20 +3610,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
   }, [selectedPresetKey, taskTemplateCatalogEnabled, templateItems]);
 
-  const presetManagementLookupName = (
-    presetManagementInputRef.current?.value || presetManagementName
-  ).trim();
-  const selectedPresetByName = presetManagementLookupName
-    ? templateItems.find(
-        (item) =>
-          item.title === presetManagementLookupName ||
-          item.key === presetManagementLookupName,
-      ) ||
-      null
-    : null;
-  const selectedPreset = presetManagementLookupName
-    ? selectedPresetByName
-    : templateItems.find((item) => item.key === selectedPresetKey) || null;
+  const selectedPreset =
+    templateItems.find((item) => item.key === selectedPresetKey) || null;
   const selectedPresetDetailQuery = useQuery({
     queryKey: [
       "task-create",
@@ -4579,15 +4566,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     definition: TaskTemplateInputDefinition,
     value: string | boolean,
   ) {
-    updateStep(localId, {
-      presetInputValues: {
-        ...(steps.find((step) => step.localId === localId)?.presetInputValues ||
-          {}),
-        [definition.name]: value,
-      },
-      presetReapplyNeeded: false,
-      presetPreview: null,
-    });
+    setSteps((current) =>
+      current.map((step) =>
+        step.localId === localId
+          ? {
+              ...step,
+              presetInputValues: {
+                ...step.presetInputValues,
+                [definition.name]: value,
+              },
+              presetReapplyNeeded: false,
+              presetPreview: null,
+            }
+          : step,
+      ),
+    );
   }
 
   function updateStep(localId: string, updates: Partial<StepState>) {
@@ -4636,7 +4629,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function handlePresetManagementNameChange(nextName: string) {
     setPresetManagementName(nextName);
     const matchingPreset = templateItems.find(
-      (item) => item.title === nextName || item.key === nextName,
+      (item) => item.key === nextName.trim(),
     );
     setSelectedPresetKey(matchingPreset?.key || "");
     setTemplateInputValues({});
@@ -6754,13 +6747,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     <legend>Step Type</legend>
                     <div className="queue-step-type-options">
                       {STEP_TYPE_OPTIONS.map((option) => (
-                        <div
+                        <label
                           key={option.value}
                           className="queue-step-type-option"
                           title={STEP_TYPE_HELP_TEXT[option.value]}
-                          onClick={() =>
-                            handleStepTypeChange(step.localId, option.value)
-                          }
                         >
                           <input
                             type="radio"
@@ -6777,8 +6767,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                               )
                             }
                           />
-                          <span>{option.label}</span>
-                        </div>
+                          <span
+                            aria-hidden="true"
+                            className="queue-step-type-option-label"
+                            data-label={option.label}
+                          />
+                        </label>
                       ))}
                     </div>
                   </fieldset>
@@ -7241,6 +7235,35 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                 </label>
                               );
                             }
+                            if (definition.type === "jira_board") {
+                              return (
+                                <label key={definition.name} htmlFor={inputId}>
+                                  {definition.label}
+                                  <select
+                                    id={inputId}
+                                    value={value}
+                                    disabled={
+                                      jiraBoardsQuery.isLoading ||
+                                      jiraBoardsQuery.isError
+                                    }
+                                    onChange={(event) =>
+                                      updateStepPresetInputValue(
+                                        step.localId,
+                                        definition,
+                                        event.target.value,
+                                      )
+                                    }
+                                  >
+                                    <option value="">Select board...</option>
+                                    {(jiraBoardsQuery.data || []).map((board) => (
+                                      <option key={board.id} value={board.id}>
+                                        {board.name || board.id}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                              );
+                            }
                             return (
                               <label key={definition.name} htmlFor={inputId}>
                                 {definition.label}
@@ -7374,20 +7397,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               Preset Name
               <input
                 id="queue-template-select"
-                ref={presetManagementInputRef}
                 list="queue-template-name-options"
                 value={presetManagementName}
                 onChange={(event) =>
                   handlePresetManagementNameChange(event.target.value)
                 }
-                onInput={(event) =>
-                  handlePresetManagementNameChange(event.currentTarget.value)
-                }
                 placeholder="Type a new preset name or choose an existing personal preset"
               />
               <datalist id="queue-template-name-options">
                 {templateItems.map((item) => (
-                  <option key={item.key} value={item.title}>
+                  <option key={item.key} value={item.key}>
                     {`${item.title} (${scopeLabel(item.scope)})`}
                   </option>
                 ))}

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -526,10 +526,16 @@ interface StepAttachmentRef {
 type StepType = "tool" | "skill" | "preset";
 
 const STEP_TYPE_HELP_TEXT: Record<StepType, string> = {
-  tool: "Tool runs a typed integration or system operation directly.",
   skill: "Skill asks an agent to perform work using reusable behavior.",
+  tool: "Tool runs a typed integration or system operation directly.",
   preset: "Preset inserts a reusable set of configured steps.",
 };
+
+const STEP_TYPE_OPTIONS: Array<{ value: StepType; label: string }> = [
+  { value: "skill", label: "Skill" },
+  { value: "tool", label: "Tool" },
+  { value: "preset", label: "Preset" },
+];
 
 interface StepState {
   localId: string;
@@ -544,6 +550,7 @@ interface StepState {
   skillArgs: string;
   skillRequiredCapabilities: string;
   presetKey: string;
+  presetInputValues: Record<string, unknown>;
   presetMessage: string | null;
   presetReapplyNeeded: boolean;
   presetPreview: PresetPreviewState | null;
@@ -1150,6 +1157,7 @@ function createStepStateEntry(
     skillArgs: "",
     skillRequiredCapabilities: "",
     presetKey: "",
+    presetInputValues: {},
     presetMessage: null,
     presetReapplyNeeded: false,
     presetPreview: null,
@@ -1222,6 +1230,13 @@ function createStepStateEntriesFromTemporalDraft(
           ? JSON.stringify(toolPayload.inputs || step.skillArgs || {}, null, 2)
           : "{}",
       presetKey,
+      presetInputValues:
+        step.stepType === "preset" &&
+        presetPayload.inputs &&
+        typeof presetPayload.inputs === "object" &&
+        !Array.isArray(presetPayload.inputs)
+          ? (presetPayload.inputs as Record<string, unknown>)
+          : {},
       presetPreview:
         step.stepType === "preset"
           ? presetPreviewStateFromDraftPayload(presetKey, presetPayload)
@@ -2819,9 +2834,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedDependencies, setSelectedDependencies] = useState<string[]>([]);
   const [dependencyMessage, setDependencyMessage] = useState<string | null>(null);
   const [selectedPresetKey, setSelectedPresetKey] = useState("");
+  const [presetManagementName, setPresetManagementName] = useState("");
+  const [stepPresetDetails, setStepPresetDetails] = useState<
+    Record<string, TaskTemplateDetail>
+  >({});
   const [templateInputValues, setTemplateInputValues] = useState<
     Record<string, string | boolean>
   >({});
+  const presetManagementInputRef = useRef<HTMLInputElement | null>(null);
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
   const [presetReapplyNeeded, setPresetReapplyNeeded] = useState(false);
   const [appliedTemplateFeatureRequest, setAppliedTemplateFeatureRequest] =
@@ -3587,11 +3607,24 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const preferred = preferredTemplate(templateItems);
     if (preferred) {
       setSelectedPresetKey(preferred.key);
+      setPresetManagementName(preferred.title);
     }
   }, [selectedPresetKey, taskTemplateCatalogEnabled, templateItems]);
 
-  const selectedPreset =
-    templateItems.find((item) => item.key === selectedPresetKey) || null;
+  const presetManagementLookupName = (
+    presetManagementInputRef.current?.value || presetManagementName
+  ).trim();
+  const selectedPresetByName = presetManagementLookupName
+    ? templateItems.find(
+        (item) =>
+          item.title === presetManagementLookupName ||
+          item.key === presetManagementLookupName,
+      ) ||
+      null
+    : null;
+  const selectedPreset = presetManagementLookupName
+    ? selectedPresetByName
+    : templateItems.find((item) => item.key === selectedPresetKey) || null;
   const selectedPresetDetailQuery = useQuery({
     queryKey: [
       "task-create",
@@ -3623,76 +3656,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       return (await response.json()) as TaskTemplateDetail;
-    },
-  });
-  const selectedPresetInputs = selectedPresetDetailQuery.data?.inputs || [];
-  const visiblePresetInputs = selectedPresetInputs.filter((definition) =>
-    isVisiblePresetInput(selectedPreset?.slug, definition),
-  );
-  const presetJiraProjectInput = visiblePresetInputs.find((definition) =>
-    isJiraProjectInputKey(definition.name),
-  );
-  const presetJiraBoardInput = visiblePresetInputs.find(
-    (definition) => definition.type === "jira_board",
-  );
-  const presetJiraProjectKey = String(
-    (presetJiraProjectInput
-      ? templateInputValues[presetJiraProjectInput.name] ??
-        presetJiraProjectInput.default
-      : "") ||
-      jiraIntegration?.defaultProjectKey ||
-      "",
-  ).trim();
-  const presetNeedsJiraProjects = Boolean(
-    jiraIntegration?.enabled &&
-      (presetJiraProjectInput || presetJiraBoardInput),
-  );
-  const presetJiraProjectsQuery = useQuery({
-    queryKey: [
-      "task-create",
-      "preset-jira",
-      "projects",
-      jiraIntegration?.endpoints.projects,
-    ],
-    enabled: presetNeedsJiraProjects,
-    queryFn: async (): Promise<JiraProject[]> => {
-      const endpoint = jiraIntegration?.endpoints.projects || "";
-      const response = await fetch(endpoint, {
-        headers: { Accept: "application/json" },
-      });
-      if (!response.ok) {
-        throw new Error(
-          await responseErrorMessage(response, "Failed to load Jira projects."),
-        );
-      }
-      return readJiraItems<JiraProject>(await response.json());
-    },
-  });
-  const presetJiraBoardsQuery = useQuery({
-    queryKey: [
-      "task-create",
-      "preset-jira",
-      "boards",
-      jiraIntegration?.endpoints.boards,
-      presetJiraProjectKey,
-    ],
-    enabled: Boolean(
-      jiraIntegration?.enabled && presetJiraBoardInput && presetJiraProjectKey,
-    ),
-    queryFn: async (): Promise<JiraBoard[]> => {
-      const endpoint = interpolatePath(
-        jiraIntegration?.endpoints.boards || "",
-        { projectKey: presetJiraProjectKey },
-      );
-      const response = await fetch(endpoint, {
-        headers: { Accept: "application/json" },
-      });
-      if (!response.ok) {
-        throw new Error(
-          await responseErrorMessage(response, "Failed to load Jira boards."),
-        );
-      }
-      return readJiraItems<JiraBoard>(await response.json());
     },
   });
   const selectedPresetDeleteEnabled =
@@ -4221,12 +4184,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
   }
 
-  function handleTemplateFeatureRequestChange(value: string) {
-    setTemplateFeatureRequest(value);
-    setPresetJiraProvenance(null);
-    updatePresetReapplyStateForObjective(value, selectedObjectiveAttachmentFiles);
-  }
-
   function addDependency(workflowId: string) {
     const normalizedId = workflowId.trim();
     if (!normalizedId) {
@@ -4296,24 +4253,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     });
   }
 
-  function updateObjectiveAttachments(files: File[]) {
-    const limitMessage = attachmentLimitMessage(attachmentPolicy);
-    const nextTotalCount =
-      files.length +
-      Object.values(selectedStepAttachmentFiles).flat().length +
-      persistedAttachmentRefs.length;
-    if (nextTotalCount > attachmentPolicy.maxCount) {
-      setSubmitMessage(limitMessage);
-      return;
-    }
-    if (submitMessage === limitMessage) {
-      setSubmitMessage(null);
-    }
-    clearAttachmentTargetError(attachmentTargetKey("objective"));
-    setSelectedObjectiveAttachmentFiles(files);
-    updatePresetReapplyStateForObjective(templateFeatureRequest, files);
-  }
-
   function removePersistedObjectiveAttachment(artifactId: string) {
     setPersistedObjectiveAttachments((current) =>
       current.filter((attachment) => attachment.artifactId !== artifactId),
@@ -4333,26 +4272,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           : step,
       ),
     );
-  }
-
-  function removeObjectiveAttachment(fileToRemove: File) {
-    const targetKey = attachmentTargetKey("objective");
-    const previewKey = `${targetKey}:${attachmentFileKey(fileToRemove)}`;
-    setAttachmentTargetErrors((current) => {
-      const next = { ...current };
-      delete next[targetKey];
-      return next;
-    });
-    setPreviewFailureMessages((current) => {
-      const next = { ...current };
-      delete next[previewKey];
-      return next;
-    });
-    setSelectedObjectiveAttachmentFiles((current) => {
-      const next = current.filter((file) => file !== fileToRemove);
-      updatePresetReapplyStateForObjective(templateFeatureRequest, next);
-      return next;
-    });
   }
 
   function removeStepAttachment(localId: string, fileToRemove: File) {
@@ -4634,7 +4553,38 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function updateStepPreset(localId: string, presetKey: string) {
     updateStep(localId, {
       presetKey,
+      presetInputValues: {},
       presetMessage: null,
+      presetReapplyNeeded: false,
+      presetPreview: null,
+    });
+    const preset = templateItems.find((item) => item.key === presetKey);
+    if (!preset || stepPresetDetails[presetKey]) {
+      return;
+    }
+    void loadPresetDetail(preset)
+      .then((detail) => {
+        setStepPresetDetails((current) => ({
+          ...current,
+          [presetKey]: detail,
+        }));
+      })
+      .catch(() => {
+        updateStep(localId, { presetMessage: "Failed to load preset options." });
+      });
+  }
+
+  function updateStepPresetInputValue(
+    localId: string,
+    definition: TaskTemplateInputDefinition,
+    value: string | boolean,
+  ) {
+    updateStep(localId, {
+      presetInputValues: {
+        ...(steps.find((step) => step.localId === localId)?.presetInputValues ||
+          {}),
+        [definition.name]: value,
+      },
       presetReapplyNeeded: false,
       presetPreview: null,
     });
@@ -4681,6 +4631,18 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const nextType: StepType =
       value === "tool" || value === "preset" ? value : "skill";
     updateStep(localId, { stepType: nextType, presetPreview: null });
+  }
+
+  function handlePresetManagementNameChange(nextName: string) {
+    setPresetManagementName(nextName);
+    const matchingPreset = templateItems.find(
+      (item) => item.title === nextName || item.key === nextName,
+    );
+    setSelectedPresetKey(matchingPreset?.key || "");
+    setTemplateInputValues({});
+    templateInputMemoryRef.current = {};
+    setTemplateMessage(null);
+    setPresetReapplyNeeded(false);
   }
 
   function addStep() {
@@ -4737,6 +4699,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function resolveTemplateInputs(
     inputs: TaskTemplateInputDefinition[],
     explicitInputValues: Record<string, unknown> = templateInputValues,
+    objectiveText: string = templateFeatureRequest,
   ): {
     values: Record<string, unknown>;
     assumptions: string[];
@@ -4744,7 +4707,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const values: Record<string, unknown> = {};
     const assumptions: string[] = [];
     const primaryInstructions = String(steps[0]?.instructions || "").trim();
-    const explicitFeatureRequest = templateFeatureRequest.trim();
+    const explicitFeatureRequest = objectiveText.trim();
     const repositoryValue = repository.trim();
 
     inputs.forEach((definition) => {
@@ -4871,46 +4834,26 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     return { values, assumptions };
   }
 
-  function templateInputDisplayValue(
+  function presetInputDisplayValue(
     definition: TaskTemplateInputDefinition,
+    inputValues: Record<string, unknown>,
   ): string {
-    const explicit = templateInputValues[definition.name];
+    const explicit = inputValues[definition.name];
     if (explicit !== undefined) {
       return String(explicit);
     }
-    if (definition.type === "jira_board") {
-      return String(definition.default || jiraIntegration?.defaultBoardId || "").trim();
+    if (isRepositoryInputKey(definition.name)) {
+      return String(definition.default || repository || defaultRepository || "").trim();
     }
     if (isJiraProjectInputKey(definition.name)) {
       return String(
         definition.default || jiraIntegration?.defaultProjectKey || "",
       ).trim();
     }
-    if (isRepositoryInputKey(definition.name)) {
-      return String(definition.default || repository || defaultRepository || "").trim();
+    if (definition.type === "jira_board") {
+      return String(definition.default || jiraIntegration?.defaultBoardId || "").trim();
     }
     return String(definition.default ?? "").trim();
-  }
-
-  function updateTemplateInputValue(
-    definition: TaskTemplateInputDefinition,
-    value: string | boolean,
-  ) {
-    const normalized = value;
-    setTemplateInputValues((current) => {
-      const next = { ...current, [definition.name]: normalized };
-      if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
-        next[presetJiraBoardInput.name] = "";
-      }
-      return next;
-    });
-    templateInputMemoryRef.current[definition.name] = normalized;
-    if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
-      templateInputMemoryRef.current[presetJiraBoardInput.name] = "";
-    }
-    if (appliedTemplates.length > 0) {
-      setPresetReapplyNeeded(true);
-    }
   }
 
   async function loadPresetDetail(
@@ -4967,10 +4910,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     preset,
     detail,
     inputValues,
+    objectiveText = templateFeatureRequest,
   }: {
     preset: TemplateOption;
     detail: TaskTemplateDetail;
     inputValues: Record<string, unknown>;
+    objectiveText?: string;
   }): Promise<PresetPreviewState> {
     const scopeParams = {
       scope: preset.scope,
@@ -4979,6 +4924,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const { values: inputs, assumptions } = resolveTemplateInputs(
       detail.inputs || [],
       inputValues,
+      objectiveText,
     );
     const version =
       detail.version || detail.latestVersion || preset.latestVersion || "1.0.0";
@@ -5128,57 +5074,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
   }
 
-  async function applyPresetToDraft({
-    preset,
-    detail,
-    inputValues,
-    setMessage,
-  }: {
-    preset: TemplateOption;
-    detail: TaskTemplateDetail;
-    inputValues: Record<string, unknown>;
-    setMessage: (message: string) => void;
-  }) {
-    const preview = await expandPresetForDraft({ preset, detail, inputValues });
-    applyPresetPreviewToDraft({ preset, detail, preview, setMessage });
-  }
-
-  async function handleApplyPreset() {
-    if (isApplyingPreset) return;
-    if (!selectedPreset) {
-      setTemplateMessage("Choose a preset first.");
-      return;
-    }
-    const detail = selectedPresetDetailQuery.data;
-    if (!detail) {
-      setTemplateMessage(
-        selectedPresetDetailQuery.isError
-          ? "Failed to load preset details."
-          : "Preset options are still loading.",
-      );
-      return;
-    }
-    setIsApplyingPreset(true);
-    setPresetReapplyNeeded(false);
-    setTemplateMessage("Applying preset...");
-
-    try {
-      await applyPresetToDraft({
-        preset: selectedPreset,
-        detail,
-        inputValues: templateInputValues,
-        setMessage: setTemplateMessage,
-      });
-      setPresetReapplyNeeded(false);
-    } catch (error) {
-      const failure =
-        error instanceof Error ? error : new Error("Failed to apply preset.");
-      setTemplateMessage(`Failed to apply preset: ${failure.message}`);
-    } finally {
-      setIsApplyingPreset(false);
-    }
-  }
-
   async function handlePreviewStepPreset(localId: string) {
     if (isApplyingPreset) return;
     const step = steps.find((candidate) => candidate.localId === localId);
@@ -5197,14 +5092,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const detail =
         selectedPreset?.key === preset.key && selectedPresetDetailQuery.data
           ? selectedPresetDetailQuery.data
-          : await loadPresetDetail(preset);
+          : stepPresetDetails[preset.key] || (await loadPresetDetail(preset));
+      setStepPresetDetails((current) => ({
+        ...current,
+        [preset.key]: detail,
+      }));
       const preview = await expandPresetForDraft({
         preset,
         detail,
-        inputValues:
-          step.presetPreview?.presetKey === preset.key
-            ? step.presetPreview.inputs
-            : {},
+        inputValues: step.presetInputValues,
+        objectiveText: step.instructions,
       });
       updateStep(localId, {
         presetPreview: preview,
@@ -5245,7 +5142,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const detail =
         selectedPreset?.key === preset.key && selectedPresetDetailQuery.data
           ? selectedPresetDetailQuery.data
-          : await loadPresetDetail(preset);
+          : stepPresetDetails[preset.key] || (await loadPresetDetail(preset));
+      setStepPresetDetails((current) => ({
+        ...current,
+        [preset.key]: detail,
+      }));
       applyPresetPreviewToDraft({
         preset,
         detail,
@@ -5268,14 +5169,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!taskTemplateSaveEnabled) {
       return;
     }
-    const title = window.prompt("Preset title", "");
-    if (title === null || !title.trim()) {
-      setTemplateMessage("Preset save cancelled.");
+    const title = presetManagementName.trim();
+    if (!title) {
+      setTemplateMessage("Enter a Preset Name before saving.");
       return;
     }
-    const description =
-      window.prompt("Preset description", `Saved from task draft: ${title}`) ||
-      "";
 
     const presetSteps: Record<string, unknown>[] = [];
     for (let index = 0; index < steps.length; index += 1) {
@@ -5347,8 +5245,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         },
         body: JSON.stringify({
           scope: "personal",
-          title: title.trim(),
-          description: description.trim() || title.trim(),
+          title,
+          description: `Saved from task draft: ${title}`,
           steps: presetSteps,
           suggestedInputs: [],
           tags: [],
@@ -5360,7 +5258,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       const created = (await response.json()) as { title?: string };
-      setTemplateMessage(`Saved preset '${created.title || title.trim()}'.`);
+      setTemplateMessage(`Saved preset '${created.title || title}'.`);
       await templateOptionsQuery.refetch();
     } catch (error) {
       const failure =
@@ -5405,6 +5303,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       setSelectedPresetKey("");
+      setPresetManagementName("");
       setPresetReapplyNeeded(false);
       setTemplateMessage(`Deleted preset '${selectedPreset.title}'.`);
       await templateOptionsQuery.refetch();
@@ -6464,9 +6363,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the task starts";
   const publishModeTooltip = "Select how MoonMind publishes task changes";
-  const applyPresetDisabled = Boolean(
-    isApplyingPreset || (selectedPreset && selectedPresetDetailQuery.isLoading),
-  );
   const applyPresetTooltip = presetReapplyNeeded
     ? "Reapply the selected preset to update preset-derived steps"
     : selectedPreset && selectedPresetDetailQuery.isLoading
@@ -6785,6 +6681,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               const isPrimaryStep = index === 0;
               const stepLabel = isPrimaryStep ? " (Primary)" : "";
               const showSkillArgsField = showAdvancedStepOptions;
+              const stepPreset =
+                templateItems.find((item) => item.key === step.presetKey) ||
+                null;
+              const stepPresetDetail =
+                (stepPreset?.key === selectedPreset?.key
+                  ? selectedPresetDetailQuery.data
+                  : undefined) ||
+                (stepPreset ? stepPresetDetails[stepPreset.key] : undefined);
+              const stepPresetInputs = (stepPresetDetail?.inputs || []).filter(
+                (definition) => isVisiblePresetInput(stepPreset?.slug, definition),
+              );
               return (
                 <section
                   key={step.localId}
@@ -6839,31 +6746,49 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     </div>
                   </div>
 
-                  <label className="queue-step-type-field">
-                    Step Type
-                    <select
-                      aria-label="Step Type"
-                      aria-describedby={`queue-step-type-help-${index}`}
-                      data-step-field="stepType"
-                      data-step-index={String(index)}
-                      value={step.stepType}
-                      onChange={(event) =>
-                        handleStepTypeChange(step.localId, event.target.value)
-                      }
-                    >
-                      <option value="tool">Tool</option>
-                      <option value="skill">Skill</option>
-                      <option value="preset">Preset</option>
-                    </select>
-                    <span id={`queue-step-type-help-${index}`} className="small">
-                      {STEP_TYPE_HELP_TEXT[step.stepType]}
-                    </span>
-                  </label>
+                  <fieldset
+                    className="queue-step-type-field"
+                    role="radiogroup"
+                    aria-label="Step Type"
+                  >
+                    <legend>Step Type</legend>
+                    <div className="queue-step-type-options">
+                      {STEP_TYPE_OPTIONS.map((option) => (
+                        <div
+                          key={option.value}
+                          className="queue-step-type-option"
+                          title={STEP_TYPE_HELP_TEXT[option.value]}
+                          onClick={() =>
+                            handleStepTypeChange(step.localId, option.value)
+                          }
+                        >
+                          <input
+                            type="radio"
+                            aria-label={`Step Type ${option.label}`}
+                            name={`queue-step-type-${step.localId}`}
+                            data-step-field="stepType"
+                            data-step-index={String(index)}
+                            value={option.value}
+                            checked={step.stepType === option.value}
+                            onChange={(event) =>
+                              handleStepTypeChange(
+                                step.localId,
+                                event.target.value,
+                              )
+                            }
+                          />
+                          <span>{option.label}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </fieldset>
 
-                  <div className="stack">
+                  <div className="stack queue-step-instructions-block">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
-                        Instructions
+                        {step.stepType === "preset"
+                          ? "Feature Request / Initial Instructions"
+                          : "Instructions"}
                       </label>
                       <JiraProvenanceChip
                         label={`Step ${index + 1} instructions`}
@@ -6892,7 +6817,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       data-step-field="instructions"
                       data-step-index={String(index)}
                       placeholder={
-                        isPrimaryStep
+                        step.stepType === "preset"
+                          ? "Describe the feature request this preset should execute."
+                          : isPrimaryStep
                           ? "Describe the task to execute against the repository."
                           : "Step-specific instructions (leave blank to continue from the task objective)."
                       }
@@ -7152,7 +7079,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   ) : null}
 
                   {step.stepType === "skill" ? (
-                    <>
+                    <div className="stack queue-step-type-panel">
                       <label>
                         Skill (optional)
                         <input
@@ -7214,7 +7141,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           />
                         </label>
                       ) : null}
-                    </>
+                    </div>
                   ) : null}
 
                   {step.stepType === "preset" ? (
@@ -7238,6 +7165,103 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           ))}
                         </select>
                       </label>
+                      {stepPresetInputs.length > 0 ? (
+                        <div className="grid-2">
+                          {stepPresetInputs.map((definition) => {
+                            const inputId = `queue-step-${step.localId}-preset-input-${definition.name}`;
+                            const value = presetInputDisplayValue(
+                              definition,
+                              step.presetInputValues,
+                            );
+                            if (definition.type === "enum") {
+                              return (
+                                <label key={definition.name} htmlFor={inputId}>
+                                  {definition.label}
+                                  <select
+                                    id={inputId}
+                                    value={value}
+                                    onChange={(event) =>
+                                      updateStepPresetInputValue(
+                                        step.localId,
+                                        definition,
+                                        event.target.value,
+                                      )
+                                    }
+                                  >
+                                    {(definition.options || []).map((option) => (
+                                      <option key={option} value={option}>
+                                        {templateEnumOptionLabel(
+                                          definition,
+                                          option,
+                                        )}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                              );
+                            }
+                            if (definition.type === "boolean") {
+                              return (
+                                <label key={definition.name} htmlFor={inputId}>
+                                  {definition.label}
+                                  <input
+                                    id={inputId}
+                                    type="checkbox"
+                                    checked={value === "true"}
+                                    onChange={(event) =>
+                                      updateStepPresetInputValue(
+                                        step.localId,
+                                        definition,
+                                        event.target.checked,
+                                      )
+                                    }
+                                  />
+                                </label>
+                              );
+                            }
+                            if (
+                              definition.type === "textarea" ||
+                              definition.type === "markdown"
+                            ) {
+                              return (
+                                <label key={definition.name} htmlFor={inputId}>
+                                  {definition.label}
+                                  <textarea
+                                    id={inputId}
+                                    value={value}
+                                    placeholder={definition.placeholder || ""}
+                                    onChange={(event) =>
+                                      updateStepPresetInputValue(
+                                        step.localId,
+                                        definition,
+                                        event.target.value,
+                                      )
+                                    }
+                                  />
+                                </label>
+                              );
+                            }
+                            return (
+                              <label key={definition.name} htmlFor={inputId}>
+                                {definition.label}
+                                <input
+                                  id={inputId}
+                                  type="text"
+                                  value={value}
+                                  placeholder={definition.placeholder || ""}
+                                  onChange={(event) =>
+                                    updateStepPresetInputValue(
+                                      step.localId,
+                                      definition,
+                                      event.target.value,
+                                    )
+                                  }
+                                />
+                              </label>
+                            );
+                          })}
+                        </div>
+                      ) : null}
                       <button
                         type="button"
                         className="secondary"
@@ -7341,310 +7365,34 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         {taskTemplateCatalogEnabled ? (
           <section
             className="card stack"
-            aria-label="Task Presets"
+            aria-label="Preset Management"
           >
             <div className="actions">
-              <strong>Task Presets (optional)</strong>
+              <strong>Preset Management</strong>
             </div>
             <label>
-              Preset
-              <select
+              Preset Name
+              <input
                 id="queue-template-select"
-                value={selectedPresetKey}
-                onChange={(event) => {
-                  setSelectedPresetKey(event.target.value);
-                  setTemplateInputValues({});
-                  templateInputMemoryRef.current = {};
-                  setTemplateMessage(null);
-                  setPresetReapplyNeeded(false);
-                }}
-              >
-                <option value="">Select preset...</option>
+                ref={presetManagementInputRef}
+                list="queue-template-name-options"
+                value={presetManagementName}
+                onChange={(event) =>
+                  handlePresetManagementNameChange(event.target.value)
+                }
+                onInput={(event) =>
+                  handlePresetManagementNameChange(event.currentTarget.value)
+                }
+                placeholder="Type a new preset name or choose an existing personal preset"
+              />
+              <datalist id="queue-template-name-options">
                 {templateItems.map((item) => (
-                  <option key={item.key} value={item.key}>
+                  <option key={item.key} value={item.title}>
                     {`${item.title} (${scopeLabel(item.scope)})`}
                   </option>
                 ))}
-              </select>
+              </datalist>
             </label>
-            <div className="stack">
-              <div className="queue-field-heading">
-                <label htmlFor="queue-template-feature-request">
-                  Feature Request / Initial Instructions
-                </label>
-                <JiraProvenanceChip
-                  label="Feature Request / Initial Instructions"
-                  provenance={presetJiraProvenance}
-                />
-                {jiraIntegration?.enabled ? (
-                  <button
-                    type="button"
-                    className="secondary jira-browse-button"
-                    aria-label="Browse Jira issues for preset instructions"
-                    title="Browse Jira issues for preset instructions"
-                    onClick={() => openJiraBrowser({ kind: "preset" })}
-                  >
-                    Browse Jira issue
-                  </button>
-                ) : null}
-              </div>
-              <textarea
-                id="queue-template-feature-request"
-                placeholder="Describe the feature request this preset should execute."
-                value={templateFeatureRequest}
-                onChange={(event) =>
-                  handleTemplateFeatureRequestChange(event.target.value)
-                }
-              />
-              {selectedPresetDetailQuery.isError ? (
-                <p className="notice small">Failed to load preset options.</p>
-              ) : null}
-              {visiblePresetInputs.length > 0 ? (
-                <div className="grid-2">
-                  {visiblePresetInputs.map((definition) => {
-                    const inputId = `queue-template-input-${definition.name}`;
-                    const value = templateInputDisplayValue(definition);
-                    if (
-                      isJiraProjectInputKey(definition.name) &&
-                      jiraIntegration?.enabled
-                    ) {
-                      return (
-                        <label key={definition.name} htmlFor={inputId}>
-                          {definition.label}
-                          <select
-                            id={inputId}
-                            value={value}
-                            disabled={
-                              presetJiraProjectsQuery.isLoading ||
-                              presetJiraProjectsQuery.isError
-                            }
-                            onChange={(event) =>
-                              updateTemplateInputValue(
-                                definition,
-                                event.target.value,
-                              )
-                            }
-                          >
-                            <option value="">Select project...</option>
-                            {(presetJiraProjectsQuery.data || []).map((project) => (
-                              <option
-                                key={project.projectKey}
-                                value={project.projectKey}
-                              >
-                                {project.name
-                                  ? `${project.name} (${project.projectKey})`
-                                  : project.projectKey}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      );
-                    }
-                    if (definition.type === "jira_board") {
-                      return (
-                        <label key={definition.name} htmlFor={inputId}>
-                          {definition.label}
-                          <select
-                            id={inputId}
-                            value={value}
-                            disabled={
-                              !presetJiraProjectKey ||
-                              presetJiraBoardsQuery.isLoading ||
-                              presetJiraBoardsQuery.isError
-                            }
-                            onChange={(event) =>
-                              updateTemplateInputValue(
-                                definition,
-                                event.target.value,
-                              )
-                            }
-                          >
-                            <option value="">No board selected</option>
-                            {(presetJiraBoardsQuery.data || []).map((board) => (
-                              <option key={board.id} value={board.id}>
-                                {board.name || board.id}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      );
-                    }
-                    if (definition.type === "enum") {
-                      return (
-                        <label key={definition.name} htmlFor={inputId}>
-                          {definition.label}
-                          <select
-                            id={inputId}
-                            value={value}
-                            onChange={(event) =>
-                              updateTemplateInputValue(
-                                definition,
-                                event.target.value,
-                              )
-                            }
-                          >
-                            {(definition.options || []).map((option) => (
-                              <option key={option} value={option}>
-                                {templateEnumOptionLabel(definition, option)}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      );
-                    }
-                    if (definition.type === "boolean") {
-                      return (
-                        <label key={definition.name} htmlFor={inputId}>
-                          {definition.label}
-                          <input
-                            id={inputId}
-                            type="checkbox"
-                            checked={value === "true"}
-                            onChange={(event) =>
-                              updateTemplateInputValue(
-                                definition,
-                                event.target.checked,
-                              )
-                            }
-                          />
-                        </label>
-                      );
-                    }
-                    if (
-                      definition.type === "textarea" ||
-                      definition.type === "markdown"
-                    ) {
-                      return (
-                        <label key={definition.name} htmlFor={inputId}>
-                          {definition.label}
-                          <textarea
-                            id={inputId}
-                            value={value}
-                            placeholder={definition.placeholder || ""}
-                            onChange={(event) =>
-                              updateTemplateInputValue(
-                                definition,
-                                event.target.value,
-                              )
-                            }
-                          />
-                        </label>
-                      );
-                    }
-                    return (
-                      <label key={definition.name} htmlFor={inputId}>
-                        {definition.label}
-                        <input
-                          id={inputId}
-                          type="text"
-                          value={value}
-                          placeholder={definition.placeholder || ""}
-                          onChange={(event) =>
-                            updateTemplateInputValue(
-                              definition,
-                              event.target.value,
-                            )
-                          }
-                        />
-                      </label>
-                    );
-                  })}
-                </div>
-              ) : null}
-              {presetJiraProjectsQuery.isError ? (
-                <p className="notice small">Failed to load Jira projects.</p>
-              ) : null}
-              {presetJiraBoardsQuery.isError ? (
-                <p className="notice small">Failed to load Jira boards.</p>
-              ) : null}
-              {attachmentPolicy.enabled ? (
-                <div className="queue-step-attachments">
-                  <label>
-                    {`Feature Request / Initial Instructions ${attachmentLabel}`}
-                    <input
-                      type="file"
-                      data-step-field="objective-attachments"
-                      accept={attachmentPolicy.allowedContentTypes.join(",")}
-                      multiple
-                      aria-label="Feature Request / Initial Instructions attachments"
-                      onChange={(event) => {
-                        updateObjectiveAttachments(
-                          Array.from(event.currentTarget.files || []),
-                        );
-                        event.currentTarget.value = "";
-                      }}
-                    />
-                  </label>
-                  {attachmentTargetErrors[attachmentTargetKey("objective")] ? (
-                    <p className="notice error">
-                      {attachmentTargetErrors[attachmentTargetKey("objective")]}
-                    </p>
-                  ) : null}
-                  {selectedObjectiveAttachmentFiles.length > 0 ? (
-                    <ul className="list queue-step-attachments-list">
-                      {selectedObjectiveAttachmentFiles.map((file) => (
-                        <li key={`${file.name}-${file.size}-${file.lastModified}`}>
-                          <span>
-                            <strong>{file.name}</strong>{" "}
-                            <span className="small">
-                              {`${file.type || "application/octet-stream"}, ${formatAttachmentBytes(file.size)}`}
-                            </span>
-                          </span>
-                          <AttachmentPreview
-                            file={file}
-                            alt={`Preview of objective attachment ${file.name}`}
-                            onError={() =>
-                              markAttachmentPreviewFailed(
-                                attachmentTargetKey("objective"),
-                                "Feature Request / Initial Instructions",
-                                file,
-                              )
-                            }
-                          />
-                          {previewFailureMessages[
-                            `${attachmentTargetKey("objective")}:${attachmentFileKey(file)}`
-                          ] ? (
-                            <p className="small notice error">
-                              {
-                                previewFailureMessages[
-                                  `${attachmentTargetKey("objective")}:${attachmentFileKey(file)}`
-                                ]
-                              }
-                            </p>
-                          ) : null}
-                          {attachmentTargetErrors[
-                            attachmentTargetKey("objective")
-                          ] ? (
-                            <button
-                              type="button"
-                              className="secondary"
-                              aria-label={`Retry upload for objective attachment ${file.name}`}
-                              title={`Retry upload for objective attachment ${file.name}`}
-                              onClick={() =>
-                                clearAttachmentTargetError(
-                                  attachmentTargetKey("objective"),
-                                )
-                              }
-                            >
-                              Retry
-                            </button>
-                          ) : null}
-                          <button
-                            type="button"
-                            className="secondary"
-                            aria-label={`Remove objective attachment ${file.name}`}
-                            title={`Remove objective attachment ${file.name}`}
-                            onClick={() => removeObjectiveAttachment(file)}
-                          >
-                            Remove
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
             <div className="actions queue-template-actions">
               {taskTemplateSaveEnabled ? (
                 <button
@@ -7675,17 +7423,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <TrashIcon />
                 </button>
               ) : null}
-              <button
-                type="button"
-                id="queue-template-apply"
-                onClick={handleApplyPreset}
-                aria-disabled={applyPresetDisabled}
-                aria-busy={isApplyingPreset}
-                title={applyPresetTooltip}
-                disabled={applyPresetDisabled}
-              >
-                {presetReapplyNeeded ? "Reapply preset" : "Apply"}
-              </button>
             </div>
             <p className="small" id="queue-template-message">
               {presetStatusText}

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3335,8 +3335,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     },
   });
 
-  const jiraBoardProjectKey =
-    selectedJiraProjectKey || jiraIntegration?.defaultProjectKey || "";
+  const jiraBoardProjectKey = jiraBrowserOpen
+    ? selectedJiraProjectKey
+    : selectedJiraProjectKey || jiraIntegration?.defaultProjectKey || "";
   const jiraBoardsQuery = useQuery({
     queryKey: [
       "task-create",
@@ -3643,6 +3644,76 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       return (await response.json()) as TaskTemplateDetail;
+    },
+  });
+  const selectedPresetInputs = selectedPresetDetailQuery.data?.inputs || [];
+  const visiblePresetInputs = selectedPresetInputs.filter((definition) =>
+    isVisiblePresetInput(selectedPreset?.slug, definition),
+  );
+  const presetJiraProjectInput = visiblePresetInputs.find((definition) =>
+    isJiraProjectInputKey(definition.name),
+  );
+  const presetJiraBoardInput = visiblePresetInputs.find(
+    (definition) => definition.type === "jira_board",
+  );
+  const presetJiraProjectKey = String(
+    (presetJiraProjectInput
+      ? templateInputValues[presetJiraProjectInput.name] ??
+        presetJiraProjectInput.default
+      : "") ||
+      jiraIntegration?.defaultProjectKey ||
+      "",
+  ).trim();
+  const presetNeedsJiraProjects = Boolean(
+    jiraIntegration?.enabled &&
+      (presetJiraProjectInput || presetJiraBoardInput),
+  );
+  const presetJiraProjectsQuery = useQuery({
+    queryKey: [
+      "task-create",
+      "preset-jira",
+      "projects",
+      jiraIntegration?.endpoints.projects,
+    ],
+    enabled: presetNeedsJiraProjects,
+    queryFn: async (): Promise<JiraProject[]> => {
+      const endpoint = jiraIntegration?.endpoints.projects || "";
+      const response = await fetch(endpoint, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load Jira projects."),
+        );
+      }
+      return readJiraItems<JiraProject>(await response.json());
+    },
+  });
+  const presetJiraBoardsQuery = useQuery({
+    queryKey: [
+      "task-create",
+      "preset-jira",
+      "boards",
+      jiraIntegration?.endpoints.boards,
+      presetJiraProjectKey,
+    ],
+    enabled: Boolean(
+      jiraIntegration?.enabled && presetJiraBoardInput && presetJiraProjectKey,
+    ),
+    queryFn: async (): Promise<JiraBoard[]> => {
+      const endpoint = interpolatePath(
+        jiraIntegration?.endpoints.boards || "",
+        { projectKey: presetJiraProjectKey },
+      );
+      const response = await fetch(endpoint, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load Jira boards."),
+        );
+      }
+      return readJiraItems<JiraBoard>(await response.json());
     },
   });
   const selectedPresetDeleteEnabled =
@@ -4171,6 +4242,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
   }
 
+  function handleTemplateFeatureRequestChange(value: string) {
+    setTemplateFeatureRequest(value);
+    setPresetJiraProvenance(null);
+    updatePresetReapplyStateForObjective(value, selectedObjectiveAttachmentFiles);
+  }
+
   function addDependency(workflowId: string) {
     const normalizedId = workflowId.trim();
     if (!normalizedId) {
@@ -4240,10 +4317,48 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     });
   }
 
+  function updateObjectiveAttachments(files: File[]) {
+    const limitMessage = attachmentLimitMessage(attachmentPolicy);
+    const nextTotalCount =
+      files.length +
+      Object.values(selectedStepAttachmentFiles).flat().length +
+      persistedAttachmentRefs.length;
+    if (nextTotalCount > attachmentPolicy.maxCount) {
+      setSubmitMessage(limitMessage);
+      return;
+    }
+    if (submitMessage === limitMessage) {
+      setSubmitMessage(null);
+    }
+    clearAttachmentTargetError(attachmentTargetKey("objective"));
+    setSelectedObjectiveAttachmentFiles(files);
+    updatePresetReapplyStateForObjective(templateFeatureRequest, files);
+  }
+
   function removePersistedObjectiveAttachment(artifactId: string) {
     setPersistedObjectiveAttachments((current) =>
       current.filter((attachment) => attachment.artifactId !== artifactId),
     );
+  }
+
+  function removeObjectiveAttachment(fileToRemove: File) {
+    const targetKey = attachmentTargetKey("objective");
+    const previewKey = `${targetKey}:${attachmentFileKey(fileToRemove)}`;
+    setAttachmentTargetErrors((current) => {
+      const next = { ...current };
+      delete next[targetKey];
+      return next;
+    });
+    setPreviewFailureMessages((current) => {
+      const next = { ...current };
+      delete next[previewKey];
+      return next;
+    });
+    setSelectedObjectiveAttachmentFiles((current) => {
+      const next = current.filter((file) => file !== fileToRemove);
+      updatePresetReapplyStateForObjective(templateFeatureRequest, next);
+      return next;
+    });
   }
 
   function removePersistedStepAttachment(localId: string, artifactId: string) {
@@ -4849,6 +4964,33 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     return String(definition.default ?? "").trim();
   }
 
+  function templateInputDisplayValue(
+    definition: TaskTemplateInputDefinition,
+  ): string {
+    return presetInputDisplayValue(definition, templateInputValues);
+  }
+
+  function updateTemplateInputValue(
+    definition: TaskTemplateInputDefinition,
+    value: string | boolean,
+  ) {
+    const normalized = value;
+    setTemplateInputValues((current) => {
+      const next = { ...current, [definition.name]: normalized };
+      if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
+        next[presetJiraBoardInput.name] = "";
+      }
+      return next;
+    });
+    templateInputMemoryRef.current[definition.name] = normalized;
+    if (isJiraProjectInputKey(definition.name) && presetJiraBoardInput) {
+      templateInputMemoryRef.current[presetJiraBoardInput.name] = "";
+    }
+    if (appliedTemplates.length > 0) {
+      setPresetReapplyNeeded(true);
+    }
+  }
+
   async function loadPresetDetail(
     preset: TemplateOption,
   ): Promise<TaskTemplateDetail> {
@@ -5065,6 +5207,57 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setMessage(
       `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`,
     );
+  }
+
+  async function applyPresetToDraft({
+    preset,
+    detail,
+    inputValues,
+    setMessage,
+  }: {
+    preset: TemplateOption;
+    detail: TaskTemplateDetail;
+    inputValues: Record<string, unknown>;
+    setMessage: (message: string) => void;
+  }) {
+    const preview = await expandPresetForDraft({ preset, detail, inputValues });
+    applyPresetPreviewToDraft({ preset, detail, preview, setMessage });
+  }
+
+  async function handleApplyPreset() {
+    if (isApplyingPreset) return;
+    if (!selectedPreset) {
+      setTemplateMessage("Choose a preset first.");
+      return;
+    }
+    const detail = selectedPresetDetailQuery.data;
+    if (!detail) {
+      setTemplateMessage(
+        selectedPresetDetailQuery.isError
+          ? "Failed to load preset details."
+          : "Preset options are still loading.",
+      );
+      return;
+    }
+    setIsApplyingPreset(true);
+    setPresetReapplyNeeded(false);
+    setTemplateMessage("Applying preset...");
+
+    try {
+      await applyPresetToDraft({
+        preset: selectedPreset,
+        detail,
+        inputValues: templateInputValues,
+        setMessage: setTemplateMessage,
+      });
+      setPresetReapplyNeeded(false);
+    } catch (error) {
+      const failure =
+        error instanceof Error ? error : new Error("Failed to apply preset.");
+      setTemplateMessage(`Failed to apply preset: ${failure.message}`);
+    } finally {
+      setIsApplyingPreset(false);
+    }
   }
 
   async function handlePreviewStepPreset(localId: string) {
@@ -6356,6 +6549,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the task starts";
   const publishModeTooltip = "Select how MoonMind publishes task changes";
+  const applyPresetDisabled = Boolean(
+    isApplyingPreset || (selectedPreset && selectedPresetDetailQuery.isLoading),
+  );
   const applyPresetTooltip = presetReapplyNeeded
     ? "Reapply the selected preset to update preset-derived steps"
     : selectedPreset && selectedPresetDetailQuery.isLoading
@@ -7305,7 +7501,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           !step.presetPreview
                         }
                         aria-busy={isApplyingPreset}
-                        title={applyPresetTooltip}
+                        title="Apply the previewed preset to this step"
                         disabled={
                           isApplyingPreset ||
                           !step.presetKey ||
@@ -7412,6 +7608,309 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 ))}
               </datalist>
             </label>
+            <label>
+              Preset
+              <select
+                id="queue-template-preset-select"
+                value={selectedPresetKey}
+                onChange={(event) => {
+                  const nextKey = event.target.value;
+                  const nextPreset =
+                    templateItems.find((item) => item.key === nextKey) || null;
+                  setSelectedPresetKey(nextKey);
+                  setPresetManagementName(nextPreset?.title || "");
+                  setTemplateInputValues({});
+                  templateInputMemoryRef.current = {};
+                  setTemplateMessage(null);
+                  setPresetReapplyNeeded(false);
+                }}
+              >
+                <option value="">Select preset...</option>
+                {templateItems.map((item) => (
+                  <option key={item.key} value={item.key}>
+                    {`${item.title} (${scopeLabel(item.scope)})`}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="stack">
+              <div className="queue-field-heading">
+                <label htmlFor="queue-template-feature-request">
+                  Feature Request / Initial Instructions
+                </label>
+                <JiraProvenanceChip
+                  label="Feature Request / Initial Instructions"
+                  provenance={presetJiraProvenance}
+                />
+                {jiraIntegration?.enabled ? (
+                  <button
+                    type="button"
+                    className="secondary jira-browse-button"
+                    aria-label="Browse Jira issues for preset instructions"
+                    title="Browse Jira issues for preset instructions"
+                    onClick={() => openJiraBrowser({ kind: "preset" })}
+                  >
+                    Browse Jira issue
+                  </button>
+                ) : null}
+              </div>
+              <textarea
+                id="queue-template-feature-request"
+                placeholder="Describe the feature request this preset should execute."
+                value={templateFeatureRequest}
+                onChange={(event) =>
+                  handleTemplateFeatureRequestChange(event.target.value)
+                }
+              />
+              {selectedPresetDetailQuery.isError ? (
+                <p className="notice small">Failed to load preset options.</p>
+              ) : null}
+              {visiblePresetInputs.length > 0 ? (
+                <div className="grid-2">
+                  {visiblePresetInputs.map((definition) => {
+                    const inputId = `queue-template-input-${definition.name}`;
+                    const value = templateInputDisplayValue(definition);
+                    if (
+                      isJiraProjectInputKey(definition.name) &&
+                      jiraIntegration?.enabled
+                    ) {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            disabled={
+                              presetJiraProjectsQuery.isLoading ||
+                              presetJiraProjectsQuery.isError
+                            }
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            <option value="">Select project...</option>
+                            {(presetJiraProjectsQuery.data || []).map((project) => (
+                              <option
+                                key={project.projectKey}
+                                value={project.projectKey}
+                              >
+                                {project.name
+                                  ? `${project.name} (${project.projectKey})`
+                                  : project.projectKey}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "jira_board") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            disabled={
+                              !presetJiraProjectKey ||
+                              presetJiraBoardsQuery.isLoading ||
+                              presetJiraBoardsQuery.isError
+                            }
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            <option value="">No board selected</option>
+                            {(presetJiraBoardsQuery.data || []).map((board) => (
+                              <option key={board.id} value={board.id}>
+                                {board.name || board.id}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "enum") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <select
+                            id={inputId}
+                            value={value}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            {(definition.options || []).map((option) => (
+                              <option key={option} value={option}>
+                                {templateEnumOptionLabel(definition, option)}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      );
+                    }
+                    if (definition.type === "boolean") {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <input
+                            id={inputId}
+                            type="checkbox"
+                            checked={value === "true"}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.checked,
+                              )
+                            }
+                          />
+                        </label>
+                      );
+                    }
+                    if (
+                      definition.type === "textarea" ||
+                      definition.type === "markdown"
+                    ) {
+                      return (
+                        <label key={definition.name} htmlFor={inputId}>
+                          {definition.label}
+                          <textarea
+                            id={inputId}
+                            value={value}
+                            placeholder={definition.placeholder || ""}
+                            onChange={(event) =>
+                              updateTemplateInputValue(
+                                definition,
+                                event.target.value,
+                              )
+                            }
+                          />
+                        </label>
+                      );
+                    }
+                    return (
+                      <label key={definition.name} htmlFor={inputId}>
+                        {definition.label}
+                        <input
+                          id={inputId}
+                          type="text"
+                          value={value}
+                          placeholder={definition.placeholder || ""}
+                          onChange={(event) =>
+                            updateTemplateInputValue(
+                              definition,
+                              event.target.value,
+                            )
+                          }
+                        />
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : null}
+              {presetJiraProjectsQuery.isError ? (
+                <p className="notice small">Failed to load Jira projects.</p>
+              ) : null}
+              {presetJiraBoardsQuery.isError ? (
+                <p className="notice small">Failed to load Jira boards.</p>
+              ) : null}
+              {attachmentPolicy.enabled ? (
+                <div className="queue-step-attachments">
+                  <label>
+                    {`Feature Request / Initial Instructions ${attachmentLabel}`}
+                    <input
+                      type="file"
+                      data-step-field="objective-attachments"
+                      accept={attachmentPolicy.allowedContentTypes.join(",")}
+                      multiple
+                      aria-label="Feature Request / Initial Instructions attachments"
+                      onChange={(event) => {
+                        updateObjectiveAttachments(
+                          Array.from(event.currentTarget.files || []),
+                        );
+                        event.currentTarget.value = "";
+                      }}
+                    />
+                  </label>
+                  {attachmentTargetErrors[attachmentTargetKey("objective")] ? (
+                    <p className="notice error">
+                      {attachmentTargetErrors[attachmentTargetKey("objective")]}
+                    </p>
+                  ) : null}
+                  {selectedObjectiveAttachmentFiles.length > 0 ? (
+                    <ul className="list queue-step-attachments-list">
+                      {selectedObjectiveAttachmentFiles.map((file) => (
+                        <li key={`${file.name}-${file.size}-${file.lastModified}`}>
+                          <span>
+                            <strong>{file.name}</strong>{" "}
+                            <span className="small">
+                              {`${file.type || "application/octet-stream"}, ${formatAttachmentBytes(file.size)}`}
+                            </span>
+                          </span>
+                          <AttachmentPreview
+                            file={file}
+                            alt={`Preview of objective attachment ${file.name}`}
+                            onError={() =>
+                              markAttachmentPreviewFailed(
+                                attachmentTargetKey("objective"),
+                                "Feature Request / Initial Instructions",
+                                file,
+                              )
+                            }
+                          />
+                          {previewFailureMessages[
+                            `${attachmentTargetKey("objective")}:${attachmentFileKey(file)}`
+                          ] ? (
+                            <p className="small notice error">
+                              {
+                                previewFailureMessages[
+                                  `${attachmentTargetKey("objective")}:${attachmentFileKey(file)}`
+                                ]
+                              }
+                            </p>
+                          ) : null}
+                          {attachmentTargetErrors[
+                            attachmentTargetKey("objective")
+                          ] ? (
+                            <button
+                              type="button"
+                              className="secondary"
+                              aria-label={`Retry upload for objective attachment ${file.name}`}
+                              title={`Retry upload for objective attachment ${file.name}`}
+                              onClick={() =>
+                                clearAttachmentTargetError(
+                                  attachmentTargetKey("objective"),
+                                )
+                              }
+                            >
+                              Retry
+                            </button>
+                          ) : null}
+                          <button
+                            type="button"
+                            className="secondary"
+                            aria-label={`Remove objective attachment ${file.name}`}
+                            title={`Remove objective attachment ${file.name}`}
+                            onClick={() => removeObjectiveAttachment(file)}
+                          >
+                            Remove
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
             <div className="actions queue-template-actions">
               {taskTemplateSaveEnabled ? (
                 <button
@@ -7447,6 +7946,20 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               {presetStatusText}
             </p>
           </section>
+        ) : null}
+        {taskTemplateCatalogEnabled ? (
+          <button
+            type="button"
+            id="queue-template-apply"
+            className="secondary queue-template-apply-button"
+            onClick={handleApplyPreset}
+            aria-disabled={applyPresetDisabled}
+            aria-busy={isApplyingPreset}
+            title={applyPresetTooltip}
+            disabled={applyPresetDisabled}
+          >
+            {presetReapplyNeeded ? "Reapply preset" : "Apply"}
+          </button>
         ) : null}
 
         <section

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2598,6 +2598,10 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   border-color: rgb(var(--mm-accent) / 0.62);
 }
 
+.queue-step-type-option-label::before {
+  content: attr(data-label);
+}
+
 .queue-step-instructions-block {
   order: 3;
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2564,13 +2564,48 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   padding: 0;
 }
 
-.queue-step-type-field select {
-  max-width: 16rem;
+.queue-step-type-field {
+  border: 0;
+  margin: 0;
+  order: 1;
+  padding: 0;
+}
+
+.queue-step-type-field legend {
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+.queue-step-type-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.queue-step-type-option {
+  align-items: center;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 0.45rem;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.7rem;
+}
+
+.queue-step-type-option:has(input:checked) {
+  background: rgb(var(--mm-accent) / 0.13);
+  border-color: rgb(var(--mm-accent) / 0.62);
+}
+
+.queue-step-instructions-block {
+  order: 3;
 }
 
 .queue-step-type-panel {
   border: 1px solid rgb(var(--mm-border));
   border-radius: 8px;
+  order: 2;
   padding: 0.75rem;
   background: rgb(var(--mm-panel) / 0.58);
 }


### PR DESCRIPTION
There are a number of issues with the new step type selector that I want to improve:

1. Step Type should be in the order Skill, Tool, Preset, with the default being Skill
2. There should be a three-way radio button with the 3 options (skill, tool, preset) where you can just select the step type in one click (instead of a dropdown which requires 2 clicks
3. The description which appears under the dropdown like "Skill asks an agent to perform work using reusable behavior." should instead be tooltips if you hover over the radio button labels
4. The Task Presets section should become the Preset Management section and just allow for saving or deleting presets. The Preset dropdown should become the Preset Name field and allow you to type a new name for a new preset you want to create and save. Instructions, images, and similar should be removed.
5. When you select Step Type Preset, the instructions box should be used as what was previously the "Feature Request / Initial Instructions" box. The conditional options that normally appeared when you chose a preset in the past should appear for the step when you choose a preset, e.g. Jira Orchestrate asks for Jira Issue Key.
6. The box where you choose which tool, skill, or preset to use should appear right underneath the radio button and above the instructions.