### PR TITLE
[codex] Fix managed skill projection collisions

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,37 @@
 [
   {
-    "id": 4349179564,
+    "id": 4355930654,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier limit notice; no code action requested."
+    "rationale": "Qodo free-tier notification only; no code or documentation action requested."
   },
   {
-    "id": 3165251939,
+    "id": 3170697440,
     "disposition": "addressed",
-    "rationale": "Removed the dead templateInputValues state and made resolveTemplateInputs default to an empty explicit input object."
+    "rationale": "Normalized selected_skill before comparing it against normalized resolved skill names in MoonMindRunWorkflow."
   },
   {
-    "id": 4201983734,
+    "id": 3170697446,
     "disposition": "addressed",
-    "rationale": "Broad Gemini review summary; the actionable child comments covering dead state, radio accessibility, hidden select removal, duplicated filtering, and Step Type coverage were addressed."
+    "rationale": "Made directory clearing reject symlinked and non-directory paths before deleting children, with regression coverage preserving a symlink target sentinel."
   },
   {
-    "id": 3165251942,
+    "id": 3170697450,
     "disposition": "addressed",
-    "rationale": "Replaced the clickable div Step Type option wrapper with a label wrapper and removed the redundant wrapper onClick and radio aria-label."
+    "rationale": "Aligned SkillSystem docs with the transactional preserve-and-link fallback and its restore/publication guard requirements."
   },
   {
-    "id": 3165251945,
-    "disposition": "addressed",
-    "rationale": "Removed the hidden Step Type select and updated tests to use the radio controls."
-  },
-  {
-    "id": 3165251949,
-    "disposition": "addressed",
-    "rationale": "Factored visible preset input filtering into a visiblePresetInputs variable before the JSX block."
-  },
-  {
-    "id": 3165251953,
-    "disposition": "addressed",
-    "rationale": "Restored Step Type switching coverage by clicking radio options and checking the Tool, Skill, and Preset panels."
-  },
-  {
-    "id": 3165254042,
-    "disposition": "addressed",
-    "rationale": "Guarded async step preset detail updates so stale responses only apply when the step still has the same selected preset key, with a regression test."
-  },
-  {
-    "id": 4201985740,
+    "id": 4208365026,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper/summary only; the actionable Codex child comment was addressed separately."
+    "rationale": "Summary review; its actionable child comments are tracked and addressed individually."
+  },
+  {
+    "id": 4208377384,
+    "disposition": "not-applicable",
+    "rationale": "Codex review wrapper comment only; no actionable feedback."
+  },
+  {
+    "id": 3170708826,
+    "disposition": "addressed",
+    "rationale": "Delayed moving the checked-in skill tree until active materialization and manifest writing succeed, and added restore-on-projection-failure behavior plus regression coverage."
   }
 ]

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -900,11 +900,19 @@ files:
 3. **Symlink projection**: create or update `.agents/skills` only when that path
    is absent, already a MoonMind-owned projection link, or the workspace is an
    explicitly disposable non-publishing clone.
+4. **Transactional preserve-and-link fallback**: when a managed job checkout is
+   disposable but also the source used for publication, the adapter may move an
+   existing repo-authored `.agents/skills` directory into run-scoped preservation
+   storage and link the active backing store in its place only after active
+   materialization has succeeded. This fallback must restore the original tree
+   on projection failure and publication must exclude projection-only changes.
 
 Adapters must not replace a tracked or repo-authored `.agents/skills` directory
 with a symlink in the publishable checkout as the normal projection mechanism.
-That creates git-visible churn and can accidentally publish deletion or symlink
-changes for repo Skill sources.
+Any transient fallback must be treated as runtime state, not user-authored work.
+That means the fallback cannot be installed before active materialization is
+known-good, cannot leave the checkout damaged on failure, and cannot publish
+deletion or symlink changes for repo Skill sources.
 
 ### 14.5 Inline Activation Summary
 
@@ -997,7 +1005,7 @@ publishable workspace.
 | `.agents` is a directory and `.agents/skills` missing | Project active root. | No |
 | `.agents/skills` is a MoonMind-owned symlink to the same backing store | Reuse it. | No |
 | `.agents/skills` is a MoonMind-owned stale symlink | Replace it with the current active projection and record the replacement. | No |
-| `.agents/skills` is a checked-in directory | Prefer runtime namespace projection or isolated execution workspace. Do not rewrite the directory in the publishable checkout. | No, unless no safe projection strategy exists |
+| `.agents/skills` is a checked-in directory | Prefer runtime namespace projection or isolated execution workspace. If unavailable, use transactional preserve-and-link only with restore-on-failure and publication guards. | No, unless no safe projection strategy exists |
 | `.agents` is a file | Fail before runtime launch with actionable diagnostics. | Yes |
 | `.agents/skills` is a file | Fail before runtime launch with actionable diagnostics. | Yes |
 | `.agents/skills` is an external or unknown symlink | Replace only if ownership can be proven; otherwise fail before runtime launch. | Conditional |
@@ -1024,8 +1032,10 @@ Projection must satisfy all of these invariants before the runtime starts:
 1. `.agents/skills` as seen by the agent resolves to the active backing store.
 2. the visible active tree contains only the selected Skills and MoonMind-owned
    metadata.
-3. repo-authored Skill input directories are not rewritten, deleted, or converted
-   to symlinks in the publishable checkout.
+3. repo-authored Skill input directories are not lost, published as deletions,
+   or published as symlinks. Any transient preserve-and-link fallback must keep
+   a run-scoped preserved copy, restore on projection failure, and be excluded
+   from publication as runtime state.
 4. the runtime is not instructed to read an alternate visible path as a silent
    fallback.
 5. the projection decision and any collision remediation are recorded in runtime
@@ -1066,8 +1076,10 @@ The managed-runtime implementation should enforce this plan:
    adapter capabilities. Decide whether to use runtime namespace projection,
    isolated execution workspace, or symlink projection.
 4. **Protect publishable checkouts**: if `.agents/skills` is repo-authored or
-   tracked, do not replace it in the publishable checkout. Use a runtime
-   namespace projection or staging workspace instead.
+   tracked, prefer runtime namespace projection or a staging workspace. If an
+   adapter must use transactional preserve-and-link in a managed job checkout,
+   it must move the source only after active materialization succeeds, restore
+   it on projection failure, and prevent projection churn from being published.
 5. **Fail early when no safe projection exists**: hard collisions must stop
    before runtime launch and report path, object kind, attempted action,
    selected strategy, and remediation guidance.

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -884,6 +884,28 @@ The contract is:
 3. the runtime is not expected to discover Skills anywhere else;
 4. projection must fail before runtime launch if it cannot be installed safely.
 
+#### 14.4.1 Projection Strategy Order
+
+Managed runtime adapters should choose the first projection strategy that preserves
+the publishable repository workspace without changing checked-in Skill source
+files:
+
+1. **Runtime namespace projection**: bind mount or overlay the active backing
+   store at `.agents/skills` inside the launched runtime container, PTY, or
+   process namespace. This is preferred because the runtime sees the canonical
+   path while the repo checkout remains unchanged.
+2. **Isolated execution workspace**: run the agent in a prepared staging
+   workspace where `.agents/skills` can be owned by MoonMind, while publishing
+   code changes back to the canonical checkout through controlled sync rules.
+3. **Symlink projection**: create or update `.agents/skills` only when that path
+   is absent, already a MoonMind-owned projection link, or the workspace is an
+   explicitly disposable non-publishing clone.
+
+Adapters must not replace a tracked or repo-authored `.agents/skills` directory
+with a symlink in the publishable checkout as the normal projection mechanism.
+That creates git-visible churn and can accidentally publish deletion or symlink
+changes for repo Skill sources.
+
 ### 14.5 Inline Activation Summary
 
 Every managed runtime Skill step should include a compact activation block.
@@ -955,9 +977,31 @@ Examples:
 
 - `.agents` exists as a file;
 - `.agents/skills` exists as a file;
-- `.agents/skills` is an unreplaceable directory;
+- `.agents/skills` is a directory that cannot be masked through the runtime
+  namespace, staged outside the publishable checkout, or otherwise projected
+  without mutating repo-authored source files;
 - a stale symlink points to an incompatible backing store;
 - adapter or filesystem restrictions prevent projection.
+
+A checked-in `.agents/skills` directory is not by itself a business-logic
+failure. It is a normal source-input shape. It becomes a projection collision
+only if the selected adapter has no safe way to make the runtime see the active
+snapshot at `.agents/skills` without mutating that checked-in directory in the
+publishable workspace.
+
+#### 14.7.1 Collision Decision Table
+
+| Existing path | Desired handling | Terminal? |
+| --- | --- | --- |
+| `.agents` missing | Create adapter parent and project active root. | No |
+| `.agents` is a directory and `.agents/skills` missing | Project active root. | No |
+| `.agents/skills` is a MoonMind-owned symlink to the same backing store | Reuse it. | No |
+| `.agents/skills` is a MoonMind-owned stale symlink | Replace it with the current active projection and record the replacement. | No |
+| `.agents/skills` is a checked-in directory | Prefer runtime namespace projection or isolated execution workspace. Do not rewrite the directory in the publishable checkout. | No, unless no safe projection strategy exists |
+| `.agents` is a file | Fail before runtime launch with actionable diagnostics. | Yes |
+| `.agents/skills` is a file | Fail before runtime launch with actionable diagnostics. | Yes |
+| `.agents/skills` is an external or unknown symlink | Replace only if ownership can be proven; otherwise fail before runtime launch. | Conditional |
+| Filesystem or adapter cannot mount, overlay, stage, or link safely | Fail before runtime launch with actionable diagnostics. | Yes |
 
 Preferred behavior:
 
@@ -972,6 +1016,20 @@ Projection failures must include:
 - conflicting object kind,
 - attempted projection action,
 - remediation guidance.
+
+#### 14.7.2 Hard Invariants
+
+Projection must satisfy all of these invariants before the runtime starts:
+
+1. `.agents/skills` as seen by the agent resolves to the active backing store.
+2. the visible active tree contains only the selected Skills and MoonMind-owned
+   metadata.
+3. repo-authored Skill input directories are not rewritten, deleted, or converted
+   to symlinks in the publishable checkout.
+4. the runtime is not instructed to read an alternate visible path as a silent
+   fallback.
+5. the projection decision and any collision remediation are recorded in runtime
+   metadata or diagnostics.
 
 ### 14.8 Adapter Responsibilities
 
@@ -992,6 +1050,36 @@ A managed runtime adapter must not:
 2. silently fall back to a different visible path;
 3. treat runtime commands as Skills;
 4. mutate the active bundle as a way of changing policy.
+
+### 14.9 Robust Implementation Plan
+
+The managed-runtime implementation should enforce this plan:
+
+1. **Resolve and snapshot first**: resolution may read repo and local Skill
+   sources according to policy, then writes an immutable `ResolvedSkillSet` or
+   snapshot ref. Runtime projection must consume this snapshot and must not
+   rescan the repo.
+2. **Materialize outside the repo**: write selected Skill bundles and
+   `_manifest.json` under a run-scoped backing store such as
+   `/work/agent_jobs/<job_id>/runtime/skills_active/<snapshot_id>/`.
+3. **Plan projection before launch**: inspect `.agents`, `.agents/skills`, and
+   adapter capabilities. Decide whether to use runtime namespace projection,
+   isolated execution workspace, or symlink projection.
+4. **Protect publishable checkouts**: if `.agents/skills` is repo-authored or
+   tracked, do not replace it in the publishable checkout. Use a runtime
+   namespace projection or staging workspace instead.
+5. **Fail early when no safe projection exists**: hard collisions must stop
+   before runtime launch and report path, object kind, attempted action,
+   selected strategy, and remediation guidance.
+6. **Inject compact instructions**: the instruction payload names active Skills,
+   says full content is under `.agents/skills`, and gives first-read hints
+   without embedding full Skill bodies.
+7. **Verify the actual runtime view**: before submitting the turn, adapter
+   boundary tests and runtime preflight checks should confirm the agent-visible
+   `.agents/skills/_manifest.json` matches the supplied snapshot.
+8. **Publish only task changes**: publication logic must exclude runtime
+   projection artifacts and must not commit changes caused only by Skill
+   projection.
 
 ---
 

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -57,14 +57,19 @@ class AgentSkillMaterializer:
             active_dir = self.backing_root or self.workspace_root / "skills_active"
             visible_dir = self.workspace_root / ".agents" / "skills"
             manifest_path = active_dir / "_manifest.json"
+            preserve_visible_source = self._should_preserve_visible_source_dir(
+                visible_dir
+            )
 
-            self._preserve_existing_visible_source_dir(visible_dir)
-            self._validate_projection_path(visible_dir)
+            self._validate_projection_path(
+                visible_dir,
+                allow_existing_visible_dir=preserve_visible_source,
+            )
 
             try:
                 active_dir.mkdir(parents=True, exist_ok=True)
                 self._clear_directory(active_dir)
-            except OSError as ex:
+            except (OSError, RuntimeError) as ex:
                 raise RuntimeError(f"Failed to prepare skills_active directory: {ex}") from ex
 
             for skill in resolved_skillset.skills:
@@ -125,12 +130,16 @@ class AgentSkillMaterializer:
                 ) from ex
 
             try:
+                if preserve_visible_source:
+                    self._move_visible_source_to_preservation_root(visible_dir)
                 links = ensure_shared_skill_links(
                     run_root=self.workspace_root,
                     skills_active_path=active_dir,
                     require_gemini_link=False,
                 )
             except (OSError, SkillWorkspaceError) as ex:
+                if preserve_visible_source:
+                    self._restore_preserved_visible_source(visible_dir)
                 raise RuntimeError(
                     self._projection_error_message(visible_dir, cause=str(ex))
                 ) from ex
@@ -162,27 +171,36 @@ class AgentSkillMaterializer:
             
         return result
 
-    def _preserve_existing_visible_source_dir(self, visible_dir: Path) -> None:
+    def _should_preserve_visible_source_dir(self, visible_dir: Path) -> bool:
+        if self.source_preservation_root is None:
+            return False
+        if not visible_dir.exists() or visible_dir.is_symlink():
+            return False
+        return visible_dir.is_dir()
+
+    def _move_visible_source_to_preservation_root(self, visible_dir: Path) -> None:
         if self.source_preservation_root is None:
             return
-        if not visible_dir.exists() or visible_dir.is_symlink():
-            return
-        if not visible_dir.is_dir():
-            return
-
         try:
             self.source_preservation_root.parent.mkdir(parents=True, exist_ok=True)
             if self.source_preservation_root.exists():
-                self._clear_directory(self.source_preservation_root)
-            else:
-                self.source_preservation_root.mkdir(parents=True)
-            for child in visible_dir.iterdir():
-                target = self.source_preservation_root / child.name
-                if child.is_dir() and not child.is_symlink():
-                    shutil.copytree(child, target, symlinks=True)
-                else:
-                    shutil.copy2(child, target, follow_symlinks=False)
-            shutil.rmtree(visible_dir)
+                self._remove_directory_path(self.source_preservation_root)
+            shutil.move(str(visible_dir), str(self.source_preservation_root))
+        except OSError as ex:
+            raise RuntimeError(
+                self._projection_error_message(visible_dir, cause=str(ex))
+            ) from ex
+
+    def _restore_preserved_visible_source(self, visible_dir: Path) -> None:
+        if self.source_preservation_root is None:
+            return
+        try:
+            if visible_dir.is_symlink():
+                visible_dir.unlink()
+            elif visible_dir.exists():
+                self._remove_directory_path(visible_dir)
+            if self.source_preservation_root.exists():
+                shutil.move(str(self.source_preservation_root), str(visible_dir))
         except OSError as ex:
             raise RuntimeError(
                 self._projection_error_message(visible_dir, cause=str(ex))
@@ -190,11 +208,24 @@ class AgentSkillMaterializer:
 
     @staticmethod
     def _clear_directory(path: Path) -> None:
+        if path.is_symlink():
+            raise RuntimeError(f"refusing to clear symlinked directory: {path}")
+        if not path.is_dir():
+            raise RuntimeError(f"refusing to clear non-directory path: {path}")
         for child in path.iterdir():
             if child.is_dir() and not child.is_symlink():
                 shutil.rmtree(child)
             else:
                 child.unlink()
+
+    @staticmethod
+    def _remove_directory_path(path: Path) -> None:
+        if path.is_symlink():
+            raise RuntimeError(f"refusing to remove symlinked directory: {path}")
+        if path.is_dir():
+            shutil.rmtree(path)
+            return
+        path.unlink()
 
     @staticmethod
     def _extract_skill_bundle(payload: bytes, skill_dir: Path) -> None:
@@ -219,11 +250,20 @@ class AgentSkillMaterializer:
         if not (skill_dir / "SKILL.md").is_file():
             raise RuntimeError("skill bundle did not contain SKILL.md")
 
-    def _validate_projection_path(self, visible_dir: Path) -> None:
+    def _validate_projection_path(
+        self,
+        visible_dir: Path,
+        *,
+        allow_existing_visible_dir: bool = False,
+    ) -> None:
         agents_dir = visible_dir.parent
         if agents_dir.exists() and not agents_dir.is_dir():
             raise RuntimeError(self._projection_error_message(agents_dir))
-        if visible_dir.exists() and not visible_dir.is_symlink():
+        if (
+            visible_dir.exists()
+            and not visible_dir.is_symlink()
+            and not (allow_existing_visible_dir and visible_dir.is_dir())
+        ):
             raise RuntimeError(self._projection_error_message(visible_dir))
 
     @staticmethod

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -24,12 +24,18 @@ class AgentSkillMaterializer:
         workspace_root: str,
         artifact_service: Any | None = None,
         backing_root: str | None = None,
+        source_preservation_root: str | None = None,
     ) -> None:
         if not workspace_root:
             raise ValueError("workspace_root must be provided")
         self.workspace_root = Path(workspace_root).resolve()
         self._artifact_service = artifact_service
         self.backing_root = Path(backing_root).resolve() if backing_root else None
+        self.source_preservation_root = (
+            Path(source_preservation_root).resolve()
+            if source_preservation_root
+            else None
+        )
 
     async def materialize(
         self,
@@ -52,6 +58,7 @@ class AgentSkillMaterializer:
             visible_dir = self.workspace_root / ".agents" / "skills"
             manifest_path = active_dir / "_manifest.json"
 
+            self._preserve_existing_visible_source_dir(visible_dir)
             self._validate_projection_path(visible_dir)
 
             try:
@@ -154,6 +161,32 @@ class AgentSkillMaterializer:
             result.prompt_index_ref = f"index_{resolved_skillset.snapshot_id}"
             
         return result
+
+    def _preserve_existing_visible_source_dir(self, visible_dir: Path) -> None:
+        if self.source_preservation_root is None:
+            return
+        if not visible_dir.exists() or visible_dir.is_symlink():
+            return
+        if not visible_dir.is_dir():
+            return
+
+        try:
+            self.source_preservation_root.parent.mkdir(parents=True, exist_ok=True)
+            if self.source_preservation_root.exists():
+                self._clear_directory(self.source_preservation_root)
+            else:
+                self.source_preservation_root.mkdir(parents=True)
+            for child in visible_dir.iterdir():
+                target = self.source_preservation_root / child.name
+                if child.is_dir() and not child.is_symlink():
+                    shutil.copytree(child, target, symlinks=True)
+                else:
+                    shutil.copy2(child, target, follow_symlinks=False)
+            shutil.rmtree(visible_dir)
+        except OSError as ex:
+            raise RuntimeError(
+                self._projection_error_message(visible_dir, cause=str(ex))
+            ) from ex
 
     @staticmethod
     def _clear_directory(path: Path) -> None:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4067,10 +4067,14 @@ class TemporalAgentRuntimeActivities:
                 / "skills_active"
                 / resolved_skillset.snapshot_id
             )
+            skill_source_preservation_root = (
+                run_root / "runtime" / "skill_sources" / "repo_agents_skills"
+            )
             materializer = AgentSkillMaterializer(
                 workspace_root=str(workspace),
                 artifact_service=self._artifact_service,
                 backing_root=str(skills_backing_root),
+                source_preservation_root=str(skill_source_preservation_root),
             )
             await materializer.materialize(
                 resolved_skillset=resolved_skillset,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3928,8 +3928,9 @@ class MoonMindRunWorkflow:
             **self._execute_kwargs_for_route(route),
         )
         if selected_skill:
+            normalized_skill = str(selected_skill).strip().lower()
             resolved_skill_names = self._resolved_skillset_skill_names(resolved)
-            if selected_skill not in resolved_skill_names:
+            if normalized_skill not in resolved_skill_names:
                 raise ValueError(
                     f"selected skill '{selected_skill}' was not resolved into the "
                     "agent skill snapshot"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Optional, TypedDict
 
@@ -3927,6 +3927,13 @@ class MoonMindRunWorkflow:
             ],
             **self._execute_kwargs_for_route(route),
         )
+        if selected_skill:
+            resolved_skill_names = self._resolved_skillset_skill_names(resolved)
+            if selected_skill not in resolved_skill_names:
+                raise ValueError(
+                    f"selected skill '{selected_skill}' was not resolved into the "
+                    "agent skill snapshot"
+                )
         manifest_ref = self._resolved_skillset_field(
             resolved,
             "manifest_ref",
@@ -3940,6 +3947,36 @@ class MoonMindRunWorkflow:
             "snapshotId",
         )
         return str(snapshot_id) if snapshot_id else None
+
+    @staticmethod
+    def _resolved_skillset_skill_names(resolved: Any) -> set[str]:
+        if resolved is None:
+            return set()
+        skills = (
+            resolved.get("skills")
+            if isinstance(resolved, WorkflowMapping)
+            else getattr(resolved, "skills", None)
+        )
+        if not isinstance(skills, Iterable) or isinstance(skills, (str, bytes)):
+            return set()
+        names: set[str] = set()
+        for skill in skills:
+            if isinstance(skill, WorkflowMapping):
+                raw_name = (
+                    skill.get("skill_name")
+                    or skill.get("skillName")
+                    or skill.get("name")
+                )
+            else:
+                raw_name = (
+                    getattr(skill, "skill_name", None)
+                    or getattr(skill, "skillName", None)
+                    or getattr(skill, "name", None)
+                )
+            name = str(raw_name or "").strip().lower()
+            if name:
+                names.add(name)
+        return names
 
     @staticmethod
     def _resolved_skillset_field(resolved: Any, *keys: str) -> Any:

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -199,6 +199,60 @@ async def test_materializer_rejects_incompatible_agents_skills_path(tmp_path: Pa
     assert source_file.read_text(encoding="utf-8") == "do not rewrite"
 
 @pytest.mark.asyncio
+async def test_materializer_preserves_checked_in_skills_until_projection_ready(
+    tmp_path: Path,
+):
+    source_dir = tmp_path / ".agents" / "skills"
+    source_skill = source_dir / "repo-skill" / "SKILL.md"
+    source_skill.parent.mkdir(parents=True)
+    source_skill.write_text("checked-in source input\n", encoding="utf-8")
+    materializer = AgentSkillMaterializer(
+        str(tmp_path),
+        artifact_service=_StaticArtifactService({}),
+        source_preservation_root=str(tmp_path / "runtime" / "repo_agents_skills"),
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="missing_content_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[_skill("active", "missing-artifact")],
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to materialize content"):
+        await materializer.materialize(
+            resolved_skillset=skillset,
+            runtime_id="test_runtime",
+            mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+        )
+
+    assert source_dir.is_dir()
+    assert source_skill.read_text(encoding="utf-8") == "checked-in source input\n"
+    assert not (tmp_path / ".agents" / "skills").is_symlink()
+
+@pytest.mark.asyncio
+async def test_materializer_refuses_to_clear_symlinked_active_dir(tmp_path: Path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "keep.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    backing_link = tmp_path / "skills_active"
+    backing_link.symlink_to(outside)
+    materializer = AgentSkillMaterializer(str(tmp_path))
+    skillset = ResolvedSkillSet(
+        snapshot_id="symlink_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[],
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to clear symlinked directory"):
+        await materializer.materialize(
+            resolved_skillset=skillset,
+            runtime_id="test_runtime",
+            mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+@pytest.mark.asyncio
 async def test_materializer_does_not_block_on_incompatible_gemini_skills_path(
     tmp_path: Path,
 ):

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2637,7 +2637,7 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_prepare_turn_instructions_fails_when_active_projection_collides(
+async def test_agent_runtime_prepare_turn_instructions_preserves_checked_in_skills_before_projection(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2675,34 +2675,43 @@ async def test_agent_runtime_prepare_turn_instructions_fails_when_active_project
     )
     activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
 
-    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
-        await activities.agent_runtime_prepare_turn_instructions(
-            {
-                "request": {
-                    "agentKind": "managed",
-                    "agentId": "codex",
-                    "correlationId": "corr-1",
-                    "idempotencyKey": "idem-1",
-                    "resolvedSkillsetRef": "art-pr-resolver-snapshot",
-                    "parameters": {
-                        "instructions": "Resolve the PR.",
-                        "metadata": {
-                            "moonmind": {
-                                "selectedSkill": "pr-resolver",
-                            },
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "resolvedSkillsetRef": "art-pr-resolver-snapshot",
+                "parameters": {
+                    "instructions": "Resolve the PR.",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "pr-resolver",
                         },
                     },
                 },
-                "workspacePath": str(workspace),
-            }
-        )
+            },
+            "workspacePath": str(workspace),
+        }
+    )
 
-    message = str(exc_info.value)
-    assert "skill projection failed before runtime launch" in message
-    assert "object kind: directory" in message
-    assert (
-        checked_in_skill / "SKILL.md"
-    ).read_text(encoding="utf-8") == "checked-in source input\n"
+    assert result.startswith("Active MoonMind skill snapshot:")
+    visible_skills = workspace / ".agents" / "skills"
+    assert visible_skills.is_symlink()
+    assert (visible_skills / "pr-resolver" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == "resolved active body\n"
+    preserved_skill = (
+        managed_root
+        / "job-1"
+        / "runtime"
+        / "skill_sources"
+        / "repo_agents_skills"
+        / "pr-resolver"
+        / "SKILL.md"
+    )
+    assert preserved_skill.read_text(encoding="utf-8") == "checked-in source input\n"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -14,8 +14,21 @@ import pytest
 pytest.importorskip("temporalio")
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
-from moonmind.schemas.agent_skill_models import ResolvedSkillSet
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
+)
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _resolved_skill(skill_name: str) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name=skill_name,
+        provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN),
+    )
+
 
 class TestAgentKindForId(unittest.TestCase):
     """Verify the _agent_kind_for_id static method."""
@@ -234,7 +247,7 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             snapshot_id="skillset-wf-step-1",
             resolved_at=datetime.now(UTC),
             manifest_ref="artifact://skillsets/selected-skill",
-            skills=[],
+            skills=[_resolved_skill("moonspec-breakdown")],
         )
 
         with patch(
@@ -261,13 +274,77 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(kwargs["args"][1:], ["owner-1", "/workspace/repo", False, False])
 
+    async def test_agent_node_adds_selected_skill_to_task_level_selector(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/selected-skill",
+            skills=[
+                _resolved_skill("jira-breakdown-orchestrate"),
+                _resolved_skill("moonspec-breakdown"),
+            ],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills={"include": [{"name": "jira-breakdown-orchestrate"}]},
+                node_inputs={
+                    "selectedSkill": "moonspec-breakdown",
+                    "workspaceRoot": "/workspace/repo",
+                },
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/selected-skill")
+        args, kwargs = execute_activity.call_args
+        self.assertEqual(args, ("agent_skill.resolve",))
+        selector = kwargs["args"][0]
+        self.assertEqual(
+            [(entry.name, entry.version) for entry in selector.include],
+            [("jira-breakdown-orchestrate", None), ("moonspec-breakdown", None)],
+        )
+
+    async def test_agent_node_rejects_unresolved_selected_skill_before_launch(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/selected-skill",
+            skills=[_resolved_skill("jira-breakdown-orchestrate")],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "selected skill 'moonspec-breakdown' was not resolved",
+            ):
+                await wf._resolve_agent_node_skillset_ref(
+                    task_skills={"include": [{"name": "jira-breakdown-orchestrate"}]},
+                    node_inputs={
+                        "selectedSkill": "moonspec-breakdown",
+                        "workspaceRoot": "/workspace/repo",
+                    },
+                    node_id="step-1",
+                    existing_skillset_ref=None,
+                )
+
     async def test_agent_node_accepts_mapping_skill_resolution_result(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"
         resolved = {
             "snapshotId": "skillset-wf-step-1",
             "manifestRef": "artifact://skillsets/selected-skill",
-            "skills": [],
+            "skills": [{"skillName": "moonspec-breakdown"}],
         }
 
         with patch(


### PR DESCRIPTION
## Summary

Fixes managed-runtime skill projection when a target repository already contains a checked-in `.agents/skills` directory.

The failed workflow showed that `agent_runtime.prepare_turn_instructions` treated that normal repo skill-source shape as a hard projection collision. The runtime then retried the same setup failure and the plan node ended in `execution_error`.

## Changes

- Preserve existing repo-authored `.agents/skills` content into run-scoped runtime storage before installing the active projection for managed Codex turns.
- Materialize the resolved active snapshot at the canonical runtime-visible `.agents/skills` path so the agent sees only selected skills.
- Validate that selected skills are actually present in the resolved snapshot before launch.
- Tighten `docs/Steps/SkillSystem.md` with a collision decision table, projection strategy order, hard invariants, and a robust implementation plan.
- Add regression coverage for checked-in skill source preservation plus active projection.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/workflows/temporal/test_agent_runtime_activities.py -k 'preserves_checked_in_skills_before_projection' -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/services/test_skill_materialization.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/workflows/temporal/test_agent_runtime_activities.py -k 'skill or projection or prepare_turn_instructions' -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `git diff --check`
