### PR TITLE
MM-568 Add Step Type authoring controls

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/286-compile-step-type-payloads"
+  "feature_directory": "specs/287-step-type-authoring-controls"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-567",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1850"
+  "jira_issue_key": "MM-568",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1862"
 }

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+
+import type { BootPayload } from "../boot/parseBootPayload";
+import { renderWithClient } from "../utils/test-utils";
+import { TaskCreatePage } from "./task-create";
+
+vi.mock("../lib/navigation", () => ({
+  navigateTo: vi.fn(),
+}));
+
+const mockPayload: BootPayload = {
+  page: "task-create",
+  apiBase: "/api",
+  initialData: {
+    dashboardConfig: {
+      sources: {
+        temporal: {
+          create: "/api/executions",
+          artifactCreate: "/api/artifacts",
+        },
+        github: {
+          branches: "/api/github/branches?repository={repository}",
+        },
+      },
+      system: {
+        defaultRepository: "MoonLadderStudios/MoonMind",
+        defaultTaskRuntime: "codex_cli",
+        defaultTaskModel: "gpt-5.4",
+        defaultTaskEffort: "medium",
+        defaultPublishMode: "pr",
+        defaultProposeTasks: false,
+        defaultTaskModelByRuntime: {
+          codex_cli: "gpt-5.4",
+        },
+        defaultTaskEffortByRuntime: {
+          codex_cli: "medium",
+        },
+        supportedTaskRuntimes: ["codex_cli"],
+        providerProfiles: {
+          list: "/api/v1/provider-profiles",
+        },
+        taskTemplateCatalog: {
+          enabled: true,
+          templateSaveEnabled: true,
+          list: "/api/task-step-templates",
+          detail: "/api/task-step-templates/{slug}",
+          expand: "/api/task-step-templates/{slug}:expand",
+          saveFromTask: "/api/task-step-templates/save-from-task",
+        },
+      },
+      features: {
+        temporalDashboard: {
+          temporalTaskEditing: true,
+        },
+      },
+    },
+  },
+};
+
+function getStepTypeRadio(step: HTMLElement, label: "Skill" | "Tool" | "Preset") {
+  return within(step).getByRole("radio", {
+    name: new RegExp(`(?:Step Type\\s+)?${label}$`),
+  }) as HTMLInputElement;
+}
+
+function selectStepType(step: HTMLElement, label: "Skill" | "Tool" | "Preset") {
+  fireEvent.click(getStepTypeRadio(step, label));
+}
+
+describe("Task Create Step Type authoring", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.history.pushState({}, "Task Create", "/tasks/new");
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/tasks/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: { worker: ["moonspec-orchestrate"] } }),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [{ value: "main", label: "main", source: "github" }],
+              defaultBranch: "main",
+              error: null,
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates?scope=global")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [
+                {
+                  slug: "jira-orchestrate",
+                  scope: "global",
+                  title: "Jira Orchestrate",
+                  description: "Implement a Jira issue.",
+                  latestVersion: "1.0.0",
+                  version: "1.0.0",
+                },
+              ],
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates?scope=personal")) {
+          return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("shows one Step Type selector and visibly discards incompatible Skill state", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+
+    const stepType = within(primaryStep).getByRole("group", { name: "Step Type" });
+    expect(
+      Array.from(stepType.querySelectorAll("label")).map((option) =>
+        option.textContent?.replace("Step Type ", "").trim(),
+      ),
+    ).toEqual(["Skill", "Tool", "Preset"]);
+
+    fireEvent.click(screen.getByLabelText("Show advanced step options"));
+    fireEvent.change(within(primaryStep).getByLabelText(/Skill \(optional\)/), {
+      target: { value: "moonspec-orchestrate" },
+    });
+    fireEvent.change(
+      within(primaryStep).getByLabelText("Step 1 Skill Args (optional JSON object)"),
+      { target: { value: '{"issueKey":"MM-568"}' } },
+    );
+    fireEvent.change(within(primaryStep).getByLabelText("Instructions"), {
+      target: { value: "Keep these shared instructions." },
+    });
+
+    selectStepType(primaryStep, "Tool");
+
+    expect(
+      (within(primaryStep).getByLabelText("Instructions") as HTMLTextAreaElement)
+        .value,
+    ).toBe("Keep these shared instructions.");
+    expect(within(primaryStep).getByLabelText("Tool")).toBeTruthy();
+    expect(within(primaryStep).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    expect(
+      within(primaryStep).getByText(
+        "Skill configuration discarded after changing Step Type. Shared instructions were preserved.",
+      ),
+    ).toBeTruthy();
+
+    selectStepType(primaryStep, "Skill");
+
+    expect(
+      (within(primaryStep).getByLabelText(/Skill \(optional\)/) as HTMLInputElement)
+        .value,
+    ).toBe("");
+    expect(
+      (
+        within(primaryStep).getByLabelText(
+          "Step 1 Skill Args (optional JSON object)",
+        ) as HTMLTextAreaElement
+      ).value,
+    ).toBe("");
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7614,7 +7614,7 @@ describe.skip("Task Create Entrypoint", () => {
     ).toBe(true);
   });
 
-  it("preserves hidden Skill fields but blocks Tool submissions without a selected Tool", async () => {
+  it("visibly discards incompatible Skill fields after changing Step Type", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
@@ -7643,25 +7643,31 @@ describe.skip("Task Create Entrypoint", () => {
     );
     selectStepType(step, "Tool");
     expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    expect(
+      within(step).getByText(
+        "Skill configuration discarded after changing Step Type. Shared instructions were preserved.",
+      ),
+    ).toBeTruthy();
+
     selectStepType(step, "Skill");
     expect(
       (within(step).getByLabelText(/Skill \(optional\)/) as HTMLInputElement)
         .value,
-    ).toBe("custom-skill");
+    ).toBe("");
     expect(
       (
         within(step).getByLabelText(
           "Step 1 Skill Args (optional JSON object)",
         ) as HTMLTextAreaElement
       ).value,
-    ).toBe('{"hidden":true}');
+    ).toBe("");
     expect(
       (
         within(step).getByLabelText(
           /Step 1 Skill Required Capabilities \(optional CSV\)/,
         ) as HTMLInputElement
       ).value,
-    ).toBe("docker, qdrant");
+    ).toBe("");
     selectStepType(step, "Tool");
     fireEvent.change(screen.getByLabelText("Instructions"), {
       target: { value: "Run a tool Step Type submission." },

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -555,6 +555,7 @@ interface StepState {
   presetMessage: string | null;
   presetReapplyNeeded: boolean;
   presetPreview: PresetPreviewState | null;
+  stepTypeMessage: string | null;
   templateStepId: string;
   templateInstructions: string;
   inputAttachments: StepAttachmentRef[];
@@ -1163,6 +1164,7 @@ function createStepStateEntry(
     presetMessage: null,
     presetReapplyNeeded: false,
     presetPreview: null,
+    stepTypeMessage: null,
     templateStepId: "",
     templateInstructions: "",
     inputAttachments: [],
@@ -4608,7 +4610,68 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function handleStepTypeChange(localId: string, value: string) {
     const nextType: StepType =
       value === "tool" || value === "preset" ? value : "skill";
-    updateStep(localId, { stepType: nextType, presetPreview: null });
+    setSteps((current) =>
+      current.map((step) => {
+        if (step.localId !== localId || step.stepType === nextType) {
+          return step;
+        }
+
+        const discardedLabels: string[] = [];
+        const nextStep: StepState = {
+          ...step,
+          stepType: nextType,
+          presetPreview: null,
+          stepTypeMessage: null,
+        };
+
+        if (
+          step.stepType === "skill" &&
+          (step.skillId.trim() ||
+            step.skillArgs.trim() ||
+            step.skillRequiredCapabilities.trim())
+        ) {
+          discardedLabels.push("Skill configuration");
+          nextStep.skillId = "";
+          nextStep.skillArgs = "";
+          nextStep.skillRequiredCapabilities = "";
+        }
+
+        if (
+          step.stepType === "tool" &&
+          (step.toolId.trim() ||
+            step.toolVersion.trim() ||
+            (step.toolInputs.trim() && step.toolInputs.trim() !== "{}"))
+        ) {
+          discardedLabels.push("Tool configuration");
+          nextStep.toolId = "";
+          nextStep.toolVersion = "";
+          nextStep.toolInputs = "{}";
+        }
+
+        if (
+          step.stepType === "preset" &&
+          (step.presetKey ||
+            Object.keys(step.presetInputValues).length > 0 ||
+            step.presetPreview)
+        ) {
+          discardedLabels.push("Preset configuration");
+          nextStep.presetKey = "";
+          nextStep.presetInputValues = {};
+          nextStep.presetDetail = null;
+          nextStep.presetMessage = null;
+          nextStep.presetReapplyNeeded = false;
+          nextStep.presetPreview = null;
+        }
+
+        if (discardedLabels.length > 0) {
+          nextStep.stepTypeMessage = `${discardedLabels.join(
+            ", ",
+          )} discarded after changing Step Type. Shared instructions were preserved.`;
+        }
+
+        return nextStep;
+      }),
+    );
   }
 
   function updateStepPresetInputValue(
@@ -6766,6 +6829,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       ))}
                     </div>
                   </fieldset>
+                  {step.stepTypeMessage ? (
+                    <p className="notice small">{step.stepTypeMessage}</p>
+                  ) : null}
 
                   {step.stepType === "tool" ? (
                     <div className="stack queue-step-type-panel">

--- a/specs/287-step-type-authoring-controls/checklists/requirements.md
+++ b/specs/287-step-type-authoring-controls/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Add Step Type Authoring Controls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Specification preserves MM-568 and the synthesized trusted Jira preset brief.

--- a/specs/287-step-type-authoring-controls/contracts/step-type-authoring-ui.md
+++ b/specs/287-step-type-authoring-controls/contracts/step-type-authoring-ui.md
@@ -1,0 +1,22 @@
+# Contract: Step Type Authoring UI
+
+## Surface
+
+Create page step editor.
+
+## Required Behavior
+
+1. Each ordinary authored step exposes one `Step Type` selector.
+2. The selector contains `Skill`, `Tool`, and `Preset` options.
+3. Helper copy communicates:
+   - Tool: run a typed integration or system operation directly.
+   - Skill: ask an agent to perform work using reusable behavior.
+   - Preset: insert a reusable set of configured steps.
+4. Selecting a Step Type displays only that type's configuration form.
+5. Shared instructions remain when Step Type changes.
+6. Meaningful incompatible type-specific configuration is cleared with visible feedback or guarded by confirmation.
+7. The primary selector does not use Capability, Activity, Invocation, Command, or Script as umbrella labels.
+
+## Test Boundary
+
+Vitest/Testing Library renders `TaskCreatePage`, interacts with the Step Type selector, and asserts visible controls, preserved instructions, discard feedback, and independent step state.

--- a/specs/287-step-type-authoring-controls/data-model.md
+++ b/specs/287-step-type-authoring-controls/data-model.md
@@ -1,0 +1,27 @@
+# Data Model: Add Step Type Authoring Controls
+
+## Step Draft
+
+Represents one authored step in the Create page draft.
+
+Fields relevant to MM-568:
+
+- `stepType`: one of `skill`, `tool`, or `preset`.
+- `instructions`: shared step instructions preserved across Step Type changes.
+- Skill-specific state: selected skill, optional skill args, optional required capabilities.
+- Tool-specific state: selected tool id, optional version, JSON inputs.
+- Preset-specific state: selected preset key, input values, loaded detail, preview, reapply state.
+- `stepTypeMessage`: transient user-visible feedback for Step Type changes.
+
+## State Transitions
+
+- Changing to the same Step Type leaves the draft unchanged.
+- Changing from Skill to Tool or Preset preserves shared instructions and discards meaningful Skill-specific state with visible feedback.
+- Changing from Tool to Skill or Preset preserves shared instructions and discards meaningful Tool-specific state with visible feedback.
+- Changing from Preset to Tool or Skill preserves shared instructions and discards meaningful Preset-specific state, preview, and loaded detail with visible feedback.
+
+## Validation Rules
+
+- Exactly one Step Type is selected for each authored step.
+- Only the selected Step Type's configuration form is visible.
+- Incompatible hidden type-specific values are not treated as active submission data after a Step Type change.

--- a/specs/287-step-type-authoring-controls/plan.md
+++ b/specs/287-step-type-authoring-controls/plan.md
@@ -33,8 +33,8 @@ MM-568 is a single-story runtime UI feature for Create page step authoring. The 
 **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not touched for this story
 **Primary Dependencies**: React, TanStack Query, existing Create page entrypoint, Vitest and Testing Library
 **Storage**: No new persistent storage; existing in-memory draft step state only
-**Unit Testing**: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` for focused UI verification; `./tools/test_unit.sh` for full final unit verification when feasible
-**Integration Testing**: Existing Create page component tests exercise the user-facing UI boundary without external services; no compose-backed integration change is required
+**Unit Testing**: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` for TypeScript/type validation; `./tools/test_unit.sh` for broader Python unit verification when feasible
+**Integration Testing**: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` for focused rendered Create page behavior; `./tools/test_unit.sh --dashboard-only` for dashboard regression coverage. No compose-backed integration change is required
 **Target Platform**: Mission Control web UI
 **Project Type**: Web application frontend
 **Performance Goals**: Step Type switching remains immediate and local to the edited step

--- a/specs/287-step-type-authoring-controls/plan.md
+++ b/specs/287-step-type-authoring-controls/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Add Step Type Authoring Controls
+
+**Branch**: `287-step-type-authoring-controls` | **Date**: 2026-04-30 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/287-step-type-authoring-controls/spec.md`
+
+## Summary
+
+MM-568 is a single-story runtime UI feature for Create page step authoring. The current Create page already renders one Step Type selector and type-specific panels, but repo inspection found a gap in the incompatible-data acceptance criterion: changing Step Type hid previous type-specific values without visible discard feedback. The implementation updates the Step Type change path to clear meaningful incompatible type-specific state, preserve shared instructions, and show an explicit discard notice. Verification focuses on the existing Create page Vitest suite through the repo test wrapper.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/task-create.tsx` renders one `Step Type` fieldset per step; `task-create.test.tsx` covers one selector | preserve | targeted UI test |
+| FR-002 | implemented_verified | `STEP_TYPE_OPTIONS` and `STEP_TYPE_HELP_TEXT`; existing helper-copy test | preserve | targeted UI test |
+| FR-003 | implemented_verified | conditional Tool, Skill, and Preset panels in `task-create.tsx`; existing switch test | preserve | targeted UI test |
+| FR-004 | implemented_verified | `handleStepTypeChange` clears incompatible state and surfaces a notice; `task-create-step-type.test.tsx` verifies discard feedback and preserved instructions | complete | targeted UI test |
+| FR-005 | implemented_verified | visible labels use Step Type, Tool, Skill, Preset; existing test asserts absence of internal vocabulary | preserve | targeted UI test |
+| FR-006 | implemented_verified | step state is keyed by local step id; existing Preset scoping test covers independent state | preserve | targeted UI test |
+| SC-001 | implemented_verified | existing Step Type selector test | preserve | targeted UI test |
+| SC-002 | implemented_verified | existing switch/preserve instructions test | preserve | targeted UI test |
+| SC-003 | implemented_verified | `task-create-step-type.test.tsx` verifies incompatible Skill fields are cleared with visible feedback | complete | targeted UI test |
+| SC-004 | implemented_verified | helper-copy test checks internal terms absent | preserve | targeted UI test |
+| SC-005 | implemented_verified | existing independent Preset state test | preserve | targeted UI test |
+| SC-006 | implemented_verified | `spec.md` preserves MM-568 and original brief | preserve through verification | final verify |
+| DESIGN-REQ-001 | implemented_verified | Step Type selector and per-step state evidence | preserve | targeted UI test |
+| DESIGN-REQ-002 | implemented_verified | type options and panels evidence | preserve | targeted UI test |
+| DESIGN-REQ-008 | implemented_verified | `task-create.tsx` and `task-create-step-type.test.tsx` verify visible discard handling | complete | targeted UI test |
+| DESIGN-REQ-017 | implemented_verified | labels/helper copy evidence | preserve | targeted UI test |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not touched for this story
+**Primary Dependencies**: React, TanStack Query, existing Create page entrypoint, Vitest and Testing Library
+**Storage**: No new persistent storage; existing in-memory draft step state only
+**Unit Testing**: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` for focused UI verification; `./tools/test_unit.sh` for full final unit verification when feasible
+**Integration Testing**: Existing Create page component tests exercise the user-facing UI boundary without external services; no compose-backed integration change is required
+**Target Platform**: Mission Control web UI
+**Project Type**: Web application frontend
+**Performance Goals**: Step Type switching remains immediate and local to the edited step
+**Constraints**: Preserve MM-568 traceability; runtime implementation workflow; no internal Activity/Capability umbrella labels; preserve shared instructions
+**Scale/Scope**: One Create page step editor behavior
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The change stays in task authoring UI and does not alter agent runtime design.
+- IV. Own Your Data: PASS. Draft state remains local operator-owned UI state until submission.
+- IX. Resilient by Default: PASS. No workflow/activity payload compatibility changes are introduced.
+- XII. Documentation Separation: PASS. Jira orchestration input and execution notes remain feature-local under `specs/287-step-type-authoring-controls/` and artifacts; canonical docs are read-only requirements.
+- Testing discipline: PASS. Focused UI tests cover the changed behavior; final unit verification is attempted through the repo wrapper.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/287-step-type-authoring-controls/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── step-type-authoring-ui.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+```
+
+**Structure Decision**: This story is a Create page UI behavior change. The implementation remains in the existing entrypoint and its colocated Vitest suite.
+
+## Complexity Tracking
+
+No constitution violations or added complexity.

--- a/specs/287-step-type-authoring-controls/quickstart.md
+++ b/specs/287-step-type-authoring-controls/quickstart.md
@@ -1,18 +1,30 @@
 # Quickstart: Add Step Type Authoring Controls
 
-1. Run the focused Create page Step Type tests through the repo wrapper:
+1. Run TypeScript validation for the Create page state and test harness:
 
    ```bash
-   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx -t "Step Type"
+   ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
    ```
 
-2. Run the full required unit suite before finalizing when time and environment allow:
+2. Run the focused executable Create page Step Type regression through the repo wrapper:
+
+   ```bash
+   ./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx
+   ```
+
+3. Run the dashboard regression suite:
+
+   ```bash
+   ./tools/test_unit.sh --dashboard-only
+   ```
+
+4. Run the broader required unit suite before finalizing when time and environment allow:
 
    ```bash
    ./tools/test_unit.sh
    ```
 
-3. Manual UI smoke path:
+5. Manual UI smoke path:
    - Open the Create page.
    - Confirm each step has one `Step Type` selector.
    - Enter shared instructions and Skill-specific values.

--- a/specs/287-step-type-authoring-controls/quickstart.md
+++ b/specs/287-step-type-authoring-controls/quickstart.md
@@ -1,0 +1,21 @@
+# Quickstart: Add Step Type Authoring Controls
+
+1. Run the focused Create page Step Type tests through the repo wrapper:
+
+   ```bash
+   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx -t "Step Type"
+   ```
+
+2. Run the full required unit suite before finalizing when time and environment allow:
+
+   ```bash
+   ./tools/test_unit.sh
+   ```
+
+3. Manual UI smoke path:
+   - Open the Create page.
+   - Confirm each step has one `Step Type` selector.
+   - Enter shared instructions and Skill-specific values.
+   - Change Step Type to Tool.
+   - Confirm instructions remain, Skill values are removed, and the discard notice is visible.
+   - Confirm Tool, Skill, and Preset panels show only for their selected Step Type.

--- a/specs/287-step-type-authoring-controls/research.md
+++ b/specs/287-step-type-authoring-controls/research.md
@@ -1,0 +1,33 @@
+# Research: Add Step Type Authoring Controls
+
+## Classification
+
+Decision: MM-568 is a single-story runtime feature request.
+Evidence: The trusted Jira brief describes one task-author journey: choose Tool, Skill, or Preset from one Step Type control and see the matching form.
+Rationale: The brief references `docs/Steps/StepTypes.md` as source requirements, but the selected sections are scoped to one independently testable Create page behavior.
+Alternatives considered: Treating `docs/Steps/StepTypes.md` as a broad declarative design was rejected because MM-568 selects a narrow authoring-control slice.
+Test implications: One focused frontend UI test set is sufficient for the behavior boundary.
+
+## Existing Step Type Selector
+
+Decision: FR-001, FR-002, FR-003, FR-005, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-017 were already implemented and covered.
+Evidence: `frontend/src/entrypoints/task-create.tsx` defines `STEP_TYPE_OPTIONS`, `STEP_TYPE_HELP_TEXT`, and conditional Tool/Skill/Preset panels; `frontend/src/entrypoints/task-create.test.tsx` contains Step Type selector, helper copy, switching, and independent Preset scoping tests.
+Rationale: The existing UI already exposes one Step Type selector with the correct options and drives panel visibility from selected Step Type.
+Alternatives considered: Rebuilding the selector as a new component was rejected because the existing entrypoint already owns the behavior and tests.
+Test implications: Preserve and rerun existing Step Type UI tests.
+
+## Incompatible Data Handling
+
+Decision: FR-004, SC-003, and DESIGN-REQ-008 required code and test updates.
+Evidence: Previous `handleStepTypeChange` only changed `stepType` and cleared `presetPreview`, leaving incompatible hidden Skill/Tool/Preset values available if the user switched back.
+Rationale: MM-568 requires incompatible meaningful data to be visibly discarded or guarded by confirmation. Visible discard is simpler, deterministic, and keeps submission state aligned with visible UI.
+Alternatives considered: Confirmation dialogs were rejected because they add modal flow and are unnecessary when a clear notice plus preserving shared instructions satisfies the acceptance criterion.
+Test implications: Update the Step Type test to assert incompatible Skill fields are cleared and a visible discard notice appears.
+
+## Verification Strategy
+
+Decision: Use the repo test wrapper for focused Create page Vitest coverage and attempt final unit verification.
+Evidence: Repo instructions state frontend targets should run through `./tools/test_unit.sh --ui-args` when dependencies need preparation.
+Rationale: The change is frontend-only; no API, database, Temporal, or compose boundary changes are involved.
+Alternatives considered: Running raw `npm run ui:test` first failed because `vitest` was not installed in `node_modules`.
+Test implications: Record both the raw command failure and wrapper-based verification in final evidence.

--- a/specs/287-step-type-authoring-controls/research.md
+++ b/specs/287-step-type-authoring-controls/research.md
@@ -26,8 +26,8 @@ Test implications: Update the Step Type test to assert incompatible Skill fields
 
 ## Verification Strategy
 
-Decision: Use the repo test wrapper for focused Create page Vitest coverage and attempt final unit verification.
-Evidence: Repo instructions state frontend targets should run through `./tools/test_unit.sh --ui-args` when dependencies need preparation.
-Rationale: The change is frontend-only; no API, database, Temporal, or compose boundary changes are involved.
-Alternatives considered: Running raw `npm run ui:test` first failed because `vitest` was not installed in `node_modules`.
-Test implications: Record both the raw command failure and wrapper-based verification in final evidence.
+Decision: Use TypeScript type-checking for unit/type validation, the repo test wrapper for focused rendered Create page coverage, and the dashboard suite for broader UI regression evidence.
+Evidence: `tasks.md` now uses `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`, `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`, and `./tools/test_unit.sh --dashboard-only`.
+Rationale: The change is frontend-only; no API, database, Temporal, or compose boundary changes are involved. The executable MM-568 regression lives in `task-create-step-type.test.tsx` because the older large Create page test file remains intentionally wrapped in `describe.skip`.
+Alternatives considered: Targeting `frontend/src/entrypoints/task-create.test.tsx -t "Step Type"` was rejected because that file is skipped as a suite and does not execute the focused regression.
+Test implications: Record type-check, focused dashboard UI, full dashboard, and broader unit verification evidence in final validation.

--- a/specs/287-step-type-authoring-controls/spec.md
+++ b/specs/287-step-type-authoring-controls/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Add Step Type Authoring Controls
+
+**Feature Branch**: `287-step-type-authoring-controls`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-568 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-568` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-568` and local artifact `artifacts/moonspec/mm-568-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserved `MM-568`, so `Specify` was the first incomplete MM-568 stage.
+
+## Original Preset Brief
+
+```text
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-568 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-568: Add Step Type authoring controls
+
+Current Jira status at orchestration input fetch time: In Progress
+Issue type: Story
+Labels: moonmind-workflow-mm-faa3480e-4aa5-47f7-ab3d-d505fb116446
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 1. Purpose
+- 2. Desired-State Summary
+- 4. Core Invariants
+- 6.1 Step editor
+- 6.2 Step type picker
+- 10. Naming Policy
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-008
+- DESIGN-REQ-017
+As a task author, I can choose Tool, Skill, or Preset from one Step Type control so the editor shows only the configuration appropriate for that step.
+Acceptance Criteria
+- The editor shows exactly one Step Type selector with Tool, Skill, and Preset options.
+- Changing Step Type changes the visible type-specific form.
+- Compatible fields are preserved across changes where possible.
+- Incompatible meaningful data is either visibly discarded or requires confirmation before removal.
+- Primary UI labels use Step Type and avoid Capability, Activity, Invocation, Command, or Script as the umbrella label.
+Requirements
+- Every authored step must have one selected Step Type.
+- The selected Step Type must drive available sub-options.
+- The product-facing picker must use Tool, Skill, and Preset helper text from the design.
+```
+
+## User Story - Step Type Authoring Controls
+
+**Summary**: As a task author, I can choose Tool, Skill, or Preset from one Step Type control so the editor shows only the configuration appropriate for that step.
+
+**Goal**: Task authors configure each step through one clear Step Type selector that drives the visible configuration form, preserves compatible shared fields, and makes incompatible type-specific data removal explicit.
+
+**Independent Test**: Render the Create page step editor, verify one Step Type selector with Tool, Skill, and Preset options, switch among types, and confirm the visible form, preserved shared instructions, explicit incompatible-data discard notice, helper copy, and label vocabulary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author opens the step editor, **When** they inspect an authored step, **Then** exactly one user-facing Step Type selector is visible for that step.
+2. **Given** the Step Type selector is visible, **When** the author inspects the options, **Then** Tool, Skill, and Preset are available with concise helper text from the source design or equivalent product copy.
+3. **Given** the author changes Step Type, **When** the selected value changes to Tool, Skill, or Preset, **Then** only the matching type-specific configuration form is visible below the selector.
+4. **Given** the author entered shared step instructions and type-specific values, **When** the author changes Step Type, **Then** shared instructions are preserved and incompatible meaningful type-specific data is visibly discarded or requires confirmation before removal.
+5. **Given** the primary Step Type UI is visible, **When** labels and helper copy are inspected, **Then** the umbrella label is Step Type and the primary choices do not use Capability, Activity, Invocation, Command, or Script.
+
+### Edge Cases
+
+- A newly added step starts with one valid selected Step Type and can be changed independently from other steps.
+- Preset-specific selections and preview state are scoped to the step and cleared when the step changes away from Preset.
+- Tool-specific values are not submitted or silently retained as active values after changing to Skill or Preset.
+- Skill-specific values are not submitted or silently retained as active values after changing to Tool or Preset.
+- The separate preset management surface, if present, is not treated as the canonical Step Type authoring selector.
+
+## Assumptions
+
+- Runtime mode applies: this story verifies Create page behavior, not documentation-only wording.
+- Existing adjacent Step Type stories may already satisfy part of the selector and helper-copy behavior, but MM-568 must preserve its own Jira traceability and complete the incompatible-data handling acceptance criterion.
+- Instructions are treated as compatible shared step data across Tool, Skill, and Preset.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | docs/Steps/StepTypes.md sections 1, 2, 4 | Every authored step has exactly one Step Type that determines what the step represents and which fields are shown. | In scope | FR-001, FR-003, FR-006 |
+| DESIGN-REQ-002 | docs/Steps/StepTypes.md sections 2, 6.1, 6.2 | The Step Type control offers Tool, Skill, and Preset and renders type-specific configuration below the selector. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-008 | docs/Steps/StepTypes.md sections 4, 6.1 | Changing Step Type preserves compatible fields and explicitly handles incompatible meaningful data before or when it is removed. | In scope | FR-004 |
+| DESIGN-REQ-017 | docs/Steps/StepTypes.md section 10 | Primary authoring labels use Step Type, Tool, Skill, and Preset and avoid internal runtime terminology as the umbrella label. | In scope | FR-002, FR-005 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The step editor MUST expose exactly one user-facing Step Type selector for each ordinary authored step.
+- **FR-002**: The Step Type selector MUST offer Tool, Skill, and Preset with concise helper text matching the source design intent.
+- **FR-003**: The selected Step Type MUST determine which type-specific configuration form is visible below the selector.
+- **FR-004**: Changing Step Type MUST preserve compatible shared fields and MUST either visibly discard incompatible meaningful type-specific data or require confirmation before removing it.
+- **FR-005**: Primary Step Type labels and helper copy MUST use Step Type, Tool, Skill, and Preset and MUST NOT use Capability, Activity, Invocation, Command, or Script as the umbrella label.
+- **FR-006**: Each authored step MUST maintain its own selected Step Type and type-specific draft state independently from other authored steps.
+
+### Key Entities
+
+- **Step Draft**: A user-authored task step with shared instructions, selected Step Type, and type-specific draft state.
+- **Step Type**: The user-facing discriminator with Tool, Skill, and Preset options.
+- **Type-Specific Configuration Form**: The visible controls controlled by the selected Step Type.
+- **Discard Notice**: User-visible feedback that incompatible type-specific data was removed after a Step Type change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests verify a rendered step has one accessible Step Type selector with Tool, Skill, and Preset options.
+- **SC-002**: Frontend tests verify switching among Tool, Skill, and Preset changes the visible configuration form while preserving shared instructions.
+- **SC-003**: Frontend tests verify incompatible type-specific values are cleared with visible feedback or guarded by confirmation when Step Type changes.
+- **SC-004**: Frontend tests verify primary Step Type UI avoids Capability, Activity, Invocation, Command, and Script as umbrella labels.
+- **SC-005**: Frontend tests verify multiple authored steps keep independent Step Type and Preset state.
+- **SC-006**: Final verification preserves Jira issue key `MM-568` and the original Jira preset brief in MoonSpec artifacts and delivery metadata.

--- a/specs/287-step-type-authoring-controls/tasks.md
+++ b/specs/287-step-type-authoring-controls/tasks.md
@@ -3,15 +3,16 @@
 **Input**: Design documents from `specs/287-step-type-authoring-controls/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
 
-**Tests**: Unit tests and integration-style frontend component tests are REQUIRED. This story is UI-only; the Create page Vitest suite is the integration boundary for the rendered authoring workflow.
+**Tests**: Unit tests and integration-style frontend component tests are REQUIRED. This story is UI-only; the Create page Vitest boundary is the executable integration surface for the rendered authoring workflow.
 
-**Source Traceability**: MM-568 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-006, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, and DESIGN-REQ-017.
+**Source Traceability**: MM-568 Jira preset brief is preserved in `spec.md`. Tasks cover exactly one story: FR-001 through FR-006, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, and DESIGN-REQ-017.
 
 **Test Commands**:
 
-- Focused UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
-- Full unit verification: `./tools/test_unit.sh`
-- Final verification: `/speckit.verify`
+- Unit/type validation: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
+- Focused integration UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
+- Dashboard integration suite: `./tools/test_unit.sh --dashboard-only`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -21,20 +22,22 @@
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-**Purpose**: Confirm existing frontend test and source locations for the story.
+**Purpose**: Confirm existing frontend source, test tooling, and feature-local artifact structure for the story.
 
 - [X] T001 Confirm active feature artifacts preserve MM-568 in `specs/287-step-type-authoring-controls/spec.md` (SC-006)
-- [X] T002 Confirm Create page source and test files in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`
+- [X] T002 Confirm Create page source and test files in `frontend/src/entrypoints/task-create.tsx`, `frontend/src/entrypoints/task-create.test.tsx`, and `frontend/src/entrypoints/task-create-step-type.test.tsx`
+- [X] T003 Confirm frontend unit/type and dashboard integration commands are available through `./node_modules/.bin/tsc` and `./tools/test_unit.sh --dashboard-only`
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: No new infrastructure is needed; use existing Create page draft state and Vitest harness.
+**Purpose**: Reuse existing Create page draft state and Vitest harness; no new infrastructure is required.
 
-- [X] T003 Verify existing Step Type selector state and helper-copy coverage in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-002, FR-003, FR-005, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-017)
+- [X] T004 Verify existing Step Type selector state and helper-copy coverage in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-002, FR-003, FR-005, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-017)
+- [X] T005 Verify the MM-568 gap from `specs/287-step-type-authoring-controls/research.md`: incompatible Step Type data needed visible discard handling (FR-004, SC-003, DESIGN-REQ-008)
 
-**Checkpoint**: Foundation ready - story test and implementation work can now begin
+**Checkpoint**: Foundation ready - one-story test and implementation work can begin
 
 ---
 
@@ -44,35 +47,58 @@
 
 **Independent Test**: Render the Create page step editor, verify one Step Type selector with Tool, Skill, and Preset options, switch among types, and confirm visible forms, preserved instructions, explicit incompatible-data discard feedback, helper copy, and label vocabulary.
 
-**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, DESIGN-REQ-017
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, acceptance scenarios 1-5, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, DESIGN-REQ-017
 
-**Test Plan**:
+**Unit Test Plan**:
 
-- Unit/UI: Create page Vitest tests for selector, helper copy, switching panels, independent step state, and incompatible data discard feedback.
-- Integration: Rendered Create page workflow through Testing Library; no backend or compose integration is changed.
+- Type-check the Create page Step Type state model and focused test harness.
+- Command: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
 
-### Tests (write first)
+**Integration Test Plan**:
 
-- [X] T004 Add focused Step Type test for visible incompatible Skill data discard in `frontend/src/entrypoints/task-create-step-type.test.tsx` and align existing skipped coverage in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, SC-003, DESIGN-REQ-008)
-- [X] T005 Run focused UI verification with `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` and record result (FR-001 through FR-006)
+- Render `TaskCreatePage`, interact with the Step Type selector, and verify visible UI behavior through Testing Library.
+- Command: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
+- Broader dashboard regression command: `./tools/test_unit.sh --dashboard-only`
+
+### Unit Tests (write first)
+
+- [X] T006 Add focused TypeScript-covered test harness for Step Type behavior in `frontend/src/entrypoints/task-create-step-type.test.tsx` (FR-001, FR-004, SC-001, SC-003)
+- [X] T007 Run `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` to validate the Step Type state and test harness types (FR-004)
+
+### Integration Tests (write first)
+
+- [X] T008 Add focused rendered Create page integration test in `frontend/src/entrypoints/task-create-step-type.test.tsx` for one Step Type selector, preserved shared instructions, visible Skill discard notice, and cleared incompatible Skill fields (FR-001, FR-003, FR-004, SC-001, SC-002, SC-003, DESIGN-REQ-008)
+- [X] T009 Align existing skipped Create page coverage in `frontend/src/entrypoints/task-create.test.tsx` with the new incompatible-data discard expectation for future unskip work (FR-004, SC-003)
+
+### Red-First Confirmation
+
+- [X] T010 Confirm the pre-implementation behavior gap from `specs/287-step-type-authoring-controls/research.md`: `handleStepTypeChange` previously only changed `stepType` and cleared `presetPreview`, so incompatible Skill, Tool, and Preset values were hidden rather than visibly discarded (FR-004, DESIGN-REQ-008)
+- [X] T011 Confirm the focused integration test exercises the gap by asserting the visible discard notice and cleared Skill fields in `frontend/src/entrypoints/task-create-step-type.test.tsx` (FR-004, SC-003)
 
 ### Implementation
 
-- [X] T006 Add transient Step Type discard feedback state in `frontend/src/entrypoints/task-create.tsx` (FR-004, DESIGN-REQ-008)
-- [X] T007 Update `handleStepTypeChange` in `frontend/src/entrypoints/task-create.tsx` to preserve shared instructions while clearing incompatible Skill, Tool, or Preset configuration with visible feedback (FR-004, SC-003, DESIGN-REQ-008)
-- [X] T008 Render the Step Type discard notice in `frontend/src/entrypoints/task-create.tsx` near the Step Type selector (FR-004)
+- [X] T012 Add transient Step Type discard feedback state in `frontend/src/entrypoints/task-create.tsx` (FR-004, DESIGN-REQ-008)
+- [X] T013 Update `handleStepTypeChange` in `frontend/src/entrypoints/task-create.tsx` to preserve shared instructions while clearing incompatible Skill, Tool, or Preset configuration with visible feedback (FR-004, SC-003, DESIGN-REQ-008)
+- [X] T014 Render the Step Type discard notice in `frontend/src/entrypoints/task-create.tsx` near the Step Type selector (FR-004)
 
-**Checkpoint**: The story is functionally complete once T005 passes.
+### Story Validation
+
+- [X] T015 Run focused integration UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` (FR-001 through FR-006, SC-001 through SC-005)
+- [X] T016 Run dashboard integration regression suite: `./tools/test_unit.sh --dashboard-only` (FR-001 through FR-006)
+- [X] T017 Run unit/type validation: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` (FR-004)
+
+**Checkpoint**: The single story is fully functional, covered by type validation and rendered UI integration tests, and testable independently.
 
 ---
 
-## Phase 4: Polish & Cross-Cutting Concerns
+## Phase 4: Polish & Verification
 
-**Purpose**: Verify feature-local artifacts and final test evidence.
+**Purpose**: Verify feature-local artifacts and final test evidence without adding hidden scope.
 
-- [X] T009 Create feature-local planning, data model, contract, and quickstart artifacts in `specs/287-step-type-authoring-controls/` (SC-006)
-- [X] T010 Run Python unit suite and dashboard tests for final required unit verification
-- [X] T011 Run `/speckit.verify` equivalent read-only verification against `specs/287-step-type-authoring-controls/spec.md`
+- [X] T018 Create feature-local planning, data model, contract, quickstart, and checklist artifacts in `specs/287-step-type-authoring-controls/` (SC-006)
+- [X] T019 Preserve MM-568 and the original Jira preset brief in `specs/287-step-type-authoring-controls/spec.md` for final verification (SC-006)
+- [X] T020 Run broader Python unit verification through `./tools/test_unit.sh` as final required unit evidence where environment allows
+- [X] T021 Run `/moonspec-verify` equivalent read-only verification against `specs/287-step-type-authoring-controls/spec.md`
 
 ---
 
@@ -83,23 +109,32 @@
 - **Setup (Phase 1)**: No dependencies
 - **Foundational (Phase 2)**: Depends on Setup completion
 - **Story (Phase 3)**: Depends on Foundational completion
-- **Polish (Phase 4)**: Depends on story implementation and focused test evidence
+- **Polish & Verification (Phase 4)**: Depends on story implementation and validation
 
 ### Within The Story
 
-- T004 should precede T006-T008 in strict TDD runs.
-- T005 validates T004 and T006-T008 together.
-- T010 and T011 are final verification tasks.
+- Unit test tasks T006-T007 precede implementation tasks T012-T014.
+- Integration test tasks T008-T009 precede implementation tasks T012-T014.
+- Red-first confirmation tasks T010-T011 document the verified FR-004 gap before implementation.
+- Story validation tasks T015-T017 run after implementation.
+- Final `/moonspec-verify` task T021 runs after tests pass.
 
 ### Parallel Opportunities
 
-- Feature artifact review and focused UI test authoring can run independently before implementation.
-- No production code tasks should run in parallel because the story touches one frontend source file.
+- T006 and T008 can be prepared in parallel because they touch the focused test file and validate different test dimensions.
+- T007 and T015-T016 are command-only validation tasks and should run after the relevant tests exist.
+- No production implementation tasks should run in parallel because the story touches one frontend source file.
 
 ## Implementation Strategy
 
 1. Preserve MM-568 and the trusted preset brief in `spec.md`.
 2. Reuse existing Step Type selector implementation and tests for already-covered requirements.
-3. Complete the incompatible-data gap by visibly discarding prior type-specific state on Step Type changes.
-4. Verify through focused Create page UI tests, then full unit verification when feasible.
-5. Run final MoonSpec verification and preserve evidence in the final report.
+3. Add focused unit/type and rendered UI integration coverage for the incompatible-data gap.
+4. Confirm the existing gap in `handleStepTypeChange`, then visibly discard prior type-specific state on Step Type changes.
+5. Validate with focused UI, full dashboard, type-check, broader unit verification, and final `/moonspec-verify`.
+
+## Notes
+
+- This task list covers exactly one story.
+- The public/integration boundary is the rendered Create page step editor.
+- Existing `frontend/src/entrypoints/task-create.test.tsx` remains intentionally skipped by its outer `describe.skip`; the executable MM-568 regression coverage lives in `frontend/src/entrypoints/task-create-step-type.test.tsx`.

--- a/specs/287-step-type-authoring-controls/tasks.md
+++ b/specs/287-step-type-authoring-controls/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: Add Step Type Authoring Controls
+
+**Input**: Design documents from `specs/287-step-type-authoring-controls/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style frontend component tests are REQUIRED. This story is UI-only; the Create page Vitest suite is the integration boundary for the rendered authoring workflow.
+
+**Source Traceability**: MM-568 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-006, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, and DESIGN-REQ-017.
+
+**Test Commands**:
+
+- Focused UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
+- Full unit verification: `./tools/test_unit.sh`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing frontend test and source locations for the story.
+
+- [X] T001 Confirm active feature artifacts preserve MM-568 in `specs/287-step-type-authoring-controls/spec.md` (SC-006)
+- [X] T002 Confirm Create page source and test files in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new infrastructure is needed; use existing Create page draft state and Vitest harness.
+
+- [X] T003 Verify existing Step Type selector state and helper-copy coverage in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-002, FR-003, FR-005, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-017)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Step Type Authoring Controls
+
+**Summary**: As a task author, I can choose Tool, Skill, or Preset from one Step Type control so the editor shows only the configuration appropriate for that step.
+
+**Independent Test**: Render the Create page step editor, verify one Step Type selector with Tool, Skill, and Preset options, switch among types, and confirm visible forms, preserved instructions, explicit incompatible-data discard feedback, helper copy, and label vocabulary.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-008, DESIGN-REQ-017
+
+**Test Plan**:
+
+- Unit/UI: Create page Vitest tests for selector, helper copy, switching panels, independent step state, and incompatible data discard feedback.
+- Integration: Rendered Create page workflow through Testing Library; no backend or compose integration is changed.
+
+### Tests (write first)
+
+- [X] T004 Add focused Step Type test for visible incompatible Skill data discard in `frontend/src/entrypoints/task-create-step-type.test.tsx` and align existing skipped coverage in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, SC-003, DESIGN-REQ-008)
+- [X] T005 Run focused UI verification with `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` and record result (FR-001 through FR-006)
+
+### Implementation
+
+- [X] T006 Add transient Step Type discard feedback state in `frontend/src/entrypoints/task-create.tsx` (FR-004, DESIGN-REQ-008)
+- [X] T007 Update `handleStepTypeChange` in `frontend/src/entrypoints/task-create.tsx` to preserve shared instructions while clearing incompatible Skill, Tool, or Preset configuration with visible feedback (FR-004, SC-003, DESIGN-REQ-008)
+- [X] T008 Render the Step Type discard notice in `frontend/src/entrypoints/task-create.tsx` near the Step Type selector (FR-004)
+
+**Checkpoint**: The story is functionally complete once T005 passes.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify feature-local artifacts and final test evidence.
+
+- [X] T009 Create feature-local planning, data model, contract, and quickstart artifacts in `specs/287-step-type-authoring-controls/` (SC-006)
+- [X] T010 Run Python unit suite and dashboard tests for final required unit verification
+- [X] T011 Run `/speckit.verify` equivalent read-only verification against `specs/287-step-type-authoring-controls/spec.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion
+- **Story (Phase 3)**: Depends on Foundational completion
+- **Polish (Phase 4)**: Depends on story implementation and focused test evidence
+
+### Within The Story
+
+- T004 should precede T006-T008 in strict TDD runs.
+- T005 validates T004 and T006-T008 together.
+- T010 and T011 are final verification tasks.
+
+### Parallel Opportunities
+
+- Feature artifact review and focused UI test authoring can run independently before implementation.
+- No production code tasks should run in parallel because the story touches one frontend source file.
+
+## Implementation Strategy
+
+1. Preserve MM-568 and the trusted preset brief in `spec.md`.
+2. Reuse existing Step Type selector implementation and tests for already-covered requirements.
+3. Complete the incompatible-data gap by visibly discarding prior type-specific state on Step Type changes.
+4. Verify through focused Create page UI tests, then full unit verification when feasible.
+5. Run final MoonSpec verification and preserve evidence in the final report.


### PR DESCRIPTION
## Jira
- Issue: MM-568

## MoonSpec
- Active feature path: `specs/287-step-type-authoring-controls`
- Verification verdict: FULLY_IMPLEMENTED

## Summary
- Adds visible Step Type discard feedback when switching away from Skill, Tool, or Preset-specific configuration.
- Preserves shared step instructions while clearing incompatible type-specific values.
- Preserves MM-568 MoonSpec artifacts and validation tasks.

## Tests run
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` - PASS
- `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` - PASS
- `./tools/test_unit.sh --dashboard-only` - PASS
- `./tools/test_unit.sh` - PASS earlier in this run after the implementation commit; no Python code changed after that.

## Remaining risks
- Existing `frontend/src/entrypoints/task-create.test.tsx` remains intentionally wrapped in `describe.skip`; executable MM-568 regression coverage is in `frontend/src/entrypoints/task-create-step-type.test.tsx`.
- No known implementation gaps remain.