### PR TITLE
[codex] Expand step presets in place

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,37 @@
 [
   {
-    "id": 4355930654,
+    "id": 4357009057,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notification only; no code or documentation action requested."
+    "rationale": "Qodo review summary only; no requested code change."
   },
   {
-    "id": 3170697440,
+    "id": 4357009307,
     "disposition": "addressed",
-    "rationale": "Normalized selected_skill before comparing it against normalized resolved skill names in MoonMindRunWorkflow."
+    "rationale": "Addressed both reported issues by invalidating stale preset previews and writing in-place expansion completion messages to the global preset status."
   },
   {
-    "id": 3170697446,
+    "id": 3171488902,
     "disposition": "addressed",
-    "rationale": "Made directory clearing reject symlinked and non-directory paths before deleting children, with regression coverage preserving a symlink target sentinel."
+    "rationale": "Added current-state validation before applying async preset expansion results so removed or changed preset steps are not mutated."
   },
   {
-    "id": 3170697450,
-    "disposition": "addressed",
-    "rationale": "Aligned SkillSystem docs with the transactional preserve-and-link fallback and its restore/publication guard requirements."
-  },
-  {
-    "id": 4208365026,
+    "id": 4209275635,
     "disposition": "not-applicable",
-    "rationale": "Summary review; its actionable child comments are tracked and addressed individually."
+    "rationale": "Automated Codex review summary; the actionable inline comment is tracked separately."
   },
   {
-    "id": 4208377384,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment only; no actionable feedback."
-  },
-  {
-    "id": 3170708826,
+    "id": 3171502561,
     "disposition": "addressed",
-    "rationale": "Delayed moving the checked-in skill tree until active materialization and manifest writing succeed, and added restore-on-projection-failure behavior plus regression coverage."
+    "rationale": "Preset-step instruction edits now clear cached previews, and tests cover regeneration after instructions change."
+  },
+  {
+    "id": 3171514617,
+    "disposition": "addressed",
+    "rationale": "Preset selection and preset inputs are disabled while expansion is in progress, with current-state guards before applying async results."
+  },
+  {
+    "id": 4209307861,
+    "disposition": "addressed",
+    "rationale": "Review-level race-condition recommendation was addressed by disabling preset controls during expansion and guarding stale async results."
   }
 ]

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import {
   afterEach,
   beforeEach,
@@ -126,6 +126,46 @@ describe("Task Create Step Type authoring", () => {
         if (url.startsWith("/api/task-step-templates?scope=personal")) {
           return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
         }
+        if (url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              slug: "jira-orchestrate",
+              scope: "global",
+              title: "Jira Orchestrate",
+              description: "Implement a Jira issue.",
+              latestVersion: "1.0.0",
+              version: "1.0.0",
+              inputs: [],
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates/jira-orchestrate:expand?scope=global")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              steps: [
+                {
+                  id: "tpl:jira-orchestrate:1.0.0:01",
+                  title: "Read Jira issue",
+                  instructions: "Read the selected Jira issue.",
+                  skill: { id: "jira-implement" },
+                },
+                {
+                  id: "tpl:jira-orchestrate:1.0.0:02",
+                  title: "Implement Jira issue",
+                  instructions: "Implement the selected Jira issue.",
+                  skill: { id: "moonspec-orchestrate" },
+                },
+              ],
+              appliedTemplate: {
+                slug: "jira-orchestrate",
+                version: "1.0.0",
+              },
+              warnings: [],
+            }),
+          } as Response);
+        }
         return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
       });
   });
@@ -188,5 +228,73 @@ describe("Task Create Step Type authoring", () => {
       ).value,
     ).toBe("");
     expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("expands a preset step in place and pushes following steps down", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add Step" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
+
+    const firstStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    const secondStep = (await screen.findByText("Step 2")).closest(
+      "section",
+    ) as HTMLElement;
+    const thirdStep = (await screen.findByText("Step 3")).closest(
+      "section",
+    ) as HTMLElement;
+
+    fireEvent.change(within(firstStep).getByLabelText("Instructions"), {
+      target: { value: "Keep first manual skill." },
+    });
+    fireEvent.change(within(thirdStep).getByLabelText("Instructions"), {
+      target: { value: "Keep trailing skill." },
+    });
+    selectStepType(secondStep, "Preset");
+
+    const presetSelect = within(secondStep).getByLabelText(
+      "Preset",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-orchestrate" },
+    });
+
+    fireEvent.click(within(secondStep).getByRole("button", { name: "Expand" }));
+
+    await screen.findByDisplayValue("Read the selected Jira issue.");
+    expect(screen.getByDisplayValue("Implement the selected Jira issue.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Keep first manual skill.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Keep trailing skill.")).toBeTruthy();
+
+    const renderedSteps = Array.from(
+      document.querySelectorAll<HTMLElement>(".queue-step-section"),
+    );
+    expect(renderedSteps).toHaveLength(4);
+    const [renderedFirst, renderedSecond, renderedThird, renderedFourth] =
+      renderedSteps;
+    if (!renderedFirst || !renderedSecond || !renderedThird || !renderedFourth) {
+      throw new Error("Expected four rendered steps after preset expansion.");
+    }
+    expect(
+      (within(renderedFirst).getByLabelText("Instructions") as HTMLTextAreaElement)
+        .value,
+    ).toBe("Keep first manual skill.");
+    expect(
+      (within(renderedSecond).getByLabelText("Instructions") as HTMLTextAreaElement)
+        .value,
+    ).toBe("Read the selected Jira issue.");
+    expect(
+      (within(renderedThird).getByLabelText("Instructions") as HTMLTextAreaElement)
+        .value,
+    ).toBe("Implement the selected Jira issue.");
+    expect(
+      (within(renderedFourth).getByLabelText("Instructions") as HTMLTextAreaElement)
+        .value,
+    ).toBe("Keep trailing skill.");
   });
 });

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -85,7 +85,7 @@ describe("Task Create Step Type authoring", () => {
     window.localStorage.clear();
     fetchSpy = vi
       .spyOn(window, "fetch")
-      .mockImplementation((input: RequestInfo | URL) => {
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
         if (url.startsWith("/api/tasks/skills")) {
           return Promise.resolve({
@@ -136,11 +136,24 @@ describe("Task Create Step Type authoring", () => {
               description: "Implement a Jira issue.",
               latestVersion: "1.0.0",
               version: "1.0.0",
-              inputs: [],
+              inputs: [
+                {
+                  name: "feature_request",
+                  label: "Feature Request",
+                  type: "text",
+                  required: true,
+                },
+              ],
             }),
           } as Response);
         }
         if (url.startsWith("/api/task-step-templates/jira-orchestrate:expand?scope=global")) {
+          const body = JSON.parse(String(init?.body || "{}")) as {
+            inputs?: { feature_request?: string };
+          };
+          const featureRequest = String(
+            body.inputs?.feature_request || "the selected Jira issue",
+          );
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -148,13 +161,13 @@ describe("Task Create Step Type authoring", () => {
                 {
                   id: "tpl:jira-orchestrate:1.0.0:01",
                   title: "Read Jira issue",
-                  instructions: "Read the selected Jira issue.",
+                  instructions: `Read ${featureRequest}.`,
                   skill: { id: "jira-implement" },
                 },
                 {
                   id: "tpl:jira-orchestrate:1.0.0:02",
                   title: "Implement Jira issue",
-                  instructions: "Implement the selected Jira issue.",
+                  instructions: `Implement ${featureRequest}.`,
                   skill: { id: "moonspec-orchestrate" },
                 },
               ],
@@ -253,6 +266,12 @@ describe("Task Create Step Type authoring", () => {
       target: { value: "Keep trailing skill." },
     });
     selectStepType(secondStep, "Preset");
+    fireEvent.change(
+      within(secondStep).getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "the selected Jira issue" },
+      },
+    );
 
     const presetSelect = within(secondStep).getByLabelText(
       "Preset",
@@ -270,6 +289,9 @@ describe("Task Create Step Type authoring", () => {
     expect(screen.getByDisplayValue("Implement the selected Jira issue.")).toBeTruthy();
     expect(screen.getByDisplayValue("Keep first manual skill.")).toBeTruthy();
     expect(screen.getByDisplayValue("Keep trailing skill.")).toBeTruthy();
+    expect(
+      await screen.findByText("Applied preset 'Jira Orchestrate' (2 steps)."),
+    ).toBeTruthy();
 
     const renderedSteps = Array.from(
       document.querySelectorAll<HTMLElement>(".queue-step-section"),
@@ -296,5 +318,125 @@ describe("Task Create Step Type authoring", () => {
       (within(renderedFourth).getByLabelText("Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep trailing skill.");
+  });
+
+  it("regenerates a preset preview after preset instructions change", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-orchestrate" },
+    });
+    const instructions = within(step).getByLabelText(
+      "Feature Request / Initial Instructions",
+    );
+    fireEvent.change(instructions, { target: { value: "old issue" } });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
+    await waitFor(() => {
+      const previewCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).startsWith(
+          "/api/task-step-templates/jira-orchestrate:expand?scope=global",
+        ),
+      );
+      expect(previewCall).toBeTruthy();
+      const body = JSON.parse(String(previewCall?.[1]?.body || "{}"));
+      expect(body.inputs.feature_request).toBe("old issue");
+    });
+
+    fireEvent.change(instructions, { target: { value: "new issue" } });
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+
+    expect(await screen.findByDisplayValue("Read new issue.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Implement new issue.")).toBeTruthy();
+    expect(screen.queryByDisplayValue("Read old issue.")).toBeNull();
+
+    const expandCalls = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).startsWith(
+        "/api/task-step-templates/jira-orchestrate:expand?scope=global",
+      ),
+    );
+    expect(expandCalls).toHaveLength(2);
+  });
+
+  it("ignores async preset expansion results after the preset step changes", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    let resolveExpand: ((response: Response) => void) | null = null;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-orchestrate:expand?scope=global",
+        )
+      ) {
+        return new Promise<Response>((resolve) => {
+          resolveExpand = resolve;
+        });
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText("Preset") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-orchestrate" },
+    });
+    const instructions = within(step).getByLabelText(
+      "Feature Request / Initial Instructions",
+    );
+    fireEvent.change(instructions, { target: { value: "old issue" } });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    await waitFor(() => {
+      expect(resolveExpand).not.toBeNull();
+      expect(presetSelect.disabled).toBe(true);
+    });
+    fireEvent.change(instructions, { target: { value: "new issue" } });
+
+    const resolve = resolveExpand as ((response: Response) => void) | null;
+    if (!resolve) {
+      throw new Error("Preset expansion request did not start.");
+    }
+    resolve({
+      ok: true,
+      json: async () => ({
+        steps: [
+          {
+            id: "tpl:jira-orchestrate:1.0.0:01",
+            title: "Read Jira issue",
+            instructions: "Read old issue.",
+            skill: { id: "jira-implement" },
+          },
+        ],
+        appliedTemplate: {
+          slug: "jira-orchestrate",
+          version: "1.0.0",
+        },
+        warnings: [],
+      }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(presetSelect.disabled).toBe(false);
+    });
+    expect(screen.queryByDisplayValue("Read old issue.")).toBeNull();
+    expect(
+      (instructions as HTMLTextAreaElement).value,
+    ).toBe("new issue");
   });
 });

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7162,7 +7162,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(within(step).getByLabelText("Preset")).toBeTruthy();
     expect(within(step).getByRole("button", { name: "Preview" })).toBeTruthy();
     expect(
-      within(step).getByRole("button", { name: "Apply preview" }),
+      within(step).getByRole("button", { name: "Expand" }),
     ).toBeTruthy();
     expect(within(step).queryByLabelText(/Skill \(optional\)/)).toBeNull();
     expect(within(step).queryByLabelText("Tool")).toBeNull();
@@ -7406,7 +7406,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
     expect(await within(step).findByText("Clarify spec")).toBeTruthy();
-    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
 
     expect(await screen.findByDisplayValue("Clarify the {{ inputs.feature_name }} scope.")).toBeTruthy();
     expect(screen.getByDisplayValue("Write a plan for the task builder recovery.")).toBeTruthy();
@@ -7481,7 +7481,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
     expect(await within(step).findByText("Fetch Jira issue")).toBeTruthy();
-    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
 
     expect(await screen.findByDisplayValue("Fetch MM-558.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
@@ -7602,7 +7602,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     fireEvent.click(within(step).getByRole("button", { name: "Preview" }));
     expect(await within(step).findByText("Clarify spec")).toBeTruthy();
-    fireEvent.click(within(step).getByRole("button", { name: "Apply preview" }));
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
 
     expect(await screen.findByDisplayValue("Clarify the {{ inputs.feature_name }} scope.")).toBeTruthy();
     expect(

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -5183,7 +5183,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
   }
 
-  async function handleApplyStepPreset(localId: string) {
+  async function handleExpandStepPreset(localId: string) {
     if (isApplyingPreset) return;
     const step = steps.find((candidate) => candidate.localId === localId);
     const preset = templateItems.find((item) => item.key === step?.presetKey);
@@ -5191,15 +5191,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       updateStep(localId, { presetMessage: "Choose a preset first." });
       return;
     }
-    if (!step.presetPreview || step.presetPreview.presetKey !== preset.key) {
-      updateStep(localId, {
-        presetMessage: "Preview the selected preset before applying.",
-      });
-      return;
-    }
     setIsApplyingPreset(true);
     updateStep(localId, {
-      presetMessage: "Applying preset preview...",
+      presetMessage: "Expanding preset...",
       presetReapplyNeeded: false,
     });
     try {
@@ -5207,18 +5201,30 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         step.presetDetail && step.presetKey === preset.key
           ? step.presetDetail
           : await loadPresetDetail(preset);
+      const preview =
+        step.presetPreview && step.presetPreview.presetKey === preset.key
+          ? step.presetPreview
+          : await expandPresetForDraft({
+              preset,
+              detail,
+              inputValues: resolveTemplateInputs(
+                detail.inputs || [],
+                step.presetInputValues,
+                step.instructions,
+              ).values,
+            });
       applyPresetPreviewToDraft({
         preset,
         detail,
-        preview: step.presetPreview,
+        preview,
         replaceLocalId: localId,
         setMessage: (message) => updateStep(localId, { presetMessage: message }),
       });
     } catch (error) {
       const failure =
-        error instanceof Error ? error : new Error("Failed to apply preset.");
+        error instanceof Error ? error : new Error("Failed to expand preset.");
       updateStep(localId, {
-        presetMessage: `Failed to apply preset: ${failure.message}`,
+        presetMessage: `Failed to expand preset: ${failure.message}`,
       });
     } finally {
       setIsApplyingPreset(false);
@@ -6423,9 +6429,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the task starts";
   const publishModeTooltip = "Select how MoonMind publishes task changes";
-  const applyPresetTooltip = presetReapplyNeeded
-    ? "Preview the selected preset again before applying"
-    : "Apply the selected preset preview to the task draft";
+  const expandStepPresetTooltip =
+    "Expand the selected preset into editable steps at this position";
   const modeLoadError =
     pageMode.mode !== "create" && !temporalTaskEditingEnabled
       ? "Temporal task editing is not enabled."
@@ -7333,19 +7338,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         className="secondary"
                         aria-disabled={
                           isApplyingPreset ||
-                          !step.presetKey ||
-                          !step.presetPreview
+                          !step.presetKey
                         }
                         aria-busy={isApplyingPreset}
-                        title={applyPresetTooltip}
+                        title={expandStepPresetTooltip}
                         disabled={
                           isApplyingPreset ||
-                          !step.presetKey ||
-                          !step.presetPreview
+                          !step.presetKey
                         }
-                        onClick={() => handleApplyStepPreset(step.localId)}
+                        onClick={() => handleExpandStepPreset(step.localId)}
                       >
-                        Apply preview
+                        Expand
                       </button>
                       {step.presetPreview ? (
                         <div

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1189,6 +1189,16 @@ function presetInputValuesFromPayload(
   );
 }
 
+function presetInputValueSignature(
+  inputValues: Record<string, string | boolean>,
+): string {
+  return JSON.stringify(
+    Object.entries(inputValues).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+}
+
 function createStepStateEntriesFromTemporalDraft(
   draft: ReturnType<typeof buildTemporalSubmissionDraftFromExecution>,
 ): StepState[] {
@@ -2809,6 +2819,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     ?.supportedTaskRuntimes || ["codex_cli", "gemini_cli", "claude_code"];
 
   const [steps, setSteps] = useState<StepState[]>([createStepStateEntry(1)]);
+  const stepsRef = useRef<StepState[]>(steps);
   const [nextStepNumber, setNextStepNumber] = useState(2);
   const [showAdvancedStepOptions, setShowAdvancedStepOptions] = useState(false);
   const [runtime, setRuntime] = useState(defaultRuntime);
@@ -2905,6 +2916,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const temporalDraftAppliedRef = useRef<string | null>(null);
   const jiraProjectSelectionInitializedRef = useRef(false);
   const jiraBoardSelectionInitializedRef = useRef(false);
+
+  useEffect(() => {
+    stepsRef.current = steps;
+  }, [steps]);
 
   const temporalDraftQuery = useQuery({
     queryKey: [
@@ -4542,6 +4557,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
   }
 
+  function currentStepPresetMatches(
+    localId: string,
+    presetKey: string,
+    expectedInstructions?: string,
+    expectedInputValues?: Record<string, string | boolean>,
+  ): boolean {
+    const currentStep = stepsRef.current.find((step) => step.localId === localId);
+    const inputValuesMatch =
+      expectedInputValues === undefined ||
+      presetInputValueSignature(currentStep?.presetInputValues || {}) ===
+        presetInputValueSignature(expectedInputValues);
+    return Boolean(
+      currentStep &&
+        currentStep.stepType === "preset" &&
+        currentStep.presetKey === presetKey &&
+        (expectedInstructions === undefined ||
+          currentStep.instructions === expectedInstructions) &&
+        inputValuesMatch,
+    );
+  }
+
   async function handleStepPresetSelectionChange(
     localId: string,
     presetKey: string,
@@ -4590,6 +4626,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           !showAdvancedStepOptions
         ) {
           nextStep.skillArgs = "";
+        }
+        if (
+          Object.prototype.hasOwnProperty.call(updates, "instructions") &&
+          nextStep.stepType === "preset" &&
+          nextStep.instructions !== step.instructions
+        ) {
+          nextStep.presetReapplyNeeded = Boolean(step.presetPreview);
+          nextStep.presetPreview = null;
         }
         return nextStep;
       }),
@@ -5146,6 +5190,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       updateStep(localId, { presetMessage: "Choose a preset first." });
       return;
     }
+    const requestedInstructions = step.instructions;
+    const requestedInputValues = { ...step.presetInputValues };
     setIsApplyingPreset(true);
     updateStep(localId, {
       presetMessage: "Previewing preset...",
@@ -5166,7 +5212,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           step.instructions,
         ).values,
       });
-      updateStep(localId, {
+      if (
+        !currentStepPresetMatches(
+          localId,
+          preset.key,
+          requestedInstructions,
+          requestedInputValues,
+        )
+      ) {
+        return;
+      }
+      updateStepPresetIfCurrent(localId, preset.key, {
         presetDetail: detail,
         presetPreview: preview,
         presetMessage: `Previewed preset '${preset.title}' (${preview.previewSteps.length} steps).`,
@@ -5174,10 +5230,19 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     } catch (error) {
       const failure =
         error instanceof Error ? error : new Error("Failed to preview preset.");
-      updateStep(localId, {
-        presetMessage: `Failed to preview preset: ${failure.message}`,
-        presetPreview: null,
-      });
+      if (
+        currentStepPresetMatches(
+          localId,
+          preset.key,
+          requestedInstructions,
+          requestedInputValues,
+        )
+      ) {
+        updateStepPresetIfCurrent(localId, preset.key, {
+          presetMessage: `Failed to preview preset: ${failure.message}`,
+          presetPreview: null,
+        });
+      }
     } finally {
       setIsApplyingPreset(false);
     }
@@ -5191,6 +5256,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       updateStep(localId, { presetMessage: "Choose a preset first." });
       return;
     }
+    const requestedInstructions = step.instructions;
+    const requestedInputValues = { ...step.presetInputValues };
     setIsApplyingPreset(true);
     updateStep(localId, {
       presetMessage: "Expanding preset...",
@@ -5213,19 +5280,38 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 step.instructions,
               ).values,
             });
+      if (
+        !currentStepPresetMatches(
+          localId,
+          preset.key,
+          requestedInstructions,
+          requestedInputValues,
+        )
+      ) {
+        return;
+      }
       applyPresetPreviewToDraft({
         preset,
         detail,
         preview,
         replaceLocalId: localId,
-        setMessage: (message) => updateStep(localId, { presetMessage: message }),
+        setMessage: (message) => setTemplateMessage(message),
       });
     } catch (error) {
       const failure =
         error instanceof Error ? error : new Error("Failed to expand preset.");
-      updateStep(localId, {
-        presetMessage: `Failed to expand preset: ${failure.message}`,
-      });
+      if (
+        currentStepPresetMatches(
+          localId,
+          preset.key,
+          requestedInstructions,
+          requestedInputValues,
+        )
+      ) {
+        updateStepPresetIfCurrent(localId, preset.key, {
+          presetMessage: `Failed to expand preset: ${failure.message}`,
+        });
+      }
     } finally {
       setIsApplyingPreset(false);
     }
@@ -6960,6 +7046,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         Preset
                         <select
                           value={step.presetKey}
+                          disabled={isApplyingPreset}
+                          aria-disabled={isApplyingPreset}
                           onChange={(event) => {
                             void handleStepPresetSelectionChange(
                               step.localId,
@@ -7240,6 +7328,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                     <select
                                       id={inputId}
                                       value={value}
+                                      disabled={isApplyingPreset}
                                       onChange={(event) =>
                                         updateStepPresetInputValue(
                                           step.localId,
@@ -7268,6 +7357,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                       id={inputId}
                                       type="checkbox"
                                       checked={value === "true"}
+                                      disabled={isApplyingPreset}
                                       onChange={(event) =>
                                         updateStepPresetInputValue(
                                           step.localId,
@@ -7290,6 +7380,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                       id={inputId}
                                       value={value}
                                       placeholder={definition.placeholder || ""}
+                                      disabled={isApplyingPreset}
                                       onChange={(event) =>
                                         updateStepPresetInputValue(
                                           step.localId,
@@ -7309,6 +7400,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                     type="text"
                                     value={value}
                                     placeholder={definition.placeholder || ""}
+                                    disabled={isApplyingPreset}
                                     onChange={(event) =>
                                       updateStepPresetInputValue(
                                         step.localId,


### PR DESCRIPTION
## Summary
- Rename the step-level preset action to Expand and allow it to expand a selected preset without requiring a preview first.
- Reuse an existing preview when available, otherwise call the preset expand endpoint before replacing the preset step in-place.
- Add regression coverage for expanding a middle preset step so generated steps push later skill steps down.

## Validation
- npm run ui:typecheck
- npm run ui:lint
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create-step-type.test.tsx
