### PR TITLE
[codex] Fix skill projection publish filtering

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,22 @@
 [
   {
-    "id": 4357009057,
+    "id": 4209468049,
     "disposition": "not-applicable",
-    "rationale": "Qodo review summary only; no requested code change."
+    "rationale": "Bot review summary only; no actionable request beyond the inline discussion."
   },
   {
-    "id": 4357009307,
+    "id": 3171663351,
     "disposition": "addressed",
-    "rationale": "Addressed both reported issues by invalidating stale preset previews and writing in-place expansion completion messages to the global preset status."
+    "rationale": "Refactored test_api_service_mounts_agent_runtime_workspace_volume to use _has_volume_mount."
   },
   {
-    "id": 3171488902,
-    "disposition": "addressed",
-    "rationale": "Added current-state validation before applying async preset expansion results so removed or changed preset steps are not mutated."
-  },
-  {
-    "id": 4209275635,
+    "id": 4357283451,
     "disposition": "not-applicable",
-    "rationale": "Automated Codex review summary; the actionable inline comment is tracked separately."
+    "rationale": "Qodo walkthrough summary only; no remediation requested."
   },
   {
-    "id": 3171502561,
+    "id": 4357283529,
     "disposition": "addressed",
-    "rationale": "Preset-step instruction edits now clear cached previews, and tests cover regeneration after instructions change."
-  },
-  {
-    "id": 3171514617,
-    "disposition": "addressed",
-    "rationale": "Preset selection and preset inputs are disabled while expansion is in progress, with current-state guards before applying async results."
-  },
-  {
-    "id": 4209307861,
-    "disposition": "addressed",
-    "rationale": "Review-level race-condition recommendation was addressed by disabling preset controls during expansion and guarding stale async results."
+    "rationale": "Restored _should_exclude_publish_path to a Path-only contract, normalized string workspace_path at the publish call site, and added relative-path/string-workspace regression coverage."
   }
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -465,6 +465,7 @@ services:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
       - ./services:/app/services:ro
+      - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
       - codex_auth_volume:${CODEX_VOLUME_PATH:-/home/app/.codex}
       - claude_auth_volume:${CLAUDE_VOLUME_PATH:-/home/app/.claude}
@@ -552,6 +553,7 @@ services:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
       - ./services:/app/services:ro
+      - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
       - codex_auth_volume:${CODEX_VOLUME_PATH:-/home/app/.codex}
       - claude_auth_volume:${CLAUDE_VOLUME_PATH:-/home/app/.claude}

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5182,7 +5182,7 @@ class TemporalAgentRuntimeActivities:
     def _should_exclude_publish_path(
         path_text: str,
         *,
-        workspace: str | Path | None = None,
+        workspace: Path | None = None,
     ) -> bool:
         """Skip runtime scaffolding paths that should never be published."""
         normalized = str(path_text or "").strip().rstrip("/")
@@ -5195,7 +5195,7 @@ class TemporalAgentRuntimeActivities:
             normalized == ".agents/skills"
             or normalized.startswith(".agents/skills/")
         ):
-            projection = Path(workspace) / ".agents" / "skills"
+            projection = workspace.expanduser().resolve() / ".agents" / "skills"
             if projection.is_symlink():
                 return True
         return False
@@ -5448,10 +5448,14 @@ class TemporalAgentRuntimeActivities:
             return {}
 
         try:
+            workspace_path = Path(workspace).expanduser().resolve()
             changed_paths = tuple(
                 path
                 for path in self._parse_git_status_paths(status_stdout)
-                if not self._should_exclude_publish_path(path, workspace=workspace)
+                if not self._should_exclude_publish_path(
+                    path,
+                    workspace=workspace_path,
+                )
             )
         except ValueError as exc:
             return {

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5182,7 +5182,7 @@ class TemporalAgentRuntimeActivities:
     def _should_exclude_publish_path(
         path_text: str,
         *,
-        workspace: Path | None = None,
+        workspace: str | Path | None = None,
     ) -> bool:
         """Skip runtime scaffolding paths that should never be published."""
         normalized = str(path_text or "").strip().rstrip("/")
@@ -5195,7 +5195,7 @@ class TemporalAgentRuntimeActivities:
             normalized == ".agents/skills"
             or normalized.startswith(".agents/skills/")
         ):
-            projection = workspace / ".agents" / "skills"
+            projection = Path(workspace) / ".agents" / "skills"
             if projection.is_symlink():
                 return True
         return False

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -77,30 +77,10 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
         api_service, dict
     ), "api service is missing from docker-compose.yaml"
 
-    volumes = api_service.get("volumes", [])
-    assert isinstance(volumes, list), "api service volumes must be a list"
-
-    found_mount = False
-    for v in volumes:
-        if isinstance(v, str):
-            parts = v.split(":")
-            if (
-                len(parts) >= 2
-                and parts[0] == "agent_workspaces"
-                and parts[1] == "/work/agent_jobs"
-            ):
-                found_mount = True
-                break
-        elif isinstance(v, dict):
-            if (
-                v.get("source") == "agent_workspaces"
-                and v.get("target") == "/work/agent_jobs"
-            ):
-                found_mount = True
-                break
-
-    assert (
-        found_mount
+    assert _has_volume_mount(
+        api_service,
+        "agent_workspaces",
+        "/work/agent_jobs",
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"
 
 

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -6,6 +6,22 @@ from pathlib import Path
 
 import yaml
 
+
+def _has_volume_mount(service_config: dict, source: str, target: str) -> bool:
+    volumes = service_config.get("volumes", [])
+    assert isinstance(volumes, list), "service volumes must be a list"
+
+    for volume in volumes:
+        if isinstance(volume, str):
+            parts = volume.split(":")
+            if len(parts) >= 2 and parts[0] == source and parts[1] == target:
+                return True
+        elif isinstance(volume, dict):
+            if volume.get("source") == source and volume.get("target") == target:
+                return True
+    return False
+
+
 def test_docker_compose_has_temporal_worker_auto_start_configured():
     """Verify that temporal workers are configured to start by default without sleeping."""
     compose_path = Path("docker-compose.yaml")
@@ -21,6 +37,7 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
         "temporal-worker-artifacts",
         "temporal-worker-llm",
         "temporal-worker-sandbox",
+        "temporal-worker-agent-runtime",
         "temporal-worker-integrations",
     ]
 
@@ -45,6 +62,7 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
             "sleep" not in command_var
         ), f"Worker '{fleet}' must not be configured to sleep. Found: {command_var}"
 
+
 def test_api_service_mounts_agent_runtime_workspace_volume():
     """Mission Control observability must read managed-run records from agent_workspaces."""
     compose_path = Path("docker-compose.yaml")
@@ -55,26 +73,56 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
     compose_data = yaml.safe_load(compose_path.read_text())
     services = compose_data.get("services", {})
     api_service = services.get("api")
-    assert isinstance(api_service, dict), "api service is missing from docker-compose.yaml"
+    assert isinstance(
+        api_service, dict
+    ), "api service is missing from docker-compose.yaml"
 
     volumes = api_service.get("volumes", [])
     assert isinstance(volumes, list), "api service volumes must be a list"
-    
+
     found_mount = False
     for v in volumes:
         if isinstance(v, str):
             parts = v.split(":")
-            if len(parts) >= 2 and parts[0] == "agent_workspaces" and parts[1] == "/work/agent_jobs":
+            if (
+                len(parts) >= 2
+                and parts[0] == "agent_workspaces"
+                and parts[1] == "/work/agent_jobs"
+            ):
                 found_mount = True
                 break
         elif isinstance(v, dict):
-            if v.get("source") == "agent_workspaces" and v.get("target") == "/work/agent_jobs":
+            if (
+                v.get("source") == "agent_workspaces"
+                and v.get("target") == "/work/agent_jobs"
+            ):
                 found_mount = True
                 break
 
     assert (
         found_mount
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"
+
+
+def test_agent_runtime_worker_mounts_agent_skill_catalog():
+    """Selected managed-session skills resolve from the deployment skill catalog."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    service_config = services.get("temporal-worker-agent-runtime")
+    assert isinstance(
+        service_config, dict
+    ), "temporal-worker-agent-runtime service is missing from docker-compose.yaml"
+
+    assert _has_volume_mount(service_config, "./.agents", "/app/.agents"), (
+        "temporal-worker-agent-runtime must mount ./.agents at /app/.agents so "
+        "selected agent skills can be materialized for managed sessions"
+    )
+
 
 def test_agent_workspaces_init_avoids_recursive_permission_repair():
     """Workspace init should only normalize hot directories, not recurse the whole volume."""

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2855,7 +2855,8 @@ async def test_publish_path_filter_excludes_generated_skill_projection_symlink(
     )
 
 
-async def test_publish_path_filter_accepts_workspace_string_for_skill_projection(
+async def test_publish_path_filter_normalizes_relative_workspace_path(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     workspace = tmp_path / "repo"
@@ -2864,11 +2865,46 @@ async def test_publish_path_filter_accepts_workspace_string_for_skill_projection
     projection = workspace / ".agents" / "skills"
     projection.parent.mkdir(parents=True)
     projection.symlink_to(backing, target_is_directory=True)
+    monkeypatch.chdir(tmp_path)
 
     assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
         ".agents/skills/pr-resolver/SKILL.md",
-        workspace=str(workspace),
+        workspace=Path("repo"),
     )
+
+
+async def test_commit_workspace_changes_filters_skill_projection_from_string_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    backing = tmp_path / "runtime" / "skills_active"
+    backing.mkdir(parents=True)
+    projection = workspace / ".agents" / "skills"
+    projection.parent.mkdir(parents=True)
+    projection.symlink_to(backing, target_is_directory=True)
+    activities = TemporalAgentRuntimeActivities()
+    recorded_calls: list[tuple[object, ...]] = []
+
+    async def _mock_exec(*args, **kwargs):
+        recorded_calls.append(args)
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(
+            return_value=(b" D .agents/skills/pr-resolver/SKILL.md\0", b"")
+        )
+        proc.returncode = 0
+        return proc
+
+    original_env = dict()
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(asyncio, "create_subprocess_exec", _mock_exec)
+        result = await activities._commit_workspace_changes_if_needed(
+            str(workspace),
+            run_id="run-1",
+            env=original_env,
+        )
+
+    assert result == {}
+    assert len(recorded_calls) == 1
 
 
 async def test_publish_path_filter_allows_checked_in_skill_directory(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2855,6 +2855,22 @@ async def test_publish_path_filter_excludes_generated_skill_projection_symlink(
     )
 
 
+async def test_publish_path_filter_accepts_workspace_string_for_skill_projection(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    backing = tmp_path / "runtime" / "skills_active"
+    backing.mkdir(parents=True)
+    projection = workspace / ".agents" / "skills"
+    projection.parent.mkdir(parents=True)
+    projection.symlink_to(backing, target_is_directory=True)
+
+    assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        ".agents/skills/pr-resolver/SKILL.md",
+        workspace=str(workspace),
+    )
+
+
 async def test_publish_path_filter_allows_checked_in_skill_directory(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Fix post-agent publish filtering when managed-run records provide `workspace_path` as a string.
- Keep generated `.agents/skills` symlink projections out of publish commits so checked-in skill-source paths are not recorded as deletions.
- Mount `.agents` into the agent-runtime worker so selected managed-session skills can resolve from the deployment catalog.

## Root Cause
Task `mm:901466c6-d1f5-4cac-aa74-f75557344825` failed during post-agent publish because `_should_exclude_publish_path()` typed `workspace` as a `Path`, but `_commit_workspace_changes_if_needed()` passed the stored workspace string. The filter then evaluated `workspace / ".agents" / "skills"` and raised `TypeError: unsupported operand type(s) for /: 'str' and 'str'`.

## Validation
- `./tools/test_unit.sh --python-only tests/test_local_dev.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/test_fetch_result_push.py` -> 159 passed.
- `git diff --check` -> passed.

## Notes
- A full `./tools/test_unit.sh` run also launches the frontend suite and currently fails in `entrypoints/task-detail.test.tsx` (`falls back to merged logs when structured history returns 404`), unrelated to this backend publish fix.
