### PR TITLE
MM-575 Define Step Type authoring model

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/287-step-type-authoring-controls"
+  "feature_directory": "specs/288-define-step-type-authoring-model"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-568",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1862"
+  "jira_issue_key": "MM-575",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1865"
 }

--- a/specs/288-define-step-type-authoring-model/checklists/requirements.md
+++ b/specs/288-define-step-type-authoring-model/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Define Step Type Authoring Model
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves the trusted `MM-575` Jira preset brief and maps all in-scope DESIGN-REQ rows to FR coverage.

--- a/specs/288-define-step-type-authoring-model/contracts/step-type-authoring-model.md
+++ b/specs/288-define-step-type-authoring-model/contracts/step-type-authoring-model.md
@@ -1,0 +1,25 @@
+# Contract: Step Type Authoring Model
+
+## Authoring UI Contract
+
+- Each authored step exposes one user-facing `Step Type` selector.
+- Valid choices are `Tool`, `Skill`, and `Preset`.
+- Selecting `Tool` shows Tool configuration only.
+- Selecting `Skill` shows Skill configuration only.
+- Selecting `Preset` shows Preset selection, preview, and apply controls only.
+- Switching Step Type preserves shared instructions.
+- Switching Step Type clears or visibly handles incompatible type-specific state.
+- The selector and helper copy use Step Type vocabulary, not capability/activity/invocation/command/script as the umbrella label.
+
+## Runtime Payload Contract
+
+- Runtime executable steps accept `type: tool` or `type: skill`.
+- Runtime executable steps reject `type: preset`, `type: activity`, and case variants such as `Activity`.
+- Tool steps reject an attached Skill payload.
+- Skill steps reject a non-skill Tool payload.
+- Preset-derived runtime steps carry provenance as metadata after expansion, not as unresolved runtime work.
+
+## Verification Surface
+
+- `frontend/src/entrypoints/task-create-step-type.test.tsx` verifies the rendered authoring UI contract.
+- `tests/unit/workflows/tasks/test_task_contract.py` verifies executable payload contract rejection paths.

--- a/specs/288-define-step-type-authoring-model/data-model.md
+++ b/specs/288-define-step-type-authoring-model/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Define Step Type Authoring Model
+
+## Step Draft
+
+Represents a user-authored step before final runtime submission.
+
+Fields:
+- `instructions`: shared authoring instructions preserved across Step Type changes.
+- `stepType`: exactly one of `skill`, `tool`, or `preset` in draft state.
+- Skill-specific state: selected skill ID, skill arguments, required capabilities.
+- Tool-specific state: tool ID, optional version, typed input object text.
+- Preset-specific state: selected preset, preset input values, preview/application state.
+- `stepTypeMessage`: transient user-visible feedback when incompatible type-specific state is discarded.
+
+Validation rules:
+- A draft has one selected Step Type at a time.
+- Hidden incompatible type-specific state must not be submitted as active configuration.
+- Shared instructions remain compatible across Step Type changes.
+
+## Executable Step Payload
+
+Represents a runtime-ready step.
+
+Fields:
+- `type`: executable Step Type, `tool` or `skill`.
+- `tool`: required for Tool steps and incompatible with Skill payloads.
+- `skill`: required for Skill steps and incompatible with non-skill Tool payloads.
+- `source`: optional provenance metadata for preset-derived steps.
+
+Validation rules:
+- `preset`, `activity`, and arbitrary command-like values are not executable Step Types.
+- Tool steps must not include Skill payloads.
+- Skill steps must not include non-skill Tool payloads.
+
+## Preset Expansion
+
+Represents authoring-time expansion of a Preset step into executable steps.
+
+Fields:
+- preset identifier and version.
+- preset input values.
+- resulting Tool and/or Skill steps.
+- provenance linking generated steps back to the preset.
+
+Validation rules:
+- Runtime submission must use expanded executable steps, not unresolved preset invocation.

--- a/specs/288-define-step-type-authoring-model/plan.md
+++ b/specs/288-define-step-type-authoring-model/plan.md
@@ -7,6 +7,34 @@
 
 Verify and complete the Step Type authoring model for Create page steps and runtime executable payload validation. Existing related Step Type work appears to provide the UI selector, separated type-specific draft state, visible incompatible-data discard behavior, preset expansion, and runtime rejection for mixed/non-executable payloads; this plan focuses on MM-575 traceability and direct validation of the authoring-model contract.
 
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/task-create.tsx` defines explicit `stepType` draft state and renders one Step Type radio group; `frontend/src/entrypoints/task-create-step-type.test.tsx` asserts Skill, Tool, and Preset choices. | No new implementation; preserve MM-575 traceability and final verification. | Focused UI integration + final unit verify |
+| FR-002 | implemented_verified | `frontend/src/entrypoints/task-create.tsx` conditionally renders Tool, Skill, and Preset configuration panels from `step.stepType`; focused UI test verifies panel changes. | No new implementation; keep rendered UI coverage. | Focused UI integration + type validation |
+| FR-003 | implemented_verified | `handleStepTypeChange` preserves instructions, clears incompatible Skill/Tool/Preset state, and sets a visible discard message; focused UI test covers Skill-to-Tool discard. | No new implementation; verify existing coverage remains passing. | Focused UI integration |
+| FR-004 | implemented_verified | `tests/unit/workflows/tasks/test_task_contract.py` rejects `preset`, `activity`, `Activity`, Tool-with-Skill, and Skill-with-non-Skill-Tool payloads. | No new implementation; retain runtime contract verification. | Runtime contract unit + final unit verify |
+| FR-005 | implemented_verified | Step Type selector labels and feature artifacts use Step Type, Tool, Skill, Preset, Expansion, Plan, and Activity terminology from `docs/Steps/StepTypes.md`. | No new implementation; final verification checks terminology. | Focused UI integration + final verify |
+| FR-006 | implemented_verified | The primary selector legend is `Step Type`; options are Skill, Tool, and Preset; no umbrella capability/activity/invocation/command/script label is used. | No new implementation; final verification checks primary labels. | Focused UI integration |
+| SCN-001 | implemented_verified | Focused UI test asserts exactly one `Step Type` group with Skill, Tool, and Preset labels. | No new implementation. | Focused UI integration |
+| SCN-002 | implemented_verified | Conditional panels in `task-create.tsx` and focused UI test verify visible controls follow selected Step Type. | No new implementation. | Focused UI integration |
+| SCN-003 | implemented_verified | `handleStepTypeChange` and focused UI test verify shared instructions are preserved and incompatible Skill state is visibly discarded. | No new implementation. | Focused UI integration |
+| SCN-004 | implemented_verified | Runtime contract tests reject mixed Tool/Skill payloads before execution. | No new implementation. | Runtime contract unit |
+| SCN-005 | implemented_verified | Step Type UI labels and artifacts preserve source design terminology. | No new implementation. | Focused UI integration + final verify |
+| SC-001 | implemented_verified | Focused UI test verifies one Step Type selector with Tool, Skill, and Preset choices. | No new implementation. | Focused UI integration |
+| SC-002 | implemented_verified | Focused UI test verifies Step Type switching changes controls while preserving instructions. | No new implementation. | Focused UI integration |
+| SC-003 | implemented_verified | Focused UI test verifies incompatible type-specific data is visibly cleared/handled. | No new implementation. | Focused UI integration |
+| SC-004 | implemented_verified | Python runtime contract tests verify non-executable and mixed payload rejection. | No new implementation. | Runtime contract unit |
+| SC-005 | implemented_verified | `spec.md`, tasks, and verification artifacts preserve MM-575 and the original preset brief. | No new implementation; preserve traceability through final verification. | Final MoonSpec verify |
+| DESIGN-REQ-001 | implemented_verified | Explicit Step Type state and rendered selector in `task-create.tsx`; UI test coverage. | No new implementation. | Focused UI integration |
+| DESIGN-REQ-002 | implemented_verified | Tool/Skill/Preset selector and type-specific panels in `task-create.tsx`; UI test coverage. | No new implementation. | Focused UI integration |
+| DESIGN-REQ-003 | implemented_verified | Source terminology is preserved in spec, contracts, and UI labels. | No new implementation. | Final verify |
+| DESIGN-REQ-005 | implemented_verified | Runtime contract rejects unresolved preset execution; preset expansion behavior is covered by existing focused UI tests. | No new implementation. | Runtime contract unit + focused UI integration |
+| DESIGN-REQ-006 | implemented_verified | `handleStepTypeChange` visibly handles incompatible fields and preserves shared instructions. | No new implementation. | Focused UI integration |
+| DESIGN-REQ-014 | implemented_verified | Primary selector uses Step Type as umbrella label; capability/activity terms are not primary discriminator labels. | No new implementation. | Focused UI integration + final verify |
+
 ## Technical Context
 
 **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for runtime payload contract tests  

--- a/specs/288-define-step-type-authoring-model/plan.md
+++ b/specs/288-define-step-type-authoring-model/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Define Step Type Authoring Model
+
+**Branch**: `288-define-step-type-authoring-model` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/288-define-step-type-authoring-model/spec.md`
+
+## Summary
+
+Verify and complete the Step Type authoring model for Create page steps and runtime executable payload validation. Existing related Step Type work appears to provide the UI selector, separated type-specific draft state, visible incompatible-data discard behavior, preset expansion, and runtime rejection for mixed/non-executable payloads; this plan focuses on MM-575 traceability and direct validation of the authoring-model contract.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for runtime payload contract tests  
+**Primary Dependencies**: React, Vitest, Testing Library, Pydantic v2, pytest  
+**Storage**: No new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh` with targeted Python pytest paths; TypeScript type checking via frontend tsconfig  
+**Integration Testing**: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` as rendered Create page boundary  
+**Target Platform**: MoonMind Mission Control and Temporal execution payload validation  
+**Project Type**: Web application plus Python service contracts  
+**Performance Goals**: Step Type switching remains immediate for ordinary task authoring  
+**Constraints**: Do not introduce compatibility aliases for unsupported Step Type values; preserve MM-575 in artifacts and delivery metadata  
+**Scale/Scope**: One independently testable story covering one authored step model and runtime validation boundary
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS - feature preserves agent/tool/preset orchestration boundaries.
+- II. One-Click Agent Deployment: PASS - no deployment or secret changes.
+- III. Avoid Vendor Lock-In: PASS - Step Type model is MoonMind-owned and provider-neutral.
+- IV. Own Your Data: PASS - no external storage changes.
+- V. Skills Are First-Class and Easy to Add: PASS - Skill remains a first-class Step Type.
+- VI. Replaceable Scaffolding: PASS - behavior is guarded by contract and UI tests.
+- VII. Runtime Configurability: PASS - no hardcoded operator configuration changes.
+- VIII. Modular and Extensible Architecture: PASS - validates existing UI/runtime boundaries.
+- IX. Resilient by Default: PASS - runtime payload validation rejects unsupported shapes fail-fast.
+- X. Facilitate Continuous Improvement: PASS - final verification records evidence and remaining risks.
+- XI. Spec-Driven Development: PASS - spec, plan, tasks, and verification artifacts precede final closure.
+- XII. Canonical Documentation Separation: PASS - canonical docs are read-only source requirements; execution notes stay feature-local.
+- XIII. Pre-release Compatibility Policy: PASS - no compatibility aliases or hidden fallback semantics are added.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/288-define-step-type-authoring-model/
+|-- spec.md
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- step-type-authoring-model.md
+|-- tasks.md
+`-- verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create-step-type.test.tsx
+tests/unit/workflows/tasks/test_task_contract.py
+```
+
+**Structure Decision**: Reuse the existing Create page authoring surface and Python runtime task contract boundary. No new modules are planned unless verification exposes a gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/288-define-step-type-authoring-model/quickstart.md
+++ b/specs/288-define-step-type-authoring-model/quickstart.md
@@ -15,4 +15,6 @@ Automated checks:
 ./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx
 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
 ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
+./tools/test_unit.sh
+/moonspec-verify
 ```

--- a/specs/288-define-step-type-authoring-model/quickstart.md
+++ b/specs/288-define-step-type-authoring-model/quickstart.md
@@ -1,0 +1,18 @@
+# Quickstart: Define Step Type Authoring Model
+
+1. Open Mission Control Create page.
+2. Inspect Step 1 and confirm the selector is labeled `Step Type`.
+3. Confirm the choices are `Skill`, `Tool`, and `Preset`.
+4. Enter shared instructions and type-specific Skill state.
+5. Change Step Type to `Tool`.
+6. Confirm instructions remain and Skill-specific state is visibly discarded.
+7. Attempt to submit a Tool step without choosing a Tool and confirm validation blocks submission.
+8. Apply a Preset step and confirm expanded steps are Tool and/or Skill steps.
+
+Automated checks:
+
+```bash
+./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
+./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
+```

--- a/specs/288-define-step-type-authoring-model/research.md
+++ b/specs/288-define-step-type-authoring-model/research.md
@@ -3,7 +3,7 @@
 ## Request Classification
 
 Decision: Classify MM-575 as one independently testable runtime story and do not run `moonspec-breakdown`.
-Evidence: `artifacts/moonspec/MM-575-orchestration-input.md` contains one user story, one acceptance set, and one requirement cluster for explicit Step Type authoring; `specs/288-define-step-type-authoring-model/spec.md` preserves that brief.
+Evidence: The committed `specs/288-define-step-type-authoring-model/spec.md` reproduces the normalized MM-575 Jira preset brief with one user story, one acceptance set, and one requirement cluster for explicit Step Type authoring.
 Rationale: The Jira preset brief asks for one cohesive authoring model: explicit selected Step Type, matching visible controls, explicit incompatible-data handling, and consistent terminology.
 Alternatives considered: Treating `docs/Steps/StepTypes.md` as a broad design was rejected because the Jira issue selects specific sections and coverage IDs for one story.
 Test implications: No breakdown tests; proceed with one-spec UI integration and runtime contract validation.

--- a/specs/288-define-step-type-authoring-model/research.md
+++ b/specs/288-define-step-type-authoring-model/research.md
@@ -1,21 +1,73 @@
 # Research: Define Step Type Authoring Model
 
-## Decision 1: Treat MM-575 as a single-story runtime feature
+## Request Classification
 
-Decision: Classify the Jira preset brief as one independently testable runtime story because it asks for the selected Step Type to be explicit, type-specific controls to change with the selection, incompatible data to be handled explicitly, and terminology to remain consistent.
+Decision: Classify MM-575 as one independently testable runtime story and do not run `moonspec-breakdown`.
+Evidence: `artifacts/moonspec/MM-575-orchestration-input.md` contains one user story, one acceptance set, and one requirement cluster for explicit Step Type authoring; `specs/288-define-step-type-authoring-model/spec.md` preserves that brief.
+Rationale: The Jira preset brief asks for one cohesive authoring model: explicit selected Step Type, matching visible controls, explicit incompatible-data handling, and consistent terminology.
+Alternatives considered: Treating `docs/Steps/StepTypes.md` as a broad design was rejected because the Jira issue selects specific sections and coverage IDs for one story.
+Test implications: No breakdown tests; proceed with one-spec UI integration and runtime contract validation.
 
-Rationale: The Jira issue includes one user story and one cohesive acceptance set. It references `docs/Steps/StepTypes.md` as source requirements rather than as documentation-only work.
+## FR-001 Explicit Step Type State
 
-Alternatives considered: Running `moonspec-breakdown` was rejected because the issue is already preselected to one story.
+Decision: implemented_verified.
+Evidence: `frontend/src/entrypoints/task-create.tsx` defines `StepState.stepType`, initializes new steps with `stepType: "skill"`, and renders one `Step Type` radio group; `frontend/src/entrypoints/task-create-step-type.test.tsx` asserts Skill, Tool, and Preset options.
+Rationale: Current code and tests together prove each authored step has exactly one selected Step Type in draft state.
+Alternatives considered: Adding new state was rejected because it would duplicate the existing model.
+Test implications: Focused UI integration and TypeScript type validation are sufficient.
 
-## Decision 2: Validate both authoring UI and runtime payload boundaries
+## FR-002 Type-Specific Controls
 
-Decision: Use Create page rendered tests for authoring behavior and Python task contract tests for executable payload validation.
+Decision: implemented_verified.
+Evidence: `frontend/src/entrypoints/task-create.tsx` conditionally renders Tool, Skill, and Preset panels based on `step.stepType`; the focused UI test switches Step Type and verifies visible controls.
+Rationale: The UI already presents the correct configuration surface for the selected Step Type.
+Alternatives considered: Broader Create page regression coverage was considered, but the focused Step Type test is the more direct integration boundary.
+Test implications: Focused UI integration plus dashboard final verification.
 
-Rationale: MM-575 includes both draft authoring semantics and invalid mixed-type draft detection. The UI test proves visible Step Type behavior; the runtime contract test proves invalid execution shapes fail before Temporal execution.
+## FR-003 Incompatible Data Handling
 
-## Decision 3: Reuse existing Step Type implementation when evidence passes
+Decision: implemented_verified.
+Evidence: `handleStepTypeChange` preserves shared step fields, clears incompatible Skill, Tool, and Preset fields, and sets `stepTypeMessage`; the focused UI test verifies preserved instructions and visible Skill discard feedback.
+Rationale: The current behavior meets the explicit handling requirement without adding confirmation complexity.
+Alternatives considered: Confirmation prompts were unnecessary because visible discard feedback satisfies the spec and keeps authoring flow simple.
+Test implications: Focused UI integration.
 
-Decision: Do not add code unless current tests or inspection reveal a gap.
+## FR-004 Runtime Payload Validation
 
-Rationale: Related Step Type stories have already introduced the selector, separated draft state, discard notice, and mixed payload rejection. MM-575 still requires its own MoonSpec traceability and final verification evidence.
+Decision: implemented_verified.
+Evidence: `tests/unit/workflows/tasks/test_task_contract.py` rejects non-executable Step Types (`preset`, `activity`, `Activity`) and mixed Tool/Skill payloads.
+Rationale: Runtime payload validation prevents unresolved Preset steps and invalid mixed executable shapes from reaching execution.
+Alternatives considered: Adding compatibility aliases was rejected by the project compatibility policy.
+Test implications: Runtime contract unit test and final `./tools/test_unit.sh`.
+
+## FR-005 Terminology Consistency
+
+Decision: implemented_verified.
+Evidence: `docs/Steps/StepTypes.md` defines Task, Step, Step Type, Tool, Skill, Preset, Expansion, Plan, and Activity; `spec.md`, `contracts/step-type-authoring-model.md`, and the Create page selector preserve those terms.
+Rationale: The behavior and artifacts align to the canonical terminology.
+Alternatives considered: No terminology rewrite is needed because canonical docs remain the desired-state source.
+Test implications: Final MoonSpec verification plus focused UI label checks.
+
+## FR-006 Umbrella Label Guardrail
+
+Decision: implemented_verified.
+Evidence: The Create page selector legend is `Step Type`; the focused UI test locates the group by `Step Type` and asserts Skill, Tool, and Preset options.
+Rationale: Capability, Activity, invocation, command, and script are not used as the umbrella authoring label.
+Alternatives considered: No code change is needed; adding new label indirection would increase drift risk.
+Test implications: Focused UI integration and final verification.
+
+## SC and Acceptance Coverage
+
+Decision: implemented_verified for SC-001 through SC-005 and acceptance scenarios 1-5.
+Evidence: `frontend/src/entrypoints/task-create-step-type.test.tsx` covers selector choices, control switching, instruction preservation, and visible discard feedback; `tests/unit/workflows/tasks/test_task_contract.py` covers executable payload rejection; `spec.md` and `verification.md` preserve MM-575 traceability.
+Rationale: The direct UI and contract tests cover the observable story and runtime boundary.
+Alternatives considered: Adding duplicate tests was rejected because current focused tests already exercise the required behavior.
+Test implications: Run focused UI, runtime contract, TypeScript, and final unit verification.
+
+## Design Artifact Strategy
+
+Decision: Keep `data-model.md`, `contracts/step-type-authoring-model.md`, and `quickstart.md` because the story has draft-state data, a public authoring UI contract, and a runtime payload contract.
+Evidence: The feature involves Step Draft, Executable Step Payload, and Preset Expansion concepts, plus UI and runtime validation surfaces.
+Rationale: These artifacts are required by the active plan workflow for data, contracts, and executable validation guidance.
+Alternatives considered: Skipping contracts was rejected because the story exposes user-facing UI behavior and execution payload validation.
+Test implications: Quickstart includes focused UI, runtime contract, and type validation commands.

--- a/specs/288-define-step-type-authoring-model/research.md
+++ b/specs/288-define-step-type-authoring-model/research.md
@@ -1,0 +1,21 @@
+# Research: Define Step Type Authoring Model
+
+## Decision 1: Treat MM-575 as a single-story runtime feature
+
+Decision: Classify the Jira preset brief as one independently testable runtime story because it asks for the selected Step Type to be explicit, type-specific controls to change with the selection, incompatible data to be handled explicitly, and terminology to remain consistent.
+
+Rationale: The Jira issue includes one user story and one cohesive acceptance set. It references `docs/Steps/StepTypes.md` as source requirements rather than as documentation-only work.
+
+Alternatives considered: Running `moonspec-breakdown` was rejected because the issue is already preselected to one story.
+
+## Decision 2: Validate both authoring UI and runtime payload boundaries
+
+Decision: Use Create page rendered tests for authoring behavior and Python task contract tests for executable payload validation.
+
+Rationale: MM-575 includes both draft authoring semantics and invalid mixed-type draft detection. The UI test proves visible Step Type behavior; the runtime contract test proves invalid execution shapes fail before Temporal execution.
+
+## Decision 3: Reuse existing Step Type implementation when evidence passes
+
+Decision: Do not add code unless current tests or inspection reveal a gap.
+
+Rationale: Related Step Type stories have already introduced the selector, separated draft state, discard notice, and mixed payload rejection. MM-575 still requires its own MoonSpec traceability and final verification evidence.

--- a/specs/288-define-step-type-authoring-model/spec.md
+++ b/specs/288-define-step-type-authoring-model/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Define Step Type Authoring Model
+
+**Feature Branch**: `288-define-step-type-authoring-model`
+**Created**: 2026-05-01
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-575 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+Preserved source Jira preset brief: `MM-575` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-575` and local artifact `artifacts/moonspec/MM-575-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserved `MM-575`, so `Specify` was the first incomplete MM-575 stage.
+
+## Original Preset Brief
+
+```text
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-575 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-575: Define the Step Type authoring model
+
+Current Jira status at orchestration input fetch time: In Progress
+Issue type: Story
+Labels: moonmind-workflow-mm-911309af-6b4f-48e7-8835-e533aa9af8cf
+
+Canonical source: normalized Jira preset brief synthesized from trusted jira.get_issue response fields because the MCP issue response did not expose recommendedImports.presetInstructions, normalizedPresetBrief, presetBrief, or presetInstructions, and the Implementation plan and Source fields were null.
+Trusted response artifact: artifacts/moonspec/MM-575-trusted-jira-get-issue.json
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 1. Purpose
+- 2. Desired-State Summary
+- 3. Terminology
+- 4. Core Invariants
+- 6.1 Step editor
+- 6.2 Step type picker
+- 10. Naming Policy
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-003
+- DESIGN-REQ-005
+- DESIGN-REQ-006
+- DESIGN-REQ-014
+
+As a task author, I can choose exactly one Step Type for each step so the editor shows the right fields and uses consistent product terminology.
+
+Acceptance Criteria
+- Every authored step has exactly one Step Type with canonical values tool, skill, or preset.
+- Changing Step Type updates the visible configuration controls and handles incompatible data explicitly.
+- The product-facing label is Step Type, not capability, activity, invocation, command, or script.
+- Task, Step, Tool, Skill, Preset, Expansion, Plan, and Activity terminology follows the design definitions.
+
+Requirements
+- Represent the selected Step Type explicitly in draft state.
+- Keep type-specific payloads separate enough that invalid mixed-type drafts can be detected.
+- Reserve capability terminology for security or worker-placement contexts only.
+```
+
+## User Story - Step Type Authoring Model
+
+**Summary**: As a task author, I can choose exactly one Step Type for each step so the editor shows the right fields and uses consistent product terminology.
+
+**Goal**: Each authored step has one explicit Step Type value, type-specific draft data remains separated enough to detect invalid mixed-type drafts, and product copy consistently uses the Step Type vocabulary.
+
+**Independent Test**: Render the Create page step editor, verify one Step Type selector with Tool, Skill, and Preset options, switch among types, and confirm that visible controls, preserved instructions, discarded incompatible data, submitted payload shape, and terminology all match the Step Type model.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author opens an authored step, **When** they inspect its discriminator control, **Then** the step exposes exactly one control named Step Type with Tool, Skill, and Preset choices.
+2. **Given** the author changes the Step Type, **When** the selected value changes to Tool, Skill, or Preset, **Then** only the matching type-specific configuration controls are visible below the selector.
+3. **Given** a step has meaningful type-specific values, **When** the author changes to an incompatible Step Type, **Then** shared instructions are preserved and incompatible type-specific data is explicitly cleared or otherwise handled visibly.
+4. **Given** a step is submitted or compiled for execution, **When** its Step Type is Tool or Skill, **Then** the payload contains only the compatible executable payload for that type and rejects mixed Tool/Skill payloads.
+5. **Given** the Step Type model appears in the authoring surface, **When** labels, helper copy, and validation messages are inspected, **Then** they use Step Type, Tool, Skill, Preset, Expansion, Plan, and Activity terminology according to the design definitions and do not use capability as the umbrella label.
+
+### Edge Cases
+
+- A newly created step defaults to one valid Step Type and does not require a second discriminator before it can be edited.
+- Hidden Skill, Tool, or Preset state is not silently submitted after the author changes to another Step Type.
+- Preset remains an authoring-time placeholder; applied presets must produce executable Tool or Skill steps before runtime execution.
+- Runtime validation rejects non-executable Step Types such as preset or activity in execution payloads.
+
+## Assumptions
+
+- Runtime intent applies: this story verifies product behavior in the Create page authoring surface and execution payload validation, not documentation-only wording.
+- Related Step Type work may already satisfy parts of MM-575; this spec preserves MM-575 traceability and verifies the authoring-model requirements directly.
+- Preset authoring can remain a preview/apply workflow as long as runtime submissions use expanded executable steps.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | docs/Steps/StepTypes.md sections 1, 2, 4 | Every authored step has exactly one Step Type that determines what the step represents, which fields are shown, and how it is validated. | In scope | FR-001, FR-002, FR-003 |
+| DESIGN-REQ-002 | docs/Steps/StepTypes.md sections 2, 3, 6.1, 6.2 | The Step Type control offers Tool, Skill, and Preset and renders type-specific configuration below the selector. | In scope | FR-001, FR-002, FR-006 |
+| DESIGN-REQ-003 | docs/Steps/StepTypes.md section 3 | Task, Step, Tool, Skill, Preset, Expansion, Plan, and Activity terminology follows the design definitions. | In scope | FR-005 |
+| DESIGN-REQ-005 | docs/Steps/StepTypes.md sections 4, 5.3 | Preset steps are authoring-time placeholders and must expand into executable Tool and/or Skill steps before runtime execution. | In scope | FR-004 |
+| DESIGN-REQ-006 | docs/Steps/StepTypes.md sections 4, 6.1 | Changing Step Type must preserve compatible fields and clearly handle incompatible fields. | In scope | FR-003 |
+| DESIGN-REQ-014 | docs/Steps/StepTypes.md section 10 | Product-facing copy uses Step Type as the umbrella term and avoids capability/activity/invocation/command/script as ordinary authoring labels. | In scope | FR-005, FR-006 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each authored step MUST represent its selected Step Type explicitly as exactly one of Tool, Skill, or Preset in draft state.
+- **FR-002**: The step editor MUST show only the configuration controls that correspond to the selected Step Type.
+- **FR-003**: Changing Step Type MUST preserve compatible shared instructions and MUST explicitly clear, preserve, or confirm removal of incompatible type-specific data.
+- **FR-004**: Runtime executable payloads MUST reject non-executable Step Types and mixed Tool/Skill payloads.
+- **FR-005**: User-facing authoring copy MUST use Step Type, Tool, Skill, Preset, Expansion, Plan, and Activity according to the source design terminology.
+- **FR-006**: Product-facing labels MUST NOT use capability, activity, invocation, command, or script as the umbrella label for the Step Type selector.
+
+### Key Entities
+
+- **Step Draft**: A user-authored step with shared instructions, one selected Step Type, and separated type-specific draft state.
+- **Step Type**: The user-facing discriminator with canonical values Tool, Skill, and Preset.
+- **Executable Step Payload**: The runtime-ready representation after authoring that can execute as Tool or Skill and cannot contain incompatible mixed payloads.
+- **Preset Expansion**: The deterministic authoring-time process that turns a Preset step into concrete executable Tool and/or Skill steps.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests verify one Step Type selector with exactly Tool, Skill, and Preset choices for an authored step.
+- **SC-002**: Frontend tests verify switching Step Type changes visible controls while preserving shared instructions.
+- **SC-003**: Frontend tests verify incompatible type-specific data is visibly cleared or handled on Step Type changes.
+- **SC-004**: Runtime contract tests verify non-executable Step Types and mixed executable payloads are rejected.
+- **SC-005**: Verification evidence confirms primary authoring labels use Step Type vocabulary and preserve `MM-575` traceability.

--- a/specs/288-define-step-type-authoring-model/spec.md
+++ b/specs/288-define-step-type-authoring-model/spec.md
@@ -15,9 +15,9 @@ Source design path (optional): .
 Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
 Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
 
-Preserved source Jira preset brief: `MM-575` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for downstream verification.
+Preserved source Jira preset brief: `MM-575` from the trusted `jira.get_issue` response, reproduced in `## Original Preset Brief` below for durable downstream verification. Raw local orchestration captures were treated as transient run artifacts; the reproduced brief is the committed traceability record.
 
-Original brief reference: trusted `jira.get_issue` MCP response for `MM-575` and local artifact `artifacts/moonspec/MM-575-orchestration-input.md`.
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-575`, with the normalized brief reproduced below for permanence.
 Classification: single-story runtime feature request.
 Resume decision: no existing Moon Spec feature directory preserved `MM-575`, so `Specify` was the first incomplete MM-575 stage.
 
@@ -33,7 +33,7 @@ Issue type: Story
 Labels: moonmind-workflow-mm-911309af-6b4f-48e7-8835-e533aa9af8cf
 
 Canonical source: normalized Jira preset brief synthesized from trusted jira.get_issue response fields because the MCP issue response did not expose recommendedImports.presetInstructions, normalizedPresetBrief, presetBrief, or presetInstructions, and the Implementation plan and Source fields were null.
-Trusted response artifact: artifacts/moonspec/MM-575-trusted-jira-get-issue.json
+Trusted response source: runtime `jira.get_issue` response for `MM-575`; relevant normalized fields are reproduced in this committed brief.
 
 Source Reference
 Source Document: docs/Steps/StepTypes.md

--- a/specs/288-define-step-type-authoring-model/tasks.md
+++ b/specs/288-define-step-type-authoring-model/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Define Step Type Authoring Model
+
+**Input**: Design documents from `specs/288-define-step-type-authoring-model/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and rendered Create page integration-style frontend tests are REQUIRED. This story spans UI authoring state and runtime payload validation.
+
+**Source Traceability**: MM-575 Jira preset brief is preserved in `spec.md`. Tasks cover exactly one story: FR-001 through FR-006, acceptance scenarios 1-5, SC-001 through SC-005, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-005, DESIGN-REQ-006, and DESIGN-REQ-014.
+
+**Test Commands**:
+
+- Focused UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
+- Runtime contract verification: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py`
+- Unit/type validation: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+- [X] T001 Preserve MM-575 trusted Jira preset brief in `specs/288-define-step-type-authoring-model/spec.md` and `artifacts/moonspec/MM-575-orchestration-input.md` (SC-005)
+- [X] T002 Confirm source requirements in `docs/Steps/StepTypes.md` cover DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-005, DESIGN-REQ-006, and DESIGN-REQ-014
+- [X] T003 Confirm relevant existing implementation and tests are in `frontend/src/entrypoints/task-create.tsx`, `frontend/src/entrypoints/task-create-step-type.test.tsx`, and `tests/unit/workflows/tasks/test_task_contract.py`
+
+## Phase 2: Foundational Validation
+
+- [X] T004 Verify existing draft state has explicit `stepType` and separated Skill, Tool, and Preset state in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-002)
+- [X] T005 Verify runtime task contract rejects non-executable Step Type values and mixed payloads in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-005)
+
+## Phase 3: Story - Step Type Authoring Model
+
+**Summary**: As a task author, I can choose exactly one Step Type for each step so the editor shows the right fields and uses consistent product terminology.
+
+**Independent Test**: Render the Create page step editor, verify one Step Type selector with Tool, Skill, and Preset options, switch among types, and confirm visible forms, preserved instructions, explicit incompatible-data handling, runtime payload rejection, and terminology.
+
+### Unit Tests (write/confirm first)
+
+- [X] T006 Confirm runtime contract tests cover rejection of `preset`, `activity`, and `Activity` executable step types in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, SC-004)
+- [X] T007 Confirm runtime contract tests cover Tool-with-Skill and Skill-with-non-Skill-Tool mixed payload rejection in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, SC-004)
+
+### Integration Tests (write/confirm first)
+
+- [X] T008 Confirm rendered Create page test covers one Step Type selector with Skill, Tool, and Preset options in `frontend/src/entrypoints/task-create-step-type.test.tsx` (FR-001, SC-001)
+- [X] T009 Confirm rendered Create page test covers preserved shared instructions and visible incompatible Skill discard on Step Type change in `frontend/src/entrypoints/task-create-step-type.test.tsx` (FR-002, FR-003, SC-002, SC-003)
+
+### Red-First Confirmation
+
+- [X] T010 Confirm no new production code is required because existing related Step Type implementation already includes explicit state, visible discard handling, and runtime rejection coverage (FR-001 through FR-006)
+
+### Implementation
+
+- [X] T011 Reuse existing Step Type selector rendering and `handleStepTypeChange` behavior in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-002, FR-003, FR-005, FR-006)
+- [X] T012 Reuse existing runtime task contract validation in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004)
+
+### Story Validation
+
+- [X] T013 Run focused UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` (FR-001, FR-002, FR-003, FR-005, FR-006)
+- [X] T014 Run runtime contract verification: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py` (FR-004)
+- [X] T015 Run unit/type validation: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` (FR-001 through FR-006)
+
+## Phase 4: Polish & Verification
+
+- [X] T016 Create feature-local planning, data model, contract, quickstart, checklist, and task artifacts in `specs/288-define-step-type-authoring-model/` (SC-005)
+- [X] T017 Run `/moonspec-verify` equivalent read-only verification and write `specs/288-define-step-type-authoring-model/verification.md` (SC-005)
+
+## Dependencies & Execution Order
+
+- T001-T003 precede validation.
+- T006-T009 are test-confirmation tasks and precede implementation closure.
+- T013-T015 run after artifact creation and before final verification.
+- T017 runs after tests pass or exact blockers are documented.
+
+## Implementation Strategy
+
+1. Preserve MM-575 and the trusted preset brief in feature artifacts.
+2. Treat `docs/Steps/StepTypes.md` as runtime source requirements.
+3. Reuse existing Step Type UI and runtime validation where evidence passes.
+4. Run focused UI, runtime contract, and type validation.
+5. Write final `verification.md` with requirement coverage and test evidence.

--- a/specs/288-define-step-type-authoring-model/tasks.md
+++ b/specs/288-define-step-type-authoring-model/tasks.md
@@ -32,7 +32,7 @@
 
 ## Phase 1: Setup
 
-- [X] T001 Preserve MM-575 trusted Jira preset brief in `specs/288-define-step-type-authoring-model/spec.md` and `artifacts/moonspec/MM-575-orchestration-input.md` (SC-005)
+- [X] T001 Preserve MM-575 trusted Jira preset brief in `specs/288-define-step-type-authoring-model/spec.md` as the committed traceability record (SC-005)
 - [X] T002 Confirm source requirements in `docs/Steps/StepTypes.md` cover DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-005, DESIGN-REQ-006, and DESIGN-REQ-014
 - [X] T003 Confirm relevant existing implementation and tests are in `frontend/src/entrypoints/task-create.tsx`, `frontend/src/entrypoints/task-create-step-type.test.tsx`, and `tests/unit/workflows/tasks/test_task_contract.py`
 

--- a/specs/288-define-step-type-authoring-model/tasks.md
+++ b/specs/288-define-step-type-authoring-model/tasks.md
@@ -7,6 +7,8 @@
 
 **Source Traceability**: MM-575 Jira preset brief is preserved in `spec.md`. Tasks cover exactly one story: FR-001 through FR-006, acceptance scenarios 1-5, SC-001 through SC-005, and DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-005, DESIGN-REQ-006, and DESIGN-REQ-014.
 
+**Requirement Status Summary**: `plan.md` classifies every in-scope FR, acceptance scenario, SC, and DESIGN-REQ row as `implemented_verified`. This task list therefore preserves traceability, confirms existing unit and integration evidence, retains red-first reasoning as verification of prior coverage, and requires final validation rather than adding new production implementation tasks.
+
 **Test Commands**:
 
 - Focused UI verification: `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx`
@@ -19,6 +21,14 @@
 - **[P]**: Can run in parallel (different files, no dependencies)
 - Include exact file paths in descriptions
 - Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Requirement Status Coverage
+
+| Status from plan.md | Covered IDs | Task handling |
+| --- | --- | --- |
+| implemented_verified | FR-001, FR-002, FR-003, FR-005, FR-006; SCN-001, SCN-002, SCN-003, SCN-005; SC-001, SC-002, SC-003, SC-005; DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-014 | Existing Create page implementation and rendered UI tests are confirmed in T004, T008, T009, T011, T013, T015, and T017. |
+| implemented_verified | FR-004; SCN-004; SC-004; DESIGN-REQ-005 | Existing runtime contract tests are confirmed in T005, T006, T007, T012, T014, and T017. |
+
 
 ## Phase 1: Setup
 
@@ -78,6 +88,7 @@
 
 1. Preserve MM-575 and the trusted preset brief in feature artifacts.
 2. Treat `docs/Steps/StepTypes.md` as runtime source requirements.
-3. Reuse existing Step Type UI and runtime validation where evidence passes.
-4. Run focused UI, runtime contract, and type validation.
-5. Write final `verification.md` with requirement coverage and test evidence.
+3. Carry forward the `implemented_verified` status from `plan.md` for every in-scope FR, scenario, SC, and DESIGN-REQ row.
+4. Reuse existing Step Type UI and runtime validation where evidence passes; do not add production implementation tasks unless validation fails.
+5. Run focused UI, runtime contract, and type validation.
+6. Write final `verification.md` with requirement coverage and test evidence.

--- a/specs/288-define-step-type-authoring-model/verification.md
+++ b/specs/288-define-step-type-authoring-model/verification.md
@@ -1,0 +1,56 @@
+# MoonSpec Verification Report
+
+**Feature**: Define Step Type Authoring Model  
+**Spec**: `/work/agent_jobs/mm:ae921b44-0c56-4085-95a9-e3b28e9d61e8/repo/specs/288-define-step-type-authoring-model/spec.md`  
+**Original Request Source**: spec.md `Input` / trusted Jira preset brief for `MM-575`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused UI integration | `./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx` | PASS | 1 Vitest file passed, 4 tests passed. Canvas `getContext` jsdom warnings are existing non-fatal output. |
+| Runtime contract unit | `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py` | PASS | 25 Python tests passed; dashboard suite also ran through the unit runner with 17 passed and 1 skipped files. |
+| Type validation | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS | TypeScript completed with exit code 0. |
+| Full unit suite | `./tools/test_unit.sh` | PASS | 4251 Python tests passed, 1 xpassed, 16 subtests passed; frontend suite: 17 passed, 1 skipped files, 262 passed and 222 skipped tests. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `frontend/src/entrypoints/task-create.tsx` `stepType` state and Step Type radio group; `frontend/src/entrypoints/task-create-step-type.test.tsx` selector assertions | VERIFIED | Each draft step carries exactly one selected Step Type with Skill, Tool, or Preset options. |
+| FR-002 | `frontend/src/entrypoints/task-create.tsx` conditional Tool/Skill/Preset panels; focused UI test | VERIFIED | Visible controls are driven by the selected Step Type. |
+| FR-003 | `handleStepTypeChange` preserves instructions, clears incompatible state, and sets a visible discard message; focused UI test | VERIFIED | Incompatible Skill state is visibly discarded while shared instructions remain. |
+| FR-004 | `tests/unit/workflows/tasks/test_task_contract.py` rejects preset/activity executable types and mixed Tool/Skill payloads | VERIFIED | Runtime executable payload validation rejects non-executable and mixed shapes. |
+| FR-005 | Step Type UI labels, contract tests, and source artifact mapping use Step Type terminology | VERIFIED | Authoring model follows the source design vocabulary. |
+| FR-006 | Step Type legend/options in Create page and focused UI assertions | VERIFIED | Capability/activity/invocation/command/script are not the umbrella selector label. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Scenario 1 | Focused UI test checks one `Step Type` group with Skill, Tool, Preset labels | VERIFIED | Matches exactly one visible discriminator control. |
+| Scenario 2 | `task-create.tsx` renders mutually exclusive type-specific panels | VERIFIED | Existing test switches Step Type and observes panel changes. |
+| Scenario 3 | Focused UI test covers preserved instructions and visible Skill discard notice | VERIFIED | Incompatible state is cleared and user-visible feedback is shown. |
+| Scenario 4 | Runtime contract tests reject mixed executable payloads | VERIFIED | Invalid mixed Tool/Skill submissions fail validation. |
+| Scenario 5 | UI labels and spec/contract mapping preserve Step Type vocabulary | VERIFIED | Primary selector uses Step Type, Tool, Skill, Preset. |
+
+## Source Design Coverage
+
+| Source Requirement | Status | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-001 | VERIFIED | Explicit Step Type state, selector, and validation evidence. |
+| DESIGN-REQ-002 | VERIFIED | Tool/Skill/Preset selector and type-specific panels. |
+| DESIGN-REQ-003 | VERIFIED | Artifacts and UI use the documented terminology. |
+| DESIGN-REQ-005 | VERIFIED | Runtime rejects unresolved preset execution; preset expansion behavior is covered by existing focused UI tests. |
+| DESIGN-REQ-006 | VERIFIED | `handleStepTypeChange` preserves shared instructions and visibly clears incompatible state. |
+| DESIGN-REQ-014 | VERIFIED | Primary selector vocabulary is Step Type, not capability/activity/invocation/command/script. |
+
+## Constitution Check
+
+All applicable constitution gates remain PASS. The change is spec-driven, keeps canonical docs read-only, adds no compatibility aliases, and validates runtime payload rejection at the contract boundary.
+
+## Remaining Risks
+
+None for `MM-575`. The full unit suite reports existing warnings, but no failing tests.

--- a/specs/288-define-step-type-authoring-model/verification.md
+++ b/specs/288-define-step-type-authoring-model/verification.md
@@ -1,7 +1,7 @@
 # MoonSpec Verification Report
 
 **Feature**: Define Step Type Authoring Model  
-**Spec**: `/work/agent_jobs/mm:ae921b44-0c56-4085-95a9-e3b28e9d61e8/repo/specs/288-define-step-type-authoring-model/spec.md`  
+**Spec**: spec.md
 **Original Request Source**: spec.md `Input` / trusted Jira preset brief for `MM-575`  
 **Verdict**: FULLY_IMPLEMENTED  
 **Confidence**: HIGH


### PR DESCRIPTION
## Summary
- Preserve MM-575 MoonSpec traceability for the Step Type authoring model.
- Align plan, research, tasks, and quickstart with implemented and verified requirement coverage.
- Keep implementation scope unchanged because existing Step Type UI and runtime contract coverage satisfy the story.

## Jira
- MM-575

## MoonSpec
- Feature path: specs/288-define-step-type-authoring-model/
- Verification verdict: FULLY_IMPLEMENTED

## Tests
- ./tools/test_unit.sh --dashboard-only --ui-args entrypoints/task-create-step-type.test.tsx
- ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- ./tools/test_unit.sh

## Remaining risks
- None
