### PR TITLE
Fix Codex empty task_complete handling

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1141,10 +1141,35 @@ class CodexManagedSessionRuntime:
             recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
             if recovered_error:
                 return "failed", recovered_error
-            return "failed", "codex app-server turn/completed produced no assistant output"
+            return "completed", None
         if scan.assistant_text:
             return "completed", None
         return None
+
+    def _completed_turn_without_assistant_outcome(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> tuple[str, str | None]:
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        rollout_scan = self._scan_rollout_for_turn(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+            turn_started_at=state.last_control_at,
+        )
+        if rollout_scan.error_text:
+            return "failed", rollout_scan.error_text
+        if rollout_scan.saw_task_complete:
+            recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
+            if recovered_error:
+                return "failed", recovered_error
+            return "completed", None
+        return "failed", "codex app-server turn/completed produced no assistant output"
 
     def _resolved_rollout_path(
         self,
@@ -1475,15 +1500,19 @@ class CodexManagedSessionRuntime:
                 vendor_turn_id=active_turn_id,
             )
         if status == "completed" and not assistant_text:
-            error_text = "codex app-server turn/completed produced no assistant output"
-            self._append_spool(
-                "stderr",
-                (
-                    "codex app-server turn completed without assistant output: "
-                    f"{active_turn_id}\n"
-                ),
+            status, error_text = self._completed_turn_without_assistant_outcome(
+                state=state,
+                thread_payload=thread_payload,
+                vendor_turn_id=active_turn_id,
             )
-            status = "failed"
+            if status == "failed":
+                self._append_spool(
+                    "stderr",
+                    (
+                        "codex app-server turn completed without assistant output: "
+                        f"{active_turn_id}\n"
+                    ),
+                )
         self._finalize_turn(
             state=state,
             turn_id=active_turn_id,
@@ -1634,15 +1663,21 @@ class CodexManagedSessionRuntime:
                 vendor_turn_id=vendor_turn_id,
             )
             if not assistant_text:
-                error_text = "codex app-server turn/completed produced no assistant output"
-                self._append_spool(
-                    "stderr",
-                    (
-                        "codex app-server turn completed without assistant output: "
-                        f"{vendor_turn_id}\n"
-                    ),
+                status, error_text = self._completed_turn_without_assistant_outcome(
+                    state=state,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=vendor_turn_id,
                 )
-                status = "failed"
+                if status == "failed":
+                    self._append_spool(
+                        "stderr",
+                        (
+                            "codex app-server turn completed without assistant output: "
+                            f"{vendor_turn_id}\n"
+                        ),
+                    )
+                else:
+                    metadata["assistantTextMissing"] = True
             else:
                 metadata["assistantText"] = assistant_text
         if error_text:

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -61,6 +61,11 @@ class _RolloutTurnScan:
     saw_task_complete: bool = False
     error_text: str | None = None
 
+@dataclass(frozen=True)
+class _CompletedTurnInspection:
+    assistant_text: str = ""
+    rollout_scan: _RolloutTurnScan | None = None
+
 @dataclass
 class _RolloutLiveMirror:
     path: str | None = None
@@ -601,6 +606,23 @@ class CodexManagedSessionRuntime:
                 parts.append(text.strip())
         return "\n".join(parts).strip()
 
+    @classmethod
+    def _error_text_from_value(cls, value: Any) -> str | None:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+        if isinstance(value, Mapping):
+            for field_name in ("message", "error", "reason", "detail"):
+                recovered = cls._error_text_from_value(value.get(field_name))
+                if recovered:
+                    return recovered
+        if isinstance(value, list):
+            for item in value:
+                recovered = cls._error_text_from_value(item)
+                if recovered:
+                    return recovered
+        return None
+
     @staticmethod
     def _payload_references_turn(payload: Any, vendor_turn_id: str) -> bool:
         if not vendor_turn_id:
@@ -732,9 +754,11 @@ class CodexManagedSessionRuntime:
                     continue
                 saw_task_complete = True
                 for field_name in ("error", "reason", "message"):
-                    value = event_payload.get(field_name)
-                    if isinstance(value, str) and value.strip():
-                        error_text = value.strip()
+                    extracted_error = self._error_text_from_value(
+                        event_payload.get(field_name)
+                    )
+                    if extracted_error:
+                        error_text = extracted_error
                         break
         except OSError:
             return _RolloutTurnScan()
@@ -1152,16 +1176,18 @@ class CodexManagedSessionRuntime:
         state: CodexSessionRuntimeState,
         thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
+        rollout_scan: _RolloutTurnScan | None = None,
     ) -> tuple[str, str | None]:
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        rollout_scan = self._scan_rollout_for_turn(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-            turn_started_at=state.last_control_at,
-        )
+        if rollout_scan is None:
+            vendor_thread_path = self._resolved_rollout_path(
+                state=state,
+                thread_payload=thread_payload,
+            )
+            rollout_scan = self._scan_rollout_for_turn(
+                vendor_thread_path,
+                vendor_turn_id=vendor_turn_id,
+                turn_started_at=state.last_control_at,
+            )
         if rollout_scan.error_text:
             return "failed", rollout_scan.error_text
         if rollout_scan.saw_task_complete:
@@ -1193,6 +1219,33 @@ class CodexManagedSessionRuntime:
             state.vendor_thread_path = recovered_path
         return recovered_path
 
+    def _inspect_completed_turn(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> _CompletedTurnInspection:
+        assistant_text = self._extract_assistant_text(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if assistant_text:
+            return _CompletedTurnInspection(assistant_text=assistant_text)
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        rollout_scan = self._scan_rollout_for_turn(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+            turn_started_at=state.last_control_at,
+        )
+        return _CompletedTurnInspection(
+            assistant_text=rollout_scan.assistant_text,
+            rollout_scan=rollout_scan,
+        )
+
     def _assistant_text_for_completed_turn(
         self,
         *,
@@ -1200,21 +1253,11 @@ class CodexManagedSessionRuntime:
         thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
     ) -> str:
-        assistant_text = self._extract_assistant_text(
-            thread_payload,
-            vendor_turn_id=vendor_turn_id,
-        )
-        if assistant_text:
-            return assistant_text
-        vendor_thread_path = self._resolved_rollout_path(
+        return self._inspect_completed_turn(
             state=state,
             thread_payload=thread_payload,
-        )
-        return self._extract_assistant_text_from_rollout(
-            vendor_thread_path,
             vendor_turn_id=vendor_turn_id,
-            turn_started_at=state.last_control_at,
-        )
+        ).assistant_text
 
     @staticmethod
     def _find_turn_payload(
@@ -1379,13 +1422,13 @@ class CodexManagedSessionRuntime:
         )
         return vendor_thread_id
 
-    @staticmethod
+    @classmethod
     def _terminal_turn_outcome(
+        cls,
         turn_payload: Mapping[str, Any],
     ) -> tuple[str, str | None] | None:
         raw_status = str(turn_payload.get("status") or "").strip().lower()
-        error_value = turn_payload.get("error")
-        error_text = str(error_value).strip() if error_value not in (None, "") else None
+        error_text = cls._error_text_from_value(turn_payload.get("error"))
         if raw_status == "completed":
             return "completed", None
         if raw_status in {"failed", "error"}:
@@ -1493,17 +1536,24 @@ class CodexManagedSessionRuntime:
 
         status, error_text = outcome
         assistant_text = ""
+        completed_turn_inspection: _CompletedTurnInspection | None = None
         if status == "completed":
-            assistant_text = self._assistant_text_for_completed_turn(
+            completed_turn_inspection = self._inspect_completed_turn(
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=active_turn_id,
             )
+            assistant_text = completed_turn_inspection.assistant_text
         if status == "completed" and not assistant_text:
             status, error_text = self._completed_turn_without_assistant_outcome(
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=active_turn_id,
+                rollout_scan=(
+                    completed_turn_inspection.rollout_scan
+                    if completed_turn_inspection is not None
+                    else None
+                ),
             )
             if status == "failed":
                 self._append_spool(
@@ -1656,17 +1706,20 @@ class CodexManagedSessionRuntime:
 
         assistant_text = ""
         metadata: dict[str, Any] = {}
+        completed_turn_inspection: _CompletedTurnInspection | None = None
         if status == "completed":
-            assistant_text = self._assistant_text_for_completed_turn(
+            completed_turn_inspection = self._inspect_completed_turn(
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=vendor_turn_id,
             )
+            assistant_text = completed_turn_inspection.assistant_text
             if not assistant_text:
                 status, error_text = self._completed_turn_without_assistant_outcome(
                     state=state,
                     thread_payload=thread_payload,
                     vendor_turn_id=vendor_turn_id,
+                    rollout_scan=completed_turn_inspection.rollout_scan,
                 )
                 if status == "failed":
                     self._append_spool(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -685,6 +685,70 @@ def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
     assert handle.status == "ready"
     assert handle.metadata["lastAssistantText"] == "Recovered from task_complete event"
 
+def test_runtime_send_turn_accepts_empty_task_complete_event(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-04-10T17:57:55.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata == {"assistantTextMissing": True}
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert "lastAssistantText" not in handle.metadata
+
 def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -749,6 +749,60 @@ def test_runtime_send_turn_accepts_empty_task_complete_event(
     assert handle.status == "ready"
     assert "lastAssistantText" not in handle.metadata
 
+def test_runtime_send_turn_fails_empty_task_complete_with_structured_error(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-04-10T17:57:55.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "error": {"message": "provider returned structured failure"},
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["reason"] == "provider returned structured failure"
+
 def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     tmp_path: Path,
 ) -> None:
@@ -818,6 +872,92 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     )
     assert handle.status == "busy"
     assert handle.metadata["lastTurnStatus"] == "running"
+
+def test_runtime_session_status_accepts_empty_task_complete_after_running_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T17:55:16.922Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    assert response.status == "running"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+    with transcript_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-10T17:57:55.661Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_complete",
+                        "turn_id": "vendor-turn-1",
+                        "last_agent_message": None,
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert handle.status == "ready"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastTurnStatus"] == "completed"
+    assert "lastAssistantText" not in handle.metadata
 
 def test_runtime_send_turn_stays_running_when_large_rollout_tail_has_active_turn(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Treat successful Codex task_complete events without final assistant text as completed empty turns
- Preserve failure behavior when rollout events or Codex logs contain errors
- Add regression coverage for empty task_complete events

## Tests
- pytest tests/unit/services/temporal/runtime/test_codex_session_runtime.py -q
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh