### PR TITLE
Restyle Step Type radios as a connected segmented control

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,47 +1,27 @@
 [
   {
-    "id": 4349179564,
+    "id": 4360791766,
     "disposition": "not-applicable",
     "rationale": "Qodo free-tier limit notice; no code action requested."
   },
   {
-    "id": 3165251939,
+    "id": 3174456211,
     "disposition": "addressed",
-    "rationale": "Removed the dead templateInputValues state and made resolveTemplateInputs default to an empty explicit input object."
+    "rationale": "Updated the segmented-control overflow and edge radii so the keyboard focus box-shadow remains visible on the first and last Step Type options."
   },
   {
-    "id": 4201983734,
-    "disposition": "addressed",
-    "rationale": "Broad Gemini review summary; the actionable child comments covering dead state, radio accessibility, hidden select removal, duplicated filtering, and Step Type coverage were addressed."
-  },
-  {
-    "id": 3165251942,
-    "disposition": "addressed",
-    "rationale": "Replaced the clickable div Step Type option wrapper with a label wrapper and removed the redundant wrapper onClick and radio aria-label."
-  },
-  {
-    "id": 3165251945,
-    "disposition": "addressed",
-    "rationale": "Removed the hidden Step Type select and updated tests to use the radio controls."
-  },
-  {
-    "id": 3165251949,
-    "disposition": "addressed",
-    "rationale": "Factored visible preset input filtering into a visiblePresetInputs variable before the JSX block."
-  },
-  {
-    "id": 3165251953,
-    "disposition": "addressed",
-    "rationale": "Restored Step Type switching coverage by clicking radio options and checking the Tool, Skill, and Preset panels."
-  },
-  {
-    "id": 3165254042,
-    "disposition": "addressed",
-    "rationale": "Guarded async step preset detail updates so stale responses only apply when the step still has the same selected preset key, with a regression test."
-  },
-  {
-    "id": 4201985740,
+    "id": 4212560240,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper/summary only; the actionable Codex child comment was addressed separately."
+    "rationale": "Codex review wrapper comment; the actionable inline focus-ring feedback is tracked separately."
+  },
+  {
+    "id": 3174457616,
+    "disposition": "addressed",
+    "rationale": "Replaced the selected Step Type segment's hardcoded #fff text color with the theme variable rgb(var(--mm-accent-contrast))."
+  },
+  {
+    "id": 4212561724,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the actionable hardcoded-color feedback is tracked separately."
   }
 ]

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2544,25 +2544,66 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
 .queue-step-type-options {
   display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  align-items: stretch;
+  background: var(--mm-input-well);
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.5);
+  overflow: hidden;
 }
 
 .queue-step-type-option {
   align-items: center;
-  border: 1px solid rgb(var(--mm-border));
-  border-radius: 8px;
+  border: 0;
+  border-left: 1px solid rgb(var(--mm-border));
+  color: rgb(var(--mm-ink));
   cursor: pointer;
   display: inline-flex;
-  flex-direction: row;
-  gap: 0.4rem;
+  flex: 1 1 0;
+  font-weight: 600;
+  justify-content: center;
   min-height: 2.25rem;
-  padding: 0.45rem 0.7rem;
+  min-width: 0;
+  padding: 0.5rem 0.9rem;
+  position: relative;
+  text-align: center;
+  transition: var(--mm-control-transition);
+}
+
+.queue-step-type-option:first-child {
+  border-left: 0;
+}
+
+.queue-step-type-option:hover:not(:has(input:checked)) {
+  background: rgb(var(--mm-accent) / 0.08);
+  color: rgb(var(--mm-accent));
 }
 
 .queue-step-type-option:has(input:checked) {
-  border-color: rgb(var(--mm-accent));
-  background: rgb(var(--mm-accent) / 0.1);
+  background: rgb(var(--mm-accent));
+  border-left-color: transparent;
+  color: #fff;
+}
+
+.queue-step-type-option:has(input:checked) + .queue-step-type-option {
+  border-left-color: transparent;
+}
+
+.queue-step-type-option:has(input:focus-visible) {
+  box-shadow: var(--mm-control-focus-ring);
+  z-index: 1;
+}
+
+.queue-step-type-option input[type="radio"] {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .queue-step-type-panel {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -10,6 +10,7 @@
   --mm-muted: 95 102 122;
   --mm-border: 214 220 235;
   --mm-accent: 130 72 246;
+  --mm-accent-contrast: 255 255 255;
   --mm-accent-2: 34 211 238;
   --mm-accent-warm: 244 114 182;
   --mm-ok: 34 197 94;
@@ -68,6 +69,7 @@
   --mm-muted: 174 170 204;
   --mm-border: 92 84 136;
   --mm-accent: 130 72 246;
+  --mm-accent-contrast: 255 255 255;
   --mm-accent-2: 125 249 255;
   --mm-accent-warm: 249 115 22;
   --mm-ok: 74 222 128;
@@ -2549,7 +2551,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   border: 1px solid rgb(var(--mm-border));
   border-radius: 10px;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.5);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .queue-step-type-option {
@@ -2572,6 +2574,13 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
 .queue-step-type-option:first-child {
   border-left: 0;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+}
+
+.queue-step-type-option:last-child {
+  border-bottom-right-radius: 9px;
+  border-top-right-radius: 9px;
 }
 
 .queue-step-type-option:hover:not(:has(input:checked)) {
@@ -2582,7 +2591,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .queue-step-type-option:has(input:checked) {
   background: rgb(var(--mm-accent));
   border-left-color: transparent;
-  color: #fff;
+  color: rgb(var(--mm-accent-contrast));
 }
 
 .queue-step-type-option:has(input:checked) + .queue-step-type-option {


### PR DESCRIPTION
## Summary
- Replace the three separate bordered chips for Skill / Tool / Preset with a single connected segmented control inspired by the iOS pill style.
- Selected segment now inverts to a filled `--mm-accent` background with white text; unselected segments share dividers and tint to accent on hover.
- Visually hide the native radio input (still accessible via the existing `sr-only` label and `getByRole("radio")` queries) so the segment label sits on its own.

All values reuse existing MoonMind design tokens (`--mm-accent`, `--mm-border`, `--mm-input-well`, `--mm-control-focus-ring`, `--mm-control-transition`) and the inset top-highlight motif already used by `.queue-step-extension-button`, so the new control reads as native in both light and dark themes.

CSS-only change to `frontend/src/styles/mission-control.css` — no JSX or test updates required (the `.queue-step-type-option` class and radio roles are preserved).

## Test plan
- [x] `npm run ui:lint`
- [x] `npm run ui:build`
- [ ] Visually verify the Step Type selector on the Task Create page in light and dark themes
- [ ] Confirm keyboard navigation: Tab into the group, arrow keys move between radios, focus ring is visible on the focused segment
- [ ] Confirm hover state on unselected segments tints to accent and the selected segment's seam blends cleanly into adjacent dividers

🤖 Generated with [Claude Code](https://claude.com/claude-code)