### PR TITLE
[codex] Make merge automation launch resolver for conflicts

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,27 @@
 [
   {
-    "id": 4357009057,
+    "id": 4361162624,
     "disposition": "not-applicable",
-    "rationale": "Qodo review summary only; no requested code change."
+    "rationale": "Qodo quota notice is informational and contains no requested code change."
   },
   {
-    "id": 4357009307,
+    "id": 3174796895,
     "disposition": "addressed",
-    "rationale": "Addressed both reported issues by invalidating stale preset previews and writing in-place expansion completion messages to the global preset status."
+    "rationale": "Added explicit detection for GitHub REST mergeable=false conflict responses."
   },
   {
-    "id": 3171488902,
-    "disposition": "addressed",
-    "rationale": "Added current-state validation before applying async preset expansion results so removed or changed preset steps are not mutated."
-  },
-  {
-    "id": 4209275635,
+    "id": 4212956261,
     "disposition": "not-applicable",
-    "rationale": "Automated Codex review summary; the actionable inline comment is tracked separately."
+    "rationale": "Broad review summary; its actionable points are tracked by the line comments."
   },
   {
-    "id": 3171502561,
+    "id": 3174796906,
     "disposition": "addressed",
-    "rationale": "Preset-step instruction edits now clear cached previews, and tests cover regeneration after instructions change."
+    "rationale": "Conflict readiness now includes a non-retryable merge_conflict blocker with GitHub source evidence."
   },
   {
-    "id": 3171514617,
+    "id": 3174796910,
     "disposition": "addressed",
-    "rationale": "Preset selection and preset inputs are disabled while expansion is in progress, with current-state guards before applying async results."
-  },
-  {
-    "id": 4209307861,
-    "disposition": "addressed",
-    "rationale": "Review-level race-condition recommendation was addressed by disabling preset controls during expansion and guarding stale async results."
+    "rationale": "Updated readiness tests to assert the merge_conflict blocker and added boolean mergeable=false coverage."
   }
 ]

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -81,6 +81,8 @@ def _pull_request_has_merge_conflicts(pr_data: Mapping[str, Any]) -> bool:
         return True
     if merge_state_status in _CONFLICTING_MERGE_STATE_STATUSES:
         return True
+    if mergeable is False:
+        return True
     if (
         isinstance(mergeable, str)
         and mergeable.strip().upper() in _CONFLICTING_MERGEABLE_VALUES
@@ -489,7 +491,14 @@ class GitHubService:
                     checksPassing=checks_passing,
                     automatedReviewComplete=automated_review_complete,
                     policyAllowed=True,
-                    blockers=[],
+                    blockers=[
+                        {
+                            "kind": "merge_conflict",
+                            "summary": "Pull request has merge conflicts.",
+                            "retryable": False,
+                            "source": "github",
+                        }
+                    ],
                 )
 
             if checks_required and pr_merged is not True and not blockers:

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -65,6 +65,29 @@ class PullRequestReadinessResult(BaseModel):
 _GITHUB_PR_URL_RE = re.compile(
     r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"
 )
+_CONFLICTING_MERGEABLE_STATES = {"dirty"}
+_CONFLICTING_MERGE_STATE_STATUSES = {"CONFLICTING", "DIRTY"}
+_CONFLICTING_MERGEABLE_VALUES = {"CONFLICTING", "DIRTY"}
+
+
+def _pull_request_has_merge_conflicts(pr_data: Mapping[str, Any]) -> bool:
+    mergeable_state = str(pr_data.get("mergeable_state") or "").strip().lower()
+    merge_state_status = str(
+        pr_data.get("mergeStateStatus") or pr_data.get("merge_state_status") or ""
+    ).strip().upper()
+    mergeable = pr_data.get("mergeable")
+
+    if mergeable_state in _CONFLICTING_MERGEABLE_STATES:
+        return True
+    if merge_state_status in _CONFLICTING_MERGE_STATE_STATUSES:
+        return True
+    if (
+        isinstance(mergeable, str)
+        and mergeable.strip().upper() in _CONFLICTING_MERGEABLE_VALUES
+    ):
+        return True
+    return False
+
 
 class GitHubService:
     """Thin wrapper around the GitHub REST API for pull-request operations.
@@ -405,6 +428,7 @@ class GitHubService:
         checks_complete: bool | None = None
         checks_passing: bool | None = None
         automated_review_complete: bool | None = None
+        merge_conflicted = False
 
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             try:
@@ -419,6 +443,7 @@ class GitHubService:
                 head = pr_data.get("head") if isinstance(pr_data, dict) else {}
                 if isinstance(head, dict):
                     observed_head_sha = str(head.get("sha") or head_sha)
+                merge_conflicted = _pull_request_has_merge_conflicts(pr_data)
             except httpx.HTTPStatusError as exc:
                 blockers.append(
                     {
@@ -452,6 +477,19 @@ class GitHubService:
                         "retryable": False,
                         "source": "github",
                     }
+                )
+
+            if pr_open is True and pr_merged is not True and merge_conflicted:
+                return PullRequestReadinessResult(
+                    headSha=observed_head_sha,
+                    ready=True,
+                    pullRequestOpen=pr_open,
+                    pullRequestMerged=pr_merged,
+                    checksComplete=checks_complete,
+                    checksPassing=checks_passing,
+                    automatedReviewComplete=automated_review_complete,
+                    policyAllowed=True,
+                    blockers=[],
                 )
 
             if checks_required and pr_merged is not True and not blockers:

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -328,6 +328,45 @@ async def test_evaluate_pull_request_readiness_ignores_empty_combined_status_pen
     assert result.blockers == []
 
 @pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_opens_for_merge_conflicts_before_checks(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        return_value=_mock_get_response(
+            200,
+            {
+                "state": "open",
+                "merged": False,
+                "mergeable": False,
+                "mergeable_state": "dirty",
+                "head": {"sha": "abc123"},
+            },
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "required"},
+        )
+
+    assert result.ready is True
+    assert result.blockers == []
+    assert result.checks_complete is None
+    assert result.automated_review_complete is None
+    mock_client.get.assert_called_once()
+
+@pytest.mark.asyncio
 async def test_evaluate_pull_request_readiness_respects_failed_combined_status_without_check_runs(
     monkeypatch,
 ):

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -361,7 +361,53 @@ async def test_evaluate_pull_request_readiness_opens_for_merge_conflicts_before_
         )
 
     assert result.ready is True
-    assert result.blockers == []
+    assert result.blockers == [
+        {
+            "kind": "merge_conflict",
+            "summary": "Pull request has merge conflicts.",
+            "retryable": False,
+            "source": "github",
+        }
+    ]
+    assert result.checks_complete is None
+    assert result.automated_review_complete is None
+    mock_client.get.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_detects_boolean_mergeable_conflict(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        return_value=_mock_get_response(
+            200,
+            {
+                "state": "open",
+                "merged": False,
+                "mergeable": False,
+                "mergeable_state": "clean",
+                "head": {"sha": "abc123"},
+            },
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "required"},
+        )
+
+    assert result.ready is True
+    assert result.blockers[0]["kind"] == "merge_conflict"
     assert result.checks_complete is None
     assert result.automated_review_complete is None
     mock_client.get.assert_called_once()


### PR DESCRIPTION
## Summary
- detect GitHub merge-conflict states before merge automation waits on checks or automated review
- return resolver-ready readiness evidence for open conflicted PRs so `pr-resolver` can handle conflict remediation
- add a regression test for dirty mergeability with required checks/review configured

## Root Cause
Merge automation treated GitHub `pending` status with no reported checks as a wait-only `checks_running` blocker before considering merge conflicts. Conflicted PRs could therefore poll indefinitely and never launch `pr-resolver`.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_github_service.py`
- `./tools/test_unit.sh`