### PR TITLE
Polish Step Type segmented control: glass, glow, slide, shimmer

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,27 @@
 [
   {
-    "id": 4360791766,
+    "id": 4361276169,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier limit notice; no code action requested."
+    "rationale": "Qodo free-tier limit notice; informational bot message with no code action requested."
   },
   {
-    "id": 3174456211,
+    "id": 3174886044,
     "disposition": "addressed",
-    "rationale": "Updated the segmented-control overflow and edge radii so the keyboard focus box-shadow remains visible on the first and last Step Type options."
+    "rationale": "Removed clipping from the Step Type segmented control so the existing focus ring remains visible."
   },
   {
-    "id": 4212560240,
+    "id": 4213051744,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment; the actionable inline focus-ring feedback is tracked separately."
+    "rationale": "Codex review summary wrapper; actionable inline feedback is tracked separately."
   },
   {
-    "id": 3174457616,
+    "id": 3174887989,
     "disposition": "addressed",
-    "rationale": "Replaced the selected Step Type segment's hardcoded #fff text color with the theme variable rgb(var(--mm-accent-contrast))."
+    "rationale": "Removed the redundant Step Type -webkit-backdrop-filter declaration while keeping the standard backdrop-filter."
   },
   {
-    "id": 4212561724,
+    "id": 4213053751,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; the actionable hardcoded-color feedback is tracked separately."
+    "rationale": "Gemini review summary wrapper; actionable inline feedback is tracked separately."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -264,6 +264,19 @@ describe('Mission Control shared entry', () => {
     );
   });
 
+  it('keeps the Step Type segmented control focus ring visible', async () => {
+    const stepTypeBlock = cssRuleBlock(missionControlCss, '.queue-step-type-options');
+    const stepTypeFocusBlock = cssRuleBlock(
+      missionControlCss,
+      '.queue-step-type-option:has(input:focus-visible)',
+    );
+
+    expect(stepTypeBlock).toContain('backdrop-filter: blur(14px) saturate(140%)');
+    expect(stepTypeBlock).not.toContain('-webkit-backdrop-filter');
+    expect(stepTypeBlock).not.toContain('overflow: hidden');
+    expect(stepTypeFocusBlock).toContain('box-shadow: var(--mm-control-focus-ring)');
+  });
+
   it('keeps liquidGL opt-in and away from default dense surfaces', async () => {
     expect(cssRuleBlock(missionControlCss, '.panel')).not.toContain('liquid');
     expect(cssRuleBlock(missionControlCss, '.card')).not.toContain('liquid');

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactElement } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import type { BootPayload } from "../boot/parseBootPayload";
@@ -559,10 +560,14 @@ const STEP_TYPE_HELP_TEXT: Record<StepType, string> = {
   preset: "Preset inserts a reusable set of configured steps.",
 };
 
-const STEP_TYPE_OPTIONS: Array<{ value: StepType; label: string }> = [
-  { value: "skill", label: "Skill" },
-  { value: "tool", label: "Tool" },
-  { value: "preset", label: "Preset" },
+const STEP_TYPE_OPTIONS: Array<{
+  value: StepType;
+  label: string;
+  Icon: () => ReactElement;
+}> = [
+  { value: "skill", label: "Skill", Icon: SkillSparkleIcon },
+  { value: "tool", label: "Tool", Icon: ToolWrenchIcon },
+  { value: "preset", label: "Preset", Icon: PresetLayersIcon },
 ];
 
 interface StepState {
@@ -2774,6 +2779,34 @@ function TrashIcon() {
       <path d="M14 11v6" />
       <path d="M6 7l1 13h10l1-13" />
       <path d="M9 7V4h6v3" />
+    </svg>
+  );
+}
+
+function SkillSparkleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 4l1.6 4.4L18 10l-4.4 1.6L12 16l-1.6-4.4L6 10l4.4-1.6L12 4z" />
+      <path d="M18.5 15l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8z" />
+    </svg>
+  );
+}
+
+function ToolWrenchIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M14.7 6.3a4 4 0 0 1 5 5l-2.3-.6-1.4 1.4.6 2.3a4 4 0 0 1-5-5l2.3.6 1.4-1.4-.6-2.3z" />
+      <path d="M13 11l-7 7a1.8 1.8 0 1 0 2.5 2.5l7-7" />
+    </svg>
+  );
+}
+
+function PresetLayersIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 4l8 4-8 4-8-4 8-4z" />
+      <path d="M4 12l8 4 8-4" />
+      <path d="M4 16l8 4 8-4" />
     </svg>
   );
 }
@@ -7181,30 +7214,38 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <fieldset className="queue-step-type-field">
                     <legend>Step Type</legend>
                     <div className="queue-step-type-options">
-                      {STEP_TYPE_OPTIONS.map((option) => (
-                        <label
-                          key={option.value}
-                          className="queue-step-type-option"
-                          title={STEP_TYPE_HELP_TEXT[option.value]}
-                        >
-                          <input
-                            type="radio"
-                            name={`queue-step-type-${step.localId}`}
-                            value={option.value}
-                            checked={step.stepType === option.value}
-                            data-step-field="stepType"
-                            data-step-index={String(index)}
-                            onChange={(event) =>
-                              handleStepTypeChange(
-                                step.localId,
-                                event.target.value,
-                              )
-                            }
-                          />
-                          <span className="sr-only">Step Type </span>
-                          {option.label}
-                        </label>
-                      ))}
+                      {STEP_TYPE_OPTIONS.map((option) => {
+                        const Icon = option.Icon;
+                        return (
+                          <label
+                            key={option.value}
+                            className="queue-step-type-option"
+                            title={STEP_TYPE_HELP_TEXT[option.value]}
+                          >
+                            <input
+                              type="radio"
+                              name={`queue-step-type-${step.localId}`}
+                              value={option.value}
+                              checked={step.stepType === option.value}
+                              data-step-field="stepType"
+                              data-step-index={String(index)}
+                              onChange={(event) =>
+                                handleStepTypeChange(
+                                  step.localId,
+                                  event.target.value,
+                                )
+                              }
+                            />
+                            <span className="queue-step-type-option-icon">
+                              <Icon />
+                            </span>
+                            <span className="sr-only">Step Type </span>
+                            <span className="queue-step-type-option-label">
+                              {option.label}
+                            </span>
+                          </label>
+                        );
+                      })}
                     </div>
                   </fieldset>
                   {step.stepTypeMessage ? (

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2555,8 +2555,6 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
     inset 0 1px 0 rgb(255 255 255 / 0.08),
     inset 0 -1px 0 rgb(0 0 0 / 0.25);
   backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
-  overflow: hidden;
   isolation: isolate;
 }
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2545,62 +2545,165 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 }
 
 .queue-step-type-options {
+  position: relative;
   display: inline-flex;
   align-items: stretch;
   background: var(--mm-input-well);
   border: 1px solid rgb(var(--mm-border));
   border-radius: 10px;
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.5);
-  overflow: visible;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    inset 0 -1px 0 rgb(0 0 0 / 0.25);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* Sliding thumb: gradient fill, glossy highlight, neon halo */
+.queue-step-type-options::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(100% / 3);
+  border-radius: 9px;
+  background:
+    linear-gradient(
+        115deg,
+        transparent 35%,
+        rgb(255 255 255 / 0.22) 50%,
+        transparent 65%
+      )
+      0 0 / 220% 100% no-repeat,
+    linear-gradient(180deg, rgb(255 255 255 / 0.22), transparent 55%),
+    linear-gradient(
+      135deg,
+      rgb(var(--mm-accent)) 0%,
+      rgb(var(--mm-accent-2)) 100%
+    );
+  box-shadow:
+    0 0 0 1px rgb(var(--mm-accent) / 0.55),
+    0 0 18px rgb(var(--mm-accent) / 0.55),
+    0 0 32px rgb(var(--mm-accent-2) / 0.22),
+    inset 0 1px 0 rgb(255 255 255 / 0.4);
+  transform: translateX(0);
+  transition: transform 360ms cubic-bezier(0.34, 1.3, 0.5, 1);
+  animation: queue-step-type-thumb-shimmer 5.5s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.queue-step-type-options:has(
+    .queue-step-type-option:nth-child(2) input:checked
+  )::before {
+  transform: translateX(100%);
+}
+
+.queue-step-type-options:has(
+    .queue-step-type-option:nth-child(3) input:checked
+  )::before {
+  transform: translateX(200%);
+}
+
+@keyframes queue-step-type-thumb-shimmer {
+  0%,
+  100% {
+    background-position:
+      -60% 0,
+      0 0,
+      0 0;
+  }
+  50% {
+    background-position:
+      160% 0,
+      0 0,
+      0 0;
+  }
+}
+
+/* Animated cyberpunk scan border */
+.queue-step-type-options::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    120deg,
+    rgb(var(--mm-accent) / 0) 0%,
+    rgb(var(--mm-accent) / 0.55) 30%,
+    rgb(var(--mm-accent-2) / 0.65) 50%,
+    rgb(var(--mm-accent) / 0.55) 70%,
+    rgb(var(--mm-accent) / 0) 100%
+  );
+  background-size: 220% 100%;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: queue-step-type-scan 6s linear infinite;
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 2;
+}
+
+@keyframes queue-step-type-scan {
+  0% {
+    background-position: 0% 0;
+  }
+  100% {
+    background-position: 220% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .queue-step-type-options::before,
+  .queue-step-type-options::after {
+    animation: none;
+  }
+  .queue-step-type-options::before {
+    transition: none;
+  }
 }
 
 .queue-step-type-option {
   align-items: center;
   border: 0;
-  border-left: 1px solid rgb(var(--mm-border));
-  color: rgb(var(--mm-ink));
+  color: rgb(var(--mm-muted));
   cursor: pointer;
   display: inline-flex;
   flex: 1 1 0;
   font-weight: 600;
+  gap: 0.4rem;
   justify-content: center;
+  letter-spacing: 0.08em;
   min-height: 2.25rem;
   min-width: 0;
   padding: 0.5rem 0.9rem;
   position: relative;
   text-align: center;
+  text-transform: uppercase;
   transition: var(--mm-control-transition);
-}
-
-.queue-step-type-option:first-child {
-  border-left: 0;
-  border-bottom-left-radius: 9px;
-  border-top-left-radius: 9px;
-}
-
-.queue-step-type-option:last-child {
-  border-bottom-right-radius: 9px;
-  border-top-right-radius: 9px;
+  z-index: 3;
 }
 
 .queue-step-type-option:hover:not(:has(input:checked)) {
-  background: rgb(var(--mm-accent) / 0.08);
   color: rgb(var(--mm-accent));
 }
 
 .queue-step-type-option:has(input:checked) {
-  background: rgb(var(--mm-accent));
-  border-left-color: transparent;
   color: rgb(var(--mm-accent-contrast));
-}
-
-.queue-step-type-option:has(input:checked) + .queue-step-type-option {
-  border-left-color: transparent;
+  text-shadow: 0 0 12px rgb(var(--mm-accent-contrast) / 0.5);
 }
 
 .queue-step-type-option:has(input:focus-visible) {
   box-shadow: var(--mm-control-focus-ring);
-  z-index: 1;
+  border-radius: 9px;
+  z-index: 4;
 }
 
 .queue-step-type-option input[type="radio"] {
@@ -2613,6 +2716,30 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.queue-step-type-option-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.queue-step-type-option-icon svg {
+  width: 1rem;
+  height: 1rem;
+  stroke: currentcolor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.queue-step-type-option:has(input:checked) .queue-step-type-option-icon svg {
+  filter: drop-shadow(0 0 6px rgb(var(--mm-accent-contrast) / 0.55));
+}
+
+.queue-step-type-option-label {
+  font-size: 0.78rem;
 }
 
 .queue-step-type-panel {


### PR DESCRIPTION
## Summary
- Adds a sliding gradient thumb (accent → accent-2) that animates between Skill / Tool / Preset segments via `:has()` + `transform`, with a neon halo and glossy top highlight.
- Wraps the track in liquid glass — `backdrop-filter: blur + saturate`, top highlight + bottom inner shadow — and overlays an animated 1px cyberpunk scan border using `mask-composite: exclude`.
- Adds a slow shimmer sweep across the thumb plus per-segment leading icons (sparkle / wrench / layers), uppercase tracked labels, and a soft text/icon glow on the selected segment.
- Honors `prefers-reduced-motion` (disables all loops + the slide transition).
- Keeps each option's accessible name ending in its label (`Skill` / `Tool` / `Preset`), so existing radio-lookup helpers in `task-create.test.tsx` keep matching.

## Test plan
- [ ] Load Task Create in dark mode and confirm the thumb slides between Skill/Tool/Preset with a springy ease, the halo/glow reads, and the scan border + shimmer animate without jitter.
- [ ] Repeat in light mode and confirm contrast on the selected label and icon.
- [ ] Tab into the control and confirm the focus ring still appears on the focused segment.
- [ ] Toggle OS reduced-motion and confirm the slide / shimmer / scan animations stop.
- [ ] `npm run ui:typecheck`, `npm run ui:lint`, `npm run ui:test:task-create` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)