### PR TITLE
MM-579 preserve flattened preset provenance

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/291-preview-apply-preset-steps"
+  "feature_directory": "specs/292-submit-flattened-executable-steps-with-provenance"
 }

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -80,6 +80,7 @@ def _build_task_preview(
     raw_steps = task.get("steps")
     steps = raw_steps if isinstance(raw_steps, list) else []
     step_source_kinds: list[str] = []
+    preset_source_metadata: list[dict[str, object]] = []
     for step in steps:
         if not isinstance(step, dict):
             continue
@@ -89,6 +90,22 @@ def _build_task_preview(
         kind = str(source_node.get("kind") or "").strip()
         if kind:
             step_source_kinds.append(kind)
+        if kind in _PRESET_SOURCE_KINDS:
+            metadata: dict[str, object] = {"kind": kind}
+            for key in (
+                "presetId",
+                "presetSlug",
+                "presetVersion",
+                "includePath",
+                "originalStepId",
+            ):
+                value = source_node.get(key)
+                if value is None or value == "":
+                    continue
+                if key == "includePath" and not isinstance(value, list):
+                    continue
+                metadata[key] = value
+            preset_source_metadata.append(metadata)
     preset_provenance = "manual"
     if authored_preset_count > 0:
         preset_provenance = "preserved-binding"
@@ -124,6 +141,7 @@ def _build_task_preview(
         presetProvenance=preset_provenance,
         authoredPresetCount=authored_preset_count,
         stepSourceKinds=step_source_kinds,
+        presetSourceMetadata=preset_source_metadata,
     )
 
 def _serialize_similar(similar: list[TaskProposal] | None) -> list[dict[str, object]]:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,37 @@
 [
   {
-    "id": 4360936262,
+    "id": 4361302204,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notification is informational and does not request a code or documentation change."
+    "rationale": "Qodo free-tier notice only; no code action requested."
   },
   {
-    "id": 3174592231,
+    "id": 3174920141,
     "disposition": "addressed",
-    "rationale": "Extracted the MM-578 success fetch mock into mockMm578PresetFetch and made the preview-failure test override only the failing expand endpoint while delegating all other requests."
+    "rationale": "The router now defines _PRESET_SOURCE_KINDS locally before use."
   },
   {
-    "id": 3174592234,
+    "id": 3174920149,
     "disposition": "addressed",
-    "rationale": "Added npm run ui:test:task-create and updated the MM-578 plan to use the shorter focused test command."
+    "rationale": "Imported Sequence from collections.abc for the runtime isinstance check."
   },
   {
-    "id": 4212720212,
+    "id": 3174920155,
+    "disposition": "addressed",
+    "rationale": "Imported Mapping from collections.abc for the runtime isinstance checks."
+  },
+  {
+    "id": 4213092169,
     "disposition": "not-applicable",
-    "rationale": "Broad review summary duplicated the two actionable comments, which were handled individually."
+    "rationale": "General review summary; specific actionable import findings are tracked separately."
+  },
+  {
+    "id": 3174930124,
+    "disposition": "addressed",
+    "rationale": "Canonical task payload validation now accepts stored preset provenance version keys and serializes canonical presetVersion."
+  },
+  {
+    "id": 4213103269,
+    "disposition": "not-applicable",
+    "rationale": "Codex review overview; the actionable child comment is tracked separately."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12366,6 +12366,9 @@ describe("Task Create MM-578 Preset preview and apply", () => {
               source: {
                 kind: "preset-derived",
                 presetId: "mm-578-preset",
+                presetVersion: "1.0.0",
+                includePath: ["root", "fetch"],
+                originalStepId: "fetch-jira-issue",
               },
             },
             {
@@ -12375,6 +12378,13 @@ describe("Task Create MM-578 Preset preview and apply", () => {
               skill: {
                 id: "moonspec-orchestrate",
                 args: { issueKey: "MM-578" },
+              },
+              source: {
+                kind: "preset-derived",
+                presetId: "mm-578-preset",
+                presetVersion: "1.0.0",
+                includePath: ["root", "implement"],
+                originalStepId: "implement-preset-story",
               },
             },
           ],
@@ -12484,7 +12494,7 @@ describe("Task Create MM-578 Preset preview and apply", () => {
     expect(screen.getByDisplayValue("Edited generated MM-578 step.")).toBeTruthy();
   });
 
-  it("submits applied preset-generated Tool steps with executable binding", async () => {
+  it("submits applied preset-generated Tool and Skill steps with executable binding and provenance", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
@@ -12525,8 +12535,33 @@ describe("Task Create MM-578 Preset preview and apply", () => {
         id: "jira.get_issue",
         inputs: { issueKey: "MM-578" },
       },
+      source: {
+        kind: "preset-derived",
+        presetId: "mm-578-preset",
+        presetVersion: "1.0.0",
+        includePath: ["root", "fetch"],
+        originalStepId: "fetch-jira-issue",
+      },
     });
     expect(request.payload.task.steps[0]?.["skill"]).toBeUndefined();
+    expect(request.payload.task.steps[1]).toEqual({
+      id: "tpl:mm-578-preset:1.0.0:02",
+      title: "Implement preset story",
+      type: "skill",
+      instructions: "Implement MM-578.",
+      skill: {
+        id: "moonspec-orchestrate",
+        args: { issueKey: "MM-578" },
+      },
+      source: {
+        kind: "preset-derived",
+        presetId: "mm-578-preset",
+        presetVersion: "1.0.0",
+        includePath: ["root", "implement"],
+        originalStepId: "implement-preset-story",
+      },
+    });
+    expect(request.payload.task.steps[1]?.["tool"]).toBeUndefined();
   });
 
   it("keeps drafts unchanged on preview failure and blocks unresolved Preset submission", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -590,6 +590,7 @@ interface StepState {
   templateAttachments: StepAttachmentRef[];
   generatedTool?: TaskTemplateStepSkill;
   generatedSkill?: TaskTemplateStepSkill;
+  source?: Record<string, unknown>;
   storyOutput?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
 }
@@ -1507,6 +1508,21 @@ function executableGeneratedToolPayload(
   return step.generatedTool;
 }
 
+function executableGeneratedSkillPayload(
+  step: StepState | null | undefined,
+): TaskTemplateStepSkill | null {
+  if (step?.stepType !== "skill" || !step.generatedSkill) {
+    return null;
+  }
+  const skillId = String(
+    step.generatedSkill.id || step.generatedSkill.name || "",
+  ).trim();
+  if (!skillId) {
+    return null;
+  }
+  return step.generatedSkill;
+}
+
 function manualToolPayload(
   step: StepState | null | undefined,
   inputs: Record<string, unknown>,
@@ -2039,6 +2055,18 @@ function mapExpandedStepToState(
   const jiraOrchestration =
     nonEmptyRecordValue(step.jiraOrchestration) ||
     nonEmptyRecordValue(step.jira_orchestration);
+  const source = nonEmptyRecordValue(step.source);
+  const normalizedSource = source
+    ? {
+        ...source,
+        ...(!source.presetVersion && source.version
+          ? { presetVersion: source.version }
+          : {}),
+      }
+    : undefined;
+  if (normalizedSource && "version" in normalizedSource) {
+    delete normalizedSource.version;
+  }
   const templateAttachments = Array.isArray(step.inputAttachments)
     ? step.inputAttachments
     : Array.isArray(step.attachments)
@@ -2057,6 +2085,7 @@ function mapExpandedStepToState(
     templateAttachments,
     ...(step.tool ? { generatedTool: step.tool } : {}),
     ...(step.skill ? { generatedSkill: step.skill } : {}),
+    ...(normalizedSource ? { source: normalizedSource } : {}),
     ...(storyOutput ? { storyOutput } : {}),
     ...(jiraOrchestration ? { jiraOrchestration } : {}),
   });
@@ -6004,6 +6033,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const stepIsSkill = step.stepType === "skill";
       const stepIsTool = step.stepType === "tool";
       const generatedToolPayload = executableGeneratedToolPayload(step);
+      const generatedSkillPayload = executableGeneratedSkillPayload(step);
       const stepSkillId = stepIsSkill ? step.skillId.trim() : "";
       const stepSkillArgsRaw = stepIsSkill && showAdvancedStepOptions
         ? step.skillArgs.trim()
@@ -6026,7 +6056,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         Boolean(stepSkillId) ||
         Boolean(stepSkillArgsRaw) ||
         stepSkillCaps.length > 0 ||
-        Boolean(generatedToolPayload);
+        Boolean(generatedToolPayload) ||
+        Boolean(generatedSkillPayload);
       let stepSkillArgs: Record<string, unknown> = {};
       let stepToolInputs: Record<string, unknown> = {};
       if (stepIsTool && !generatedToolPayload) {
@@ -6317,8 +6348,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         stepPayload.title = step.title.trim();
       }
       const generatedToolPayload = executableGeneratedToolPayload(step);
+      const generatedSkillPayload = executableGeneratedSkillPayload(step);
       if (generatedToolPayload) {
         stepPayload.tool = generatedToolPayload;
+      } else if (generatedSkillPayload) {
+        stepPayload.skill = generatedSkillPayload;
       } else if (step.stepType === "tool") {
         const toolPayload = manualToolPayload(step, stepToolInputs);
         if (toolPayload) {
@@ -6422,6 +6456,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             Boolean(sourceStep.title.trim()) ||
             Boolean(sourceStep.storyOutput) ||
             Boolean(
+              sourceStep.source && Object.keys(sourceStep.source).length > 0,
+            ) ||
+            Boolean(
               sourceStep.jiraOrchestration &&
                 Object.keys(sourceStep.jiraOrchestration).length > 0,
             );
@@ -6435,6 +6472,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             ...(hasSubmittedStepShape ? { type: submittedStepType } : {}),
             ...(sourceStep.storyOutput
               ? { storyOutput: sourceStep.storyOutput }
+              : {}),
+            ...(sourceStep.source && Object.keys(sourceStep.source).length > 0
+              ? { source: sourceStep.source }
               : {}),
             ...(sourceStep.jiraOrchestration &&
             Object.keys(sourceStep.jiraOrchestration).length > 0

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6416,6 +6416,10 @@ export interface components {
             authoredPresetCount: number;
             /** Stepsourcekinds */
             stepSourceKinds?: string[];
+            /** Presetsourcemetadata */
+            presetSourceMetadata?: {
+                [key: string]: unknown;
+            }[];
         };
         /**
          * TaskTemplateAppliedMetadataSchema

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -39,6 +39,9 @@ class TaskProposalTaskPreview(BaseModel):
     preset_provenance: Optional[str] = Field(None, alias="presetProvenance")
     authored_preset_count: int = Field(0, alias="authoredPresetCount")
     step_source_kinds: list[str] = Field(default_factory=list, alias="stepSourceKinds")
+    preset_source_metadata: list[dict[str, Any]] = Field(
+        default_factory=list, alias="presetSourceMetadata"
+    )
 
 class TaskProposalModel(BaseModel):
     """Serialized proposal model."""

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -36,6 +36,7 @@ _PROPOSALS_WRITE_CAPABILITY = "proposals_write"
 _LEGACY_TASK_WORKER_RUNTIME_CAPABILITIES = frozenset(
     {"codex", "gemini_cli", "claude", "jules"}
 )
+_PRESET_SOURCE_KINDS = frozenset({"preset-derived", "preset-include", "detached"})
 _NOTIFICATION_CATEGORIES = {"security", "tests"}
 _DEDUP_SLUG_PATTERN = re.compile(r"[^a-z0-9]+")
 _MOONMIND_SIGNAL_TAGS = frozenset(
@@ -315,6 +316,33 @@ class TaskProposalService:
         task["publish"] = publish
         normalized_payload["task"] = task
         return normalized_payload
+
+    @staticmethod
+    def _enforce_flat_preset_derived_steps(payload: Mapping[str, Any]) -> None:
+        task = payload.get("task")
+        if not isinstance(task, Mapping):
+            return
+        steps = task.get("steps")
+        if not isinstance(steps, Sequence) or isinstance(steps, (str, bytes)):
+            return
+        for index, raw_step in enumerate(steps):
+            if not isinstance(raw_step, Mapping):
+                continue
+            source = raw_step.get("source")
+            source_kind = ""
+            if isinstance(source, Mapping):
+                source_kind = str(source.get("kind") or "").strip()
+            if source_kind not in _PRESET_SOURCE_KINDS:
+                continue
+            step_type = str(raw_step.get("type") or "").strip().lower()
+            if step_type == "tool" and isinstance(raw_step.get("tool"), Mapping):
+                continue
+            if step_type == "skill" and isinstance(raw_step.get("skill"), Mapping):
+                continue
+            raise TaskProposalValidationError(
+                "stored task payload is invalid: preset-derived proposal steps "
+                f"must be flat executable Tool or Skill steps at task.steps[{index}]"
+            )
 
     @staticmethod
     def _proposal_has_explicit_skill(task: Mapping[str, Any]) -> bool:
@@ -750,6 +778,7 @@ class TaskProposalService:
             raise TaskProposalValidationError(
                 f"stored task payload is invalid: {exc}"
             ) from exc
+        self._enforce_flat_preset_derived_steps(payload)
         if runtime_mode_override is not None:
             normalized_runtime_mode = self._normalize_proposal_runtime_mode(
                 runtime_mode_override
@@ -769,6 +798,7 @@ class TaskProposalService:
                 raise TaskProposalValidationError(
                     f"runtimeMode override is invalid: {exc}"
                 ) from exc
+            self._enforce_flat_preset_derived_steps(payload)
         payload = self._enforce_proposal_pr_publish_mode(payload)
         request["payload"] = payload
 

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -6,9 +6,10 @@ import hashlib
 import json
 import logging
 import re
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from datetime import UTC, datetime
-from typing import Any, Mapping, Sequence
+from typing import Any
 from uuid import UUID
 
 import httpx

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -885,7 +885,7 @@ class TaskStepSource(BaseModel):
     )
     preset_id: str | None = Field(None, alias="presetId")
     preset_slug: str | None = Field(None, alias="presetSlug")
-    version: str | None = Field(None, alias="version")
+    preset_version: str | None = Field(None, alias="presetVersion")
     include_path: list[str] | None = Field(None, alias="includePath")
     original_step_id: str | None = Field(None, alias="originalStepId")
 
@@ -893,7 +893,7 @@ class TaskStepSource(BaseModel):
         "kind",
         "preset_id",
         "preset_slug",
-        "version",
+        "preset_version",
         "original_step_id",
         mode="before",
     )
@@ -922,7 +922,7 @@ class AuthoredPresetBinding(BaseModel):
 
     preset_id: str | None = Field(None, alias="presetId")
     preset_slug: str | None = Field(None, alias="presetSlug")
-    version: str | None = Field(None, alias="version")
+    preset_version: str | None = Field(None, alias="presetVersion")
     alias: str | None = Field(None, alias="alias")
     include_path: list[str] | None = Field(None, alias="includePath")
     input_mapping: dict[str, Any] | None = Field(None, alias="inputMapping")
@@ -931,7 +931,7 @@ class AuthoredPresetBinding(BaseModel):
     @field_validator(
         "preset_id",
         "preset_slug",
-        "version",
+        "preset_version",
         "alias",
         "scope",
         mode="before",

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -77,6 +77,22 @@ def _clean_optional_str(value: object) -> str | None:
     cleaned = _clean_str(value)
     return cleaned or None
 
+
+def _normalize_preset_version_alias(value: object) -> object:
+    if not isinstance(value, Mapping):
+        return value
+    if "version" not in value:
+        return value
+    normalized = dict(value)
+    legacy_version = _clean_optional_str(normalized.pop("version"))
+    current_version = _clean_optional_str(normalized.get("presetVersion"))
+    if legacy_version and current_version and legacy_version != current_version:
+        raise TaskContractError("presetVersion conflicts with legacy version")
+    if legacy_version and not current_version:
+        normalized["presetVersion"] = legacy_version
+    return normalized
+
+
 def _contains_data_image_url(value: object) -> bool:
     if isinstance(value, str):
         return _DATA_IMAGE_URL_PATTERN.match(value.strip()) is not None
@@ -880,6 +896,11 @@ class TaskStepSource(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_version(cls, value: object) -> object:
+        return _normalize_preset_version_alias(value)
+
     kind: Literal["manual", "preset-derived", "preset-include", "detached"] | None = (
         Field(None, alias="kind")
     )
@@ -919,6 +940,11 @@ class AuthoredPresetBinding(BaseModel):
     """Optional preset binding metadata used to compile a task payload."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_version(cls, value: object) -> object:
+        return _normalize_preset_version_alias(value)
 
     preset_id: str | None = Field(None, alias="presetId")
     preset_slug: str | None = Field(None, alias="presetSlug")

--- a/specs/292-submit-flattened-executable-steps-with-provenance/checklists/requirements.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Submit Flattened Executable Steps with Provenance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification preserves `MM-579` and the original Jira preset brief in the `**Input**` field for final verification.
+- Runtime intent is explicit; `docs/Steps/StepTypes.md` is treated as source requirements, not as a docs-only target.
+- The request is a single Jira preset brief and does not require `moonspec-breakdown`.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/contracts/flattened-executable-provenance.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/contracts/flattened-executable-provenance.md
@@ -1,0 +1,70 @@
+# Contract: Flattened Executable Steps With Provenance
+
+## Executable Submission Contract
+
+Default executable task submissions contain concrete Tool and Skill steps only.
+
+Accepted executable Step Types:
+- `tool`
+- `skill`
+
+Rejected by default at executable boundaries:
+- `preset`
+- `activity`
+- `Activity`
+- arbitrary script or shell-shaped step overrides
+
+Preset-derived work must be applied before submission. Applying a preset replaces the temporary Preset placeholder with concrete executable steps.
+
+## Preset Provenance Contract
+
+Preset-derived executable steps carry source metadata when available:
+
+```json
+{
+  "source": {
+    "kind": "preset-derived",
+    "presetId": "jira.implementation_flow",
+    "presetVersion": "2026-04-28",
+    "includePath": ["root", "implementation"],
+    "originalStepId": "implement"
+  }
+}
+```
+
+Rules:
+- Preset application, review, and proposal surfaces preserve `source.kind`, `source.presetId`, `source.presetVersion`, and `source.originalStepId` for preset-derived steps when the expansion source provides those values.
+- `source.includePath` is preserved when the expansion source provides an include path.
+- Source metadata is audit and reconstruction data, not hidden runtime work.
+- Missing, stale, partial, or unavailable source metadata must not force runtime catalog lookup when the executable Tool/Skill payload is otherwise valid.
+
+## Runtime Materialization Contract
+
+| Submitted Step | Runtime behavior |
+| --- | --- |
+| Tool step | Materializes as a typed tool execution node. |
+| Skill step | Materializes as an agent-facing skill/runtime execution node. |
+| Preset step | Rejected before runtime execution by default. |
+
+Runtime materialization must use the flat executable payload, not live preset catalog state.
+
+## Proposal Promotion Contract
+
+Stored promotable proposals contain a reviewed flat executable payload.
+
+Promotion must:
+- validate the stored payload before execution,
+- preserve reviewed steps, instructions, authored preset bindings, and step source metadata,
+- reject unresolved Preset steps,
+- avoid live preset re-expansion unless the operator explicitly requests refresh through preview and validation,
+- keep any runtime override bounded to runtime selection fields without rewriting reviewed steps or provenance.
+
+## Explicit Refresh Contract
+
+Refreshing a draft or proposal from a preset catalog entry is an explicit operator action.
+
+Refresh must:
+- show a preview of replacement executable steps,
+- validate generated steps before mutation,
+- preserve the current reviewed payload if preview or validation fails,
+- replace the stored flat payload only after explicit confirmation.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/data-model.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: Submit Flattened Executable Steps with Provenance
+
+## ExecutableStep
+
+Represents a submitted task step that can be executed without resolving a preset catalog entry.
+
+Fields:
+- `id`: optional stable step identity.
+- `title`: optional display label.
+- `instructions`: optional step-level instructions.
+- `type`: executable Step Type, either `tool` or `skill`.
+- `tool`: typed operation payload when `type` is `tool`.
+- `skill`: agent-facing behavior payload when `type` is `skill`.
+- `source`: optional `PresetProvenance` metadata when the step was generated from a preset.
+
+Validation rules:
+- `type` must be `tool` or `skill` at executable submission and promotion boundaries.
+- `type: "preset"` is rejected by default because Preset is an authoring-time placeholder.
+- A Tool step must carry a Tool payload and must not carry a Skill payload.
+- A Skill step must carry or resolve to Skill behavior and must not carry a non-Skill Tool payload.
+
+## PresetProvenance
+
+Metadata attached to an executable step generated from a preset.
+
+Fields:
+- `kind`: `preset-derived` for generated steps, with existing manual/detached values remaining non-runtime metadata.
+- `presetId`: identifier for the source preset.
+- `presetVersion`: version of the source preset used for expansion.
+- `includePath`: ordered include path when the step came from a nested include.
+- `originalStepId`: identifier of the source preset step.
+
+Validation rules:
+- Provenance is optional for runtime execution.
+- Preset application, review, and proposal surfaces preserve `kind`, `presetId`, `presetVersion`, and `originalStepId` when the expansion source provides those values.
+- `includePath` is preserved when the expansion source provides an include path.
+- Missing, stale, or partial provenance must not make an otherwise valid executable Tool or Skill step require live preset lookup.
+- Provenance must not control runtime materialization.
+- Provenance may be used for audit, review, grouping, proposal reconstruction, and explicit refresh workflows.
+
+## FlatExecutablePayload
+
+Reviewed task or proposal payload ready for execution.
+
+Fields:
+- `instructions`: task-level instructions.
+- `steps`: ordered list of `ExecutableStep` entries.
+- `authoredPresets`: optional audit/reconstruction binding metadata for applied presets.
+
+Validation rules:
+- The payload must not contain unresolved Preset steps by default.
+- The payload remains executable when provenance is stale or live preset catalog access is unavailable.
+- The payload is the source of truth for proposal promotion unless the operator explicitly refreshes it through preview and validation.
+
+## PromotableProposal
+
+Stored proposal that can be promoted into a task execution.
+
+Fields:
+- `taskCreateRequest`: reviewed task creation envelope containing a `FlatExecutablePayload`.
+- `status`: proposal lifecycle state.
+- `review metadata`: priority, origin, decision note, and related proposal metadata.
+
+Validation rules:
+- Promotion validates the stored flat executable payload before execution.
+- Promotion rejects unresolved Preset steps.
+- Promotion preserves reviewed steps and provenance metadata.
+- Promotion does not silently re-expand live preset catalog entries.
+
+## State Transitions
+
+1. `Preset draft step` -> explicit preview request.
+2. `Preset preview` -> generated executable Tool/Skill steps plus warnings or validation errors.
+3. `Applied preset` -> `FlatExecutablePayload` with executable steps and provenance metadata.
+4. `FlatExecutablePayload` -> runtime plan or promoted execution after validation.
+5. `Refresh requested` -> preview and validation before replacing the stored flat payload.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/moonspec_align_report.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/moonspec_align_report.md
@@ -1,0 +1,33 @@
+# MoonSpec Alignment Report: Submit Flattened Executable Steps with Provenance
+
+**Feature**: `292-submit-flattened-executable-steps-with-provenance`  
+**Date**: 2026-05-01  
+**Source issue**: `MM-579`
+
+## Summary
+
+Alignment reviewed `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/flattened-executable-provenance.md`, `quickstart.md`, and `tasks.md` after task generation.
+
+## Findings And Remediation
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| Provenance completeness language in downstream artifacts could be read as a runtime validation blocker, conflicting with FR-005 and DESIGN-REQ-016, which require runtime correctness to avoid depending on provenance or live catalog lookup. | Medium | Updated `data-model.md`, `contracts/flattened-executable-provenance.md`, `research.md`, and `tasks.md` so complete provenance is preserved by preset application/review/proposal surfaces when source data is available, while missing/stale/partial provenance never forces live preset lookup for otherwise valid Tool/Skill steps. |
+
+## Key Decision
+
+Provenance completeness is a generation and review requirement, not a runtime dependency. This preserves the higher-authority MM-579 requirement that preset-derived steps carry provenance when generated, while also preserving the explicit runtime independence requirement.
+
+## Gate Results
+
+- Specify gate: PASS. `spec.md` has exactly one user story, preserves `MM-579`, and has no clarification markers.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and contract artifacts exist and keep unit/integration strategies explicit.
+- Tasks gate: PASS. `tasks.md` has 35 sequential tasks, exactly one story phase, unit and integration tests before implementation, red-first confirmation tasks, conditional fallback tasks, and final `/moonspec-verify` work.
+- Coverage gate: PASS. All `FR-*`, `SC-*`, and in-scope `DESIGN-REQ-*` IDs from `spec.md` appear in `plan.md` and `tasks.md`.
+
+## Validation Evidence
+
+- Artifact presence check: PASS.
+- Placeholder check: PASS. No unresolved clarification markers, numeric template placeholders, sample task IDs, or legacy verify-command markers remain.
+- Task format check: PASS. All task lines match `- [ ] T### [P?] ...`.
+- Story count check: PASS. One `## User Story` section in `spec.md` and one `## Phase 3: Story` section in `tasks.md`.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/plan.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Submit Flattened Executable Steps with Provenance
+
+**Branch**: `292-submit-flattened-executable-steps-with-provenance` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)  
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:d840afab-0992-4107-91d1-bcee9ae1b804/repo/specs/292-submit-flattened-executable-steps-with-provenance/spec.md`
+
+## Summary
+
+MM-579 requires preset-derived work to submit and promote as reviewed flat executable Tool and Skill steps while preserving provenance for audit, grouping, reconstruction, and explicit refresh. Repo inspection shows adjacent Step Type work already previews/applies presets in the Create page, rejects unresolved Preset steps at executable boundaries, materializes explicit Tool/Skill steps without live preset lookup, and preserves proposal provenance in several paths. The remaining delivery risk is MM-579-specific provenance completeness, especially the canonical `presetVersion` field and include-path/original-step coverage across submitted steps and promoted proposals. The plan is TDD-first: add focused unit and integration-boundary tests for flat Tool/Skill submission, provenance metadata, proposal promotion, and explicit refresh behavior, then patch the existing task contract, Create page mapping, and proposal surfaces only where those tests expose drift.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | Create page MM-578 tests preview/apply generated Tool and Skill steps; submission test asserts generated Tool binding only. | Add MM-579-focused submission test proving all applied generated steps submit as Tool/Skill and no Preset placeholder remains; patch serialization if needed. | frontend integration |
+| FR-002 | implemented_verified | `TaskStepSpec._reject_forbidden_step_overrides` rejects `type: "preset"`; Create page blocks unresolved Preset submission; proposal service rejects unresolved Preset steps. | No new implementation beyond final verification. | unit + frontend integration |
+| FR-003 | partial | `TaskStepSource` preserves `kind`, `presetId`, `includePath`, and `originalStepId`, but current models/tests use `version` rather than the source-design `presetVersion` field. | Add canonical `presetVersion` preservation tests and update task/proposal/frontend metadata mapping if tests fail. | unit + frontend integration |
+| FR-004 | partial | Proposal preview reports preset provenance and Create page displays source labels, but MM-579-specific audit/grouping/reconstruction evidence for complete source metadata is missing. | Add tests that complete preset source metadata remains visible to review/proposal surfaces; patch preview/labels if needed. | API unit + frontend integration |
+| FR-005 | implemented_verified | Runtime planner maps explicit Tool/Skill steps based on executable type and carries `source` only as metadata; unit tests cover Tool and Skill plan nodes. | No new implementation. | unit |
+| FR-006 | implemented_verified | Create page preset preview/apply tests cover expansion before mutation, validation failure preserving the draft, and unresolved Preset blocking. | No new implementation unless MM-579 provenance tests expose expansion metadata loss. | frontend integration |
+| FR-007 | partial | `TaskProposalService.promote_proposal` validates stored `CanonicalTaskPayload`, but existing provenance-preservation tests allow legacy source-only proposal steps without explicit Tool/Skill type. | Add promotion tests requiring preset-derived proposals to contain flat executable Tool/Skill steps; patch validation if needed. | unit |
+| FR-008 | partial | Promotion validates stored payloads and rejects unresolved Preset steps; no live re-expansion call is evident, but flat executable proposal enforcement is incomplete. | Verify promotion uses stored flat payload and zero live catalog expansion; strengthen validation if proposal tests fail. | unit |
+| FR-009 | implemented_unverified | Create page has reapply-needed messaging and stale preview invalidation tests adjacent to this story. | Add MM-579-focused explicit refresh/preview regression for draft refresh; document proposal refresh as out of implementation scope unless existing product surface exposes it. | frontend integration |
+| FR-010 | partial | `spec.md` preserves MM-579 and original preset brief; planning artifacts are being generated. | Preserve MM-579 in plan, research, data model, contract, quickstart, tasks, verification, commit, and PR metadata. | artifact review |
+| SCN-001 | implemented_unverified | MM-578 tests prove applied preview replaces a Preset placeholder with generated editable steps. | Add MM-579 submission assertion for final flat payload shape. | frontend integration |
+| SCN-002 | partial | Task contract and proposal tests preserve some source metadata. | Add complete provenance metadata tests, including canonical preset version and include path. | unit + frontend integration |
+| SCN-003 | implemented_verified | Runtime planner uses executable Tool/Skill steps and does not depend on preset provenance. | No new implementation. | unit |
+| SCN-004 | partial | Proposal promotion validates stored payload and rejects `type: "preset"`, but does not yet prove all preset-derived proposal steps are explicit Tool/Skill steps. | Add flat proposal payload promotion tests and code contingency. | unit |
+| SCN-005 | implemented_unverified | Reapply-needed UI behavior exists, but MM-579-specific explicit preview before refresh needs targeted evidence. | Add focused Create-page regression around explicit preview/validation before refresh changes stored draft steps. | frontend integration |
+| DESIGN-REQ-004 | implemented_unverified | Preset preview/apply creates concrete Tool and Skill steps in the Create page. | Verify final submitted payload remains concrete Tool/Skill only. | frontend integration |
+| DESIGN-REQ-006 | partial | Source metadata exists but canonical `presetVersion` coverage is missing. | Add metadata model and UI/proposal preservation coverage. | unit + frontend integration |
+| DESIGN-REQ-015 | implemented_verified | Runtime/task contract and UI block unresolved Preset steps at executable submission boundaries. | No new implementation beyond final verification. | unit + frontend integration |
+| DESIGN-REQ-016 | partial | Runtime ignores source metadata for execution and preview surfaces expose provenance summary; complete audit/reconstruction metadata coverage is missing. | Add complete provenance and review-surface tests. | unit + API unit + frontend integration |
+| DESIGN-REQ-023 | partial | Promotion validates stored payloads and rejects Preset steps; explicit flat proposal enforcement and refresh evidence need strengthening. | Add proposal promotion and refresh tests; patch validation if needed. | unit + frontend integration |
+| SC-001 | implemented_verified | Existing task contract and Create page tests reject unresolved Preset and accept executable Tool/Skill shapes. | No new implementation beyond final verification. | unit + frontend integration |
+| SC-002 | partial | Source metadata preservation exists, but complete required metadata including `presetVersion` is not fully covered. | Add provenance completeness tests. | unit + frontend integration |
+| SC-003 | implemented_verified | Runtime planner does not require live preset lookup and uses explicit executable steps. | No new implementation. | unit |
+| SC-004 | partial | Promotion has validation and unresolved Preset rejection; zero automatic live re-expansion should be locked by tests. | Add promotion no-reexpand/flat-payload tests. | unit |
+| SC-005 | implemented_unverified | Reapply-needed and stale-preview UI behavior exists. | Add MM-579 refresh preview regression. | frontend integration |
+| SC-006 | partial | MM-579 traceability is present in `spec.md`; planning and downstream artifacts still need preservation. | Carry traceability through generated artifacts and final verification. | artifact review |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control Create page behavior  
+**Primary Dependencies**: Pydantic v2 task contract models, FastAPI proposal API router, existing task proposal service, React, TanStack Query, Vitest, Testing Library, pytest  
+**Storage**: Existing task submission payloads, task proposal rows, and artifact-backed task input snapshots only; no new persistent storage planned  
+**Unit Testing**: Focused Python unit tests through `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`  
+**Integration Testing**: Create page render/submission integration-boundary coverage through `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`; compose-backed `integration_ci` is not required unless implementation touches worker topology or persisted execution boundaries  
+**Target Platform**: MoonMind task authoring, executable task contract, runtime planning, and proposal promotion surfaces  
+**Project Type**: Web application plus Python service contracts  
+**Performance Goals**: Preset apply and promotion validation remain linear in step count; refresh requires explicit operator action and does not perform background catalog expansion during promotion  
+**Constraints**: Preserve MM-579 traceability; keep Preset non-executable by default; do not introduce live preset lookup for runtime correctness; do not add hidden compatibility aliases for unsupported Step Types  
+**Scale/Scope**: One runtime behavior story spanning Create page preset application, canonical task payload validation, runtime materialization, and proposal promotion/review metadata
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Work strengthens existing task/preset/proposal orchestration contracts rather than introducing a new agent layer.
+- II. One-Click Agent Deployment: PASS. No new required external services, credentials, or deployment prerequisites.
+- III. Avoid Vendor Lock-In: PASS. Tool, Skill, Preset, and proposal behavior remain provider-neutral.
+- IV. Own Your Data: PASS. Provenance and proposal data remain in MoonMind-owned task payloads and proposal records.
+- V. Skills Are First-Class and Easy to Add: PASS. Skill steps remain executable first-class steps distinct from Tool and Preset.
+- VI. Scientific Method: PASS. Plan requires focused failing tests before production changes and final verification evidence.
+- VII. Runtime Configurability: PASS. No hardcoded model, provider, or deployment configuration is introduced.
+- VIII. Modular and Extensible Architecture: PASS. Planned work stays within existing Create page, task contract, runtime planner, and proposal service/API boundaries.
+- IX. Resilient by Default: PASS. Invalid unresolved Preset payloads fail before runtime execution or proposal promotion.
+- X. Facilitate Continuous Improvement: PASS. Artifacts preserve MM-579 traceability and will feed final verification.
+- XI. Spec-Driven Development: PASS. `spec.md` and this plan precede MM-579 implementation tasks.
+- XII. Canonical Documentation Separation: PASS. Runtime rollout details stay in feature artifacts; canonical docs are source requirements only.
+- XIII. Pre-release Compatibility Policy: PASS. Unsupported executable Step Type values continue to fail fast; canonical metadata changes should update all callers/tests/docs in one change rather than adding silent semantic aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/292-submit-flattened-executable-steps-with-provenance/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── flattened-executable-provenance.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create.test.tsx
+moonmind/workflows/tasks/task_contract.py
+tests/unit/workflows/tasks/test_task_contract.py
+moonmind/workflows/task_proposals/service.py
+tests/unit/workflows/task_proposals/test_service.py
+api_service/api/routers/task_proposals.py
+tests/unit/api/routers/test_task_proposals.py
+moonmind/workflows/temporal/worker_runtime.py
+tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+```
+
+**Structure Decision**: Use the existing Create page preset preview/apply flow for authoring and submission behavior, the canonical task contract for executable payload validation and provenance shape, the runtime planner for source-independent execution, and proposal service/API tests for promotion and review behavior.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/quickstart.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Submit Flattened Executable Steps with Provenance
+
+## Focused Unit Tests
+
+Run the backend contract, runtime, and proposal tests first:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+```
+
+Expected coverage:
+- Tool and Skill executable steps are accepted.
+- Preset, Activity, and shell-shaped executable steps are rejected.
+- Preset-derived source metadata preserves `presetId`, `presetVersion`, `includePath`, and `originalStepId`.
+- Runtime materialization does not require preset provenance or live catalog lookup.
+- Proposal promotion validates a flat executable payload, preserves provenance, rejects unresolved Preset steps, and does not silently re-expand a live preset.
+
+## Focused Frontend Integration-Boundary Tests
+
+Run the Create page target through the managed dashboard runner:
+
+```bash
+./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected coverage:
+- Applying a preset replaces the Preset placeholder with editable executable Tool and Skill steps.
+- Submitting the applied preset sends only Tool and Skill steps.
+- Preset-derived steps retain complete provenance metadata in the submitted payload.
+- Preview failure leaves the draft unchanged.
+- Refresh/reapply requires explicit preview and validation before replacing reviewed steps.
+
+## Full Unit Verification
+
+Before final verification, run:
+
+```bash
+./tools/test_unit.sh
+```
+
+If the full suite is blocked by an unrelated environment issue, record the exact blocker and preserve focused test evidence.
+
+## End-to-End Story Check
+
+1. Start with a task draft containing a configured Preset step.
+2. Preview expansion and confirm generated Tool and Skill steps plus warnings are visible before mutation.
+3. Apply the preview and confirm the Preset placeholder is replaced.
+4. Submit or promote the reviewed task payload.
+5. Confirm the executable payload contains only Tool and Skill steps.
+6. Confirm preset provenance remains visible for audit/review and does not control runtime execution.
+7. Confirm catalog refresh requires explicit preview and validation.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/research.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/research.md
@@ -1,0 +1,73 @@
+# Research: Submit Flattened Executable Steps with Provenance
+
+## FR-001 / DESIGN-REQ-004 - Applied Preset Submission Shape
+
+Decision: Implemented but MM-579-specific verification is missing.
+Evidence: `frontend/src/entrypoints/task-create.tsx` applies preset previews into generated step state; `frontend/src/entrypoints/task-create.test.tsx` has MM-578 coverage for preview/apply and a submission assertion for a generated Tool step.
+Rationale: Existing behavior likely submits applied generated Tool and Skill steps, but current focused submission evidence only asserts the generated Tool step. MM-579 requires proving the whole payload is flat executable Tool/Skill work.
+Alternatives considered: Treat MM-578 evidence as sufficient. Rejected because MM-579 is specifically about flattened executable submission with provenance, so the submitted multi-step payload needs direct coverage.
+Test implications: Frontend integration-boundary test first; implementation contingency in Create page serialization if the test fails.
+
+## FR-002 / DESIGN-REQ-015 - Unresolved Preset Rejection
+
+Decision: Implemented and verified.
+Evidence: `moonmind/workflows/tasks/task_contract.py::TaskStepSpec._reject_forbidden_step_overrides`; `tests/unit/workflows/tasks/test_task_contract.py::test_task_steps_reject_non_executable_step_types`; `tests/unit/workflows/task_proposals/test_service.py::test_promote_proposal_rejects_unresolved_preset_steps`; MM-578 Create page unresolved Preset submission test.
+Rationale: Runtime submission, proposal promotion, and UI submission boundaries all reject unresolved Preset steps.
+Alternatives considered: Add a new linked-preset runtime mode. Rejected because MM-579 explicitly keeps runtime payloads flat by default and does not request linked-preset execution.
+Test implications: No new implementation; rerun focused tests during final verification.
+
+## FR-003 / DESIGN-REQ-006 - Complete Provenance Metadata
+
+Decision: Partial; code preserves provenance metadata but canonical `presetVersion` coverage is missing.
+Evidence: `TaskStepSource` currently models `kind`, `presetId`, `presetSlug`, `version`, `includePath`, and `originalStepId`; proposal tests preserve `includePath` and `originalStepId`; source design examples use `presetVersion`.
+Rationale: MM-579 names `presetVersion` as required metadata for preset-derived source provenance when that provenance is produced by preset application or surfaced for review. The existing `version` field may represent the same concept, but the current code and tests do not prove the canonical source field survives. Because MoonMind is pre-release, the plan should update the canonical shape consistently rather than hide the mismatch, while preserving the separate rule that runtime execution cannot depend on provenance completeness.
+Alternatives considered: Document `version` as equivalent to `presetVersion`. Rejected because the Jira preset brief and source design explicitly name `presetVersion`, and hidden transforms would weaken traceability.
+Test implications: Unit tests for task contract and proposal promotion plus frontend submission tests for complete source metadata.
+
+## FR-004 / DESIGN-REQ-016 - Audit, UI Grouping, Proposal Reconstruction, And Review
+
+Decision: Partial; adjacent review surfaces exist, but MM-579 complete-metadata evidence is missing.
+Evidence: `api_service/api/routers/task_proposals.py::_build_task_preview` summarizes preset provenance; `test_get_proposal_preview_includes_preset_provenance` covers preview metadata; Create page source label helpers display preset origin.
+Rationale: Existing surfaces use provenance, but the tests do not yet assert complete MM-579 metadata across audit/review/reconstruction cases.
+Alternatives considered: Add a new storage model for provenance. Rejected because existing task payload and proposal payload metadata should carry the required data.
+Test implications: API unit and frontend integration tests; implementation contingency in preview/label mapping if fields are dropped.
+
+## FR-005 / SC-003 - Runtime Independence From Provenance
+
+Decision: Implemented and verified.
+Evidence: `moonmind/workflows/temporal/worker_runtime.py` maps executable Tool and Skill steps by selected Step Type and selected Tool/Skill; `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covers explicit Tool and Skill plan nodes with source metadata carried as inputs only.
+Rationale: Runtime materialization does not require live preset lookup or provenance to choose execution behavior.
+Alternatives considered: Resolve preset catalog during runtime planning. Rejected because source requirements say runtime correctness must not depend on live catalog lookup.
+Test implications: Existing unit tests are sufficient; rerun during final verification.
+
+## FR-006 - Deterministic Validated Preset Expansion
+
+Decision: Implemented and verified by adjacent Create page behavior.
+Evidence: MM-578 Create page tests cover preview before mutation, generated-step warnings, validation failure preserving the draft, apply replacement, and unresolved Preset blocking.
+Rationale: Preset expansion is already an explicit preview/apply action with visible validation behavior before executable submission.
+Alternatives considered: Expand automatically on selection. Rejected because it removes the required preview/validation decision point.
+Test implications: Existing focused frontend tests plus MM-579 submission/provenance tests.
+
+## FR-007 / FR-008 / DESIGN-REQ-023 - Promotable Proposal Flat Payload
+
+Decision: Partial; promotion validates stored payloads, but explicit Tool/Skill flatness for preset-derived proposals needs stronger coverage.
+Evidence: `TaskProposalService.promote_proposal` validates stored `CanonicalTaskPayload`; proposal service tests preserve provenance and reject unresolved Preset steps. Existing provenance-preservation proposal tests include source metadata but not explicit Tool/Skill step type.
+Rationale: MM-579 requires stored promotable proposals to be executable by default. Accepting legacy source-only steps may be compatible with earlier behavior but does not prove flat Tool/Skill executable intent.
+Alternatives considered: Defer proposal enforcement because runtime submission validation already exists. Rejected because MM-579 explicitly includes promotion semantics.
+Test implications: Unit tests for proposal promotion requiring explicit Tool/Skill steps, no live catalog re-expansion, provenance preservation, and invalid stored Preset rejection.
+
+## FR-009 / SC-005 - Explicit Refresh From Catalog
+
+Decision: Implemented but MM-579-specific verification is missing for drafts; proposal refresh may remain out of scope if no explicit proposal refresh UI exists.
+Evidence: Create page reapply-needed messaging and stale preview invalidation are covered by adjacent tests; source design requires explicit preview and validation before refresh.
+Rationale: The authoring surface already treats reapply as explicit. MM-579 should add a focused regression to prevent automatic refresh from changing reviewed flat payloads.
+Alternatives considered: Automatically refresh applied preset-derived steps on catalog updates. Rejected because it would drift from reviewed operator intent.
+Test implications: Frontend integration test first; document any proposal-refresh limitation in final verification if no product surface exists.
+
+## FR-010 / SC-006 - MM-579 Traceability
+
+Decision: Partial until downstream artifacts and final verification exist.
+Evidence: `spec.md` preserves MM-579 and the original Jira preset brief; `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` are generated in this step.
+Rationale: Traceability must remain visible through tasks, implementation notes, verification, commit text, and PR metadata.
+Alternatives considered: Rely only on Jira link metadata. Rejected because MoonSpec verification compares local artifacts to the original request.
+Test implications: Artifact review in `/moonspec-verify`.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/spec.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Submit Flattened Executable Steps with Provenance
+
+**Feature Branch**: `292-submit-flattened-executable-steps-with-provenance`
+**Created**: 2026-05-01
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-579 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-579 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-579
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Submit flattened executable steps with provenance
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-579 from MM project
+Summary: Submit flattened executable steps with provenance
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 5.3 preset
+- 7.1 Authoring payload
+- 13. Proposal and Promotion Semantics
+Coverage IDs:
+- DESIGN-REQ-004
+- DESIGN-REQ-006
+- DESIGN-REQ-015
+- DESIGN-REQ-016
+- DESIGN-REQ-023
+
+As an operator, I can submit tasks that contain only executable Tool and Skill steps by default, while preset-derived steps retain provenance for audit and reconstruction without runtime lookup.
+
+Acceptance Criteria
+- Executable submission contains only Tool and Skill steps by default.
+- Preset-derived steps carry source.kind, presetId, presetVersion, includePath when applicable, and originalStepId metadata.
+- Runtime correctness does not depend on preset provenance metadata or live catalog lookup.
+- Promotion validates the stored flat payload and only refreshes from catalog after explicit user action with preview.
+
+Requirements
+- Preset expansion is deterministic and validated before execution.
+- Preset provenance supports audit, UI grouping, proposal reconstruction, and review.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-579 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+Preserved source Jira preset brief: `MM-579` from the trusted `jira.get_issue` response, reproduced in the `**Input**` field above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-579` and local artifact `artifacts/moonspec/MM-579-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserved `MM-579`, so `Specify` was the first incomplete MM-579 stage.
+
+## User Story - Flatten Preset-Derived Executable Submissions
+
+**Summary**: As an operator, I can submit tasks that contain only executable Tool and Skill steps by default, while preset-derived steps retain provenance for audit and reconstruction without runtime lookup.
+
+**Goal**: Task submission and proposal promotion use the reviewed flat executable steps as the source of truth, while preserving preset provenance only as metadata for audit, grouping, reconstruction, and explicit refresh workflows.
+
+**Independent Test**: Apply a preset into executable Tool and Skill steps, submit or promote the resulting task, and verify that execution accepts only the flat Tool and Skill steps, provenance remains visible, no live preset lookup is required for correctness, and any catalog refresh requires explicit preview and validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task draft contains a configured preset, **When** the operator applies it for submission, **Then** the submitted task contains executable Tool and Skill steps rather than an unresolved Preset step.
+2. **Given** executable steps were derived from a preset, **When** the submitted task is reviewed, executed, or audited, **Then** each derived step retains source metadata identifying the preset, version, original step, and include path when present.
+3. **Given** preset provenance is missing, partial, stale, or references a catalog entry that is unavailable, **When** the flat executable steps are otherwise valid, **Then** runtime execution still proceeds from the executable Tool and Skill steps without requiring live catalog lookup.
+4. **Given** a stored proposal contains preset-derived executable steps, **When** the proposal is promoted, **Then** promotion validates and uses the stored flat payload without silently re-expanding a live preset catalog entry.
+5. **Given** an operator wants a draft or proposal refreshed from a newer preset catalog entry, **When** refresh is requested, **Then** the system requires an explicit preview and validation step before replacing the reviewed flat payload.
+
+**Edge Cases**:
+
+- A preset expands into multiple levels of included steps; provenance preserves the include path for derived executable steps when that path exists.
+- A derived step has no include path because it came directly from the selected preset; the step remains valid when other required provenance fields are present.
+- A stale preset version remains recorded in provenance; runtime execution still uses the flat executable steps and does not refresh automatically.
+- A submitted task still contains an unresolved Preset step; validation rejects it before runtime execution.
+- A promoted proposal has provenance metadata but no live preset catalog access; promotion still validates the stored executable payload.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST submit executable task payloads that contain only Tool and Skill steps by default after a preset has been applied.
+- **FR-002**: The system MUST reject unresolved Preset steps in runtime submission or promotion paths unless an explicit future linked-preset mode is selected outside this story's scope.
+- **FR-003**: Preset-derived executable steps MUST preserve provenance metadata containing source kind, preset identifier, preset version, original step identifier, and include path when an include path exists.
+- **FR-004**: Preset provenance metadata MUST be usable for audit, review, UI grouping, and proposal reconstruction.
+- **FR-005**: Runtime execution MUST NOT depend on preset provenance metadata or live preset catalog lookup when the submitted Tool and Skill steps are otherwise valid.
+- **FR-006**: Preset expansion MUST be deterministic and validated before the resulting executable steps can be submitted.
+- **FR-007**: Stored promotable proposals derived from presets MUST contain a reviewed flat executable payload before promotion.
+- **FR-008**: Proposal promotion MUST validate the stored flat executable payload and MUST NOT silently re-expand a live preset catalog entry.
+- **FR-009**: Refreshing a draft or proposal from a preset catalog entry MUST require an explicit operator action with preview and validation before the stored flat payload changes.
+- **FR-010**: Validation and verification evidence for this feature MUST preserve Jira issue key `MM-579` and the original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Executable Step**: A task step that is ready for runtime execution as either Tool or Skill.
+- **Preset Step**: An authoring-time placeholder that must be applied into executable steps before default runtime submission.
+- **Preset Provenance**: Metadata on a derived executable step that records where the step came from, including preset identity, preset version, original step identity, and include path when available.
+- **Flat Executable Payload**: The reviewed task or proposal payload containing executable Tool and Skill steps without unresolved Preset steps.
+- **Promotable Proposal**: A stored proposal that can become an executable task after validating its flat executable payload.
+
+## Assumptions
+
+- The ordinary runtime path does not include a linked-preset execution mode; any future linked-preset mode will be explicit and visibly distinct from default preset application.
+- The feature may rely on existing product terminology for Tool, Skill, Preset, proposal, promotion, and provenance.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+|----|--------|---------------------|-------|---------------------|
+| DESIGN-REQ-004 | `docs/Steps/StepTypes.md` section 5.3 `preset` | Applying a preset produces concrete executable Tool and Skill steps, and the default submitted form should not keep the Preset step as executable work. | In scope | FR-001, FR-002, FR-006 |
+| DESIGN-REQ-006 | `docs/Steps/StepTypes.md` section 5.3 `preset` | Preset-derived steps preserve source metadata identifying the preset origin, version, original step, and include path where applicable. | In scope | FR-003, FR-004 |
+| DESIGN-REQ-015 | `docs/Steps/StepTypes.md` section 7.1 `Authoring payload` | Executable task submissions should contain Tool and Skill steps by default, while Preset steps remain authoring-time placeholders. | In scope | FR-001, FR-002 |
+| DESIGN-REQ-016 | `docs/Steps/StepTypes.md` section 7.1 `Authoring payload` | Preset provenance is metadata for audit, grouping, reconstruction, and review, and must not be required for runtime correctness. | In scope | FR-003, FR-004, FR-005 |
+| DESIGN-REQ-023 | `docs/Steps/StepTypes.md` section 13 `Proposal and Promotion Semantics` | Proposals preserve executable intent by storing flat executable payloads, validating those payloads during promotion, and requiring explicit preview for catalog refresh. | In scope | FR-007, FR-008, FR-009 |
+
+## Success Criteria
+
+- **SC-001**: In all covered submission scenarios, unresolved Preset steps are rejected before runtime execution and executable Tool and Skill steps are accepted.
+- **SC-002**: 100% of preset-derived executable steps in covered scenarios retain required provenance metadata, with include path retained whenever the source expansion provides one.
+- **SC-003**: Covered runtime execution scenarios succeed from valid flat executable payloads even when preset provenance is stale or live preset catalog access is unavailable.
+- **SC-004**: Covered proposal promotion scenarios validate the stored flat payload and perform zero automatic live preset re-expansions.
+- **SC-005**: Covered refresh scenarios require explicit operator preview and validation before replacing a stored draft or proposal payload from the preset catalog.
+- **SC-006**: Final verification can trace `MM-579`, the original Jira preset brief, and all in-scope source design requirements through the MoonSpec artifacts.

--- a/specs/292-submit-flattened-executable-steps-with-provenance/tasks.md
+++ b/specs/292-submit-flattened-executable-steps-with-provenance/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Submit Flattened Executable Steps with Provenance
+
+**Input**: Design documents from `/work/agent_jobs/mm:d840afab-0992-4107-91d1-bcee9ae1b804/repo/specs/292-submit-flattened-executable-steps-with-provenance/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/flattened-executable-provenance.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped around exactly one story: flatten preset-derived executable submissions while preserving provenance for audit and reconstruction.
+
+**Source Traceability**: MM-579 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-010, SCN-001 through SCN-005, SC-001 through SC-006, and DESIGN-REQ-004, DESIGN-REQ-006, DESIGN-REQ-015, DESIGN-REQ-016, and DESIGN-REQ-023.
+
+**Requirement Status Summary**: `plan.md` classifies 13 rows as `partial`, 6 as `implemented_unverified`, and 7 as `implemented_verified`. This task list adds code-and-test tasks for partial rows, verification-first tests with conditional fallback implementation for implemented-unverified rows, and final validation for already-verified rows.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+- Integration tests: `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and has no dependency on an incomplete task.
+- Every task references exact file paths and requirement, scenario, success criterion, or source IDs where applicable.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active feature artifacts and existing test harnesses are ready before story work.
+
+- [X] T001 Verify active feature pointer `.specify/feature.json` resolves to `specs/292-submit-flattened-executable-steps-with-provenance` for MM-579 traceability (FR-010, SC-006)
+- [X] T002 Confirm required upstream artifacts exist in `specs/292-submit-flattened-executable-steps-with-provenance/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/flattened-executable-provenance.md`, and `quickstart.md` (FR-010, SC-006)
+- [X] T003 [P] Confirm backend unit test targets are available in `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, and `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+- [X] T004 [P] Confirm Create page integration-boundary test target is available in `frontend/src/entrypoints/task-create.test.tsx`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish the exact current contract surfaces before adding MM-579 tests.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T005 Inspect current executable step and provenance validation in `moonmind/workflows/tasks/task_contract.py` against `specs/292-submit-flattened-executable-steps-with-provenance/contracts/flattened-executable-provenance.md` (FR-002, FR-003, DESIGN-REQ-006, DESIGN-REQ-015)
+- [X] T006 Inspect current proposal promotion and preview behavior in `moonmind/workflows/task_proposals/service.py` and `api_service/api/routers/task_proposals.py` for stored flat-payload validation and provenance display (FR-004, FR-007, FR-008, DESIGN-REQ-016, DESIGN-REQ-023)
+- [X] T007 Inspect current preset preview/apply submission mapping in `frontend/src/entrypoints/task-create.tsx` for generated Tool/Skill flattening, source metadata preservation, and explicit refresh behavior (FR-001, FR-003, FR-006, FR-009, DESIGN-REQ-004)
+- [X] T008 Inspect runtime planner behavior in `moonmind/workflows/temporal/worker_runtime.py` to confirm provenance is carried as metadata and not used for live preset lookup (FR-005, SC-003)
+
+**Checkpoint**: Foundation ready - test and implementation work can begin.
+
+---
+
+## Phase 3: Story - Flatten Preset-Derived Executable Submissions
+
+**Summary**: As an operator, I can submit tasks that contain only executable Tool and Skill steps by default, while preset-derived steps retain provenance for audit and reconstruction without runtime lookup.
+
+**Independent Test**: Apply a preset into executable Tool and Skill steps, submit or promote the resulting task, and verify that execution accepts only the flat Tool and Skill steps, provenance remains visible, no live preset lookup is required for correctness, and any catalog refresh requires explicit preview and validation.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-004, DESIGN-REQ-006, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-023
+
+**Unit Test Plan**: Cover task contract provenance shape, unresolved Preset rejection, runtime materialization independence, proposal flat-payload validation, proposal provenance preservation, and proposal preview metadata.
+
+**Integration Test Plan**: Cover Create page preset preview/apply/submission, complete submitted provenance, draft-preserving preview failure, and explicit reapply/refresh before replacing reviewed steps.
+
+### Unit Tests (write first)
+
+- [X] T009 [P] Add failing task contract unit tests for canonical `source.presetVersion`, `source.includePath`, and `source.originalStepId` preservation in `tests/unit/workflows/tasks/test_task_contract.py` (FR-003, SCN-002, SC-002, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T010 [P] Add task contract unit tests proving executable Tool/Skill steps with missing, partial, or stale source provenance still validate without live preset lookup while complete provenance fields are preserved when provided in `tests/unit/workflows/tasks/test_task_contract.py` (FR-003, FR-005, SCN-002, SCN-003, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T011 [P] Add failing proposal service unit tests requiring preset-derived promotable proposal steps to be explicit flat `type: "tool"` or `type: "skill"` entries in `tests/unit/workflows/task_proposals/test_service.py` (FR-007, FR-008, SCN-004, SC-004, DESIGN-REQ-023)
+- [X] T012 [P] Add failing proposal service unit tests preserving `presetVersion`, `includePath`, and `originalStepId` through promotion in `tests/unit/workflows/task_proposals/test_service.py` (FR-003, FR-004, FR-007, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T013 [P] Add failing proposal API preview tests exposing complete preset provenance metadata in `tests/unit/api/routers/test_task_proposals.py` (FR-004, SCN-002, DESIGN-REQ-016)
+- [X] T014 [P] Add runtime planner verification tests that valid Tool/Skill steps still materialize when source provenance is missing, stale, or catalog-unresolvable in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` (FR-005, SCN-003, SC-003, DESIGN-REQ-016)
+- [X] T015 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` and confirm T009-T014 fail only for the expected MM-579 gaps before production changes
+
+### Integration Tests (write first)
+
+- [X] T016 [P] Add failing Create page integration-boundary test that applies a preset and submits only flat Tool/Skill steps with no unresolved Preset placeholder in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, SCN-001, SC-001, DESIGN-REQ-004, DESIGN-REQ-015)
+- [X] T017 [P] Add failing Create page integration-boundary test that submitted preset-derived Tool and Skill steps retain `source.kind`, `source.presetId`, `source.presetVersion`, `source.includePath` when provided, and `source.originalStepId` in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-002, SC-002, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T018 [P] Add failing Create page integration-boundary test that reapply/refresh requires explicit preview and validation before replacing reviewed generated steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-009, SCN-005, SC-005, DESIGN-REQ-023)
+- [X] T019 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T016-T018 fail only for the expected MM-579 gaps before production changes
+
+### Conditional Fallback Implementation For Implemented-Unverified Rows
+
+- [X] T020 If T016 exposes flat-submission drift, update applied preset submission serialization in `frontend/src/entrypoints/task-create.tsx` so all generated steps submit as explicit Tool or Skill steps with no Preset placeholder (FR-001, SCN-001, DESIGN-REQ-004)
+- [X] T021 If T018 exposes refresh drift, update reapply/refresh handling in `frontend/src/entrypoints/task-create.tsx` so catalog refresh requires explicit preview and validation before replacing reviewed steps (FR-009, SCN-005, DESIGN-REQ-023)
+- [X] T022 If T014 exposes runtime provenance coupling, update runtime materialization in `moonmind/workflows/temporal/worker_runtime.py` so execution depends on Tool/Skill payloads and never on live preset catalog lookup (FR-005, SCN-003)
+
+### Implementation
+
+- [X] T023 Update `TaskStepSource` and related canonical task payload serialization in `moonmind/workflows/tasks/task_contract.py` to preserve canonical `presetVersion` alongside required preset-derived source metadata (FR-003, FR-004, SCN-002, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T024 Update proposal promotion validation in `moonmind/workflows/task_proposals/service.py` so stored preset-derived proposals must validate as flat executable Tool/Skill payloads and preserve source metadata without live preset re-expansion (FR-007, FR-008, SCN-004, SC-004, DESIGN-REQ-023)
+- [X] T025 Update proposal preview serialization in `api_service/api/routers/task_proposals.py` to expose complete preset provenance summary needed for audit/review without making it runtime input (FR-004, DESIGN-REQ-016)
+- [X] T026 Update preset expansion-to-step mapping in `frontend/src/entrypoints/task-create.tsx` to retain complete preset-derived source metadata, including `presetVersion`, include path, and original step id when returned by expansion (FR-003, FR-004, SCN-002, DESIGN-REQ-006, DESIGN-REQ-016)
+- [X] T027 Keep unresolved Preset, Activity, and shell-shaped executable guardrails intact in `moonmind/workflows/tasks/task_contract.py` while adding MM-579 provenance behavior (FR-002, SC-001, DESIGN-REQ-015)
+
+### Story Validation
+
+- [X] T028 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` and fix failures until backend MM-579 tests pass (FR-002, FR-003, FR-004, FR-005, FR-007, FR-008, SC-002, SC-003, SC-004)
+- [X] T029 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx` and fix failures until Create page MM-579 tests pass (FR-001, FR-003, FR-004, FR-006, FR-009, SC-001, SC-002, SC-005)
+- [X] T030 Run `rg -n "MM-579|presetVersion|DESIGN-REQ-004|DESIGN-REQ-006|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-023" specs/292-submit-flattened-executable-steps-with-provenance` to confirm traceability remains present (FR-010, SC-006)
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T031 [P] Review `specs/292-submit-flattened-executable-steps-with-provenance/contracts/flattened-executable-provenance.md` against implemented behavior and update only if implementation reveals a contract clarification need (FR-010, DESIGN-REQ-023)
+- [X] T032 [P] Review `specs/292-submit-flattened-executable-steps-with-provenance/data-model.md` against final provenance field names and state transitions, especially `presetVersion` (FR-003, FR-010, DESIGN-REQ-006)
+- [X] T033 [P] Review `specs/292-submit-flattened-executable-steps-with-provenance/quickstart.md` so commands and expected coverage match final test evidence (FR-010, SC-006)
+- [X] T034 Run full unit verification with `./tools/test_unit.sh` and record any unrelated blocker with focused test evidence if the full suite cannot complete
+- [X] T035 Run `/moonspec-verify` after implementation and tests pass, validating against `specs/292-submit-flattened-executable-steps-with-provenance/spec.md`, `plan.md`, `tasks.md`, the preserved MM-579 Jira preset brief, and focused test evidence
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish And Verification (Phase 4)**: Depends on story tests and implementation passing.
+
+### Within The Story
+
+- Unit tests T009-T014 must be written before implementation tasks T023-T027.
+- Integration tests T016-T018 must be written before implementation tasks T020-T027.
+- Red-first confirmation tasks T015 and T019 must complete before production changes.
+- Conditional fallback tasks T020-T022 run only if verification tests expose drift in implemented-unverified rows.
+- Core data/validation changes T023-T027 precede story validation T028-T030.
+- Final verification T035 runs only after focused and full verification tasks have completed or blockers are documented.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel.
+- T009, T011, T013, T014, T016, T017, and T018 can be authored in parallel because they touch different focused test concerns, though same-file test edits should be coordinated.
+- T023, T024, T025, and T026 can be implemented in parallel after red-first confirmation because they touch distinct production files.
+- T031, T032, and T033 can run in parallel after story validation.
+
+---
+
+## Parallel Example
+
+```bash
+# Backend test authoring can be split by boundary:
+Task: "Add failing task contract provenance tests in tests/unit/workflows/tasks/test_task_contract.py"
+Task: "Add failing proposal promotion tests in tests/unit/workflows/task_proposals/test_service.py"
+Task: "Add failing proposal preview tests in tests/unit/api/routers/test_task_proposals.py"
+
+# Production implementation can be split after red-first confirmation:
+Task: "Update task provenance model in moonmind/workflows/tasks/task_contract.py"
+Task: "Update proposal promotion validation in moonmind/workflows/task_proposals/service.py"
+Task: "Update Create page source metadata mapping in frontend/src/entrypoints/task-create.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+1. Confirm all MM-579 artifacts and test targets exist.
+2. Inspect current task contract, proposal, runtime, and Create page boundaries.
+3. Add failing unit tests for canonical provenance, flat proposal payloads, preview metadata, and runtime provenance independence.
+4. Add failing Create page integration-boundary tests for flat submission, complete provenance, and explicit refresh.
+5. Confirm red-first failures with the focused unit and frontend commands.
+6. Implement only the failing gaps, preserving already-verified unresolved Preset rejection and runtime independence behavior.
+7. Rerun focused backend and frontend tests until green.
+8. Run full unit verification or record exact unrelated blockers.
+9. Run `/moonspec-verify` against MM-579 and the preserved Jira preset brief.
+
+---
+
+## Notes
+
+- This task list covers exactly one story and does not create broad Step Type refactors beyond MM-579.
+- Implemented-verified rows are preserved through final validation rather than unnecessary implementation tasks.
+- Implemented-unverified rows include conditional fallback implementation tasks that are skipped when verification tests pass.
+- The final implementation must preserve `MM-579` in artifacts, commit text, PR metadata, and verification output.

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -293,13 +293,20 @@ def test_get_proposal_preview_includes_preset_provenance(
                 "authoredPresets": [
                     {
                         "presetId": "runtime-quality-followup",
+                        "presetVersion": "2026-04-17",
                         "includePath": ["root", "regression-coverage"],
                     }
                 ],
                 "steps": [
                     {
                         "title": "Add regression coverage",
-                        "source": {"kind": "preset-derived"},
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetId": "runtime-quality-followup",
+                            "presetVersion": "2026-04-17",
+                            "includePath": ["root", "regression-coverage"],
+                            "originalStepId": "add-regression-test",
+                        },
                     }
                 ],
             },
@@ -315,6 +322,15 @@ def test_get_proposal_preview_includes_preset_provenance(
     assert preview["presetProvenance"] == "preserved-binding"
     assert preview["authoredPresetCount"] == 1
     assert preview["stepSourceKinds"] == ["preset-derived"]
+    assert preview["presetSourceMetadata"] == [
+        {
+            "kind": "preset-derived",
+            "presetId": "runtime-quality-followup",
+            "presetVersion": "2026-04-17",
+            "includePath": ["root", "regression-coverage"],
+            "originalStepId": "add-regression-test",
+        }
+    ]
 
 def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
     test_client, service, _execution_service = client

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -448,7 +448,7 @@ async def test_promote_proposal_applies_runtime_override() -> None:
                     "authoredPresets": [
                         {
                             "presetId": "runtime-quality-followup",
-                            "version": "2026-04-17",
+                            "presetVersion": "2026-04-17",
                         }
                     ],
                     "steps": [
@@ -459,6 +459,7 @@ async def test_promote_proposal_applies_runtime_override() -> None:
                             "source": {
                                 "kind": "preset-derived",
                                 "presetId": "runtime-quality-followup",
+                                "presetVersion": "2026-04-17",
                             },
                         }
                     ],
@@ -483,12 +484,13 @@ async def test_promote_proposal_applies_runtime_override() -> None:
     assert final_request["payload"]["task"]["authoredPresets"] == [
         {
             "presetId": "runtime-quality-followup",
-            "version": "2026-04-17",
+            "presetVersion": "2026-04-17",
         }
     ]
     assert final_request["payload"]["task"]["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
+        "presetVersion": "2026-04-17",
     }
     assert (
         updated_proposal.task_create_request["payload"]["task"]["runtime"]["mode"]
@@ -516,17 +518,23 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
                     "authoredPresets": [
                         {
                             "presetId": "runtime-quality-followup",
-                            "version": "2026-04-17",
+                            "presetVersion": "2026-04-17",
                             "includePath": ["root", "regression-coverage"],
                         }
                     ],
                     "steps": [
                         {
+                            "type": "skill",
                             "title": "Add regression coverage",
                             "instructions": "Write the regression test.",
+                            "skill": {
+                                "id": "moonspec-implement",
+                                "args": {"issueKey": "MM-579"},
+                            },
                             "source": {
                                 "kind": "preset-derived",
                                 "presetId": "runtime-quality-followup",
+                                "presetVersion": "2026-04-17",
                                 "includePath": ["root", "regression-coverage"],
                                 "originalStepId": "add-regression-test",
                             },
@@ -550,16 +558,59 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
     assert task["authoredPresets"] == [
         {
             "presetId": "runtime-quality-followup",
-            "version": "2026-04-17",
+            "presetVersion": "2026-04-17",
             "includePath": ["root", "regression-coverage"],
         }
     ]
     assert task["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
+        "presetVersion": "2026-04-17",
         "includePath": ["root", "regression-coverage"],
         "originalStepId": "add-regression-test",
     }
+
+@pytest.mark.asyncio
+async def test_promote_proposal_rejects_preset_derived_steps_without_flat_type() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Add regression coverage",
+                    "steps": [
+                        {
+                            "title": "Add regression coverage",
+                            "instructions": "Write the regression test.",
+                            "source": {
+                                "kind": "preset-derived",
+                                "presetId": "runtime-quality-followup",
+                                "presetVersion": "2026-04-17",
+                            },
+                        }
+                    ],
+                },
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    with pytest.raises(TaskProposalValidationError, match="flat executable"):
+        await service.promote_proposal(
+            proposal_id=proposal.id,
+            promoted_by_user_id=uuid4(),
+        )
+
+    repo.commit.assert_not_awaited()
 
 @pytest.mark.asyncio
 async def test_promote_proposal_rejects_unresolved_preset_steps() -> None:

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from moonmind.workflows.tasks.task_contract import (
     build_canonical_task_view,
     build_effective_task_skill_selectors,
+    CanonicalTaskPayload,
     TaskExecutionSpec,
     TaskStepSpec,
 )
@@ -83,6 +84,47 @@ def test_task_step_spec_with_step_skills() -> None:
     assert spec.skills is not None
     assert spec.skills.exclude == ["bad-skill"]
     assert spec.skills.materialization_mode == "none"
+
+def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
+    payload = CanonicalTaskPayload.model_validate(
+        {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "Run stored proposal.",
+                "authoredPresets": [
+                    {
+                        "presetId": "runtime-quality-followup",
+                        "version": "2026-04-17",
+                    }
+                ],
+                "steps": [
+                    {
+                        "type": "skill",
+                        "instructions": "Implement issue.",
+                        "skill": {"id": "moonspec-implement"},
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetId": "runtime-quality-followup",
+                            "version": "2026-04-17",
+                        },
+                    }
+                ],
+            },
+        }
+    )
+
+    task = payload.model_dump(by_alias=True, exclude_none=True)["task"]
+    assert task["authoredPresets"] == [
+        {
+            "presetId": "runtime-quality-followup",
+            "presetVersion": "2026-04-17",
+        }
+    ]
+    assert task["steps"][0]["source"] == {
+        "kind": "preset-derived",
+        "presetId": "runtime-quality-followup",
+        "presetVersion": "2026-04-17",
+    }
 
 def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
     spec = TaskExecutionSpec.model_validate(

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -101,6 +101,9 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
                     "source": {
                         "kind": "preset-derived",
                         "presetId": "jira-flow",
+                        "presetVersion": "2026-04-24",
+                        "includePath": ["root", "fetch"],
+                        "originalStepId": "fetch-jira-issue",
                     },
                 },
                 {
@@ -116,12 +119,63 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
         }
     )
 
-    dumped_steps = [step.model_dump(by_alias=True) for step in spec.steps]
+    dumped_steps = [
+        step.model_dump(by_alias=True, exclude_none=True) for step in spec.steps
+    ]
     assert dumped_steps[0]["type"] == "tool"
     assert dumped_steps[0]["tool"]["id"] == "jira.get_issue"
-    assert dumped_steps[0]["source"]["presetId"] == "jira-flow"
+    assert dumped_steps[0]["source"] == {
+        "kind": "preset-derived",
+        "presetId": "jira-flow",
+        "presetVersion": "2026-04-24",
+        "includePath": ["root", "fetch"],
+        "originalStepId": "fetch-jira-issue",
+    }
     assert dumped_steps[1]["type"] == "skill"
     assert dumped_steps[1]["skill"]["id"] == "moonspec-implement"
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        None,
+        {"kind": "detached"},
+        {
+            "kind": "preset-derived",
+            "presetId": "stale-preset",
+            "presetVersion": "missing-from-catalog",
+        },
+        {
+            "kind": "preset-include",
+            "presetSlug": "parent-flow",
+            "presetVersion": "2026-04-24",
+            "includePath": ["root", "child"],
+            "originalStepId": "child-step",
+        },
+    ],
+)
+def test_task_steps_validate_without_resolving_source_provenance(
+    source: dict[str, object] | None,
+) -> None:
+    step: dict[str, object] = {
+        "id": "fetch-issue",
+        "type": "tool",
+        "instructions": "Fetch issue.",
+        "tool": {"id": "jira.get_issue", "inputs": {"issueKey": "MM-579"}},
+    }
+    if source is not None:
+        step["source"] = source
+
+    spec = TaskExecutionSpec.model_validate(
+        {"instructions": "Run explicit steps.", "steps": [step]}
+    )
+
+    dumped = spec.model_dump(by_alias=True, exclude_none=True)["steps"][0]
+    assert dumped["type"] == "tool"
+    assert dumped["tool"]["id"] == "jira.get_issue"
+    if source is None:
+        assert "source" not in dumped or dumped["source"] is None
+    else:
+        assert dumped["source"] == source
 
 @pytest.mark.parametrize("step_type", ["preset", "activity", "Activity"])
 def test_task_steps_reject_non_executable_step_types(step_type: str) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -261,6 +261,9 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
                         "source": {
                             "kind": "preset-derived",
                             "presetId": "jira-flow",
+                            "presetVersion": "catalog-version-that-need-not-exist",
+                            "includePath": ["root", "fetch"],
+                            "originalStepId": "fetch-jira-issue",
                         },
                     }
                 ],
@@ -277,7 +280,64 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     assert plan["nodes"][0]["inputs"]["type"] == "tool"
-    assert plan["nodes"][0]["inputs"]["source"]["presetId"] == "jira-flow"
+    assert plan["nodes"][0]["inputs"]["source"] == {
+        "kind": "preset-derived",
+        "presetId": "jira-flow",
+        "presetVersion": "catalog-version-that-need-not-exist",
+        "includePath": ["root", "fetch"],
+        "originalStepId": "fetch-jira-issue",
+    }
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        None,
+        {"kind": "detached"},
+        {
+            "kind": "preset-derived",
+            "presetId": "removed-preset",
+            "presetVersion": "stale",
+        },
+    ],
+)
+def test_runtime_planner_materializes_tool_steps_without_source_lookup(
+    source: dict[str, object] | None,
+):
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+    step: dict[str, object] = {
+        "id": "fetch-issue",
+        "type": "tool",
+        "instructions": "Fetch MM-579.",
+        "tool": {
+            "id": "jira.get_issue",
+            "version": "1.0.0",
+            "inputs": {"issueKey": "MM-579"},
+        },
+    }
+    if source is not None:
+        step["source"] = source
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run explicit tool step.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [step],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["tool"]["name"] == "jira.get_issue"
+    if source is None:
+        assert "source" not in plan["nodes"][0]["inputs"]
+    else:
+        assert plan["nodes"][0]["inputs"]["source"] == source
 
 def test_runtime_planner_maps_explicit_skill_step_to_agent_runtime_node():
     planner = _build_runtime_planner()


### PR DESCRIPTION
## Jira

- Jira issue key: MM-579

## MoonSpec

- Active feature path: `specs/292-submit-flattened-executable-steps-with-provenance`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary

Implements MM-579 by making preset-derived executable submissions and proposal promotions use reviewed flat Tool/Skill payloads while preserving provenance metadata for audit and reconstruction.

## Changes

- Adds canonical `presetVersion` provenance support for task step sources and authored preset bindings.
- Preserves preset-derived source metadata through Create page preset expansion and submission, including generated Skill steps.
- Adds proposal promotion validation requiring preset-derived stored steps to be flat executable Tool or Skill payloads.
- Exposes complete preset source metadata in proposal preview responses.
- Adds MoonSpec artifacts for `292-submit-flattened-executable-steps-with-provenance` with MM-579 traceability.

## Tests run

- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
  - `110 passed`; dashboard suite also completed with `18 passed`.
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`
  - `7 passed | 222 skipped`.
- `./tools/test_unit.sh`
  - `4264 passed, 1 xpassed, 16 subtests passed`; dashboard suite `18 passed`.

## Remaining risks

- Full unit run reports existing warnings unrelated to MM-579, including deprecated Google Generative AI package warnings, async mark warnings, and Pydantic deprecation warnings.
- Hermetic integration suite was not rerun in this PR creation step; MM-579 changes are covered by the focused unit/API/runtime and Create page boundary tests above.