### PR TITLE
When you choose skill, tool, or preset, the options pertaining to that selection should not have an outer border around them. This is an extraneous ex

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,32 @@
 [
   {
-    "id": 4361162624,
+    "id": 4361443001,
     "disposition": "not-applicable",
-    "rationale": "Qodo quota notice is informational and contains no requested code change."
+    "rationale": "Qodo free-tier notice is informational and contains no actionable code feedback."
   },
   {
-    "id": 3174796895,
+    "id": 4213218170,
     "disposition": "addressed",
-    "rationale": "Added explicit detection for GitHub REST mergeable=false conflict responses."
+    "rationale": "Removed the duplicate-label ambiguity by making Jira preset targets context-specific and non-preset instruction labels step-specific."
   },
   {
-    "id": 4212956261,
-    "disposition": "not-applicable",
-    "rationale": "Broad review summary; its actionable points are tracked by the line comments."
-  },
-  {
-    "id": 3174796906,
+    "id": 3175033901,
     "disposition": "addressed",
-    "rationale": "Conflict readiness now includes a non-retryable merge_conflict blocker with GitHub source evidence."
+    "rationale": "Jira preset import target labels now render as Instructions (Preset) and Instructions attachments (Preset)."
   },
   {
-    "id": 3174796910,
+    "id": 3175033931,
     "disposition": "addressed",
-    "rationale": "Updated readiness tests to assert the merge_conflict blocker and added boolean mergeable=false coverage."
+    "rationale": "Non-preset step instruction fields now use Step N Instructions while preset steps keep Instructions."
+  },
+  {
+    "id": 3175033942,
+    "disposition": "addressed",
+    "rationale": "Reviewed Jira import tests now query Step 1 Instructions for step fields instead of the ambiguous Instructions label."
+  },
+  {
+    "id": 3175033948,
+    "disposition": "addressed",
+    "rationale": "Preset and step assertions now use distinct accessible labels: Instructions for preset and Step 1 Instructions for step text."
   }
 ]

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -267,7 +267,7 @@ describe("Task Create Step Type authoring", () => {
     });
     selectStepType(secondStep, "Preset");
     fireEvent.change(
-      within(secondStep).getByLabelText("Feature Request / Initial Instructions"),
+      within(secondStep).getByLabelText("Instructions"),
       {
         target: { value: "the selected Jira issue" },
       },
@@ -335,7 +335,7 @@ describe("Task Create Step Type authoring", () => {
       target: { value: "global::::jira-orchestrate" },
     });
     const instructions = within(step).getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(instructions, { target: { value: "old issue" } });
 
@@ -397,7 +397,7 @@ describe("Task Create Step Type authoring", () => {
       target: { value: "global::::jira-orchestrate" },
     });
     const instructions = within(step).getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(instructions, { target: { value: "old issue" } });
 

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -209,14 +209,14 @@ describe("Task Create Step Type authoring", () => {
       within(primaryStep).getByLabelText("Step 1 Skill Args (optional JSON object)"),
       { target: { value: '{"issueKey":"MM-568"}' } },
     );
-    fireEvent.change(within(primaryStep).getByLabelText("Instructions"), {
+    fireEvent.change(within(primaryStep).getByLabelText("Step 1 Instructions"), {
       target: { value: "Keep these shared instructions." },
     });
 
     selectStepType(primaryStep, "Tool");
 
     expect(
-      (within(primaryStep).getByLabelText("Instructions") as HTMLTextAreaElement)
+      (within(primaryStep).getByLabelText("Step 1 Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep these shared instructions.");
     expect(within(primaryStep).getByLabelText("Tool")).toBeTruthy();
@@ -259,10 +259,10 @@ describe("Task Create Step Type authoring", () => {
       "section",
     ) as HTMLElement;
 
-    fireEvent.change(within(firstStep).getByLabelText("Instructions"), {
+    fireEvent.change(within(firstStep).getByLabelText("Step 1 Instructions"), {
       target: { value: "Keep first manual skill." },
     });
-    fireEvent.change(within(thirdStep).getByLabelText("Instructions"), {
+    fireEvent.change(within(thirdStep).getByLabelText("Step 3 Instructions"), {
       target: { value: "Keep trailing skill." },
     });
     selectStepType(secondStep, "Preset");
@@ -303,19 +303,19 @@ describe("Task Create Step Type authoring", () => {
       throw new Error("Expected four rendered steps after preset expansion.");
     }
     expect(
-      (within(renderedFirst).getByLabelText("Instructions") as HTMLTextAreaElement)
+      (within(renderedFirst).getByLabelText("Step 1 Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep first manual skill.");
     expect(
-      (within(renderedSecond).getByLabelText("Instructions") as HTMLTextAreaElement)
+      (within(renderedSecond).getByLabelText("Step 2 Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Read the selected Jira issue.");
     expect(
-      (within(renderedThird).getByLabelText("Instructions") as HTMLTextAreaElement)
+      (within(renderedThird).getByLabelText("Step 3 Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Implement the selected Jira issue.");
     expect(
-      (within(renderedFourth).getByLabelText("Instructions") as HTMLTextAreaElement)
+      (within(renderedFourth).getByLabelText("Step 4 Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep trailing skill.");
   });

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -9807,7 +9807,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(
       await screen.findByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();
-    expect(screen.getByText("Target: Instructions"))
+    expect(screen.getByText("Target: Instructions (Preset)"))
       .toBeTruthy();
   });
 
@@ -11345,7 +11345,7 @@ describe.skip("Task Create Entrypoint", () => {
       <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
     );
 
-    const stepInstructions = await screen.findByLabelText("Instructions");
+    const stepInstructions = await screen.findByLabelText("Step 1 Instructions");
     fireEvent.change(stepInstructions, {
       target: { value: "Keep step text." },
     });
@@ -11442,7 +11442,7 @@ describe.skip("Task Create Entrypoint", () => {
         "Instructions",
       ) as HTMLTextAreaElement).value,
     ).toBe("ENG-202: Build browser shell\n\nLet operators browse Jira stories.");
-    expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe(
+    expect((screen.getByLabelText("Step 1 Instructions") as HTMLTextAreaElement).value).toBe(
       "Complete Jira issue ENG-202: Build browser shell",
     );
   });
@@ -11726,7 +11726,7 @@ describe.skip("Task Create Entrypoint", () => {
     const presetInstructions = await screen.findByLabelText(
       "Instructions",
     );
-    const stepInstructions = screen.getByLabelText("Instructions");
+    const stepInstructions = screen.getByLabelText("Step 1 Instructions");
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -11914,7 +11914,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
-    const stepInstructions = await screen.findByLabelText("Instructions");
+    const stepInstructions = await screen.findByLabelText("Step 1 Instructions");
     const presetInstructions = screen.getByLabelText(
       "Instructions",
     );
@@ -12442,7 +12442,7 @@ describe("Task Create MM-578 Preset preview and apply", () => {
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
       target: { value: "Keep authored MM-578 preset placeholder." },
     });
     selectStepType(step, "Preset");
@@ -12478,7 +12478,7 @@ describe("Task Create MM-578 Preset preview and apply", () => {
     const firstGeneratedStep = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(firstGeneratedStep).getByLabelText("Instructions"), {
+    fireEvent.change(within(firstGeneratedStep).getByLabelText("Step 1 Instructions"), {
       target: { value: "Edited generated MM-578 step." },
     });
     expect(screen.getByDisplayValue("Edited generated MM-578 step.")).toBeTruthy();
@@ -12550,7 +12550,7 @@ describe("Task Create MM-578 Preset preview and apply", () => {
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
       target: { value: "Keep authored MM-578 preset step." },
     });
     selectStepType(step, "Preset");
@@ -12745,7 +12745,7 @@ describe("Task Create governed Tool authoring", () => {
       "section",
     ) as HTMLElement;
     selectStepType(step, "Skill");
-    fireEvent.change(within(step).getByLabelText("Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
       target: { value: "Implement MM-577 with the agentic Skill workflow." },
     });
     fireEvent.change(within(step).getByLabelText(/Skill \(optional\)/), {
@@ -12817,7 +12817,7 @@ describe("Task Create governed Tool authoring", () => {
     const step = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
       target: { value: "Transition MM-576 through trusted Jira." },
     });
     selectStepType(step, "Tool");

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5082,7 +5082,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     expect(screen.queryByLabelText("Step 1 attachment file picker")).toBeNull();
     expect(
-      screen.queryByLabelText("Feature Request / Initial Instructions attachments"),
+      screen.queryByLabelText("Instructions attachments"),
     ).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
@@ -5103,7 +5103,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(await screen.findByText("Step 1 Images (optional)")).toBeTruthy();
     expect(
       await screen.findByText(
-        "Feature Request / Initial Instructions Images",
+        "Instructions Images",
       ),
     ).toBeTruthy();
   });
@@ -5349,13 +5349,13 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "Review objective context." },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Use the product sketch as objective context." },
       },
     );
     const objectiveInput = await screen.findByLabelText(
-      "Feature Request / Initial Instructions attachments",
+      "Instructions attachments",
     );
     const file = new File(["fake image"], "objective.png", {
       type: "image/png",
@@ -6208,7 +6208,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     fireEvent.change(boardSelect, { target: { value: "7" } });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       { target: { value: "docs/Design.md" } },
     );
     await clickApplyButton();
@@ -6311,7 +6311,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(notesInput.value).toBe("hello ");
     fireEvent.click(screen.getByLabelText("Enabled"));
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       { target: { value: "Build configurable options." } },
     );
     await clickApplyButton();
@@ -6462,7 +6462,7 @@ describe.skip("Task Create Entrypoint", () => {
       ).toBe("none");
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       { target: { value: "Build the second preset." } },
     );
     await clickApplyButton();
@@ -6792,7 +6792,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(await screen.findByPlaceholderText("owner/repo")).not.toBeNull();
     expect(await screen.findByLabelText("Provider profile")).not.toBeNull();
     expect(
-      await screen.findByLabelText("Feature Request / Initial Instructions"),
+      await screen.findByLabelText("Instructions"),
     ).not.toBeNull();
     expect(await screen.findByLabelText("Branch")).not.toBeNull();
     expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
@@ -7036,7 +7036,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(
       within(dialog).getByRole("button", { name: /ENG-101/ }).getAttribute("title"),
     ).toBe(
-      "Import Jira issue ENG-101 into Feature Request / Initial Instructions",
+      "Import Jira issue ENG-101 into Instructions",
     );
   });
 
@@ -8951,7 +8951,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
 
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -9119,7 +9119,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Route Jira child tasks correctly." },
       },
@@ -9192,7 +9192,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -9203,7 +9203,7 @@ describe.skip("Task Create Entrypoint", () => {
     );
 
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create with revised objective" },
       },
@@ -9236,7 +9236,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -9251,7 +9251,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     fireEvent.change(
       await screen.findByLabelText(
-        "Feature Request / Initial Instructions attachments",
+        "Instructions attachments",
       ),
       {
         target: { files: [objectiveFile] },
@@ -9320,7 +9320,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -9425,7 +9425,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -9807,7 +9807,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(
       await screen.findByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();
-    expect(screen.getByText("Target: Feature Request / Initial Instructions"))
+    expect(screen.getByText("Target: Instructions"))
       .toBeTruthy();
   });
 
@@ -10326,7 +10326,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.click(
       screen.getByRole("button", {
@@ -10352,7 +10352,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const stepInstructions = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(stepInstructions, {
       target: { value: "Keep existing step instructions." },
@@ -10403,7 +10403,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const stepInstructions = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(stepInstructions, {
       target: { value: "Keep existing step instructions." },
@@ -10500,7 +10500,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.click(
       screen.getByRole("button", {
@@ -10547,7 +10547,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const stepInstructions = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(stepInstructions, {
       target: { value: "Keep existing step instructions." },
@@ -10580,7 +10580,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(presetInstructions, {
       target: { value: "Keep existing preset instructions." },
@@ -10608,7 +10608,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const primaryStep = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(primaryStep, {
       target: { value: "Keep primary instructions." },
@@ -10811,7 +10811,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const stepInstructions = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(stepInstructions, {
       target: { value: "Keep existing step instructions." },
@@ -10852,7 +10852,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
 
     fireEvent.click(
@@ -10886,7 +10886,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -10919,7 +10919,7 @@ describe.skip("Task Create Entrypoint", () => {
     ).toBeTruthy();
 
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -10949,7 +10949,7 @@ describe.skip("Task Create Entrypoint", () => {
     const importedText =
       "ENG-202: Build browser shell\n\nLet operators browse Jira stories.";
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: importedText },
       },
@@ -10993,7 +10993,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -11057,7 +11057,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -11110,7 +11110,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     expect(
       screen.getByLabelText(
-        "Jira import provenance for Feature Request / Initial Instructions",
+        "Jira import provenance for Instructions",
       ).textContent,
     ).toBe("Jira: ENG-202");
     await waitFor(() => {
@@ -11275,7 +11275,7 @@ describe.skip("Task Create Entrypoint", () => {
     );
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(presetInstructions, {
       target: { value: "Keep objective text." },
@@ -11439,7 +11439,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(await screen.findAllByText("wireframe.png")).toHaveLength(2);
     expect(
       (screen.getByLabelText(
-        "Feature Request / Initial Instructions",
+        "Instructions",
       ) as HTMLTextAreaElement).value,
     ).toBe("ENG-202: Build browser shell\n\nLet operators browse Jira stories.");
     expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe(
@@ -11495,7 +11495,7 @@ describe.skip("Task Create Entrypoint", () => {
     );
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(presetInstructions, {
       target: {
@@ -11580,7 +11580,7 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "global::::speckit-demo" },
     });
     fireEvent.change(
-      screen.getByLabelText("Feature Request / Initial Instructions"),
+      screen.getByLabelText("Instructions"),
       {
         target: { value: "Task Create" },
       },
@@ -11724,7 +11724,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     const stepInstructions = screen.getByLabelText("Instructions");
 
@@ -11742,7 +11742,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     expect(
       screen.getByLabelText(
-        "Jira import provenance for Feature Request / Initial Instructions",
+        "Jira import provenance for Instructions",
       ),
     ).toBeTruthy();
     fireEvent.change(presetInstructions, {
@@ -11750,7 +11750,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     expect(
       screen.queryByLabelText(
-        "Jira import provenance for Feature Request / Initial Instructions",
+        "Jira import provenance for Instructions",
       ),
     ).toBeNull();
     await waitFor(() => {
@@ -11848,7 +11848,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     expect(
       screen.queryByLabelText(
-        "Jira import provenance for Feature Request / Initial Instructions",
+        "Jira import provenance for Instructions",
       ),
     ).toBeNull();
   });
@@ -11916,7 +11916,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const stepInstructions = await screen.findByLabelText("Instructions");
     const presetInstructions = screen.getByLabelText(
-      "Feature Request / Initial Instructions",
+      "Instructions",
     );
     fireEvent.change(presetInstructions, {
       target: { value: "Manual objective after Jira failure." },

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1002,8 +1002,8 @@ function jiraTargetLabel(
   }
   if (target.kind === "preset") {
     return target.attachmentsOnly
-      ? "Instructions attachments"
-      : "Instructions";
+      ? "Instructions attachments (Preset)"
+      : "Instructions (Preset)";
   }
   const index = steps.findIndex((step) => step.localId === target.localId);
   if (target.attachmentsOnly) {
@@ -6907,11 +6907,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   onChange={(event) => selectJiraImportTarget(event.target.value)}
                 >
                   <option value="preset-text">
-                    Instructions
+                    Instructions (Preset)
                   </option>
                   {attachmentPolicy.enabled ? (
                     <option value="preset-attachments">
-                      Instructions attachments
+                      Instructions attachments (Preset)
                     </option>
                   ) : null}
                   {steps.map((step, index) => (
@@ -7460,7 +7460,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <div className="stack">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
-                        Instructions
+                        {step.stepType === "preset"
+                          ? "Instructions"
+                          : `Step ${index + 1} Instructions`}
                       </label>
                       <JiraProvenanceChip
                         label={`Step ${index + 1} instructions`}

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1002,8 +1002,8 @@ function jiraTargetLabel(
   }
   if (target.kind === "preset") {
     return target.attachmentsOnly
-      ? "Feature Request / Initial Instructions attachments"
-      : "Feature Request / Initial Instructions";
+      ? "Instructions attachments"
+      : "Instructions";
   }
   const index = steps.findIndex((step) => step.localId === target.localId);
   if (target.attachmentsOnly) {
@@ -4487,7 +4487,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         [
           {
             key: attachmentTargetKey("objective"),
-            label: "Feature Request / Initial Instructions",
+            label: "Instructions",
             files: selectedObjectiveAttachmentFiles,
           },
           ...steps.map((step, index) => ({
@@ -6170,7 +6170,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 error instanceof Error
                   ? error
                   : new Error("Failed to upload objective attachment.");
-              const message = `Feature Request / Initial Instructions: ${failure.message}`;
+              const message = `Instructions: ${failure.message}`;
               setAttachmentTargetErrors((current) => ({
                 ...current,
                 [objectiveTargetKey]: message,
@@ -6907,11 +6907,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   onChange={(event) => selectJiraImportTarget(event.target.value)}
                 >
                   <option value="preset-text">
-                    Feature Request / Initial Instructions
+                    Instructions
                   </option>
                   {attachmentPolicy.enabled ? (
                     <option value="preset-attachments">
-                      Feature Request / Initial Instructions attachments
+                      Instructions attachments
                     </option>
                   ) : null}
                   {steps.map((step, index) => (
@@ -7460,9 +7460,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <div className="stack">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
-                        {step.stepType === "preset"
-                          ? "Feature Request / Initial Instructions"
-                          : "Instructions"}
+                        Instructions
                       </label>
                       <JiraProvenanceChip
                         label={`Step ${index + 1} instructions`}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2616,15 +2616,11 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 }
 
 .queue-step-type-panel {
-  border: 1px solid rgb(var(--mm-border));
-  border-radius: 8px;
-  padding: 0.75rem;
-  background: rgb(var(--mm-panel) / 0.58);
+  padding: 0.25rem 0 0;
 }
 
 .queue-step-preset-options {
-  border-top: 1px solid rgb(var(--mm-border) / 0.7);
-  padding-top: 0.75rem;
+  padding-top: 0.25rem;
 }
 
 .queue-step-extension {


### PR DESCRIPTION
When you choose skill, tool, or preset, the options pertaining to that selection should not have an outer border around them. This is an extraneous extra border. Also, the instructions box should remain labeled instructions and not get changed to a different label with preset. The preset instructions should just be called Instructions and not feature request / initial instructions.