### PR TITLE
[codex] Fix Jira post-merge issue key propagation

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -100,6 +100,16 @@ _TERMINAL_LAST_ERROR_UNSET = object()
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 _PR_OPTIONAL_AGENT_SKILLS = frozenset({"jira-issue-creator", "jira-pr-verify", "jira-verify"})
+_JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
+_JIRA_BACKED_AGENT_SKILLS = frozenset(
+    {
+        "jira-orchestrate",
+        "jira-issue-updater",
+        "jira-issue-creator",
+        "jira-pr-verify",
+        "jira-verify",
+    }
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -3462,7 +3472,11 @@ class MoonMindRunWorkflow:
                 or post_merge_jira_config.get("issue_key"),
                 max_chars=40,
             )
-            effective_jira_issue_key = jira_issue_key or post_merge_issue_key
+            effective_jira_issue_key = (
+                jira_issue_key
+                or post_merge_issue_key
+                or self._canonical_jira_issue_key_from_parameters(parameters)
+            )
             post_merge_jira: dict[str, Any] = dict(post_merge_jira_config)
             if effective_jira_issue_key and "enabled" not in post_merge_jira:
                 post_merge_jira["enabled"] = True
@@ -3506,6 +3520,104 @@ class MoonMindRunWorkflow:
                 ),
             }
         return None
+
+    def _canonical_jira_issue_key_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> str | None:
+        task_payload = self._mapping_value(parameters, "task")
+        explicit_key = self._first_explicit_jira_issue_key(parameters, task_payload)
+        if explicit_key:
+            return explicit_key
+        if not self._is_jira_backed_task(parameters, task_payload):
+            return None
+        keys: set[str] = set()
+        for text in self._jira_issue_key_text_sources(parameters, task_payload):
+            keys.update(
+                match.group(0).upper()
+                for match in _JIRA_ISSUE_KEY_PATTERN.finditer(text)
+            )
+            if len(keys) > 1:
+                return None
+        if len(keys) == 1:
+            return next(iter(keys))
+        return None
+
+    def _first_explicit_jira_issue_key(
+        self,
+        parameters: Mapping[str, Any],
+        task_payload: Mapping[str, Any],
+    ) -> str | None:
+        mappings: list[Mapping[str, Any]] = [parameters, task_payload]
+        for key in ("metadata", "origin", "inputs", "input", "traceability"):
+            nested = task_payload.get(key)
+            if isinstance(nested, Mapping):
+                mappings.append(nested)
+        for mapping in mappings:
+            candidate = self._coerce_text(
+                mapping.get("jiraIssueKey")
+                or mapping.get("jira_issue_key")
+                or mapping.get("issueKey")
+                or mapping.get("issue_key"),
+                max_chars=40,
+            )
+            if candidate and _JIRA_ISSUE_KEY_PATTERN.fullmatch(candidate.upper()):
+                return candidate.upper()
+        return None
+
+    def _is_jira_backed_task(
+        self,
+        parameters: Mapping[str, Any],
+        task_payload: Mapping[str, Any],
+    ) -> bool:
+        skill_names: set[str] = set()
+        for payload in (parameters, task_payload):
+            for key in ("tool", "skill"):
+                nested = payload.get(key)
+                if isinstance(nested, Mapping):
+                    name = self._coerce_text(
+                        nested.get("name") or nested.get("id"),
+                        max_chars=120,
+                    )
+                    if name:
+                        skill_names.add(name.lower())
+        skills_payload = task_payload.get("skills")
+        if isinstance(skills_payload, Mapping):
+            include = skills_payload.get("include")
+            if isinstance(include, Sequence) and not isinstance(include, (str, bytes)):
+                for item in include:
+                    if isinstance(item, Mapping):
+                        name = self._coerce_text(
+                            item.get("name") or item.get("id"),
+                            max_chars=120,
+                        )
+                        if name:
+                            skill_names.add(name.lower())
+                    else:
+                        name = self._coerce_text(item, max_chars=120)
+                        if name:
+                            skill_names.add(name.lower())
+        return bool(skill_names & _JIRA_BACKED_AGENT_SKILLS)
+
+    def _jira_issue_key_text_sources(
+        self,
+        parameters: Mapping[str, Any],
+        task_payload: Mapping[str, Any],
+    ) -> Iterable[str]:
+        for payload in (parameters, task_payload):
+            for key in ("title", "instructions", "summary", "description"):
+                value = payload.get(key)
+                if isinstance(value, str):
+                    yield value
+        steps = task_payload.get("steps")
+        if isinstance(steps, Sequence) and not isinstance(steps, (str, bytes)):
+            for step in steps:
+                if not isinstance(step, Mapping):
+                    continue
+                for key in ("title", "instructions", "summary", "description"):
+                    value = step.get(key)
+                    if isinstance(value, str):
+                        yield value
 
     @staticmethod
     def _normalize_positive_int(

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -30,6 +30,56 @@ def test_merge_automation_request_can_be_enabled_from_task_publish() -> None:
     assert request["mergeMethod"] == "squash"
     assert request["jiraIssueKey"] == "MM-341"
 
+def test_merge_automation_request_infers_jira_orchestrate_issue_key() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(
+        {
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "instructions": (
+                "Change Jira issue THOR-336 to status In Progress before "
+                "implementation starts."
+            ),
+            "task": {
+                "tool": {"type": "skill", "name": "jira-orchestrate"},
+                "skill": {"name": "jira-orchestrate", "version": "1.0"},
+                "instructions": (
+                    "Use the trusted Jira issue updater workflow for THOR-336."
+                ),
+                "steps": [
+                    {
+                        "title": "Move Jira issue to Code Review",
+                        "instructions": "Preserve Jira issue THOR-336 in the PR.",
+                    }
+                ],
+            },
+        }
+    )
+
+    assert request is not None
+    assert request["jiraIssueKey"] == "THOR-336"
+    assert request["postMergeJira"]["enabled"] is True
+    assert request["postMergeJira"]["required"] is True
+
+def test_merge_automation_request_does_not_guess_ambiguous_jira_issue_key() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(
+        {
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "task": {
+                "skill": {"name": "jira-orchestrate"},
+                "instructions": "Coordinate THOR-336 and THOR-337.",
+            },
+        }
+    )
+
+    assert request is not None
+    assert request["jiraIssueKey"] is None
+    assert "enabled" not in request["postMergeJira"]
+
 def test_build_merge_gate_start_payload_from_published_pr() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._repo = "MoonLadderStudios/MoonMind"
@@ -65,6 +115,40 @@ def test_build_merge_gate_start_payload_from_published_pr() -> None:
     assert payload["jiraIssueKey"] == "MM-341"
     assert payload["mergeAutomationConfig"]["resolver"]["mergeMethod"] == "squash"
     assert payload["resolverTemplate"]["repository"] == "MoonLadderStudios/MoonMind"
+
+def test_build_merge_gate_start_payload_carries_inferred_jira_orchestrate_key() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/Tactics"
+    workflow._publish_context["branch"] = "159-grid-overlay-controller"
+    workflow._publish_context["baseRef"] = "main"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "instructions": (
+                "Change Jira issue THOR-336 to status In Progress before "
+                "implementation starts."
+            ),
+            "task": {
+                "skill": {"name": "jira-orchestrate", "version": "1.0"},
+                "tool": {"type": "skill", "name": "jira-orchestrate"},
+                "instructions": (
+                    "Use the trusted Jira issue updater workflow for THOR-336."
+                ),
+                "publish": {"mode": "pr"},
+            },
+        },
+        pull_request_url="https://github.com/MoonLadderStudios/Tactics/pull/1685",
+        head_sha="c1092740a1f12857d820534963ae99b40e0e307c",
+        parent_workflow_id="mm:23c4e893-7765-469d-bcb7-7f66331e1ad4",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["jiraIssueKey"] == "THOR-336"
+    assert payload["mergeAutomationConfig"]["gate"]["jira"]["issueKey"] == "THOR-336"
+    assert payload["mergeAutomationConfig"]["postMergeJira"]["enabled"] is True
 
 def test_build_merge_gate_start_payload_preserves_parent_runtime_profile() -> None:
     workflow = MoonMindRunWorkflow()


### PR DESCRIPTION
## Summary

Fixes the post-merge Jira completion gap where Jira Orchestrate tasks could start merge automation without carrying the canonical Jira issue key into `MoonMind.MergeAutomation`.

The parent run now preserves a single exact Jira key for Jira-backed task shapes when no explicit merge automation key is present, enabling required `postMergeJira` completion for runs like `THOR-336`. Ambiguous task text with multiple Jira keys still fails closed and does not guess.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_run_merge_gate_start.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`