### PR TITLE
The expand button that appears when you select Preset from the radio button on the Create Page should be styled like the other purple buttons like "Ad

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12415,7 +12415,9 @@ describe("Task Create MM-578 Preset expansion", () => {
     ).toBeTruthy();
     expect(screen.queryByDisplayValue("Fetch MM-578.")).toBeNull();
 
-    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    const expandButton = within(step).getByRole("button", { name: "Expand" });
+    expect(expandButton.classList.contains("secondary")).toBe(false);
+    fireEvent.click(expandButton);
 
     expect(await screen.findByDisplayValue("Fetch MM-578.")).toBeTruthy();
     expect(screen.getByDisplayValue("Implement MM-578.")).toBeTruthy();

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7731,7 +7731,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       ) : null}
                       <button
                         type="button"
-                        className="secondary"
                         aria-disabled={
                           isApplyingPreset ||
                           !step.presetKey


### PR DESCRIPTION
The expand button that appears when you select Preset from the radio button on the Create Page should be styled like the other purple buttons like "Add dependency".