### PR TITLE
Restore create page floating bar glass and contain halo

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,17 @@
 [
   {
-    "id": 4362680134,
+    "id": 4363278826,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and does not request a code change."
+    "rationale": "Qodo free-tier notice is informational and contains no actionable code feedback."
   },
   {
-    "id": 3175936226,
+    "id": 3176313686,
     "disposition": "addressed",
-    "rationale": "Removed the unnecessary will-change performance hint from the submit arrow SVG styling."
+    "rationale": "Restored flex centering and overflow clipping for the absolute-positioned icon submit arrow, with CSS test coverage."
   },
   {
-    "id": 3175936232,
+    "id": 4214662171,
     "disposition": "addressed",
-    "rationale": "Simplified the arrow-cycle keyframes to transform-only movement using overflow clipping instead of opacity and stationary hidden frames."
-  },
-  {
-    "id": 3175936234,
-    "disposition": "addressed",
-    "rationale": "Removed the redundant opacity reset from the reduced-motion override."
-  },
-  {
-    "id": 3175936235,
-    "disposition": "addressed",
-    "rationale": "Updated the submit arrow animation test regex to match the simplified transform-only keyframes."
-  },
-  {
-    "id": 4214213268,
-    "disposition": "addressed",
-    "rationale": "Applied the review summary recommendations for will-change removal, keyframe simplification, reduced-motion cleanup, and matching test coverage."
+    "rationale": "Review summary duplicates the submit-arrow centering and clipping concern addressed in the inline CSS change."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -219,7 +219,7 @@ describe('Mission Control shared entry', () => {
       /\.panel\s*\{[^}]*background:\s*var\(--mm-glass-fill\);[^}]*border:\s*1px solid var\(--mm-glass-border\);[^}]*box-shadow:\s*var\(--mm-elevation-panel\);/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*background:[^}]*linear-gradient\([^}]*var\(--mm-glass-fill\);[^}]*border:\s*1px solid var\(--mm-glass-border\);[^}]*box-shadow:\s*var\(--mm-elevation-floating\);/s,
+      /\.queue-floating-bar\s*\{[^}]*background:\s*var\(--mm-glass-fill\);[^}]*border:\s*1px solid var\(--mm-glass-border\);[^}]*box-shadow:\s*var\(--mm-elevation-floating\);/s,
     );
     expect(missionControlCss).toMatch(
       /\.queue-floating-bar \.queue-inline-selector select,\s*\.queue-floating-bar \.queue-inline-selector input\s*\{[^}]*background:\s*var\(--mm-input-well\);[^}]*border-color:\s*var\(--mm-glass-edge\);/s,

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7847,7 +7847,7 @@ describe.skip("Task Create Entrypoint", () => {
       /\.queue-step-instructions,\s*\.queue-step-skill-args\s*\{[^}]*background:\s*var\(--mm-input-well\);/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*background:[^}]*linear-gradient\([^}]*var\(--mm-glass-fill\);/s,
+      /\.queue-floating-bar\s*\{[^}]*background:\s*var\(--mm-glass-fill\);/s,
     );
   });
 
@@ -7996,13 +7996,10 @@ describe.skip("Task Create Entrypoint", () => {
 
   it("keeps MM-429 liquid glass fallback shell complete before enhancement initializes", async () => {
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*position:\s*fixed;[^}]*background:[^}]*linear-gradient\([^}]*var\(--mm-glass-fill\);[^}]*border:\s*1px solid var\(--mm-glass-border\);[^}]*box-shadow:\s*var\(--mm-elevation-floating\);[^}]*display:\s*grid;/s,
+      /\.queue-floating-bar\s*\{[^}]*position:\s*fixed;[^}]*background:\s*var\(--mm-glass-fill\);[^}]*border:\s*1px solid var\(--mm-glass-border\);[^}]*box-shadow:\s*var\(--mm-elevation-floating\);[^}]*display:\s*grid;/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar--liquid-glass\s*\{[^}]*position:\s*fixed;[^}]*isolation:\s*isolate;[^}]*overflow:\s*visible;/s,
-    );
-    expect(missionControlCss).toMatch(
-      /\.queue-floating-bar::before\s*\{[^}]*inset:\s*-1\.25rem;[^}]*radial-gradient\([^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*50%,\s*white\)/s,
+      /\.queue-floating-bar--liquid-glass\s*\{[^}]*position:\s*fixed;[^}]*isolation:\s*isolate;[^}]*overflow:\s*hidden;/s,
     );
     expect(missionControlCss).toMatch(
       /\.queue-submit-primary-ripple\s*\{[^}]*inset:\s*-0\.7rem;[^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*42%,\s*white\)/s,

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12199,6 +12199,9 @@ describe("Task Create submit arrow animation", () => {
     );
 
     expect(css).toMatch(
+      /\.queue-submit-primary--icon \.queue-submit-primary-arrow\s*\{[^}]*display:\s*flex;[^}]*align-items:\s*center;[^}]*justify-content:\s*center;[^}]*overflow:\s*hidden;/s,
+    );
+    expect(css).toMatch(
       /\.queue-submit-primary--icon:not\(:disabled\):not\(\[aria-disabled="true"\]\):hover\s*\.queue-submit-primary-arrow\s*svg\s*\{[^}]*animation:\s*queue-submit-primary-arrow-cycle\s+460ms\s+cubic-bezier\(0\.33,\s*0,\s*0\.2,\s*1\)\s+both;/s,
     );
     expect(css).toMatch(

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2991,6 +2991,10 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .queue-submit-primary--icon .queue-submit-primary-arrow {
   position: absolute;
   inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
   width: auto;
   height: auto;
   border-radius: inherit;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2911,14 +2911,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   width: min(100% - 2rem, 70rem);
   padding: 0.55rem 0.7rem;
   border-radius: 1.5rem;
-  background:
-    linear-gradient(
-      135deg,
-      rgb(255 255 255 / 0.18) 0%,
-      rgb(255 255 255 / 0.05) 34%,
-      rgb(255 255 255 / 0.12) 100%
-    ),
-    var(--mm-glass-fill);
+  background: var(--mm-glass-fill);
   border: 1px solid var(--mm-glass-border);
   box-shadow: var(--mm-elevation-floating);
   backdrop-filter: blur(26px) saturate(1.65);
@@ -2929,41 +2922,6 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
-.queue-floating-bar::before {
-  content: "";
-  position: absolute;
-  inset: -1.25rem;
-  border-radius: 2.35rem;
-  background:
-    radial-gradient(
-      circle at calc(100% - 2.1rem) 50%,
-      color-mix(in srgb, rgb(var(--mm-action-primary)) 50%, white) 0%,
-      rgb(var(--mm-accent-2) / 0.16) 34%,
-      rgb(var(--mm-action-primary) / 0) 64%
-    ),
-    linear-gradient(
-      115deg,
-      rgb(255 255 255 / 0.16),
-      rgb(255 255 255 / 0.02) 44%,
-      rgb(255 255 255 / 0.12)
-    );
-  opacity: 0.68;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.queue-floating-bar::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.36),
-    inset 0 -1px 0 rgb(255 255 255 / 0.08);
-  pointer-events: none;
-  z-index: 0;
-}
-
 .queue-floating-bar--liquid-glass[data-liquid-gl-initialized="true"] {
   border-color: rgb(255 255 255 / 0.22);
 }
@@ -2971,12 +2929,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 .queue-floating-bar--liquid-glass {
   position: fixed;
   isolation: isolate;
-  overflow: visible;
-}
-
-.queue-floating-bar--liquid-glass > * {
-  position: relative;
-  z-index: 1;
+  overflow: hidden;
 }
 
 .queue-floating-bar--liquid-glass[data-liquid-gl-initialized="true"] > * {
@@ -3021,12 +2974,11 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   border-radius: 999px;
   flex: 0 0 auto;
   white-space: nowrap;
-  border: 2px solid color-mix(in srgb, rgb(var(--mm-action-primary)) 66%, white);
+  border: 2px solid rgb(var(--mm-action-primary) / 0.85);
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.34),
-    0 0 0 1px color-mix(in srgb, rgb(var(--mm-action-primary)) 42%, white),
-    0 0 24px color-mix(in srgb, rgb(var(--mm-action-primary)) 54%, white),
-    0 0 46px rgb(var(--mm-accent-2) / 0.32),
+    inset 0 1px 0 rgb(255 255 255 / 0.22),
+    0 0 0 1px rgb(var(--mm-action-primary) / 0.5),
+    0 0 18px rgb(var(--mm-action-primary) / 0.55),
     0 12px 24px -14px rgb(var(--mm-action-primary) / 0.84);
   transition:
     box-shadow 240ms ease-out,
@@ -3037,11 +2989,17 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 }
 
 .queue-submit-primary--icon .queue-submit-primary-arrow {
-  width: 1.65rem;
-  height: 1.65rem;
+  position: absolute;
+  inset: 0;
+  width: auto;
+  height: auto;
+  border-radius: inherit;
 }
 
 .queue-submit-primary--icon .queue-submit-primary-arrow svg {
+  width: 1.65rem;
+  height: 1.65rem;
+  flex: 0 0 auto;
   stroke-width: 3;
 }
 
@@ -3052,27 +3010,26 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 }
 
 .queue-submit-primary--icon:hover {
-  border-color: color-mix(in srgb, rgb(var(--mm-action-primary)) 48%, white);
+  border-color: rgb(var(--mm-action-primary));
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.42),
-    0 0 0 3px color-mix(in srgb, rgb(var(--mm-action-primary)) 42%, white),
-    0 0 38px 8px color-mix(in srgb, rgb(var(--mm-action-primary)) 58%, white),
-    0 0 64px 12px rgb(var(--mm-accent-2) / 0.4),
+    inset 0 1px 0 rgb(255 255 255 / 0.3),
+    0 0 0 3px rgb(var(--mm-action-primary) / 0.6),
+    0 0 32px 6px rgb(var(--mm-action-primary) / 0.78),
     0 18px 36px -14px rgb(var(--mm-action-primary) / 0.95);
 }
 
 .queue-submit-primary--icon:focus-visible {
-  border-color: color-mix(in srgb, rgb(var(--mm-action-primary)) 48%, white);
+  border-color: rgb(var(--mm-action-primary));
 }
 
 .queue-submit-primary--icon:active,
 .queue-submit-primary--icon.is-clicked {
-  border-color: color-mix(in srgb, rgb(var(--mm-action-primary)) 42%, white);
+  border-color: rgb(var(--mm-action-primary));
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.42),
-    0 0 0 4px color-mix(in srgb, rgb(var(--mm-action-primary)) 38%, white),
-    0 0 46px 10px color-mix(in srgb, rgb(var(--mm-action-primary)) 56%, white),
-    0 0 76px 18px rgb(var(--mm-accent-2) / 0.44);
+    inset 0 1px 0 rgb(255 255 255 / 0.34),
+    0 0 0 4px rgb(var(--mm-action-primary) / 0.7),
+    0 0 38px 8px rgb(var(--mm-action-primary) / 0.85),
+    0 0 16px 1px rgb(var(--mm-action-primary) / 0.85);
 }
 
 @keyframes queue-submit-primary-arrow-cycle {


### PR DESCRIPTION
## Summary
- Revert the `::before`/`::after` diffusion layers and `overflow: visible` introduced by #1884 so the floating bar restores its liquid glass appearance and stays within its own borders.
- Drop the layered linear-gradient that was masking the liquid glass canvas, and shrink the create button's box-shadow back to a small green halo (no oversized accent-2 ring or white-mixed bloom).
- Reshape the icon-variant arrow span to fill the button as a circular mask (`position: absolute; inset: 0; border-radius: inherit`), so the hover animation is clipped by the button's outer circle instead of an inner 1.65rem box.
- Update the (currently `describe.skip`'d) liquid glass fallback regex assertions to match the restored CSS.

## Test plan
- [ ] Load the create page and confirm the floating bar shows the liquid glass distortion/blur of the content behind it.
- [ ] Verify the bar's contents do not bleed past its rounded borders, and only a small green halo surrounds the create button at rest, on hover, and on click.
- [ ] Hover the create button and confirm the arrow animation appears clipped by the circular outer edge rather than an inner border.
- [ ] `npx vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx -t "Task Create submit arrow animation"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)