### PR TITLE
[codex] Recover merge automation after external PR merge

### DIFF
--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -495,6 +495,51 @@ class MoonMindMergeAutomationWorkflow:
             return False
         return True
 
+    async def _evaluate_readiness_once(self) -> tuple[Any, Any]:
+        if self._input is None:
+            evaluation: dict[str, Any] = {}
+            return evaluation, classify_readiness(evaluation, tracked_head_sha="")
+        evaluation = await workflow.execute_activity(
+            "merge_automation.evaluate_readiness",
+            self._input.model_dump(by_alias=True, mode="json"),
+            start_to_close_timeout=timedelta(minutes=2),
+            task_queue=INTEGRATIONS_TASK_QUEUE,
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        evidence = classify_readiness(
+            evaluation if isinstance(evaluation, Mapping) else {},
+            tracked_head_sha=self._input.pull_request.head_sha,
+        )
+        return evaluation, evidence
+
+    async def _finish_if_pr_merged_after_resolver_issue(self) -> dict[str, Any] | None:
+        if self._input is None:
+            return None
+        if not workflow.patched("merge-automation-post-resolver-merged-recovery-v1"):
+            return None
+        evaluation, evidence = await self._evaluate_readiness_once()
+        if self._refresh_tracked_head_sha(evaluation):
+            evidence = classify_readiness(
+                evaluation if isinstance(evaluation, Mapping) else {},
+                tracked_head_sha=self._input.pull_request.head_sha,
+            )
+        self._blockers = list(evidence.blockers)
+        await self._write_gate_snapshot(evidence_ready=evidence.ready)
+        if not evidence.pull_request_merged:
+            return None
+        self._summary = (
+            "Pull request is already merged; recovered after resolver "
+            "disposition validation failed."
+        )
+        if not await self._complete_post_merge_jira(
+            resolver_disposition=DISPOSITION_ALREADY_MERGED
+        ):
+            return await self._finish()
+        self._status = STATE_ALREADY_MERGED
+        self._publish_visibility()
+        return await self._finish()
+
     @workflow.run
     async def run(self, payload: dict[str, Any]) -> dict[str, Any]:
         self._input = MergeAutomationStartInput.model_validate(payload)
@@ -508,18 +553,7 @@ class MoonMindMergeAutomationWorkflow:
                 self._publish_visibility()
                 return await self._finish()
 
-            evaluation = await workflow.execute_activity(
-                "merge_automation.evaluate_readiness",
-                self._input.model_dump(by_alias=True, mode="json"),
-                start_to_close_timeout=timedelta(minutes=2),
-                task_queue=INTEGRATIONS_TASK_QUEUE,
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-            )
-            evidence = classify_readiness(
-                evaluation if isinstance(evaluation, Mapping) else {},
-                tracked_head_sha=self._input.pull_request.head_sha,
-            )
+            evaluation, evidence = await self._evaluate_readiness_once()
             if self._refresh_tracked_head_sha_on_next_evaluation:
                 self._refresh_tracked_head_sha_on_next_evaluation = False
                 if self._refresh_tracked_head_sha(evaluation):
@@ -614,11 +648,17 @@ class MoonMindMergeAutomationWorkflow:
                 ).strip()
                 resolver_disposition = self._resolver_disposition(resolver_result)
                 if resolver_status != "success":
+                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
                     return await self._failed_resolver_summary(
                         summary="pr-resolver child run did not complete successfully.",
                         blocker_kind=DISPOSITION_FAILED,
                     )
                 if not resolver_disposition:
+                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
                     return await self._failed_resolver_summary(
                         summary=(
                             "pr-resolver child result missing "
@@ -627,6 +667,9 @@ class MoonMindMergeAutomationWorkflow:
                         blocker_kind="resolver_disposition_invalid",
                     )
                 if resolver_disposition not in ALLOWED_DISPOSITIONS:
+                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
                     return await self._failed_resolver_summary(
                         summary=(
                             "pr-resolver child result has unsupported "
@@ -661,11 +704,17 @@ class MoonMindMergeAutomationWorkflow:
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MANUAL_REVIEW:
+                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
                     return await self._failed_resolver_summary(
                         summary="pr-resolver requested manual review.",
                         blocker_kind=DISPOSITION_MANUAL_REVIEW,
                     )
                 if resolver_disposition == DISPOSITION_FAILED:
+                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
                     return await self._failed_resolver_summary(
                         summary="pr-resolver reported failure.",
                         blocker_kind=DISPOSITION_FAILED,

--- a/specs/293-merge-automation-merged-pr-recovery/plan.md
+++ b/specs/293-merge-automation-merged-pr-recovery/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Merge Automation Merged PR Recovery
+
+## Summary
+
+Add a narrow post-resolver recovery path in `MoonMind.MergeAutomation`: before turning a malformed or non-success resolver disposition into a failed merge automation result, re-run the existing readiness activity and accept success only if GitHub reports the PR is merged. Keep the resolver output contract strict for all non-merged evidence.
+
+## Technical Context
+
+- Python 3.12
+- Temporal Python SDK workflows and activities
+- Existing GitHub readiness activity: `merge_automation.evaluate_readiness`
+- Existing post-merge Jira activity: `merge_automation.complete_post_merge_jira`
+- Existing pr-resolver result writers and managed runtime adapters
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Recovery uses existing provider readiness activity.
+- II. One-Click Agent Deployment: PASS. No new dependencies or services.
+- III. Avoid Vendor Lock-In: PASS. GitHub-specific evidence remains inside the existing GitHub readiness boundary.
+- IV. Own Your Data: PASS. Recovery evidence is captured in existing local artifacts and workflow state.
+- V. Skills Are First-Class and Easy to Add: PASS. The resolver skill contract remains explicit.
+- VI. Thin Scaffolding, Thick Contracts: PASS. The workflow does not parse agent prose; it checks provider state.
+- VII. Runtime Configurability: PASS. No new required operator config.
+- VIII. Modular and Extensible Architecture: PASS. Edits stay within merge automation and existing adapter tests.
+- IX. Resilient by Default: PASS. A completed external merge no longer produces a false failed task.
+- X. Facilitate Continuous Improvement: PASS. Failure summaries remain deterministic when recovery is not justified.
+- XI. Spec-Driven Development: PASS. This spec defines the behavior change.
+- XII. Canonical Documentation: PASS. Migration detail stays in this feature artifact.
+- XIII. Pre-Release Compatibility Policy: PASS. A Temporal patch marker guards the new workflow branch for replay safety.
+
+## Implementation Strategy
+
+1. Extract the existing readiness activity call into a workflow helper without changing command ordering.
+2. Add a patched recovery helper that re-evaluates readiness before resolver-disposition failures.
+3. If the fresh evidence reports the PR merged, refresh tracked PR metadata, run post-merge Jira completion, and finish as `already_merged`.
+4. Add workflow tests for missing disposition recovery and continued invalid-disposition failure.
+5. Run focused tests, then the full unit suite.
+
+## Test Strategy
+
+- `pytest tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`
+- `pytest tests/unit/test_pr_resolver_tools.py`
+- `pytest tests/unit/workflows/adapters/test_managed_agent_adapter.py`
+- `pytest tests/unit/workflows/adapters/test_codex_session_adapter.py`
+- `./tools/test_unit.sh`

--- a/specs/293-merge-automation-merged-pr-recovery/spec.md
+++ b/specs/293-merge-automation-merged-pr-recovery/spec.md
@@ -1,0 +1,34 @@
+# Feature Specification: Merge Automation Merged PR Recovery
+
+**Feature Branch**: `293-merge-automation-merged-pr-recovery`  
+**Created**: 2026-05-02  
+**Status**: Draft  
+**Input**: Make merge automation resilient when a PR is merged but the resolver child returns an incomplete merge disposition contract.
+
+## User Scenarios & Testing
+
+### Primary User Story
+
+As an operator running PR merge automation, I need the workflow to move on successfully when GitHub authoritatively reports that the target PR is already merged, even if the resolver child returned an incomplete or invalid merge automation disposition.
+
+### Acceptance Scenarios
+
+1. **Given** `pr-resolver` returns success without `mergeAutomationDisposition`, **when** a fresh merge automation readiness check reports `pullRequestMerged=true`, **then** merge automation completes successfully as `already_merged`.
+2. **Given** `pr-resolver` returns an unsupported disposition, **when** GitHub does not report the PR as merged, **then** merge automation keeps the deterministic `resolver_disposition_invalid` failure.
+3. **Given** the resolver child reports failure or manual review, **when** a fresh readiness check reports `pullRequestMerged=true`, **then** merge automation completes successfully after required post-merge Jira completion.
+4. **Given** resolver result artifacts are written by `pr-resolver`, **when** the adapter fetches the child run result, **then** explicit `mergeAutomationDisposition` remains propagated to `MoonMind.Run` output metadata.
+
+## Requirements
+
+- **FR-001**: Merge automation MUST perform one fresh authoritative readiness evaluation before failing a resolver child for missing, unsupported, manual-review, or failed merge disposition.
+- **FR-002**: Merge automation MUST only recover to success when the fresh readiness evidence reports `pullRequestMerged=true`.
+- **FR-003**: Recovery MUST run the same required post-merge Jira completion path used by normal `merged` and `already_merged` resolver dispositions.
+- **FR-004**: Recovery MUST NOT infer merge success from resolver free-form output text.
+- **FR-005**: If the fresh readiness evidence does not confirm the PR is merged, missing and unsupported dispositions MUST continue to fail deterministically.
+- **FR-006**: Resolver producer and adapter boundaries MUST continue to emit and propagate explicit `mergeAutomationDisposition` values for normal terminal results.
+
+## Success Criteria
+
+- **SC-001**: Workflow tests prove missing resolver dispositions recover when the second readiness check observes the PR as merged.
+- **SC-002**: Workflow tests prove invalid dispositions still fail when GitHub does not confirm a merge.
+- **SC-003**: Existing adapter and resolver tests continue to prove explicit disposition propagation.

--- a/specs/293-merge-automation-merged-pr-recovery/tasks.md
+++ b/specs/293-merge-automation-merged-pr-recovery/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Merge Automation Merged PR Recovery
+
+- [x] T001 Add spec artifacts for the recovery contract.
+- [x] T002 Add patched merge automation recovery after malformed or failed resolver dispositions.
+- [x] T003 Preserve normal fail-fast behavior when fresh readiness does not confirm the PR is merged.
+- [x] T004 Add workflow tests for merged-PR recovery and non-merged invalid disposition failure.
+- [x] T005 Run focused producer, adapter, and workflow tests.
+- [x] T006 Run full unit verification.
+- [x] T007 Commit, push, and open a non-draft PR.

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -413,8 +413,16 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
         "execute_child_workflow",
         fake_execute_child_workflow,
     )
-    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
-    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
     monkeypatch.setattr(
         merge_automation_module.workflow,
         "upsert_search_attributes",
@@ -1311,6 +1319,97 @@ async def test_merge_automation_invalid_dispositions_fail_deterministically(
     assert result["summary"] == expected_summary
     assert result["blockers"]
     assert result["blockers"][0]["kind"] == "resolver_disposition_invalid"
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resolver_result",
+    [
+        {"status": "success"},
+        {"status": "success", "mergeAutomationDisposition": "manual_review"},
+        {"status": "failed"},
+    ],
+)
+async def test_merge_automation_recovers_resolver_contract_issue_when_pr_is_merged(
+    monkeypatch: pytest.MonkeyPatch,
+    resolver_result: dict[str, Any],
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        if activity_type != "merge_automation.evaluate_readiness":
+            return {}
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "abc123",
+                "ready": True,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": True,
+                "checksPassing": True,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        return {
+            "headSha": "def456",
+            "ready": False,
+            "pullRequestOpen": False,
+            "pullRequestMerged": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        return resolver_result
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 2
+    assert result["status"] == "already_merged"
+    assert result["latestHeadSha"] == "def456"
+    expected_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="abc123",
+    )
+    assert result["resolverChildWorkflowIds"] == [f"{expected_resolver_id}:1"]
+    assert result["summary"] == (
+        "Pull request is already merged; recovered after resolver "
+        "disposition validation failed."
+    )
 
 @pytest.mark.asyncio
 async def test_merge_automation_ignores_wait_condition_timeout_only(


### PR DESCRIPTION
## Summary
- add a patched merge automation recovery path that re-checks GitHub readiness before failing malformed or failed resolver dispositions
- complete successfully as `already_merged` only when the fresh readiness evidence reports `pullRequestMerged=true`
- add MoonSpec artifacts and workflow coverage for the recovery contract while preserving fail-fast behavior when the PR is not merged

## Root Cause
A resolver child could finish after the PR was merged but return a generic or incomplete result without `mergeAutomationDisposition`. Merge automation treated that as a contract failure without re-checking authoritative PR state, so the parent task failed even though the PR side effect had completed.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/test_pr_resolver_tools.py`
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
- `./tools/test_unit.sh`
