### PR TITLE
[codex] Route merge conflicts through pr-resolver

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,22 @@
 [
   {
-    "id": 4363278826,
+    "id": 4365347415,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and contains no actionable code feedback."
+    "rationale": "Qodo free-tier notice; no actionable code feedback."
   },
   {
-    "id": 3176313686,
+    "id": 3177603333,
     "disposition": "addressed",
-    "rationale": "Restored flex centering and overflow clipping for the absolute-positioned icon submit arrow, with CSS test coverage."
+    "rationale": "Refactored _is_non_blocking_blocker to accept the normalized blocker kind directly."
   },
   {
-    "id": 4214662171,
+    "id": 3177603335,
     "disposition": "addressed",
-    "rationale": "Review summary duplicates the submit-arrow centering and clipping concern addressed in the inline CSS change."
+    "rationale": "Updated the blocker classification loop to normalize each blocker kind once and pass it to helper functions."
+  },
+  {
+    "id": 4215859538,
+    "disposition": "not-applicable",
+    "rationale": "Review summary describes the inline Gemini suggestions already tracked separately."
   }
 ]

--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -410,6 +410,9 @@ Completed-but-failing checks do not keep the gate closed by themselves. Once
 required checks have reported and are no longer running, the gate may launch
 `pr-resolver` so resolver-owned CI remediation can proceed.
 
+Detected merge conflicts are also resolver-actionable. They should open the
+gate for `pr-resolver` instead of leaving merge automation in external wait.
+
 ### 12.2 Gate semantics
 
 The gate opens when the configured external merge-readiness signal is complete for the **current head SHA**.

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -226,6 +226,7 @@ class MergeAutomationConfigModel(BaseModel):
 ReadinessBlockerKind = Literal[
     "checks_running",
     "checks_failed",
+    "merge_conflict",
     "automated_review_pending",
     "jira_status_pending",
     "pull_request_closed",

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -364,6 +364,7 @@ class MoonMindMergeAutomationWorkflow:
         return classify_readiness(
             evaluation,
             tracked_head_sha=self._input.pull_request.head_sha,
+            actionable_merge_conflicts=self._actionable_merge_conflicts_enabled(),
         )
 
     def _should_refresh_pre_resolver_head(
@@ -384,6 +385,10 @@ class MoonMindMergeAutomationWorkflow:
         if observed_head_sha == self._input.pull_request.head_sha:
             return False
         return any(blocker.kind == "stale_revision" for blocker in blockers)
+
+    @staticmethod
+    def _actionable_merge_conflicts_enabled() -> bool:
+        return workflow.patched("merge-automation-actionable-merge-conflict-v1")
 
     async def _failed_resolver_summary(
         self,
@@ -498,7 +503,11 @@ class MoonMindMergeAutomationWorkflow:
     async def _evaluate_readiness_once(self) -> tuple[Any, Any]:
         if self._input is None:
             evaluation: dict[str, Any] = {}
-            return evaluation, classify_readiness(evaluation, tracked_head_sha="")
+            return evaluation, classify_readiness(
+                evaluation,
+                tracked_head_sha="",
+                actionable_merge_conflicts=self._actionable_merge_conflicts_enabled(),
+            )
         evaluation = await workflow.execute_activity(
             "merge_automation.evaluate_readiness",
             self._input.model_dump(by_alias=True, mode="json"),
@@ -510,6 +519,7 @@ class MoonMindMergeAutomationWorkflow:
         evidence = classify_readiness(
             evaluation if isinstance(evaluation, Mapping) else {},
             tracked_head_sha=self._input.pull_request.head_sha,
+            actionable_merge_conflicts=self._actionable_merge_conflicts_enabled(),
         )
         return evaluation, evidence
 
@@ -523,6 +533,7 @@ class MoonMindMergeAutomationWorkflow:
             evidence = classify_readiness(
                 evaluation if isinstance(evaluation, Mapping) else {},
                 tracked_head_sha=self._input.pull_request.head_sha,
+                actionable_merge_conflicts=self._actionable_merge_conflicts_enabled(),
             )
         self._blockers = list(evidence.blockers)
         await self._write_gate_snapshot(evidence_ready=evidence.ready)
@@ -560,6 +571,9 @@ class MoonMindMergeAutomationWorkflow:
                     evidence = classify_readiness(
                         evaluation if isinstance(evaluation, Mapping) else {},
                         tracked_head_sha=self._input.pull_request.head_sha,
+                        actionable_merge_conflicts=(
+                            self._actionable_merge_conflicts_enabled()
+                        ),
                     )
             if workflow.patched("merge-automation-refresh-stale-current-head"):
                 evidence = self._refresh_current_head_for_stale_wait(
@@ -576,6 +590,7 @@ class MoonMindMergeAutomationWorkflow:
                 evidence = classify_readiness(
                     evaluation if isinstance(evaluation, Mapping) else {},
                     tracked_head_sha=self._input.pull_request.head_sha,
+                    actionable_merge_conflicts=self._actionable_merge_conflicts_enabled(),
                 )
             self._blockers = list(evidence.blockers)
             await self._write_gate_snapshot(evidence_ready=evidence.ready)

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -78,13 +78,10 @@ def _normalize_blocker_kind(
 
 def _blocker_from_mapping(
     payload: Mapping[str, Any],
+    kind: str,
     *,
     actionable_merge_conflicts: bool,
 ) -> ReadinessBlockerModel:
-    kind = _normalize_blocker_kind(
-        payload.get("kind"),
-        actionable_merge_conflicts=actionable_merge_conflicts,
-    )
     known_kinds = set(BASE_KNOWN_BLOCKER_KINDS)
     if actionable_merge_conflicts:
         known_kinds.update(ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS)
@@ -100,14 +97,10 @@ def _blocker_from_mapping(
     )
 
 def _is_non_blocking_blocker(
-    payload: Mapping[str, Any],
+    kind: str,
     *,
     actionable_merge_conflicts: bool,
 ) -> bool:
-    kind = _normalize_blocker_kind(
-        payload.get("kind"),
-        actionable_merge_conflicts=actionable_merge_conflicts,
-    )
     if kind in ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS and not actionable_merge_conflicts:
         return False
     return kind in NON_BLOCKING_BLOCKER_KINDS
@@ -147,20 +140,21 @@ def classify_readiness(
 
     for raw in payload.get("blockers") or []:
         if isinstance(raw, Mapping):
-            raw_kind = _normalize_blocker_kind(
+            kind = _normalize_blocker_kind(
                 raw.get("kind"),
                 actionable_merge_conflicts=actionable_merge_conflicts,
             )
             if _is_non_blocking_blocker(
-                raw,
+                kind,
                 actionable_merge_conflicts=actionable_merge_conflicts,
             ):
-                if raw_kind in ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS:
+                if kind in ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS:
                     actionable_merge_conflict_seen = True
                 continue
             blockers.append(
                 _blocker_from_mapping(
                     raw,
+                    kind,
                     actionable_merge_conflicts=actionable_merge_conflicts,
                 )
             )

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -26,8 +26,7 @@ TERMINAL_BLOCKER_KINDS = {
     "stale_revision",
     "policy_denied",
 }
-NON_BLOCKING_BLOCKER_KINDS = {"checks_failed"}
-KNOWN_BLOCKER_KINDS = {
+BASE_KNOWN_BLOCKER_KINDS = {
     "checks_running",
     "checks_failed",
     "automated_review_pending",
@@ -36,6 +35,14 @@ KNOWN_BLOCKER_KINDS = {
     "stale_revision",
     "policy_denied",
     "external_state_unavailable",
+}
+ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS = {"merge_conflict"}
+NON_BLOCKING_BLOCKER_KINDS = {
+    "checks_failed",
+    *ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS,
+}
+BLOCKER_KIND_ALIASES = {
+    "merge_conflicts": "merge_conflict",
 }
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     initial_interval=timedelta(seconds=5),
@@ -59,9 +66,29 @@ def sanitize_blocker_summary(value: str | None) -> str:
     text = _TOKEN_ASSIGNMENT_PATTERN.sub(r"\1:<redacted>", text)
     return (text or "External readiness is blocked.")[:500]
 
-def _blocker_from_mapping(payload: Mapping[str, Any]) -> ReadinessBlockerModel:
-    kind = str(payload.get("kind") or "external_state_unavailable").strip()
-    if kind not in KNOWN_BLOCKER_KINDS:
+def _normalize_blocker_kind(
+    value: object,
+    *,
+    actionable_merge_conflicts: bool,
+) -> str:
+    kind = str(value or "external_state_unavailable").strip()
+    if actionable_merge_conflicts:
+        return BLOCKER_KIND_ALIASES.get(kind, kind)
+    return kind
+
+def _blocker_from_mapping(
+    payload: Mapping[str, Any],
+    *,
+    actionable_merge_conflicts: bool,
+) -> ReadinessBlockerModel:
+    kind = _normalize_blocker_kind(
+        payload.get("kind"),
+        actionable_merge_conflicts=actionable_merge_conflicts,
+    )
+    known_kinds = set(BASE_KNOWN_BLOCKER_KINDS)
+    if actionable_merge_conflicts:
+        known_kinds.update(ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS)
+    if kind not in known_kinds:
         kind = "external_state_unavailable"
     return ReadinessBlockerModel.model_validate(
         {
@@ -72,8 +99,17 @@ def _blocker_from_mapping(payload: Mapping[str, Any]) -> ReadinessBlockerModel:
         }
     )
 
-def _is_non_blocking_blocker(payload: Mapping[str, Any]) -> bool:
-    kind = str(payload.get("kind") or "").strip()
+def _is_non_blocking_blocker(
+    payload: Mapping[str, Any],
+    *,
+    actionable_merge_conflicts: bool,
+) -> bool:
+    kind = _normalize_blocker_kind(
+        payload.get("kind"),
+        actionable_merge_conflicts=actionable_merge_conflicts,
+    )
+    if kind in ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS and not actionable_merge_conflicts:
+        return False
     return kind in NON_BLOCKING_BLOCKER_KINDS
 
 def _default_blocker(kind: str, summary: str, *, retryable: bool, source: str) -> dict[str, Any]:
@@ -88,6 +124,7 @@ def classify_readiness(
     payload: Mapping[str, Any],
     *,
     tracked_head_sha: str,
+    actionable_merge_conflicts: bool = True,
 ) -> ReadinessEvidenceModel:
     """Normalize provider readiness evidence into bounded merge-gate evidence."""
 
@@ -97,6 +134,7 @@ def classify_readiness(
         or payload.get("pull_request_merged") is True
     )
     blockers: list[ReadinessBlockerModel] = []
+    actionable_merge_conflict_seen = False
     if not pull_request_merged and head_sha != str(tracked_head_sha).strip():
         blockers.append(
             ReadinessBlockerModel(
@@ -109,9 +147,23 @@ def classify_readiness(
 
     for raw in payload.get("blockers") or []:
         if isinstance(raw, Mapping):
-            if _is_non_blocking_blocker(raw):
+            raw_kind = _normalize_blocker_kind(
+                raw.get("kind"),
+                actionable_merge_conflicts=actionable_merge_conflicts,
+            )
+            if _is_non_blocking_blocker(
+                raw,
+                actionable_merge_conflicts=actionable_merge_conflicts,
+            ):
+                if raw_kind in ACTIONABLE_MERGE_CONFLICT_BLOCKER_KINDS:
+                    actionable_merge_conflict_seen = True
                 continue
-            blockers.append(_blocker_from_mapping(raw))
+            blockers.append(
+                _blocker_from_mapping(
+                    raw,
+                    actionable_merge_conflicts=actionable_merge_conflicts,
+                )
+            )
 
     if not pull_request_merged and (
         payload.get("pullRequestOpen") is False
@@ -196,7 +248,9 @@ def classify_readiness(
     checks_failed_but_actionable = (
         not pull_request_merged and checks_are_failing and checks_are_complete
     )
-    ready = (explicit_ready or checks_failed_but_actionable) and not deduped
+    ready = (
+        explicit_ready or checks_failed_but_actionable or actionable_merge_conflict_seen
+    ) and not deduped
     return ReadinessEvidenceModel.model_validate(
         {
             **dict(payload),

--- a/specs/179-merge-gate/data-model.md
+++ b/specs/179-merge-gate/data-model.md
@@ -97,7 +97,7 @@ Operator-visible reason that a gate remains waiting or blocked.
 
 Fields:
 
-- `kind`: bounded value such as `checks_running`, `checks_failed`, `automated_review_pending`, `jira_status_pending`, `pull_request_closed`, `stale_revision`, `policy_denied`, `external_state_unavailable`.
+- `kind`: bounded value such as `checks_running`, `checks_failed`, `merge_conflict`, `automated_review_pending`, `jira_status_pending`, `pull_request_closed`, `stale_revision`, `policy_denied`, `external_state_unavailable`.
 - `summary`: sanitized human-readable explanation.
 - `retryable`: boolean.
 - `source`: optional bounded source label such as `github`, `jira`, or `policy`.

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -121,6 +121,75 @@ def test_classify_readiness_allows_resolver_launch_when_checks_failed_but_are_co
     assert evidence.ready is True
     assert evidence.blockers == []
 
+def test_classify_readiness_allows_resolver_launch_for_merge_conflicts() -> None:
+    evidence = classify_readiness(
+        {
+            "headSha": "abc123",
+            "ready": False,
+            "pullRequestOpen": True,
+            "checksComplete": None,
+            "checksPassing": None,
+            "automatedReviewComplete": None,
+            "jiraStatusAllowed": True,
+            "policyAllowed": True,
+            "blockers": [
+                {
+                    "kind": "merge_conflict",
+                    "summary": "Pull request has merge conflicts.",
+                    "retryable": False,
+                    "source": "github",
+                }
+            ],
+        },
+        tracked_head_sha="abc123",
+    )
+
+    assert evidence.ready is True
+    assert evidence.blockers == []
+
+def test_classify_readiness_normalizes_plural_merge_conflict_blocker() -> None:
+    evidence = classify_readiness(
+        {
+            "headSha": "abc123",
+            "ready": True,
+            "pullRequestOpen": True,
+            "blockers": [
+                {
+                    "kind": "merge_conflicts",
+                    "summary": "Pull request has merge conflicts.",
+                    "retryable": False,
+                    "source": "github",
+                }
+            ],
+        },
+        tracked_head_sha="abc123",
+    )
+
+    assert evidence.ready is True
+    assert evidence.blockers == []
+
+def test_classify_readiness_preserves_pre_patch_merge_conflict_wait_behavior() -> None:
+    evidence = classify_readiness(
+        {
+            "headSha": "abc123",
+            "ready": True,
+            "pullRequestOpen": True,
+            "blockers": [
+                {
+                    "kind": "merge_conflict",
+                    "summary": "Pull request has merge conflicts.",
+                    "retryable": False,
+                    "source": "github",
+                }
+            ],
+        },
+        tracked_head_sha="abc123",
+        actionable_merge_conflicts=False,
+    )
+
+    assert evidence.ready is False
+    assert evidence.blockers[0].kind == "external_state_unavailable"
+
 def test_classify_readiness_maps_unknown_blocker_kind_to_external_unavailable() -> None:
     evidence = classify_readiness(
         {

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -605,6 +605,77 @@ async def test_merge_automation_launches_resolver_when_checks_are_failing_but_co
     assert result["blockers"] == []
 
 @pytest.mark.asyncio
+async def test_merge_automation_launches_resolver_for_merge_conflicts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    child_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert activity_type == "merge_automation.evaluate_readiness"
+        return {
+            "headSha": "abc123",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": None,
+            "checksPassing": None,
+            "automatedReviewComplete": None,
+            "jiraStatusAllowed": True,
+            "blockers": [
+                {
+                    "kind": "merge_conflict",
+                    "summary": "Pull request has merge conflicts.",
+                    "retryable": False,
+                    "source": "github",
+                }
+            ],
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal child_calls
+        assert workflow_type == "MoonMind.Run"
+        assert payload["initial_parameters"]["task"]["tool"]["name"] == "pr-resolver"
+        child_calls += 1
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert child_calls == 1
+    assert result["status"] == "merged"
+    assert result["blockers"] == []
+
+@pytest.mark.asyncio
 async def test_merge_automation_adopts_initial_waiting_head_sha_before_resolver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat merge-conflict readiness evidence as resolver-actionable instead of wait-only external state.
- Add a Temporal patch guard so in-flight merge automation histories replay deterministically.
- Add classifier and workflow-boundary tests proving merge conflicts launch a child MoonMind.Run with pr-resolver.

## Root cause
GitHub readiness emitted `merge_conflict`, but the merge gate did not include that kind in the bounded readiness contract. The classifier downgraded it to `external_state_unavailable`, which kept merge automation polling instead of launching pr-resolver.

## Validation
- `.venv/bin/pytest tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/workflows/adapters/test_github_service.py -q`
- `git diff --check`
- `.venv/bin/python -m compileall -q moonmind/schemas/temporal_models.py moonmind/workflows/temporal/workflows/merge_gate.py moonmind/workflows/temporal/workflows/merge_automation.py tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`

Note: the full `./tools/test_unit.sh` Python suite passed, but the wrapper hit unrelated flaky frontend live-log Vitest timing. Rerunning the exact failing Vitest cases directly passed.