### PR TITLE
Restore visible glass sheen on create page floating bar

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2922,6 +2922,35 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
+.queue-floating-bar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      135deg,
+      rgb(255 255 255 / 0.16) 0%,
+      rgb(255 255 255 / 0.03) 42%,
+      rgb(255 255 255 / 0.12) 100%
+    );
+  opacity: 0.9;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.queue-floating-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.32),
+    inset 0 -1px 0 rgb(255 255 255 / 0.06);
+  pointer-events: none;
+  z-index: 1;
+}
+
 .queue-floating-bar--liquid-glass[data-liquid-gl-initialized="true"] {
   border-color: rgb(255 255 255 / 0.22);
 }
@@ -2930,6 +2959,11 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   position: fixed;
   isolation: isolate;
   overflow: hidden;
+}
+
+.queue-floating-bar--liquid-glass > * {
+  position: relative;
+  z-index: 2;
 }
 
 .queue-floating-bar--liquid-glass[data-liquid-gl-initialized="true"] > * {


### PR DESCRIPTION
## Summary
- The liquidGL lens overrides the bar's inline `background`/`backdrop-filter`, and #1887 left no other visible glass character on the bar — so when the WebGL output was subtle (heavy `frost: 6` over dark page atmosphere) or the snapshot had not yet revealed, the bar read as a flat dark panel.
- Added contained `.queue-floating-bar::before` (diagonal sheen) and `::after` (inset top/bottom edge highlights) at `inset: 0`. Pseudo-elements survive the lens's inline overrides and stay within the bar's borders, so no diffusion halo escapes the way #1884's did.
- Re-added `.queue-floating-bar--liquid-glass > * { position: relative; z-index: 2 }` so inputs/buttons stack above the new pseudos.

## Test plan
- [x] \`npm run ui:typecheck\`
- [x] \`./node_modules/.bin/vitest run frontend/src/entrypoints/task-create.test.tsx\` (8 passed)
- [x] \`./node_modules/.bin/vitest run frontend/src/entrypoints/mission-control.test.tsx\` (30 passed)
- [ ] Visual check: liquid glass sheen and edge highlights visible on create page floating bar in dark theme without halo bleeding past the bar's borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)