### PR TITLE
Fix Jira Orchestrate publish handling

### DIFF
--- a/.agents/skills/jira-issue-updater/SKILL.md
+++ b/.agents/skills/jira-issue-updater/SKILL.md
@@ -14,7 +14,7 @@ Update an existing Jira task, story, bug, subtask, or other issue type. Use this
 - Optional: replacement or appended description text.
 - Optional: issue type context, for example `Task`, `Story`, `Bug`, `Sub-task`, or a project-specific Jira issue type.
 - Optional: field/update payload details from the user or Jira edit metadata, including labels, priority, assignee, components, due dates, or project-specific custom fields.
-- Optional: MoonMind API base URL and authenticated session/token, only when calling the HTTP MCP endpoint directly.
+- Optional: `MOONMIND_URL` and authenticated runtime session/token, only when calling the HTTP MCP endpoint directly.
 
 ## Outputs
 
@@ -129,7 +129,7 @@ Example tool payload:
 When no native Jira tool is exposed but an authenticated MoonMind API endpoint is available, call:
 
 ```bash
-curl -sS -X POST "$MOONMIND_API_BASE/mcp/tools/call" \
+curl -sS -X POST "$MOONMIND_URL/mcp/tools/call" \
   -H "Content-Type: application/json" \
   -d '{
     "tool": "jira.get_transitions",

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,62 @@
 [
   {
-    "id": 4365347415,
+    "id": 4366838058,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice; no actionable code feedback."
+    "rationale": "Qodo free-tier notice is informational and contains no code feedback."
   },
   {
-    "id": 3177603333,
+    "id": 3178553694,
     "disposition": "addressed",
-    "rationale": "Refactored _is_non_blocking_blocker to accept the normalized blocker kind directly."
+    "rationale": "Moved jira-orchestrate into the self-managed publish set so non-none publish modes fail fast instead of being silently coerced."
   },
   {
-    "id": 3177603335,
+    "id": 3178553698,
     "disposition": "addressed",
-    "rationale": "Updated the blocker classification loop to normalize each blocker kind once and pass it to helper functions."
+    "rationale": "Removed the forced-none publish helper in favor of consolidated self-managed publish enforcement."
   },
   {
-    "id": 4215859538,
+    "id": 3178553699,
+    "disposition": "addressed",
+    "rationale": "Removed the hidden publish-mode override path; invalid jira-orchestrate publish modes now raise TaskContractError."
+  },
+  {
+    "id": 3178553700,
+    "disposition": "addressed",
+    "rationale": "Removed is_forced_none_publish_skill from the module exports."
+  },
+  {
+    "id": 3178553701,
+    "disposition": "addressed",
+    "rationale": "Added shared Jira agent skill constants and reused them in activity, worker, and workflow runtime paths."
+  },
+  {
+    "id": 4216664516,
     "disposition": "not-applicable",
-    "rationale": "Review summary describes the inline Gemini suggestions already tracked separately."
+    "rationale": "Review summary comment; individual actionable findings were handled separately."
+  },
+  {
+    "id": 3178555326,
+    "disposition": "addressed",
+    "rationale": "Replaced the first jira-issue-updater hint's implicit string literal concatenation with explicit concatenation."
+  },
+  {
+    "id": 3178555328,
+    "disposition": "addressed",
+    "rationale": "Replaced the status-change hint's implicit string literal concatenation with explicit concatenation."
+  },
+  {
+    "id": 3178555329,
+    "disposition": "addressed",
+    "rationale": "Replaced the blocked-state hint's implicit string literal concatenation with explicit concatenation."
+  },
+  {
+    "id": 3178561208,
+    "disposition": "addressed",
+    "rationale": "Classified jira-issue-updater as PR-optional in MoonMindRunWorkflow plan analysis and added regression coverage."
+  },
+  {
+    "id": 4216669780,
+    "disposition": "not-applicable",
+    "rationale": "Codex review wrapper comment; the actionable inline finding was handled separately."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5967,7 +5967,9 @@ describe.skip("Task Create Entrypoint", () => {
           }),
         } as Response);
       }
-      if (url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")) {
+      if (
+        url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")
+      ) {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -6020,6 +6022,121 @@ describe.skip("Task Create Entrypoint", () => {
     expect(within(presetSection).queryByLabelText("Orchestration Mode")).toBeNull();
     expect(within(presetSection).queryByLabelText("Source Design Path")).toBeNull();
     expect(within(presetSection).queryByLabelText("Constraints")).toBeNull();
+    expect((screen.getByLabelText("Publish Mode") as HTMLSelectElement).value).toBe(
+      "none",
+    );
+  });
+
+  it("submits Jira Orchestrate preset runs without automatic publishing", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-orchestrate",
+                scope: "global",
+                title: "Jira Orchestrate",
+                description: "Run MoonSpec from a Jira issue.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-orchestrate",
+            scope: "global",
+            title: "Jira Orchestrate",
+            description: "Run MoonSpec from a Jira issue.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "jira_issue_key",
+                label: "Jira Issue Key",
+                type: "text",
+                required: true,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-orchestrate:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-orchestrate:1",
+                title: "Move Jira issue",
+                instructions: "Transition THOR-352 to In Progress.",
+                tool: { type: "skill", name: "jira-issue-updater" },
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-orchestrate",
+              version: "1.0.0",
+              inputs: { jira_issue_key: "THOR-352" },
+              stepIds: ["tpl:jira-orchestrate:1"],
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSection = screen.getByLabelText("Task Presets");
+    await within(presetSection).findByLabelText("Jira Issue Key");
+    expect((screen.getByLabelText("Publish Mode") as HTMLSelectElement).value).toBe(
+      "none",
+    );
+
+    fireEvent.change(within(presetSection).getByLabelText("Jira Issue Key"), {
+      target: { value: "THOR-352" },
+    });
+    await clickApplyButton();
+    await screen.findByDisplayValue("Transition THOR-352 to In Progress.");
+
+    const publishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(publishSelect.value).toBe("none");
+    expect(
+      Array.from(publishSelect.options).some(
+        (option) => option.value === "pr_with_merge_automation",
+      ),
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const payload = latestCreateRequest().payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(payload.publishMode).toBe("none");
+    expect(task.publish).toMatchObject({ mode: "none" });
+    expect(payload).not.toHaveProperty("mergeAutomation");
+    expect(task.skills).toEqual({ include: [{ name: "jira-orchestrate" }] });
   });
 
   it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -29,6 +29,10 @@ const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
+const SELF_MANAGED_PUBLISH_SKILLS = new Set([
+  ...PR_RESOLVER_SKILLS,
+  JIRA_ORCHESTRATE_PRESET_SLUG,
+]);
 const MOONSPEC_ORCHESTRATE_PRESET_SLUG = "moonspec-orchestrate";
 const HIDDEN_PRESET_INPUT_KEYS: Record<string, Set<string>> = {
   [JIRA_ORCHESTRATE_PRESET_SLUG]: new Set([
@@ -1333,6 +1337,10 @@ function hasExplicitSkillSelection(skillId: string): boolean {
 
 function isResolverSkill(skillId: string): boolean {
   return PR_RESOLVER_SKILLS.has(skillId.trim().toLowerCase());
+}
+
+function isSelfManagedPublishSkill(skillId: string): boolean {
+  return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
 }
 
 function resolveEffectiveSkillId(
@@ -3306,7 +3314,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const primarySkill = String(steps[0]?.skillId || "")
       .trim()
       .toLowerCase();
-    if (isResolverSkill(primarySkill)) {
+    if (isSelfManagedPublishSkill(primarySkill)) {
       setPublishMode("none");
     }
   }, [steps[0]?.skillId]);
@@ -3826,17 +3834,20 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (
       pageMode.mode === "create" &&
       (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG ||
-        selectedPreset?.slug === JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG)
+        selectedPreset?.slug === JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG ||
+        selectedPreset?.slug === JIRA_ORCHESTRATE_PRESET_SLUG)
     ) {
       setPublishMode("none");
     }
   }, [pageMode.mode, selectedPreset?.slug]);
 
-  const mergeAutomationAvailable = !isResolverSkill(effectiveSkillId);
+  const mergeAutomationAvailable = !isSelfManagedPublishSkill(effectiveSkillId);
 
   useEffect(() => {
     if (!mergeAutomationAvailable && isMergeAutomationPublishMode(publishMode)) {
-      setPublishMode(isResolverSkill(effectiveSkillId) ? "none" : "pr");
+      setPublishMode(
+        isSelfManagedPublishSkill(effectiveSkillId) ? "none" : "pr",
+      );
     }
   }, [effectiveSkillId, mergeAutomationAvailable, publishMode]);
 
@@ -5828,7 +5839,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       appliedTemplates,
     );
     const effectivePublishMode =
-      isResolverSkill(effectiveSubmissionSkillId) && isMergeAutomationPublishMode(publishMode)
+      isSelfManagedPublishSkill(effectiveSubmissionSkillId)
         ? "none"
         : normalizedPublishMode;
     const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions
@@ -6444,7 +6455,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const shouldSubmitMergeAutomation =
       isMergeAutomationPublishMode(publishMode) &&
       effectivePublishMode === "pr" &&
-      !isResolverSkill(effectiveSubmissionSkillId);
+      !isSelfManagedPublishSkill(effectiveSubmissionSkillId);
 
     const taskPayload: Record<string, unknown> = {
       instructions: objectiveInstructionsForSubmit,

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1335,10 +1335,6 @@ function hasExplicitSkillSelection(skillId: string): boolean {
   return normalized !== "" && normalized !== "auto";
 }
 
-function isResolverSkill(skillId: string): boolean {
-  return PR_RESOLVER_SKILLS.has(skillId.trim().toLowerCase());
-}
-
 function isSelfManagedPublishSkill(skillId: string): boolean {
   return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
 }

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -33,8 +33,9 @@ _CONTAINER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"})
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
-_SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
-_FORCED_NONE_PUBLISH_SKILLS = frozenset({"jira-orchestrate"})
+_SELF_MANAGED_PUBLISH_SKILLS = frozenset(
+    {"pr-resolver", "batch-pr-resolver", "jira-orchestrate"}
+)
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
     re.IGNORECASE,
@@ -254,17 +255,10 @@ def is_self_managed_publish_skill(skill_id: object) -> bool:
 
     return _normalize_skill_id(skill_id) in _SELF_MANAGED_PUBLISH_SKILLS
 
-def is_forced_none_publish_skill(skill_id: object) -> bool:
-    """Return True when the selected skill must run without automatic publishing."""
-
-    return _normalize_skill_id(skill_id) in _FORCED_NONE_PUBLISH_SKILLS
-
 def resolve_publish_mode_for_skill(skill_id: object, requested_mode: object) -> str:
     """Resolve publish mode for a skill while enforcing self-managed constraints."""
 
     publish_mode = _normalize_publish_mode(requested_mode)
-    if is_forced_none_publish_skill(skill_id):
-        return "none"
     if is_self_managed_publish_skill(skill_id):
         if publish_mode != "none":
             raise TaskContractError(
@@ -1836,7 +1830,6 @@ __all__ = [
     "build_task_stage_plan",
     "build_canonical_task_view",
     "has_attachment_mutation_fields",
-    "is_forced_none_publish_skill",
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",
     "resolve_publish_mode_for_skill",

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -34,6 +34,7 @@ _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
+_FORCED_NONE_PUBLISH_SKILLS = frozenset({"jira-orchestrate"})
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
     re.IGNORECASE,
@@ -253,10 +254,17 @@ def is_self_managed_publish_skill(skill_id: object) -> bool:
 
     return _normalize_skill_id(skill_id) in _SELF_MANAGED_PUBLISH_SKILLS
 
+def is_forced_none_publish_skill(skill_id: object) -> bool:
+    """Return True when the selected skill must run without automatic publishing."""
+
+    return _normalize_skill_id(skill_id) in _FORCED_NONE_PUBLISH_SKILLS
+
 def resolve_publish_mode_for_skill(skill_id: object, requested_mode: object) -> str:
     """Resolve publish mode for a skill while enforcing self-managed constraints."""
 
     publish_mode = _normalize_publish_mode(requested_mode)
+    if is_forced_none_publish_skill(skill_id):
+        return "none"
     if is_self_managed_publish_skill(skill_id):
         if publish_mode != "none":
             raise TaskContractError(
@@ -1828,6 +1836,7 @@ __all__ = [
     "build_task_stage_plan",
     "build_canonical_task_view",
     "has_attachment_mutation_fields",
+    "is_forced_none_publish_skill",
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",
     "resolve_publish_mode_for_skill",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4181,7 +4181,12 @@ class TemporalAgentRuntimeActivities:
     ) -> str:
         params = parameters if isinstance(parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
-        if selected_skill not in {"jira-issue-creator", "jira-pr-verify", "jira-verify"}:
+        if selected_skill not in {
+            "jira-issue-creator",
+            "jira-issue-updater",
+            "jira-pr-verify",
+            "jira-verify",
+        }:
             return instructions
         if "MoonMind trusted Jira tools" in instructions:
             return instructions
@@ -4209,6 +4214,27 @@ class TemporalAgentRuntimeActivities:
                     "`jira.create_issue`.",
                     "- Treat the task as blocked if Jira tool calls are unavailable "
                     "or no Jira issue key is returned.",
+                ]
+            )
+        elif selected_skill == "jira-issue-updater":
+            tool_lines.extend(
+                [
+                    "- Fetch the Jira issue through `jira.get_issue` when current "
+                    "fields or status are needed.",
+                    "- For status changes, call `jira.get_transitions`, match the "
+                    "target status against transition names or target statuses, "
+                    "then call `jira.transition_issue` with Jira's returned ID.",
+                    "- Example transitions call: "
+                    + '`{"tool":"jira.get_transitions",'
+                    + '"arguments":{"issueKey":"<ISSUE_KEY>",'
+                    + '"expandFields":true}}`.',
+                    "- Example transition call: "
+                    + '`{"tool":"jira.transition_issue",'
+                    + '"arguments":{"issueKey":"<ISSUE_KEY>",'
+                    + '"transitionId":"<TRANSITION_ID>"}}`.',
+                    "- Treat the task as blocked if trusted Jira tool calls are "
+                    "unavailable, the transition is denied, or no matching "
+                    "transition exists.",
                 ]
             )
         elif selected_skill == "jira-pr-verify":

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -66,6 +66,7 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
     RuntimeMaterializationMode,
 )
+from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
@@ -1101,7 +1102,7 @@ def _iter_requested_registry_tools(
         ).strip()
         if not tool_name:
             continue
-        if tool_name.lower() in {"jira-issue-creator", "jira-pr-verify", "jira-verify"}:
+        if tool_name.lower() in JIRA_AGENT_SKILLS:
             continue
         tool_version = str(selected_payload.get("version") or "").strip() or "1.0"
         key = (tool_name, tool_version)
@@ -4181,12 +4182,7 @@ class TemporalAgentRuntimeActivities:
     ) -> str:
         params = parameters if isinstance(parameters, Mapping) else {}
         selected_skill = selected_agent_skill(params)
-        if selected_skill not in {
-            "jira-issue-creator",
-            "jira-issue-updater",
-            "jira-pr-verify",
-            "jira-verify",
-        }:
+        if selected_skill not in JIRA_AGENT_SKILLS:
             return instructions
         if "MoonMind trusted Jira tools" in instructions:
             return instructions
@@ -4220,10 +4216,10 @@ class TemporalAgentRuntimeActivities:
             tool_lines.extend(
                 [
                     "- Fetch the Jira issue through `jira.get_issue` when current "
-                    "fields or status are needed.",
+                    + "fields or status are needed.",
                     "- For status changes, call `jira.get_transitions`, match the "
-                    "target status against transition names or target statuses, "
-                    "then call `jira.transition_issue` with Jira's returned ID.",
+                    + "target status against transition names or target statuses, "
+                    + "then call `jira.transition_issue` with Jira's returned ID.",
                     "- Example transitions call: "
                     + '`{"tool":"jira.get_transitions",'
                     + '"arguments":{"issueKey":"<ISSUE_KEY>",'
@@ -4233,8 +4229,8 @@ class TemporalAgentRuntimeActivities:
                     + '"arguments":{"issueKey":"<ISSUE_KEY>",'
                     + '"transitionId":"<TRANSITION_ID>"}}`.',
                     "- Treat the task as blocked if trusted Jira tool calls are "
-                    "unavailable, the transition is denied, or no matching "
-                    "transition exists.",
+                    + "unavailable, the transition is denied, or no matching "
+                    + "transition exists.",
                 ]
             )
         elif selected_skill == "jira-pr-verify":

--- a/moonmind/workflows/temporal/jira_agent_skills.py
+++ b/moonmind/workflows/temporal/jira_agent_skills.py
@@ -1,0 +1,14 @@
+"""Shared Jira-backed agent skill identifiers for Temporal runtime paths."""
+
+JIRA_AGENT_SKILLS = frozenset(
+    {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
+)
+
+JIRA_BACKED_AGENT_SKILLS = frozenset(
+    {
+        "jira-orchestrate",
+        *JIRA_AGENT_SKILLS,
+    }
+)
+
+__all__ = ["JIRA_AGENT_SKILLS", "JIRA_BACKED_AGENT_SKILLS"]

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -76,6 +76,7 @@ from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
 )
 from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
+from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow as MoonMindRun
 from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
 from moonmind.workflows.temporal.workflows.agent_session import (
@@ -569,9 +570,7 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
         return str(settings.workflow.default_task_runtime or "gemini_cli").strip().lower()
     return normalized
 
-_JIRA_AGENT_SKILLS = frozenset(
-    {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
-)
+_JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _JIRA_STORY_OUTPUT_TOOLS = frozenset(
     {"story.create_jira_issues", "story.create_jira_orchestrate_tasks"}
 )

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -569,7 +569,9 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
         return str(settings.workflow.default_task_runtime or "gemini_cli").strip().lower()
     return normalized
 
-_JIRA_AGENT_SKILLS = frozenset({"jira-issue-creator", "jira-pr-verify", "jira-verify"})
+_JIRA_AGENT_SKILLS = frozenset(
+    {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
+)
 _JIRA_STORY_OUTPUT_TOOLS = frozenset(
     {"story.create_jira_issues", "story.create_jira_orchestrate_tasks"}
 )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -41,6 +41,10 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.agent_skills.selection import selected_agent_skill
     from moonmind.config.settings import settings
     from moonmind.utils.logging import scrub_github_tokens
+    from moonmind.workflows.temporal.jira_agent_skills import (
+        JIRA_AGENT_SKILLS,
+        JIRA_BACKED_AGENT_SKILLS,
+    )
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.tasks.task_contract import (
         build_effective_task_skill_selectors,
@@ -99,17 +103,9 @@ DEPENDENCY_RECONCILE_INTERVAL = timedelta(seconds=30)
 _TERMINAL_LAST_ERROR_UNSET = object()
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
-_PR_OPTIONAL_AGENT_SKILLS = frozenset({"jira-issue-creator", "jira-pr-verify", "jira-verify"})
+_PR_OPTIONAL_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
-_JIRA_BACKED_AGENT_SKILLS = frozenset(
-    {
-        "jira-orchestrate",
-        "jira-issue-updater",
-        "jira-issue-creator",
-        "jira-pr-verify",
-        "jira-verify",
-    }
-)
+_JIRA_BACKED_AGENT_SKILLS = JIRA_BACKED_AGENT_SKILLS
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -820,11 +820,10 @@ def test_create_task_shaped_execution_applies_default_publish_mode(
     assert initial_parameters["publishMode"] == "pr"
     assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
-def test_create_task_shaped_execution_forces_jira_orchestrate_publish_none(
+def test_create_task_shaped_execution_rejects_jira_orchestrate_auto_publish(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
-    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -839,6 +838,36 @@ def test_create_task_shaped_execution_forces_jira_orchestrate_publish_none(
                     "skill": {"id": "jira-orchestrate"},
                     "runtime": {"mode": "codex"},
                     "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["message"] == (
+        "task.publish.mode must be 'none' when using skill 'jira-orchestrate'"
+    )
+    service.create_execution.assert_not_awaited()
+
+def test_create_task_shaped_execution_allows_jira_orchestrate_publish_none(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "none",
+                "task": {
+                    "instructions": "Run Jira Orchestrate for THOR-352.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "skill": {"id": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "publish": {"mode": "none"},
                 },
             },
         },

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -820,6 +820,38 @@ def test_create_task_shaped_execution_applies_default_publish_mode(
     assert initial_parameters["publishMode"] == "pr"
     assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
+def test_create_task_shaped_execution_forces_jira_orchestrate_publish_none(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "task": {
+                    "instructions": "Run Jira Orchestrate for THOR-352.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "skill": {"id": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.call_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["publishMode"] == "none"
+    assert initial_parameters["task"]["publish"]["mode"] == "none"
+    assert initial_parameters["requiredCapabilities"] == []
+
 def test_create_task_shaped_execution_preserves_report_output_contract(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -528,7 +528,8 @@ async def test_default_skill_registry_payload_auto_placeholder_filtered():
     assert ("auto", "1.0") not in keyset
 
 @pytest.mark.parametrize(
-    "skill_name", ["jira-issue-creator", "jira-pr-verify", "jira-verify"]
+    "skill_name",
+    ["jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"],
 )
 async def test_default_skill_registry_payload_excludes_agent_only_jira_skill(
     skill_name: str,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2557,6 +2557,39 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_verify_tool_hin
     assert "Verify KANDY-3607 against this branch." in result
     assert "Managed Codex CLI note:" in result
 
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_adds_jira_issue_updater_tool_hint() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Transition THOR-352 to In Progress.",
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "jira-issue-updater",
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    assert "MoonMind trusted Jira tools:" in result
+    assert "`$MOONMIND_URL`" in result
+    assert "POST $MOONMIND_URL/mcp/tools/call" in result
+    assert "jira.get_issue" in result
+    assert "jira.get_transitions" in result
+    assert "jira.transition_issue" in result
+    assert "Transition THOR-352 to In Progress." in result
+    assert "Managed Codex CLI note:" in result
+
 
 @pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_materializes_selected_skill_snapshot(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1096,6 +1096,38 @@ def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     assert "targetBranch" not in node["inputs"]
     assert "commit your work" not in node["inputs"]["instructions"]
 
+def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_updater():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Transition THOR-352 to In Progress.",
+                "tool": {"type": "skill", "name": "jira-issue-updater"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+    assert node["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert node["inputs"]["selectedSkill"] == "jira-issue-updater"
+    assert node["inputs"]["publishMode"] == "none"
+    assert node["inputs"]["instructions"].startswith("Use $jira-issue-updater.")
+    assert "targetBranch" not in node["inputs"]
+    assert "commit your work" not in node["inputs"]["instructions"]
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_verify():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -529,6 +529,16 @@ class TestJiraAgentPublishHelpers(unittest.TestCase):
 
         self.assertTrue(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
 
+    def test_jira_issue_updater_agent_plan_makes_pr_publish_optional(self) -> None:
+        nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"selectedSkill": "jira-issue-updater"},
+            }
+        ]
+
+        self.assertTrue(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
+
     def test_jira_verify_agent_plan_makes_pr_publish_optional(self) -> None:
         nodes = [
             {


### PR DESCRIPTION
## Summary
- force Jira Orchestrate submissions to publishMode none so the preset owns PR creation instead of parent auto-publish
- treat jira-issue-updater as a Jira-only managed skill with trusted Jira MCP tool hints
- update the Jira updater skill docs and Create page publish/merge automation handling for Jira Orchestrate

## Tests
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --no-xdist
- npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx