### PR TITLE
[codex] Fix create floating bar liquid glass

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -8005,6 +8005,14 @@ describe.skip("Task Create Entrypoint", () => {
       /\.queue-submit-primary-ripple\s*\{[^}]*inset:\s*-0\.7rem;[^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*42%,\s*white\)/s,
     );
     expect(missionControlCss).toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+    );
+    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::before\s*\{/);
+    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::after\s*\{/);
+    expect(missionControlCss).toMatch(
       /\.queue-floating-bar--liquid-glass\[data-liquid-gl-initialized="true"\]\s*>\s*\*\s*\{[^}]*pointer-events:\s*auto;/s,
     );
     expect(missionControlCss).toMatch(
@@ -12191,6 +12199,23 @@ describe.skip("Task Create Entrypoint", () => {
 });
 
 describe("Task Create submit arrow animation", () => {
+  it("keeps fallback sheen off the active liquidGL canvas surface", async () => {
+    const { readFileSync } = await import("node:fs");
+    const css = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      "utf8",
+    );
+
+    expect(css).toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+    );
+    expect(css).toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+    );
+    expect(css).not.toMatch(/\.queue-floating-bar::before\s*\{/);
+    expect(css).not.toMatch(/\.queue-floating-bar::after\s*\{/);
+  });
+
   it("cycles the create arrow out right and back in from the left on hover", async () => {
     const { readFileSync } = await import("node:fs");
     const css = readFileSync(

--- a/frontend/src/lib/liquidGL/useLiquidGL.test.tsx
+++ b/frontend/src/lib/liquidGL/useLiquidGL.test.tsx
@@ -55,6 +55,7 @@ describe("useLiquidGL", () => {
 
     const element = document.querySelector(".liquid-glass-panel");
     expect(element?.getAttribute("data-liquid-gl-initialized")).toBe("true");
+    expect(element?.getAttribute("data-liquid-gl-renderer")).toBe("canvas");
 
     unmount();
 
@@ -90,6 +91,7 @@ describe("useLiquidGL", () => {
 
     const element = document.querySelector<HTMLElement>(".liquid-glass-panel");
     expect(element?.getAttribute("data-liquid-gl-initialized")).toBe("true");
+    expect(element?.getAttribute("data-liquid-gl-renderer")).toBe("canvas");
     expect(element?.style.opacity).toBe("1");
     expect(element?.style.visibility).toBe("visible");
     expect(element?.style.pointerEvents).toBe("auto");
@@ -137,6 +139,7 @@ describe("useLiquidGL", () => {
 
     const element = document.querySelector(".liquid-glass-panel");
     expect(element?.hasAttribute("data-liquid-gl-initialized")).toBe(false);
+    expect(element?.hasAttribute("data-liquid-gl-renderer")).toBe(false);
   });
 
   it("shows the CSS fallback shell when liquidGL initialization fails", async () => {
@@ -166,6 +169,7 @@ describe("useLiquidGL", () => {
 
     const element = document.querySelector(".liquid-glass-panel");
     expect(element?.hasAttribute("data-liquid-gl-initialized")).toBe(false);
+    expect(element?.hasAttribute("data-liquid-gl-renderer")).toBe(false);
     expect((element as HTMLElement | null)?.style.opacity).toBe("1");
     expect((element as HTMLElement | null)?.style.visibility).toBe("visible");
     expect((element as HTMLElement | null)?.style.pointerEvents).toBe("auto");
@@ -261,6 +265,7 @@ describe("useLiquidGL", () => {
     const element = document.querySelector<HTMLElement>(".liquid-glass-panel");
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(element?.getAttribute("data-liquid-gl-initialized")).toBe("true");
+    expect(element?.getAttribute("data-liquid-gl-renderer")).toBe("canvas");
     expect(element?.style.opacity).toBe("1");
   });
 
@@ -307,6 +312,7 @@ describe("useLiquidGL", () => {
     expect(element?.getAttribute("data-liquid-gl-initialized")).toBe(
       "true",
     );
+    expect(element?.getAttribute("data-liquid-gl-renderer")).toBe("canvas");
     expect(element?.style.opacity).toBe("1");
     expect(element?.style.visibility).toBe("visible");
     expect(element?.style.pointerEvents).toBe("auto");
@@ -352,6 +358,7 @@ describe("useLiquidGL", () => {
     const element = document.querySelector<HTMLElement>(".liquid-glass-panel");
     expect(liquidGL).toHaveBeenCalled();
     expect(element?.hasAttribute("data-liquid-gl-initialized")).toBe(false);
+    expect(element?.hasAttribute("data-liquid-gl-renderer")).toBe(false);
     expect(element?.style.opacity).toBe("1");
     expect(element?.style.visibility).toBe("visible");
     expect(element?.style.pointerEvents).toBe("auto");
@@ -398,11 +405,13 @@ describe("useLiquidGL", () => {
       on: expect.objectContaining({ init: expect.any(Function) }),
     });
     expect(target.getAttribute("data-liquid-gl-initialized")).toBe("true");
+    expect(target.getAttribute("data-liquid-gl-renderer")).toBe("canvas");
 
     unmount();
 
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(target.hasAttribute("data-liquid-gl-target-id")).toBe(false);
+    expect(target.hasAttribute("data-liquid-gl-renderer")).toBe(false);
     target.remove();
   });
 
@@ -424,8 +433,10 @@ describe("useLiquidGL", () => {
     });
 
     expect(liquidGL).toHaveBeenCalledTimes(1);
-    expect(document.querySelector(".liquid-glass-panel")?.getAttribute("data-liquid-gl-initialized")).toBe(
+    const element = document.querySelector(".liquid-glass-panel");
+    expect(element?.getAttribute("data-liquid-gl-initialized")).toBe(
       "true",
     );
+    expect(element?.getAttribute("data-liquid-gl-renderer")).toBe("css-fallback");
   });
 });

--- a/frontend/src/lib/liquidGL/useLiquidGL.ts
+++ b/frontend/src/lib/liquidGL/useLiquidGL.ts
@@ -3,12 +3,14 @@ import { useEffect } from "react";
 import { getLiquidGL, type LiquidGLOptions } from "./index";
 
 const INITIALIZED_ATTR = "data-liquid-gl-initialized";
+const RENDERER_ATTR = "data-liquid-gl-renderer";
 const TARGET_ATTR = "data-liquid-gl-target-id";
 const INIT_RETRY_DELAY_MS = 120;
 const INIT_STALL_TIMEOUT_MS = 1800;
 const MAX_INIT_ATTEMPTS = 20;
 
 type LiquidGLInstance = { destroy?: () => void } | HTMLElement;
+type LiquidGLRendererMode = "canvas" | "css-fallback";
 
 type UseLiquidGLArgs = {
   enabled?: boolean;
@@ -57,6 +59,7 @@ export function useLiquidGL({ enabled = true, options }: UseLiquidGLArgs): void 
       });
       liquidGLInstances = [];
       initializedElement?.removeAttribute(INITIALIZED_ATTR);
+      initializedElement?.removeAttribute(RENDERER_ATTR);
       initializedElement = null;
       attributedTargetElement?.removeAttribute(TARGET_ATTR);
       attributedTargetElement = null;
@@ -89,10 +92,14 @@ export function useLiquidGL({ enabled = true, options }: UseLiquidGLArgs): void 
       return `[${TARGET_ATTR}="${targetId}"]`;
     };
 
-    const markInitialized = (element: HTMLElement) => {
+    const markInitialized = (
+      element: HTMLElement,
+      rendererMode: LiquidGLRendererMode,
+    ) => {
       initializedElement = element;
       showFallback(element);
       element.setAttribute(INITIALIZED_ATTR, "true");
+      element.setAttribute(RENDERER_ATTR, rendererMode);
       if (stallTimerId !== null) {
         window.clearTimeout(stallTimerId);
         stallTimerId = null;
@@ -148,7 +155,7 @@ export function useLiquidGL({ enabled = true, options }: UseLiquidGLArgs): void 
                 return;
               }
               didInitialize = true;
-              markInitialized(element);
+              markInitialized(element, "canvas");
               options.on?.init?.(lens);
             },
           },
@@ -176,8 +183,13 @@ export function useLiquidGL({ enabled = true, options }: UseLiquidGLArgs): void 
       const isFallbackResult = liquidGLInstances.every(
         (instance) => instance instanceof HTMLElement,
       );
-      if (isFallbackResult || options.reveal === false) {
-        markInitialized(element);
+      if (isFallbackResult) {
+        markInitialized(element, "css-fallback");
+        return;
+      }
+
+      if (options.reveal === false) {
+        markInitialized(element, "canvas");
         return;
       }
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2922,7 +2922,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
-.queue-floating-bar::before {
+.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -2939,7 +2939,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   z-index: 0;
 }
 
-.queue-floating-bar::after {
+.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::after {
   content: "";
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- Mark liquidGL targets with a renderer mode so CSS can distinguish real canvas rendering from CSS fallback rendering.
- Keep the floating-bar fallback sheen on CSS fallback only, so the active WebGL liquidGL canvas is not masked by pseudo-elements.
- Add focused regression coverage while preserving the newer create-button arrow and shockwave behavior.

## Root Cause
The latest floating-bar sheen was implemented with pseudo-elements on the same target that liquidGL enhances. liquidGL renders its canvas behind the target, so those pseudo-elements could paint above the refraction layer and flatten the liquid-glass effect.

## Validation
- `npm run ui:test -- frontend/src/lib/liquidGL/useLiquidGL.test.tsx frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` (Python suite passed; full Vitest pass surfaced one Task Detail live-log timing failure)
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` (rerun of that failing file passed)
