### PR TITLE
Restore floating bar glass sheen alongside liquidGL canvas

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -8122,13 +8122,11 @@ describe.skip("Task Create Entrypoint", () => {
       /\.queue-submit-primary-ripple\s*\{[^}]*inset:\s*-0\.7rem;[^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*42%,\s*white\)/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
-    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::before\s*\{/);
-    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::after\s*\{/);
     expect(missionControlCss).toMatch(
       /\.queue-floating-bar--liquid-glass\[data-liquid-gl-initialized="true"\]\s*>\s*\*\s*\{[^}]*pointer-events:\s*auto;/s,
     );
@@ -12316,7 +12314,7 @@ describe.skip("Task Create Entrypoint", () => {
 });
 
 describe("Task Create submit arrow animation", () => {
-  it("keeps fallback sheen off the active liquidGL canvas surface", async () => {
+  it("keeps the floating-bar sheen visible alongside the liquidGL canvas surface", async () => {
     const { readFileSync } = await import("node:fs");
     const css = readFileSync(
       `${process.cwd()}/frontend/src/styles/mission-control.css`,
@@ -12324,13 +12322,14 @@ describe("Task Create submit arrow animation", () => {
     );
 
     expect(css).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(css).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
-    expect(css).not.toMatch(/\.queue-floating-bar::before\s*\{/);
-    expect(css).not.toMatch(/\.queue-floating-bar::after\s*\{/);
+    expect(css).not.toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before/,
+    );
   });
 
   it("cycles the create arrow out right and back in from the left on hover", async () => {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2922,7 +2922,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
-.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::before {
+.queue-floating-bar::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -2939,7 +2939,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   z-index: 0;
 }
 
-.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::after {
+.queue-floating-bar::after {
   content: "";
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- PR #1896 gated the `.queue-floating-bar` `::before`/`::after` sheen behind `:not([data-liquid-gl-renderer="canvas"])`, suppressing the pseudo-elements whenever liquidGL initialized — on the theory that they would flatten the WebGL refraction.
- liquidGL also strips the bar's own `background` and `backdrop-filter` on init (vendor sets them to transparent / `none`). The WebGL refraction alone (heavy `frost: 6` over the dark page) is too subtle to register as glass, so with the sheen suppressed the bar reads as fully transparent and underlying card content bleeds through (per the user's screenshot from v20260503.2361).
- Drop the renderer-mode gate so the diagonal sheen and inset edge highlight render at all times. WebGL provides the refraction; CSS provides the visible glass character — they're complementary, not exclusive. The `data-liquid-gl-renderer` attribute is still set in `useLiquidGL.ts` (cheap, possibly useful later).

## Root Cause
PR #1896's premise — that the sheen "flattens" the liquidGL output — inverted the actual relationship: PR #1894 added the sheen *because* liquidGL nullifies the bar's intrinsic backdrop. Hiding it whenever the canvas renderer is active just brings back the same flat-bar regression #1894 was meant to fix.

## Test plan
- [x] `vitest run frontend/src/lib/liquidGL/useLiquidGL.test.tsx frontend/src/entrypoints/task-create.test.tsx` — 20 passed
- [x] `vitest run frontend/src/entrypoints/mission-control.test.tsx` — 30 passed
- [x] `tsc --noEmit -p frontend/tsconfig.json` — clean
- [ ] Visual check: floating bar shows diagonal sheen + inset edge highlight on the create page in the next preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)