### PR TITLE
Why when I expand the Jira Orchestrate preset does my publish mode selector drop the option for PR with Merge Automation?

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,62 +1,22 @@
 [
   {
-    "id": 4366838058,
+    "id": 4367289597,
     "disposition": "not-applicable",
-    "rationale": "Qodo free-tier notice is informational and contains no code feedback."
+    "rationale": "Qodo quota notice; no code action requested."
   },
   {
-    "id": 3178553694,
+    "id": 3178846598,
     "disposition": "addressed",
-    "rationale": "Moved jira-orchestrate into the self-managed publish set so non-none publish modes fail fast instead of being silently coerced."
+    "rationale": "Self-managed publish skills now force any selected publish mode to none and disable the Publish Mode selector."
   },
   {
-    "id": 3178553698,
+    "id": 3178846599,
     "disposition": "addressed",
-    "rationale": "Removed the forced-none publish helper in favor of consolidated self-managed publish enforcement."
+    "rationale": "The PR with Merge Automation option remains visible and disabled when merge automation is unavailable."
   },
   {
-    "id": 3178553699,
+    "id": 4216908391,
     "disposition": "addressed",
-    "rationale": "Removed the hidden publish-mode override path; invalid jira-orchestrate publish modes now raise TaskContractError."
-  },
-  {
-    "id": 3178553700,
-    "disposition": "addressed",
-    "rationale": "Removed is_forced_none_publish_skill from the module exports."
-  },
-  {
-    "id": 3178553701,
-    "disposition": "addressed",
-    "rationale": "Added shared Jira agent skill constants and reused them in activity, worker, and workflow runtime paths."
-  },
-  {
-    "id": 4216664516,
-    "disposition": "not-applicable",
-    "rationale": "Review summary comment; individual actionable findings were handled separately."
-  },
-  {
-    "id": 3178555326,
-    "disposition": "addressed",
-    "rationale": "Replaced the first jira-issue-updater hint's implicit string literal concatenation with explicit concatenation."
-  },
-  {
-    "id": 3178555328,
-    "disposition": "addressed",
-    "rationale": "Replaced the status-change hint's implicit string literal concatenation with explicit concatenation."
-  },
-  {
-    "id": 3178555329,
-    "disposition": "addressed",
-    "rationale": "Replaced the blocked-state hint's implicit string literal concatenation with explicit concatenation."
-  },
-  {
-    "id": 3178561208,
-    "disposition": "addressed",
-    "rationale": "Classified jira-issue-updater as PR-optional in MoonMindRunWorkflow plan analysis and added regression coverage."
-  },
-  {
-    "id": 4216669780,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper comment; the actionable inline finding was handled separately."
+    "rationale": "Summary review concerns are covered by the self-managed forced-none enforcement and disabled merge automation option."
   }
 ]

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -392,7 +392,7 @@ Rules:
 8. Raw JSON remains available as an advanced fallback for unsupported schemas, descriptor failures, and power users.
 9. Skill schemas must not be treated as a place to store secrets.
 10. Runtime adapters must not broaden the selected Skill set during execution. Runtime materialization uses the resolved Skill snapshot.
-11. Resolver-style Skills such as `pr-resolver` or `batch-pr-resolver` may enforce publish constraints. When a Skill owns commit/push/merge behavior, the Create page must require or force `publishMode = "none"` and must not also submit ordinary merge automation.
+11. Resolver-style Skills such as `pr-resolver` or `batch-pr-resolver`, and self-managed publish presets such as Jira Orchestrate, may enforce publish constraints. When a Skill or expanded Preset owns commit/push/merge behavior, the Create page must require or force `publishMode = "none"`, explain that constraint in the publish control or apply feedback, and must not also submit ordinary merge automation.
 
 Representative Skill payload:
 
@@ -624,7 +624,7 @@ Rules:
 9. The Create page does not author a separate target branch.
 10. Cross-branch publishing remains a broader task-publishing capability, not an ordinary Create-page control.
 11. Merge automation is available only for applicable `publishMode = "pr"` tasks.
-12. Merge automation is hidden or disabled when the selected Skill owns merge/publish behavior, such as `pr-resolver` or `batch-pr-resolver`.
+12. Merge automation is hidden or disabled when the selected Skill or expanded Preset owns merge/publish behavior, such as `pr-resolver`, `batch-pr-resolver`, or Jira Orchestrate. The Publish Mode control should make the forced-None reason discoverable instead of silently removing the PR-with-merge choice.
 13. Merge automation copy must explain that MoonMind waits for readiness and uses resolver behavior. It must not imply unsafe direct auto-merge.
 
 ---

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -290,7 +290,9 @@ describe("Task Create Step Type authoring", () => {
     expect(screen.getByDisplayValue("Keep first manual skill.")).toBeTruthy();
     expect(screen.getByDisplayValue("Keep trailing skill.")).toBeTruthy();
     expect(
-      await screen.findByText("Applied preset 'Jira Orchestrate' (2 steps)."),
+      await screen.findByText(
+        /Applied preset 'Jira Orchestrate' \(2 steps\)\. .*Publish Mode is forced to None/,
+      ),
     ).toBeTruthy();
 
     const renderedSteps = Array.from(

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6111,11 +6111,17 @@ describe.skip("Task Create Entrypoint", () => {
     });
     await clickApplyButton();
     await screen.findByDisplayValue("Transition THOR-352 to In Progress.");
+    await screen.findByText(
+      /Jira Orchestrate manages its own PR\/publish flow, so Publish Mode is forced to None and merge automation is unavailable\./,
+    );
 
     const publishSelect = screen.getByLabelText(
       "Publish Mode",
     ) as HTMLSelectElement;
     expect(publishSelect.value).toBe("none");
+    expect(publishSelect.getAttribute("title")).toBe(
+      "Publishing is forced to None because the selected preset or resolver manages its own publish flow",
+    );
     expect(
       Array.from(publishSelect.options).some(
         (option) => option.value === "pr_with_merge_automation",

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6122,11 +6122,12 @@ describe.skip("Task Create Entrypoint", () => {
     expect(publishSelect.getAttribute("title")).toBe(
       "Publishing is forced to None because the selected preset or resolver manages its own publish flow",
     );
-    expect(
-      Array.from(publishSelect.options).some(
-        (option) => option.value === "pr_with_merge_automation",
-      ),
-    ).toBe(false);
+    expect(publishSelect.disabled).toBe(true);
+    const mergeAutomationOption = Array.from(publishSelect.options).find(
+      (option) => option.value === "pr_with_merge_automation",
+    );
+    expect(mergeAutomationOption).toBeTruthy();
+    expect(mergeAutomationOption?.disabled).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -6793,6 +6794,9 @@ describe.skip("Task Create Entrypoint", () => {
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
       ).toBe("none");
     });
+    expect(
+      (screen.getByLabelText("Publish Mode") as HTMLSelectElement).disabled,
+    ).toBe(true);
     fireEvent.change(
       within(primaryStep as HTMLElement).getByLabelText("Instructions"),
       {
@@ -6814,7 +6818,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(payload).not.toHaveProperty("mergeAutomation");
   });
 
-  it("hides merge automation when the effective template skill is a resolver", async () => {
+  it("disables merge automation when the effective template skill is a resolver", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     fireEvent.change(await screen.findByLabelText("Publish Mode"), {
@@ -6843,6 +6847,15 @@ describe.skip("Task Create Entrypoint", () => {
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
       ).toBe("none");
     });
+    const publishModeAfterPreset = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(publishModeAfterPreset.disabled).toBe(true);
+    expect(
+      Array.from(publishModeAfterPreset.options).find(
+        (option) => option.value === "pr_with_merge_automation",
+      )?.disabled,
+    ).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -5434,8 +5434,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       expansion.warnings.length > 0
         ? ` ${expansion.warnings.join(" ")}`
         : "";
+    const publishConstraintSuffix = isSelfManagedPublishSkill(
+      String(expansion.appliedTemplate?.slug || preset.slug),
+    )
+      ? ` ${preset.title} manages its own PR/publish flow, so Publish Mode is forced to None and merge automation is unavailable.`
+      : "";
     setMessage(
-      `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}${warningSuffix}`,
+      `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}${warningSuffix}${publishConstraintSuffix}`,
     );
   }
 
@@ -6712,7 +6717,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       ? branchStatusMessage ||
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the task starts";
-  const publishModeTooltip = "Select how MoonMind publishes task changes";
+  const publishModeTooltip = !mergeAutomationAvailable
+    ? "Publishing is forced to None because the selected preset or resolver manages its own publish flow"
+    : "Select how MoonMind publishes task changes";
   const expandStepPresetTooltip =
     "Expand the selected preset into editable steps at this position";
   const modeLoadError =

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3840,12 +3840,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const mergeAutomationAvailable = !isSelfManagedPublishSkill(effectiveSkillId);
 
   useEffect(() => {
-    if (!mergeAutomationAvailable && isMergeAutomationPublishMode(publishMode)) {
-      setPublishMode(
-        isSelfManagedPublishSkill(effectiveSkillId) ? "none" : "pr",
-      );
+    if (!mergeAutomationAvailable && publishMode !== "none") {
+      setPublishMode("none");
     }
-  }, [effectiveSkillId, mergeAutomationAvailable, publishMode]);
+  }, [mergeAutomationAvailable, publishMode]);
 
   const availableDependencyOptions = useMemo(
     () =>
@@ -8268,15 +8266,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 title={publishModeTooltip}
                 value={publishMode}
                 onChange={(event) => setPublishMode(event.target.value)}
+                disabled={!mergeAutomationAvailable}
               >
                 <option value="none">None</option>
                 <option value="branch">Branch</option>
                 <option value="pr">PR</option>
-                {mergeAutomationAvailable ? (
-                  <option value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}>
-                    PR with Merge Automation
-                  </option>
-                ) : null}
+                <option
+                  value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}
+                  disabled={!mergeAutomationAvailable}
+                >
+                  PR with Merge Automation
+                </option>
               </select>
             </div>
             <button


### PR DESCRIPTION
Why when I expand the Jira Orchestrate preset does my publish mode selector drop the option for PR with Merge Automation?