### PR TITLE
[codex] Fix liquid glass snapshot rendering

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,17 @@
 [
   {
-    "id": 4367289597,
+    "id": 4369054821,
     "disposition": "not-applicable",
-    "rationale": "Qodo quota notice; no code action requested."
+    "rationale": "Qodo free-tier limit notice is informational and does not request a code change."
   },
   {
-    "id": 3178846598,
+    "id": 3179986518,
     "disposition": "addressed",
-    "rationale": "Self-managed publish skills now force any selected publish mode to none and disable the Publish Mode selector."
+    "rationale": "Updated sanitizeCloneForHtml2Canvas to iterate clonedDocument.querySelectorAll('*') directly and avoid redundant root processing and Array.from conversion."
   },
   {
-    "id": 3178846599,
-    "disposition": "addressed",
-    "rationale": "The PR with Merge Automation option remains visible and disabled when merge automation is unavailable."
-  },
-  {
-    "id": 4216908391,
-    "disposition": "addressed",
-    "rationale": "Summary review concerns are covered by the self-managed forced-none enforcement and disabled merge automation option."
+    "id": 4218140747,
+    "disposition": "not-applicable",
+    "rationale": "Review summary only; the actionable inline optimization comment from the same review was addressed."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -8141,11 +8141,13 @@ describe.skip("Task Create Entrypoint", () => {
       /\.queue-submit-primary-ripple\s*\{[^}]*inset:\s*-0\.7rem;[^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*42%,\s*white\)/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
+    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::before\s*\{/);
+    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::after\s*\{/);
     expect(missionControlCss).toMatch(
       /\.queue-floating-bar--liquid-glass\[data-liquid-gl-initialized="true"\]\s*>\s*\*\s*\{[^}]*pointer-events:\s*auto;/s,
     );
@@ -12333,7 +12335,7 @@ describe.skip("Task Create Entrypoint", () => {
 });
 
 describe("Task Create submit arrow animation", () => {
-  it("keeps the floating-bar sheen visible alongside the liquidGL canvas surface", async () => {
+  it("keeps fallback sheen off the active liquidGL canvas surface", async () => {
     const { readFileSync } = await import("node:fs");
     const css = readFileSync(
       `${process.cwd()}/frontend/src/styles/mission-control.css`,
@@ -12341,14 +12343,13 @@ describe("Task Create submit arrow animation", () => {
     );
 
     expect(css).toMatch(
-      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(css).toMatch(
-      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
-    expect(css).not.toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before/,
-    );
+    expect(css).not.toMatch(/\.queue-floating-bar::before\s*\{/);
+    expect(css).not.toMatch(/\.queue-floating-bar::after\s*\{/);
   });
 
   it("cycles the create arrow out right and back in from the left on hover", async () => {

--- a/frontend/src/lib/liquidGL/liquidGL.vendor.js
+++ b/frontend/src/lib/liquidGL/liquidGL.vendor.js
@@ -20,6 +20,113 @@
     };
   }
 
+  const HTML2CANVAS_COLOR_PROPS = [
+    ["color", "color"],
+    ["backgroundColor", "background-color"],
+    ["backgroundImage", "background-image"],
+    ["borderTopColor", "border-top-color"],
+    ["borderRightColor", "border-right-color"],
+    ["borderBottomColor", "border-bottom-color"],
+    ["borderLeftColor", "border-left-color"],
+    ["boxShadow", "box-shadow"],
+    ["textShadow", "text-shadow"],
+    ["outlineColor", "outline-color"],
+    ["textDecorationColor", "text-decoration-color"],
+    ["caretColor", "caret-color"],
+    ["columnRuleColor", "column-rule-color"],
+    ["fill", "fill"],
+    ["stroke", "stroke"],
+  ];
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function parseCssColorChannel(value) {
+    const text = String(value || "").trim();
+    if (!text || text === "none") return null;
+    if (text.endsWith("%")) {
+      const percent = Number.parseFloat(text);
+      return Number.isFinite(percent)
+        ? clamp(Math.round((percent / 100) * 255), 0, 255)
+        : null;
+    }
+    const number = Number.parseFloat(text);
+    if (!Number.isFinite(number)) return null;
+    return clamp(Math.round(number <= 1 ? number * 255 : number), 0, 255);
+  }
+
+  function parseCssAlphaChannel(value) {
+    const text = String(value || "").trim();
+    if (!text || text === "none") return 1;
+    if (text.endsWith("%")) {
+      const percent = Number.parseFloat(text);
+      return Number.isFinite(percent) ? clamp(percent / 100, 0, 1) : 1;
+    }
+    const number = Number.parseFloat(text);
+    return Number.isFinite(number) ? clamp(number, 0, 1) : 1;
+  }
+
+  function colorFunctionToRgba(_match, _space, body) {
+    const [channelText, alphaText] = String(body || "").split("/");
+    const channels = channelText.trim().split(/\s+/).filter(Boolean);
+    if (channels.length < 3) return "rgba(255, 255, 255, 1)";
+
+    const r = parseCssColorChannel(channels[0]);
+    const g = parseCssColorChannel(channels[1]);
+    const b = parseCssColorChannel(channels[2]);
+    if (r === null || g === null || b === null) {
+      return "rgba(255, 255, 255, 1)";
+    }
+
+    const alpha = parseCssAlphaChannel(alphaText);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  function html2CanvasFallbackValue(propName, value) {
+    if (/backgroundImage|boxShadow|textShadow/.test(propName)) {
+      return "none";
+    }
+    if (/Color|color|fill|stroke|caretColor/.test(propName)) {
+      return value.includes("transparent")
+        ? "rgba(0, 0, 0, 0)"
+        : "rgba(255, 255, 255, 1)";
+    }
+    return value;
+  }
+
+  function sanitizeHtml2CanvasColorValue(propName, value) {
+    if (!value || typeof value !== "string") return value;
+    let sanitized = value.replace(
+      /color\(\s*([a-z0-9-]+)\s+([^)]*)\)/gi,
+      colorFunctionToRgba
+    );
+    if (/color-mix\(|oklch\(|oklab\(|lch\(|lab\(/i.test(sanitized)) {
+      sanitized = html2CanvasFallbackValue(propName, sanitized);
+    }
+    return sanitized;
+  }
+
+  function sanitizeCloneForHtml2Canvas(clonedDocument) {
+    const view = clonedDocument.defaultView;
+    if (!view) return;
+    const nodes = [clonedDocument.documentElement].concat(
+      Array.from(clonedDocument.querySelectorAll("*"))
+    );
+
+    nodes.forEach((node) => {
+      if (!node || !node.style) return;
+      const style = view.getComputedStyle(node);
+      HTML2CANVAS_COLOR_PROPS.forEach(([propName, cssName]) => {
+        const value = style.getPropertyValue(cssName);
+        const sanitized = sanitizeHtml2CanvasColorValue(propName, value);
+        if (sanitized && sanitized !== value) {
+          node.style[propName] = sanitized;
+        }
+      });
+    });
+  }
+
   /* --------------------------------------------------
    *  Helper : Effective z-index (highest stacking context)
    * ------------------------------------------------*/
@@ -669,6 +776,7 @@
             scrollY: 0,
             scale: scale,
             ignoreElements: ignoreElementsFunc,
+            onclone: sanitizeCloneForHtml2Canvas,
           });
 
           this._uploadTexture(snapCanvas);
@@ -1118,6 +1226,7 @@
             logging: false,
             ignoreElements: (n) =>
               n.tagName === "CANVAS" || n.hasAttribute("data-liquid-ignore"),
+            onclone: sanitizeCloneForHtml2Canvas,
           })
             .then((cv) => {
               if (cv.width > 0 && cv.height > 0) {

--- a/frontend/src/lib/liquidGL/liquidGL.vendor.js
+++ b/frontend/src/lib/liquidGL/liquidGL.vendor.js
@@ -110,11 +110,8 @@
   function sanitizeCloneForHtml2Canvas(clonedDocument) {
     const view = clonedDocument.defaultView;
     if (!view) return;
-    const nodes = [clonedDocument.documentElement].concat(
-      Array.from(clonedDocument.querySelectorAll("*"))
-    );
 
-    nodes.forEach((node) => {
+    clonedDocument.querySelectorAll("*").forEach((node) => {
       if (!node || !node.style) return;
       const style = view.getComputedStyle(node);
       HTML2CANVAS_COLOR_PROPS.forEach(([propName, cssName]) => {

--- a/frontend/src/lib/liquidGL/liquidGL.vendor.test.ts
+++ b/frontend/src/lib/liquidGL/liquidGL.vendor.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("liquidGL vendor html2canvas integration", () => {
+  it("sanitizes modern CSS color functions before html2canvas parses snapshots", () => {
+    const source = readFileSync(
+      `${process.cwd()}/frontend/src/lib/liquidGL/liquidGL.vendor.js`,
+      "utf8",
+    );
+
+    expect(source).toContain("function sanitizeCloneForHtml2Canvas");
+    expect(source).toContain("colorFunctionToRgba");
+    expect(source).toContain("color-mix\\(");
+    expect(source.match(/onclone:\s*sanitizeCloneForHtml2Canvas/g)).toHaveLength(
+      2,
+    );
+  });
+});

--- a/frontend/src/lib/liquidGL/liquidGL.vendor.test.ts
+++ b/frontend/src/lib/liquidGL/liquidGL.vendor.test.ts
@@ -12,6 +12,8 @@ describe("liquidGL vendor html2canvas integration", () => {
     expect(source).toContain("function sanitizeCloneForHtml2Canvas");
     expect(source).toContain("colorFunctionToRgba");
     expect(source).toContain("color-mix\\(");
+    expect(source).toContain('clonedDocument.querySelectorAll("*").forEach');
+    expect(source).not.toContain("Array.from(clonedDocument.querySelectorAll");
     expect(source.match(/onclone:\s*sanitizeCloneForHtml2Canvas/g)).toHaveLength(
       2,
     );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2922,7 +2922,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
-.queue-floating-bar::before {
+.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -2939,7 +2939,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   z-index: 0;
 }
 
-.queue-floating-bar::after {
+.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::after {
   content: "";
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- sanitize liquidGL html2canvas snapshot clones so computed `color(srgb ...)` values do not crash snapshot capture
- keep fallback floating-bar sheen off the active liquidGL canvas renderer so the real refraction is not clouded over
- add regression coverage for the html2canvas sanitizer and Create-page liquidGL layering contract

## Root Cause
`html2canvas` 1.4.1 cannot parse modern browser-computed `color(...)` values produced from MoonMind `color-mix(...)` CSS. liquidGL depends on html2canvas snapshots, so every snapshot attempt failed before WebGL had a texture to refract.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/liquidGL/useLiquidGL.test.tsx frontend/src/lib/liquidGL/liquidGL.vendor.test.ts`
- `npm run ui:test -- frontend/src/lib/liquidGL/liquidGL.vendor.test.ts`
- `npm run ui:build`
- `npm run ui:typecheck`

Note: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/liquidGL/useLiquidGL.test.tsx` was started, but the wrapper expanded into the full Python unit suite and stalled in unrelated runtime-session tests near the tail; I terminated that stale process and used focused UI verification for this UI-only fix.