### PR TITLE
Codex Auth button should say OAuth instead on the Settings page with provider profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MoonMind is an open-source platform that orchestrates leading AI agents out of t
 5. Open [http://localhost:8000/tasks](http://localhost:8000/tasks)
 6. In Settings:
     - Add a GitHub personal access token
-    - Add an API key or click Auth to authenticate a provider profile
+    - Add an API key or click OAuth to authenticate a provider profile
     - Configure any other secrets or setting you want to adjust for your first task
 7. Click Create and submit a task!
 
@@ -30,7 +30,7 @@ MoonMind is an open-source platform that orchestrates leading AI agents out of t
 If you already have a subscription with a model provider:
 
 1. Go to Settings
-2. Click Auth next to the profile
+2. Click OAuth next to the profile
 3. Follow the instructions on the new tab
 4. Go back to Settings and click Finalize
 

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -517,7 +517,7 @@ describe('ProviderProfilesManager form controls', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('starts a Codex OAuth session from the profile Auth action', async () => {
+  it('starts a Codex OAuth session from the profile OAuth action', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -532,7 +532,7 @@ describe('ProviderProfilesManager form controls', () => {
 
     renderProviderProfilesManager([codexOauthProfile]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Auth codex-oauth' }));
+    fireEvent.click(screen.getByRole('button', { name: 'OAuth codex-oauth' }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -577,7 +577,7 @@ describe('ProviderProfilesManager form controls', () => {
     const { queryClient } = renderProviderProfilesManager([codexOauthProfile]);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Auth codex-oauth' }));
+    fireEvent.click(screen.getByRole('button', { name: 'OAuth codex-oauth' }));
 
     expect(await screen.findByText('OAuth: Awaiting User')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Finalize codex-oauth' }));
@@ -620,7 +620,7 @@ describe('ProviderProfilesManager form controls', () => {
 
     renderProviderProfilesManager([codexOauthProfile]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Auth codex-oauth' }));
+    fireEvent.click(screen.getByRole('button', { name: 'OAuth codex-oauth' }));
 
     expect(await screen.findByText('OAuth: Failed')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Retry codex-oauth' }));
@@ -637,7 +637,7 @@ describe('ProviderProfilesManager form controls', () => {
 
     expect(screen.getByRole('button', { name: 'Connect with Claude OAuth claude-anthropic' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Use Anthropic API key claude-anthropic' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Auth claude-anthropic' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'OAuth claude-anthropic' })).toBeNull();
     expect(screen.getByText('Claude credentials not connected')).toBeTruthy();
   });
 
@@ -652,7 +652,7 @@ describe('ProviderProfilesManager form controls', () => {
     ).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Validate OAuth claude-anthropic-connected' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Disconnect OAuth claude-anthropic-connected' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Auth claude-anthropic-connected' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'OAuth claude-anthropic-connected' })).toBeNull();
     expect(screen.getByText('Claude OAuth ready')).toBeTruthy();
   });
 

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1390,9 +1390,9 @@ export function ProviderProfilesManager({
                           className="rounded-full border border-emerald-300 dark:border-emerald-700 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 transition hover:border-emerald-500 dark:hover:border-emerald-500"
                           onClick={() => startOAuthMutation.mutate(profile)}
                           disabled={startOAuthMutation.isPending}
-                          aria-label={`Auth ${profile.profile_id}`}
+                          aria-label={`OAuth ${profile.profile_id}`}
                         >
-                          Auth
+                          OAuth
                         </button>
                       ) : null}
                       {authModel.kind === 'claude_credentials'


### PR DESCRIPTION
Codex Auth button should say OAuth instead on the Settings page with provider profiles