### PR TITLE
[codex] Restore create liquid glass sheen

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -8222,13 +8222,14 @@ describe.skip("Task Create Entrypoint", () => {
       /\.queue-submit-primary-ripple\s*\{[^}]*inset:\s*-0\.7rem;[^}]*color-mix\(in srgb,\s*rgb\(var\(--mm-action-primary\)\)\s*42%,\s*white\)/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
-    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::before\s*\{/);
-    expect(missionControlCss).not.toMatch(/\.queue-floating-bar::after\s*\{/);
+    expect(missionControlCss).not.toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before/,
+    );
     expect(missionControlCss).toMatch(
       /\.queue-floating-bar--liquid-glass\[data-liquid-gl-initialized="true"\]\s*>\s*\*\s*\{[^}]*pointer-events:\s*auto;/s,
     );
@@ -12414,7 +12415,7 @@ describe.skip("Task Create Entrypoint", () => {
 });
 
 describe("Task Create submit arrow animation", () => {
-  it("keeps fallback sheen off the active liquidGL canvas surface", async () => {
+  it("keeps the floating-bar sheen visible alongside the liquidGL canvas surface", async () => {
     const { readFileSync } = await import("node:fs");
     const css = readFileSync(
       `${process.cwd()}/frontend/src/styles/mission-control.css`,
@@ -12422,13 +12423,14 @@ describe("Task Create submit arrow animation", () => {
     );
 
     expect(css).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before\s*\{[^}]*background:\s*linear-gradient/s,
+      /\.queue-floating-bar::before\s*\{[^}]*background:\s*linear-gradient/s,
     );
     expect(css).toMatch(
-      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
+      /\.queue-floating-bar::after\s*\{[^}]*box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.32\)/s,
     );
-    expect(css).not.toMatch(/\.queue-floating-bar::before\s*\{/);
-    expect(css).not.toMatch(/\.queue-floating-bar::after\s*\{/);
+    expect(css).not.toMatch(
+      /\.queue-floating-bar:not\(\[data-liquid-gl-renderer="canvas"\]\)::before/,
+    );
   });
 
   it("cycles the create arrow out right and back in from the left on hover", async () => {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2922,7 +2922,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   isolation: isolate;
 }
 
-.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::before {
+.queue-floating-bar::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -2939,7 +2939,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   z-index: 0;
 }
 
-.queue-floating-bar:not([data-liquid-gl-renderer="canvas"])::after {
+.queue-floating-bar::after {
   content: "";
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- Keep the Create page floating bar sheen and inset edge highlights visible even after liquidGL initializes with the canvas renderer.
- Update Create page regression coverage so the sheen cannot be gated off by `data-liquid-gl-renderer="canvas"` again.

## Root Cause
The recent renderer-mode gate hid `.queue-floating-bar::before` and `::after` whenever liquidGL reported a canvas renderer. liquidGL also clears the target element's own background and backdrop-filter during initialization, so removing those pseudo-elements made the bar read as transparent instead of liquid glass.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/liquidGL/useLiquidGL.test.tsx frontend/src/lib/liquidGL/liquidGL.vendor.test.ts`
- `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:build`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Note: I also attempted the browser E2E smoke test, but this environment is missing the Playwright Chromium binary, so Chromium could not launch.