### PR TITLE
I do not want the box to be labeled "Step 1 Instructions" when you choose skill on the create task page. It should just be labeled "Instructions".

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,12 @@
 [
   {
-    "id": 3183649166,
+    "id": 3184131746,
     "disposition": "addressed",
-    "rationale": "Removed the CSS :active selector from the arrow-exit animation so click exit is driven only by React state."
+    "rationale": "Extracted the preset/skill instruction-label decision into usesGenericInstructionsLabel(stepType)."
   },
   {
-    "id": 3183649177,
-    "disposition": "addressed",
-    "rationale": "Updated the CSS test to reuse a suite-level CSS fixture and assert the state-driven selector without :active."
-  },
-  {
-    "id": 4222500444,
+    "id": 4223053049,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable :active selector and redundant test fixture items are covered by the linked review comments."
-  },
-  {
-    "id": 3183656357,
-    "disposition": "addressed",
-    "rationale": "Cleared arrow-exit state when the exit animation is canceled and when submission or form-blocked state changes."
-  },
-  {
-    "id": 4222510205,
-    "disposition": "not-applicable",
-    "rationale": "Codex review wrapper text only; no standalone code change requested beyond the actionable review comment."
+    "rationale": "Top-level review summary only; its actionable suggestion is covered by review comment 3184131746."
   }
 ]

--- a/frontend/src/entrypoints/task-create-step-type.test.tsx
+++ b/frontend/src/entrypoints/task-create-step-type.test.tsx
@@ -209,7 +209,7 @@ describe("Task Create Step Type authoring", () => {
       within(primaryStep).getByLabelText("Step 1 Skill Args (optional JSON object)"),
       { target: { value: '{"issueKey":"MM-568"}' } },
     );
-    fireEvent.change(within(primaryStep).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(primaryStep).getByLabelText("Instructions"), {
       target: { value: "Keep these shared instructions." },
     });
 
@@ -259,10 +259,10 @@ describe("Task Create Step Type authoring", () => {
       "section",
     ) as HTMLElement;
 
-    fireEvent.change(within(firstStep).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(firstStep).getByLabelText("Instructions"), {
       target: { value: "Keep first manual skill." },
     });
-    fireEvent.change(within(thirdStep).getByLabelText("Step 3 Instructions"), {
+    fireEvent.change(within(thirdStep).getByLabelText("Instructions"), {
       target: { value: "Keep trailing skill." },
     });
     selectStepType(secondStep, "Preset");
@@ -303,19 +303,19 @@ describe("Task Create Step Type authoring", () => {
       throw new Error("Expected four rendered steps after preset expansion.");
     }
     expect(
-      (within(renderedFirst).getByLabelText("Step 1 Instructions") as HTMLTextAreaElement)
+      (within(renderedFirst).getByLabelText("Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep first manual skill.");
     expect(
-      (within(renderedSecond).getByLabelText("Step 2 Instructions") as HTMLTextAreaElement)
+      (within(renderedSecond).getByLabelText("Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Read the selected Jira issue.");
     expect(
-      (within(renderedThird).getByLabelText("Step 3 Instructions") as HTMLTextAreaElement)
+      (within(renderedThird).getByLabelText("Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Implement the selected Jira issue.");
     expect(
-      (within(renderedFourth).getByLabelText("Step 4 Instructions") as HTMLTextAreaElement)
+      (within(renderedFourth).getByLabelText("Instructions") as HTMLTextAreaElement)
         .value,
     ).toBe("Keep trailing skill.");
   });

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12733,7 +12733,7 @@ describe("Task Create MM-578 Preset expansion", () => {
     const step = (await screen.findByText("Step 1")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Keep authored MM-578 preset placeholder." },
     });
     selectStepType(step, "Preset");
@@ -12846,7 +12846,7 @@ describe("Task Create MM-578 Preset expansion", () => {
     const step = (await screen.findByText("Step 1")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Keep unresolved MM-578 preset placeholder." },
     });
     await chooseMm578Preset(step);
@@ -13002,7 +13002,7 @@ describe("Task Create MM-578 Preset expansion", () => {
     const step = (await screen.findByText("Step 1")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Create a regular task." },
     });
     const createButton = screen.getByRole("button", { name: "Create" });
@@ -13264,7 +13264,7 @@ describe("Task Create MM-578 Preset expansion", () => {
     const step = (await screen.findByText("Step 1")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Keep authored MM-578 preset step." },
     });
     selectStepType(step, "Preset");
@@ -13461,7 +13461,7 @@ describe("Task Create governed Tool authoring", () => {
       "section",
     ) as HTMLElement;
     selectStepType(step, "Skill");
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Implement MM-577 with the agentic Skill workflow." },
     });
     fireEvent.change(within(step).getByLabelText(/Skill \(optional\)/), {
@@ -13533,7 +13533,7 @@ describe("Task Create governed Tool authoring", () => {
     const step = (await screen.findByText("Step 1")).closest(
       "section",
     ) as HTMLElement;
-    fireEvent.change(within(step).getByLabelText("Step 1 Instructions"), {
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
       target: { value: "Transition MM-576 through trusted Jira." },
     });
     selectStepType(step, "Tool");

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7654,7 +7654,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <div className="stack">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
-                        {step.stepType === "preset"
+                        {step.stepType === "preset" || step.stepType === "skill"
                           ? "Instructions"
                           : `Step ${index + 1} Instructions`}
                       </label>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -576,6 +576,10 @@ const STEP_TYPE_OPTIONS: Array<{
   { value: "preset", label: "Preset", Icon: PresetLayersIcon },
 ];
 
+function usesGenericInstructionsLabel(stepType: StepType): boolean {
+  return stepType === "preset" || stepType === "skill";
+}
+
 interface StepState {
   localId: string;
   id: string;
@@ -7654,7 +7658,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <div className="stack">
                     <div className="queue-field-heading">
                       <label htmlFor={`queue-step-instructions-${step.localId}`}>
-                        {step.stepType === "preset" || step.stepType === "skill"
+                        {usesGenericInstructionsLabel(step.stepType)
                           ? "Instructions"
                           : `Step ${index + 1} Instructions`}
                       </label>


### PR DESCRIPTION
I do not want the box to be labeled "Step 1 Instructions" when you choose skill on the create task page. It should just be labeled "Instructions".