### PR TITLE
Selecting the preset Jira Breakdown and Orchestrate on the create page should automatically set publish mode to None for the main task, since the addi

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3184131746,
+    "id": 3184504531,
     "disposition": "addressed",
-    "rationale": "Extracted the preset/skill instruction-label decision into usesGenericInstructionsLabel(stepType)."
+    "rationale": "Publish gating now considers only active applied template step IDs, so stale Jira Breakdown provenance no longer forces publish mode none. Covered by a Create page regression test."
   },
   {
-    "id": 4223053049,
+    "id": 4223507965,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its actionable suggestion is covered by review comment 3184131746."
+    "rationale": "Automated review summary only; the actionable child review comment was addressed separately."
+  },
+  {
+    "id": 3184504777,
+    "disposition": "addressed",
+    "rationale": "Jira Breakdown preset slugs were moved into SELF_MANAGED_PUBLISH_SKILLS so existing self-managed publish checks drive the UI and submit behavior consistently."
+  },
+  {
+    "id": 4223508343,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary only; the actionable child review comment was addressed separately."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12720,6 +12720,169 @@ describe("Task Create MM-578 Preset expansion", () => {
     fetchSpy.mockRestore();
   });
 
+  it("defaults parent publish mode to none when selecting Jira Breakdown and Orchestrate as a Preset step", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown-orchestrate",
+                scope: "global",
+                title: "Jira Breakdown and Orchestrate",
+                description: "Create dependent Jira Orchestrate tasks.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-breakdown-orchestrate?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-breakdown-orchestrate",
+            scope: "global",
+            title: "Jira Breakdown and Orchestrate",
+            description: "Create dependent Jira Orchestrate tasks.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Declarative Design Path or Text",
+                type: "markdown",
+                required: true,
+              },
+              {
+                name: "publish_mode",
+                label: "Publish Mode",
+                type: "enum",
+                required: true,
+                default: "pr_with_merge_automation",
+                options: ["pr", "pr_with_merge_automation"],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-breakdown-orchestrate:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                title: "Break down declarative design",
+                instructions: "Break down the feature request.",
+                skill: { id: "moonspec-breakdown", args: {} },
+              },
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                title: "Create Jira stories",
+                instructions: "Create Jira stories.",
+                skill: { id: "story.create_jira_issues", args: {} },
+              },
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                title: "Create dependent Jira Orchestrate tasks",
+                instructions: "Create one Jira Orchestrate task per story.",
+                skill: { id: "story.create_jira_orchestrate_tasks", args: {} },
+                jiraOrchestration: {
+                  task: {
+                    repository: "MoonLadderStudios/MoonMind",
+                    runtime: { mode: "codex_cli" },
+                    publish: {
+                      mode: "pr",
+                      mergeAutomation: { enabled: true },
+                    },
+                  },
+                },
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-breakdown-orchestrate",
+              version: "1.0.0",
+            },
+            capabilities: ["git"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+    const taskPublishSelect = () =>
+      screen
+        .getAllByLabelText("Publish Mode")
+        .find(
+          (element): element is HTMLSelectElement =>
+            element instanceof HTMLSelectElement &&
+            element.getAttribute("name") === "publishMode",
+        ) as HTMLSelectElement;
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Break down and orchestrate MM-600." },
+    });
+    selectStepType(step, "Preset");
+    const stepPresetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(stepPresetSelect.options).some(
+          (option) =>
+            option.text === "Jira Breakdown and Orchestrate (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    expect(taskPublishSelect().value).toBe("pr");
+    fireEvent.change(stepPresetSelect, {
+      target: { value: "global::::jira-breakdown-orchestrate" },
+    });
+
+    await waitFor(() => {
+      expect(taskPublishSelect().value).toBe("none");
+    });
+    expect(taskPublishSelect().disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest();
+    const payload = request.payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(payload.publishMode).toBe("none");
+    expect(payload).not.toHaveProperty("mergeAutomation");
+    expect(task.publish).toMatchObject({ mode: "none" });
+    expect(
+      ((task.steps as Array<Record<string, unknown>>)[2]?.jiraOrchestration as {
+        task?: { publish?: Record<string, unknown> };
+      }).task?.publish,
+    ).toEqual({ mode: "pr", mergeAutomation: { enabled: true } });
+  });
+
   it("expands generated preset steps into editable executable steps", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12883,6 +12883,166 @@ describe("Task Create MM-578 Preset expansion", () => {
     ).toEqual({ mode: "pr", mergeAutomation: { enabled: true } });
   });
 
+  it("does not force none publish mode from stale Jira Breakdown preset provenance", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown-orchestrate",
+                scope: "global",
+                title: "Jira Breakdown and Orchestrate",
+                description: "Create dependent Jira Orchestrate tasks.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-breakdown-orchestrate?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-breakdown-orchestrate",
+            scope: "global",
+            title: "Jira Breakdown and Orchestrate",
+            description: "Create dependent Jira Orchestrate tasks.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "feature_request",
+                label: "Declarative Design Path or Text",
+                type: "markdown",
+                required: true,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-breakdown-orchestrate:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                title: "Break down declarative design",
+                instructions: "Break down the feature request.",
+                skill: { id: "moonspec-breakdown", args: {} },
+              },
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                title: "Create Jira stories",
+                instructions: "Create Jira stories.",
+                skill: { id: "story.create_jira_issues", args: {} },
+              },
+              {
+                id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                title: "Create dependent Jira Orchestrate tasks",
+                instructions: "Create one Jira Orchestrate task per story.",
+                skill: { id: "story.create_jira_orchestrate_tasks", args: {} },
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-breakdown-orchestrate",
+              version: "1.0.0",
+            },
+            capabilities: ["git"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+    const taskPublishSelect = () =>
+      screen
+        .getAllByLabelText("Publish Mode")
+        .find(
+          (element): element is HTMLSelectElement =>
+            element instanceof HTMLSelectElement &&
+            element.getAttribute("name") === "publishMode",
+        ) as HTMLSelectElement;
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Start from the combined preset." },
+    });
+    selectStepType(step, "Preset");
+    const stepPresetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(stepPresetSelect.options).some(
+          (option) =>
+            option.text === "Jira Breakdown and Orchestrate (Global)",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(stepPresetSelect, {
+      target: { value: "global::::jira-breakdown-orchestrate" },
+    });
+    await waitFor(() => {
+      expect(taskPublishSelect().value).toBe("none");
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    expect(
+      await screen.findByDisplayValue("Break down the feature request."),
+    ).toBeTruthy();
+
+    while (screen.getAllByRole("button", { name: "Remove step" }).length > 1) {
+      fireEvent.click(
+        screen.getAllByRole("button", { name: "Remove step" }).at(-1)!,
+      );
+    }
+    const remainingStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(remainingStep).getByLabelText("Instructions"), {
+      target: { value: "Implement this as a normal PR-publishing task." },
+    });
+
+    await waitFor(() => {
+      expect(taskPublishSelect().disabled).toBe(false);
+    });
+    fireEvent.change(taskPublishSelect(), {
+      target: { value: "pr_with_merge_automation" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest();
+    const payload = request.payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(payload.publishMode).toBe("pr");
+    expect(payload.mergeAutomation).toEqual({ enabled: true });
+    expect(task.publish).toEqual({ mode: "pr" });
+    expect(task).not.toHaveProperty("appliedStepTemplates");
+  });
+
   it("expands generated preset steps into editable executable steps", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -29,12 +29,10 @@ const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
-const MAIN_TASK_NONE_PUBLISH_PRESET_SLUGS = new Set([
-  JIRA_BREAKDOWN_PRESET_SLUG,
-  JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
-]);
 const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   ...PR_RESOLVER_SKILLS,
+  JIRA_BREAKDOWN_PRESET_SLUG,
+  JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
 ]);
 const MOONSPEC_ORCHESTRATE_PRESET_SLUG = "moonspec-orchestrate";
 const HIDDEN_PRESET_INPUT_KEYS: Record<string, Set<string>> = {
@@ -1357,10 +1355,6 @@ function isSelfManagedPublishSkill(skillId: string): boolean {
   return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
 }
 
-function presetForcesMainTaskPublishNone(slug: string): boolean {
-  return MAIN_TASK_NONE_PUBLISH_PRESET_SLUGS.has(slug.trim().toLowerCase());
-}
-
 function resolveEffectiveSkillId(
   primarySkillId: string,
   appliedTemplates: AppliedTemplateState[],
@@ -1373,6 +1367,28 @@ function resolveEffectiveSkillId(
     return primarySkillId;
   }
   return primarySkillId;
+}
+
+function activeAppliedTemplatesForSteps(
+  appliedTemplates: AppliedTemplateState[],
+  steps: StepState[],
+): AppliedTemplateState[] {
+  const activeStepIds = new Set(
+    steps
+      .map((step) => step.id.trim())
+      .filter(Boolean),
+  );
+  return appliedTemplates.filter((template) => {
+    const stepIds = Array.isArray(template.stepIds)
+      ? template.stepIds
+          .map((stepId) => String(stepId || "").trim())
+          .filter(Boolean)
+      : [];
+    return (
+      stepIds.length === 0 ||
+      stepIds.some((stepId) => activeStepIds.has(stepId))
+    );
+  });
 }
 
 function parseCapabilitiesCsv(value: string): string[] {
@@ -3846,7 +3862,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     () =>
       resolveEffectiveSkillId(
         String(steps[0]?.skillId || "").trim() || "auto",
-        appliedTemplates,
+        activeAppliedTemplatesForSteps(appliedTemplates, steps),
       ),
     [appliedTemplates, steps],
   );
@@ -3855,7 +3871,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (
       pageMode.mode === "create" &&
       selectedPreset &&
-      presetForcesMainTaskPublishNone(selectedPreset.slug)
+      isSelfManagedPublishSkill(selectedPreset.slug)
     ) {
       setPublishMode("none");
     }
@@ -4784,7 +4800,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
     if (
       pageMode.mode === "create" &&
-      presetForcesMainTaskPublishNone(preset.slug)
+      isSelfManagedPublishSkill(preset.slug)
     ) {
       setPublishMode("none");
     }
@@ -6079,16 +6095,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const primarySkillId = primaryStepIsSkill
       ? primaryValidation.value.skillId.trim() || "auto"
       : "auto";
+    const activeSubmissionAppliedTemplates = activeAppliedTemplatesForSteps(
+      submissionAppliedTemplates,
+      submissionSteps,
+    );
+    submissionAppliedTemplates = activeSubmissionAppliedTemplates;
     const effectiveSubmissionSkillId = resolveEffectiveSkillId(
       primarySkillId,
-      submissionAppliedTemplates,
-    );
-    const mainTaskPublishNoneFromPreset = submissionAppliedTemplates.some(
-      (entry) => presetForcesMainTaskPublishNone(entry.slug),
+      activeSubmissionAppliedTemplates,
     );
     const effectivePublishMode =
-      isSelfManagedPublishSkill(effectiveSubmissionSkillId) ||
-      mainTaskPublishNoneFromPreset
+      isSelfManagedPublishSkill(effectiveSubmissionSkillId)
         ? "none"
         : normalizedPublishMode;
     const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -29,6 +29,10 @@ const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
+const MAIN_TASK_NONE_PUBLISH_PRESET_SLUGS = new Set([
+  JIRA_BREAKDOWN_PRESET_SLUG,
+  JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
+]);
 const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   ...PR_RESOLVER_SKILLS,
 ]);
@@ -1351,6 +1355,10 @@ function hasExplicitSkillSelection(skillId: string): boolean {
 
 function isSelfManagedPublishSkill(skillId: string): boolean {
   return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
+}
+
+function presetForcesMainTaskPublishNone(slug: string): boolean {
+  return MAIN_TASK_NONE_PUBLISH_PRESET_SLUGS.has(slug.trim().toLowerCase());
 }
 
 function resolveEffectiveSkillId(
@@ -3846,8 +3854,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   useEffect(() => {
     if (
       pageMode.mode === "create" &&
-      (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG ||
-        selectedPreset?.slug === JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG)
+      selectedPreset &&
+      presetForcesMainTaskPublishNone(selectedPreset.slug)
     ) {
       setPublishMode("none");
     }
@@ -4773,6 +4781,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     updateStepPreset(localId, presetKey);
     if (!preset) {
       return;
+    }
+    if (
+      pageMode.mode === "create" &&
+      presetForcesMainTaskPublishNone(preset.slug)
+    ) {
+      setPublishMode("none");
     }
     updateStep(localId, { presetMessage: "Loading preset options..." });
     try {
@@ -6069,8 +6083,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       primarySkillId,
       submissionAppliedTemplates,
     );
+    const mainTaskPublishNoneFromPreset = submissionAppliedTemplates.some(
+      (entry) => presetForcesMainTaskPublishNone(entry.slug),
+    );
     const effectivePublishMode =
-      isSelfManagedPublishSkill(effectiveSubmissionSkillId)
+      isSelfManagedPublishSkill(effectiveSubmissionSkillId) ||
+      mainTaskPublishNoneFromPreset
         ? "none"
         : normalizedPublishMode;
     const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions


### PR DESCRIPTION
Selecting the preset Jira Breakdown and Orchestrate on the create page should automatically set publish mode to None for the main task, since the additional orchestrate tasks that get created by the workflow will have a separate publish mode applied to them as an input of the preset.