### PR TITLE
[codex] Fix create arrow exit timing

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,12 @@
 [
   {
-    "id": 3184131746,
+    "id": 3184548974,
     "disposition": "addressed",
-    "rationale": "Extracted the preset/skill instruction-label decision into usesGenericInstructionsLabel(stepType)."
+    "rationale": "Refactored the task-create fetch mock to use a path-based switch while preserving the delayed /api/executions response behavior."
   },
   {
-    "id": 4223053049,
+    "id": 4223560263,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its actionable suggestion is covered by review comment 3184131746."
+    "rationale": "Broad review summary duplicated the actionable inline mock-refactor feedback and did not request a separate code change."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12477,33 +12477,32 @@ describe("Task Create submit arrow animation", () => {
       .spyOn(window, "fetch")
       .mockImplementation((input: RequestInfo | URL) => {
         const url = String(input);
-        if (url.startsWith("/api/tasks/skills")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({ items: { worker: ["speckit-orchestrate"] } }),
-          } as Response);
+        switch (true) {
+          case url.startsWith("/api/tasks/skills"):
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({ items: { worker: ["speckit-orchestrate"] } }),
+            } as Response);
+          case url.startsWith("/api/task-step-templates"):
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({ items: [] }),
+            } as Response);
+          case url.startsWith("/api/v1/provider-profiles"):
+            return Promise.resolve({
+              ok: true,
+              json: async () => [],
+            } as Response);
+          case url === "/api/executions":
+            return new Promise<Response>((resolve) => {
+              resolveExecution = resolve;
+            });
+          default:
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({}),
+            } as Response);
         }
-        if (url.startsWith("/api/task-step-templates")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({ items: [] }),
-          } as Response);
-        }
-        if (url.startsWith("/api/v1/provider-profiles")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => [],
-          } as Response);
-        }
-        if (url === "/api/executions") {
-          return new Promise<Response>((resolve) => {
-            resolveExecution = resolve;
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({}),
-        } as Response);
       });
     const { unmount } = renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12470,6 +12470,97 @@ describe("Task Create submit arrow animation", () => {
       /\.queue-submit-primary-ripple\s*\{[^}]*animation:\s*queue-submit-primary-ripple\s+620ms\s+cubic-bezier\(0\.22,\s*0\.61,\s*0\.36,\s*1\)\s+forwards;/s,
     );
   });
+
+  it("keeps the create arrow exit active while submit is busy", async () => {
+    let resolveExecution: (response: Response) => void = () => {};
+    const fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/tasks/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: { worker: ["speckit-orchestrate"] } }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: [] }),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [],
+          } as Response);
+        }
+        if (url === "/api/executions") {
+          return new Promise<Response>((resolve) => {
+            resolveExecution = resolve;
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({}),
+        } as Response);
+      });
+    const { unmount } = renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    try {
+      fireEvent.change(await screen.findByLabelText("Instructions"), {
+        target: { value: "Run end-to-end regression flow." },
+      });
+
+      const createButton = screen.getByRole("button", { name: "Create" });
+      const arrow = createButton.querySelector<HTMLElement>(
+        "[data-submit-arrow='right']",
+      );
+      expect(arrow).not.toBeNull();
+
+      fireEvent.pointerDown(createButton, { button: 0 });
+      await waitFor(() => {
+        expect(
+          createButton.classList.contains("queue-submit-primary--arrow-exit"),
+        ).toBe(true);
+      });
+
+      fireEvent.click(createButton);
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/executions",
+          expect.objectContaining({
+            method: "POST",
+          }),
+        );
+        expect(createButton.getAttribute("aria-busy")).toBe("true");
+        expect(
+          createButton.classList.contains("queue-submit-primary--arrow-exit"),
+        ).toBe(true);
+      });
+    } finally {
+      resolveExecution(
+        new Response(
+          JSON.stringify({
+            workflowId: "mm:workflow-123",
+            runId: "run-123",
+            namespace: "moonmind",
+            redirectPath: "/tasks/mm:workflow-123?source=temporal",
+          }),
+          {
+            status: 201,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        ),
+      );
+      unmount();
+      fetchSpy.mockRestore();
+      vi.mocked(navigateTo).mockReset();
+    }
+  });
 });
 
 describe("Task Create MM-578 Preset expansion", () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -6980,10 +6980,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     (temporalDraftQuery.isLoading || Boolean(modeLoadError));
 
   useEffect(() => {
-    if (!showPrimaryCtaArrow || isSubmitting || isTemporalFormBlocked) {
+    if (!showPrimaryCtaArrow || isTemporalFormBlocked) {
       setIsSubmitArrowExiting(false);
     }
-  }, [isSubmitting, isTemporalFormBlocked, showPrimaryCtaArrow]);
+  }, [isTemporalFormBlocked, showPrimaryCtaArrow]);
 
   function clearSubmitArrowExit(event: React.AnimationEvent<HTMLElement>) {
     if (event.animationName === "queue-submit-primary-arrow-exit") {


### PR DESCRIPTION
## Summary
- Keep the Create-page submit arrow exit state active while submission is busy.
- Add a regression test that holds the create request pending and verifies the arrow-exit class remains during the busy state.

## Root Cause
The submit handler set `isSubmitting` immediately after pointer down, and the arrow-exit cleanup effect cleared `isSubmitArrowExiting` whenever `isSubmitting` became true. That canceled the animation before navigation was involved.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `npm run ui:typecheck`
- `npx eslint -c frontend/eslint.config.mjs frontend/src/entrypoints/task-create.tsx frontend/src/entrypoints/task-create.test.tsx`
- `git diff --check`