### PR TITLE
[codex] Improve Jira and Codex run diagnostics

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,22 @@
 [
   {
-    "id": 3183649166,
+    "id": 3184882513,
     "disposition": "addressed",
-    "rationale": "Removed the CSS :active selector from the arrow-exit animation so click exit is driven only by React state."
+    "rationale": "Removed the redundant unpublished handoff check from the exception block; the pre-try guard already covers unchanged previous_outputs/ref inputs."
   },
   {
-    "id": 3183649177,
-    "disposition": "addressed",
-    "rationale": "Updated the CSS test to reuse a suite-level CSS fixture and assert the state-driven selector without :active."
-  },
-  {
-    "id": 4222500444,
+    "id": 4223961398,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable :active selector and redundant test fixture items are covered by the linked review comments."
+    "rationale": "Review summary only; its actionable child comment 3184882513 was addressed."
   },
   {
-    "id": 3183656357,
+    "id": 3184895029,
     "disposition": "addressed",
-    "rationale": "Cleared arrow-exit state when the exit animation is canceled and when submission or form-blocked state changes."
+    "rationale": "Scoped Jira auth diagnostics now require an authenticated signal: /myself is tried first, and the fallback project/search probe only succeeds when Jira returns x-aaccountid."
   },
   {
-    "id": 4222510205,
+    "id": 4223974897,
     "disposition": "not-applicable",
-    "rationale": "Codex review wrapper text only; no standalone code change requested beyond the actionable review comment."
+    "rationale": "Informational Codex review wrapper; its actionable child comment 3184895029 was addressed."
   }
 ]

--- a/moonmind/integrations/jira/client.py
+++ b/moonmind/integrations/jira/client.py
@@ -233,7 +233,7 @@ class JiraClient:
         """Disambiguate Jira 404s that are actually bad credentials.
 
         Jira Cloud commonly returns 404 for issue/project reads when the caller
-        is anonymous or unauthorized. Probe the authenticated profile endpoint
+        is anonymous or unauthorized. Probe a low-cost authenticated endpoint
         before surfacing a misleading "not found" error.
         """
 
@@ -244,10 +244,17 @@ class JiraClient:
         ):
             return None
         try:
-            auth_response = await self._client.request(
-                method="GET",
-                url=self._resolve_request_path("/myself"),
-            )
+            if self._connection.auth_mode == "service_account_scoped":
+                auth_response = await self._client.request(
+                    method="GET",
+                    url=self._resolve_request_path("/project/search"),
+                    params={"maxResults": 1},
+                )
+            else:
+                auth_response = await self._client.request(
+                    method="GET",
+                    url=self._resolve_request_path("/myself"),
+                )
         except (httpx.TransportError, httpx.TimeoutException):
             return None
         if auth_response.status_code in {401, 403}:

--- a/moonmind/integrations/jira/client.py
+++ b/moonmind/integrations/jira/client.py
@@ -233,7 +233,7 @@ class JiraClient:
         """Disambiguate Jira 404s that are actually bad credentials.
 
         Jira Cloud commonly returns 404 for issue/project reads when the caller
-        is anonymous or unauthorized. Probe a low-cost authenticated endpoint
+        is anonymous or unauthorized. Probe the authenticated profile endpoint
         before surfacing a misleading "not found" error.
         """
 
@@ -244,19 +244,20 @@ class JiraClient:
         ):
             return None
         try:
-            if self._connection.auth_mode == "service_account_scoped":
-                auth_response = await self._client.request(
-                    method="GET",
-                    url=self._resolve_request_path("/project/search"),
-                    params={"maxResults": 1},
-                )
-            else:
-                auth_response = await self._client.request(
-                    method="GET",
-                    url=self._resolve_request_path("/myself"),
-                )
+            auth_response = await self._client.request(
+                method="GET",
+                url=self._resolve_request_path("/myself"),
+            )
         except (httpx.TransportError, httpx.TimeoutException):
             return None
+        if (
+            auth_response.status_code in {401, 403}
+            and self._connection.auth_mode == "service_account_scoped"
+        ):
+            try:
+                auth_response = await self._service_account_auth_probe()
+            except (httpx.TransportError, httpx.TimeoutException):
+                return None
         if auth_response.status_code in {401, 403}:
             return JiraToolError(
                 "Jira credentials are invalid, expired, or use the wrong auth mode.",
@@ -265,6 +266,28 @@ class JiraClient:
                 action=action,
             )
         return None
+
+    async def _service_account_auth_probe(self) -> httpx.Response:
+        """Confirm scoped-token identity when /myself rejects the token shape."""
+
+        try:
+            response = await self._client.request(
+                method="GET",
+                url=self._resolve_request_path("/project/search"),
+                params={"maxResults": 1},
+            )
+        except (httpx.TransportError, httpx.TimeoutException):
+            raise
+        if response.status_code < 400 and not response.headers.get("x-aaccountid"):
+            return httpx.Response(
+                401,
+                text=(
+                    "Jira scoped credential probe did not include an "
+                    "authenticated account header."
+                ),
+                request=response.request,
+            )
+        return response
 
     def _resolve_request_path(self, path: str) -> str:
         if not path.startswith("agile:"):

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1165,7 +1165,10 @@ class CodexManagedSessionRuntime:
             recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
             if recovered_error:
                 return "failed", recovered_error
-            return "completed", None
+            return (
+                "failed",
+                "codex app-server task_complete produced no assistant output",
+            )
         if scan.assistant_text:
             return "completed", None
         return None
@@ -1194,7 +1197,10 @@ class CodexManagedSessionRuntime:
             recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
             if recovered_error:
                 return "failed", recovered_error
-            return "completed", None
+            return (
+                "failed",
+                "codex app-server task_complete produced no assistant output",
+            )
         return "failed", "codex app-server turn/completed produced no assistant output"
 
     def _resolved_rollout_path(

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1029,12 +1029,6 @@ async def create_jira_issues_from_stories(
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
-                unpublished_reason = _unpublished_handoff_reason(
-                    previous_outputs=previous_outputs,
-                    ref=ref,
-                )
-                if unpublished_reason:
-                    raise ValueError(unpublished_reason) from exc
                 if fallback_for_missing_stories:
                     return _fallback_result(
                         reason=f"Unable to read story breakdown for Jira output: {exc}",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -722,6 +722,39 @@ def _fallback_result(
         },
     )
 
+def _unpublished_handoff_reason(
+    *,
+    previous_outputs: Mapping[str, Any],
+    ref: str,
+) -> str:
+    push_status = _string(
+        previous_outputs.get("push_status")
+        or previous_outputs.get("pushStatus")
+    )
+    push_branch = _string(
+        previous_outputs.get("push_branch")
+        or previous_outputs.get("pushBranch")
+    )
+    if not push_branch or ref != push_branch:
+        return ""
+    if push_status == "protected_branch":
+        return (
+            "Unable to read story breakdown for Jira output because "
+            f"the previous step produced it on protected branch '{push_branch}' "
+            "and it was not published. Jira story creation requires inline "
+            "stories, storyBreakdownArtifactRef, or a readable repo/ref/path "
+            "from a published handoff branch."
+        )
+    if push_status == "no_commits":
+        return (
+            "Unable to read story breakdown for Jira output because "
+            f"the previous step made no commits on handoff branch '{push_branch}'. "
+            "The story breakdown was not produced or was not captured as an "
+            "inline story payload, storyBreakdownArtifactRef, or readable "
+            "repo/ref/path handoff."
+        )
+    return ""
+
 def _issue_mapping(
     *,
     story: Mapping[str, Any],
@@ -977,6 +1010,12 @@ async def create_jira_issues_from_stories(
             or previous_story_output.get("storyBreakdownPath")
         )
         if repo and ref and path:
+            unpublished_reason = _unpublished_handoff_reason(
+                previous_outputs=previous_outputs,
+                ref=ref,
+            )
+            if unpublished_reason:
+                raise ValueError(unpublished_reason)
             try:
                 fetched = story_fetcher(repo, ref, path)
                 if inspect.isawaitable(fetched):
@@ -990,26 +1029,12 @@ async def create_jira_issues_from_stories(
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
-                push_status = _string(
-                    previous_outputs.get("push_status")
-                    or previous_outputs.get("pushStatus")
+                unpublished_reason = _unpublished_handoff_reason(
+                    previous_outputs=previous_outputs,
+                    ref=ref,
                 )
-                push_branch = _string(
-                    previous_outputs.get("push_branch")
-                    or previous_outputs.get("pushBranch")
-                )
-                if (
-                    push_status == "protected_branch"
-                    and push_branch
-                    and ref == push_branch
-                ):
-                    raise ValueError(
-                        "Unable to read story breakdown for Jira output because "
-                        f"the previous step produced it on protected branch '{push_branch}' "
-                        "and it was not published. Jira story creation requires inline "
-                        "stories, storyBreakdownArtifactRef, or a readable repo/ref/path "
-                        "from a published handoff branch."
-                    ) from exc
+                if unpublished_reason:
+                    raise ValueError(unpublished_reason) from exc
                 if fallback_for_missing_stories:
                     return _fallback_result(
                         reason=f"Unable to read story breakdown for Jira output: {exc}",

--- a/tests/unit/integrations/test_jira_client.py
+++ b/tests/unit/integrations/test_jira_client.py
@@ -232,21 +232,28 @@ async def test_request_json_preserves_issue_404_when_myself_succeeds() -> None:
 
     assert excinfo.value.code == "jira_not_found"
 
-async def test_request_json_preserves_cloud_issue_404_when_project_probe_succeeds() -> None:
+async def test_request_json_preserves_cloud_issue_404_when_scoped_probe_is_authenticated() -> None:
     connection = _build_cloud_connection()
     seen_paths: list[str] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
         seen_paths.append(request.url.path)
+        if request.url.path.endswith("/myself"):
+            return httpx.Response(
+                401,
+                text="Current user profile is not available for this token shape.",
+                headers={"content-type": "text/plain"},
+            )
         if request.url.path.endswith("/project/search"):
             assert request.url.params["maxResults"] == "1"
             return httpx.Response(
                 200,
                 json={"values": []},
-                headers={"content-type": "application/json"},
+                headers={
+                    "content-type": "application/json",
+                    "x-aaccountid": "acct-1",
+                },
             )
-        if request.url.path.endswith("/myself"):
-            raise AssertionError("service-account scoped auth probe must not use /myself")
         return httpx.Response(
             404,
             json={"errorMessages": ["No project could be found."], "errors": {}},
@@ -269,20 +276,27 @@ async def test_request_json_preserves_cloud_issue_404_when_project_probe_succeed
     assert excinfo.value.code == "jira_not_found"
     assert seen_paths == [
         "/ex/jira/cloud-abc/rest/api/3/issue/createmeta/KANDY/issuetypes",
+        "/ex/jira/cloud-abc/rest/api/3/myself",
         "/ex/jira/cloud-abc/rest/api/3/project/search",
     ]
 
-async def test_request_json_maps_cloud_issue_404_to_auth_failure_when_project_probe_rejects() -> None:
+async def test_request_json_maps_cloud_issue_404_to_auth_failure_when_project_probe_is_anonymous() -> None:
     connection = _build_cloud_connection()
     seen_paths: list[str] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
         seen_paths.append(request.url.path)
-        if request.url.path.endswith("/project/search"):
+        if request.url.path.endswith("/myself"):
             return httpx.Response(
                 401,
                 text="Client must be authenticated to access this resource.",
                 headers={"content-type": "text/plain"},
+            )
+        if request.url.path.endswith("/project/search"):
+            return httpx.Response(
+                200,
+                json={"values": []},
+                headers={"content-type": "application/json"},
             )
         return httpx.Response(
             404,
@@ -306,6 +320,7 @@ async def test_request_json_maps_cloud_issue_404_to_auth_failure_when_project_pr
     assert excinfo.value.code == "jira_auth_failed"
     assert seen_paths == [
         "/ex/jira/cloud-abc/rest/api/3/issue/createmeta/KANDY/issuetypes",
+        "/ex/jira/cloud-abc/rest/api/3/myself",
         "/ex/jira/cloud-abc/rest/api/3/project/search",
     ]
 

--- a/tests/unit/integrations/test_jira_client.py
+++ b/tests/unit/integrations/test_jira_client.py
@@ -232,6 +232,83 @@ async def test_request_json_preserves_issue_404_when_myself_succeeds() -> None:
 
     assert excinfo.value.code == "jira_not_found"
 
+async def test_request_json_preserves_cloud_issue_404_when_project_probe_succeeds() -> None:
+    connection = _build_cloud_connection()
+    seen_paths: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.endswith("/project/search"):
+            assert request.url.params["maxResults"] == "1"
+            return httpx.Response(
+                200,
+                json={"values": []},
+                headers={"content-type": "application/json"},
+            )
+        if request.url.path.endswith("/myself"):
+            raise AssertionError("service-account scoped auth probe must not use /myself")
+        return httpx.Response(
+            404,
+            json={"errorMessages": ["No project could be found."], "errors": {}},
+            headers={"content-type": "application/json"},
+        )
+
+    injected = _build_injected_client(connection, _handler)
+    client = JiraClient(connection=connection, client=injected)
+    try:
+        with pytest.raises(JiraToolError) as excinfo:
+            await client.request_json(
+                method="GET",
+                path="/issue/createmeta/KANDY/issuetypes",
+                action="list_create_issue_types",
+                context={"projectKey": "KANDY"},
+            )
+    finally:
+        await injected.aclose()
+
+    assert excinfo.value.code == "jira_not_found"
+    assert seen_paths == [
+        "/ex/jira/cloud-abc/rest/api/3/issue/createmeta/KANDY/issuetypes",
+        "/ex/jira/cloud-abc/rest/api/3/project/search",
+    ]
+
+async def test_request_json_maps_cloud_issue_404_to_auth_failure_when_project_probe_rejects() -> None:
+    connection = _build_cloud_connection()
+    seen_paths: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.endswith("/project/search"):
+            return httpx.Response(
+                401,
+                text="Client must be authenticated to access this resource.",
+                headers={"content-type": "text/plain"},
+            )
+        return httpx.Response(
+            404,
+            json={"errorMessages": ["No project could be found."], "errors": {}},
+            headers={"content-type": "application/json"},
+        )
+
+    injected = _build_injected_client(connection, _handler)
+    client = JiraClient(connection=connection, client=injected)
+    try:
+        with pytest.raises(JiraToolError) as excinfo:
+            await client.request_json(
+                method="GET",
+                path="/issue/createmeta/KANDY/issuetypes",
+                action="list_create_issue_types",
+                context={"projectKey": "KANDY"},
+            )
+    finally:
+        await injected.aclose()
+
+    assert excinfo.value.code == "jira_auth_failed"
+    assert seen_paths == [
+        "/ex/jira/cloud-abc/rest/api/3/issue/createmeta/KANDY/issuetypes",
+        "/ex/jira/cloud-abc/rest/api/3/project/search",
+    ]
+
 async def test_request_json_retries_retry_after_and_surfaces_rate_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -685,7 +685,7 @@ def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
     assert handle.status == "ready"
     assert handle.metadata["lastAssistantText"] == "Recovered from task_complete event"
 
-def test_runtime_send_turn_accepts_empty_task_complete_event(
+def test_runtime_send_turn_fails_empty_task_complete_event(
     tmp_path: Path,
 ) -> None:
     request = launch_request(tmp_path)
@@ -736,8 +736,10 @@ def test_runtime_send_turn_accepts_empty_task_complete_event(
         )
     )
 
-    assert response.status == "completed"
-    assert response.metadata == {"assistantTextMissing": True}
+    assert response.status == "failed"
+    assert response.metadata == {
+        "reason": "codex app-server task_complete produced no assistant output"
+    }
     handle = runtime.session_status(
         CodexManagedSessionLocator(
             sessionId="sess-1",
@@ -746,7 +748,7 @@ def test_runtime_send_turn_accepts_empty_task_complete_event(
             threadId="logical-thread-1",
         )
     )
-    assert handle.status == "ready"
+    assert handle.status == "failed"
     assert "lastAssistantText" not in handle.metadata
 
 def test_runtime_send_turn_fails_empty_task_complete_with_structured_error(
@@ -873,7 +875,7 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     assert handle.status == "busy"
     assert handle.metadata["lastTurnStatus"] == "running"
 
-def test_runtime_session_status_accepts_empty_task_complete_after_running_turn(
+def test_runtime_session_status_fails_empty_task_complete_after_running_turn(
     tmp_path: Path,
 ) -> None:
     request = launch_request(tmp_path)
@@ -954,9 +956,13 @@ def test_runtime_session_status_accepts_empty_task_complete_after_running_turn(
         )
     )
 
-    assert handle.status == "ready"
+    assert handle.status == "failed"
     assert handle.session_state.active_turn_id is None
-    assert handle.metadata["lastTurnStatus"] == "completed"
+    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert (
+        handle.metadata["lastTurnError"]
+        == "codex app-server task_complete produced no assistant output"
+    )
     assert "lastAssistantText" not in handle.metadata
 
 def test_runtime_send_turn_stays_running_when_large_rollout_tail_has_active_turn(

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -301,6 +301,36 @@ async def test_create_jira_issues_explains_protected_branch_handoff_failure():
         )
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_explains_no_commit_handoff_failure():
+    async def fetcher(_repo: str, _ref: str, _path: str) -> str:
+        raise AssertionError("fetcher should not run for unpublished handoff")
+
+    with pytest.raises(ValueError, match="made no commits"):
+        await create_jira_issues_from_stories(
+            {
+                "repository": "MoonLadderStudios/Tactics",
+                "targetBranch": "breakdown-branch",
+                "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+                "storyOutput": {
+                    "mode": "jira",
+                    "fallback": "fail",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeId": "10001",
+                        "dependencyMode": "none",
+                    },
+                },
+            },
+            {
+                "previousOutputs": {
+                    "push_status": "no_commits",
+                    "push_branch": "breakdown-branch",
+                },
+            },
+            story_fetcher=fetcher,
+        )
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_preserves_source_reference_when_description_truncates():
     service = _FakeJiraService()
     long_description = "x" * 40000


### PR DESCRIPTION
## Summary

- classify scoped Jira service-account 404s by probing project search instead of /myself, so valid tokens with missing project access surface as not found/permission failures
- fail Codex managed-session turns when app-server task_complete has no assistant output and no recoverable error
- explain unpublished no-commit Jira handoff branches before attempting a misleading GitHub fetch

## Root Cause

The failed breakdown run completed a Codex app-server task_complete event without assistant output after an underlying provider auth error, allowing downstream Jira output handling to continue with no story artifact. A later retry exposed a separate Jira diagnostic issue: scoped service-account tokens can succeed against project search while /myself rejects, so the client mislabeled project visibility failures as bad credentials.

## Validation

- ./tools/test_unit.sh tests/unit/integrations/test_jira_client.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_story_output_tools.py
