### PR TITLE
I want to convert the navigation options on the settings page for "Providers & Secrets, User / Workspace, Operations" into a radio button with a simil

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,12 @@
 [
   {
-    "id": 3184504531,
+    "id": 3184919504,
     "disposition": "addressed",
-    "rationale": "Publish gating now considers only active applied template step IDs, so stale Jira Breakdown provenance no longer forces publish mode none. Covered by a Create page regression test."
+    "rationale": "Added w-full to queue-step-type-options container in settings.tsx to fix sliding thumb alignment with variable label widths."
   },
   {
-    "id": 4223507965,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable child review comment was addressed separately."
-  },
-  {
-    "id": 3184504777,
+    "id": 4224002358,
     "disposition": "addressed",
-    "rationale": "Jira Breakdown preset slugs were moved into SELF_MANAGED_PUBLISH_SKILLS so existing self-managed publish checks drive the UI and submit behavior consistently."
-  },
-  {
-    "id": 4223508343,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary only; the actionable child review comment was addressed separately."
+    "rationale": "Review summary covers the same layout issue addressed by adding w-full to the navigation container."
   }
 ]

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -175,25 +175,29 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       </header>
 
       <section className="rounded-[2rem] border border-mm-border/80 bg-transparent p-3 shadow-sm">
-        <div className="flex flex-wrap gap-2">
-          {SETTINGS_SECTIONS.map((candidate) => {
-            const active = candidate.id === section;
-            return (
-              <button
+        <fieldset className="queue-step-type-field">
+          <legend className="sr-only">Settings section</legend>
+          <div className="queue-step-type-options">
+            {SETTINGS_SECTIONS.map((candidate) => (
+              <label
                 key={candidate.id}
-                type="button"
-                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-                  active
-                    ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
-                    : 'border border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:bg-transparent dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white'
-                }`}
-                onClick={() => handleSelectSection(candidate.id)}
+                className="queue-step-type-option"
+                title={candidate.description}
               >
-                {candidate.label}
-              </button>
-            );
-          })}
-        </div>
+                <input
+                  type="radio"
+                  name="settings-section"
+                  value={candidate.id}
+                  checked={candidate.id === section}
+                  onChange={() => handleSelectSection(candidate.id)}
+                />
+                <span className="queue-step-type-option-label">
+                  {candidate.label}
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
       </section>
 
       {notice ? (

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -177,7 +177,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       <section className="rounded-[2rem] border border-mm-border/80 bg-transparent p-3 shadow-sm">
         <fieldset className="queue-step-type-field">
           <legend className="sr-only">Settings section</legend>
-          <div className="queue-step-type-options">
+          <div className="queue-step-type-options w-full">
             {SETTINGS_SECTIONS.map((candidate) => (
               <label
                 key={candidate.id}


### PR DESCRIPTION
I want to convert the navigation options on the settings page for "Providers & Secrets, User / Workspace, Operations" into a radio button with a similar style as Skills, Tools, Presets on the create page.