### PR TITLE
[codex] Fix Jira blocker direction handling

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -39,10 +39,11 @@ steps:
       id: jira-issue-updater
       args: {}
   - title: Check Jira blockers before implementation
+    type: tool
     instructions: |-
-      Fetch Jira issue {{ inputs.jira_issue_key }} through the trusted Jira tool surface before any MoonSpec implementation work starts.
+      Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any MoonSpec implementation work starts.
 
-      Inspect Jira issue links or relationships for blockers where another issue blocks {{ inputs.jira_issue_key }}. If blocker status is not embedded in the first response, fetch each linked blocking issue through the trusted Jira tool surface before deciding whether to continue.
+      Jira Blocks direction is strict: for the target issue response, only an inbound Blocks relationship where Jira exposes the other issue as inwardIssue means another issue blocks {{ inputs.jira_issue_key }}. An outwardIssue Blocks relationship means {{ inputs.jira_issue_key }} blocks a later issue and MUST NOT block this orchestration.
 
       Ignore non-blocker issue links for the blocker decision.
 
@@ -51,8 +52,12 @@ steps:
       If any blocking issue is not Done, or if a blocker relationship exists but blocker status cannot be determined from trusted Jira data, stop the orchestration immediately. Report a blocked outcome in the required JSON format (targetIssueKey, decision, blockingIssues, summary) and do not proceed to any subsequent steps, including brief loading, classification, or MoonSpec implementation. Include {{ inputs.jira_issue_key }} as the targetIssueKey.
 
       Do not use raw Jira credentials, web scraping, hardcoded transition IDs, or prompt text alone to decide blocker state.
-    skill:
-      id: auto
+    targetIssueKey: "{{ inputs.jira_issue_key }}"
+    blockerPreflight:
+      targetIssueKey: "{{ inputs.jira_issue_key }}"
+      linkType: Blocks
+    tool:
+      id: jira.check_blockers
       args: {}
   - title: Load Jira preset brief
     instructions: |-

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,37 @@
 [
   {
-    "id": 3184131746,
+    "id": 3184941164,
     "disposition": "addressed",
-    "rationale": "Extracted the preset/skill instruction-label decision into usesGenericInstructionsLabel(stepType)."
+    "rationale": "Changed the blocked-outcome skip call to use the completed node's zero-based index so only downstream nodes are marked skipped and the completed node remains succeeded."
   },
   {
-    "id": 4223053049,
+    "id": 3184941177,
+    "disposition": "addressed",
+    "rationale": "Updated the fenced JSON regex to capture full code fence content instead of a non-greedy object fragment, preserving nested JSON objects."
+  },
+  {
+    "id": 3184941180,
+    "disposition": "addressed",
+    "rationale": "Updated fenced-content extraction to append only content that is a complete JSON object before calling json.loads."
+  },
+  {
+    "id": 4224028132,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its actionable suggestion is covered by review comment 3184131746."
+    "rationale": "Broad review summary; the actionable inline findings from this review were handled individually."
+  },
+  {
+    "id": 3184947007,
+    "disposition": "addressed",
+    "rationale": "Guarded the blocked-outcome short-circuit behind a replay-stable workflow.patched marker."
+  },
+  {
+    "id": 3184947011,
+    "disposition": "addressed",
+    "rationale": "Made link-type matching strict when Jira provides a type name, so configured non-Blocks link types do not classify Blocks links as blockers."
+  },
+  {
+    "id": 4224033939,
+    "disposition": "not-applicable",
+    "rationale": "Automated review metadata without an actionable code request."
   }
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -148,6 +148,9 @@ from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_r
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
 )
+from moonmind.workflows.temporal.story_output_tools import (
+    JIRA_CHECK_BLOCKERS_TOOL_NAME,
+)
 
 class CmdRes:
     def __init__(self, stdout_bytes: bytes):
@@ -971,6 +974,54 @@ def _default_registry_skill_payload(*, name: str, version: str) -> dict[str, Any
                 },
             },
             "security": {"allowed_roles": ["admin", "security_operator"]},
+        }
+
+    if name == JIRA_CHECK_BLOCKERS_TOOL_NAME:
+        return {
+            "name": name,
+            "version": version,
+            "description": (
+                "Check whether a Jira issue is blocked by unresolved inbound "
+                "Blocks links using trusted Jira data."
+            ),
+            "inputs": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "targetIssueKey": {"type": "string"},
+                        "issueKey": {"type": "string"},
+                        "jiraIssueKey": {"type": "string"},
+                        "blockerPreflight": {"type": "object"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "outputs": {
+                "schema": {
+                    "type": "object",
+                    "required": ["targetIssueKey", "decision", "summary"],
+                    "properties": {
+                        "targetIssueKey": {"type": "string"},
+                        "decision": {"type": "string", "enum": ["continue", "blocked"]},
+                        "blockingIssues": {"type": "array"},
+                        "resolvedBlockingIssues": {"type": "array"},
+                        "summary": {"type": "string"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "executor": {
+                "activity_type": "mm.tool.execute",
+                "selector": {"mode": "by_capability"},
+            },
+            "requirements": {"capabilities": ["integration:jira"]},
+            "policies": {
+                "timeouts": {
+                    "start_to_close_seconds": 60,
+                    "schedule_to_close_seconds": 120,
+                },
+                "retries": {"max_attempts": 1},
+            },
         }
 
     if name == "story.create_jira_issues":

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -15,6 +15,7 @@ from moonmind.integrations.jira.models import (
     CreateIssueRequest,
     CreateIssueLinkRequest,
     CreateSubtaskRequest,
+    GetIssueRequest,
     ListCreateIssueTypesRequest,
     SearchIssuesRequest,
 )
@@ -24,6 +25,7 @@ from moonmind.workflows.skills.tool_plan_contracts import ToolResult
 
 JIRA_CREATE_ISSUES_TOOL_NAME = "story.create_jira_issues"
 JIRA_ORCHESTRATE_TASKS_TOOL_NAME = "story.create_jira_orchestrate_tasks"
+JIRA_CHECK_BLOCKERS_TOOL_NAME = "jira.check_blockers"
 JIRA_STORY_TOOL_NAMES = frozenset(
     {JIRA_CREATE_ISSUES_TOOL_NAME, JIRA_ORCHESTRATE_TASKS_TOOL_NAME}
 )
@@ -56,6 +58,72 @@ def _list(value: Any) -> list[Any]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return list(value)
     return []
+
+def _issue_key(value: Mapping[str, Any]) -> str:
+    return _string(value.get("key") or value.get("issueKey")).upper()
+
+def _status_payload(issue: Mapping[str, Any]) -> dict[str, Any]:
+    fields = _mapping(issue.get("fields"))
+    return _mapping(fields.get("status") or issue.get("status"))
+
+def _status_name(issue: Mapping[str, Any]) -> str:
+    return _string(_status_payload(issue).get("name"))
+
+def _status_is_done(issue: Mapping[str, Any]) -> bool:
+    status = _status_payload(issue)
+    if _string(status.get("name")).lower() == "done":
+        return True
+    category = _mapping(status.get("statusCategory") or status.get("category"))
+    return _string(category.get("key") or category.get("name")).lower() == "done"
+
+def _issue_links(issue: Mapping[str, Any]) -> list[dict[str, Any]]:
+    fields = _mapping(issue.get("fields"))
+    candidates = (
+        fields.get("issuelinks")
+        or fields.get("issueLinks")
+        or issue.get("issuelinks")
+        or issue.get("issueLinks")
+        or []
+    )
+    return [dict(item) for item in _list(candidates) if isinstance(item, Mapping)]
+
+def _is_blocking_link_type(
+    link: Mapping[str, Any],
+    *,
+    link_type_name: str,
+) -> bool:
+    link_type = _mapping(link.get("type"))
+    configured = _string(link_type_name).lower() or "blocks"
+    name = _string(link_type.get("name")).lower()
+    if name and name == configured:
+        return True
+    outward = _string(link_type.get("outward")).lower()
+    inward = _string(link_type.get("inward")).lower()
+    return outward == "blocks" and inward == "is blocked by"
+
+def _blocking_issue_from_link(
+    link: Mapping[str, Any],
+    *,
+    target_issue_key: str,
+    link_type_name: str,
+) -> dict[str, Any] | None:
+    if not _is_blocking_link_type(link, link_type_name=link_type_name):
+        return None
+
+    target = target_issue_key.upper()
+    outward_issue = _mapping(link.get("outwardIssue") or link.get("outward_issue"))
+    inward_issue = _mapping(link.get("inwardIssue") or link.get("inward_issue"))
+    outward_key = _issue_key(outward_issue)
+    inward_key = _issue_key(inward_issue)
+
+    if outward_issue and inward_issue:
+        if inward_key == target and outward_key and outward_key != target:
+            return outward_issue
+        return None
+
+    if inward_issue and inward_key != target:
+        return inward_issue
+    return None
 
 def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:
     if isinstance(value, str) and value.strip():
@@ -1209,6 +1277,175 @@ async def create_jira_issues_from_stories(
         },
     )
 
+def _blocker_preflight_target_issue_key(inputs: Mapping[str, Any]) -> str:
+    nested = _mapping(
+        inputs.get("blockerPreflight")
+        or inputs.get("blocker_preflight")
+        or inputs.get("jira")
+    )
+    return _string(
+        inputs.get("targetIssueKey")
+        or inputs.get("target_issue_key")
+        or inputs.get("issueKey")
+        or inputs.get("issue_key")
+        or inputs.get("jiraIssueKey")
+        or inputs.get("jira_issue_key")
+        or nested.get("targetIssueKey")
+        or nested.get("target_issue_key")
+        or nested.get("issueKey")
+        or nested.get("issue_key")
+    ).upper()
+
+def _blocker_preflight_link_type(inputs: Mapping[str, Any]) -> str:
+    nested = _mapping(
+        inputs.get("blockerPreflight")
+        or inputs.get("blocker_preflight")
+        or inputs.get("jira")
+    )
+    return _string(
+        inputs.get("linkType")
+        or inputs.get("link_type")
+        or nested.get("linkType")
+        or nested.get("link_type")
+        or "Blocks"
+    )
+
+def _blocked_summary(
+    *,
+    target_issue_key: str,
+    unresolved: Sequence[Mapping[str, Any]],
+) -> str:
+    if not unresolved:
+        return (
+            f"Could not determine Jira blockers for {target_issue_key} from "
+            "trusted Jira data."
+        )
+    formatted = []
+    for item in unresolved:
+        issue_key = _string(item.get("issueKey"))
+        status = _string(item.get("status")) or "unknown"
+        formatted.append(f"{issue_key} ({status})" if issue_key else status)
+    joined = ", ".join(formatted)
+    return f"{target_issue_key} is blocked by unresolved Jira issue(s): {joined}."
+
+async def check_jira_blockers(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    jira_service_factory: JiraServiceFactory = JiraToolService,
+) -> ToolResult:
+    """Deterministically stop Jira Orchestrate only for true inbound blockers."""
+
+    target_issue_key = _blocker_preflight_target_issue_key(inputs)
+    link_type = _blocker_preflight_link_type(inputs)
+    if not target_issue_key:
+        raise ValueError("targetIssueKey is required for Jira blocker preflight.")
+
+    service = jira_service_factory()
+    try:
+        target_issue = await service.get_issue(
+            GetIssueRequest(
+                issueKey=target_issue_key,
+                fields=["status", "issuelinks"],
+            )
+        )
+    except Exception as exc:
+        code = _string(getattr(exc, "code", "")) or exc.__class__.__name__
+        summary = (
+            f"Could not determine Jira blockers for {target_issue_key} through "
+            f"trusted Jira data ({code})."
+        )
+        return ToolResult(
+            status="COMPLETED",
+            outputs={
+                "targetIssueKey": target_issue_key,
+                "decision": "blocked",
+                "blockingIssues": [],
+                "summary": summary,
+            },
+        )
+
+    target_mapping = _mapping(target_issue)
+    blockers: list[dict[str, Any]] = []
+    for link in _issue_links(target_mapping):
+        blocker_issue = _blocking_issue_from_link(
+            link,
+            target_issue_key=target_issue_key,
+            link_type_name=link_type,
+        )
+        if blocker_issue is None:
+            continue
+        blocker_key = _issue_key(blocker_issue)
+        if not blocker_key:
+            blockers.append(
+                {
+                    "issueKey": "",
+                    "status": "unknown",
+                    "statusKnown": False,
+                    "linkType": link_type,
+                    "relationship": "blocks",
+                }
+            )
+            continue
+        if not _status_name(blocker_issue):
+            try:
+                fetched = await service.get_issue(
+                    GetIssueRequest(issueKey=blocker_key, fields=["status"])
+                )
+                if isinstance(fetched, Mapping):
+                    blocker_issue = dict(fetched)
+            except Exception:
+                blocker_issue = {"key": blocker_key}
+        status = _status_name(blocker_issue)
+        blockers.append(
+            {
+                "issueKey": blocker_key,
+                "status": status or "unknown",
+                "statusKnown": bool(status),
+                "linkType": link_type,
+                "relationship": "blocks",
+                "done": _status_is_done(blocker_issue),
+            }
+        )
+
+    unresolved = [
+        item
+        for item in blockers
+        if not bool(item.get("statusKnown")) or not bool(item.get("done"))
+    ]
+    if unresolved:
+        return ToolResult(
+            status="COMPLETED",
+            outputs={
+                "targetIssueKey": target_issue_key,
+                "decision": "blocked",
+                "blockingIssues": unresolved,
+                "resolvedBlockingIssues": [
+                    item for item in blockers if bool(item.get("done"))
+                ],
+                "summary": _blocked_summary(
+                    target_issue_key=target_issue_key,
+                    unresolved=unresolved,
+                ),
+            },
+        )
+
+    summary = (
+        f"{target_issue_key} has no Jira blocker links."
+        if not blockers
+        else f"All Jira blockers for {target_issue_key} are Done."
+    )
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "targetIssueKey": target_issue_key,
+            "decision": "continue",
+            "blockingIssues": [],
+            "resolvedBlockingIssues": blockers,
+            "summary": summary,
+        },
+    )
+
 def register_story_output_tool_handlers(
     dispatcher: Any,
     *,
@@ -1247,8 +1484,22 @@ def register_story_output_tool_handlers(
         handler=_create_jira_orchestrate_tasks,
     )
 
+    async def _check_jira_blockers(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await check_jira_blockers(inputs, context)
+
+    dispatcher.register_skill(
+        skill_name=JIRA_CHECK_BLOCKERS_TOOL_NAME,
+        version="1.0",
+        handler=_check_jira_blockers,
+    )
+
 __all__ = [
+    "JIRA_CHECK_BLOCKERS_TOOL_NAME",
     "JIRA_STORY_TOOL_NAMES",
+    "check_jira_blockers",
     "create_jira_issues_from_stories",
     "create_jira_orchestrate_tasks_from_issue_mappings",
     "register_story_output_tool_handlers",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -95,8 +95,8 @@ def _is_blocking_link_type(
     link_type = _mapping(link.get("type"))
     configured = _string(link_type_name).lower() or "blocks"
     name = _string(link_type.get("name")).lower()
-    if name and name == configured:
-        return True
+    if name:
+        return name == configured
     outward = _string(link_type.get("outward")).lower()
     inward = _string(link_type.get("inward")).lower()
     return outward == "blocks" and inward == "is blocked by"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -162,6 +162,10 @@ _GITHUB_PR_URL_PATTERN = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+",
     re.IGNORECASE,
 )
+_JSON_OBJECT_CODE_FENCE_PATTERN = re.compile(
+    r"```(?:json)?\s*(\{.*?\})\s*```",
+    re.IGNORECASE | re.DOTALL,
+)
 # Replay-stable `workflow.patched` id for integration status polling terminal handling.
 INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 # Replay-stable patch id for parent-initiated defensive slot release on child terminal state.
@@ -263,6 +267,7 @@ class MoonMindRunWorkflow:
         self._operator_summary: Optional[str] = None
         self._last_step_id: Optional[str] = None
         self._last_step_summary: Optional[str] = None
+        self._plan_blocked_message: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
         self._merge_automation_disposition: Optional[str] = None
         self._merge_automation_head_sha: Optional[str] = None
@@ -2332,6 +2337,22 @@ class MoonMindRunWorkflow:
                 node_id=node_id,
                 execution_result=execution_result,
             )
+            blocked_message = self._blocked_outcome_message(execution_result)
+            if blocked_message:
+                self._plan_blocked_message = blocked_message
+                self._publish_status = "not_required"
+                self._publish_reason = blocked_message
+                require_pull_request_url = False
+                pull_request_url = None
+                self._summary = blocked_message
+                self._mark_remaining_plan_steps_skipped(
+                    ordered_nodes=ordered_nodes,
+                    completed_index=index,
+                    summary=blocked_message,
+                )
+                self._refresh_step_readiness(updated_at=workflow.now())
+                self._update_memo()
+                break
             self._record_publish_result(
                 parameters=parameters,
                 execution_result=execution_result,
@@ -2554,7 +2575,10 @@ class MoonMindRunWorkflow:
             self._publish_status = "published"
             self._publish_reason = "published pull request"
             self._publish_context["pullRequestUrl"] = pull_request_url
-        self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
+        if self._plan_blocked_message:
+            self._summary = self._plan_blocked_message
+        else:
+            self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 
         await self._maybe_start_merge_gate(
@@ -2598,6 +2622,135 @@ class MoonMindRunWorkflow:
             if isinstance(details, str) and details.strip():
                 return details.strip()
         return ""
+
+    @staticmethod
+    def _is_blocked_outcome_value(value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        return value.strip().lower() == "blocked"
+
+    def _blocked_outcome_message_from_mapping(
+        self,
+        payload: Mapping[str, Any],
+    ) -> str | None:
+        status_value = (
+            payload.get("decision")
+            or payload.get("status")
+            or payload.get("outcome")
+            or payload.get("result")
+        )
+        if not self._is_blocked_outcome_value(status_value):
+            return None
+
+        blockers = payload.get("blockingIssues")
+        if blockers is None:
+            blockers = payload.get("blocking_issues")
+        if blockers is None:
+            blockers = payload.get("blockers")
+
+        summary = self._coerce_text(
+            payload.get("summary")
+            or payload.get("message")
+            or payload.get("reason")
+            or payload.get("blockedReason")
+            or payload.get("blocked_reason"),
+            max_chars=700,
+        )
+        if (
+            not summary
+            and isinstance(blockers, Sequence)
+            and not isinstance(blockers, (str, bytes))
+            and blockers
+        ):
+            summary = "A plan step reported unresolved blockers."
+        if not summary:
+            return None
+        return f"Workflow blocked by plan step: {summary}"
+
+    @staticmethod
+    def _json_mapping_candidates_from_text(text: str) -> tuple[Mapping[str, Any], ...]:
+        raw_text = str(text or "").strip()
+        if not raw_text:
+            return ()
+
+        candidates: list[str] = []
+        if raw_text.startswith("{") and raw_text.endswith("}"):
+            candidates.append(raw_text)
+        for match in _JSON_OBJECT_CODE_FENCE_PATTERN.finditer(raw_text):
+            candidates.append(match.group(1))
+
+        mappings: list[Mapping[str, Any]] = []
+        for candidate in candidates:
+            try:
+                parsed = json.loads(candidate)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(parsed, Mapping):
+                mappings.append(parsed)
+        return tuple(mappings)
+
+    def _blocked_outcome_message(self, execution_result: Any) -> str | None:
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return None
+
+        mapping_candidates: list[Mapping[str, Any]] = [outputs]
+        for field in (
+            "workflowOutcome",
+            "workflow_outcome",
+            "terminalOutcome",
+            "terminal_outcome",
+            "outcome",
+            "result",
+        ):
+            value = outputs.get(field)
+            if isinstance(value, Mapping):
+                mapping_candidates.append(value)
+
+        for candidate in mapping_candidates:
+            message = self._blocked_outcome_message_from_mapping(candidate)
+            if message:
+                return message
+
+        for field in (
+            "operator_summary",
+            "operatorSummary",
+            "lastAssistantText",
+            "assistantText",
+            "summary",
+            "message",
+        ):
+            value = outputs.get(field)
+            if not isinstance(value, str):
+                continue
+            for candidate in self._json_mapping_candidates_from_text(value):
+                message = self._blocked_outcome_message_from_mapping(candidate)
+                if message:
+                    return message
+
+        return None
+
+    def _mark_remaining_plan_steps_skipped(
+        self,
+        *,
+        ordered_nodes: Sequence[Mapping[str, Any]],
+        completed_index: int,
+        summary: str,
+    ) -> None:
+        for node in ordered_nodes[completed_index:]:
+            node_id = str(node.get("id") or "").strip()
+            if not node_id:
+                continue
+            try:
+                self._mark_step_terminal(
+                    node_id,
+                    status="skipped",
+                    updated_at=workflow.now(),
+                    summary=summary,
+                    last_error=None,
+                )
+            except KeyError:
+                continue
 
     def _publish_mode(self, parameters: Mapping[str, Any]) -> str:
         value = parameters.get("publishMode")
@@ -3338,6 +3491,9 @@ class MoonMindRunWorkflow:
         *,
         parameters: Mapping[str, Any],
     ) -> tuple[str, str, bool]:
+        if self._plan_blocked_message:
+            return ("blocked", self._plan_blocked_message, False)
+
         publish_mode = self._publish_mode(parameters)
         if publish_mode == "none":
             return (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -163,7 +163,7 @@ _GITHUB_PR_URL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _JSON_OBJECT_CODE_FENCE_PATTERN = re.compile(
-    r"```(?:json)?\s*(\{.*?\})\s*```",
+    r"```(?:json)?\s*([\s\S]*?)\s*```",
     re.IGNORECASE | re.DOTALL,
 )
 # Replay-stable `workflow.patched` id for integration status polling terminal handling.
@@ -172,6 +172,7 @@ INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release-1"
 # Replay-stable patch id for task-scoped Codex terminate activity+signal finalization.
 RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
+RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH = "run-blocked-outcome-short-circuit-v1"
 # Replay-stable patch id for the v2 task-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
@@ -2338,7 +2339,10 @@ class MoonMindRunWorkflow:
                 execution_result=execution_result,
             )
             blocked_message = self._blocked_outcome_message(execution_result)
-            if blocked_message:
+            if (
+                blocked_message
+                and workflow.patched(RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH)
+            ):
                 self._plan_blocked_message = blocked_message
                 self._publish_status = "not_required"
                 self._publish_reason = blocked_message
@@ -2347,7 +2351,7 @@ class MoonMindRunWorkflow:
                 self._summary = blocked_message
                 self._mark_remaining_plan_steps_skipped(
                     ordered_nodes=ordered_nodes,
-                    completed_index=index,
+                    completed_index=index - 1,
                     summary=blocked_message,
                 )
                 self._refresh_step_readiness(updated_at=workflow.now())
@@ -2677,7 +2681,9 @@ class MoonMindRunWorkflow:
         if raw_text.startswith("{") and raw_text.endswith("}"):
             candidates.append(raw_text)
         for match in _JSON_OBJECT_CODE_FENCE_PATTERN.finditer(raw_text):
-            candidates.append(match.group(1))
+            content = match.group(1).strip()
+            if content.startswith("{") and content.endswith("}"):
+                candidates.append(content)
 
         mappings: list[Mapping[str, Any]] = []
         for candidate in candidates:
@@ -2737,7 +2743,7 @@ class MoonMindRunWorkflow:
         completed_index: int,
         summary: str,
     ) -> None:
-        for node in ordered_nodes[completed_index:]:
+        for node in ordered_nodes[completed_index + 1:]:
             node_id = str(node.get("id") or "").strip()
             if not node_id:
                 continue

--- a/specs/296-workflow-blocked-outcomes/plan.md
+++ b/specs/296-workflow-blocked-outcomes/plan.md
@@ -1,0 +1,37 @@
+# Implementation Plan: Workflow Blocked Outcomes
+
+**Branch**: `296-workflow-blocked-outcomes` | **Date**: 2026-05-04 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add a replay-stable workflow helper that recognizes explicit structured blocked outcomes in step outputs. On detection, the parent `MoonMind.Run` workflow records the current step, skips remaining plan steps, suppresses publish handling, and completes with a blocked result message.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Temporal Python SDK, Pydantic v2, pytest  
+**Storage**: Existing workflow history, memo, search attributes, and step ledger only  
+**Tests**: `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py`
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing workflow/agent contracts.
+- II. One-Click Agent Deployment: PASS. No deployment dependencies added.
+- III. Avoid Vendor Lock-In: PASS. Detection is generic structured output parsing.
+- IV. Own Your Data: PASS. Uses local workflow outputs only.
+- V. Skills Are First-Class: PASS. Works for agent and tool steps.
+- VI. Design for Deletion / Thick Contracts: PASS. Compact status contract, no prompt-specific branching.
+- VII. Runtime Configurability: PASS. No hidden external calls or hardcoded repo data.
+- VIII. Modular Architecture: PASS. Changes stay in `MoonMind.Run` workflow helpers.
+- IX. Resilient by Default: PASS. Prevents misleading publish failures and unnecessary downstream work.
+- X. Continuous Improvement: PASS. Final output reports the actionable blocker.
+- XI. Spec-Driven Development: PASS. This artifact records the behavior.
+- XII. Canonical Docs Separation: PASS. No canonical docs changed.
+- XIII. Pre-Release Compatibility: PASS. No compatibility aliases; existing behavior remains for non-blocked no-change publishes.
+
+## Implementation Strategy
+
+1. Add blocked outcome parsing for structured mappings and JSON summaries.
+2. Stop remaining plan execution and mark downstream steps skipped.
+3. Suppress publish handling for blocked outcomes.
+4. Add unit coverage for parsing, final publish outcome, and execution-stage stop behavior.

--- a/specs/296-workflow-blocked-outcomes/spec.md
+++ b/specs/296-workflow-blocked-outcomes/spec.md
@@ -1,0 +1,31 @@
+# Feature Specification: Workflow Blocked Outcomes
+
+**Feature Branch**: `296-workflow-blocked-outcomes`  
+**Created**: 2026-05-04  
+**Status**: Draft  
+**Input**:
+
+```text
+Troubleshoot and fix workflow failure for task mm:9b25b452-8bbc-4a20-8901-966e793cea33.
+Make the solution robust, performant, generally usable, and not overly tailored to any particular repo.
+```
+
+## User Story - Stop Plans On Explicit Blockers
+
+As a MoonMind operator, I want a workflow step that reports an explicit blocked outcome to stop downstream execution before implementation or publishing so the run records the real blocker instead of failing later with a misleading publish error.
+
+## Requirements
+
+- **FR-001**: The workflow MUST detect explicit structured blocked outcomes from agent or tool step outputs.
+- **FR-002**: Detection MUST be generic and MUST NOT depend on a repository name, Jira project key, branch name, or issue key.
+- **FR-003**: When a step reports a blocked outcome, the workflow MUST stop executing remaining plan steps.
+- **FR-004**: Remaining plan steps MUST be marked skipped in the step ledger.
+- **FR-005**: PR/branch publishing MUST be suppressed for blocked outcomes.
+- **FR-006**: The final workflow result MUST preserve the blocker summary without throwing a publish failure.
+- **FR-007**: Existing no-change PR publish behavior MUST still fail when no blocked outcome is present.
+
+## Success Criteria
+
+- **SC-001**: A structured `decision/status/outcome: blocked` report stops the plan after the reporting step.
+- **SC-002**: The blocked step is recorded, remaining steps are skipped, and no native PR creation is attempted.
+- **SC-003**: The final result status is `blocked` with the reported summary and `publish_failure` is false.

--- a/specs/296-workflow-blocked-outcomes/tasks.md
+++ b/specs/296-workflow-blocked-outcomes/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Workflow Blocked Outcomes
+
+- [X] T001 Diagnose `mm:9b25b452-8bbc-4a20-8901-966e793cea33` workflow history, agent artifacts, and workspace state.
+- [X] T002 Confirm the failure was caused by a structured blocker report being ignored before publish handling.
+- [X] T003 Add generic structured blocked-outcome detection in `moonmind/workflows/temporal/workflows/run.py`.
+- [X] T004 Stop remaining plan nodes and mark them skipped when a blocked outcome is detected.
+- [X] T005 Suppress PR publish failure and return a blocked final result.
+- [X] T006 Add unit tests for structured blocker parsing and blocked publish completion.
+- [X] T007 Add unit test proving execution stops after a structured blocked outcome.
+- [X] T008 Run focused and broader unit verification.

--- a/specs/297-jira-blocker-direction/plan.md
+++ b/specs/297-jira-blocker-direction/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Jira Blocker Direction
+
+**Branch**: `297-jira-blocker-direction` | **Date**: 2026-05-04 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Keep Jira dependency creation aligned with the existing `linear_blocker_chain`
+contract, and replace Jira Orchestrate's prompt-only blocker decision with a
+first-party executable tool that parses Jira `Blocks` link direction.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal tool dispatcher, pytest  
+**Storage**: Existing workflow outputs only  
+**Tests**: Focused story-output, template expansion, and startup seed tests.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing trusted Jira service.
+- II. One-Click Agent Deployment: PASS. No new services or secrets.
+- III. Avoid Vendor Lock-In: PASS. Jira-specific logic stays behind the Jira tool boundary.
+- IV. Own Your Data: PASS. Uses trusted local integration responses.
+- V. Skills Are First-Class: PASS. Adds a deterministic executable tool.
+- VI. Thick Contracts: PASS. Tool output is compact structured JSON.
+- VII. Runtime Configurability: PASS. Link type remains an input with `Blocks` default.
+- VIII. Modular Architecture: PASS. Parser and handler stay in first-party tool code.
+- IX. Resilient by Default: PASS. Fails closed only when trusted blocker status is unavailable.
+- X. Continuous Improvement: PASS. Blocked summaries explain the exact Jira issue.
+- XI. Spec-Driven Development: PASS. This artifact records the fix.
+- XII. Canonical Docs Separation: PASS. No canonical docs changed.
+- XIII. Pre-Release Compatibility: PASS. Updates internal preset/tool contracts directly.
+
+## Implementation Strategy
+
+1. Add deterministic Jira blocker-preflight parsing for `Blocks` link direction.
+2. Register the preflight as a first-party `mm.tool.execute` handler.
+3. Update Jira Orchestrate to use the deterministic tool step.
+4. Add regressions for outward-link continuation, inward-link blocking, status fetch, and preset seeding.

--- a/specs/297-jira-blocker-direction/spec.md
+++ b/specs/297-jira-blocker-direction/spec.md
@@ -1,0 +1,46 @@
+# Feature Specification: Jira Blocker Direction
+
+**Feature Branch**: `297-jira-blocker-direction`  
+**Created**: 2026-05-04  
+**Status**: Draft  
+**Input**:
+
+```text
+Jira dependencies must align with MoonMind's ordered story dependencies. Step 1
+must not be blocked by step 2. Fix blocker creation and blocker detection so the
+logic is deterministic and uses Jira link direction correctly.
+```
+
+## User Story - Directionally Correct Jira Blockers
+
+As a MoonMind operator, I want Jira blocker links and Jira Orchestrate blocker
+preflight checks to use the same ordered dependency semantics so earlier stories
+block later stories, and later stories never block earlier work due to reversed
+link interpretation.
+
+## Requirements
+
+- **FR-001**: `linear_blocker_chain` MUST continue to create links where each
+  earlier story blocks the immediately later story.
+- **FR-002**: Jira Orchestrate preflight MUST only block a target issue when
+  trusted Jira link data shows the target is on the blocked/inward side of a
+  `Blocks` relationship.
+- **FR-003**: A `Blocks` relationship where the target issue blocks another
+  issue MUST NOT block the target orchestration.
+- **FR-004**: Blocker status MUST be read from trusted Jira data, fetching the
+  linked blocker issue when status is not embedded in the target response.
+- **FR-005**: Missing trusted blocker status MUST fail closed as a blocked
+  outcome.
+- **FR-006**: The preflight MUST be executable as a deterministic MoonMind tool,
+  not dependent on prompt-only link interpretation.
+
+## Success Criteria
+
+- **SC-001**: A three-story chain creates `story1 -> story2` and
+  `story2 -> story3` Jira blocker requests.
+- **SC-002**: Target issue `MM-1` with an outward `Blocks` link to `MM-2`
+  continues even when `MM-2` is not Done.
+- **SC-003**: Target issue `MM-2` with an inward `Blocks` link from `MM-1`
+  blocks when `MM-1` is not Done.
+- **SC-004**: The seeded Jira Orchestrate preset uses the deterministic
+  blocker-preflight tool before MoonSpec implementation.

--- a/specs/297-jira-blocker-direction/tasks.md
+++ b/specs/297-jira-blocker-direction/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Jira Blocker Direction
+
+- [X] T001 Confirm existing `linear_blocker_chain` creation uses previous story as blocker and next story as blocked.
+- [X] T002 Add deterministic Jira blocker-preflight tool parsing raw Jira link direction.
+- [X] T003 Treat target `outwardIssue` Blocks links as non-blocking for the target.
+- [X] T004 Treat target `inwardIssue` Blocks links as blockers and fetch missing blocker status.
+- [X] T005 Register the tool in the first-party tool dispatcher and registry payload.
+- [X] T006 Update Jira Orchestrate preset to execute the deterministic blocker preflight.
+- [X] T007 Add regression tests for link creation order and blocker direction.
+- [X] T008 Run focused and final unit verification.

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -105,18 +105,22 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert jira_orchestrate_template is not None
         assert jira_orchestrate_template.latest_version is not None
         jira_orchestrate_steps = [
-            step["skill"]["id"]
+            (step.get("skill") or step.get("tool"))["id"]
             for step in jira_orchestrate_template.latest_version.steps
         ]
         assert jira_orchestrate_steps[0] == "jira-issue-updater"
-        assert jira_orchestrate_steps[1] == "auto"
+        assert jira_orchestrate_steps[1] == "jira.check_blockers"
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
         assert len(jira_orchestrate_steps) == 13
         blocker_step = jira_orchestrate_template.latest_version.steps[1]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
-        assert "trusted Jira tool surface" in blocker_step["instructions"]
+        assert blocker_step["type"] == "tool"
+        assert blocker_step["tool"]["id"] == "jira.check_blockers"
+        assert "deterministic trusted Jira blocker preflight" in blocker_step["instructions"]
+        assert "inwardIssue" in blocker_step["instructions"]
+        assert "outwardIssue" in blocker_step["instructions"]
         assert "Done" in blocker_step["instructions"]
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1451,9 +1451,12 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "orchestration_mode" not in {
                 item["name"] for item in template_payload["inputs"]
             }
-            assert [step["skill"]["id"] for step in template.latest_version.steps] == [
+            assert [
+                (step.get("skill") or step.get("tool"))["id"]
+                for step in template.latest_version.steps
+            ] == [
                 "jira-issue-updater",
-                "auto",
+                "jira.check_blockers",
                 "auto",
                 "auto",
                 "moonspec-specify",
@@ -1487,8 +1490,18 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "MM-328" in expanded["steps"][0]["instructions"]
             assert "In Progress" in expanded["steps"][0]["instructions"]
             assert expanded["steps"][1]["title"] == "Check Jira blockers before implementation"
-            assert "Fetch Jira issue MM-328" in expanded["steps"][1]["instructions"]
-            assert "trusted Jira tool surface" in expanded["steps"][1]["instructions"]
+            assert expanded["steps"][1]["type"] == "tool"
+            assert expanded["steps"][1]["tool"]["id"] == "jira.check_blockers"
+            assert expanded["steps"][1]["targetIssueKey"] == "MM-328"
+            assert expanded["steps"][1]["blockerPreflight"] == {
+                "targetIssueKey": "MM-328",
+                "linkType": "Blocks",
+            }
+            assert "Jira issue MM-328" in expanded["steps"][1]["instructions"]
+            assert "deterministic trusted Jira blocker preflight" in expanded["steps"][1]["instructions"]
+            assert "inwardIssue" in expanded["steps"][1]["instructions"]
+            assert "outwardIssue" in expanded["steps"][1]["instructions"]
+            assert "MUST NOT block this orchestration" in expanded["steps"][1]["instructions"]
             assert "blocker" in expanded["steps"][1]["instructions"]
             assert "Done" in expanded["steps"][1]["instructions"]
             assert "non-blocker" in expanded["steps"][1]["instructions"]

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -644,6 +644,7 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
         in {
             run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
             run_workflow_module.RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH,
+            run_workflow_module.RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH,
         },
     )
     monkeypatch.setattr(
@@ -1669,6 +1670,28 @@ def test_blocked_outcome_message_detects_structured_agent_report() -> None:
     )
 
     assert message == "Workflow blocked by plan step: THOR-354 is blocked by THOR-355."
+
+def test_blocked_outcome_message_detects_nested_json_code_fence() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    message = workflow._blocked_outcome_message(
+        {
+            "status": "COMPLETED",
+            "outputs": {
+                "operator_summary": """
+```json
+{
+  "decision": "blocked",
+  "details": {"source": "jira", "attempt": 1},
+  "summary": "Nested structured blocker parsed."
+}
+```
+""",
+            },
+        }
+    )
+
+    assert message == "Workflow blocked by plan step: Nested structured blocker parsed."
 
 def test_publish_completion_reports_blocked_outcome_without_pr_failure() -> None:
     workflow = MoonMindRunWorkflow()

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -529,6 +529,144 @@ async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_p
     assert artifact_reads == ["art_plan_1"]
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._integration = None
+    child_calls: list[str] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        normalized = _normalize_payload(payload)
+        if activity_type == "artifact.read":
+            assert normalized["artifact_ref"] == "art_plan_1"
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Runtime Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/unused",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "check-blockers",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "codex_cli",
+                                "version": "1.0",
+                            },
+                            "inputs": {"instructions": "Check blockers."},
+                        },
+                        {
+                            "id": "implement",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "codex_cli",
+                                "version": "1.0",
+                            },
+                            "inputs": {"instructions": "Implement changes."},
+                        },
+                    ],
+                    "edges": [{"from": "check-blockers", "to": "implement"}],
+                }
+            ).encode("utf-8")
+        raise AssertionError(f"unexpected activity {activity_type}")
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        node_id = str(_kwargs["id"]).rsplit(":agent:", 1)[1]
+        child_calls.append(node_id)
+        return {
+            "summary": "Agent finished",
+            "metadata": {
+                "operator_summary": (
+                    '{"decision":"blocked","summary":"Required dependency is not done."}'
+                ),
+                "push_status": "no_commits",
+                "push_branch": "generated-branch",
+                "push_base_ref": "origin/main",
+                "push_commit_count": 0,
+            },
+            "output_refs": [],
+        }
+
+    async def fake_bind_task_scoped_session(
+        self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+            run_workflow_module.RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH,
+        },
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_task_scoped_session",
+        fake_bind_task_scoped_session,
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    steps = workflow.get_step_ledger()["steps"]
+    assert child_calls == ["check-blockers"]
+    assert workflow._plan_blocked_message == (
+        "Workflow blocked by plan step: Required dependency is not done."
+    )
+    assert workflow._publish_status == "not_required"
+    assert steps[0]["status"] == "succeeded"
+    assert steps[1]["status"] == "skipped"
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_preserves_registry_read_for_unpatched_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1505,6 +1643,49 @@ def test_activity_result_failure_message_prefers_stderr_tail_over_progress_detai
         }
     )
     assert message == "gemini quota exceeded"
+
+def test_blocked_outcome_message_detects_structured_agent_report() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    message = workflow._blocked_outcome_message(
+        {
+            "status": "COMPLETED",
+            "outputs": {
+                "operator_summary": """
+```json
+{
+  "targetIssueKey": "THOR-354",
+  "decision": "blocked",
+  "blockingIssues": [
+    {"issueKey": "THOR-355", "status": "Backlog"}
+  ],
+  "summary": "THOR-354 is blocked by THOR-355."
+}
+```
+""",
+                "push_status": "no_commits",
+            },
+        }
+    )
+
+    assert message == "Workflow blocked by plan step: THOR-354 is blocked by THOR-355."
+
+def test_publish_completion_reports_blocked_outcome_without_pr_failure() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._integration = None
+    workflow._publish_status = "not_required"
+    workflow._publish_reason = "Workflow blocked by plan step: blocked upstream."
+    workflow._plan_blocked_message = (
+        "Workflow blocked by plan step: blocked upstream."
+    )
+
+    status, reason, failed = workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == "blocked"
+    assert reason == "Workflow blocked by plan step: blocked upstream."
+    assert failed is False
 
 def test_publish_completion_accepts_jira_output_without_pr_url() -> None:
     workflow = MoonMindRunWorkflow()

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -765,6 +765,37 @@ async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_don
     ]
 
 @pytest.mark.asyncio
+async def test_check_jira_blockers_respects_configured_link_type_name():
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {
+                        "name": "Blocks",
+                        "outward": "blocks",
+                        "inward": "is blocked by",
+                    },
+                    "inwardIssue": {
+                        "key": "MM-1",
+                        "fields": {"status": {"name": "Backlog"}},
+                    },
+                }
+            ]
+        },
+    }
+
+    result = await check_jira_blockers(
+        {"targetIssueKey": "MM-2", "linkType": "Depends"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["blockingIssues"] == []
+    assert [request.issue_key for request in service.get_issue_requests] == ["MM-2"]
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_dependency_mode_none_skips_links():
     service = _FakeJiraService()
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from moonmind.workflows.temporal.story_output_tools import (
+    check_jira_blockers,
     create_jira_issues_from_stories,
     create_jira_orchestrate_tasks_from_issue_mappings,
 )
@@ -17,6 +18,8 @@ class _FakeJiraService:
         self.link_requests: list[Any] = []
         self.search_requests: list[Any] = []
         self.search_response: Any = {"issues": []}
+        self.issue_responses: dict[str, Any] = {}
+        self.get_issue_requests: list[Any] = []
         self.existing_links: set[tuple[str, str]] = set()
         self.fail_link_after: int | None = None
 
@@ -41,6 +44,10 @@ class _FakeJiraService:
     async def search_issues(self, request):
         self.search_requests.append(request)
         return self.search_response
+
+    async def get_issue(self, request):
+        self.get_issue_requests.append(request)
+        return self.issue_responses.get(request.issue_key, {"key": request.issue_key})
 
     async def list_create_issue_types(self, request):
         return {
@@ -644,6 +651,118 @@ async def test_create_jira_issues_linear_blocker_chain_creates_adjacent_links():
         ("MM-2", "MM-3"),
     ]
     assert [item["status"] for item in jira["linkResults"]] == ["created", "created"]
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_ignores_outward_links_from_target_issue():
+    service = _FakeJiraService()
+    service.issue_responses["MM-1"] = {
+        "key": "MM-1",
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {
+                        "name": "Blocks",
+                        "outward": "blocks",
+                        "inward": "is blocked by",
+                    },
+                    "outwardIssue": {
+                        "key": "MM-2",
+                        "fields": {"status": {"name": "Backlog"}},
+                    },
+                }
+            ]
+        },
+    }
+
+    result = await check_jira_blockers(
+        {"targetIssueKey": "MM-1"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["blockingIssues"] == []
+    assert "no Jira blocker links" in result.outputs["summary"]
+    assert [request.issue_key for request in service.get_issue_requests] == ["MM-1"]
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_blocks_only_on_inward_unresolved_blocks_link():
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {
+                        "name": "Blocks",
+                        "outward": "blocks",
+                        "inward": "is blocked by",
+                    },
+                    "inwardIssue": {
+                        "key": "MM-1",
+                        "fields": {"status": {"name": "Backlog"}},
+                    },
+                }
+            ]
+        },
+    }
+
+    result = await check_jira_blockers(
+        {"targetIssueKey": "MM-2"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["blockingIssues"] == [
+        {
+            "issueKey": "MM-1",
+            "status": "Backlog",
+            "statusKnown": True,
+            "linkType": "Blocks",
+            "relationship": "blocks",
+            "done": False,
+        }
+    ]
+    assert result.outputs["summary"] == (
+        "MM-2 is blocked by unresolved Jira issue(s): MM-1 (Backlog)."
+    )
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_done():
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "MM-1"},
+                }
+            ]
+        },
+    }
+    service.issue_responses["MM-1"] = {
+        "key": "MM-1",
+        "fields": {
+            "status": {
+                "name": "Closed",
+                "statusCategory": {"key": "done"},
+            }
+        },
+    }
+
+    result = await check_jira_blockers(
+        {"targetIssueKey": "MM-2"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["blockingIssues"] == []
+    assert result.outputs["resolvedBlockingIssues"][0]["issueKey"] == "MM-1"
+    assert result.outputs["resolvedBlockingIssues"][0]["done"] is True
+    assert [request.issue_key for request in service.get_issue_requests] == [
+        "MM-2",
+        "MM-1",
+    ]
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_dependency_mode_none_skips_links():


### PR DESCRIPTION
## Summary
- add deterministic `jira.check_blockers` preflight using Jira `Blocks` inward/outward direction
- update Jira Orchestrate to use the trusted tool before MoonSpec work
- preserve blocked workflow outcomes so blocked runs stop cleanly instead of failing PR publish
- add specs and regression tests for blocker direction and blocked workflow completion

## Root Cause
Jira Orchestrate relied on an agent prompt to interpret Jira issue-link direction. A target issue that blocked a later issue could be misread as being blocked by that later issue, causing step 1 to stop behind step 2. The parent workflow also kept running after an explicit blocked outcome, which turned a valid block report into a misleading PR creation failure.

## Validation
- `git diff --check`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/api/test_task_step_templates_service.py tests/integration/test_startup_task_template_seeding.py`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/test_run_artifacts.py`
- `./tools/test_unit.sh`
