### PR TITLE
Fix Jira blocker preflight direction

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -43,7 +43,7 @@ steps:
     instructions: |-
       Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any MoonSpec implementation work starts.
 
-      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as outwardIssue, that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as inwardIssue, {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this orchestration.
+      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as inwardIssue and the link type says the inward relationship is "is blocked by", that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as outwardIssue and the link type says the outward relationship is "blocks", {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this orchestration.
 
       Ignore non-blocker issue links for the blocker decision.
 

--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -43,7 +43,7 @@ steps:
     instructions: |-
       Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any MoonSpec implementation work starts.
 
-      Jira Blocks direction is strict: for the target issue response, only an inbound Blocks relationship where Jira exposes the other issue as inwardIssue means another issue blocks {{ inputs.jira_issue_key }}. An outwardIssue Blocks relationship means {{ inputs.jira_issue_key }} blocks a later issue and MUST NOT block this orchestration.
+      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as outwardIssue, that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as inwardIssue, {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this orchestration.
 
       Ignore non-blocker issue links for the blocker decision.
 

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,17 @@
 [
   {
-    "id": 3184941164,
-    "disposition": "addressed",
-    "rationale": "Changed the blocked-outcome skip call to use the completed node's zero-based index so only downstream nodes are marked skipped and the completed node remains succeeded."
-  },
-  {
-    "id": 3184941177,
-    "disposition": "addressed",
-    "rationale": "Updated the fenced JSON regex to capture full code fence content instead of a non-greedy object fragment, preserving nested JSON objects."
-  },
-  {
-    "id": 3184941180,
-    "disposition": "addressed",
-    "rationale": "Updated fenced-content extraction to append only content that is a complete JSON object before calling json.loads."
-  },
-  {
-    "id": 4224028132,
+    "id": 4224428280,
     "disposition": "not-applicable",
-    "rationale": "Broad review summary; the actionable inline findings from this review were handled individually."
+    "rationale": "Bot review stated it had no feedback to provide."
   },
   {
-    "id": 3184947007,
+    "id": 3185270091,
     "disposition": "addressed",
-    "rationale": "Guarded the blocked-outcome short-circuit behind a replay-stable workflow.patched marker."
+    "rationale": "The feedback commit restores single-ended inwardIssue blocker handling and updates direction tests/template text."
   },
   {
-    "id": 3184947011,
-    "disposition": "addressed",
-    "rationale": "Made link-type matching strict when Jira provides a type name, so configured non-Blocks link types do not classify Blocks links as blockers."
-  },
-  {
-    "id": 4224033939,
+    "id": 4224429496,
     "disposition": "not-applicable",
-    "rationale": "Automated review metadata without an actionable code request."
+    "rationale": "Automated review summary wrapper; actionable child discussion 3185270091 was addressed separately."
   }
 ]

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -121,8 +121,8 @@ def _blocking_issue_from_link(
             return outward_issue
         return None
 
-    if outward_issue and outward_key != target:
-        return outward_issue
+    if inward_issue and inward_key != target:
+        return inward_issue
     return None
 
 def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -121,8 +121,8 @@ def _blocking_issue_from_link(
             return outward_issue
         return None
 
-    if inward_issue and inward_key != target:
-        return inward_issue
+    if outward_issue and outward_key != target:
+        return outward_issue
     return None
 
 def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -119,8 +119,8 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert blocker_step["type"] == "tool"
         assert blocker_step["tool"]["id"] == "jira.check_blockers"
         assert "deterministic trusted Jira blocker preflight" in blocker_step["instructions"]
-        assert "inwardIssue" in blocker_step["instructions"]
-        assert "outwardIssue" in blocker_step["instructions"]
+        assert "other issue as outwardIssue" in blocker_step["instructions"]
+        assert "other issue as inwardIssue" in blocker_step["instructions"]
         assert "Done" in blocker_step["instructions"]
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1499,8 +1499,8 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             }
             assert "Jira issue MM-328" in expanded["steps"][1]["instructions"]
             assert "deterministic trusted Jira blocker preflight" in expanded["steps"][1]["instructions"]
-            assert "inwardIssue" in expanded["steps"][1]["instructions"]
-            assert "outwardIssue" in expanded["steps"][1]["instructions"]
+            assert "other issue as outwardIssue" in expanded["steps"][1]["instructions"]
+            assert "other issue as inwardIssue" in expanded["steps"][1]["instructions"]
             assert "MUST NOT block this orchestration" in expanded["steps"][1]["instructions"]
             assert "blocker" in expanded["steps"][1]["instructions"]
             assert "Done" in expanded["steps"][1]["instructions"]

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -683,39 +683,7 @@ async def test_create_jira_issues_linear_blocker_chain_creates_adjacent_links():
     assert [item["status"] for item in jira["linkResults"]] == ["created", "created"]
 
 @pytest.mark.asyncio
-async def test_check_jira_blockers_ignores_inward_links_from_target_issue():
-    service = _FakeJiraService()
-    service.issue_responses["MM-1"] = {
-        "key": "MM-1",
-        "fields": {
-            "issuelinks": [
-                {
-                    "type": {
-                        "name": "Blocks",
-                        "outward": "blocks",
-                        "inward": "is blocked by",
-                    },
-                    "inwardIssue": {
-                        "key": "MM-2",
-                        "fields": {"status": {"name": "Backlog"}},
-                    },
-                }
-            ]
-        },
-    }
-
-    result = await check_jira_blockers(
-        {"targetIssueKey": "MM-1"},
-        jira_service_factory=lambda: service,
-    )
-
-    assert result.outputs["decision"] == "continue"
-    assert result.outputs["blockingIssues"] == []
-    assert "no Jira blocker links" in result.outputs["summary"]
-    assert [request.issue_key for request in service.get_issue_requests] == ["MM-1"]
-
-@pytest.mark.asyncio
-async def test_check_jira_blockers_blocks_only_on_outward_unresolved_blocks_link():
+async def test_check_jira_blockers_blocks_on_single_inward_unresolved_blocks_link():
     service = _FakeJiraService()
     service.issue_responses["MM-2"] = {
         "key": "MM-2",
@@ -727,7 +695,7 @@ async def test_check_jira_blockers_blocks_only_on_outward_unresolved_blocks_link
                         "outward": "blocks",
                         "inward": "is blocked by",
                     },
-                    "outwardIssue": {
+                    "inwardIssue": {
                         "key": "MM-1",
                         "fields": {"status": {"name": "Backlog"}},
                     },
@@ -755,6 +723,39 @@ async def test_check_jira_blockers_blocks_only_on_outward_unresolved_blocks_link
     assert result.outputs["summary"] == (
         "MM-2 is blocked by unresolved Jira issue(s): MM-1 (Backlog)."
     )
+    assert [request.issue_key for request in service.get_issue_requests] == ["MM-2"]
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_ignores_single_outward_links_from_target_issue():
+    service = _FakeJiraService()
+    service.issue_responses["MM-1"] = {
+        "key": "MM-1",
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {
+                        "name": "Blocks",
+                        "outward": "blocks",
+                        "inward": "is blocked by",
+                    },
+                    "outwardIssue": {
+                        "key": "MM-2",
+                        "fields": {"status": {"name": "Backlog"}},
+                    },
+                }
+            ]
+        },
+    }
+
+    result = await check_jira_blockers(
+        {"targetIssueKey": "MM-1"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["blockingIssues"] == []
+    assert "no Jira blocker links" in result.outputs["summary"]
+    assert [request.issue_key for request in service.get_issue_requests] == ["MM-1"]
 
 @pytest.mark.asyncio
 async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_done():
@@ -765,7 +766,7 @@ async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_don
             "issuelinks": [
                 {
                     "type": {"name": "Blocks"},
-                    "outwardIssue": {"key": "MM-1"},
+                    "inwardIssue": {"key": "MM-1"},
                 }
             ]
         },

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -683,7 +683,7 @@ async def test_create_jira_issues_linear_blocker_chain_creates_adjacent_links():
     assert [item["status"] for item in jira["linkResults"]] == ["created", "created"]
 
 @pytest.mark.asyncio
-async def test_check_jira_blockers_ignores_outward_links_from_target_issue():
+async def test_check_jira_blockers_ignores_inward_links_from_target_issue():
     service = _FakeJiraService()
     service.issue_responses["MM-1"] = {
         "key": "MM-1",
@@ -695,7 +695,7 @@ async def test_check_jira_blockers_ignores_outward_links_from_target_issue():
                         "outward": "blocks",
                         "inward": "is blocked by",
                     },
-                    "outwardIssue": {
+                    "inwardIssue": {
                         "key": "MM-2",
                         "fields": {"status": {"name": "Backlog"}},
                     },
@@ -715,7 +715,7 @@ async def test_check_jira_blockers_ignores_outward_links_from_target_issue():
     assert [request.issue_key for request in service.get_issue_requests] == ["MM-1"]
 
 @pytest.mark.asyncio
-async def test_check_jira_blockers_blocks_only_on_inward_unresolved_blocks_link():
+async def test_check_jira_blockers_blocks_only_on_outward_unresolved_blocks_link():
     service = _FakeJiraService()
     service.issue_responses["MM-2"] = {
         "key": "MM-2",
@@ -727,7 +727,7 @@ async def test_check_jira_blockers_blocks_only_on_inward_unresolved_blocks_link(
                         "outward": "blocks",
                         "inward": "is blocked by",
                     },
-                    "inwardIssue": {
+                    "outwardIssue": {
                         "key": "MM-1",
                         "fields": {"status": {"name": "Backlog"}},
                     },
@@ -765,7 +765,7 @@ async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_don
             "issuelinks": [
                 {
                     "type": {"name": "Blocks"},
-                    "inwardIssue": {"key": "MM-1"},
+                    "outwardIssue": {"key": "MM-1"},
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- Treat single-sided Jira GET issue links correctly: outwardIssue is the blocking issue for the queried target; inwardIssue means the target blocks another issue.
- Update Jira Orchestrate seeded preset text so the blocker preflight instructions match the deterministic direction semantics.
- Update blocker preflight and template seed tests to cover the corrected orientation.

## Verification
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py -k check_jira_blockers
- ./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py -k jira_orchestrate
- Live check: THOR-354 preflight continues, THOR-355 preflight blocks only when THOR-354 is not Done.

## Operational repair
- Stopped stale reruns that used old expanded payloads or unresolved templates.
- Synced the Jira Orchestrate seed catalog in the running service.
- Requeued THOR-355 through THOR-360 with expanded jira.check_blockers steps and a linear MoonMind dependency chain after THOR-354.
- Restored THOR-356 to Backlog after the bad stale run moved it to In Progress prematurely.