### PR TITLE
[codex] Support Jira breakdown subtask output

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2641,7 +2641,15 @@ def _normalize_story_output_payload(raw_story_output: Any) -> dict[str, Any]:
     jira_payload = _coerce_mapping(story_output.get("jira"))
     if jira_payload:
         normalized_jira: dict[str, Any] = {}
-        for key in ("projectKey", "issueTypeId", "issueTypeName", "dependencyMode"):
+        for key in (
+            "projectKey",
+            "issueTypeId",
+            "issueTypeName",
+            "boardId",
+            "dependencyMode",
+            "parentIssueKey",
+            "sourceIssueKey",
+        ):
             value = jira_payload.get(key)
             if isinstance(value, str) and value.strip():
                 normalized_jira[key] = value.strip()

--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown-orchestrate
 title: Jira Breakdown and Orchestrate
-description: Break a broad Jira or design input into stories, create Jira Story issues, then create dependent Jira Orchestrate tasks for each generated story.
+description: Break a broad Jira or design input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
 scope: global
 version: 1.0.0
 tags:
@@ -69,12 +69,14 @@ steps:
       args: {}
       requiredCapabilities:
         - git
-  - title: Create Jira stories
+  - title: Create Jira issues
     instructions: |-
       Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each story from the generated MoonSpec breakdown.
 
       Use the runtime-provided story breakdown JSON path.
       Every Jira issue must include the Source Document path from the story breakdown.
+      {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
+      {% if inputs.source_issue_key and inputs.jira_issue_type | lower in ["sub-task", "subtask", "sub task"] %}Create each generated Jira issue as a sub-task of {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
@@ -87,6 +89,7 @@ steps:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
         boardId: "{{ inputs.jira_board_id }}"
+        sourceIssueKey: "{{ inputs.source_issue_key }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3184919504,
+    "id": 3185306869,
     "disposition": "addressed",
-    "rationale": "Added w-full to queue-step-type-options container in settings.tsx to fix sliding thumb alignment with variable label widths."
+    "rationale": "Updated Jira story output creation so sourceIssueKey is only used as a parent fallback for Sub-task issue types; normal Story creation now uses create_issue even when sourceIssueKey is present."
   },
   {
-    "id": 4224002358,
-    "disposition": "addressed",
-    "rationale": "Review summary covers the same layout issue addressed by adding w-full to the navigation container."
-  },
-  {
-    "id": 3184882513,
-    "disposition": "addressed",
-    "rationale": "Removed the redundant unpublished handoff check from the exception block; the pre-try guard already covers unchanged previous_outputs/ref inputs."
-  },
-  {
-    "id": 4223961398,
+    "id": 4224468342,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; its actionable child comment 3184882513 was addressed."
+    "rationale": "Automated Codex review summary only; the actionable child review comments are classified separately."
   },
   {
-    "id": 3184895029,
+    "id": 3185321828,
     "disposition": "addressed",
-    "rationale": "Scoped Jira auth diagnostics now require an authenticated signal: /myself is tried first, and the fallback project/search probe only succeeds when Jira returns x-aaccountid."
+    "rationale": "Changed Sub-task validation to require a global fallback or every generated story to carry a parentIssueKey, preventing mixed parent coverage from passing validation."
   },
   {
-    "id": 4223974897,
+    "id": 4224484578,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper; its actionable child comment 3184895029 was addressed."
+    "rationale": "Automated review body summarizing the same actionable validation gap handled by comment 3185321828."
   }
 ]

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -308,6 +308,12 @@ def _source_issue_key(
             return _string(value)
     return ""
 
+
+def _is_subtask_issue_type_name(issue_type_name: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "", issue_type_name.strip().lower())
+    return normalized == "subtask"
+
+
 def _stable_idempotency_key(
     *,
     source_issue_key: str,
@@ -1114,6 +1120,39 @@ async def create_jira_issues_from_stories(
             )
         raise ValueError(reason)
 
+    is_subtask_issue_type = _is_subtask_issue_type_name(issue_type_name)
+    source_parent_issue_key = _source_issue_key(
+        inputs=inputs,
+        traceability=jira_payload,
+    )
+    explicit_parent_issue_key = _parent_issue_key(
+        story={},
+        jira_payload=jira_payload,
+        inputs=inputs,
+    )
+    has_story_parent_issue_key = any(
+        _parent_issue_key(story=story, jira_payload={}, inputs={})
+        for story in stories
+    )
+    if (
+        is_subtask_issue_type
+        and not source_parent_issue_key
+        and not explicit_parent_issue_key
+        and not has_story_parent_issue_key
+    ):
+        reason = (
+            "Jira issueTypeName 'Sub-task' requires sourceIssueKey or "
+            "parentIssueKey so created issues can be attached to a parent issue."
+        )
+        if fallback_on_failure:
+            return _fallback_result(
+                reason=reason,
+                inputs=inputs,
+                story_count=len(stories),
+                dependency_mode=dependency_mode,
+            )
+        raise ValueError(reason)
+
     created: list[dict[str, Any]] = []
     issue_mappings: list[dict[str, Any]] = []
     marker_label = _workflow_marker_label(inputs=inputs, context=_context)
@@ -1153,7 +1192,7 @@ async def create_jira_issues_from_stories(
                 story=story,
                 jira_payload=jira_payload,
                 inputs=inputs,
-            )
+            ) or source_parent_issue_key
             if parent_issue_key:
                 request = CreateSubtaskRequest(
                     projectKey=project_key,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1121,16 +1121,17 @@ async def create_jira_issues_from_stories(
         raise ValueError(reason)
 
     is_subtask_issue_type = _is_subtask_issue_type_name(issue_type_name)
-    source_parent_issue_key = _source_issue_key(
+    source_issue_key = _source_issue_key(
         inputs=inputs,
         traceability=jira_payload,
     )
+    source_parent_issue_key = source_issue_key if is_subtask_issue_type else ""
     explicit_parent_issue_key = _parent_issue_key(
         story={},
         jira_payload=jira_payload,
         inputs=inputs,
     )
-    has_story_parent_issue_key = any(
+    has_all_story_parent_issue_keys = all(
         _parent_issue_key(story=story, jira_payload={}, inputs={})
         for story in stories
     )
@@ -1138,11 +1139,12 @@ async def create_jira_issues_from_stories(
         is_subtask_issue_type
         and not source_parent_issue_key
         and not explicit_parent_issue_key
-        and not has_story_parent_issue_key
+        and not has_all_story_parent_issue_keys
     ):
         reason = (
             "Jira issueTypeName 'Sub-task' requires sourceIssueKey or "
-            "parentIssueKey so created issues can be attached to a parent issue."
+            "parentIssueKey for every story so created issues can be attached "
+            "to a parent issue."
         )
         if fallback_on_failure:
             return _fallback_result(

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1081,7 +1081,16 @@ async def test_import_seed_templates_skips_existing(tmp_path):
             )
             assert created_count_second == 0
 
-async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
+async def test_seed_catalog_includes_jira_breakdown_preset(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings.atlassian.jira, "jira_allowed_projects", None)
+    monkeypatch.setattr(
+        settings.atlassian.jira,
+        "jira_project_defaults_by_repository",
+        None,
+    )
     seed_dir = (
         Path(__file__).resolve().parents[3]
         / "api_service"
@@ -1262,6 +1271,7 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                     "projectKey": "GAME",
                     "issueTypeName": "Story",
                     "boardId": "",
+                    "sourceIssueKey": "GAME-404",
                     "dependencyMode": "linear_blocker_chain",
                 },
             }
@@ -1591,6 +1601,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                 "projectKey": "MM",
                 "issueTypeName": "Story",
                 "boardId": "84",
+                "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
             downstream = expanded["steps"][2]
@@ -1607,6 +1618,50 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
             assert downstream["jiraOrchestration"]["traceability"]["sourceIssueKey"] == (
                 "MM-404"
             )
+
+async def test_jira_breakdown_orchestrate_can_create_source_subtasks(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            expanded = await service.expand_template(
+                slug="jira-breakdown-orchestrate",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Sub-task",
+                    "jira_dependency_mode": "linear_blocker_chain",
+                    "publish_mode": "pr",
+                    "source_issue_key": "MM-404",
+                },
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+            )
+
+            jira_step = expanded["steps"][1]
+            assert "Create each generated Jira issue as a sub-task of MM-404" in (
+                jira_step["instructions"]
+            )
+            assert jira_step["storyOutput"]["jira"] == {
+                "projectKey": "MM",
+                "issueTypeName": "Sub-task",
+                "boardId": "",
+                "sourceIssueKey": "MM-404",
+                "dependencyMode": "linear_blocker_chain",
+            }
 
 async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
     tmp_path,

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -47,6 +47,7 @@ class _FakeJiraService:
             "issueTypes": [
                 {"id": "10005", "name": "Story"},
                 {"id": "10006", "name": "Task"},
+                {"id": "10007", "name": "Sub-task", "subtask": True},
             ]
         }
 
@@ -568,6 +569,37 @@ async def test_create_jira_issues_truncates_description_and_creates_subtasks():
     assert len(request.description) == 32767
     assert request.description.endswith("[Truncated by MoonMind before Jira export]")
     assert request.fields["labels"] == ["moonmind-workflow-workflow-123"]
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_uses_source_issue_as_subtask_parent():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Sub-task",
+                    "sourceIssueKey": "MM-100",
+                },
+            },
+            "stories": [
+                {
+                    "summary": "Create a generated child issue",
+                    "description": "As an operator, I can request sub-task output.",
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert result.outputs["jira"]["createdIssues"][0]["issueKey"] == "MM-SUB-1"
+    assert service.requests == []
+    request = service.subtask_requests[0]
+    assert request.issue_type_id == "10007"
+    assert request.parent_issue_key == "MM-100"
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_reuses_existing_issue_with_workflow_marker():

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -602,6 +602,70 @@ async def test_create_jira_issues_uses_source_issue_as_subtask_parent():
     assert request.parent_issue_key == "MM-100"
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_does_not_use_source_issue_as_story_parent():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "sourceIssueKey": "MM-100",
+                },
+            },
+            "stories": [
+                {
+                    "summary": "Create a generated story",
+                    "description": "As an operator, I can request story output.",
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert result.outputs["jira"]["createdIssues"][0]["issueKey"] == "MM-1"
+    assert service.subtask_requests == []
+    request = service.requests[0]
+    assert request.issue_type_id == "10005"
+    assert request.summary == "Create a generated story"
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_requires_each_subtask_story_to_have_parent():
+    service = _FakeJiraService()
+
+    with pytest.raises(ValueError, match="parentIssueKey for every story"):
+        await create_jira_issues_from_stories(
+            {
+                "storyOutput": {
+                    "mode": "jira",
+                    "onFailure": "fail",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeName": "Sub-task",
+                    },
+                },
+                "stories": [
+                    {
+                        "summary": "Create first child issue",
+                        "description": "First generated sub-task.",
+                        "parentIssueKey": "MM-100",
+                    },
+                    {
+                        "summary": "Create second child issue",
+                        "description": "Second generated sub-task.",
+                    },
+                ],
+            },
+            jira_service_factory=lambda: service,
+        )
+
+    assert service.requests == []
+    assert service.subtask_requests == []
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_reuses_existing_issue_with_workflow_marker():
     service = _FakeJiraService()
     service.search_response = {


### PR DESCRIPTION
## Summary
- allow jira-breakdown-orchestrate to pass a source Jira issue into Jira issue creation
- create generated issues as Jira sub-tasks when issueTypeName is Sub-task and sourceIssueKey is set
- preserve parent/source Jira fields through execution payload normalization

## Validation
- ./tools/test_unit.sh
