### PR TITLE
[codex] Fix Claude GitHub broker socket ownership

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3184131746,
+    "id": 3185322350,
     "disposition": "addressed",
-    "rationale": "Extracted the preset/skill instruction-label decision into usesGenericInstructionsLabel(stepType)."
+    "rationale": "Changed GitHub broker socket paths to use per-run subdirectories under /tmp/mm-gh and only chown the run-specific socket directory plus socket, leaving the shared root unowned by the run user."
   },
   {
-    "id": 4223053049,
+    "id": 4224485088,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; its actionable suggestion is covered by review comment 3184131746."
+    "rationale": "Review summary comment; the actionable security concern is tracked and addressed by review comments 3185322350 and 3185327508."
+  },
+  {
+    "id": 3185327508,
+    "disposition": "addressed",
+    "rationale": "Moved broker sockets from the shared /tmp/mm-gh root into digest-named per-run directories, prevented shared-root chowning, and added launcher/session/broker tests for the isolated path and ownership behavior."
+  },
+  {
+    "id": 4224490494,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper comment without separate actionable feedback beyond review comment 3185327508."
   }
 ]

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -57,6 +57,10 @@ class GitHubAuthBrokerManager:
         await self.stop(run_id)
 
         path = Path(socket_path)
+        shared_root = path.parent.parent
+        if shared_root.name == "mm-gh":
+            shared_root.mkdir(parents=True, exist_ok=True, mode=0o711)
+            shared_root.chmod(0o711)
         path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         path.parent.chmod(0o700)
         try:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -131,6 +131,20 @@ class ManagedRuntimeLauncher:
         digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
         return str(socket_root / f"{digest}.sock")
 
+    async def _make_github_broker_accessible_to_app(
+        self,
+        *,
+        socket_path: str,
+    ) -> None:
+        """Allow a root-created GitHub broker socket to be used after runuser."""
+        path = Path(socket_path)
+        await self._run_checked_command(
+            "chown",
+            "app:app",
+            str(path.parent),
+            str(path),
+        )
+
     def _resolve_workspace_ownership_root(
         self,
         *,
@@ -799,6 +813,11 @@ class ManagedRuntimeLauncher:
         deferred_cleanup_paths: list[str] = []
         github_socket_path: str | None = None
         real_gh_path = shutil.which("gh")
+        # The claude CLI refuses --dangerously-skip-permissions when running as root
+        # (security restriction). For claude_code runtime, drop to the app user.
+        _run_as_root = os.geteuid() == 0
+        _is_claude_code = profile.runtime_id == "claude_code"
+        _needs_priv_drop = _run_as_root and _is_claude_code
         process: asyncio.subprocess.Process
         try:
             if github_token and run_root is not None:
@@ -811,6 +830,10 @@ class ManagedRuntimeLauncher:
                     token=github_token,
                     socket_path=github_socket_path,
                 )
+                if _needs_priv_drop:
+                    await self._make_github_broker_accessible_to_app(
+                        socket_path=github_socket_path,
+                    )
                 deferred_cleanup_paths.append(github_socket_path)
                 if self._runtime_requires_direct_github_env(profile.runtime_id):
                     env_overrides["GITHUB_TOKEN"] = github_token
@@ -828,12 +851,6 @@ class ManagedRuntimeLauncher:
                         real_gh_path=real_gh_path,
                     )
                 )
-
-            # The claude CLI refuses --dangerously-skip-permissions when running as root
-            # (security restriction). For claude_code runtime, drop to the app user.
-            _run_as_root = os.geteuid() == 0
-            _is_claude_code = profile.runtime_id == "claude_code"
-            _needs_priv_drop = _run_as_root and _is_claude_code
 
             # Transfer the full run workspace root to the app user so it can write
             # both repo files and launcher support artifacts beside the repo.

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -129,7 +129,7 @@ class ManagedRuntimeLauncher:
         if support_root:
             material = f"{Path(support_root).resolve()}::{run_id}"
         digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
-        return str(socket_root / f"{digest}.sock")
+        return str(socket_root / digest / "github.sock")
 
     async def _make_github_broker_accessible_to_app(
         self,
@@ -835,6 +835,7 @@ class ManagedRuntimeLauncher:
                         socket_path=github_socket_path,
                     )
                 deferred_cleanup_paths.append(github_socket_path)
+                deferred_cleanup_paths.append(str(Path(github_socket_path).parent))
                 if self._runtime_requires_direct_github_env(profile.runtime_id):
                     env_overrides["GITHUB_TOKEN"] = github_token
                     env_overrides.setdefault("GIT_TERMINAL_PROMPT", "0")

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -484,7 +484,7 @@ class DockerCodexManagedSessionController:
         if support_root:
             material = f"{Path(support_root).resolve()}::{run_id}"
         digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
-        return str(resolved_socket_root / f"{digest}.sock")
+        return str(resolved_socket_root / digest / "github.sock")
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -37,6 +37,25 @@ async def test_github_auth_broker_serves_token_and_cleans_socket():
 
     assert not Path(socket_path).exists()
 
+@pytest.mark.asyncio
+async def test_github_auth_broker_keeps_shared_mm_gh_root_traversable_only(tmp_path):
+    manager = GitHubAuthBrokerManager()
+    shared_root = tmp_path / "mm-gh"
+    socket_dir = shared_root / "0123456789abcdef"
+    socket_path = socket_dir / "github.sock"
+
+    await manager.start(
+        run_id="run-1",
+        token="ghp_testtoken123",
+        socket_path=str(socket_path),
+    )
+
+    assert (shared_root.stat().st_mode & 0o777) == 0o711
+    assert (socket_dir.stat().st_mode & 0o777) == 0o700
+    assert (socket_path.stat().st_mode & 0o777) == 0o600
+
+    await manager.stop("run-1")
+
 def test_run_gh_wrapper_clears_ambient_gh_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1895,6 +1895,119 @@ async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypat
     assert "-p" in actual_cmd or "--dangerously-skip-permissions" in actual_cmd
 
 @pytest.mark.asyncio
+async def test_launch_privilege_drop_chowns_github_broker_socket_for_claude_code(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken123")
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
+    )
+
+    class _FakeGitHubAuthBrokers:
+        def __init__(self) -> None:
+            self.starts: list[dict[str, str]] = []
+            self.stops: list[str] = []
+
+        async def start(self, *, run_id: str, token: str, socket_path: str) -> None:
+            self.starts.append(
+                {"run_id": run_id, "token": token, "socket_path": socket_path}
+            )
+
+        async def stop(self, run_id: str) -> None:
+            self.stops.append(run_id)
+
+    class _FakeProcess:
+        pid = 8881
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_launch_env: dict[str, str] = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        if args[:3] == ("runuser", "-u", "app"):
+            env = kwargs.get("env")
+            if isinstance(env, dict):
+                captured_launch_env.update(env)
+        return _FakeProcess()
+
+    chown_calls: list[tuple[object, ...]] = []
+
+    async def _fake_run_checked_command(self, *cmd, **kw):
+        if cmd and cmd[0] == "chown":
+            chown_calls.append(cmd)
+        return None
+
+    original_exists = Path.exists
+
+    def _mock_exists(self):
+        if str(self) == "/home/app/.claude.json":
+            return True
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", _mock_exists)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._run_checked_command",
+        _fake_run_checked_command,
+    )
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    github_auth_brokers = _FakeGitHubAuthBrokers()
+    launcher._github_auth_brokers = github_auth_brokers
+
+    workspace_root = tmp_path / "workspaces" / "claude-gh-run" / "repo"
+    workspace_root.mkdir(parents=True)
+    (workspace_root / ".git").mkdir()
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=["claude", "-p", "hello"],
+        env_overrides={},
+        passthrough_env_keys=[],
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="claude-gh-run",
+        request=_make_request(),
+        profile=profile,
+        workspace_path=str(workspace_root),
+    )
+    await process.wait()
+
+    assert github_auth_brokers.starts == [
+        {
+            "run_id": "claude-gh-run",
+            "token": "ghp_testtoken123",
+            "socket_path": ManagedRuntimeLauncher._build_github_socket_path(
+                run_id="claude-gh-run",
+                support_root=str(workspace_root.parent),
+            ),
+        }
+    ]
+    socket_path = Path(github_auth_brokers.starts[0]["socket_path"])
+    assert (
+        "chown",
+        "app:app",
+        str(socket_path.parent),
+        str(socket_path),
+    ) in chown_calls
+    assert ("chown", "-R", "app:app", str(workspace_root.parent)) in chown_calls
+    assert "GITHUB_TOKEN" not in captured_launch_env
+    assert captured_launch_env["PATH"].startswith(
+        str(workspace_root.parent / ".moonmind" / "bin")
+    )
+
+@pytest.mark.asyncio
 async def test_launch_privilege_drop_chowns_repo_only_for_external_workspace(tmp_path, monkeypatch):
     captured_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -636,10 +636,13 @@ def test_build_github_socket_path_stays_short_for_long_workspace_paths(tmp_path)
         run_id="run-github-secret-ref-1",
         support_root=str(support_root),
     )
+    path = Path(socket_path)
 
     assert len(socket_path.encode("utf-8")) < 80
     assert str(support_root) not in socket_path
-    assert socket_path.endswith(".sock")
+    assert path.name == "github.sock"
+    assert path.parent.parent == Path("/tmp") / "mm-gh"
+    assert len(path.parent.name) == 16
 
 def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
     run_root = tmp_path / "run-1"
@@ -1976,7 +1979,7 @@ async def test_launch_privilege_drop_chowns_github_broker_socket_for_claude_code
         passthrough_env_keys=[],
     )
 
-    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+    _record, process, _cleanup, deferred_cleanup = await launcher.launch(
         run_id="claude-gh-run",
         request=_make_request(),
         profile=profile,
@@ -1995,13 +1998,20 @@ async def test_launch_privilege_drop_chowns_github_broker_socket_for_claude_code
         }
     ]
     socket_path = Path(github_auth_brokers.starts[0]["socket_path"])
+    assert socket_path.parent.parent == Path("/tmp") / "mm-gh"
     assert (
         "chown",
         "app:app",
         str(socket_path.parent),
         str(socket_path),
     ) in chown_calls
+    assert not any(
+        call == ("chown", "app:app", str(socket_path.parent.parent), str(socket_path))
+        or call == ("chown", "app:app", str(socket_path.parent.parent))
+        for call in chown_calls
+    )
     assert ("chown", "-R", "app:app", str(workspace_root.parent)) in chown_calls
+    assert str(socket_path.parent) in deferred_cleanup
     assert "GITHUB_TOKEN" not in captured_launch_env
     assert captured_launch_env["PATH"].startswith(
         str(workspace_root.parent / ".moonmind" / "bin")

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -821,6 +821,10 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
     assert github_auth_brokers.starts[0]["socket_path"].startswith(
         str(Path("/tmp") / "mm-gh")
     )
+    socket_path = Path(github_auth_brokers.starts[0]["socket_path"])
+    assert socket_path.name == "github.sock"
+    assert socket_path.parent.parent == Path("/tmp") / "mm-gh"
+    assert len(socket_path.parent.name) == 16
     assert request.session_workspace_path not in github_auth_brokers.starts[0]["socket_path"]
     docker_run_text = " ".join(docker_commands[0])
     assert token not in docker_run_text


### PR DESCRIPTION
## Summary
- Fix Claude Code managed runtime GitHub auth when the worker starts the broker as root but launches Claude as app.
- Chown the per-run GitHub broker socket and directory to app:app before the privilege drop so gh and git-credential-moonmind can connect.
- Add regression coverage for the root-to-app Claude Code launch path while preserving the no-raw-token environment contract.

## Root Cause
Claude Code is launched via runuser as app, but the GitHub auth broker socket was created by the root worker under /tmp/mm-gh with root-only permissions. The generated gh and git credential helper wrappers therefore could not connect to the broker, causing authenticated GitHub operations to fail as publish_unavailable/pr_not_found.

## Validation
- ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py tests/unit/services/temporal/runtime/test_github_auth_broker.py
- git diff --check -- moonmind/workflows/temporal/runtime/launcher.py tests/unit/services/temporal/runtime/test_launcher.py
- PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3 -m py_compile moonmind/workflows/temporal/runtime/launcher.py
