### PR TITLE
MM-586: Task-only visibility and diagnostics boundary

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_90
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_91

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_92
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_93

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f4f56b-60a7-464f-9d64-d330a95473f5_12
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_90

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_93
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_94

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_94
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_95

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_95
+../../runtime/skills_active/skillset_mm:c6f4f56b-60a7-464f-9d64-d330a95473f5_12

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_91
+../../runtime/skills_active/skillset_mm:43241135-a912-456c-9db0-80d48307852c_92

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/298-tasks-list-canonical-route-shell"
+  "feature_directory": "specs/299-task-only-visibility-diagnostics"
 }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9,7 +9,7 @@ import os
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, Optional
 from urllib.parse import quote, urlsplit
 from uuid import uuid4
 
@@ -263,14 +263,12 @@ def _normalize_temporal_list_scope(
     """Return the product-facing Temporal list scope.
 
     The default task dashboard view is intentionally not a raw Temporal
-    namespace browser. Explicit workflow-type or entry filters keep the older
-    API behavior unless the caller pins a scope.
+    namespace browser. Recognized broad workflow scopes are accepted for old
+    URLs but fail safe to task-run visibility on this ordinary list boundary.
     """
 
     normalized = str(scope or "").strip().lower()
-    if not normalized:
-        return "all" if workflow_type or entry else "tasks"
-    if normalized not in _TEMPORAL_LIST_SCOPES:
+    if normalized and normalized not in _TEMPORAL_LIST_SCOPES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
@@ -282,7 +280,15 @@ def _normalize_temporal_list_scope(
                 ),
             },
         )
-    return cast(Literal["tasks", "user", "system", "all"], normalized)
+    return "tasks"
+
+
+def _is_task_list_workflow_type(workflow_type: str | None) -> bool:
+    return str(workflow_type or "").strip() == "MoonMind.Run"
+
+
+def _is_task_list_entry(entry: str | None) -> bool:
+    return str(entry or "").strip().lower() == "run"
 
 
 def _canonicalize_execution_identifier(raw_identifier: str) -> tuple[str, bool]:
@@ -4193,11 +4199,21 @@ async def list_executions(
             scope_query = _TEMPORAL_SCOPE_QUERIES[temporal_scope]
             if scope_query:
                 query_parts.append(scope_query)
-            if workflow_type:
+            if workflow_type and not _is_task_list_workflow_type(workflow_type):
+                logger.info(
+                    "Ignoring workflowType=%s for ordinary task-list temporal query",
+                    workflow_type,
+                )
+            elif workflow_type and not scope_query:
                 query_parts.append(f'WorkflowType="{escape_val(workflow_type)}"')
             if state:
                 query_parts.append(f'mm_state="{escape_val(state)}"')
-            if entry:
+            if entry and not _is_task_list_entry(entry):
+                logger.info(
+                    "Ignoring entry=%s for ordinary task-list temporal query",
+                    entry,
+                )
+            elif entry and not scope_query:
                 query_parts.append(f'mm_entry="{escape_val(entry)}"')
             if effective_owner_type:
                 query_parts.append(

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,17 @@
 [
   {
-    "id": 3185533683,
-    "disposition": "addressed",
-    "rationale": "Replaced the transient absolute workspace path in specs/298-tasks-list-canonical-route-shell/verification.md with the repository-relative spec path."
+    "id": 4376107040,
+    "disposition": "not-applicable",
+    "rationale": "Quota warning from gemini-code-assist; no code action requested."
   },
   {
-    "id": 4224708869,
+    "id": 4224910915,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; the single actionable path portability comment is tracked separately and addressed."
+    "rationale": "Top-level automated review summary with no actionable feedback."
+  },
+  {
+    "id": 3185711626,
+    "disposition": "addressed",
+    "rationale": "Legacy workflow-scope URLs now drop stale nextPageToken before task-scoped fetching, with UI test coverage."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -64,43 +64,37 @@ describe('Tasks List Entrypoint', () => {
     });
   });
 
-  it('defaults to user task scope but exposes raw all-workflows scope', async () => {
+  it('keeps workflow-kind browsing controls out of the normal task list', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
 
-    const scopeFilter = screen.getByLabelText('Scope') as HTMLSelectElement;
-    expect(scopeFilter.value).toBe('tasks');
-    expect((screen.getByLabelText('Workflow Type') as HTMLSelectElement).disabled).toBe(true);
-
-    const baselineCalls = fetchSpy.mock.calls.length;
-    fireEvent.change(scopeFilter, { target: { value: 'all' } });
-
-    await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
-    });
+    expect(screen.queryByLabelText('Scope')).toBeNull();
+    expect(screen.queryByLabelText('Workflow Type')).toBeNull();
+    expect(screen.queryByLabelText('Entry')).toBeNull();
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=all',
+      '/api/executions?source=temporal&pageSize=50&scope=tasks',
     );
-    expect((screen.getByLabelText('Workflow Type') as HTMLSelectElement).disabled).toBe(false);
   });
 
-  it('keeps explicit task scope in the URL when entry filters are active', async () => {
+  it('normalizes legacy workflow scope URLs to task visibility with recoverable notice', async () => {
+    window.history.pushState(
+      {},
+      'Legacy',
+      '/tasks/list?scope=all&workflowType=MoonMind.ProviderProfileManager&entry=manifest&state=completed&repo=moon%2Fdemo',
+    );
+
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    const baselineCalls = fetchSpy.mock.calls.length;
 
-    fireEvent.change(screen.getByLabelText('Entry'), { target: { value: 'run' } });
-
-    await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
-    });
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&entry=run',
+      '/api/executions?source=temporal&pageSize=50&scope=tasks&state=completed&repo=moon%2Fdemo',
     );
-    expect(window.location.search).toContain('scope=tasks');
-    expect(window.location.search).toContain('entry=run');
+    expect(screen.getByText(/Workflow scope filters are not available on Tasks List/i)).toBeTruthy();
+    expect(window.location.search).toBe('?state=completed&repo=moon%2Fdemo&limit=50');
+    expect(screen.queryByText('MoonMind.ProviderProfileManager')).toBeNull();
+    expect(screen.queryByText('manifest')).toBeNull();
   });
 
   it('renders active task-list pills with the shared shimmer selector contract while keeping inactive pills plain', async () => {
@@ -299,23 +293,6 @@ describe('Tasks List Entrypoint', () => {
     expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
   });
 
-  it('preserves the default task scope in shared URLs when entry filters are set', async () => {
-    renderWithClient(<TasksListPage payload={mockPayload} />);
-
-    await screen.findAllByText('Example task');
-    const baselineCalls = fetchSpy.mock.calls.length;
-
-    fireEvent.change(screen.getByLabelText('Entry'), { target: { value: 'manifest' } });
-
-    await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
-    });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&entry=manifest',
-    );
-    expect(window.location.search).toBe('?scope=tasks&entry=manifest&limit=50');
-  });
-
   it('labels the lifecycle filter as status and exposes canonical status options', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
@@ -392,6 +369,9 @@ describe('Tasks List Entrypoint', () => {
 
     expect(controlDeck).toBeTruthy();
     expect(controlDeck?.querySelector('form.task-list-control-grid')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^Kind\./i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Workflow Type\./i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();
 
     expect(controlDeck?.classList.contains('panel--controls')).toBe(false);
     expect(

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -81,7 +81,7 @@ describe('Tasks List Entrypoint', () => {
     window.history.pushState(
       {},
       'Legacy',
-      '/tasks/list?scope=all&workflowType=MoonMind.ProviderProfileManager&entry=manifest&state=completed&repo=moon%2Fdemo',
+      '/tasks/list?scope=all&workflowType=MoonMind.ProviderProfileManager&entry=manifest&state=completed&repo=moon%2Fdemo&nextPageToken=stale-token',
     );
 
     renderWithClient(<TasksListPage payload={mockPayload} />);

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -183,7 +183,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const [temporalState, setTemporalState] = useState(() => (initial.get('state') || '').toLowerCase());
   const [repository, setRepository] = useState(() => initial.get('repo') || '');
   const [pageSize, setPageSize] = useState(() => parsePageSize(initial.get('limit')));
-  const [listCursor, setListCursor] = useState<string | null>(() => initial.get('nextPageToken')?.trim() || null);
+  const [listCursor, setListCursor] = useState<string | null>(() =>
+    ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
+  );
   const [cursorStack, setCursorStack] = useState<string[]>([]);
   const [liveUpdates, setLiveUpdates] = useState(true);
   const [sortField, setSortField] = useState<string>(() => normalizeTableSortField(initial.get('sort')));

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -18,15 +18,6 @@ type ListDashboardConfig = {
   };
 };
 
-const USER_WORKFLOW_TYPES = ['MoonMind.Run', 'MoonMind.ManifestIngest'] as const;
-const SYSTEM_WORKFLOW_TYPES = ['MoonMind.ProviderProfileManager'] as const;
-const WORKFLOW_TYPES = [...USER_WORKFLOW_TYPES, ...SYSTEM_WORKFLOW_TYPES] as const;
-const LIST_SCOPES = [
-  ['tasks', 'Tasks'],
-  ['user', 'User Workflows'],
-  ['system', 'System Workflows'],
-  ['all', 'All Workflows'],
-] as const;
 const TEMPORAL_STATUSES = [
   'scheduled',
   'initializing',
@@ -41,7 +32,8 @@ const TEMPORAL_STATUSES = [
   'failed',
   'canceled',
 ] as const;
-const ENTRY_OPTIONS = ['run', 'manifest'] as const;
+const TASK_WORKFLOW_TYPE = 'MoonMind.Run';
+const TASK_ENTRY = 'run';
 
 const TIMESTAMP_SORT_FIELDS = new Set(['scheduledFor', 'createdAt', 'closedAt']);
 const TABLE_COLUMNS = [
@@ -112,13 +104,15 @@ function summarizeRuntime(runtime: string | null | undefined): string {
   return label === '—' ? '' : label;
 }
 
-function normalizeListScope(raw: string | null): string {
-  const candidate = (raw || '').trim().toLowerCase();
-  return LIST_SCOPES.some(([value]) => value === candidate) ? candidate : 'tasks';
-}
-
-function scopeLabel(value: string): string {
-  return LIST_SCOPES.find(([scopeValue]) => scopeValue === value)?.[1] || value;
+function hasUnsupportedWorkflowScopeState(params: URLSearchParams): boolean {
+  const scope = (params.get('scope') || '').trim().toLowerCase();
+  const workflowType = (params.get('workflowType') || '').trim();
+  const entry = (params.get('entry') || '').trim().toLowerCase();
+  return Boolean(
+    (scope && scope !== 'tasks') ||
+      (workflowType && workflowType !== TASK_WORKFLOW_TYPE) ||
+      (entry && entry !== TASK_ENTRY),
+  );
 }
 
 function dependencyListSummary(row: ExecutionRow): string {
@@ -185,12 +179,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
   const initial = useMemo(() => new URLSearchParams(window.location.search), []);
 
-  const [listScope, setListScope] = useState(() =>
-    normalizeListScope(initial.get('scope') || (initial.get('workflowType') || initial.get('entry') ? 'all' : null)),
-  );
-  const [workflowType, setWorkflowType] = useState(() => initial.get('workflowType') || '');
+  const [ignoredWorkflowScopeState] = useState(() => hasUnsupportedWorkflowScopeState(initial));
   const [temporalState, setTemporalState] = useState(() => (initial.get('state') || '').toLowerCase());
-  const [entry, setEntry] = useState(() => (initial.get('entry') || '').toLowerCase());
   const [repository, setRepository] = useState(() => initial.get('repo') || '');
   const [pageSize, setPageSize] = useState(() => parsePageSize(initial.get('limit')));
   const [listCursor, setListCursor] = useState<string | null>(() => initial.get('nextPageToken')?.trim() || null);
@@ -203,19 +193,10 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     return 'desc';
   });
   const normalizedRepository = repository.trim();
-  const workflowTypeOptions = useMemo(() => {
-    if (listScope === 'user') return USER_WORKFLOW_TYPES;
-    if (listScope === 'system') return SYSTEM_WORKFLOW_TYPES;
-    return WORKFLOW_TYPES;
-  }, [listScope]);
 
   const syncUrl = useCallback(() => {
     const params = new URLSearchParams();
-    const scopeSensitiveFilterActive = Boolean(entry || workflowType);
-    if (listScope !== 'tasks' || scopeSensitiveFilterActive) params.set('scope', listScope);
-    if (listScope !== 'tasks' && workflowType) params.set('workflowType', workflowType);
     if (temporalState) params.set('state', temporalState);
-    if (entry) params.set('entry', entry);
     if (normalizedRepository) params.set('repo', normalizedRepository);
     params.set('limit', String(pageSize));
     if (listCursor) params.set('nextPageToken', listCursor);
@@ -225,10 +206,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     }
     replaceUrlQuery(params);
   }, [
-    listScope,
-    workflowType,
     temporalState,
-    entry,
     normalizedRepository,
     pageSize,
     listCursor,
@@ -244,10 +222,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     'tasks-list',
     'temporal',
     pageSize,
-    listScope,
-    workflowType,
     temporalState,
-    entry,
     normalizedRepository,
     listCursor,
   ] as const;
@@ -259,11 +234,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       const params = new URLSearchParams();
       params.set('source', 'temporal');
       params.set('pageSize', String(pageSize));
-      params.set('scope', listScope);
+      params.set('scope', 'tasks');
       if (listCursor) params.set('nextPageToken', listCursor);
-      if (listScope !== 'tasks' && workflowType) params.set('workflowType', workflowType);
       if (temporalState) params.set('state', temporalState);
-      if (entry) params.set('entry', entry);
       if (normalizedRepository) params.set('repo', normalizedRepository);
       const response = await fetch(`${payload.apiBase}/executions?${params}`);
       if (!response.ok) {
@@ -346,20 +319,14 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const activeFilters = useMemo(
     () =>
       [
-        listScope !== 'tasks' ? ['Scope', scopeLabel(listScope)] : null,
-        listScope !== 'tasks' && workflowType ? ['Workflow', workflowType] : null,
         temporalState ? ['Status', temporalState] : null,
-        entry ? ['Entry', entry] : null,
         normalizedRepository ? ['Repository', normalizedRepository] : null,
       ].filter((filter): filter is [string, string] => Boolean(filter)),
-    [listScope, workflowType, temporalState, entry, normalizedRepository],
+    [temporalState, normalizedRepository],
   );
   const hasActiveFilters = activeFilters.length > 0;
   const clearFilters = useCallback(() => {
-    setListScope('tasks');
-    setWorkflowType('');
     setTemporalState('');
-    setEntry('');
     setRepository('');
     resetToFirstPage();
   }, [resetToFirstPage]);
@@ -392,53 +359,13 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
         {!listEnabled ? (
           <div className="notice error">Temporal task list is disabled in server configuration.</div>
         ) : null}
+        {ignoredWorkflowScopeState ? (
+          <div className="notice warning">
+            Workflow scope filters are not available on Tasks List. Showing task runs only.
+          </div>
+        ) : null}
 
         <form className="task-list-control-grid" onSubmit={(event) => event.preventDefault()}>
-          <label>
-            Scope
-            <select
-              value={listScope}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                const nextScope = normalizeListScope(event.target.value);
-                setListScope(nextScope);
-                const nextWorkflowTypes =
-                  nextScope === 'user'
-                    ? USER_WORKFLOW_TYPES
-                    : nextScope === 'system'
-                      ? SYSTEM_WORKFLOW_TYPES
-                      : WORKFLOW_TYPES;
-                if (nextScope === 'tasks' || !nextWorkflowTypes.some((type) => type === workflowType)) {
-                  setWorkflowType('');
-                }
-                resetToFirstPage();
-              }}
-            >
-              {LIST_SCOPES.map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Workflow Type
-            <select
-              value={workflowType}
-              disabled={!listEnabled || listScope === 'tasks'}
-              onChange={(event) => {
-                setWorkflowType(event.target.value);
-                resetToFirstPage();
-              }}
-            >
-              <option value="">All Types</option>
-              {workflowTypeOptions.map((workflow) => (
-                <option key={workflow} value={workflow}>
-                  {workflow}
-                </option>
-              ))}
-            </select>
-          </label>
           <label>
             Status
             <select
@@ -453,24 +380,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               {TEMPORAL_STATUSES.map((status) => (
                 <option key={status} value={status}>
                   {status}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Entry
-            <select
-              value={entry}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                setEntry(event.target.value.toLowerCase());
-                resetToFirstPage();
-              }}
-            >
-              <option value="">All Entries</option>
-              {ENTRY_OPTIONS.map((entryOption) => (
-                <option key={entryOption} value={entryOption}>
-                  {entryOption}
                 </option>
               ))}
             </select>

--- a/specs/299-task-only-visibility-diagnostics/checklists/requirements.md
+++ b/specs/299-task-only-visibility-diagnostics/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Task-only Visibility and Diagnostics Boundary
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: MM-586 is classified as one runtime story and preserves the trusted Jira preset brief.
+- PASS: All in-scope source design requirements map to functional requirements.

--- a/specs/299-task-only-visibility-diagnostics/contracts/tasks-list-visibility-boundary.md
+++ b/specs/299-task-only-visibility-diagnostics/contracts/tasks-list-visibility-boundary.md
@@ -1,0 +1,54 @@
+# Contract: Tasks List Visibility Boundary
+
+## UI Contract
+
+The normal `/tasks/list` page exposes task-list controls only:
+
+- Status filter
+- Repository filter
+- Live updates toggle
+- Page size and pagination controls
+- Task table columns: ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished
+
+The normal `/tasks/list` page does not expose:
+
+- Scope control
+- Workflow Type control
+- Entry control
+- Kind column
+- Workflow Type column
+- Entry column
+
+Legacy workflow-scope URL parameters are handled as follows:
+
+| Parameter | Handling |
+| --- | --- |
+| `scope=tasks` | Normalize away because task scope is default. |
+| `scope=user`, `scope=system`, `scope=all` | Ignore for the normal page, show recoverable notice, emit task-oriented URL state. |
+| `workflowType=MoonMind.Run` | Normalize away because task runs are default. |
+| `workflowType=MoonMind.ManifestIngest` or system workflow types | Ignore for the normal page, show recoverable notice, emit task-oriented URL state. |
+| `entry=run` | Normalize away because run entries are default. |
+| `entry=manifest` | Ignore for the normal page, show recoverable notice, emit task-oriented URL state. |
+| `state=<value>` | Preserve as a Status filter. |
+| `repo=<value>` | Preserve as a Repository filter. |
+
+## API Boundary Contract
+
+For source-temporal list requests used by the normal Tasks List, effective query semantics are task-run bounded:
+
+```text
+WorkflowType="MoonMind.Run" AND mm_entry="run" AND ordinary owner scoping
+```
+
+Broadening parameters must not widen ordinary list results:
+
+- `scope=all`, `scope=user`, and `scope=system` resolve to task-run query semantics.
+- `workflowType` values other than `MoonMind.Run` are ignored for the normal source-temporal list boundary.
+- `entry` values other than `run` are ignored for the normal source-temporal list boundary.
+- Unknown `scope` values remain validation errors.
+
+## Security Contract
+
+- Ordinary users cannot list system, manifest-ingest, or all workflow rows by editing `/tasks/list` URL parameters.
+- Owner scoping remains enforced.
+- Rendered labels and filter values are text content, not trusted HTML.

--- a/specs/299-task-only-visibility-diagnostics/data-model.md
+++ b/specs/299-task-only-visibility-diagnostics/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Task-only Visibility and Diagnostics Boundary
+
+## Existing Concepts
+
+### Tasks List Query State
+
+- `state`: optional canonical task lifecycle filter preserved from old URLs.
+- `repo`: optional repository filter preserved from old URLs.
+- `limit`: page size.
+- `nextPageToken`: pagination cursor.
+- `sort` / `sortDir`: client-visible sort state.
+
+Validation rules:
+- Workflow-kind state such as `scope`, `workflowType`, and `entry` is not part of the normal Tasks List query state.
+- Old `scope`, `workflowType`, and `entry` parameters are read only to detect unsupported legacy state, then omitted from emitted URL state.
+- URL state must not include secrets.
+
+### Execution List Boundary
+
+- Effective normal list scope: task runs only.
+- Task-compatible legacy values: `workflowType=MoonMind.Run` and `entry=run`, which normalize to the same effective task-run boundary.
+- Unsupported broad values: `scope=user`, `scope=system`, `scope=all`, non-run `workflowType`, and non-run `entry` values.
+
+Validation rules:
+- Unsupported broad values fail safe to task-run query semantics for source-temporal list requests.
+- Owner scoping for ordinary users remains enforced.
+- Invalid unknown scope values still produce validation errors instead of silent broadening.
+
+## State Transitions
+
+- Initial page load reads URL state.
+- Task-compatible filters initialize Status and Repository controls.
+- Unsupported workflow-scope state sets a recoverable notice and is dropped from synchronized URL state.
+- User filter changes reset pagination and keep URL state task-oriented.

--- a/specs/299-task-only-visibility-diagnostics/moonspec_align_report.md
+++ b/specs/299-task-only-visibility-diagnostics/moonspec_align_report.md
@@ -1,0 +1,35 @@
+# MoonSpec Alignment Report
+
+**Feature**: Task-only Visibility and Diagnostics Boundary  
+**Spec**: `specs/299-task-only-visibility-diagnostics/spec.md`  
+**Date**: 2026-05-05
+
+## Alignment Summary
+
+The MM-586 artifacts are aligned around one runtime story: ordinary `/tasks/list` visibility is task-run only, while broad workflow-kind browsing is excluded from the normal Tasks List surface and old broad URL parameters fail safe.
+
+## Checks
+
+| Area | Result | Notes |
+| --- | --- | --- |
+| One-story scope | PASS | `spec.md` contains one `## User Story - Task-only Tasks List Visibility` section. |
+| Original input preservation | PASS | `spec.md` preserves the canonical MM-586 Jira preset brief in `**Input**`. |
+| Source design mapping | PASS | DESIGN-REQ-005, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-017, and DESIGN-REQ-025 map to FRs and tasks. |
+| Plan consistency | PASS | `plan.md` identifies the same source files, test commands, constraints, and requirement statuses used by `tasks.md`. |
+| Task ordering | PASS | Backend and frontend test tasks precede implementation tasks, and final validation/verification tasks are last. |
+| Constitution | PASS | No conflicts found; implementation tracking remains under `specs/299-task-only-visibility-diagnostics/`. |
+
+## Decisions
+
+- Diagnostics route creation remains out of scope. The artifacts consistently choose safe ignore plus recoverable notice for unsupported workflow-scope URL state because the source brief allows ignored, redirected, or recoverable handling.
+- Existing Status and Repository filters remain available until later column-filter stories replace the current filter controls.
+
+## Remediation
+
+No artifact remediation was required after implementation. The implementation and test evidence matched the generated spec, plan, contract, quickstart, and tasks.
+
+## Validation
+
+- `pytest tests/unit/api/test_executions_temporal.py -q`: PASS, 14 passed.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`: PASS, 1 file and 18 tests passed.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`: PASS, Python 4319 passed, 1 xpassed, 16 subtests passed; focused UI 1 file and 18 tests passed.

--- a/specs/299-task-only-visibility-diagnostics/moonspec_align_report.md
+++ b/specs/299-task-only-visibility-diagnostics/moonspec_align_report.md
@@ -6,7 +6,7 @@
 
 ## Alignment Summary
 
-The MM-586 artifacts are aligned around one runtime story: ordinary `/tasks/list` visibility is task-run only, while broad workflow-kind browsing is excluded from the normal Tasks List surface and old broad URL parameters fail safe.
+The MM-586 artifacts are aligned around one runtime story: ordinary `/tasks/list` visibility is task-run only, while broad workflow-kind browsing is excluded from the normal Tasks List surface and old broad URL parameters fail safe. This pass ran after task generation and the follow-up plan/research/tasks refresh that marked the implemented evidence as verified.
 
 ## Checks
 
@@ -15,8 +15,9 @@ The MM-586 artifacts are aligned around one runtime story: ordinary `/tasks/list
 | One-story scope | PASS | `spec.md` contains one `## User Story - Task-only Tasks List Visibility` section. |
 | Original input preservation | PASS | `spec.md` preserves the canonical MM-586 Jira preset brief in `**Input**`. |
 | Source design mapping | PASS | DESIGN-REQ-005, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-017, and DESIGN-REQ-025 map to FRs and tasks. |
-| Plan consistency | PASS | `plan.md` identifies the same source files, test commands, constraints, and requirement statuses used by `tasks.md`. |
-| Task ordering | PASS | Backend and frontend test tasks precede implementation tasks, and final validation/verification tasks are last. |
+| Plan consistency | PASS | `plan.md` identifies the same source files, test commands, constraints, and `implemented_verified` requirement statuses used by `tasks.md` and `verification.md`. |
+| Design artifacts | PASS | `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-visibility-boundary.md` remain consistent with the implemented task-only visibility boundary. |
+| Task ordering | PASS | Backend and frontend red-first test tasks precede implementation tasks, and final validation/alignment/verification tasks are last. |
 | Constitution | PASS | No conflicts found; implementation tracking remains under `specs/299-task-only-visibility-diagnostics/`. |
 
 ## Decisions
@@ -26,10 +27,13 @@ The MM-586 artifacts are aligned around one runtime story: ordinary `/tasks/list
 
 ## Remediation
 
-No artifact remediation was required after implementation. The implementation and test evidence matched the generated spec, plan, contract, quickstart, and tasks.
+Updated this alignment report only. No changes were required to `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/tasks-list-visibility-boundary.md`, or `tasks.md`; the downstream specify, plan, and tasks gates remained valid, so no regeneration was required.
 
 ## Validation
 
+- `scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: NOT RUN; script path is absent in this checkout, so validation used the active `.specify/feature.json` pointer and direct artifact checks.
+- Direct artifact checks: PASS; one user story, zero clarification placeholders, zero missing required design/task files, zero `missing`/`partial`/`implemented_unverified` plan rows, zero unchecked tasks, and zero malformed task IDs.
+- Task coverage checks: PASS; `tasks.md` retains red-first unit coverage, frontend integration-style coverage, implementation tasks, story validation, alignment, and final `/moonspec-verify` work.
 - `pytest tests/unit/api/test_executions_temporal.py -q`: PASS, 14 passed.
 - `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`: PASS, 1 file and 18 tests passed.
 - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`: PASS, Python 4319 passed, 1 xpassed, 16 subtests passed; focused UI 1 file and 18 tests passed.

--- a/specs/299-task-only-visibility-diagnostics/plan.md
+++ b/specs/299-task-only-visibility-diagnostics/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Task-only Visibility and Diagnostics Boundary
+
+**Branch**: `run-jira-orchestrate-for-mm-586-task-onl-9e439b1f` | **Date**: 2026-05-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime feature specification from `specs/299-task-only-visibility-diagnostics/spec.md`
+
+## Summary
+
+Implement the MM-586 runtime story by removing ordinary workflow-kind browsing from the Tasks List UI, normalizing legacy workflow-scope URLs to task-run visibility, showing a recoverable notice when unsupported workflow-scope state is ignored, and hardening the source-temporal execution list boundary so broad `scope`, `workflowType`, or `entry` parameters cannot widen ordinary task-list results. Current repo inspection found the table already excludes `Kind`, `Workflow Type`, and `Entry`, but the UI still exposes Scope/Workflow Type/Entry controls and the source-temporal API still honors `scope=all`; this run requires tests and implementation.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `frontend/src/entrypoints/tasks-list.tsx` defaults to `scope=tasks` but can widen via controls/URL | force task-run request semantics | UI + backend unit |
+| FR-002 | missing | UI renders `Scope`, `Workflow Type`, and `Entry` controls | remove ordinary workflow-kind controls | UI test |
+| FR-003 | partial | old URL params initialize broad list state | normalize unsafe params and show notice | UI test |
+| FR-004 | implemented_verified | table columns omit `Kind`, `Workflow Type`, and `Entry`; existing started-column regression nearby | preserve behavior, add focused assertion | UI test |
+| FR-005 | implemented_unverified | Status and Repository controls exist but are coupled to broad controls | verify preserved task filters after broad-control removal | UI test |
+| FR-006 | partial | `_normalize_temporal_list_scope()` supports all/user/system and source-temporal route appends broad filters | coerce ordinary source-temporal list to task scope and ignore widening filters | backend unit |
+| FR-007 | partial | non-admin owner scoping exists; broad workflow scope can still list all user-owned workflow types | prevent normal query params from widening beyond task runs | backend unit |
+| FR-008 | missing | no recoverable notice for ignored workflow-scope URL state | add notice when legacy workflow-scope params are ignored | UI test |
+| FR-009 | partial | URL sync can emit `scope`, `workflowType`, and `entry` | remove ignored workflow-scope params from emitted URL | UI test |
+| FR-010 | implemented_verified | React text interpolation renders labels/values as text | preserve behavior | final verify |
+| FR-011 | implemented_unverified | this feature's artifacts preserve MM-586 | carry traceability through plan/tasks/verification | final verify |
+| SC-001 | missing | no test covers broad URL normalization | add UI request assertions | UI test |
+| SC-002 | missing | existing tests expect broad controls | replace with absence/preserved filter tests | UI test |
+| SC-003 | missing | no test covers recoverable notice or URL rewrite | add UI test | UI test |
+| SC-004 | implemented_unverified | columns currently exclude forbidden headers | add focused assertion tied to MM-586 | UI test |
+| SC-005 | missing | existing backend test expects `scope=all` raw query | update/add backend tests for fail-safe task query | backend unit |
+| SC-006 | implemented_unverified | artifacts in progress | final verification | final verify |
+| DESIGN-REQ-005 | partial | normal page can still browse workflow kinds | remove broad controls and harden request boundary | UI + backend unit |
+| DESIGN-REQ-008 | implemented_unverified | table columns are task-oriented | add focused assertion | UI test |
+| DESIGN-REQ-009 | partial | system/manifest URL params can affect requests | normalize URL/API parameters safely | UI + backend unit |
+| DESIGN-REQ-017 | partial | old `state`/`repo` work, broad params unsafe | preserve task filters and ignore broad params with notice | UI test |
+| DESIGN-REQ-025 | partial | owner scoping exists, but filter params can widen workflow kinds | enforce task boundary and preserve text rendering | backend + UI test |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI  
+**Primary Dependencies**: FastAPI, Pydantic v2 response models, Temporal Python SDK client query surface, React, TanStack Query, Vitest, Testing Library, pytest  
+**Storage**: No new persistent storage; existing execution list API and browser URL state only  
+**Unit Testing**: `pytest tests/unit/api/test_executions_temporal.py -q` and final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration Testing**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`; final wrapper via `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
+**Target Platform**: MoonMind API service and Mission Control Tasks List frontend  
+**Project Type**: FastAPI backend with React/Vite frontend entrypoints  
+**Performance Goals**: No additional list fetches beyond the existing execution-list request; URL normalization must happen during initial render without extra network round trips  
+**Constraints**: Runtime implementation workflow; browser uses MoonMind APIs only; no raw credentials; diagnostics route creation is out of scope; unsupported broad workflow scope fails safe to task-run visibility  
+**Scale/Scope**: One Tasks List visibility-boundary story for ordinary task runs and legacy URL compatibility
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. Work stays inside existing dashboard and execution-list adapter boundaries.
+- II One-Click Agent Deployment: PASS. No new services, secrets, or deployment prerequisites.
+- III Avoid Vendor Lock-In: PASS. Browser access remains routed through MoonMind APIs and Temporal remains behind existing service/router boundaries.
+- IV Own Your Data: PASS. Execution state remains MoonMind-owned control-plane data.
+- V Skills Are First-Class: PASS. No skill runtime mutation.
+- VI Replaceable Scaffolding: PASS. Behavior is anchored by focused tests.
+- VII Runtime Configurability: PASS. Existing server dashboard configuration remains unchanged.
+- VIII Modular Architecture: PASS. Changes are scoped to the execution router and Tasks List entrypoint/tests.
+- IX Resilient by Default: PASS. Old URLs fail safe without exposing unauthorized workflow rows.
+- X Continuous Improvement: PASS. Verification artifacts will record the outcome.
+- XI Spec-Driven Development: PASS. This plan follows the single-story spec.
+- XII Canonical Documentation Separation: PASS. Implementation tracking remains under `specs/299-task-only-visibility-diagnostics/`.
+- XIII Pre-release Compatibility Policy: PASS. Superseded internal workflow-kind browsing behavior is removed rather than wrapped with compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/299-task-only-visibility-diagnostics/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── tasks-list-visibility-boundary.md
+├── checklists/
+│   └── requirements.md
+├── moonspec_align_report.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/api/routers/executions.py
+tests/unit/api/test_executions_temporal.py
+frontend/src/entrypoints/tasks-list.tsx
+frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+**Structure Decision**: Keep task-only UI behavior in the existing Tasks List entrypoint and enforce source-temporal list query safety in the existing executions router. No new route or persistent model is required.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/299-task-only-visibility-diagnostics/plan.md
+++ b/specs/299-task-only-visibility-diagnostics/plan.md
@@ -5,34 +5,34 @@
 
 ## Summary
 
-Implement the MM-586 runtime story by removing ordinary workflow-kind browsing from the Tasks List UI, normalizing legacy workflow-scope URLs to task-run visibility, showing a recoverable notice when unsupported workflow-scope state is ignored, and hardening the source-temporal execution list boundary so broad `scope`, `workflowType`, or `entry` parameters cannot widen ordinary task-list results. Current repo inspection found the table already excludes `Kind`, `Workflow Type`, and `Entry`, but the UI still exposes Scope/Workflow Type/Entry controls and the source-temporal API still honors `scope=all`; this run requires tests and implementation.
+Implement the MM-586 runtime story by keeping ordinary workflow-kind browsing out of the Tasks List UI, normalizing legacy workflow-scope URLs to task-run visibility, showing a recoverable notice when unsupported workflow-scope state is ignored, and hardening the source-temporal execution list boundary so broad `scope`, `workflowType`, or `entry` parameters cannot widen ordinary task-list results. Current repo inspection confirms the implementation and tests are now present: the table excludes `Kind`, `Workflow Type`, and `Entry`, the UI no longer exposes Scope/Workflow Type/Entry controls, legacy broad URL state is normalized, and the source-temporal API fails safe to task-run query semantics.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | `frontend/src/entrypoints/tasks-list.tsx` defaults to `scope=tasks` but can widen via controls/URL | force task-run request semantics | UI + backend unit |
-| FR-002 | missing | UI renders `Scope`, `Workflow Type`, and `Entry` controls | remove ordinary workflow-kind controls | UI test |
-| FR-003 | partial | old URL params initialize broad list state | normalize unsafe params and show notice | UI test |
-| FR-004 | implemented_verified | table columns omit `Kind`, `Workflow Type`, and `Entry`; existing started-column regression nearby | preserve behavior, add focused assertion | UI test |
-| FR-005 | implemented_unverified | Status and Repository controls exist but are coupled to broad controls | verify preserved task filters after broad-control removal | UI test |
-| FR-006 | partial | `_normalize_temporal_list_scope()` supports all/user/system and source-temporal route appends broad filters | coerce ordinary source-temporal list to task scope and ignore widening filters | backend unit |
-| FR-007 | partial | non-admin owner scoping exists; broad workflow scope can still list all user-owned workflow types | prevent normal query params from widening beyond task runs | backend unit |
-| FR-008 | missing | no recoverable notice for ignored workflow-scope URL state | add notice when legacy workflow-scope params are ignored | UI test |
-| FR-009 | partial | URL sync can emit `scope`, `workflowType`, and `entry` | remove ignored workflow-scope params from emitted URL | UI test |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` always sends `scope=tasks`; `frontend/src/entrypoints/tasks-list.test.tsx` asserts default and legacy request URLs | no new implementation | UI + backend unit |
+| FR-002 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` renders only Status and Repository filters; UI tests assert `Scope`, `Workflow Type`, and `Entry` are absent | no new implementation | UI test |
+| FR-003 | implemented_verified | `hasUnsupportedWorkflowScopeState()` and URL sync normalize broad legacy params; UI test covers broad URL state | no new implementation | UI test |
+| FR-004 | implemented_verified | `TABLE_COLUMNS` omits `Kind`, `Workflow Type`, and `Entry`; UI tests assert forbidden headers are absent | no new implementation | UI test |
+| FR-005 | implemented_verified | Status and Repository controls remain in `tasks-list.tsx`; UI tests cover status and repo request behavior | no new implementation | UI test |
+| FR-006 | implemented_verified | `_normalize_temporal_list_scope()` returns task scope for recognized broad scopes; backend tests cover `scope=all` and system workflow params | no new implementation | backend unit |
+| FR-007 | implemented_verified | source-temporal query construction ignores broad workflow/entry params while preserving ordinary owner scoping; backend tests assert task-run query | no new implementation | backend unit |
+| FR-008 | implemented_verified | `ignoredWorkflowScopeState` renders recoverable notice; UI legacy URL test asserts notice | no new implementation | UI test |
+| FR-009 | implemented_verified | URL sync omits `scope`, `workflowType`, and `entry`; UI legacy URL test asserts normalized URL state | no new implementation | UI test |
 | FR-010 | implemented_verified | React text interpolation renders labels/values as text | preserve behavior | final verify |
-| FR-011 | implemented_unverified | this feature's artifacts preserve MM-586 | carry traceability through plan/tasks/verification | final verify |
-| SC-001 | missing | no test covers broad URL normalization | add UI request assertions | UI test |
-| SC-002 | missing | existing tests expect broad controls | replace with absence/preserved filter tests | UI test |
-| SC-003 | missing | no test covers recoverable notice or URL rewrite | add UI test | UI test |
-| SC-004 | implemented_unverified | columns currently exclude forbidden headers | add focused assertion tied to MM-586 | UI test |
-| SC-005 | missing | existing backend test expects `scope=all` raw query | update/add backend tests for fail-safe task query | backend unit |
-| SC-006 | implemented_unverified | artifacts in progress | final verification | final verify |
-| DESIGN-REQ-005 | partial | normal page can still browse workflow kinds | remove broad controls and harden request boundary | UI + backend unit |
-| DESIGN-REQ-008 | implemented_unverified | table columns are task-oriented | add focused assertion | UI test |
-| DESIGN-REQ-009 | partial | system/manifest URL params can affect requests | normalize URL/API parameters safely | UI + backend unit |
-| DESIGN-REQ-017 | partial | old `state`/`repo` work, broad params unsafe | preserve task filters and ignore broad params with notice | UI test |
-| DESIGN-REQ-025 | partial | owner scoping exists, but filter params can widen workflow kinds | enforce task boundary and preserve text rendering | backend + UI test |
+| FR-011 | implemented_verified | `spec.md`, `plan.md`, `tasks.md`, and `verification.md` preserve MM-586 | no new implementation | final verify |
+| SC-001 | implemented_verified | UI tests assert default and legacy request URLs remain task scoped | no new implementation | UI test |
+| SC-002 | implemented_verified | UI tests assert broad controls are absent and task filters remain | no new implementation | UI test |
+| SC-003 | implemented_verified | UI legacy URL test asserts recoverable notice and URL rewrite | no new implementation | UI test |
+| SC-004 | implemented_verified | UI tests assert forbidden headers are absent | no new implementation | UI test |
+| SC-005 | implemented_verified | backend tests assert `scope=all` and system workflow params fail safe to task-run query | no new implementation | backend unit |
+| SC-006 | implemented_verified | `verification.md` records source-design and MM-586 coverage | no new implementation | final verify |
+| DESIGN-REQ-005 | implemented_verified | UI control removal plus task-scoped request tests | no new implementation | UI + backend unit |
+| DESIGN-REQ-008 | implemented_verified | `TABLE_COLUMNS` and header assertions prove task-oriented columns | no new implementation | UI test |
+| DESIGN-REQ-009 | implemented_verified | frontend legacy URL normalization and backend broad-param fail-safe tests | no new implementation | UI + backend unit |
+| DESIGN-REQ-017 | implemented_verified | old broad URL handling preserves task filters and shows notice | no new implementation | UI test |
+| DESIGN-REQ-025 | implemented_verified | backend task boundary plus JSX text rendering evidence | no new implementation | backend + UI test |
 
 ## Technical Context
 

--- a/specs/299-task-only-visibility-diagnostics/quickstart.md
+++ b/specs/299-task-only-visibility-diagnostics/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Task-only Visibility and Diagnostics Boundary
+
+## Focused Backend Validation
+
+```bash
+pytest tests/unit/api/test_executions_temporal.py -q
+```
+
+Expected evidence:
+- Default source-temporal listing queries task runs.
+- `scope=all`, `scope=system`, system `workflowType`, and `entry=manifest` fail safe to task-run query semantics for ordinary users.
+- Unknown scope values still return validation errors.
+
+## Focused Frontend Validation
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+Expected evidence:
+- The normal page request remains task scoped.
+- `Scope`, `Workflow Type`, and `Entry` controls are absent.
+- Status and Repository filters remain usable.
+- Old broad workflow URL parameters are removed from emitted URL state and show a recoverable notice.
+- `Kind`, `Workflow Type`, and `Entry` table headers are absent.
+
+## Final Unit Wrapper
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+## End-to-End Story Check
+
+Open `/tasks/list?scope=all&workflowType=MoonMind.ProviderProfileManager&entry=manifest&state=completed&repo=moon%2Fdemo`. The page should show a recoverable notice, preserve the Status and Repository task filters, request `/api/executions` with task scope only plus preserved task filters, and rewrite the browser URL without `scope`, `workflowType`, or `entry`.

--- a/specs/299-task-only-visibility-diagnostics/research.md
+++ b/specs/299-task-only-visibility-diagnostics/research.md
@@ -1,0 +1,49 @@
+# Research: Task-only Visibility and Diagnostics Boundary
+
+## FR-001 / DESIGN-REQ-005
+
+Decision: Partial behavior exists; implement task-run-only request semantics from the Tasks List UI.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` defaults to `scope=tasks` but lets users choose `all`, `system`, or `user` and sends those values to `/api/executions`.
+Rationale: The normal list must be task-oriented and not a workflow-kind browser.
+Alternatives considered: Add a diagnostics link now; rejected because the MM-586 story only requires a separated diagnostics boundary and allows safe ignore/recoverable handling.
+Test implications: UI integration-style tests.
+
+## FR-002 / SC-002
+
+Decision: Missing; remove `Scope`, `Workflow Type`, and `Entry` controls from the normal Tasks List page.
+Evidence: Existing tests currently assert these controls exist and can widen scope.
+Rationale: Ordinary workflow-kind browsing UX is explicitly out of scope for `/tasks/list`.
+Alternatives considered: Disable the controls; rejected because visible disabled workflow-kind controls still make the normal page read as a workflow browser.
+Test implications: UI integration-style tests assert absence and preserved Status/Repository controls.
+
+## FR-003 / FR-008 / FR-009 / DESIGN-REQ-017
+
+Decision: Partial; preserve task-compatible old `state` and `repo` parameters, ignore broad workflow-scope parameters, rewrite emitted URL state, and show a recoverable notice when unsafe legacy state was present.
+Evidence: Current initialization uses `scope`, `workflowType`, and `entry` to initialize broad state and syncs those params back to the URL.
+Rationale: Old shared links should not break, but must not reveal system/all/manifest workflows.
+Alternatives considered: Redirect to diagnostics; rejected because no diagnostics route is in scope for this story.
+Test implications: UI test for old URL normalization and notice.
+
+## FR-004 / DESIGN-REQ-008
+
+Decision: Implemented but add focused MM-586 verification.
+Evidence: `TABLE_COLUMNS` contains ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished. Existing tests already cover the absence of Started, but not MM-586 forbidden headers directly.
+Rationale: The forbidden headers are a primary acceptance criterion and need traceable evidence.
+Alternatives considered: No new assertion; rejected due traceability gap.
+Test implications: UI test.
+
+## FR-006 / FR-007 / DESIGN-REQ-025
+
+Decision: Partial; harden the source-temporal execution list route so ordinary query parameters cannot widen beyond task-run semantics.
+Evidence: `_TEMPORAL_SCOPE_QUERIES` supports `all`, `user`, and `system`; `test_list_executions_source_temporal_scope_all_keeps_raw_temporal_query` expects `scope=all` to omit task filtering.
+Rationale: The backend/query boundary must be fail-safe because URL parameters are user editable.
+Alternatives considered: Rely only on frontend normalization; rejected because backend boundary is explicitly required.
+Test implications: backend unit tests update broad-scope expectations and add system/manifest filter cases.
+
+## FR-010
+
+Decision: Implemented; preserve text rendering.
+Evidence: React renders filter chip labels/values and table text through JSX text interpolation, not HTML injection.
+Rationale: No new HTML rendering surface is needed for this story.
+Alternatives considered: Add sanitizer abstraction; rejected as unnecessary for non-HTML rendering.
+Test implications: final verification only.

--- a/specs/299-task-only-visibility-diagnostics/research.md
+++ b/specs/299-task-only-visibility-diagnostics/research.md
@@ -2,40 +2,40 @@
 
 ## FR-001 / DESIGN-REQ-005
 
-Decision: Partial behavior exists; implement task-run-only request semantics from the Tasks List UI.
-Evidence: `frontend/src/entrypoints/tasks-list.tsx` defaults to `scope=tasks` but lets users choose `all`, `system`, or `user` and sends those values to `/api/executions`.
+Decision: Implemented and verified; Tasks List request semantics are task-run-only.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` always sets `scope=tasks`; `frontend/src/entrypoints/tasks-list.test.tsx` asserts default and legacy URL request shapes.
 Rationale: The normal list must be task-oriented and not a workflow-kind browser.
 Alternatives considered: Add a diagnostics link now; rejected because the MM-586 story only requires a separated diagnostics boundary and allows safe ignore/recoverable handling.
 Test implications: UI integration-style tests.
 
 ## FR-002 / SC-002
 
-Decision: Missing; remove `Scope`, `Workflow Type`, and `Entry` controls from the normal Tasks List page.
-Evidence: Existing tests currently assert these controls exist and can widen scope.
+Decision: Implemented and verified; `Scope`, `Workflow Type`, and `Entry` controls are absent from the normal Tasks List page.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` renders only Status and Repository filters; `frontend/src/entrypoints/tasks-list.test.tsx` asserts the workflow-kind controls are absent.
 Rationale: Ordinary workflow-kind browsing UX is explicitly out of scope for `/tasks/list`.
 Alternatives considered: Disable the controls; rejected because visible disabled workflow-kind controls still make the normal page read as a workflow browser.
 Test implications: UI integration-style tests assert absence and preserved Status/Repository controls.
 
 ## FR-003 / FR-008 / FR-009 / DESIGN-REQ-017
 
-Decision: Partial; preserve task-compatible old `state` and `repo` parameters, ignore broad workflow-scope parameters, rewrite emitted URL state, and show a recoverable notice when unsafe legacy state was present.
-Evidence: Current initialization uses `scope`, `workflowType`, and `entry` to initialize broad state and syncs those params back to the URL.
+Decision: Implemented and verified; task-compatible old `state` and `repo` parameters are preserved, broad workflow-scope parameters are ignored, emitted URL state is rewritten, and a recoverable notice appears when unsafe legacy state was present.
+Evidence: `hasUnsupportedWorkflowScopeState()` in `frontend/src/entrypoints/tasks-list.tsx`; legacy URL coverage in `frontend/src/entrypoints/tasks-list.test.tsx`.
 Rationale: Old shared links should not break, but must not reveal system/all/manifest workflows.
 Alternatives considered: Redirect to diagnostics; rejected because no diagnostics route is in scope for this story.
 Test implications: UI test for old URL normalization and notice.
 
 ## FR-004 / DESIGN-REQ-008
 
-Decision: Implemented but add focused MM-586 verification.
-Evidence: `TABLE_COLUMNS` contains ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished. Existing tests already cover the absence of Started, but not MM-586 forbidden headers directly.
+Decision: Implemented and verified.
+Evidence: `TABLE_COLUMNS` contains ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished; `frontend/src/entrypoints/tasks-list.test.tsx` asserts `Kind`, `Workflow Type`, and `Entry` headers are absent.
 Rationale: The forbidden headers are a primary acceptance criterion and need traceable evidence.
 Alternatives considered: No new assertion; rejected due traceability gap.
 Test implications: UI test.
 
 ## FR-006 / FR-007 / DESIGN-REQ-025
 
-Decision: Partial; harden the source-temporal execution list route so ordinary query parameters cannot widen beyond task-run semantics.
-Evidence: `_TEMPORAL_SCOPE_QUERIES` supports `all`, `user`, and `system`; `test_list_executions_source_temporal_scope_all_keeps_raw_temporal_query` expects `scope=all` to omit task filtering.
+Decision: Implemented and verified; the source-temporal execution list route cannot widen ordinary query parameters beyond task-run semantics.
+Evidence: `_normalize_temporal_list_scope()` returns task scope for recognized broad scopes; `tests/unit/api/test_executions_temporal.py` covers `scope=all`, system workflow params, and unknown-scope validation.
 Rationale: The backend/query boundary must be fail-safe because URL parameters are user editable.
 Alternatives considered: Rely only on frontend normalization; rejected because backend boundary is explicitly required.
 Test implications: backend unit tests update broad-scope expectations and add system/manifest filter cases.

--- a/specs/299-task-only-visibility-diagnostics/spec.md
+++ b/specs/299-task-only-visibility-diagnostics/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Task-only Visibility and Diagnostics Boundary
+
+**Feature Branch**: `299-task-only-visibility-diagnostics`
+**Created**: 2026-05-05
+**Status**: Draft
+**Input**:
+
+```text
+# MM-586 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-586
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Task-only visibility and diagnostics boundary
+- Trusted fetch tool: `jira.get_issue`
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-586-trusted-jira-get-issue-summary.json`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Labels: moonmind-workflow-mm-af73ac39-5c56-460e-bd77-712adac541f3
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-586 from MM project
+Summary: Task-only visibility and diagnostics boundary
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-586 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-586: Task-only visibility and diagnostics boundary
+
+Source Reference
+Source Document: docs/UI/TasksListPage.md
+Source Title: Tasks List Page
+Source Sections:
+- 4. Product stance
+- 7. Column set in the desired design
+- 7.1 Admin diagnostics escape hatch
+- 12.1 Backward compatibility
+- 18. Security and privacy
+Coverage IDs:
+- DESIGN-REQ-005
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-017
+- DESIGN-REQ-025
+
+As an ordinary Tasks List user, I want the page to always show user-visible task runs and never become a workflow-kind browser so system workflows remain confined to an explicit admin diagnostics surface.
+
+Acceptance Criteria
+- The normal list request is always bounded to task-run visibility regardless of editable URL parameters.
+- The default table exposes no Kind, Workflow Type, or Entry column.
+- System and all workflow scopes are ignored safely, redirected to diagnostics when authorized, or shown in a recoverable message without revealing rows.
+- Manifest ingest URLs do not add Workflow Type or Entry columns to the task table.
+- Diagnostics access, if linked, is permission-gated and visually separate from `/tasks/list`.
+
+Requirements
+- Enforce task-oriented visibility at the backend authorization/query boundary.
+- Remove the ordinary workflow-kind browsing UX from Tasks List.
+- Fail safe for old URLs without losing task-list availability.
+
+## Relevant Implementation Notes
+
+- Source design path: `docs/UI/TasksListPage.md`.
+- Section 4 Product stance: the Tasks List page is an operator scanning surface for ordinary user-created task executions, not a generic Temporal namespace browser; system, provider-profile, monitor, maintenance, and manifest-ingest workflows belong outside the normal task table.
+- Section 7 Column set in the desired design: the default table includes task fields such as ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished, and optional Integration, while excluding `Kind`, `Workflow Type`, and `Entry`; the default query remains the task-run list equivalent to `scope=tasks`, `WorkflowType=MoonMind.Run`, and `mm_entry=run`.
+- Section 7.1 Admin diagnostics escape hatch: system and all-workflow browsing may exist only in an explicit permission-gated diagnostics surface; ordinary users must not widen `/tasks/list` into system workflow visibility by editing URL parameters.
+- Section 12.1 Backward compatibility: old `scope`, `workflowType`, `entry`, `state`, and `repo` URL parameters must fail safe, preserve valid task-list meanings where appropriate, redirect to a better page when authorized, or show recoverable messages without revealing system workflows.
+- Section 18 Security and privacy: browser requests go through MoonMind APIs, facet values share list authorization and owner scoping, hidden or unauthorized values must not appear in facet data, filter parameters must not bypass backend authorization, URL state must not contain secrets, labels render as text, and invalid filters should return structured validation errors.
+
+## MoonSpec Classification Input
+
+Classify this as a single-story runtime feature request for the Tasks List page: enforce task-only visibility and a separate permission-gated diagnostics boundary while preserving MM-586 traceability and the referenced Tasks List design requirements.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Task-only Tasks List Visibility
+
+**Summary**: As an ordinary Tasks List user, I want `/tasks/list` to show only user-visible task runs and not become a workflow-kind browser.
+
+**Goal**: Operators can trust the normal Tasks List page to remain task-oriented even when old or edited URLs request system, all-workflow, manifest, workflow-type, or entry browsing.
+
+**Independent Test**: Render `/tasks/list` with default and legacy workflow-scope URLs, inspect the browser request and visible controls, and query the execution list boundary to confirm only task-run visibility is requested or returned while recoverable messaging appears for ignored workflow-scope URL state.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ordinary user opens `/tasks/list`, **When** the list loads, **Then** the data request is bounded to task runs and no system/all workflow rows can be requested from the normal page controls.
+2. **Given** an old URL contains `scope=system`, `scope=all`, a system `workflowType`, or `entry=manifest`, **When** `/tasks/list` loads, **Then** the page fails safe by showing task runs only and providing recoverable notice without revealing system or manifest rows.
+3. **Given** an old URL contains task-compatible filters such as `state=<value>` or `repo=<value>`, **When** `/tasks/list` loads, **Then** those task-list filters remain available without reintroducing workflow-kind browsing.
+4. **Given** the default desktop table renders, **When** column headers are inspected, **Then** no `Kind`, `Workflow Type`, or `Entry` column is present.
+5. **Given** diagnostics access is not part of `/tasks/list`, **When** a user interacts with the normal page, **Then** system/all workflow browsing controls are absent from the task table surface.
+
+### Edge Cases
+
+- `scope=user` and `workflowType=MoonMind.ManifestIngest` are treated as workflow browsing state and must not expose manifest rows in `/tasks/list`.
+- `workflowType=MoonMind.Run` and `entry=run` are task-compatible legacy parameters, but the page should normalize them away because task-run visibility is the default.
+- Clearing filters must not restore ignored workflow-scope URL parameters.
+- Unauthorized or hidden workflow categories must not appear in filter chips, table columns, facet-style values, or request URLs.
+
+## Assumptions
+
+- A separate diagnostics route is not part of this story; old workflow-scope URLs fail safe on `/tasks/list` with task-run visibility and recoverable messaging.
+- Existing authenticated user scoping remains the owner boundary for ordinary task rows.
+- This story preserves the current Status and Repository controls until later column-filter stories replace them.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-005**: Source `docs/UI/TasksListPage.md` section 4. The normal Tasks List page must be task-oriented and must not act as a generic Temporal namespace or workflow-kind browser. Scope: in scope. Maps to FR-001, FR-002, FR-005, and FR-006.
+- **DESIGN-REQ-008**: Source `docs/UI/TasksListPage.md` section 7. The normal table must not include `Kind`, `Workflow Type`, or `Entry` columns and must default to task-run list semantics. Scope: in scope. Maps to FR-001 and FR-004.
+- **DESIGN-REQ-009**: Source `docs/UI/TasksListPage.md` section 7. System workflow rows and manifest ingest rows must not appear in the normal task table through filters or old URL parameters. Scope: in scope. Maps to FR-002, FR-003, and FR-007.
+- **DESIGN-REQ-017**: Source `docs/UI/TasksListPage.md` section 12.1. Existing workflow-scope URL parameters must fail safe, preserve task-compatible filters where possible, or show recoverable messaging without exposing broader workflow scopes. Scope: in scope. Maps to FR-003 and FR-008.
+- **DESIGN-REQ-025**: Source `docs/UI/TasksListPage.md` section 18. Filter parameters must not bypass backend authorization, unauthorized values must not appear in list/facet outputs, URL filter state must not contain secrets, and labels must render as text. Scope: in scope. Maps to FR-007, FR-009, and FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The normal Tasks List data request MUST be bounded to task-run visibility equivalent to task scope, `MoonMind.Run`, and run entries.
+- **FR-002**: The Tasks List UI MUST NOT expose ordinary controls for system, all-workflow, workflow-type, or entry browsing.
+- **FR-003**: The Tasks List UI MUST ignore or normalize old workflow-scope URL parameters without revealing system, all-workflow, or manifest rows.
+- **FR-004**: The default Tasks List table MUST NOT expose `Kind`, `Workflow Type`, or `Entry` columns.
+- **FR-005**: The Tasks List UI MUST preserve task-compatible Status and Repository filtering while keeping active filter chips task-oriented.
+- **FR-006**: The execution-list request boundary used by the normal Tasks List MUST fail safe to task-run visibility when scope, workflow type, or entry parameters would widen the result set.
+- **FR-007**: Non-admin ordinary users MUST NOT be able to use normal Tasks List query parameters to list system workflows, manifest ingest workflows, or all workflow scopes.
+- **FR-008**: Old URLs that contain unsupported workflow-scope state MUST produce a recoverable user-visible notice or equivalent safe handling while preserving task-list availability.
+- **FR-009**: URL state emitted by the Tasks List page MUST remove ignored workflow-scope parameters and MUST NOT include secrets.
+- **FR-010**: Labels and filter values rendered by the Tasks List MUST be displayed as text and must not render untrusted HTML.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-586` and this canonical Jira preset brief for traceability.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: UI tests prove the normal Tasks List request includes task scope and excludes `workflowType`, `entry`, `scope=system`, and `scope=all` when loaded from default and old workflow-scope URLs.
+- **SC-002**: UI tests prove `Scope`, `Workflow Type`, and `Entry` controls are absent while Status and Repository task filters remain usable.
+- **SC-003**: UI tests prove old system/all/manifest URL parameters are normalized away and a recoverable notice is visible without revealing workflow-kind rows or chips.
+- **SC-004**: UI tests prove the table headers do not include `Kind`, `Workflow Type`, or `Entry`.
+- **SC-005**: Backend route tests prove source-temporal execution listing fails safe to task-run query semantics when broad workflow-scope parameters are supplied by an ordinary user.
+- **SC-006**: Final verification confirms `MM-586`, DESIGN-REQ-005, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-017, and DESIGN-REQ-025 are preserved and covered by implementation evidence.

--- a/specs/299-task-only-visibility-diagnostics/tasks.md
+++ b/specs/299-task-only-visibility-diagnostics/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Task-only Visibility and Diagnostics Boundary
+
+**Input**: `specs/299-task-only-visibility-diagnostics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/tasks-list-visibility-boundary.md`, `quickstart.md`
+
+**Unit Test Command**: `pytest tests/unit/api/test_executions_temporal.py -q`
+**Targeted Frontend Command**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`
+**Integration Test Command**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`
+**Final Unit Wrapper**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
+
+## Source Traceability Summary
+
+- `MM-586` is preserved as the canonical Jira preset brief in `spec.md`.
+- `DESIGN-REQ-005`: normal Tasks List is task-oriented, not a workflow-kind browser.
+- `DESIGN-REQ-008`: normal table excludes `Kind`, `Workflow Type`, and `Entry` and defaults to task-run semantics.
+- `DESIGN-REQ-009`: system and manifest rows cannot appear through filters or old URL params.
+- `DESIGN-REQ-017`: old URL params fail safe while preserving task-compatible filters.
+- `DESIGN-REQ-025`: filter params cannot bypass authorization or expose hidden workflow categories.
+
+## Story
+
+As an ordinary Tasks List user, I want `/tasks/list` to show only user-visible task runs and not become a workflow-kind browser.
+
+**Independent Test**: Render `/tasks/list` with default and legacy workflow-scope URLs, inspect the browser request and visible controls, and query the execution list boundary to confirm only task-run visibility is requested or returned while recoverable messaging appears for ignored workflow-scope URL state.
+
+## Unit Test Plan
+
+- Backend unit coverage in `tests/unit/api/test_executions_temporal.py` verifies the source-temporal list boundary fails safe to task-run query semantics when ordinary users supply broad `scope`, `workflowType`, or `entry` parameters.
+- Existing unknown-scope validation remains covered.
+
+## Integration Test Plan
+
+- Integration-style UI coverage in `frontend/src/entrypoints/tasks-list.test.tsx` verifies broad controls are absent, task filters remain, legacy broad URL params are normalized with a recoverable notice, request URLs stay task-scoped, and forbidden table headers are absent.
+
+## Task Phases
+
+### Phase 1: Setup
+
+- [X] T001 Create MoonSpec feature directory and preserve MM-586 Jira preset brief in `specs/299-task-only-visibility-diagnostics/spec.md`
+- [X] T002 Create planning, research, data model, visibility contract, quickstart, and checklist artifacts under `specs/299-task-only-visibility-diagnostics/`
+
+### Phase 2: Test-First Coverage
+
+- [X] T003 Add failing backend unit coverage for broad source-temporal scope normalization in `tests/unit/api/test_executions_temporal.py`. (FR-006, FR-007, SC-005, DESIGN-REQ-005, DESIGN-REQ-009, DESIGN-REQ-025)
+- [X] T004 Add failing frontend integration-style coverage for hidden Scope/Workflow Type/Entry controls, task-scoped requests, legacy URL normalization, recoverable notice, preserved Status/Repository filters, and forbidden table headers in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-008, FR-009, SC-001, SC-002, SC-003, SC-004, DESIGN-REQ-008, DESIGN-REQ-017)
+- [X] T005 Run red-first targeted backend command `pytest tests/unit/api/test_executions_temporal.py -q` and confirm the new MM-586 backend assertions fail before production changes. (T003)
+- [X] T006 Run red-first targeted frontend command `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` and confirm the new MM-586 UI assertions fail before production changes. (T004)
+
+### Phase 3: Story Implementation
+
+- [X] T007 Harden source-temporal list scope normalization in `api_service/api/routers/executions.py` so broad scope/workflowType/entry parameters fail safe to task-run query semantics while unknown scopes still validate. (FR-001, FR-006, FR-007, DESIGN-REQ-005, DESIGN-REQ-009, DESIGN-REQ-025)
+- [X] T008 Remove ordinary workflow-kind controls and state from `frontend/src/entrypoints/tasks-list.tsx` while preserving Status, Repository, live updates, pagination, and sorting. (FR-002, FR-005, DESIGN-REQ-005, DESIGN-REQ-008)
+- [X] T009 Normalize legacy workflow-scope URL parameters and add recoverable ignored-scope notice in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-008, FR-009, DESIGN-REQ-017)
+- [X] T010 Preserve task table forbidden-column behavior and text rendering in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-010, DESIGN-REQ-008, DESIGN-REQ-025)
+
+### Phase 4: Story Validation
+
+- [X] T011 Run targeted backend validation: `pytest tests/unit/api/test_executions_temporal.py -q`
+- [X] T012 Run targeted frontend validation: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`
+- [X] T013 Run final unit wrapper: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
+
+### Final Phase: Polish And Verification
+
+- [X] T014 Run MoonSpec alignment and record result in `specs/299-task-only-visibility-diagnostics/moonspec_align_report.md`
+- [X] T015 Run final `/moonspec-verify` and record verdict in `specs/299-task-only-visibility-diagnostics/verification.md`
+
+## Dependencies
+
+- T003 and T004 depend on T001 and T002.
+- T005 depends on T003; T006 depends on T004.
+- T007 through T010 depend on red-first confirmation T005 and T006.
+- T011 through T013 depend on implementation tasks T007 through T010.
+- T014 and T015 depend on validation passing.
+
+## Parallel Opportunities
+
+- T003 and T004 may be authored in parallel because they touch different test files.
+- T007 and T008/T009 touch different production files after red-first confirmation, but T008 and T009 both edit `tasks-list.tsx` and should be coordinated sequentially.
+
+## Implementation Strategy
+
+Use strict TDD: add backend and frontend tests that fail against the current broad workflow-browsing behavior, then make the smallest scoped changes in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/tasks-list.tsx`. Preserve existing route/shell behavior from MM-585 and do not add a diagnostics route in this story. Final verification must preserve MM-586 and all in-scope DESIGN-REQ IDs.

--- a/specs/299-task-only-visibility-diagnostics/tasks.md
+++ b/specs/299-task-only-visibility-diagnostics/tasks.md
@@ -16,6 +16,10 @@
 - `DESIGN-REQ-017`: old URL params fail safe while preserving task-compatible filters.
 - `DESIGN-REQ-025`: filter params cannot bypass authorization or expose hidden workflow categories.
 
+## Requirement Status Refresh
+
+The upstream `plan.md` and `research.md` were refreshed after implementation to mark all MM-586 requirements, scenarios, and in-scope source design requirements as `implemented_verified`. This `tasks.md` remains the completed execution record for the test-first work that produced that evidence: red-first backend unit tests, red-first frontend integration-style tests, production implementation tasks, story validation commands, alignment, and final `/moonspec-verify`.
+
 ## Story
 
 As an ordinary Tasks List user, I want `/tasks/list` to show only user-visible task runs and not become a workflow-kind browser.
@@ -78,4 +82,4 @@ As an ordinary Tasks List user, I want `/tasks/list` to show only user-visible t
 
 ## Implementation Strategy
 
-Use strict TDD: add backend and frontend tests that fail against the current broad workflow-browsing behavior, then make the smallest scoped changes in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/tasks-list.tsx`. Preserve existing route/shell behavior from MM-585 and do not add a diagnostics route in this story. Final verification must preserve MM-586 and all in-scope DESIGN-REQ IDs.
+Completed via strict TDD: backend and frontend tests were added and confirmed failing against the broad workflow-browsing behavior, then the smallest scoped changes were made in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/tasks-list.tsx`. Existing route/shell behavior from MM-585 was preserved, no diagnostics route was added, and final verification preserved MM-586 plus all in-scope DESIGN-REQ IDs.

--- a/specs/299-task-only-visibility-diagnostics/verification.md
+++ b/specs/299-task-only-visibility-diagnostics/verification.md
@@ -1,0 +1,67 @@
+# MoonSpec Verification Report
+
+**Feature**: Task-only Visibility and Diagnostics Boundary  
+**Spec**: specs/299-task-only-visibility-diagnostics/spec.md  
+**Original Request Source**: `spec.md` Input preserving canonical Jira preset brief for `MM-586`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Backend source-temporal unit | `pytest tests/unit/api/test_executions_temporal.py -q` | PASS | 14 passed. Covers default task scope, broad `scope=all`, broad system workflow params, and unknown-scope validation. |
+| Focused frontend UI | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` | PASS | 1 file and 18 tests passed. Covers task-scoped requests, hidden workflow-kind controls, legacy URL normalization, recoverable notice, task filters, and forbidden headers. |
+| Final unit wrapper | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` | PASS | Python 4319 passed, 1 xpassed, 16 subtests passed; focused UI 1 file and 18 tests passed. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `frontend/src/entrypoints/tasks-list.tsx`; `frontend/src/entrypoints/tasks-list.test.tsx` | VERIFIED | UI request always sends `scope=tasks`; tests assert default and legacy request URLs. |
+| FR-002 | `frontend/src/entrypoints/tasks-list.tsx`; `frontend/src/entrypoints/tasks-list.test.tsx` | VERIFIED | Scope, Workflow Type, and Entry controls were removed from normal Tasks List. |
+| FR-003 | `frontend/src/entrypoints/tasks-list.tsx`; legacy URL UI test | VERIFIED | Broad legacy URL params are ignored for data requests and normalized out of emitted URL state. |
+| FR-004 | `TABLE_COLUMNS` in `frontend/src/entrypoints/tasks-list.tsx`; UI header assertions | VERIFIED | Table columns remain ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, Finished. |
+| FR-005 | `frontend/src/entrypoints/tasks-list.tsx`; existing and updated UI tests | VERIFIED | Status and Repository filters remain usable and task-oriented. |
+| FR-006 | `api_service/api/routers/executions.py`; backend source-temporal tests | VERIFIED | Source-temporal list boundary returns task scope for recognized broad scopes and ignores widening workflow/entry params. |
+| FR-007 | `api_service/api/routers/executions.py`; backend ordinary-user tests | VERIFIED | Ordinary owner scoping remains and broad query params cannot widen to system/manifest/all rows. |
+| FR-008 | `frontend/src/entrypoints/tasks-list.tsx`; legacy URL UI test | VERIFIED | Unsupported workflow-scope URL state shows a recoverable notice. |
+| FR-009 | URL sync in `frontend/src/entrypoints/tasks-list.tsx`; legacy URL UI test | VERIFIED | Emitted URL state excludes ignored `scope`, `workflowType`, and `entry`. |
+| FR-010 | JSX text rendering in `frontend/src/entrypoints/tasks-list.tsx`; final UI validation | VERIFIED | Labels/filter values are rendered as text; no HTML injection path was added. |
+| FR-011 | `spec.md`, `plan.md`, `tasks.md`, this verification report | VERIFIED | MM-586 is preserved across artifacts and evidence. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| SCN-001 default task-only load | Default UI request test and backend default query test | VERIFIED | Normal page and API boundary are task scoped. |
+| SCN-002 old broad URL fail-safe | Legacy URL UI test and broad backend query tests | VERIFIED | Broad workflow state is ignored safely with task-run results. |
+| SCN-003 task-compatible filters preserved | Status/Repository tests | VERIFIED | `state` and `repo` remain functional task filters. |
+| SCN-004 forbidden table headers absent | UI header assertions | VERIFIED | `Kind`, `Workflow Type`, and `Entry` are not table headers. |
+| SCN-005 diagnostics separated from normal list | UI controls absent; recoverable notice | VERIFIED | No normal workflow-kind browsing controls remain on `/tasks/list`. |
+
+## Source Design Coverage
+
+| Source Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-005 | UI control removal and task-scoped requests | VERIFIED | Normal Tasks List no longer acts as a workflow-kind browser. |
+| DESIGN-REQ-008 | `TABLE_COLUMNS` and header assertions | VERIFIED | Forbidden columns are absent and task-run scope remains default. |
+| DESIGN-REQ-009 | Backend broad-param fail-safe tests and frontend legacy URL normalization | VERIFIED | System and manifest rows cannot be requested through normal list params. |
+| DESIGN-REQ-017 | Legacy URL test | VERIFIED | Old broad params fail safe while `state` and `repo` are preserved. |
+| DESIGN-REQ-025 | Backend query boundary and text-rendered UI | VERIFIED | Query params cannot bypass ordinary task-run boundary; no unsafe rendering added. |
+
+## Constitution Coverage
+
+No constitution conflicts were found. The change keeps browser access through MoonMind APIs, introduces no new storage or services, preserves owner scoping, records migration/implementation evidence under `specs/299-task-only-visibility-diagnostics/`, and removes the superseded internal workflow-kind browsing behavior rather than adding a compatibility layer.
+
+## Original Request Alignment
+
+PASS. The implementation uses the MM-586 Jira preset brief as the canonical MoonSpec input, enforces task-oriented visibility at the request/query boundary, removes ordinary workflow-kind browsing UX, fails safe for old broad URLs, preserves task-list availability, and keeps diagnostics concerns separate from `/tasks/list`.
+
+## Gaps
+
+None found.
+
+## Decision
+
+MM-586 is fully implemented and verified for the selected single-story runtime scope.

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -151,7 +151,7 @@ def test_list_executions_source_temporal_defaults_to_task_scope(client) -> None:
         assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
 
 
-def test_list_executions_source_temporal_scope_all_keeps_raw_temporal_query(
+def test_list_executions_source_temporal_scope_all_fails_safe_to_task_query(
     client,
 ) -> None:
     test_client, _service, _user, _mock_session = client
@@ -177,7 +177,49 @@ def test_list_executions_source_temporal_scope_all_keeps_raw_temporal_query(
         )
 
         assert response.status_code == 200
-        expected_query = 'mm_owner_id="user-123"'
+        expected_query = (
+            'WorkflowType="MoonMind.Run" AND mm_entry="run" '
+            'AND mm_owner_id="user-123"'
+        )
+        mock_client.count_workflows.assert_awaited_once_with(query=expected_query)
+        assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
+
+
+def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_task_list(
+    client,
+) -> None:
+    test_client, _service, _user, _mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = []
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=0))
+
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scope": "system",
+                "workflowType": "MoonMind.ProviderProfileManager",
+                "entry": "manifest",
+            },
+        )
+
+        assert response.status_code == 200
+        expected_query = (
+            'WorkflowType="MoonMind.Run" AND mm_entry="run" '
+            'AND mm_owner_id="user-123"'
+        )
         mock_client.count_workflows.assert_awaited_once_with(query=expected_query)
         assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
 


### PR DESCRIPTION
## Summary

- Enforces task-only visibility for the normal Tasks List request/query boundary.
- Removes ordinary workflow-kind browsing controls and forbidden table columns from `/tasks/list`.
- Normalizes legacy broad workflow URL state with a recoverable notice while preserving Status and Repository filters.
- Adds MoonSpec artifacts for `specs/299-task-only-visibility-diagnostics`.

## Jira

- Jira issue key: MM-586

## MoonSpec

- Active feature path: `specs/299-task-only-visibility-diagnostics`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run

- `pytest tests/unit/api/test_executions_temporal.py -q` - PASS, 14 passed.
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` - PASS, 18 passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` - FAIL in unrelated PR-resolver skill tests because the active runtime `.agents/skills` projection lacks `fix-comments`/`pr-resolver` tool files; MM-586 targeted tests pass.

## Remaining risks

- Full unit wrapper is currently blocked by unrelated active-skill-projection test failures outside the MM-586 implementation scope.
