### PR TITLE
MM-587 Desktop columns and compound headers

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_210
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_211

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_213
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_214

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f4f56b-60a7-464f-9d64-d330a95473f5_12
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_210

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_214
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_215

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_212
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_213

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_211
+../../runtime/skills_active/skillset_mm:90315069-d03f-4c8a-afa6-f2c48ffee6d9_212

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/299-task-only-visibility-diagnostics"
+  "feature_directory": "specs/300-desktop-columns-headers"
 }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4153,6 +4153,7 @@ async def list_executions(
     entry: Optional[str] = Query(None, alias="entry"),
     repo: Optional[str] = Query(None, alias="repo"),
     integration: Optional[str] = Query(None, alias="integration"),
+    target_runtime: Optional[str] = Query(None, alias="targetRuntime"),
     scope: Optional[str] = Query(None, alias="scope"),
     page_size: int = Query(50, alias="pageSize", ge=1, le=200),
     next_page_token: Optional[str] = Query(None, alias="nextPageToken"),
@@ -4233,6 +4234,10 @@ async def list_executions(
                 query_parts.append(f'mm_repo="{escape_val(repo)}"')
             if integration:
                 query_parts.append(f'mm_integration="{escape_val(integration)}"')
+            if target_runtime:
+                query_parts.append(
+                    f'mm_target_runtime="{escape_val(target_runtime)}"'
+                )
 
             query_str = " AND ".join(query_parts) if query_parts else ""
 

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,22 @@
 [
   {
-    "id": 4376107040,
+    "id": 4376292553,
     "disposition": "not-applicable",
-    "rationale": "Quota warning from gemini-code-assist; no code action requested."
+    "rationale": "Quota warning issue comment is provider status noise and does not request a code change."
   },
   {
-    "id": 4224910915,
-    "disposition": "not-applicable",
-    "rationale": "Top-level automated review summary with no actionable feedback."
-  },
-  {
-    "id": 3185711626,
+    "id": 3185847615,
     "disposition": "addressed",
-    "rationale": "Legacy workflow-scope URLs now drop stale nextPageToken before task-scoped fetching, with UI test coverage."
+    "rationale": "Restored status, repository, and runtime filters outside the desktop-only table via mobile task filter controls with UI coverage."
+  },
+  {
+    "id": 3185847617,
+    "disposition": "addressed",
+    "rationale": "Expanded runtime filter options to include codex, claude, and codex_cloud alongside existing runtime identifiers with UI coverage."
+  },
+  {
+    "id": 4225064778,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary contains no separate actionable request beyond the line comments already addressed."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -64,6 +64,31 @@ describe('Tasks List Entrypoint', () => {
     });
   });
 
+  it('separates desktop header sorting from filter popovers', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    const scheduledHeaderButton = await screen.findByRole('button', {
+      name: /Scheduled\. Sorted descending\. Activate to sort ascending\./i,
+    });
+    const repositoryFilterButton = screen.getByRole('button', {
+      name: /Filter Repository\. No filter applied\./i,
+    });
+
+    fireEvent.click(repositoryFilterButton);
+
+    expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
+    expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
+
+    fireEvent.click(scheduledHeaderButton);
+
+    await waitFor(() => {
+      expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
+    });
+    expect(screen.queryByRole('dialog', { name: 'Scheduled filter' })).toBeNull();
+  });
+
   it('keeps workflow-kind browsing controls out of the normal task list', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
@@ -265,13 +290,14 @@ describe('Tasks List Entrypoint', () => {
     expect((await screen.findAllByText('—')).length).toBeGreaterThan(0);
   });
 
-  it('reuses the trimmed filters for both the request and the query key', async () => {
+  it('reuses the trimmed repository column filter for both the request and the query key', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
     const baselineCalls = fetchSpy.mock.calls.length;
 
-    fireEvent.change(screen.getByLabelText('Repository'), {
+    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+    fireEvent.change(screen.getByLabelText('Repository filter value'), {
       target: { value: 'owner/repo' },
     });
 
@@ -281,24 +307,27 @@ describe('Tasks List Entrypoint', () => {
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
       '/api/executions?source=temporal&pageSize=50&scope=tasks&repo=owner%2Frepo',
     );
+    await screen.findAllByText('Example task');
 
-    fireEvent.change(screen.getByLabelText('Repository'), {
+    fireEvent.click(screen.getByRole('button', { name: /Repository filter: owner\/repo/i }));
+    fireEvent.change(screen.getByLabelText('Repository filter value'), {
       target: { value: 'owner/repo ' },
     });
 
-    const repositoryInput = screen.getByLabelText('Repository') as HTMLInputElement;
+    const repositoryInput = screen.getByLabelText('Repository filter value') as HTMLInputElement;
     await waitFor(() => {
       expect(repositoryInput.value).toBe('owner/repo ');
     });
     expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
   });
 
-  it('labels the lifecycle filter as status and exposes canonical status options', async () => {
+  it('labels the lifecycle column filter as status and exposes canonical status options', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
 
-    const statusFilter = screen.getByLabelText('Status') as HTMLSelectElement;
+    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    const statusFilter = screen.getByLabelText('Status filter value') as HTMLSelectElement;
     const options = Array.from(statusFilter.options).map((option) => option.value);
 
     expect(options).toEqual([
@@ -368,7 +397,7 @@ describe('Tasks List Entrypoint', () => {
     const scheduledHeader = tableWrapper?.querySelector<HTMLElement>('th');
 
     expect(controlDeck).toBeTruthy();
-    expect(controlDeck?.querySelector('form.task-list-control-grid')).toBeTruthy();
+    expect(controlDeck?.querySelector('form.task-list-control-grid')).toBeNull();
     expect(screen.queryByRole('button', { name: /^Kind\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Workflow Type\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();
@@ -410,7 +439,7 @@ describe('Tasks List Entrypoint', () => {
     const controlGrid = controlDeck.querySelector<HTMLElement>('.task-list-control-grid');
     const tableWrapper = dataSlab.querySelector<HTMLElement>('.queue-table-wrapper[data-layout="table"]');
 
-    expect(controlGrid).toBeTruthy();
+    expect(controlGrid).toBeNull();
     expect(tableWrapper).toBeTruthy();
 
     const shellPanelStyles = getComputedStyle(shellPanel as HTMLElement);
@@ -419,11 +448,6 @@ describe('Tasks List Entrypoint', () => {
     expect(shellPanelStyles.boxShadow).toBe('none');
     expect(shellPanelStyles.paddingTop).toBe('0px');
     expect(shellPanelStyles.minHeight).toBe('0px');
-
-    const controlGridStyles = getComputedStyle(controlGrid as HTMLElement);
-    expect(controlGridStyles.width).toBe('100%');
-    expect(controlGridStyles.maxWidth).toBe('none');
-    expect(controlGridStyles.gridTemplateColumns).toBe('repeat(4, minmax(12rem, 1fr))');
 
     const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
@@ -436,24 +460,39 @@ describe('Tasks List Entrypoint', () => {
     expect(tableWrapperStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   });
 
-  it('shows active filter chips and clears filters from the control deck', async () => {
+  it('shows clickable active column filter chips and clears filters from the control deck', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'completed' } });
-    fireEvent.change(screen.getByLabelText('Repository'), { target: { value: 'owner/repo' } });
+    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    fireEvent.change(screen.getByLabelText('Status filter value'), { target: { value: 'completed' } });
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+    fireEvent.change(screen.getByLabelText('Repository filter value'), { target: { value: 'owner/repo' } });
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
+    fireEvent.change(screen.getByLabelText('Runtime filter value'), { target: { value: 'codex_cli' } });
 
     await waitFor(() => {
       const activeFilterText = document.querySelector('.task-list-filter-chips')?.textContent || '';
       expect(activeFilterText).toContain('completed');
       expect(activeFilterText).toContain('owner/repo');
+      expect(activeFilterText).toContain('Codex CLI');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Repository filter: owner/repo' }));
+    expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+        '/api/executions?source=temporal&pageSize=50&scope=tasks&state=completed&repo=owner%2Frepo&targetRuntime=codex_cli',
+      );
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
 
     await waitFor(() => {
-      expect((screen.getByLabelText('Status') as HTMLSelectElement).value).toBe('');
-      expect((screen.getByLabelText('Repository') as HTMLInputElement).value).toBe('');
+      fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+      expect((screen.getByLabelText('Status filter value') as HTMLSelectElement).value).toBe('');
     });
   });
 

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -89,6 +89,47 @@ describe('Tasks List Entrypoint', () => {
     expect(screen.queryByRole('dialog', { name: 'Scheduled filter' })).toBeNull();
   });
 
+  it('keeps task filters available outside the desktop-only table layout', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    fireEvent.change(screen.getByLabelText('Mobile Status filter value'), {
+      target: { value: 'completed' },
+    });
+    fireEvent.change(screen.getByLabelText('Mobile Repository filter value'), {
+      target: { value: 'owner/repo' },
+    });
+    fireEvent.change(screen.getByLabelText('Mobile Runtime filter value'), {
+      target: { value: 'codex_cloud' },
+    });
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+        '/api/executions?source=temporal&pageSize=50&scope=tasks&state=completed&repo=owner%2Frepo&targetRuntime=codex_cloud',
+      );
+    });
+  });
+
+  it('offers every supported runtime identifier in the runtime filter', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
+
+    const runtimeFilter = screen.getByLabelText('Runtime filter value') as HTMLSelectElement;
+    expect(Array.from(runtimeFilter.options).map((option) => option.value)).toEqual([
+      '',
+      'codex_cli',
+      'codex',
+      'claude_code',
+      'claude',
+      'gemini_cli',
+      'jules',
+      'codex_cloud',
+    ]);
+  });
+
   it('keeps workflow-kind browsing controls out of the normal task list', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -32,7 +32,15 @@ const TEMPORAL_STATUSES = [
   'failed',
   'canceled',
 ] as const;
-const RUNTIME_FILTER_OPTIONS = ['codex_cli', 'claude_code', 'gemini_cli', 'jules'] as const;
+const RUNTIME_FILTER_OPTIONS = [
+  'codex_cli',
+  'codex',
+  'claude_code',
+  'claude',
+  'gemini_cli',
+  'jules',
+  'codex_cloud',
+] as const;
 const TASK_WORKFLOW_TYPE = 'MoonMind.Run';
 const TASK_ENTRY = 'run';
 
@@ -374,14 +382,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     return `Filter ${label}. Filter active: ${field === 'targetRuntime' ? formatRuntimeLabel(value) : value}.`;
   };
 
-  const renderFilterPopover = (field: FilterField, label: string) => {
-    if (openFilter !== field) return null;
-
-    let control;
+  const renderFilterControl = (field: FilterField, labelPrefix = '') => {
     if (field === 'status') {
-      control = (
+      return (
         <label className="queue-inline-filter task-list-header-filter-control">
-          Status filter value
+          {labelPrefix}Status filter value
           <select
             value={temporalState}
             disabled={!listEnabled}
@@ -399,10 +404,12 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           </select>
         </label>
       );
-    } else if (field === 'repository') {
-      control = (
+    }
+
+    if (field === 'repository') {
+      return (
         <label className="queue-inline-filter task-list-header-filter-control">
-          Repository filter value
+          {labelPrefix}Repository filter value
           <input
             type="text"
             value={repository}
@@ -415,13 +422,15 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           />
         </label>
       );
-    } else if (field === 'targetRuntime') {
+    }
+
+    if (field === 'targetRuntime') {
       const runtimeOptions = normalizedTargetRuntime
         ? Array.from(new Set([normalizedTargetRuntime, ...RUNTIME_FILTER_OPTIONS]))
         : [...RUNTIME_FILTER_OPTIONS];
-      control = (
+      return (
         <label className="queue-inline-filter task-list-header-filter-control">
-          Runtime filter value
+          {labelPrefix}Runtime filter value
           <select
             value={targetRuntime}
             disabled={!listEnabled}
@@ -439,9 +448,17 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           </select>
         </label>
       );
-    } else {
-      control = <p className="small">No filter is available for {label} yet.</p>;
     }
+
+    return null;
+  };
+
+  const renderFilterPopover = (field: FilterField, label: string) => {
+    if (openFilter !== field) return null;
+
+    const control = renderFilterControl(field) || (
+      <p className="small">No filter is available for {label} yet.</p>
+    );
 
     return (
       <div className="task-list-header-filter-popover" role="dialog" aria-label={`${label} filter`}>
@@ -511,6 +528,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           >
             Clear filters
           </button>
+        </div>
+        <div className="task-list-mobile-filter-controls" aria-label="Mobile task filters">
+          {renderFilterControl('status', 'Mobile ')}
+          {renderFilterControl('repository', 'Mobile ')}
+          {renderFilterControl('targetRuntime', 'Mobile ')}
         </div>
       </section>
 

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -32,6 +32,7 @@ const TEMPORAL_STATUSES = [
   'failed',
   'canceled',
 ] as const;
+const RUNTIME_FILTER_OPTIONS = ['codex_cli', 'claude_code', 'gemini_cli', 'jules'] as const;
 const TASK_WORKFLOW_TYPE = 'MoonMind.Run';
 const TASK_ENTRY = 'run';
 
@@ -47,7 +48,11 @@ const TABLE_COLUMNS = [
   ['createdAt', 'Created'],
   ['closedAt', 'Finished'],
 ] as const;
+type TableColumn = (typeof TABLE_COLUMNS)[number];
+type TableField = TableColumn[0];
+type FilterField = TableField;
 const VALID_TABLE_SORT_FIELDS = new Set<string>([...TABLE_COLUMNS.map((column) => column[0]), 'integration']);
+const ACTIVE_FILTER_FIELDS = new Set<string>(['status', 'repository', 'targetRuntime']);
 
 const ExecutionRowSchema = z
   .object({
@@ -182,6 +187,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const [ignoredWorkflowScopeState] = useState(() => hasUnsupportedWorkflowScopeState(initial));
   const [temporalState, setTemporalState] = useState(() => (initial.get('state') || '').toLowerCase());
   const [repository, setRepository] = useState(() => initial.get('repo') || '');
+  const [targetRuntime, setTargetRuntime] = useState(() => initial.get('targetRuntime') || '');
+  const [openFilter, setOpenFilter] = useState<FilterField | null>(null);
   const [pageSize, setPageSize] = useState(() => parsePageSize(initial.get('limit')));
   const [listCursor, setListCursor] = useState<string | null>(() =>
     ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
@@ -195,11 +202,13 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     return 'desc';
   });
   const normalizedRepository = repository.trim();
+  const normalizedTargetRuntime = targetRuntime.trim();
 
   const syncUrl = useCallback(() => {
     const params = new URLSearchParams();
     if (temporalState) params.set('state', temporalState);
     if (normalizedRepository) params.set('repo', normalizedRepository);
+    if (normalizedTargetRuntime) params.set('targetRuntime', normalizedTargetRuntime);
     params.set('limit', String(pageSize));
     if (listCursor) params.set('nextPageToken', listCursor);
     if (sortField !== 'scheduledFor' || sortDir !== 'desc') {
@@ -210,6 +219,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   }, [
     temporalState,
     normalizedRepository,
+    normalizedTargetRuntime,
     pageSize,
     listCursor,
     sortField,
@@ -226,6 +236,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     pageSize,
     temporalState,
     normalizedRepository,
+    normalizedTargetRuntime,
     listCursor,
   ] as const;
 
@@ -240,6 +251,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       if (listCursor) params.set('nextPageToken', listCursor);
       if (temporalState) params.set('state', temporalState);
       if (normalizedRepository) params.set('repo', normalizedRepository);
+      if (normalizedTargetRuntime) params.set('targetRuntime', normalizedTargetRuntime);
       const response = await fetch(`${payload.apiBase}/executions?${params}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch: ${response.statusText}`);
@@ -318,20 +330,125 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   ]
     .filter(Boolean)
     .join(' · ');
+  const filterValueForField = useCallback(
+    (field: string): string => {
+      if (field === 'status') return temporalState;
+      if (field === 'repository') return normalizedRepository;
+      if (field === 'targetRuntime') return normalizedTargetRuntime;
+      return '';
+    },
+    [normalizedRepository, normalizedTargetRuntime, temporalState],
+  );
   const activeFilters = useMemo(
     () =>
       [
-        temporalState ? ['Status', temporalState] : null,
-        normalizedRepository ? ['Repository', normalizedRepository] : null,
-      ].filter((filter): filter is [string, string] => Boolean(filter)),
-    [temporalState, normalizedRepository],
+        temporalState ? { field: 'status' as FilterField, label: 'Status', value: temporalState } : null,
+        normalizedRepository
+          ? { field: 'repository' as FilterField, label: 'Repository', value: normalizedRepository }
+          : null,
+        normalizedTargetRuntime
+          ? {
+              field: 'targetRuntime' as FilterField,
+              label: 'Runtime',
+              value: formatRuntimeLabel(normalizedTargetRuntime),
+            }
+          : null,
+      ].filter(
+        (filter): filter is { field: FilterField; label: string; value: string } => Boolean(filter),
+      ),
+    [temporalState, normalizedRepository, normalizedTargetRuntime],
   );
   const hasActiveFilters = activeFilters.length > 0;
   const clearFilters = useCallback(() => {
     setTemporalState('');
     setRepository('');
+    setTargetRuntime('');
+    setOpenFilter(null);
     resetToFirstPage();
   }, [resetToFirstPage]);
+
+  const filterAccessibilityLabel = (field: string, label: string): string => {
+    const value = filterValueForField(field);
+    if (!ACTIVE_FILTER_FIELDS.has(field)) return `Filter ${label}. No filter available.`;
+    if (!value) return `Filter ${label}. No filter applied.`;
+    return `Filter ${label}. Filter active: ${field === 'targetRuntime' ? formatRuntimeLabel(value) : value}.`;
+  };
+
+  const renderFilterPopover = (field: FilterField, label: string) => {
+    if (openFilter !== field) return null;
+
+    let control;
+    if (field === 'status') {
+      control = (
+        <label className="queue-inline-filter task-list-header-filter-control">
+          Status filter value
+          <select
+            value={temporalState}
+            disabled={!listEnabled}
+            onChange={(event) => {
+              setTemporalState(event.target.value.toLowerCase());
+              resetToFirstPage();
+            }}
+          >
+            <option value="">All Statuses</option>
+            {TEMPORAL_STATUSES.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    } else if (field === 'repository') {
+      control = (
+        <label className="queue-inline-filter task-list-header-filter-control">
+          Repository filter value
+          <input
+            type="text"
+            value={repository}
+            disabled={!listEnabled}
+            placeholder="owner/repo"
+            onChange={(event) => {
+              setRepository(event.target.value);
+              resetToFirstPage();
+            }}
+          />
+        </label>
+      );
+    } else if (field === 'targetRuntime') {
+      const runtimeOptions = normalizedTargetRuntime
+        ? Array.from(new Set([normalizedTargetRuntime, ...RUNTIME_FILTER_OPTIONS]))
+        : [...RUNTIME_FILTER_OPTIONS];
+      control = (
+        <label className="queue-inline-filter task-list-header-filter-control">
+          Runtime filter value
+          <select
+            value={targetRuntime}
+            disabled={!listEnabled}
+            onChange={(event) => {
+              setTargetRuntime(event.target.value);
+              resetToFirstPage();
+            }}
+          >
+            <option value="">All Runtimes</option>
+            {runtimeOptions.map((runtime) => (
+              <option key={runtime} value={runtime}>
+                {formatRuntimeLabel(runtime)}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    } else {
+      control = <p className="small">No filter is available for {label} yet.</p>;
+    }
+
+    return (
+      <div className="task-list-header-filter-popover" role="dialog" aria-label={`${label} filter`}>
+        {control}
+      </div>
+    );
+  };
 
   return (
     <div className="stack">
@@ -367,48 +484,20 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           </div>
         ) : null}
 
-        <form className="task-list-control-grid" onSubmit={(event) => event.preventDefault()}>
-          <label>
-            Status
-            <select
-              value={temporalState}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                setTemporalState(event.target.value.toLowerCase());
-                resetToFirstPage();
-              }}
-            >
-              <option value="">All Statuses</option>
-              {TEMPORAL_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Repository
-            <input
-              type="text"
-              value={repository}
-              disabled={!listEnabled}
-              placeholder="owner/repo"
-              onChange={(event) => {
-                setRepository(event.target.value);
-                resetToFirstPage();
-              }}
-            />
-          </label>
-        </form>
-
         <div className="task-list-filter-row" aria-live="polite">
           {hasActiveFilters ? (
             <div className="task-list-filter-chips" aria-label="Active filters">
-              {activeFilters.map(([label, value]) => (
-                <span className="task-list-filter-chip" key={`${label}:${value}`}>
+              {activeFilters.map(({ field, label, value }) => (
+                <button
+                  type="button"
+                  className="task-list-filter-chip"
+                  key={`${label}:${value}`}
+                  onClick={() => setOpenFilter(field)}
+                  aria-label={`${label} filter: ${value}`}
+                >
                   <span>{label}</span>
                   <strong>{value}</strong>
-                </span>
+                </button>
               ))}
             </div>
           ) : (
@@ -488,17 +577,31 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                       {TABLE_COLUMNS.map(([field, label]) => {
                         const { ariaSort, ariaLabel, sortHint } = sortAccessibilityProps(field, label);
                         return (
-                          <th key={field} aria-sort={ariaSort}>
-                            <button
-                              type="button"
-                              className="table-sort-button"
-                              onClick={() => onHeaderClick(field)}
-                              aria-label={ariaLabel}
-                            >
-                              {label}
-                              {sortIndicator(field)}
-                              <span className="sr-only">{sortHint}</span>
-                            </button>
+                          <th key={field} aria-sort={ariaSort} className="task-list-compound-header-cell">
+                            <div className="task-list-compound-header">
+                              <button
+                                type="button"
+                                className="table-sort-button"
+                                onClick={() => onHeaderClick(field)}
+                                aria-label={ariaLabel}
+                              >
+                                {label}
+                                {sortIndicator(field)}
+                                <span className="sr-only">{sortHint}</span>
+                              </button>
+                              <button
+                                type="button"
+                                className={`task-list-column-filter-button${
+                                  filterValueForField(field) ? ' is-active' : ''
+                                }`}
+                                onClick={() => setOpenFilter((current) => (current === field ? null : field))}
+                                aria-label={filterAccessibilityLabel(field, label)}
+                                aria-expanded={openFilter === field}
+                              >
+                                <span aria-hidden="true">Filter</span>
+                              </button>
+                            </div>
+                            {renderFilterPopover(field, label)}
                           </th>
                         );
                       })}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -9927,6 +9927,7 @@ export interface operations {
                 entry?: string | null;
                 repo?: string | null;
                 integration?: string | null;
+                targetRuntime?: string | null;
                 scope?: string | null;
                 pageSize?: number;
                 nextPageToken?: string | null;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -554,6 +554,64 @@ h1 {
   box-shadow: var(--mm-control-focus-ring);
 }
 
+.task-list-compound-header-cell {
+  position: relative;
+}
+
+.task-list-compound-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.task-list-column-filter-button {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  min-height: 1.65rem;
+  padding: 0.12rem 0.32rem;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: none;
+}
+
+.task-list-column-filter-button:hover,
+.task-list-column-filter-button:focus-visible,
+.task-list-column-filter-button.is-active {
+  border-color: var(--mm-control-border);
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
+}
+
+.task-list-header-filter-popover {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  z-index: 8;
+  width: min(18rem, 70vw);
+  padding: 0.65rem;
+  border: 1px solid rgb(var(--mm-border) / 0.84);
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-panel) / 0.98);
+  box-shadow: 0 18px 42px -28px rgb(var(--mm-ink) / 0.7);
+}
+
+.task-list-header-filter-control {
+  width: 100%;
+}
+
 .stack {
   display: grid;
   gap: 0.9rem;
@@ -734,6 +792,21 @@ h1 {
   padding: 0.16rem 0.52rem;
   font-size: 0.78rem;
   box-shadow: inset 0 1px 0 var(--mm-glass-edge);
+}
+
+button.task-list-filter-chip {
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.2;
+}
+
+button.task-list-filter-chip:hover,
+button.task-list-filter-chip:focus-visible {
+  border-color: rgb(var(--mm-accent) / 0.7);
+  color: rgb(var(--mm-accent));
+  transform: none;
+  filter: none;
+  box-shadow: var(--mm-control-focus-ring);
 }
 
 .task-list-filter-chip strong {
@@ -1861,6 +1934,43 @@ button.secondary:hover {
   border-color: rgb(var(--mm-accent));
   box-shadow: 0 0 0 1px rgb(var(--mm-accent) / 0.22), 0 12px 24px -18px rgb(var(--mm-accent) / 0.55);
   transform: scale(var(--mm-control-hover-scale));
+}
+
+button.task-list-column-filter-button,
+button.task-list-filter-chip {
+  transform: none;
+  filter: none;
+}
+
+button.task-list-column-filter-button {
+  border-color: transparent;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+}
+
+button.task-list-column-filter-button:hover,
+button.task-list-column-filter-button:focus-visible,
+button.task-list-column-filter-button.is-active {
+  border-color: var(--mm-control-border);
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+}
+
+button.task-list-filter-chip {
+  border-color: var(--mm-control-border);
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-ink));
+  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
+}
+
+button.task-list-filter-chip:hover,
+button.task-list-filter-chip:focus-visible {
+  border-color: rgb(var(--mm-accent) / 0.7);
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
 }
 
 .button {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -819,6 +819,12 @@ button.task-list-filter-chip:focus-visible {
   flex: 0 0 auto;
 }
 
+.task-list-mobile-filter-controls {
+  display: none;
+  gap: 0.7rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -1296,6 +1302,10 @@ tr[data-proposal-id].proposal-consuming td {
 
   .task-list-clear-filters {
     width: 100%;
+  }
+
+  .task-list-mobile-filter-controls {
+    display: grid;
   }
 
   .queue-results-toolbar,

--- a/specs/300-desktop-columns-headers/checklists/requirements.md
+++ b/specs/300-desktop-columns-headers/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Desktop Columns and Compound Headers
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-05  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves `MM-587`, defines one runtime story, and maps DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-027 to functional requirements.

--- a/specs/300-desktop-columns-headers/contracts/tasks-list-column-filters.md
+++ b/specs/300-desktop-columns-headers/contracts/tasks-list-column-filters.md
@@ -1,0 +1,27 @@
+# Contract: Tasks List Column Filters
+
+## UI Contract
+
+The Tasks List desktop table renders one compound header per visible column.
+
+Each header exposes:
+
+- a sort button whose accessible name includes the column label and current sort state;
+- a filter button whose accessible name includes the column label and active/inactive filter state;
+- a popover when the filter button or active filter chip is activated.
+
+Status, Repository, and Runtime popovers expose editable controls in this story. Other visible columns may expose a disabled placeholder until their advanced filters are implemented, but they must still keep sort and filter targets separate.
+
+## API Contract
+
+`GET /api/executions` accepts:
+
+```text
+source=temporal
+scope=tasks
+state=<canonical-state>
+repo=<repository>
+targetRuntime=<runtime-id>
+```
+
+When `source=temporal`, `targetRuntime` maps to the Temporal visibility search attribute `mm_target_runtime` and remains combined with the task-scope query. Unsupported workflow scope, workflow type, and entry parameters remain ignored or normalized by the normal Tasks List path.

--- a/specs/300-desktop-columns-headers/data-model.md
+++ b/specs/300-desktop-columns-headers/data-model.md
@@ -1,0 +1,25 @@
+# Data Model: Desktop Columns and Compound Headers
+
+No persistent data model changes.
+
+## UI State
+
+- `sortField`: one visible table field, default `scheduledFor`.
+- `sortDir`: `asc` or `desc`, default `desc`.
+- `temporalState`: canonical status filter value.
+- `repository`: repository text filter value.
+- `targetRuntime`: runtime identifier filter value such as `codex_cli`.
+- `openFilter`: the currently open column filter popover, or `null`.
+- `listCursor` and `cursorStack`: existing pagination state reset by filter changes.
+
+## API Query Additions
+
+- `targetRuntime`: optional query parameter for `GET /api/executions?source=temporal&scope=tasks`.
+- Temporal visibility mapping: `targetRuntime` filters `mm_target_runtime`.
+
+## State Transitions
+
+- Sorting a column changes `sortField` and `sortDir` only.
+- Opening a column filter changes `openFilter` only.
+- Applying status, repository, or runtime filters resets pagination to the first page.
+- Clearing filters clears all three filter values and resets pagination to the first page.

--- a/specs/300-desktop-columns-headers/moonspec_align_report.md
+++ b/specs/300-desktop-columns-headers/moonspec_align_report.md
@@ -1,0 +1,30 @@
+# MoonSpec Align Report: Desktop Columns and Compound Headers
+
+**Feature**: `specs/300-desktop-columns-headers`  
+**Run Date**: 2026-05-05  
+**Source**: MM-587 canonical Jira preset brief preserved in `spec.md`
+
+## Verdict
+
+PASS. The MM-587 MoonSpec artifacts are aligned after task generation.
+
+## Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Original input preservation | PASS | `spec.md` preserves the MM-587 Jira preset brief in `**Input**`. |
+| Single-story scope | PASS | `spec.md` contains one user story: Desktop Compound Table Headers. |
+| Source design coverage | PASS | DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-011, and DESIGN-REQ-027 map to functional requirements. |
+| Plan alignment | PASS | `plan.md` marks all FR, SC, and DESIGN-REQ rows as `implemented_verified` with current code/test evidence. |
+| Design artifact alignment | PASS | `data-model.md`, `contracts/tasks-list-column-filters.md`, `research.md`, and `quickstart.md` describe the same status, repository, runtime filter story. |
+| Task coverage | PASS | `tasks.md` covers setup, red-first UI/API tests, implementation tasks, story validation, full validation, and final `/moonspec-verify`. |
+| Test strategy | PASS | Unit, integration/API, typecheck, and full unit validation commands are explicit. |
+| Constitution alignment | PASS | No canonical docs migration notes, workflow contract changes, new storage, or untested runtime-boundary changes are introduced by the artifacts. |
+
+## Remediation
+
+No remediation was required during this align pass. The only output of this step is this alignment report.
+
+## Remaining Risks
+
+Advanced filter types from the broader desired design, such as date ranges and full value checklists for every visible column, remain intentionally outside the MM-587 first-story scope and are recorded in `verification.md`.

--- a/specs/300-desktop-columns-headers/plan.md
+++ b/specs/300-desktop-columns-headers/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Desktop Columns and Compound Headers
+
+**Branch**: `300-desktop-columns-headers`  
+**Date**: 2026-05-05  
+**Spec**: `specs/300-desktop-columns-headers/spec.md`  
+**Input**: Single-story runtime spec generated from the trusted Jira preset brief for `MM-587`.
+
+## Summary
+
+Tasks List already has the desired task-oriented desktop columns, default scheduled sort, timestamp/string/status sort rules, status pills, and dependency summaries. The missing behavior is the compound header interaction model: separate sort and filter targets in every visible header, header popovers for status/repository/runtime filters, clickable filter chips, and runtime filter propagation through the task-scoped Temporal list request. Implementation will update the existing React entrypoint and its CSS, add Vitest coverage for desktop header behavior, and add FastAPI route coverage for the new `targetRuntime` filter.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` `TABLE_COLUMNS`; existing tests cover columns | preserve | UI unit |
+| FR-002 | implemented_verified | existing tests assert Kind, Workflow Type, Entry, Started absent | preserve | UI unit |
+| FR-003 | missing | current header is one sort button only | add reusable compound header | UI unit |
+| FR-004 | implemented_unverified | existing sort tests cover label sorting but not popover separation | extend tests around compound headers | UI unit |
+| FR-005 | missing | no header filter target exists | add filter buttons/popovers | UI unit |
+| FR-006 | implemented_unverified | existing `aria-sort` tests cover sort buttons | preserve through compound header refactor | UI unit |
+| FR-007 | implemented_verified | `sortRows`, `TIMESTAMP_SORT_FIELDS`, default sort state, existing scheduled sort test | preserve | UI unit |
+| FR-008 | partial | status/repository filters exist in top controls; runtime filter absent | move filters to header popovers and add runtime filter | UI unit + API route |
+| FR-009 | partial | chips render but are not clickable | make chips buttons that open matching filter | UI unit |
+| FR-010 | partial | clear filters handles status/repository only | include runtime and pagination reset | UI unit |
+| FR-011 | implemented_verified | status pill, links, date formatting, dependency summary tests exist | preserve | UI unit |
+| FR-012 | implemented_verified | existing scope normalization tests and task-scoped request | preserve while adding runtime filter | UI unit + API route |
+| FR-013 | missing | new MoonSpec artifacts required | preserve MM-587 in artifacts and verification | final verify |
+| SC-001 | implemented_unverified | existing tests cover most columns | keep explicit coverage | UI unit |
+| SC-002 | missing | no filter popover to guard against | add regression test | UI unit |
+| SC-003 | missing | no filter popover target exists | add regression test | UI unit |
+| SC-004 | partial | chips are display-only | add clickable chip tests | UI unit |
+| SC-005 | missing | API route lacks `targetRuntime` query filter | add API test and route filter | API unit |
+| SC-006 | missing | new artifacts needed | final verification report | final verify |
+| DESIGN-REQ-006 | implemented_verified | row model and dependency summary tests | preserve | UI unit |
+| DESIGN-REQ-007 | implemented_verified | table sort/format tests | preserve | UI unit |
+| DESIGN-REQ-008 | partial | top filters still present | move status/repository to header and add runtime | UI unit |
+| DESIGN-REQ-010 | implemented_verified | no excluded columns | preserve | UI unit |
+| DESIGN-REQ-011 | missing | compound controls absent | add reusable control | UI unit |
+| DESIGN-REQ-027 | implemented_verified | no system workflow browsing or multi-sort controls | preserve | UI unit |
+
+## Technical Context
+
+- **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route tests.
+- **Primary Dependencies**: React, TanStack Query, Vitest, Testing Library, FastAPI, pytest.
+- **Storage**: No new persistent storage.
+- **Unit Testing**: `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`; API route coverage through pytest.
+- **Integration Testing**: UI entrypoint render tests and FastAPI route-boundary test cover the user workflow and API request shape.
+- **Target Platform**: Browser Mission Control Tasks List and MoonMind API.
+- **Project Type**: Existing full-stack web app.
+- **Performance Goals**: Header filtering must not add extra fetches except when filter state changes; current-page sorting stays client-side.
+- **Constraints**: Preserve task-only visibility, avoid system workflow browsing, keep no multi-column sort controls, and preserve existing row formatting.
+- **Scale/Scope**: One Tasks List entrypoint and one API list query filter.
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. Uses existing Mission Control/API surfaces.
+- II One-Click Agent Deployment: PASS. No new external services.
+- III Avoid Vendor Lock-In: PASS. No vendor-specific behavior.
+- IV Own Your Data: PASS. Uses existing MoonMind API data.
+- V Skills Are First-Class: PASS. No skill runtime changes.
+- VI Replaceable Scaffolding: PASS. Small UI/API boundary change with tests.
+- VII Runtime Configurability: PASS. No hardcoded deployment config.
+- VIII Modular Architecture: PASS. Scoped to Tasks List UI and executions route filter.
+- IX Resilient by Default: PASS. No workflow/activity contract changes.
+- X Continuous Improvement: PASS. Verification artifacts capture outcome.
+- XI Spec-Driven Development: PASS. Spec, plan, tasks, and verification are created.
+- XII Canonical Documentation: PASS. No canonical docs migration notes are added.
+- XIII Pre-Release Compatibility: PASS. No compatibility wrapper is introduced; existing legacy URL safety remains.
+
+## Project Structure
+
+```text
+frontend/src/entrypoints/tasks-list.tsx
+frontend/src/entrypoints/tasks-list.test.tsx
+frontend/src/styles/mission-control.css
+api_service/api/routers/executions.py
+tests/unit/api/routers/test_executions.py
+specs/300-desktop-columns-headers/
+```
+
+## Complexity Tracking
+
+None.

--- a/specs/300-desktop-columns-headers/plan.md
+++ b/specs/300-desktop-columns-headers/plan.md
@@ -7,45 +7,45 @@
 
 ## Summary
 
-Tasks List already has the desired task-oriented desktop columns, default scheduled sort, timestamp/string/status sort rules, status pills, and dependency summaries. The missing behavior is the compound header interaction model: separate sort and filter targets in every visible header, header popovers for status/repository/runtime filters, clickable filter chips, and runtime filter propagation through the task-scoped Temporal list request. Implementation will update the existing React entrypoint and its CSS, add Vitest coverage for desktop header behavior, and add FastAPI route coverage for the new `targetRuntime` filter.
+Tasks List now has the desired task-oriented desktop columns, default scheduled sort, timestamp/string/status sort rules, status pills, dependency summaries, compound header sort/filter targets, header popovers for status/repository/runtime filters, clickable filter chips, and runtime filter propagation through the task-scoped Temporal list request. The implementation updated the existing React entrypoint and CSS, added Vitest coverage for desktop header behavior, and added FastAPI route coverage for the new `targetRuntime` filter.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` `TABLE_COLUMNS`; existing tests cover columns | preserve | UI unit |
-| FR-002 | implemented_verified | existing tests assert Kind, Workflow Type, Entry, Started absent | preserve | UI unit |
-| FR-003 | missing | current header is one sort button only | add reusable compound header | UI unit |
-| FR-004 | implemented_unverified | existing sort tests cover label sorting but not popover separation | extend tests around compound headers | UI unit |
-| FR-005 | missing | no header filter target exists | add filter buttons/popovers | UI unit |
-| FR-006 | implemented_unverified | existing `aria-sort` tests cover sort buttons | preserve through compound header refactor | UI unit |
-| FR-007 | implemented_verified | `sortRows`, `TIMESTAMP_SORT_FIELDS`, default sort state, existing scheduled sort test | preserve | UI unit |
-| FR-008 | partial | status/repository filters exist in top controls; runtime filter absent | move filters to header popovers and add runtime filter | UI unit + API route |
-| FR-009 | partial | chips render but are not clickable | make chips buttons that open matching filter | UI unit |
-| FR-010 | partial | clear filters handles status/repository only | include runtime and pagination reset | UI unit |
-| FR-011 | implemented_verified | status pill, links, date formatting, dependency summary tests exist | preserve | UI unit |
-| FR-012 | implemented_verified | existing scope normalization tests and task-scoped request | preserve while adding runtime filter | UI unit + API route |
-| FR-013 | missing | new MoonSpec artifacts required | preserve MM-587 in artifacts and verification | final verify |
-| SC-001 | implemented_unverified | existing tests cover most columns | keep explicit coverage | UI unit |
-| SC-002 | missing | no filter popover to guard against | add regression test | UI unit |
-| SC-003 | missing | no filter popover target exists | add regression test | UI unit |
-| SC-004 | partial | chips are display-only | add clickable chip tests | UI unit |
-| SC-005 | missing | API route lacks `targetRuntime` query filter | add API test and route filter | API unit |
-| SC-006 | missing | new artifacts needed | final verification report | final verify |
-| DESIGN-REQ-006 | implemented_verified | row model and dependency summary tests | preserve | UI unit |
-| DESIGN-REQ-007 | implemented_verified | table sort/format tests | preserve | UI unit |
-| DESIGN-REQ-008 | partial | top filters still present | move status/repository to header and add runtime | UI unit |
-| DESIGN-REQ-010 | implemented_verified | no excluded columns | preserve | UI unit |
-| DESIGN-REQ-011 | missing | compound controls absent | add reusable control | UI unit |
-| DESIGN-REQ-027 | implemented_verified | no system workflow browsing or multi-sort controls | preserve | UI unit |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` `TABLE_COLUMNS`; UI tests cover columns | no new implementation | UI unit |
+| FR-002 | implemented_verified | UI tests assert Kind, Workflow Type, Entry, and Started absent | no new implementation | UI unit |
+| FR-003 | implemented_verified | compound header controls in `frontend/src/entrypoints/tasks-list.tsx`; UI test covers separate targets | no new implementation | UI unit |
+| FR-004 | implemented_verified | UI test confirms sort label changes sort without opening a filter popover | no new implementation | UI unit |
+| FR-005 | implemented_verified | UI test confirms filter target opens matching popover without changing sort | no new implementation | UI unit |
+| FR-006 | implemented_verified | `aria-sort` and sort indicator tests pass after compound header refactor | no new implementation | UI unit |
+| FR-007 | implemented_verified | `sortRows`, `TIMESTAMP_SORT_FIELDS`, default sort state, and scheduled sort test | no new implementation | UI unit |
+| FR-008 | implemented_verified | status, repository, and runtime filters are available through header popovers | no new implementation | UI unit + API route |
+| FR-009 | implemented_verified | active filter chips are buttons and reopen matching popovers | no new implementation | UI unit |
+| FR-010 | implemented_verified | clear filters includes status, repository, runtime, and pagination reset | no new implementation | UI unit |
+| FR-011 | implemented_verified | status pill, links, date formatting, runtime labels, and dependency summary tests pass | no new implementation | UI unit |
+| FR-012 | implemented_verified | legacy scope normalization tests pass; runtime filter remains task-scoped | no new implementation | UI unit + API route |
+| FR-013 | implemented_verified | MM-587 is preserved in spec, plan, tasks, and verification artifacts | no new implementation | final verify |
+| SC-001 | implemented_verified | UI tests cover default and excluded columns | no new implementation | UI unit |
+| SC-002 | implemented_verified | UI test covers sort target without popover | no new implementation | UI unit |
+| SC-003 | implemented_verified | UI test covers filter target without sort change | no new implementation | UI unit |
+| SC-004 | implemented_verified | UI test covers clickable status, repository, and runtime chips | no new implementation | UI unit |
+| SC-005 | implemented_verified | API route test confirms `mm_target_runtime` query with task scope | no new implementation | API unit |
+| SC-006 | implemented_verified | `verification.md` preserves MM-587 and source design IDs | no new implementation | final verify |
+| DESIGN-REQ-006 | implemented_verified | row model and dependency summary tests pass | no new implementation | UI unit |
+| DESIGN-REQ-007 | implemented_verified | table sort/format tests pass | no new implementation | UI unit |
+| DESIGN-REQ-008 | implemented_verified | column header filters and active chips replace top status/repository filters | no new implementation | UI unit |
+| DESIGN-REQ-010 | implemented_verified | desired columns preserved; excluded columns absent | no new implementation | UI unit |
+| DESIGN-REQ-011 | implemented_verified | compound controls, sort/filter separation, `aria-sort`, and single-sort behavior covered | no new implementation | UI unit |
+| DESIGN-REQ-027 | implemented_verified | no system workflow browsing or multi-sort controls introduced | no new implementation | UI unit |
 
 ## Technical Context
 
 - **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route tests.
 - **Primary Dependencies**: React, TanStack Query, Vitest, Testing Library, FastAPI, pytest.
 - **Storage**: No new persistent storage.
-- **Unit Testing**: `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`; API route coverage through pytest.
-- **Integration Testing**: UI entrypoint render tests and FastAPI route-boundary test cover the user workflow and API request shape.
+- **Unit Testing**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`; API route coverage through `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`.
+- **Integration Testing**: UI entrypoint render tests and FastAPI route-boundary test cover the user workflow and API request shape; full repository validation uses `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
 - **Target Platform**: Browser Mission Control Tasks List and MoonMind API.
 - **Project Type**: Existing full-stack web app.
 - **Performance Goals**: Header filtering must not add extra fetches except when filter state changes; current-page sorting stays client-side.

--- a/specs/300-desktop-columns-headers/quickstart.md
+++ b/specs/300-desktop-columns-headers/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Desktop Columns and Compound Headers
+
+1. Run the focused UI tests:
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+2. Run the focused API test:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py
+```
+
+3. Run the full unit suite before finalizing:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+4. Manual browser check:
+
+- Open `/tasks/list`.
+- Confirm headers show separate label sort controls and filter controls.
+- Open Runtime, Repository, and Status filters from headers.
+- Confirm active filter chips reopen their matching popovers.
+- Confirm Kind, Workflow Type, Entry, and Started remain absent.

--- a/specs/300-desktop-columns-headers/research.md
+++ b/specs/300-desktop-columns-headers/research.md
@@ -2,32 +2,32 @@
 
 ## FR-001 / FR-002 / DESIGN-REQ-010
 
-Decision: Preserve the current desktop column list and excluded columns.
-Evidence: `frontend/src/entrypoints/tasks-list.tsx` defines ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished. Existing UI tests assert Kind, Workflow Type, Entry, and Started are absent.
+Decision: implemented_verified; preserve the current desktop column list and excluded columns.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` defines ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished. UI tests assert Kind, Workflow Type, Entry, and Started are absent.
 Rationale: The desired default column set already matches the current implementation.
 Alternatives considered: Rebuild column rendering from a new schema; rejected because the existing tuple model is sufficient.
 Test implications: UI unit coverage remains required after the header refactor.
 
 ## FR-003 Through FR-006 / DESIGN-REQ-011
 
-Decision: Add a reusable compound table header that renders a sort button and a separate filter button/popover.
-Evidence: Current implementation renders one `.table-sort-button` per header and has no header filter target.
+Decision: implemented_verified; use a reusable compound table header that renders a sort button and a separate filter button/popover.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` renders compound header controls. `frontend/src/entrypoints/tasks-list.test.tsx` verifies sort and filter targets remain independent.
 Rationale: A small local component keeps the behavior consistent across visible columns without changing row rendering.
 Alternatives considered: Keep top filters and add icon-only controls later; rejected because the story explicitly moves filtering into headers.
 Test implications: UI tests must prove label clicks do not open filters and filter clicks do not change sort.
 
 ## FR-008 Through FR-010 / DESIGN-REQ-008
 
-Decision: Move status and repository controls from the top control grid into column popovers, add runtime filtering, and keep active chips in the control deck.
-Evidence: Current state has top Status and Repository controls, display-only chips, and no runtime filter state.
+Decision: implemented_verified; status and repository controls moved from the top control grid into column popovers, runtime filtering was added, and active chips remain in the control deck.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` owns status, repository, and runtime filter state through header popovers. `frontend/src/entrypoints/tasks-list.test.tsx` covers active chip behavior and clear filters.
 Rationale: This directly implements the first version of the column-filter model while preserving live updates, page size, and pagination outside the filter controls.
 Alternatives considered: Implement every future filter type from the design, including date ranges; rejected as outside the MM-587 acceptance criteria and too broad for one story.
 Test implications: UI tests for status/repository/runtime popovers, chips, clear filters, URL state, and API request parameters.
 
 ## SC-005 Runtime API Filter
 
-Decision: Add an optional `targetRuntime` query parameter to `GET /api/executions` for Temporal task list queries and filter by `mm_target_runtime`.
-Evidence: `api_service/api/routers/executions.py` already filters Temporal list queries by `mm_state`, `mm_repo`, and `mm_integration`; row serialization already exposes `targetRuntime`.
+Decision: implemented_verified; `GET /api/executions` accepts optional `targetRuntime` for Temporal task list queries and filters by `mm_target_runtime`.
+Evidence: `api_service/api/routers/executions.py` includes `targetRuntime` in the Temporal visibility query. `tests/unit/api/routers/test_executions.py` verifies the task-scoped query includes `mm_target_runtime`.
 Rationale: Runtime column filters should constrain fetched task results, not only current-page client rows.
 Alternatives considered: Client-side runtime filtering only; rejected because it would be misleading across paginated Temporal results.
 Test implications: API route-boundary test confirms `mm_target_runtime` is included with task scope.

--- a/specs/300-desktop-columns-headers/research.md
+++ b/specs/300-desktop-columns-headers/research.md
@@ -1,0 +1,33 @@
+# Research: Desktop Columns and Compound Headers
+
+## FR-001 / FR-002 / DESIGN-REQ-010
+
+Decision: Preserve the current desktop column list and excluded columns.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` defines ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished. Existing UI tests assert Kind, Workflow Type, Entry, and Started are absent.
+Rationale: The desired default column set already matches the current implementation.
+Alternatives considered: Rebuild column rendering from a new schema; rejected because the existing tuple model is sufficient.
+Test implications: UI unit coverage remains required after the header refactor.
+
+## FR-003 Through FR-006 / DESIGN-REQ-011
+
+Decision: Add a reusable compound table header that renders a sort button and a separate filter button/popover.
+Evidence: Current implementation renders one `.table-sort-button` per header and has no header filter target.
+Rationale: A small local component keeps the behavior consistent across visible columns without changing row rendering.
+Alternatives considered: Keep top filters and add icon-only controls later; rejected because the story explicitly moves filtering into headers.
+Test implications: UI tests must prove label clicks do not open filters and filter clicks do not change sort.
+
+## FR-008 Through FR-010 / DESIGN-REQ-008
+
+Decision: Move status and repository controls from the top control grid into column popovers, add runtime filtering, and keep active chips in the control deck.
+Evidence: Current state has top Status and Repository controls, display-only chips, and no runtime filter state.
+Rationale: This directly implements the first version of the column-filter model while preserving live updates, page size, and pagination outside the filter controls.
+Alternatives considered: Implement every future filter type from the design, including date ranges; rejected as outside the MM-587 acceptance criteria and too broad for one story.
+Test implications: UI tests for status/repository/runtime popovers, chips, clear filters, URL state, and API request parameters.
+
+## SC-005 Runtime API Filter
+
+Decision: Add an optional `targetRuntime` query parameter to `GET /api/executions` for Temporal task list queries and filter by `mm_target_runtime`.
+Evidence: `api_service/api/routers/executions.py` already filters Temporal list queries by `mm_state`, `mm_repo`, and `mm_integration`; row serialization already exposes `targetRuntime`.
+Rationale: Runtime column filters should constrain fetched task results, not only current-page client rows.
+Alternatives considered: Client-side runtime filtering only; rejected because it would be misleading across paginated Temporal results.
+Test implications: API route-boundary test confirms `mm_target_runtime` is included with task scope.

--- a/specs/300-desktop-columns-headers/spec.md
+++ b/specs/300-desktop-columns-headers/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Desktop Columns and Compound Headers
+
+**Feature Branch**: `300-desktop-columns-headers`  
+**Created**: 2026-05-05  
+**Status**: Draft  
+**Input**: User description: """
+Use the Jira preset brief for MM-587 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-587 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-587
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Desktop columns and compound headers
+- Labels: `moonmind-workflow-mm-af73ac39-5c56-460e-bd77-712adac541f3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-587-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-587 from MM project
+Summary: Desktop columns and compound headers
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-587 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-587: Desktop columns and compound headers
+
+Source Reference
+Source Document: docs/UI/TasksListPage.md
+Source Title: Tasks List Page
+Source Sections:
+- 5.5 Current row model
+- 5.6 Current desktop table
+- 6. Desired page layout after column filters
+- 7. Column set in the desired design
+- 8. Column header interaction model
+- 8.1 Sort behavior
+- 20. Non-goals
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-027
+
+As an operator scanning tasks on desktop, I want each visible task column to own sorting and filtering controls so the table behaves like a compact operational spreadsheet.
+
+Acceptance Criteria
+- The default desktop table includes the desired task columns and excludes Kind, Workflow Type, Entry, and Started.
+- Clicking a header label toggles sort without opening a filter popover.
+- Clicking a filter icon opens the matching filter popover without changing sort.
+- Sorted headers show direction and preserve `aria-sort` behavior.
+- The initial sort is `scheduledFor` descending with documented timestamp and string sort defaults.
+- Only one primary sort is required and multi-column sort controls are absent.
+
+Requirements
+- Implement reusable sortable/filterable table-header controls.
+- Keep existing row display formatting and dependency summaries where still applicable.
+- Do not introduce excluded non-goal behaviors.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI behavior story for the Tasks List desktop table and does not require MoonSpec breakdown.
+
+## User Story - Desktop Compound Table Headers
+
+**Summary**: As an operator scanning tasks on desktop, I want each visible task column to own sorting and filtering controls so the table behaves like a compact operational spreadsheet.
+
+**Goal**: The normal Tasks List desktop table keeps its task-focused column model while each visible header separates sorting from filtering, preserves accessible sort state, and exposes column filter controls for status, repository, and runtime without reintroducing system workflow browsing.
+
+**Independent Test**: Render the Tasks List page with sample Temporal rows, activate header sort labels and filter buttons independently, and verify API requests, URL state, active chips, table columns, accessibility labels, and row formatting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Tasks List page renders on desktop, **When** the table is shown, **Then** visible columns are ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished, while Kind, Workflow Type, Entry, and Started are absent.
+2. **Given** the page has loaded, **When** an operator clicks a header label, **Then** that column becomes the only primary sort target, timestamp columns default to descending, non-timestamp columns default to ascending, and no filter popover opens.
+3. **Given** the page has loaded, **When** an operator clicks a header filter control, **Then** the matching filter popover opens without changing the current sort.
+4. **Given** a column is sorted, **When** the operator reviews the header, **Then** the header preserves `aria-sort` and shows the matching ascending or descending indicator.
+5. **Given** status, repository, or runtime filters are active, **When** the operator reviews filter chips, **Then** chips identify active filters and clicking a chip reopens the matching column filter.
+6. **Given** rows are blocked on dependencies, **When** the table renders filtered or sorted results, **Then** dependency summaries remain visible under the title where applicable.
+
+### Edge Cases
+
+- Legacy workflow scope, workflow type, and entry URL parameters must not widen the normal Tasks List into system workflow visibility.
+- Clearing filters must reset status, repository, and runtime filters and return pagination to the first page.
+- Filtering must not clear the current sort unless the sorted column is no longer available.
+- Runtime values should remain machine-readable in API/query state while displayed with existing human-readable labels.
+
+## Requirements
+
+- **FR-001**: The normal Tasks List desktop table MUST show ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished columns by default.
+- **FR-002**: The normal Tasks List desktop table MUST NOT show Kind, Workflow Type, Entry, or Started columns.
+- **FR-003**: Each visible desktop table header MUST present the sort target and filter target as separate controls.
+- **FR-004**: Activating a header sort target MUST update only the single primary sort field and direction and MUST NOT open a filter popover.
+- **FR-005**: Activating a header filter target MUST open the matching filter popover and MUST NOT change the current sort field or direction.
+- **FR-006**: Sorted headers MUST preserve `aria-sort` behavior and visible ascending or descending direction.
+- **FR-007**: The initial sort MUST be `scheduledFor` descending, with timestamp columns defaulting to descending when first sorted and non-timestamp columns defaulting to ascending.
+- **FR-008**: Status, Repository, and Runtime filters MUST be available through column header popovers instead of top-of-page filter controls.
+- **FR-009**: Active filter chips MUST summarize status, repository, and runtime filters and clicking a chip MUST reopen the corresponding column filter.
+- **FR-010**: Clearing filters MUST clear status, repository, and runtime filters and reset pagination state.
+- **FR-011**: Existing row display formatting, status pills, task links, date formatting, and dependency summaries MUST remain intact.
+- **FR-012**: Normal Tasks List filtering MUST remain task-scoped and MUST NOT expose system workflow browsing through ordinary column filters or legacy URL parameters.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-587` and this canonical Jira preset brief.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | `docs/UI/TasksListPage.md` section 5.5 | The table row model includes task id, runtime, skills, repository, status, title, timestamps, dependency identifiers, and dependency blocking metadata. | In scope | FR-001, FR-011 |
+| DESIGN-REQ-007 | `docs/UI/TasksListPage.md` section 5.6 | The current desktop table uses task-focused columns, scheduled descending default sort, timestamp/string/status sort rules, status pills, and dependency summaries. | In scope | FR-001, FR-002, FR-006, FR-007, FR-011 |
+| DESIGN-REQ-008 | `docs/UI/TasksListPage.md` section 6 | Top filter dropdowns are replaced by column header filters; active filters remain summarized as chips; live updates, page size, and pagination stay outside table filters. | In scope | FR-008, FR-009, FR-010, FR-012 |
+| DESIGN-REQ-010 | `docs/UI/TasksListPage.md` section 7 | The desired desktop table uses task columns and excludes Kind, Workflow Type, and Entry from the normal page. | In scope | FR-001, FR-002, FR-012 |
+| DESIGN-REQ-011 | `docs/UI/TasksListPage.md` sections 8 and 8.1 | Header controls separate sort and filter targets, preserve `aria-sort`, show sorted/filter-active indicators, and keep single-column sort behavior. | In scope | FR-003, FR-004, FR-005, FR-006, FR-007 |
+| DESIGN-REQ-027 | `docs/UI/TasksListPage.md` section 20 | Excluded non-goal behaviors, including ordinary system workflow browsing and multi-column sort controls, must not be introduced. | In scope | FR-002, FR-007, FR-012 |
+
+## Success Criteria
+
+- **SC-001**: UI tests prove all default desktop columns are present and excluded columns remain absent.
+- **SC-002**: UI tests prove sort target activation changes sort state without opening a filter popover.
+- **SC-003**: UI tests prove filter target activation opens the matching popover without changing sort state.
+- **SC-004**: UI tests prove active status, repository, and runtime chips are clickable and reopen matching filters.
+- **SC-005**: API or integration-boundary tests prove runtime filtering is sent through the normal task-scoped Temporal list request.
+- **SC-006**: Final verification preserves `MM-587` and all in-scope source design requirement IDs.
+
+## Assumptions
+
+- Runtime filtering can use the existing `targetRuntime` identifier values already displayed in row data.
+- Date range and advanced checklist filters remain outside this first story unless already present; this story requires the compound header and basic status, repository, and runtime filter migration.

--- a/specs/300-desktop-columns-headers/tasks.md
+++ b/specs/300-desktop-columns-headers/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Desktop Columns and Compound Headers
+
+**Input**: `specs/300-desktop-columns-headers/spec.md`  
+**Plan**: `specs/300-desktop-columns-headers/plan.md`  
+**Unit test command**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
+**Integration/API test command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`  
+**Source Traceability**: `MM-587`; FR-001 through FR-013; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027.
+
+## Story
+
+As an operator scanning tasks on desktop, I want each visible task column to own sorting and filtering controls so the table behaves like a compact operational spreadsheet.
+
+## Tasks
+
+- [X] T001 Create MoonSpec artifacts in `specs/300-desktop-columns-headers/` preserving MM-587.
+- [X] T002 [P] Add failing UI tests for separate sort and filter header targets in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-011)
+- [X] T003 [P] Add failing UI tests for status, repository, runtime header filters, clickable chips, clear filters, and excluded columns in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001, FR-002, FR-008, FR-009, FR-010, FR-012, SC-001, SC-004, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-027)
+- [X] T004 [P] Add failing API route test for `targetRuntime` filtering in `tests/unit/api/routers/test_executions.py`. (SC-005)
+- [X] T005 Implement compound table header controls and filter popovers in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-004, FR-005, FR-006, FR-008, FR-009, FR-010, FR-012)
+- [X] T006 Implement runtime filter request and URL state in `frontend/src/entrypoints/tasks-list.tsx`. (FR-008, FR-010, SC-005)
+- [X] T007 Implement `targetRuntime` Temporal query filtering in `api_service/api/routers/executions.py`. (SC-005)
+- [X] T008 Add compound header and popover styling in `frontend/src/styles/mission-control.css`. (FR-003, FR-005)
+- [X] T009 Verify existing row formatting and dependency summary tests still pass in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-011, DESIGN-REQ-006, DESIGN-REQ-007)
+- [X] T010 Run focused UI tests: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`.
+- [X] T011 Run focused API tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`.
+- [X] T012 Run full unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T013 Run final `/moonspec-verify` and write `specs/300-desktop-columns-headers/verification.md`. (FR-013, SC-006)
+
+## Dependencies
+
+T001 before all other tasks. T002, T003, and T004 before implementation tasks. T005 through T008 before T010 and T011. T012 before final verification.

--- a/specs/300-desktop-columns-headers/tasks.md
+++ b/specs/300-desktop-columns-headers/tasks.md
@@ -4,28 +4,60 @@
 **Plan**: `specs/300-desktop-columns-headers/plan.md`  
 **Unit test command**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
 **Integration/API test command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`  
+**Full validation command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
 **Source Traceability**: `MM-587`; FR-001 through FR-013; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027.
 
 ## Story
 
 As an operator scanning tasks on desktop, I want each visible task column to own sorting and filtering controls so the table behaves like a compact operational spreadsheet.
 
-## Tasks
+**Independent Test**: Render the Tasks List page with sample Temporal rows, activate header sort labels and filter buttons independently, and verify API requests, URL state, active chips, table columns, accessibility labels, and row formatting.
 
-- [X] T001 Create MoonSpec artifacts in `specs/300-desktop-columns-headers/` preserving MM-587.
-- [X] T002 [P] Add failing UI tests for separate sort and filter header targets in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-011)
-- [X] T003 [P] Add failing UI tests for status, repository, runtime header filters, clickable chips, clear filters, and excluded columns in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001, FR-002, FR-008, FR-009, FR-010, FR-012, SC-001, SC-004, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-027)
-- [X] T004 [P] Add failing API route test for `targetRuntime` filtering in `tests/unit/api/routers/test_executions.py`. (SC-005)
-- [X] T005 Implement compound table header controls and filter popovers in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-004, FR-005, FR-006, FR-008, FR-009, FR-010, FR-012)
-- [X] T006 Implement runtime filter request and URL state in `frontend/src/entrypoints/tasks-list.tsx`. (FR-008, FR-010, SC-005)
-- [X] T007 Implement `targetRuntime` Temporal query filtering in `api_service/api/routers/executions.py`. (SC-005)
-- [X] T008 Add compound header and popover styling in `frontend/src/styles/mission-control.css`. (FR-003, FR-005)
-- [X] T009 Verify existing row formatting and dependency summary tests still pass in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-011, DESIGN-REQ-006, DESIGN-REQ-007)
-- [X] T010 Run focused UI tests: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`.
-- [X] T011 Run focused API tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`.
-- [X] T012 Run full unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
-- [X] T013 Run final `/moonspec-verify` and write `specs/300-desktop-columns-headers/verification.md`. (FR-013, SC-006)
+**Traceability IDs**: FR-001 through FR-013; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027.
 
-## Dependencies
+## Unit Test Plan
 
-T001 before all other tasks. T002, T003, and T004 before implementation tasks. T005 through T008 before T010 and T011. T012 before final verification.
+- UI unit coverage in `frontend/src/entrypoints/tasks-list.test.tsx` verifies default/excluded columns, compound header sort/filter separation, `aria-sort`, filter popovers, active chips, clear filters, runtime URL/request state, row formatting, and dependency summaries.
+- Shared CSS regression coverage in `frontend/src/entrypoints/mission-control.test.tsx` verifies the new controls do not break existing Mission Control button/control contracts.
+
+## Integration/API Test Plan
+
+- API route-boundary coverage in `tests/unit/api/routers/test_executions.py` verifies `targetRuntime` is included as `mm_target_runtime` in the task-scoped Temporal visibility query.
+- Full repository validation uses `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`, which runs Python unit tests and the frontend Vitest suite in this managed container.
+
+## Phase 1: Setup
+
+- [X] T001 Create MoonSpec artifacts in `specs/300-desktop-columns-headers/` preserving MM-587 and the original Jira preset brief. (FR-013, SC-006)
+
+## Phase 2: Foundational
+
+- [X] T002 Verify the active feature points at `specs/300-desktop-columns-headers` in `.specify/feature.json` before task execution. (FR-013)
+
+## Phase 3: Story - Desktop Compound Table Headers
+
+- [X] T003 [P] Add failing UI unit tests for separate sort and filter header targets in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-011)
+- [X] T004 [P] Add failing UI unit tests for status, repository, runtime header filters, clickable chips, clear filters, and excluded columns in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001, FR-002, FR-008, FR-009, FR-010, FR-012, SC-001, SC-004, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-027)
+- [X] T005 [P] Add failing API route-boundary test for `targetRuntime` filtering in `tests/unit/api/routers/test_executions.py`. (SC-005)
+- [X] T006 Confirm red-first failures for T003, T004, and T005 before production implementation by running the focused UI/API commands and observing the expected missing-behavior failures. (FR-003, FR-005, FR-008, SC-005)
+- [X] T007 Implement compound table header controls and filter popovers in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-004, FR-005, FR-006, FR-008, FR-009, FR-010, FR-012)
+- [X] T008 Implement runtime filter request and URL state in `frontend/src/entrypoints/tasks-list.tsx`. (FR-008, FR-010, SC-005)
+- [X] T009 Implement `targetRuntime` Temporal query filtering in `api_service/api/routers/executions.py`. (SC-005)
+- [X] T010 Add compound header and popover styling in `frontend/src/styles/mission-control.css`. (FR-003, FR-005)
+- [X] T011 Verify existing row formatting, status pill, runtime label, date formatting, and dependency summary tests still pass in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-011, DESIGN-REQ-006, DESIGN-REQ-007)
+- [X] T012 Run focused UI story validation: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`. (SC-001, SC-002, SC-003, SC-004)
+- [X] T013 Run focused API story validation: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`. (SC-005)
+
+## Final Phase: Polish And Verification
+
+- [X] T014 Run shared Mission Control CSS regression validation: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/mission-control.test.tsx`. (FR-003, FR-005)
+- [X] T015 Run frontend typecheck: `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`. (FR-001 through FR-012)
+- [X] T016 Run full unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`. (FR-001 through FR-013, SC-001 through SC-006)
+- [X] T017 Run final `/moonspec-verify` and write `specs/300-desktop-columns-headers/verification.md`. (FR-013, SC-006)
+
+## Dependencies And Execution Order
+
+T001 and T002 precede story work. T003, T004, and T005 are parallel test-authoring tasks and precede T006. T006 precedes implementation tasks T007 through T010. T011 through T013 validate the story after implementation. T014 through T017 are final polish and verification tasks.
+
+## Implementation Strategy
+
+The current plan marks every requirement as `implemented_verified`. This task list preserves the completed TDD sequence and validation evidence rather than adding new implementation work. Future changes to the MM-587 story should re-open the relevant task phase, add failing tests before code changes, and rerun final `/moonspec-verify`.

--- a/specs/300-desktop-columns-headers/verification.md
+++ b/specs/300-desktop-columns-headers/verification.md
@@ -1,0 +1,49 @@
+# MoonSpec Verification Report
+
+**Feature**: `specs/300-desktop-columns-headers`  
+**Original Request Source**: `spec.md` Input preserving trusted Jira preset brief for `MM-587`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Verified At**: 2026-05-05
+
+## Summary
+
+The MM-587 Tasks List desktop table story is fully implemented. The normal table keeps the task-focused columns, excludes Kind, Workflow Type, Entry, and Started, separates every visible header into sort and filter targets, provides header popovers for Status, Repository, and Runtime filters, keeps active filters as clickable chips, and sends `targetRuntime` through the task-scoped Temporal list query.
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `TABLE_COLUMNS` in `frontend/src/entrypoints/tasks-list.tsx`; `tasks-list.test.tsx` table column assertions |
+| FR-002 | VERIFIED | UI tests assert Kind, Workflow Type, Entry, and Started are absent |
+| FR-003 | VERIFIED | Compound header markup in `tasks-list.tsx`; `separates desktop header sorting from filter popovers` |
+| FR-004 | VERIFIED | Sort button test confirms sort changes without opening Scheduled filter |
+| FR-005 | VERIFIED | Filter button test confirms Repository popover opens without changing Scheduled sort |
+| FR-006 | VERIFIED | Existing and updated UI tests confirm `aria-sort` and visible sort state |
+| FR-007 | VERIFIED | Existing scheduled sort test and timestamp sort logic preserved |
+| FR-008 | VERIFIED | Header popovers provide Status, Repository, and Runtime filter controls; top filter form removed |
+| FR-009 | VERIFIED | Active chips are buttons and reopen matching filter popovers |
+| FR-010 | VERIFIED | Clear filters clears status, repository, runtime, and resets list state |
+| FR-011 | VERIFIED | Existing status pill, date, task link, runtime label, and dependency summary tests pass |
+| FR-012 | VERIFIED | Existing legacy scope normalization tests pass; API runtime filter remains combined with `scope=tasks` |
+| FR-013 | VERIFIED | `MM-587` is preserved in spec, plan, tasks, and this verification report |
+| DESIGN-REQ-006 | VERIFIED | Row model and dependency metadata remain covered by UI tests |
+| DESIGN-REQ-007 | VERIFIED | Desktop table sort, status pill, timestamp, and dependency behaviors pass |
+| DESIGN-REQ-008 | VERIFIED | Column header filters and chips replace top status/repository filters; live updates and pagination remain outside filters |
+| DESIGN-REQ-010 | VERIFIED | Desired default columns are preserved; excluded columns remain absent |
+| DESIGN-REQ-011 | VERIFIED | Separate sort/filter controls, indicators, `aria-sort`, and single primary sort are covered |
+| DESIGN-REQ-027 | VERIFIED | No system workflow browsing or multi-column sort controls were introduced |
+
+## Validation Commands
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx` | NOT RUN | The managed workspace path contains a colon, which breaks npm's PATH lookup for `node_modules/.bin`; direct bin invocation was used instead. |
+| `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` | PASS | 19 tests passed |
+| `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/mission-control.test.tsx` | PASS | 49 tests passed |
+| `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS | TypeScript frontend typecheck passed |
+| `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` | PASS | 132 Python tests passed; full frontend suite also passed through the wrapper |
+| `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 4324 Python tests passed, 1 xpassed, 16 subtests passed; 19 frontend test files passed |
+
+## Residual Risk
+
+Advanced filter types from the broader desired design, such as date ranges and full value checklists for every visible column, remain outside this MM-587 first-story scope. The implemented story covers the required compound header model and the active Status, Repository, and Runtime filters.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -284,6 +284,47 @@ def test_list_executions_passes_temporal_filters_for_admin() -> None:
     assert kwargs["page_size"] == 25
     assert kwargs["next_page_token"] == "token-123"
 
+def test_list_executions_temporal_query_includes_target_runtime_filter() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scope": "tasks",
+                "targetRuntime": "codex_cli",
+            },
+        )
+
+    assert response.status_code == 200
+    query = temporal_client.count_workflows.await_args.kwargs["query"]
+    assert 'WorkflowType="MoonMind.Run"' in query
+    assert 'mm_entry="run"' in query
+    assert 'mm_target_runtime="codex_cli"' in query
+    temporal_client.list_workflows.assert_called_once()
+    assert (
+        temporal_client.list_workflows.call_args.kwargs["query"]
+        == temporal_client.count_workflows.await_args.kwargs["query"]
+    )
+
 def test_list_executions_rejects_non_admin_owner_type_override() -> None:
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
## Summary

- Jira issue key: MM-587
- Active MoonSpec feature path: specs/300-desktop-columns-headers
- Verification verdict: FULLY_IMPLEMENTED

## Changes

- Adds compound desktop table headers with separate sort and filter controls.
- Moves Status, Repository, and Runtime filters into header popovers with clickable active filter chips.
- Propagates targetRuntime through the task-scoped Temporal executions query.
- Preserves MM-587 MoonSpec artifacts and final verification evidence.

## Tests Run

- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh

## Remaining Risks

- Advanced filters such as date ranges and full value checklists for every visible column remain outside the MM-587 first-story scope.
