### PR TITLE
I want to change the name of the status "WAITING_ON_DEPENDENCIES" to "AWAITING TASK". This is to save space and also because AWAITING matches AWAITING

### DIFF
--- a/frontend/src/components/ExecutionStatusPill.tsx
+++ b/frontend/src/components/ExecutionStatusPill.tsx
@@ -1,6 +1,7 @@
 import { useMemo, type CSSProperties } from 'react';
 
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
+import { formatStatusLabel } from '../utils/formatters';
 
 type GlyphStyle = CSSProperties & {
   '--mm-letter-count'?: number;
@@ -29,7 +30,7 @@ function splitGraphemes(value: string): string[] {
 }
 
 function visibleStatusLabel(status: string | null | undefined): string {
-  return String(status || '—').trim().replace(/\s+/g, ' ') || '—';
+  return formatStatusLabel(status);
 }
 
 export function ExecutionStatusPill({ status }: { status: string | null | undefined }) {

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
+import { formatStatusLabel } from '../../utils/formatters';
+
 interface SecretMetadata {
   slug: string;
   secretRef?: string;
@@ -158,7 +160,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     if (status === 'rotated') {
       return <span className="badge badge-neutral">Rotated</span>;
     }
-    return <span className="badge badge-error">{status}</span>;
+    return <span className="badge badge-error">{formatStatusLabel(status)}</span>;
   };
 
   const copySecretRef = async (secretRef: string) => {

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { formatStatusLabel } from '../../utils/formatters';
+
 const WorkerSnapshotSchema = z.object({
   system: z
     .object({
@@ -736,8 +738,8 @@ export function OperationsSettingsSection({
                         ? deploymentState.services
                             .map(
                               (service) =>
-                                `${service.name}: ${service.state}${
-                                  service.health ? ` / ${service.health}` : ''
+                                `${service.name}: ${formatStatusLabel(service.state)}${
+                                  service.health ? ` / ${formatStatusLabel(service.health)}` : ''
                                 }`,
                             )
                             .join(', ')
@@ -767,7 +769,7 @@ export function OperationsSettingsSection({
                         className="rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-800/50"
                       >
                         <div className="font-semibold text-slate-900 dark:text-white">
-                          {action.status || 'UNKNOWN'}
+                          {formatStatusLabel(action.status, 'UNKNOWN')}
                         </div>
                         <div className="mt-1 break-all text-slate-600 dark:text-slate-400">
                           {action.requestedImage || 'Requested image unavailable'}

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -777,8 +777,8 @@ describe('ProviderProfilesManager form controls', () => {
       name: 'Anthropic API key enrollment for claude-anthropic',
     });
     expect(dialog).toBeTruthy();
-    expect(screen.getByText('not_connected')).toBeTruthy();
-    expect(screen.getByText('awaiting_external_step')).toBeTruthy();
+    expect(screen.getByText('not connected')).toBeTruthy();
+    expect(screen.getByText('awaiting external step')).toBeTruthy();
     expect(screen.getByText(/Use an Anthropic API key for Claude Code launches/i)).toBeTruthy();
     expect(dialog.textContent).not.toMatch(/terminal OAuth/i);
   });
@@ -789,7 +789,7 @@ describe('ProviderProfilesManager form controls', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Use Anthropic API key claude-anthropic' }));
     fireEvent.click(screen.getByRole('button', { name: 'Continue to API key paste' }));
 
-    expect(screen.getByText('awaiting_token_paste')).toBeTruthy();
+    expect(screen.getByText('awaiting token paste')).toBeTruthy();
     expect((screen.getByLabelText('Anthropic API key') as HTMLInputElement).type).toBe('password');
 
     fireEvent.click(screen.getByRole('button', { name: 'Validate and save Anthropic API key' }));
@@ -839,9 +839,9 @@ describe('ProviderProfilesManager form controls', () => {
     const payload = JSON.parse(String((requestInit as RequestInit).body));
     expect(payload).toEqual({ token: submittedToken });
 
-    expect(await screen.findByText('validating_token')).toBeTruthy();
-    expect(screen.getByText('saving_secret')).toBeTruthy();
-    expect(screen.getByText('updating_profile')).toBeTruthy();
+    expect(await screen.findByText('validating token')).toBeTruthy();
+    expect(screen.getByText('saving secret')).toBeTruthy();
+    expect(screen.getByText('updating profile')).toBeTruthy();
     expect(await screen.findByText('ready')).toBeTruthy();
     expect(screen.queryByDisplayValue(submittedToken)).toBeNull();
     expect(await screen.findByText('Anthropic API key ready')).toBeTruthy();

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
+import { formatStatusLabel } from '../../utils/formatters';
+
 export interface ProviderProfile {
   profile_id: string;
   runtime_id: string;
@@ -479,7 +481,7 @@ function providerAuthModel(profile: ProviderProfile): ProviderAuthModel {
 
   return {
     kind: 'claude_credentials',
-    statusLabel: commandBehaviorString(profile, 'auth_status_label'),
+    statusLabel: formatStatusLabel(commandBehaviorString(profile, 'auth_status_label'), ''),
     actions: claudeCredentialActions(profile),
     readiness: normalizeReadinessMetadata(commandBehaviorValue(profile, 'auth_readiness')),
   };
@@ -662,7 +664,7 @@ export function ProviderProfilesManager({
         step: 'ready',
         token: '',
         failureReason: null,
-        statusLabel: result.status_label ?? result.statusLabel ?? current.statusLabel,
+        statusLabel: formatStatusLabel(result.status_label ?? result.statusLabel ?? current.statusLabel, ''),
         readiness: normalizeReadinessMetadata(result.readiness) ?? current.readiness,
       }));
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
@@ -1568,7 +1570,7 @@ export function ProviderProfilesManager({
                     : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
                 }`}
               >
-                {step}
+                {formatStatusLabel(step)}
               </span>
             ))}
           </div>
@@ -1612,13 +1614,13 @@ export function ProviderProfilesManager({
 
           {['validating_token', 'saving_secret', 'updating_profile'].includes(claudeEnrollment.step) ? (
             <div className="mt-5 rounded-xl border border-sky-200 dark:border-sky-900/60 bg-sky-50 dark:bg-sky-950/30 p-4 text-sm font-medium text-sky-800 dark:text-sky-300">
-              Processing Anthropic API key enrollment: {claudeEnrollment.step}
+              Processing Anthropic API key enrollment: {formatStatusLabel(claudeEnrollment.step)}
             </div>
           ) : null}
 
           {claudeEnrollment.step === 'ready' ? (
             <div className="mt-5 rounded-xl border border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-950/30 p-4 text-sm font-medium text-emerald-800 dark:text-emerald-300">
-              {claudeEnrollment.statusLabel ?? 'Anthropic API key ready'}
+              {formatStatusLabel(claudeEnrollment.statusLabel ?? 'Anthropic API key ready')}
             </div>
           ) : null}
 

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -2,6 +2,7 @@ import { DataTable } from '../components/tables/DataTable';
 import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
+import { formatStatusLabel } from '../utils/formatters';
 import { useMemo, useState, type FormEvent } from 'react';
 
 const ManifestRunSchema = z
@@ -71,7 +72,7 @@ function runStage(run: ManifestRun): string {
 }
 
 function statusLabel(run: ManifestRun): string {
-  const status = displayValue(run.status || run.rawState || run.state || run.temporalStatus);
+  const status = formatStatusLabel(run.status || run.rawState || run.state || run.temporalStatus);
   const stage = runStage(run);
   if (!stage) {
     return status;
@@ -414,7 +415,7 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
                   <option value="all">All statuses</option>
                   {statusOptions.map((status) => (
                     <option key={status} value={status}>
-                      {status}
+                      {formatStatusLabel(status)}
                     </option>
                   ))}
                 </select>

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -4,6 +4,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { BootPayload } from '../boot/parseBootPayload';
+import { formatStatusLabel } from '../utils/formatters';
 
 type OAuthTerminalInitialData = {
   sessionId?: string;
@@ -475,7 +476,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
           <button type="button" className="secondary" onClick={pasteClipboardToTerminal}>
             Paste from clipboard
           </button>
-          <span className="oauth-terminal-status">{status}</span>
+          <span className="oauth-terminal-status">{formatStatusLabel(status)}</span>
         </div>
       </header>
       <section className="oauth-terminal-paste-box">

--- a/frontend/src/entrypoints/proposals.tsx
+++ b/frontend/src/entrypoints/proposals.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
-import { formatTaskSkills } from '../utils/formatters';
+import { formatStatusLabel, formatTaskSkills } from '../utils/formatters';
 import { BootPayload } from '../boot/parseBootPayload';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
@@ -209,7 +209,7 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
               <option value="">All States</option>
               {PROPOSAL_STATUSES.map((s) => (
                 <option key={s} value={s}>
-                  {s}
+                  {formatStatusLabel(s)}
                 </option>
               ))}
             </select>
@@ -311,7 +311,7 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
                         <td>{row.repository || '—'}</td>
                         <td>
                           <span {...executionStatusPillProps(row.status)}>
-                            {row.status || '—'}
+                            {formatStatusLabel(row.status)}
                           </span>
                         </td>
                         <td>{row.title}</td>
@@ -364,7 +364,7 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
                       </div>
                       <div className="queue-card-status">
                         <span {...executionStatusPillProps(row.status)}>
-                          {row.status || '—'}
+                          {formatStatusLabel(row.status)}
                         </span>
                       </div>
                     </div>

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -418,7 +418,7 @@ describe('Task Detail Entrypoint', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
 
-    const waitingPill = await screen.findByText('waiting_on_dependencies');
+    const waitingPill = await screen.findByText('AWAITING TASK');
     expect(waitingPill.closest('span')?.dataset.effect).toBeUndefined();
   });
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -7,7 +7,7 @@ import { BootPayload } from '../boot/parseBootPayload';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge';
-import { formatRuntimeLabel } from '../utils/formatters';
+import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
 import {
   recordTemporalTaskEditingClientEvent,
   taskEditForRerunHref,
@@ -898,9 +898,7 @@ function formatDurationMs(value: number | null | undefined): string {
 }
 
 function formatDependencyResolution(value: string | null | undefined): string {
-  const normalized = String(value || '').trim();
-  if (!normalized) return '—';
-  return normalized.replaceAll('_', ' ');
+  return formatStatusLabel(value);
 }
 
 function dependencyHref(workflowId: string): string {
@@ -930,7 +928,7 @@ function MergeAutomationPanel({
     <section className="stack">
       <h3>Merge Automation</h3>
       <div className="grid-2">
-        <Card label="Status">{mergeAutomation.status || '—'}</Card>
+        <Card label="Status">{formatStatusLabel(mergeAutomation.status)}</Card>
         {mergeAutomation.cycles !== undefined && mergeAutomation.cycles !== null ? (
           <Card label="Cycles">{String(mergeAutomation.cycles)}</Card>
         ) : null}
@@ -969,7 +967,7 @@ function MergeAutomationPanel({
                 <a href={child.detailHref || dependencyHref(child.workflowId)}>
                   <code className="text-xs break-all">{child.workflowId}</code>
                 </a>
-                {child.status ? <span className="small"> {child.status}</span> : null}
+                {child.status ? <span className="small"> {formatStatusLabel(child.status)}</span> : null}
                 {child.taskRunId ? (
                   <span className="small">
                     {' '}
@@ -1996,7 +1994,7 @@ function StepCheckBadge({ check }: { check: z.infer<typeof StepLedgerCheckSchema
   const statusPillClassName = executionStatusPillProps(check.status).className;
   return (
     <span className={`step-check-badge ${checkStatusClass} ${statusPillClassName}`}>
-      {check.kind.replaceAll('_', ' ')}: {check.status.replaceAll('_', ' ')}
+      {check.kind.replaceAll('_', ' ')}: {formatStatusLabel(check.status)}
     </span>
   );
 }
@@ -2094,7 +2092,7 @@ function StepWorkloadDetails({
       <ul className="step-detail-list">
         <li><strong>Runner profile:</strong> <code className="text-xs break-all">{formatOptionalValue(workload.profileId)}</code></li>
         <li><strong>Image:</strong> <code className="text-xs break-all">{formatOptionalValue(workload.imageRef)}</code></li>
-        <li><strong>Status:</strong> {formatOptionalValue(workload.status)}</li>
+        <li><strong>Status:</strong> {formatStatusLabel(workload.status)}</li>
         <li><strong>Exit code:</strong> {formatOptionalValue(workload.exitCode)}</li>
         <li><strong>Duration:</strong> {formatOptionalValue(workload.durationSeconds)}s</li>
         <li><strong>Tool:</strong> <code className="text-xs break-all">{formatOptionalValue(workload.toolName)}</code></li>
@@ -2224,7 +2222,7 @@ function StepLedgerRowCard({
   return (
     <article className={`step-tl-row${expanded ? ' step-tl-expanded' : ''}${isLast ? ' step-tl-last' : ''}`}>
       <div className="step-tl-gutter" aria-hidden="true">
-        <span className={`step-tl-icon ${cssClass}`} title={row.status.replaceAll('_', ' ')}>{icon}</span>
+        <span className={`step-tl-icon ${cssClass}`} title={formatStatusLabel(row.status)}>{icon}</span>
         {!isLast ? <span className="step-tl-line" /> : null}
       </div>
       <div className="step-tl-content">
@@ -2239,7 +2237,7 @@ function StepLedgerRowCard({
             <span className="step-tl-title">{row.title}</span>
             <span className="step-tl-right">
               <code className="step-tl-tool">{formatStepToolLabel(row.tool)}</code>
-              <span {...executionStatusPillProps(row.status)}>{row.status.replaceAll('_', ' ')}</span>
+              <span {...executionStatusPillProps(row.status)}>{formatStatusLabel(row.status)}</span>
               {row.attempt > 1 ? <span className="step-attempt-pill">Attempt {row.attempt}</span> : null}
               <span className={`step-tl-chevron${expanded ? ' step-tl-chevron-open' : ''}`} aria-hidden="true">›</span>
             </span>
@@ -3307,7 +3305,7 @@ function RemediationRelationshipsPanel({
                   <code className="text-xs break-all">{item.remediationWorkflowId}</code>
                 </a>
                 <div className="grid-2">
-                  <Card label="Status">{item.status || '—'}</Card>
+                  <Card label="Status">{formatStatusLabel(item.status)}</Card>
                   <Card label="Authority">{item.authorityMode || '—'}</Card>
                   <Card label="Latest Action">{item.latestActionSummary || '—'}</Card>
                   <Card label="Resolution">{item.resolution || '—'}</Card>
@@ -3355,7 +3353,7 @@ function RemediationRelationshipsPanel({
                   <Card label="Pinned Run"><code className="text-xs break-all">{item.targetRunId || '—'}</code></Card>
                   <Card label="Mode">{item.mode || '—'}</Card>
                   <Card label="Authority">{item.authorityMode || '—'}</Card>
-                  <Card label="Status">{item.status || '—'}</Card>
+                  <Card label="Status">{formatStatusLabel(item.status)}</Card>
                   <Card label="Evidence Bundle">{item.contextArtifactRef || 'Missing'}</Card>
                   <Card label="Approval">{item.approvalState?.decision || 'not_required'}</Card>
                 </div>
@@ -4072,9 +4070,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             </FactGroup>
 
             <FactGroup title="Temporal">
-              <Fact label="Temporal Status">{execution.temporalStatus || '—'}</Fact>
-              <Fact label="Current State">{execution.rawState || execution.state || '—'}</Fact>
-              {execution.closeStatus ? <Fact label="Close Status">{execution.closeStatus}</Fact> : null}
+              <Fact label="Temporal Status">{formatStatusLabel(execution.temporalStatus)}</Fact>
+              <Fact label="Current State">{formatStatusLabel(execution.rawState || execution.state)}</Fact>
+              {execution.closeStatus ? <Fact label="Close Status">{formatStatusLabel(execution.closeStatus)}</Fact> : null}
               <Fact label="Source">Temporal</Fact>
               <Fact label="Workflow Type">{execution.workflowType || '—'}</Fact>
               <Fact label="Entry">{execution.entry || '—'}</Fact>
@@ -4103,7 +4101,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               ) : null}
               {runSummary.publish ? (
                 <div className="grid-2">
-                  <Card label="Publish Status">{runSummary.publish.status || '—'}</Card>
+                  <Card label="Publish Status">{formatStatusLabel(runSummary.publish.status)}</Card>
                   <Card label="Publish Mode">{runSummary.publish.mode || '—'}</Card>
                 </div>
               ) : null}
@@ -4250,14 +4248,14 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                               <strong>{item.title || item.workflowId}</strong>
                             </a>
                             <code className="text-xs break-all">{item.workflowId}</code>
-                            <span {...executionStatusPillProps(stateLabel)}>{stateLabel}</span>
+                            <span {...executionStatusPillProps(stateLabel)}>{formatStatusLabel(stateLabel)}</span>
                             {item.summary ? <p className="small">{item.summary}</p> : null}
                             {outcome?.message ? <p className="small">{outcome.message}</p> : null}
                             {outcome?.failureCategory ? (
                               <p className="small">Failure category: <code>{outcome.failureCategory}</code></p>
                             ) : null}
                             {(outcome?.closeStatus || item.closeStatus) ? (
-                              <p className="small">Close status: {outcome?.closeStatus || item.closeStatus}</p>
+                              <p className="small">Close status: {formatStatusLabel(outcome?.closeStatus || item.closeStatus)}</p>
                             ) : null}
                           </div>
                         </li>
@@ -4279,9 +4277,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                             <strong>{item.title || item.workflowId}</strong>
                           </a>
                           <code className="text-xs break-all">{item.workflowId}</code>
-                          <span {...executionStatusPillProps(item.state)}>{item.state || 'unknown'}</span>
+                          <span {...executionStatusPillProps(item.state)}>{formatStatusLabel(item.state, 'unknown')}</span>
                           {item.summary ? <p className="small">{item.summary}</p> : null}
-                          {item.closeStatus ? <p className="small">Close status: {item.closeStatus}</p> : null}
+                          {item.closeStatus ? <p className="small">Close status: {formatStatusLabel(item.closeStatus)}</p> : null}
                         </div>
                       </li>
                     ))}
@@ -4455,7 +4453,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   <tr>
                     <td>Last update</td>
                     <td>{formatWhen(execution.updatedAt)}</td>
-                    <td>State: {(execution.state || '').replaceAll('_', ' ')}</td>
+                    <td>State: {formatStatusLabel(execution.state, '')}</td>
                   </tr>
                   {execution.waitingReason || execution.attentionRequired ? (
                     <tr>
@@ -4471,7 +4469,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                     <tr>
                       <td>Closed</td>
                       <td>{formatWhen(execution.closedAt)}</td>
-                      <td>Close status: {execution.closeStatus || execution.temporalStatus || '—'}</td>
+                      <td>Close status: {formatStatusLabel(execution.closeStatus || execution.temporalStatus)}</td>
                     </tr>
                   ) : null}
                 </tbody>
@@ -4508,7 +4506,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                             <code>{artifact.artifactId}</code>
                           </td>
                           <td>{artifact.sizeBytes ?? '—'}</td>
-                          <td>{String(artifact.status ?? '—')}</td>
+                          <td>{formatStatusLabel(artifact.status)}</td>
                           <td>
                             <a
                               className="button secondary"

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -310,7 +310,7 @@ describe('Tasks List Entrypoint', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
 
-    const waitingPills = screen.getAllByText('waiting_on_dependencies');
+    const waitingPills = screen.getAllByText('AWAITING TASK');
     expect(waitingPills.length).toBeGreaterThan(0);
     for (const pill of waitingPills) {
       expect(pill.closest('span')?.dataset.effect).toBeUndefined();
@@ -320,7 +320,7 @@ describe('Tasks List Entrypoint', () => {
       document.querySelectorAll<HTMLElement>('.queue-table-cell-status span.status, .queue-card-status span.status'),
     );
 
-    const awaitingPills = nonExecutingStatusPills.filter((pill) => pill.textContent === 'awaiting_external');
+    const awaitingPills = nonExecutingStatusPills.filter((pill) => pill.textContent === 'awaiting external');
     expect(awaitingPills.length).toBeGreaterThan(0);
     for (const pill of awaitingPills) {
       expect(pill.dataset.effect).toBeUndefined();
@@ -425,6 +425,7 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
     const options = Array.from(statusFilter.options).map((option) => option.value);
+    const optionLabels = Array.from(statusFilter.options).map((option) => option.textContent);
 
     expect(options).toEqual([
       '',
@@ -436,6 +437,21 @@ describe('Tasks List Entrypoint', () => {
       'executing',
       'proposals',
       'awaiting_external',
+      'finalizing',
+      'completed',
+      'failed',
+      'canceled',
+    ]);
+    expect(optionLabels).toEqual([
+      'All Statuses',
+      'scheduled',
+      'initializing',
+      'AWAITING TASK',
+      'planning',
+      'AWAITING SLOT',
+      'executing',
+      'proposals',
+      'awaiting external',
       'finalizing',
       'completed',
       'failed',

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { BootPayload } from '../boot/parseBootPayload';
-import { formatRuntimeLabel, formatTaskSkills } from '../utils/formatters';
+import { formatRuntimeLabel, formatStatusLabel, formatTaskSkills } from '../utils/formatters';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
 
@@ -342,7 +342,7 @@ function filterSummary(field: FilterField, filters: ColumnFilters): string {
     const suffix = filter.values.length > 1 ? ` +${filter.values.length - 1}` : '';
     return `${filter.mode === 'exclude' ? 'not ' : ''}${first}${suffix}`;
   };
-  if (field === 'status') return summarizeValues(filters.status);
+  if (field === 'status') return summarizeValues(filters.status, formatStatusLabel);
   if (field === 'targetRuntime') return summarizeValues(filters.targetRuntime, formatRuntimeLabel);
   if (field === 'targetSkill') return summarizeValues(filters.targetSkill);
   if (field === 'repository') {
@@ -668,7 +668,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               <option value="">All Statuses</option>
               {TEMPORAL_STATUSES.map((status) => (
                 <option key={status} value={status}>
-                  {status}
+                  {formatStatusLabel(status)}
                 </option>
               ))}
             </select>

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -1,3 +1,5 @@
+import { formatStatusLabel } from './formatters';
+
 export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   jiraIssue: 'MM-488',
   relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491'],
@@ -46,9 +48,7 @@ function executionStatusBaseClasses(key: string): string {
 }
 
 function executionStatusVisibleLabel(status: string | null | undefined): string {
-  return String(status || 'executing')
-    .trim()
-    .replace(/\s+/g, ' ');
+  return formatStatusLabel(status, 'executing');
 }
 
 export function executionStatusPillProps(status: string | null | undefined): ExecutionStatusPillProps {

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatStatusLabel } from './formatters';
+
+describe('formatStatusLabel', () => {
+  it('uses compact user-facing labels for dependency and slot waits', () => {
+    expect(formatStatusLabel('waiting_on_dependencies')).toBe('AWAITING TASK');
+    expect(formatStatusLabel('WAITING ON DEPENDENCIES')).toBe('AWAITING TASK');
+    expect(formatStatusLabel('awaiting_slot')).toBe('AWAITING SLOT');
+  });
+
+  it('replaces status underscores with spaces without changing raw filter values', () => {
+    expect(formatStatusLabel('awaiting_external')).toBe('awaiting external');
+    expect(formatStatusLabel('validating_token')).toBe('validating token');
+    expect(formatStatusLabel(null)).toBe('—');
+  });
+});

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -8,6 +8,18 @@ export function formatTaskSkills(
   return skillId || '—';
 }
 
+const STATUS_DISPLAY_NAMES: Record<string, string> = {
+  awaiting_slot: 'AWAITING SLOT',
+  waiting_on_dependencies: 'AWAITING TASK',
+};
+
+export function formatStatusLabel(status: string | null | undefined, fallback = '—'): string {
+  const raw = String(status || fallback).trim();
+  if (!raw) return fallback;
+  const key = raw.toLowerCase().replace(/[\s_]+/g, '_');
+  return STATUS_DISPLAY_NAMES[key] || raw.replace(/_/g, ' ').replace(/\s+/g, ' ');
+}
+
 const RUNTIME_DISPLAY_NAMES: Record<string, string> = {
   codex_cli: 'Codex CLI',
   codex: 'Codex CLI',


### PR DESCRIPTION
I want to change the name of the status "WAITING_ON_DEPENDENCIES" to "AWAITING TASK". This is to save space and also because AWAITING matches AWAITING SLOT more closely. I also want to change all visually displayed statuses to not contain underscores to make them more user friendly. Any underscores should become spaces instead.