### PR TITLE
[codex] Fix Jira blocker tool inputs

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -58,7 +58,11 @@ steps:
       linkType: Blocks
     tool:
       id: jira.check_blockers
-      args: {}
+      args:
+        targetIssueKey: "{{ inputs.jira_issue_key }}"
+        blockerPreflight:
+          targetIssueKey: "{{ inputs.jira_issue_key }}"
+          linkType: Blocks
   - title: Load Jira preset brief
     instructions: |-
       Fetch Jira issue {{ inputs.jira_issue_key }} through the trusted Jira tool surface.

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -617,6 +617,16 @@ def _selected_step_tool_name(step_entry: Mapping[str, Any]) -> str:
     )
     return str(step_tool.get("name") or step_tool.get("id") or "").strip()
 
+
+def _selected_step_tool_inputs(step_entry: Mapping[str, Any]) -> dict[str, Any]:
+    step_tool = _coerce_mapping(step_entry.get("tool")) or _coerce_mapping(
+        step_entry.get("skill")
+    )
+    return dict(
+        _coerce_mapping(step_tool.get("inputs"))
+        or _coerce_mapping(step_tool.get("args"))
+    )
+
 def _canonical_step_fingerprint(step_entry: Mapping[str, Any]) -> str:
     try:
         return json.dumps(step_entry, sort_keys=True, separators=(",", ":"))
@@ -1134,6 +1144,9 @@ def _build_runtime_planner():
                     },
                     "instructions": step_instructions,
                 }
+                step_tool_inputs = _selected_step_tool_inputs(step_entry)
+                for key, value in step_tool_inputs.items():
+                    step_node_inputs.setdefault(key, value)
 
                 # Per-step tool/skill override
                 step_tool_name = _selected_step_tool_name(step_entry)

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1502,6 +1502,13 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert expanded["steps"][1]["title"] == "Check Jira blockers before implementation"
             assert expanded["steps"][1]["type"] == "tool"
             assert expanded["steps"][1]["tool"]["id"] == "jira.check_blockers"
+            assert expanded["steps"][1]["tool"]["inputs"] == {
+                "targetIssueKey": "MM-328",
+                "blockerPreflight": {
+                    "targetIssueKey": "MM-328",
+                    "linkType": "Blocks",
+                },
+            }
             assert expanded["steps"][1]["targetIssueKey"] == "MM-328"
             assert expanded["steps"][1]["blockerPreflight"] == {
                 "targetIssueKey": "MM-328",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -280,6 +280,7 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     assert plan["nodes"][0]["inputs"]["type"] == "tool"
+    assert plan["nodes"][0]["inputs"]["issueKey"] == "MM-559"
     assert plan["nodes"][0]["inputs"]["source"] == {
         "kind": "preset-derived",
         "presetId": "jira-flow",


### PR DESCRIPTION
## Summary
- Pass Jira Orchestrate blocker preflight inputs through the typed `jira.check_blockers` tool args.
- Preserve per-step tool inputs when the runtime planner dispatches `mm.tool.execute`.
- Add regression coverage for seeded template expansion and planner tool input propagation.

## Root Cause
The blocker step carried `targetIssueKey` at the expanded step level, but the typed tool dispatch path only used the tool input payload. The Jira blocker preflight therefore received an empty input object and failed before implementation could begin.

## Validation
- `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py::test_seed_catalog_includes_jira_orchestrate_preset`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node`
- `PYTEST_ADDOPTS='--basetemp=/tmp/t' ./tools/test_unit.sh`
