### PR TITLE
Run Jira Orchestrate for MM-590: Executions list and facet API support for column filters

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_611
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_612

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:5a8ab5d3-0ee3-4400-90fc-1262aa76ccab_487
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_611

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_615
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_616

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_612
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_613

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_613
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_614

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_614
+../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_615

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/302-shareable-filter-url"
+  "feature_directory": "specs/303-executions-list-facets"
 }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -53,6 +53,8 @@ from moonmind.schemas.temporal_models import (
     ExecutionActionCapabilityModel,
     ExecutionDependencySummaryModel,
     ExecutionDebugFieldsModel,
+    ExecutionFacetItemModel,
+    ExecutionFacetResponse,
     ExecutionMergeAutomationModel,
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProjectionDiagnosticModel,
@@ -136,6 +138,53 @@ _PENDING_REMEDIATION_APPROVAL_STATUSES = frozenset(
 _GITHUB_PULL_REQUEST_PATH_PATTERN = re.compile(
     r"^/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+$",
     re.IGNORECASE,
+)
+_EXECUTION_FILTER_VALUE_LIMIT = 50
+_EXECUTION_FILTER_VALUE_MAX_LENGTH = 200
+_EXECUTION_TEXT_FILTER_MAX_LENGTH = 200
+_EXECUTION_FACET_PAGE_SIZE_LIMIT = 200
+_EXECUTION_SORT_FIELDS = {
+    "taskId": "WorkflowId",
+    "targetRuntime": "mm_target_runtime",
+    "targetSkill": "mm_target_skill",
+    "repository": "mm_repo",
+    "integration": "mm_integration",
+    "status": "mm_state",
+    "scheduledFor": "mm_scheduled_for",
+    "createdAt": "StartTime",
+    "closedAt": "CloseTime",
+}
+_EXECUTION_FACET_ATTRS = {
+    "status": "mm_state",
+    "targetRuntime": "mm_target_runtime",
+    "targetSkill": "mm_target_skill",
+    "repository": "mm_repo",
+    "integration": "mm_integration",
+}
+_EXECUTION_FACET_FILTER_ALIASES = {
+    "status": frozenset({"state", "stateIn", "stateNotIn"}),
+    "targetRuntime": frozenset(
+        {"targetRuntime", "targetRuntimeIn", "targetRuntimeNotIn", "targetRuntimeBlank"}
+    ),
+    "targetSkill": frozenset({"targetSkillIn", "targetSkillNotIn", "targetSkillBlank"}),
+    "repository": frozenset(
+        {"repo", "repoExact", "repoIn", "repoNotIn", "repoContains", "repoBlank"}
+    ),
+    "integration": frozenset({"integration"}),
+}
+_TEMPORAL_STATUS_VALUES = (
+    "scheduled",
+    "initializing",
+    "waiting_on_dependencies",
+    "planning",
+    "awaiting_slot",
+    "executing",
+    "proposals",
+    "awaiting_external",
+    "finalizing",
+    "completed",
+    "failed",
+    "canceled",
 )
 
 
@@ -289,6 +338,447 @@ def _is_task_list_workflow_type(workflow_type: str | None) -> bool:
 
 def _is_task_list_entry(entry: str | None) -> bool:
     return str(entry or "").strip().lower() == "run"
+
+
+def _escape_temporal_value(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+def _split_temporal_values(raw: str | list[str] | None, *, alias: str) -> list[str]:
+    if not raw:
+        return []
+    parts = raw if isinstance(raw, list) else [raw]
+    seen: set[str] = set()
+    values: list[str] = []
+    for item in parts:
+        for part in str(item or "").split(","):
+            value = part.strip()
+            if not value or value in seen:
+                continue
+            if len(value) > _EXECUTION_FILTER_VALUE_MAX_LENGTH:
+                raise TemporalExecutionValidationError(
+                    f"{alias} values must be {_EXECUTION_FILTER_VALUE_MAX_LENGTH} characters or fewer."
+                )
+            seen.add(value)
+            values.append(value)
+    if len(values) > _EXECUTION_FILTER_VALUE_LIMIT:
+        raise TemporalExecutionValidationError(
+            f"{alias} accepts at most {_EXECUTION_FILTER_VALUE_LIMIT} values."
+        )
+    return values
+
+
+def _raw_query_values(request: Request, alias: str, fallback: str | None) -> list[str]:
+    values = request.query_params.getlist(alias)
+    if not values and fallback is not None:
+        values = [fallback]
+    return _split_temporal_values(values, alias=alias)
+
+
+def _validate_non_contradictory_values(
+    include_alias: str,
+    include_values: list[str],
+    exclude_alias: str,
+    exclude_values: list[str],
+) -> None:
+    if include_values and exclude_values:
+        raise TemporalExecutionValidationError(
+            f"Cannot combine {include_alias} and {exclude_alias}."
+        )
+
+
+def _normalize_text_filter(raw: str | None, *, alias: str) -> str | None:
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    if len(value) > _EXECUTION_TEXT_FILTER_MAX_LENGTH:
+        raise TemporalExecutionValidationError(
+            f"{alias} must be {_EXECUTION_TEXT_FILTER_MAX_LENGTH} characters or fewer."
+        )
+    return value
+
+
+def _validate_blank_mode(raw: str | None, *, alias: str) -> str | None:
+    value = str(raw or "").strip().lower()
+    if not value:
+        return None
+    if value not in {"include", "exclude"}:
+        raise TemporalExecutionValidationError(
+            f"{alias} must be one of: include, exclude."
+        )
+    return value
+
+
+def _normalize_date_bound(raw: str | None, *, alias: str, end_of_day: bool = False) -> str | None:
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    candidate = f"{value}T00:00:00Z" if len(value) == 10 else value
+    try:
+        datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TemporalExecutionValidationError(
+            f"{alias} must be an ISO 8601 date or timestamp."
+        ) from exc
+    if len(value) == 10:
+        suffix = "T23:59:59.999999Z" if end_of_day else "T00:00:00Z"
+        return f"{value}{suffix}"
+    return value.replace("+00:00", "Z")
+
+
+def _datetime_range_parts(
+    attr: str,
+    start_raw: str | None,
+    end_raw: str | None,
+    *,
+    start_alias: str,
+    end_alias: str,
+) -> list[str]:
+    parts: list[str] = []
+    start_value = _normalize_date_bound(start_raw, alias=start_alias)
+    end_value = _normalize_date_bound(end_raw, alias=end_alias, end_of_day=True)
+    if start_value and end_value:
+        start_dt = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(end_value.replace("Z", "+00:00"))
+        if start_dt > end_dt:
+            raise TemporalExecutionValidationError(
+                f"{start_alias} must be before or equal to {end_alias}."
+            )
+    if start_value:
+        parts.append(f'{attr}>="{_escape_temporal_value(start_value)}"')
+    if end_value:
+        parts.append(f'{attr}<="{_escape_temporal_value(end_value)}"')
+    return parts
+
+
+def _any_temporal_query(attr: str, values: list[str]) -> str | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return f'{attr}="{_escape_temporal_value(values[0])}"'
+    return "(" + " OR ".join(
+        f'{attr}="{_escape_temporal_value(value)}"' for value in values
+    ) + ")"
+
+
+def _append_exact_or_multi_temporal_filter(
+    query_parts: list[str],
+    attr: str,
+    *,
+    exact: str | None = None,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> None:
+    exact_value = str(exact or "").strip()
+    if exact_value:
+        if len(exact_value) > _EXECUTION_FILTER_VALUE_MAX_LENGTH:
+            raise TemporalExecutionValidationError(
+                f"{attr} exact value must be {_EXECUTION_FILTER_VALUE_MAX_LENGTH} characters or fewer."
+            )
+        query_parts.append(f'{attr}="{_escape_temporal_value(exact_value)}"')
+    include_query = _any_temporal_query(attr, include or [])
+    if include_query and not exact_value:
+        query_parts.append(include_query)
+    for value in exclude or []:
+        query_parts.append(f'{attr}!="{_escape_temporal_value(value)}"')
+
+
+def _append_datetime_temporal_filter(
+    query_parts: list[str],
+    attr: str,
+    start_raw: str | None,
+    end_raw: str | None,
+    *,
+    start_alias: str,
+    end_alias: str,
+    blank_mode: str | None = None,
+) -> None:
+    range_parts = _datetime_range_parts(
+        attr,
+        start_raw,
+        end_raw,
+        start_alias=start_alias,
+        end_alias=end_alias,
+    )
+    blank_value = _validate_blank_mode(blank_mode, alias=f"{attr} blank")
+    if blank_value == "include":
+        null_query = f"{attr} IS NULL"
+        if range_parts:
+            range_query = " AND ".join(range_parts)
+            query_parts.append(f"({null_query} OR ({range_query}))")
+        else:
+            query_parts.append(null_query)
+        return
+    if blank_value == "exclude":
+        query_parts.append(f"{attr} IS NOT NULL")
+    query_parts.extend(range_parts)
+
+
+def _append_contains_temporal_filter(
+    query_parts: list[str],
+    attr: str,
+    raw: str | None,
+    *,
+    alias: str,
+) -> None:
+    value = _normalize_text_filter(raw, alias=alias)
+    if value:
+        query_parts.append(f'{attr} LIKE "%{_escape_temporal_value(value)}%"')
+
+
+def _build_temporal_execution_query(
+    *,
+    request: Request,
+    workflow_type: str | None,
+    state: str | None,
+    state_in: str | None,
+    state_not_in: str | None,
+    entry: str | None,
+    repo: str | None,
+    repo_exact: str | None,
+    repo_in: str | None,
+    repo_not_in: str | None,
+    integration: str | None,
+    target_runtime: str | None,
+    target_runtime_in: str | None,
+    target_runtime_not_in: str | None,
+    target_skill_in: str | None,
+    target_skill_not_in: str | None,
+    scheduled_from: str | None,
+    scheduled_to: str | None,
+    scheduled_blank: str | None,
+    created_from: str | None,
+    created_to: str | None,
+    finished_from: str | None,
+    finished_to: str | None,
+    finished_blank: str | None,
+    scope: str | None,
+    owner_type: str | None,
+    owner_id: str | None,
+    sort: str | None = None,
+    sort_dir: str | None = None,
+    exclude_aliases: frozenset[str] = frozenset(),
+    include_order: bool = False,
+) -> tuple[str, str]:
+    query_parts: list[str] = []
+
+    def excluded(alias: str) -> bool:
+        return alias in exclude_aliases
+
+    state_in_values = [] if excluded("stateIn") else _raw_query_values(request, "stateIn", state_in)
+    state_not_in_values = [] if excluded("stateNotIn") else _raw_query_values(request, "stateNotIn", state_not_in)
+    repo_in_values = [] if excluded("repoIn") else _raw_query_values(request, "repoIn", repo_in)
+    repo_not_in_values = [] if excluded("repoNotIn") else _raw_query_values(request, "repoNotIn", repo_not_in)
+    target_runtime_in_values = [] if excluded("targetRuntimeIn") else _raw_query_values(request, "targetRuntimeIn", target_runtime_in)
+    target_runtime_not_in_values = [] if excluded("targetRuntimeNotIn") else _raw_query_values(request, "targetRuntimeNotIn", target_runtime_not_in)
+    target_skill_in_values = [] if excluded("targetSkillIn") else _raw_query_values(request, "targetSkillIn", target_skill_in)
+    target_skill_not_in_values = [] if excluded("targetSkillNotIn") else _raw_query_values(request, "targetSkillNotIn", target_skill_not_in)
+
+    _validate_non_contradictory_values("stateIn", state_in_values, "stateNotIn", state_not_in_values)
+    _validate_non_contradictory_values("repoIn", repo_in_values, "repoNotIn", repo_not_in_values)
+    _validate_non_contradictory_values(
+        "targetRuntimeIn",
+        target_runtime_in_values,
+        "targetRuntimeNotIn",
+        target_runtime_not_in_values,
+    )
+    _validate_non_contradictory_values(
+        "targetSkillIn",
+        target_skill_in_values,
+        "targetSkillNotIn",
+        target_skill_not_in_values,
+    )
+
+    temporal_scope = _normalize_temporal_list_scope(
+        scope,
+        workflow_type=workflow_type,
+        entry=entry,
+    )
+    scope_query = _TEMPORAL_SCOPE_QUERIES[temporal_scope]
+    if scope_query:
+        query_parts.append(scope_query)
+    if workflow_type and not _is_task_list_workflow_type(workflow_type):
+        logger.info(
+            "Ignoring workflowType=%s for ordinary task-list temporal query",
+            workflow_type,
+        )
+    elif workflow_type and not scope_query:
+        query_parts.append(f'WorkflowType="{_escape_temporal_value(workflow_type)}"')
+    if state and not excluded("state") and not (state_in_values or state_not_in_values):
+        query_parts.append(f'mm_state="{_escape_temporal_value(state)}"')
+    _append_exact_or_multi_temporal_filter(
+        query_parts,
+        "mm_state",
+        include=state_in_values,
+        exclude=state_not_in_values,
+    )
+    if entry and not _is_task_list_entry(entry):
+        logger.info("Ignoring entry=%s for ordinary task-list temporal query", entry)
+    elif entry and not scope_query:
+        query_parts.append(f'mm_entry="{_escape_temporal_value(entry)}"')
+    if owner_type:
+        query_parts.append(f'mm_owner_type="{_escape_temporal_value(owner_type)}"')
+    if owner_id:
+        query_parts.append(f'mm_owner_id="{_escape_temporal_value(owner_id)}"')
+    _append_exact_or_multi_temporal_filter(
+        query_parts,
+        "mm_repo",
+        exact=None if excluded("repoExact") or excluded("repo") else repo_exact or repo,
+        include=repo_in_values,
+        exclude=repo_not_in_values,
+    )
+    if not excluded("repoContains"):
+        _append_contains_temporal_filter(
+            query_parts, "mm_repo", request.query_params.get("repoContains"), alias="repoContains"
+        )
+    if integration and not excluded("integration"):
+        query_parts.append(f'mm_integration="{_escape_temporal_value(integration)}"')
+    _append_exact_or_multi_temporal_filter(
+        query_parts,
+        "mm_target_runtime",
+        exact=None if excluded("targetRuntime") else target_runtime,
+        include=target_runtime_in_values,
+        exclude=target_runtime_not_in_values,
+    )
+    _append_exact_or_multi_temporal_filter(
+        query_parts,
+        "mm_target_skill",
+        include=target_skill_in_values,
+        exclude=target_skill_not_in_values,
+    )
+    if not excluded("taskId"):
+        _append_exact_or_multi_temporal_filter(
+            query_parts,
+            "WorkflowId",
+            exact=request.query_params.get("taskId"),
+        )
+    if not excluded("taskIdContains"):
+        _append_contains_temporal_filter(
+            query_parts,
+            "WorkflowId",
+            request.query_params.get("taskIdContains"),
+            alias="taskIdContains",
+        )
+    if not excluded("titleContains"):
+        _append_contains_temporal_filter(
+            query_parts,
+            "mm_title",
+            request.query_params.get("titleContains"),
+            alias="titleContains",
+        )
+    _append_datetime_temporal_filter(
+        query_parts,
+        "mm_scheduled_for",
+        None if excluded("scheduledFrom") else scheduled_from,
+        None if excluded("scheduledTo") else scheduled_to,
+        start_alias="scheduledFrom",
+        end_alias="scheduledTo",
+        blank_mode=None if excluded("scheduledBlank") else scheduled_blank,
+    )
+    _append_datetime_temporal_filter(
+        query_parts,
+        "StartTime",
+        None if excluded("createdFrom") else created_from,
+        None if excluded("createdTo") else created_to,
+        start_alias="createdFrom",
+        end_alias="createdTo",
+    )
+    _append_datetime_temporal_filter(
+        query_parts,
+        "CloseTime",
+        None if excluded("finishedFrom") else finished_from,
+        None if excluded("finishedTo") else finished_to,
+        start_alias="finishedFrom",
+        end_alias="finishedTo",
+        blank_mode=None if excluded("finishedBlank") else finished_blank,
+    )
+
+    count_query = " AND ".join(query_parts) if query_parts else ""
+    list_query = count_query
+    if include_order and sort:
+        sort_attr = _EXECUTION_SORT_FIELDS.get(sort)
+        if sort_attr is None:
+            raise TemporalExecutionValidationError(
+                "sort must be one of: " + ", ".join(sorted(_EXECUTION_SORT_FIELDS)) + "."
+            )
+        direction = str(sort_dir or "desc").strip().lower()
+        if direction not in {"asc", "desc"}:
+            raise TemporalExecutionValidationError("sortDir must be one of: asc, desc.")
+        order_clause = f"ORDER BY {sort_attr} {direction.upper()}"
+        list_query = f"{count_query} {order_clause}".strip()
+    elif sort_dir and str(sort_dir).strip().lower() not in {"asc", "desc"}:
+        raise TemporalExecutionValidationError("sortDir must be one of: asc, desc.")
+    return count_query, list_query
+
+
+def _and_temporal_query(base_query: str, clause: str) -> str:
+    return f"{base_query} AND {clause}" if base_query else clause
+
+
+def _facet_label(facet: str, value: str) -> str:
+    if facet == "targetRuntime":
+        labels = {
+            "codex_cli": "Codex CLI",
+            "claude_code": "Claude Code",
+            "gemini_cli": "Gemini CLI",
+            "codex_cloud": "Codex Cloud",
+        }
+        return labels.get(value, value.replace("_", " ").title())
+    if facet == "status":
+        return value.replace("_", " ").title()
+    return value
+
+
+async def _facet_value_from_workflow(workflow: object, facet: str) -> str:
+    search_attributes = getattr(workflow, "search_attributes", {}) or {}
+    if facet == "status":
+        return _coerce_temporal_scalar(search_attributes.get("mm_state"))
+    if facet == "repository":
+        return _coerce_temporal_scalar(
+            search_attributes.get("mm_repository") or search_attributes.get("mm_repo")
+        )
+    if facet == "integration":
+        return _coerce_temporal_scalar(search_attributes.get("mm_integration"))
+    if facet == "targetRuntime":
+        value = _coerce_temporal_scalar(
+            search_attributes.get("mm_target_runtime")
+            or search_attributes.get("mm_runtime")
+            or search_attributes.get("runtime")
+        )
+        if value:
+            return value
+    if facet == "targetSkill":
+        value = _coerce_temporal_scalar(
+            search_attributes.get("mm_target_skill")
+            or search_attributes.get("mm_skill_id")
+            or search_attributes.get("mm_skill")
+            or search_attributes.get("skillId")
+            or search_attributes.get("skill")
+        )
+        if value:
+            return value
+    memo_fn = getattr(workflow, "memo", None)
+    memo: object | None = None
+    if callable(memo_fn):
+        maybe_memo = memo_fn()
+        if hasattr(maybe_memo, "__await__"):
+            memo = await maybe_memo
+        else:
+            memo = maybe_memo
+    if not isinstance(memo, Mapping):
+        return ""
+    if facet == "targetRuntime":
+        return _coerce_temporal_scalar(
+            memo.get("targetRuntime") or memo.get("target_runtime")
+        )
+    if facet == "targetSkill":
+        return _coerce_temporal_scalar(
+            memo.get("targetSkill")
+            or memo.get("target_skill")
+            or memo.get("skillId")
+            or memo.get("skill")
+        )
+    return ""
 
 
 def _canonicalize_execution_identifier(raw_identifier: str) -> tuple[str, bool]:
@@ -4173,6 +4663,8 @@ async def list_executions(
     finished_to: Optional[str] = Query(None, alias="finishedTo"),
     finished_blank: Optional[str] = Query(None, alias="finishedBlank"),
     scope: Optional[str] = Query(None, alias="scope"),
+    sort: Optional[str] = Query(None, alias="sort"),
+    sort_dir: Optional[str] = Query(None, alias="sortDir"),
     page_size: int = Query(50, alias="pageSize", ge=1, le=200),
     next_page_token: Optional[str] = Query(None, alias="nextPageToken"),
     source: Optional[str] = Query(None),
@@ -4213,203 +4705,46 @@ async def list_executions(
             )
 
             client = temporal_client
-
-            def escape_val(v: str) -> str:
-                return v.replace('"', '\\"')
-
-            def split_csv(raw: str | list[str] | None) -> list[str]:
-                if not raw:
-                    return []
-                parts = raw if isinstance(raw, list) else [raw]
-                seen: set[str] = set()
-                values: list[str] = []
-                for item in parts:
-                    for part in item.split(","):
-                        value = part.strip()
-                        if value and value not in seen:
-                            seen.add(value)
-                            values.append(value)
-                return values
-
-            def raw_query_values(alias: str, fallback: str | None) -> list[str]:
-                values = request.query_params.getlist(alias)
-                if not values and fallback is not None:
-                    values = [fallback]
-                return split_csv(values)
-
-            def validate_non_contradictory(
-                include_alias: str,
-                include_raw: str | list[str] | None,
-                exclude_alias: str,
-                exclude_raw: str | list[str] | None,
-            ) -> None:
-                if split_csv(include_raw) and split_csv(exclude_raw):
-                    raise TemporalExecutionValidationError(
-                        f"Cannot combine {include_alias} and {exclude_alias}."
-                    )
-
-            def any_query(attr: str, values: list[str]) -> str | None:
-                if not values:
-                    return None
-                if len(values) == 1:
-                    return f'{attr}="{escape_val(values[0])}"'
-                return "(" + " OR ".join(
-                    f'{attr}="{escape_val(value)}"' for value in values
-                ) + ")"
-
-            def append_exact_or_multi_filter(
-                attr: str,
-                *,
-                exact: str | None = None,
-                include: str | list[str] | None = None,
-                exclude: str | list[str] | None = None,
-            ) -> None:
-                exact_value = (exact or "").strip()
-                if exact_value:
-                    query_parts.append(f'{attr}="{escape_val(exact_value)}"')
-                include_query = any_query(attr, split_csv(include))
-                if include_query and not exact_value:
-                    query_parts.append(include_query)
-                for value in split_csv(exclude):
-                    query_parts.append(f'{attr}!="{escape_val(value)}"')
-
-            def normalize_date_bound(
-                raw: str | None,
-                *,
-                end_of_day: bool = False,
-            ) -> str | None:
-                value = (raw or "").strip()
-                if not value:
-                    return None
-                if len(value) == 10:
-                    suffix = "T23:59:59.999999Z" if end_of_day else "T00:00:00Z"
-                    return f"{value}{suffix}"
-                return value.replace("+00:00", "Z")
-
-            def datetime_range_parts(
-                attr: str,
-                start_raw: str | None,
-                end_raw: str | None,
-            ) -> list[str]:
-                parts: list[str] = []
-                start_value = normalize_date_bound(start_raw)
-                end_value = normalize_date_bound(end_raw, end_of_day=True)
-                if start_value:
-                    parts.append(f'{attr}>="{escape_val(start_value)}"')
-                if end_value:
-                    parts.append(f'{attr}<="{escape_val(end_value)}"')
-                return parts
-
-            def append_datetime_filter(
-                attr: str,
-                start_raw: str | None,
-                end_raw: str | None,
-                blank_mode: str | None = None,
-            ) -> None:
-                range_parts = datetime_range_parts(attr, start_raw, end_raw)
-                blank_value = (blank_mode or "").strip().lower()
-                if blank_value == "include":
-                    null_query = f"{attr} IS NULL"
-                    if range_parts:
-                        range_query = " AND ".join(range_parts)
-                        query_parts.append(f"({null_query} OR ({range_query}))")
-                    else:
-                        query_parts.append(null_query)
-                    return
-                if blank_value == "exclude":
-                    query_parts.append(f"{attr} IS NOT NULL")
-                query_parts.extend(range_parts)
-
-            query_parts = []
-            state_in_values = raw_query_values("stateIn", state_in)
-            state_not_in_values = raw_query_values("stateNotIn", state_not_in)
-            repo_in_values = raw_query_values("repoIn", repo_in)
-            repo_not_in_values = raw_query_values("repoNotIn", repo_not_in)
-            target_runtime_in_values = raw_query_values("targetRuntimeIn", target_runtime_in)
-            target_runtime_not_in_values = raw_query_values("targetRuntimeNotIn", target_runtime_not_in)
-            target_skill_in_values = raw_query_values("targetSkillIn", target_skill_in)
-            target_skill_not_in_values = raw_query_values("targetSkillNotIn", target_skill_not_in)
-            validate_non_contradictory("stateIn", state_in_values, "stateNotIn", state_not_in_values)
-            validate_non_contradictory("repoIn", repo_in_values, "repoNotIn", repo_not_in_values)
-            validate_non_contradictory(
-                "targetRuntimeIn",
-                target_runtime_in_values,
-                "targetRuntimeNotIn",
-                target_runtime_not_in_values,
-            )
-            validate_non_contradictory(
-                "targetSkillIn",
-                target_skill_in_values,
-                "targetSkillNotIn",
-                target_skill_not_in_values,
-            )
-            temporal_scope = _normalize_temporal_list_scope(
-                scope,
+            count_query, list_query = _build_temporal_execution_query(
+                request=request,
                 workflow_type=workflow_type,
+                state=state,
+                state_in=state_in,
+                state_not_in=state_not_in,
                 entry=entry,
+                repo=repo,
+                repo_exact=repo_exact,
+                repo_in=repo_in,
+                repo_not_in=repo_not_in,
+                integration=integration,
+                target_runtime=target_runtime,
+                target_runtime_in=target_runtime_in,
+                target_runtime_not_in=target_runtime_not_in,
+                target_skill_in=target_skill_in,
+                target_skill_not_in=target_skill_not_in,
+                scheduled_from=scheduled_from,
+                scheduled_to=scheduled_to,
+                scheduled_blank=scheduled_blank,
+                created_from=created_from,
+                created_to=created_to,
+                finished_from=finished_from,
+                finished_to=finished_to,
+                finished_blank=finished_blank,
+                scope=scope,
+                owner_type=effective_owner_type,
+                owner_id=effective_owner,
+                sort=sort,
+                sort_dir=sort_dir,
+                include_order=True,
             )
-            scope_query = _TEMPORAL_SCOPE_QUERIES[temporal_scope]
-            if scope_query:
-                query_parts.append(scope_query)
-            if workflow_type and not _is_task_list_workflow_type(workflow_type):
-                logger.info(
-                    "Ignoring workflowType=%s for ordinary task-list temporal query",
-                    workflow_type,
-                )
-            elif workflow_type and not scope_query:
-                query_parts.append(f'WorkflowType="{escape_val(workflow_type)}"')
-            if state and not (state_in_values or state_not_in_values):
-                query_parts.append(f'mm_state="{escape_val(state)}"')
-            append_exact_or_multi_filter(
-                "mm_state",
-                include=state_in_values,
-                exclude=state_not_in_values,
-            )
-            if entry and not _is_task_list_entry(entry):
-                logger.info(
-                    "Ignoring entry=%s for ordinary task-list temporal query",
-                    entry,
-                )
-            elif entry and not scope_query:
-                query_parts.append(f'mm_entry="{escape_val(entry)}"')
-            if effective_owner_type:
-                query_parts.append(
-                    f'mm_owner_type="{escape_val(effective_owner_type)}"'
-                )
-            if effective_owner:
-                query_parts.append(f'mm_owner_id="{escape_val(effective_owner)}"')
-            append_exact_or_multi_filter(
-                "mm_repo",
-                exact=repo_exact or repo,
-                include=repo_in_values,
-                exclude=repo_not_in_values,
-            )
-            if integration:
-                query_parts.append(f'mm_integration="{escape_val(integration)}"')
-            append_exact_or_multi_filter(
-                "mm_target_runtime",
-                exact=target_runtime,
-                include=target_runtime_in_values,
-                exclude=target_runtime_not_in_values,
-            )
-            append_exact_or_multi_filter(
-                "mm_target_skill",
-                include=target_skill_in_values,
-                exclude=target_skill_not_in_values,
-            )
-            append_datetime_filter("mm_scheduled_for", scheduled_from, scheduled_to, scheduled_blank)
-            append_datetime_filter("StartTime", created_from, created_to)
-            append_datetime_filter("CloseTime", finished_from, finished_to, finished_blank)
-
-            query_str = " AND ".join(query_parts) if query_parts else ""
 
             import base64
             token_bytes = base64.b64decode(next_page_token) if next_page_token else None
 
-            count_info = await client.count_workflows(query=query_str)
+            count_info = await client.count_workflows(query=count_query)
 
             iterator = client.list_workflows(
-                query=query_str,
+                query=list_query,
                 page_size=page_size,
                 next_page_token=token_bytes,
             )
@@ -4564,6 +4899,223 @@ async def list_executions(
             default=None,
         ),
     )
+
+@router.get("/facets", response_model=ExecutionFacetResponse)
+async def list_execution_facets(
+    *,
+    request: Request,
+    facet: Literal[
+        "status",
+        "targetRuntime",
+        "targetSkill",
+        "repository",
+        "integration",
+    ] = Query(..., alias="facet"),
+    workflow_type: Optional[str] = Query(None, alias="workflowType"),
+    owner_type: Optional[str] = Query(None, alias="ownerType"),
+    state: Optional[str] = Query(None, alias="state"),
+    state_in: Optional[str] = Query(None, alias="stateIn"),
+    state_not_in: Optional[str] = Query(None, alias="stateNotIn"),
+    owner_id: Optional[str] = Query(None, alias="ownerId"),
+    entry: Optional[str] = Query(None, alias="entry"),
+    repo: Optional[str] = Query(None, alias="repo"),
+    repo_exact: Optional[str] = Query(None, alias="repoExact"),
+    repo_in: Optional[str] = Query(None, alias="repoIn"),
+    repo_not_in: Optional[str] = Query(None, alias="repoNotIn"),
+    integration: Optional[str] = Query(None, alias="integration"),
+    target_runtime: Optional[str] = Query(None, alias="targetRuntime"),
+    target_runtime_in: Optional[str] = Query(None, alias="targetRuntimeIn"),
+    target_runtime_not_in: Optional[str] = Query(None, alias="targetRuntimeNotIn"),
+    target_skill_in: Optional[str] = Query(None, alias="targetSkillIn"),
+    target_skill_not_in: Optional[str] = Query(None, alias="targetSkillNotIn"),
+    scheduled_from: Optional[str] = Query(None, alias="scheduledFrom"),
+    scheduled_to: Optional[str] = Query(None, alias="scheduledTo"),
+    scheduled_blank: Optional[str] = Query(None, alias="scheduledBlank"),
+    created_from: Optional[str] = Query(None, alias="createdFrom"),
+    created_to: Optional[str] = Query(None, alias="createdTo"),
+    finished_from: Optional[str] = Query(None, alias="finishedFrom"),
+    finished_to: Optional[str] = Query(None, alias="finishedTo"),
+    finished_blank: Optional[str] = Query(None, alias="finishedBlank"),
+    scope: Optional[str] = Query(None, alias="scope"),
+    search: Optional[str] = Query(None, alias="search"),
+    page_size: int = Query(50, alias="pageSize", ge=1, le=_EXECUTION_FACET_PAGE_SIZE_LIMIT),
+    next_page_token: Optional[str] = Query(None, alias="nextPageToken"),
+    source: Optional[str] = Query(None),
+    user: User = Depends(get_current_user()),
+    temporal_client: Client = Depends(get_temporal_client),
+) -> ExecutionFacetResponse:
+    if source not in {None, _TEMPORAL_SOURCE}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_execution_query",
+                "message": "facets currently support source=temporal only.",
+            },
+        )
+    if _is_execution_admin(user):
+        effective_owner_type = owner_type
+        effective_owner = owner_id
+    else:
+        normalized_owner_type = str(owner_type or "").strip().lower()
+        if owner_type is not None and owner_type != "user":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "execution_forbidden",
+                    "message": "Cannot list non-user executions.",
+                },
+            )
+        if owner_id is not None and owner_id != _owner_id(user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "execution_forbidden",
+                    "message": "Cannot list executions for another user.",
+                },
+            )
+        effective_owner = _owner_id(user)
+        effective_owner_type = "user" if normalized_owner_type == "user" else None
+
+    try:
+        facet_attr = _EXECUTION_FACET_ATTRS.get(facet)
+        if facet_attr is None:
+            raise TemporalExecutionValidationError(
+                "facet must be one of: " + ", ".join(sorted(_EXECUTION_FACET_ATTRS)) + "."
+            )
+        search_value = _normalize_text_filter(search, alias="search")
+        base_query, _ = _build_temporal_execution_query(
+            request=request,
+            workflow_type=workflow_type,
+            state=state,
+            state_in=state_in,
+            state_not_in=state_not_in,
+            entry=entry,
+            repo=repo,
+            repo_exact=repo_exact,
+            repo_in=repo_in,
+            repo_not_in=repo_not_in,
+            integration=integration,
+            target_runtime=target_runtime,
+            target_runtime_in=target_runtime_in,
+            target_runtime_not_in=target_runtime_not_in,
+            target_skill_in=target_skill_in,
+            target_skill_not_in=target_skill_not_in,
+            scheduled_from=scheduled_from,
+            scheduled_to=scheduled_to,
+            scheduled_blank=scheduled_blank,
+            created_from=created_from,
+            created_to=created_to,
+            finished_from=finished_from,
+            finished_to=finished_to,
+            finished_blank=finished_blank,
+            scope=scope,
+            owner_type=effective_owner_type,
+            owner_id=effective_owner,
+            exclude_aliases=_EXECUTION_FACET_FILTER_ALIASES.get(facet, frozenset()),
+        )
+        client = temporal_client
+
+        if facet == "status":
+            values = [
+                value
+                for value in _TEMPORAL_STATUS_VALUES
+                if not search_value or search_value.lower() in value.lower()
+            ][:page_size]
+            items = []
+            for value in values:
+                count_info = await client.count_workflows(
+                    query=_and_temporal_query(
+                        base_query,
+                        f'{facet_attr}="{_escape_temporal_value(value)}"',
+                    )
+                )
+                items.append(
+                    ExecutionFacetItemModel(
+                        value=value,
+                        label=_facet_label(facet, value),
+                        count=count_info.count,
+                    )
+                )
+            return ExecutionFacetResponse(
+                facet=facet,
+                items=items,
+                blankCount=None,
+                truncated=len(_TEMPORAL_STATUS_VALUES) > page_size,
+                nextPageToken=None,
+                countMode="exact",
+                source="authoritative",
+            )
+
+        import base64
+
+        token_bytes = base64.b64decode(next_page_token) if next_page_token else None
+        iterator = client.list_workflows(
+            query=base_query,
+            page_size=page_size,
+            next_page_token=token_bytes,
+        )
+        await iterator.fetch_next_page()
+
+        seen: set[str] = set()
+        values: list[str] = []
+        for workflow in iterator.current_page or []:
+            value = (await _facet_value_from_workflow(workflow, facet)).strip()
+            if not value or value in seen:
+                continue
+            if search_value and search_value.lower() not in value.lower():
+                continue
+            seen.add(value)
+            values.append(value)
+
+        items = []
+        for value in values[:page_size]:
+            count_info = await client.count_workflows(
+                query=_and_temporal_query(
+                    base_query,
+                    f'{facet_attr}="{_escape_temporal_value(value)}"',
+                )
+            )
+            items.append(
+                ExecutionFacetItemModel(
+                    value=value,
+                    label=_facet_label(facet, value),
+                    count=count_info.count,
+                )
+            )
+        blank_info = await client.count_workflows(
+            query=_and_temporal_query(base_query, f"{facet_attr} IS NULL")
+        )
+        next_token = (
+            base64.b64encode(iterator.next_page_token).decode("utf-8")
+            if iterator.next_page_token
+            else None
+        )
+        return ExecutionFacetResponse(
+            facet=facet,
+            items=items,
+            blankCount=blank_info.count,
+            truncated=bool(iterator.next_page_token),
+            nextPageToken=next_token,
+            countMode="exact",
+            source="authoritative",
+        )
+    except TemporalExecutionValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_execution_query",
+                "message": str(exc),
+            },
+        ) from exc
+    except RPCError as exc:
+        logger.warning("Failed to list Temporal execution facets: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "temporal_unavailable",
+                "message": "Temporal service unavailable.",
+            },
+        ) from exc
 
 @router.get("/{workflow_id}/steps", response_model=StepLedgerSnapshotModel)
 async def describe_execution_steps(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
 import logging
 import os
@@ -713,6 +715,40 @@ def _build_temporal_execution_query(
 
 def _and_temporal_query(base_query: str, clause: str) -> str:
     return f"{base_query} AND {clause}" if base_query else clause
+
+
+def _decode_execution_facet_page_token(next_page_token: str | None) -> bytes | None:
+    if not next_page_token:
+        return None
+    try:
+        return base64.b64decode(next_page_token, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise TemporalExecutionValidationError(
+            "nextPageToken must be a valid base64 token."
+        ) from exc
+
+
+def _decode_execution_status_facet_offset(next_page_token: str | None) -> int:
+    token_bytes = _decode_execution_facet_page_token(next_page_token)
+    if token_bytes is None:
+        return 0
+    try:
+        offset = int(token_bytes.decode("ascii"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise TemporalExecutionValidationError(
+            "nextPageToken must be a valid status facet page token."
+        ) from exc
+    if offset < 0:
+        raise TemporalExecutionValidationError(
+            "nextPageToken must be a valid status facet page token."
+        )
+    return offset
+
+
+def _encode_execution_status_facet_offset(offset: int | None) -> str | None:
+    if offset is None:
+        return None
+    return base64.b64encode(str(offset).encode("ascii")).decode("utf-8")
 
 
 def _facet_label(facet: str, value: str) -> str:
@@ -5016,11 +5052,19 @@ async def list_execution_facets(
         client = temporal_client
 
         if facet == "status":
-            values = [
+            matching_values = [
                 value
                 for value in _TEMPORAL_STATUS_VALUES
                 if not search_value or search_value.lower() in value.lower()
-            ][:page_size]
+            ]
+            status_offset = _decode_execution_status_facet_offset(next_page_token)
+            values = matching_values[status_offset : status_offset + page_size]
+            next_status_offset = status_offset + page_size
+            status_next_page_token = (
+                _encode_execution_status_facet_offset(next_status_offset)
+                if next_status_offset < len(matching_values)
+                else None
+            )
             items = []
             for value in values:
                 count_info = await client.count_workflows(
@@ -5040,15 +5084,13 @@ async def list_execution_facets(
                 facet=facet,
                 items=items,
                 blankCount=None,
-                truncated=len(_TEMPORAL_STATUS_VALUES) > page_size,
-                nextPageToken=None,
+                truncated=status_next_page_token is not None,
+                nextPageToken=status_next_page_token,
                 countMode="exact",
                 source="authoritative",
             )
 
-        import base64
-
-        token_bytes = base64.b64decode(next_page_token) if next_page_token else None
+        token_bytes = _decode_execution_facet_page_token(next_page_token)
         iterator = client.list_workflows(
             query=base_query,
             page_size=page_size,

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": 4376768789,
+    "id": 4377068969,
     "disposition": "not-applicable",
-    "rationale": "Quota warning is an external automation status message and does not request a code change."
+    "rationale": "Quota warning from Gemini bot; no repository action required."
   },
   {
-    "id": 3186247357,
+    "id": 3186528575,
     "disposition": "addressed",
-    "rationale": "Frontend filter validation now recomputes after user filter edits, with regression coverage for clearing an initially contradictory URL."
+    "rationale": "Added base64 validation for facet nextPageToken so malformed dynamic facet tokens return structured invalid_execution_query 422 responses."
   },
   {
-    "id": 3186247359,
+    "id": 3186528579,
     "disposition": "addressed",
-    "rationale": "Backend canonical filter values are normalized before legacy state suppression, with regression coverage for state=completed plus empty stateIn."
+    "rationale": "Added real offset pagination for static status facets using the filtered canonical status list and nextPageToken."
   },
   {
-    "id": 4225517449,
+    "id": 4225851317,
     "disposition": "not-applicable",
-    "rationale": "Review summary container; actionable child review comments are classified separately."
+    "rationale": "Automated review summary wrapper; actionable child review comments are tracked separately."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -36,6 +36,11 @@ describe('Tasks List Entrypoint', () => {
     } as Response);
   });
 
+  const executionListCalls = () =>
+    fetchSpy.mock.calls.filter(([url]) => String(url).startsWith('/api/executions?'));
+
+  const lastExecutionListUrl = () => executionListCalls().at(-1)?.[0];
+
   it('announces the current sort state on table headers', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
@@ -234,7 +239,7 @@ describe('Tasks List Entrypoint', () => {
   });
 
   it('shows a clear validation error for contradictory canonical URL filters', async () => {
-    const baselineCalls = fetchSpy.mock.calls.length;
+    const baselineCalls = executionListCalls().length;
     window.history.pushState(
       {},
       'Contradictory filters',
@@ -245,11 +250,11 @@ describe('Tasks List Entrypoint', () => {
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
     expect(screen.getByText('Cannot combine targetRuntimeIn and targetRuntimeNotIn.')).toBeTruthy();
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
   });
 
   it('recovers from contradictory canonical URL filters after filters are cleared', async () => {
-    const baselineCalls = fetchSpy.mock.calls.length;
+    const baselineCalls = executionListCalls().length;
     window.history.pushState(
       {},
       'Recover contradictory filters',
@@ -259,15 +264,15 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+      expect(executionListCalls().length).toBe(baselineCalls + 1);
     });
     expect(screen.queryByText('Cannot combine stateIn and stateNotIn.')).toBeNull();
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+    expect(lastExecutionListUrl()).toBe(
       '/api/executions?source=temporal&pageSize=50&scope=tasks',
     );
     expect(window.location.search).toBe('?limit=50');
@@ -445,20 +450,20 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    const baselineCalls = fetchSpy.mock.calls.length;
+    const baselineCalls = executionListCalls().length;
 
     fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
     fireEvent.change(screen.getByLabelText('Repository filter value'), {
       target: { value: 'owner/repo' },
     });
 
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
     fireEvent.click(screen.getByRole('button', { name: 'Apply Repository filter' }));
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+      expect(executionListCalls().length).toBe(baselineCalls + 1);
     });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+    expect(lastExecutionListUrl()).toBe(
       '/api/executions?source=temporal&pageSize=50&scope=tasks&repoExact=owner%2Frepo',
     );
     await screen.findAllByText('Example task');
@@ -472,7 +477,7 @@ describe('Tasks List Entrypoint', () => {
     await waitFor(() => {
       expect(repositoryInput.value).toBe('owner/repo ');
     });
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+    expect(executionListCalls().length).toBe(baselineCalls + 1);
   }, 10_000);
 
   it('labels the lifecycle column filter as status and exposes canonical status options', async () => {
@@ -502,15 +507,15 @@ describe('Tasks List Entrypoint', () => {
     expect(options).toContain('completed');
     expect(options).not.toContain('succeeded');
 
-    const baselineCalls = fetchSpy.mock.calls.length;
+    const baselineCalls = executionListCalls().length;
     fireEvent.change(statusFilter, { target: { value: 'completed' } });
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
     fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+      expect(executionListCalls().length).toBe(baselineCalls + 1);
     });
-    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+    expect(lastExecutionListUrl()).toBe(
       '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed',
     );
   });
@@ -519,26 +524,26 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    const baselineCalls = fetchSpy.mock.calls.length;
+    const baselineCalls = executionListCalls().length;
 
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'completed' } });
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
     fireEvent.click(screen.getByRole('button', { name: 'Cancel Status filter' }));
     expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
 
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'failed' } });
     fireEvent.keyDown(screen.getByRole('dialog', { name: 'Status filter' }), { key: 'Escape' });
     expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
 
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'planning' } });
     fireEvent.mouseDown(document.body);
     expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
-    expect(fetchSpy.mock.calls.length).toBe(baselineCalls);
+    expect(executionListCalls().length).toBe(baselineCalls);
   });
 
   it('applies status exclude semantics and removes only the selected chip', async () => {
@@ -632,6 +637,47 @@ describe('Tasks List Entrypoint', () => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('finishedBlank=include');
     });
     expect(screen.getByRole('button', { name: 'Finished filter: blank' })).toBeTruthy();
+  });
+
+  it('shows a current-page values notice when facet values fail to load', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/executions/facets')) {
+        return Promise.resolve({
+          ok: false,
+          statusText: 'Service Unavailable',
+          json: async () => ({ detail: { code: 'temporal_unavailable' } }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              taskId: 'task-123',
+              source: 'temporal',
+              title: 'Example task',
+              status: 'completed',
+              state: 'completed',
+              rawState: 'completed',
+              repository: 'owner/repo',
+              createdAt: '2026-03-28T00:00:00Z',
+            },
+          ],
+        }),
+      } as Response);
+    });
+
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+
+    expect(
+      (await screen.findAllByText('Facet values unavailable. Showing current page values only.')).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole('option', { name: 'owner/repo' })).toBeTruthy();
+    expect(screen.getAllByText('Example task').length).toBeGreaterThan(0);
   });
 
   it('renders pagination as arrow buttons beside the table summary', async () => {
@@ -761,7 +807,7 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Repository filter: owner/repo' }));
     expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cli',
       );
     });

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -124,6 +124,24 @@ const ExecutionListResponseSchema = z.object({
 
 type ExecutionRow = z.infer<typeof ExecutionRowSchema>;
 
+const ExecutionFacetResponseSchema = z.object({
+  facet: z.enum(['status', 'targetRuntime', 'targetSkill', 'repository', 'integration']),
+  items: z.array(
+    z.object({
+      value: z.string(),
+      label: z.string(),
+      count: z.number(),
+    }),
+  ),
+  blankCount: z.number().nullable().optional(),
+  countMode: z.string().optional(),
+  truncated: z.boolean().optional(),
+  nextPageToken: z.string().nullable().optional(),
+  source: z.string().optional(),
+});
+
+type ExecutionFacetResponse = z.infer<typeof ExecutionFacetResponseSchema>;
+
 function readListDashboardConfig(payload: BootPayload): ListDashboardConfig | undefined {
   const raw = payload.initialData as { dashboardConfig?: ListDashboardConfig } | undefined;
   return raw?.dashboardConfig;
@@ -359,6 +377,14 @@ function appendFilterParams(params: URLSearchParams, filters: ColumnFilters) {
   appendDateParams(params, filters.closedAt, 'finishedFrom', 'finishedTo', 'finishedBlank');
 }
 
+function facetForFilterField(field: FilterField | null): ExecutionFacetResponse['facet'] | null {
+  if (field === 'status') return 'status';
+  if (field === 'targetRuntime') return 'targetRuntime';
+  if (field === 'targetSkill') return 'targetSkill';
+  if (field === 'repository') return 'repository';
+  return null;
+}
+
 function filterSummary(field: FilterField, filters: ColumnFilters): string {
   const summarizeValues = (filter: ValueFilter, formatter = (value: string) => value) => {
     if (filter.blank === 'include' && filter.values.length === 0) return 'blank';
@@ -471,6 +497,31 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       return ExecutionListResponseSchema.parse(await response.json());
     },
     refetchInterval: liveUpdates && listEnabled ? listPollMs : false,
+  });
+
+  const openFacet = facetForFilterField(openFilter);
+  const {
+    data: facetData,
+    isError: isFacetError,
+    isFetching: isFacetFetching,
+  } = useQuery({
+    queryKey: ['tasks-list-facet', openFacet, filters] as const,
+    enabled: listEnabled && filterValidationErrors.length === 0 && Boolean(openFacet),
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set('source', 'temporal');
+      params.set('facet', openFacet as string);
+      params.set('pageSize', '50');
+      params.set('scope', 'tasks');
+      appendFilterParams(params, filters);
+      const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch facets: ${response.statusText}`);
+      }
+      return ExecutionFacetResponseSchema.parse(await response.json());
+    },
+    staleTime: listPollMs,
+    retry: false,
   });
 
   useEffect(() => {
@@ -661,11 +712,16 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   };
 
   const valueOptionsForField = (field: FilterField): string[] => {
-    if (field === 'status') return [...TEMPORAL_STATUSES];
+    const facetValues =
+      facetData && facetForFilterField(field) === facetData.facet
+        ? facetData.items.map((item) => item.value)
+        : [];
+    if (field === 'status') return uniqueValues([...facetValues, ...TEMPORAL_STATUSES]);
     if (field === 'targetRuntime') {
       return uniqueValues([
         ...filters.targetRuntime.values,
         ...draftFilters.targetRuntime.values,
+        ...facetValues,
         ...RUNTIME_FILTER_OPTIONS,
       ]);
     }
@@ -673,6 +729,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       return uniqueValues([
         ...filters.targetSkill.values,
         ...draftFilters.targetSkill.values,
+        ...facetValues,
         ...(data?.items || []).flatMap((row) => [row.targetSkill, ...(row.taskSkills || [])]),
       ]);
     }
@@ -680,10 +737,29 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       return uniqueValues([
         ...filters.repository.values,
         ...draftFilters.repository.values,
+        ...facetValues,
         ...(data?.items || []).map((row) => row.repository),
       ]);
     }
     return [];
+  };
+
+  const renderFacetNotice = (field: FilterField) => {
+    if (facetForFilterField(field) !== openFacet) return null;
+    if (isFacetError) {
+      return (
+        <p className="small task-list-facet-notice" role="status">
+          Facet values unavailable. Showing current page values only.
+        </p>
+      );
+    }
+    if (isFacetFetching) {
+      return <p className="small task-list-facet-notice">Loading facet values...</p>;
+    }
+    if (facetData?.truncated) {
+      return <p className="small task-list-facet-notice">Facet values truncated by the server.</p>;
+    }
+    return null;
   };
 
   const renderFilterControl = (field: FilterField, labelPrefix = '') => {
@@ -728,50 +804,57 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               Exclude canceled
             </label>
           ) : null}
+          {renderFacetNotice('status')}
         </div>
       );
     }
 
     if (field === 'repository') {
       return (
-        <label className="queue-inline-filter task-list-header-filter-control">
-          {labelPrefix}Repository filter value
-          <input
-            type="text"
-            value={isMobile ? filters.repository.exactText || '' : draftFilters.repository.exactText || ''}
-            disabled={!listEnabled}
-            placeholder="owner/repo"
-            onChange={(event) => {
-              if (isMobile) applyMobileRepository(event.target.value);
-              else updateDraftRepository(event.target.value);
-            }}
-          />
-          {!isMobile && valueOptionsForField('repository').length > 0 ? (
-            <select
-              aria-label="Repository value selection"
-              value={draftFilters.repository.values[0] || ''}
+        <div className="queue-inline-filter task-list-header-filter-control">
+          <label>
+            {labelPrefix}Repository filter value
+            <input
+              type="text"
+              value={isMobile ? filters.repository.exactText || '' : draftFilters.repository.exactText || ''}
               disabled={!listEnabled}
+              placeholder="owner/repo"
               onChange={(event) => {
-                setDraftFilters((current) => ({
-                  ...current,
-                  repository: {
-                    ...current.repository,
-                    mode: 'include',
-                    values: event.target.value ? [event.target.value] : [],
-                    exactText: event.target.value ? '' : current.repository.exactText || '',
-                  },
-                }));
+                if (isMobile) applyMobileRepository(event.target.value);
+                else updateDraftRepository(event.target.value);
               }}
-            >
-              <option value="">Repository values</option>
-              {valueOptionsForField('repository').map((repo) => (
-                <option key={repo} value={repo}>
-                  {repo}
-                </option>
-              ))}
-            </select>
+            />
+          </label>
+          {!isMobile && valueOptionsForField('repository').length > 0 ? (
+            <label>
+              Repository values
+              <select
+                aria-label="Repository value selection"
+                value={draftFilters.repository.values[0] || ''}
+                disabled={!listEnabled}
+                onChange={(event) => {
+                  setDraftFilters((current) => ({
+                    ...current,
+                    repository: {
+                      ...current.repository,
+                      mode: 'include',
+                      values: event.target.value ? [event.target.value] : [],
+                      exactText: event.target.value ? '' : current.repository.exactText || '',
+                    },
+                  }));
+                }}
+              >
+                <option value="">Repository values</option>
+                {valueOptionsForField('repository').map((repo) => (
+                  <option key={repo} value={repo}>
+                    {repo}
+                  </option>
+                ))}
+              </select>
+            </label>
           ) : null}
-        </label>
+          {renderFacetNotice('repository')}
+        </div>
       );
     }
 
@@ -813,6 +896,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               ))}
             </select>
           </label>
+          {renderFacetNotice('targetRuntime')}
         </div>
       );
     }
@@ -863,6 +947,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               ))}
             </select>
           </label>
+          {renderFacetNotice('targetSkill')}
         </div>
       );
     }

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1263,6 +1263,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/facets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Execution Facets */
+        get: operations["list_execution_facets_api_executions_facets_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions/{workflow_id}/steps": {
         parameters: {
             query?: never;
@@ -3841,6 +3858,52 @@ export interface components {
             closeStatus?: string | null;
             /** Workflowtype */
             workflowType?: string | null;
+        };
+        /**
+         * ExecutionFacetItemModel
+         * @description One value bucket returned by an execution list facet query.
+         */
+        ExecutionFacetItemModel: {
+            /** Value */
+            value: string;
+            /** Label */
+            label: string;
+            /** Count */
+            count: number;
+        };
+        /**
+         * ExecutionFacetResponse
+         * @description Facet values and counts for execution list column filters.
+         */
+        ExecutionFacetResponse: {
+            /**
+             * Facet
+             * @enum {string}
+             */
+            facet: "status" | "targetRuntime" | "targetSkill" | "repository" | "integration";
+            /** Items */
+            items?: components["schemas"]["ExecutionFacetItemModel"][];
+            /** Blankcount */
+            blankCount?: number | null;
+            /**
+             * Countmode
+             * @default exact
+             * @enum {string}
+             */
+            countMode: "exact" | "estimated_or_unknown";
+            /**
+             * Truncated
+             * @default false
+             */
+            truncated: boolean;
+            /** Nextpagetoken */
+            nextPageToken?: string | null;
+            /**
+             * Source
+             * @default authoritative
+             * @enum {string}
+             */
+            source: "authoritative" | "current_page_fallback";
         };
         /**
          * ExecutionInterventionAuditEntryModel
@@ -9946,6 +10009,8 @@ export interface operations {
                 finishedTo?: string | null;
                 finishedBlank?: string | null;
                 scope?: string | null;
+                sort?: string | null;
+                sortDir?: string | null;
                 pageSize?: number;
                 nextPageToken?: string | null;
                 source?: string | null;
@@ -9998,6 +10063,67 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionModel"] | components["schemas"]["ScheduleCreatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_execution_facets_api_executions_facets_get: {
+        parameters: {
+            query: {
+                facet: "status" | "targetRuntime" | "targetSkill" | "repository" | "integration";
+                workflowType?: string | null;
+                ownerType?: string | null;
+                state?: string | null;
+                stateIn?: string | null;
+                stateNotIn?: string | null;
+                ownerId?: string | null;
+                entry?: string | null;
+                repo?: string | null;
+                repoExact?: string | null;
+                repoIn?: string | null;
+                repoNotIn?: string | null;
+                integration?: string | null;
+                targetRuntime?: string | null;
+                targetRuntimeIn?: string | null;
+                targetRuntimeNotIn?: string | null;
+                targetSkillIn?: string | null;
+                targetSkillNotIn?: string | null;
+                scheduledFrom?: string | null;
+                scheduledTo?: string | null;
+                scheduledBlank?: string | null;
+                createdFrom?: string | null;
+                createdTo?: string | null;
+                finishedFrom?: string | null;
+                finishedTo?: string | null;
+                finishedBlank?: string | null;
+                scope?: string | null;
+                search?: string | null;
+                pageSize?: number;
+                nextPageToken?: string | null;
+                source?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionFacetResponse"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1198,3 +1198,35 @@ class ExecutionListResponse(BaseModel):
     stale_state: bool = Field(False, alias="staleState")
     degraded_count: bool = Field(False, alias="degradedCount")
     refreshed_at: datetime | None = Field(None, alias="refreshedAt")
+
+class ExecutionFacetItemModel(BaseModel):
+    """One value bucket returned by an execution list facet query."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    value: str = Field(..., alias="value")
+    label: str = Field(..., alias="label")
+    count: int = Field(..., alias="count")
+
+class ExecutionFacetResponse(BaseModel):
+    """Facet values and counts for execution list column filters."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    facet: Literal[
+        "status",
+        "targetRuntime",
+        "targetSkill",
+        "repository",
+        "integration",
+    ] = Field(..., alias="facet")
+    items: list[ExecutionFacetItemModel] = Field(default_factory=list, alias="items")
+    blank_count: int | None = Field(None, alias="blankCount")
+    count_mode: Literal["exact", "estimated_or_unknown"] = Field(
+        "exact", alias="countMode"
+    )
+    truncated: bool = Field(False, alias="truncated")
+    next_page_token: Optional[str] = Field(None, alias="nextPageToken")
+    source: Literal["authoritative", "current_page_fallback"] = Field(
+        "authoritative", alias="source"
+    )

--- a/specs/303-executions-list-facets/checklists/requirements.md
+++ b/specs/303-executions-list-facets/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Executions List and Facet API Support for Column Filters
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The preserved Jira preset brief names `/tasks/list` and source sections because those are source traceability inputs. The generated user story keeps implementation details out of stakeholder-facing requirements except where the feature is explicitly an external request/response contract.

--- a/specs/303-executions-list-facets/contracts/executions-list-facets.md
+++ b/specs/303-executions-list-facets/contracts/executions-list-facets.md
@@ -1,0 +1,79 @@
+# Contract: Executions List and Facets
+
+## List Request
+
+`GET /api/executions?source=temporal&pageSize=<n>&scope=tasks&sort=<field>&sortDir=<asc|desc>`
+
+Supported canonical filter parameters:
+- `stateIn`, `stateNotIn`
+- `targetRuntimeIn`, `targetRuntimeNotIn`
+- `targetSkillIn`, `targetSkillNotIn`
+- `repoIn`, `repoNotIn`, `repoExact`, `repoContains`
+- `taskId`, `taskIdContains`, `titleContains`
+- `scheduledFrom`, `scheduledTo`, `scheduledBlank`
+- `createdFrom`, `createdTo`
+- `finishedFrom`, `finishedTo`, `finishedBlank`
+
+Response shape extends the existing execution list response:
+
+```json
+{
+  "items": [],
+  "nextPageToken": null,
+  "count": 0,
+  "countMode": "exact",
+  "uiQueryModel": "compatibility_adapter",
+  "staleState": false,
+  "degradedCount": false,
+  "refreshedAt": "2026-05-05T00:00:00Z"
+}
+```
+
+Validation failures return HTTP 422:
+
+```json
+{
+  "detail": {
+    "code": "invalid_execution_query",
+    "message": "Cannot combine stateIn and stateNotIn."
+  }
+}
+```
+
+## Facet Request
+
+`GET /api/executions/facets?source=temporal&facet=targetRuntime&pageSize=50&stateIn=executing,completed`
+
+Supported facets:
+- `status`
+- `targetRuntime`
+- `targetSkill`
+- `repository`
+- `integration`
+
+The facet request accepts the same active filter parameters as the list request. The requested facet's own filter is excluded from the facet universe by default; all other filters remain active.
+
+Response:
+
+```json
+{
+  "facet": "targetRuntime",
+  "items": [
+    { "value": "codex_cli", "label": "Codex CLI", "count": 18 }
+  ],
+  "blankCount": 2,
+  "countMode": "exact",
+  "truncated": false,
+  "nextPageToken": null,
+  "source": "authoritative"
+}
+```
+
+Validation failures return HTTP 422 with `invalid_execution_query` and a safe message. Temporal outages return HTTP 503 with `temporal_unavailable`.
+
+## Security Requirements
+
+- Normal list and facet queries are always task-run scoped for non-admin users.
+- Non-admin users cannot request another owner or non-user owner type.
+- Facet values and counts are derived from the same authorization-constrained universe as rows.
+- Values are treated as text and never trusted HTML by the client.

--- a/specs/303-executions-list-facets/data-model.md
+++ b/specs/303-executions-list-facets/data-model.md
@@ -1,0 +1,73 @@
+# Data Model: Executions List and Facet API Support for Column Filters
+
+## Execution List Query
+
+Represents task-list request state.
+
+Fields:
+- `source`: existing execution source selector; this story targets Temporal-backed list behavior.
+- `pageSize`: bounded page size, preserving existing limits.
+- `nextPageToken`: opaque pagination cursor.
+- `sort`: supported canonical task field.
+- `sortDir`: `asc` or `desc`.
+- `stateIn` / `stateNotIn`: canonical lifecycle state filters.
+- `targetRuntimeIn` / `targetRuntimeNotIn`: raw runtime identifier filters.
+- `targetSkillIn` / `targetSkillNotIn`: raw skill identifier filters.
+- `repoIn` / `repoNotIn` / `repoExact` / `repoContains`: repository filters.
+- `taskId` / `taskIdContains` / `titleContains`: text filters.
+- `scheduledFrom` / `scheduledTo` / `createdFrom` / `createdTo` / `finishedFrom` / `finishedTo`: date range filters.
+- `scheduledBlank` / `finishedBlank`: blank/null filters for meaningful nullable date fields.
+
+Validation:
+- Include and exclude filters for the same field cannot both be present.
+- Text filters are trimmed for query behavior and bounded by configured constants.
+- Value-list filters are deduplicated and bounded.
+- Date range bounds must be parseable and not reversed.
+- Sort fields and directions must be from the supported set.
+
+## Execution List Result
+
+Existing paginated response for authorized task rows.
+
+Fields:
+- `items`: serialized execution rows.
+- `nextPageToken`: opaque cursor for the next page.
+- `count`: filtered result count when available.
+- `countMode`: count confidence.
+- `uiQueryModel`, `staleState`, `degradedCount`, `refreshedAt`: existing metadata.
+
+## Facet Query
+
+Represents a request for one facet field under the current filter context.
+
+Fields:
+- `source`: execution source selector; this story targets Temporal.
+- `facet`: one supported facet field, such as status, runtime, skill, repository, or integration.
+- `search`: optional bounded text search for facet values.
+- `pageSize`: bounded number of facet values.
+- `nextPageToken`: optional facet pagination cursor.
+- Active list filters: same canonical filters as Execution List Query.
+
+Rules:
+- The requested facet's own filter is excluded by default from the query used to discover values.
+- All other active filters remain in scope.
+- Task and owner authorization constraints always remain in scope.
+
+## Facet Result
+
+Fields:
+- `facet`: requested facet field.
+- `items`: list of `{ value, label, count }` entries.
+- `blankCount`: count for blank values when meaningful.
+- `countMode`: count confidence.
+- `truncated`: whether more values may exist beyond this response.
+- `nextPageToken`: optional cursor for more facet values.
+- `source`: `authoritative` or `current_page_fallback` where exposed to the client.
+
+## Filter Validation Error
+
+Structured HTTP 422 detail for invalid filter input.
+
+Fields:
+- `code`: stable error code, expected to be `invalid_execution_query` for this route family.
+- `message`: safe, operator-readable validation message.

--- a/specs/303-executions-list-facets/moonspec_align_report.md
+++ b/specs/303-executions-list-facets/moonspec_align_report.md
@@ -1,0 +1,33 @@
+# MoonSpec Alignment Report: Executions List and Facet API Support for Column Filters
+
+**Feature**: specs/303-executions-list-facets
+**Source**: MM-590 canonical Jira preset brief preserved in spec.md
+**Date**: 2026-05-05
+
+## Verdict
+
+PASS. The artifacts describe exactly one runtime story, preserve the original MM-590 Jira preset brief, and align source design mappings across spec.md, plan.md, research.md, data-model.md, contracts, quickstart, and tasks.md.
+
+## Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Original input preserved | PASS | spec.md Input contains the canonical MM-590 orchestration input and Jira brief. |
+| One story only | PASS | spec.md defines one `## User Story - Server-Authoritative Column Filter Data`. |
+| Source design coverage | PASS | DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, and DESIGN-REQ-025 map to FR rows and tasks. |
+| Plan status coverage | PASS | plan.md Requirement Status covers FR-001 through FR-008, SC-001 through SC-007, and source requirements. |
+| Contract coverage | PASS | contracts/executions-list-facets.md defines list and facet request/response/error/security contracts. |
+| TDD task order | PASS | tasks.md places unit and contract/frontend tests before implementation tasks T015-T018. |
+| Unit and integration coverage | PASS | tasks.md includes backend unit, API contract, frontend unit, targeted commands, full unit verification, and final MoonSpec verify. |
+| Constitution alignment | PASS | plan.md records PASS for all constitution gates with no complexity exceptions. |
+
+## Key Decisions
+
+- Treat `MM-590` as a single runtime story because the Jira brief scopes one independently testable API/facet data slice for Tasks List column filters.
+- Keep the full Google Sheets-style popover implementation out of scope; this story only requires authoritative API/facet data and visible current-page fallback when facets fail.
+- Reuse the existing `/api/executions` boundary and add `/api/executions/facets` rather than creating a separate task-list service.
+
+## Remaining Risks
+
+- Temporal visibility query capabilities may constrain contains/text matching; implementation must validate this with tests and fail structurally rather than emitting raw query failures.
+- Full hermetic integration tests may require Docker availability in the managed runtime.

--- a/specs/303-executions-list-facets/moonspec_align_report.md
+++ b/specs/303-executions-list-facets/moonspec_align_report.md
@@ -31,3 +31,9 @@ PASS. The artifacts describe exactly one runtime story, preserve the original MM
 
 - Temporal visibility query capabilities may constrain contains/text matching; implementation must validate this with tests and fail structurally rather than emitting raw query failures.
 - Full hermetic integration tests may require Docker availability in the managed runtime.
+
+## Validation
+
+- `scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: unavailable in this checkout; active feature was resolved from `.specify/feature.json`.
+- Direct artifact check: PASS. `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/executions-list-facets.md`, `quickstart.md`, `tasks.md`, and `checklists/requirements.md` were re-read for source preservation, one-story scope, requirement coverage, task order, test strategy, and unresolved placeholders.
+- Coverage scan: PASS. FR-001 through FR-008, SC-001 through SC-007, DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, and DESIGN-REQ-025 remain mapped through plan and tasks.

--- a/specs/303-executions-list-facets/plan.md
+++ b/specs/303-executions-list-facets/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Executions List and Facet API Support for Column Filters
+
+**Branch**: `303-executions-list-facets` | **Date**: 2026-05-05 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/303-executions-list-facets/spec.md`
+
+## Summary
+
+Implement the `MM-590` task-list backend contract by extending the existing Temporal-backed executions list route with bounded canonical filter parsing, server-side sort parameters, additional text/value filters, and a new facet request surface. The existing Tasks List client already sends several canonical filter params and falls safe to task scope, but it currently derives popover values from the loaded page and has no authoritative facet/error/fallback state. Unit tests will cover filter validation and query construction; integration/contract tests will cover list/facet request behavior and Tasks List client fallback behavior.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `api_service/api/routers/executions.py` builds Temporal queries for state/repo/runtime/skill/date but ignores `sort`/`sortDir` and lacks ID/title/repo text filters | add bounded sort parsing and missing supported filter params | unit + contract |
+| FR-002 | partial | include/exclude helpers exist for some fields; blank handling exists for scheduled/finished only | add text filters, repeated/comma value handling bounds, date validation, and blank validation | unit + contract |
+| FR-003 | partial | `ExecutionListResponse` returns `count`, `countMode`, and `nextPageToken`; sorting is current-page custom ordering rather than request-controlled | preserve count metadata and add sort query support without breaking pagination tokens | unit + contract |
+| FR-004 | missing | no `/api/executions/facets` route or facet response model found | add facet models and Temporal-backed facet route for status/runtime/skill/repository/integration with counts and blank count | unit + contract |
+| FR-005 | partial | `frontend/src/entrypoints/tasks-list.tsx` uses current-page values but does not call facets or show authoritative/fallback notice | add facet fetch path and visible fallback/error notice inside filter controls | frontend unit |
+| FR-006 | partial | task scope and owner enforcement are tested in `tests/unit/api/test_executions_temporal.py`; no facet boundary exists | reuse task-scope/owner query for facets and test system value exclusion | unit + contract |
+| FR-007 | partial | contradictory include/exclude validation exists for four pairs only | add structured validation for unsupported facets/sorts, invalid blank modes, oversize lists/text, and invalid date ranges | unit + contract |
+| FR-008 | implemented_unverified | `spec.md` preserves `MM-590` and source mappings | keep traceability in artifacts, tasks, verification, and commit/PR metadata | final verify |
+| SC-001 | partial | existing list tests cover some filters, not multi-filter plus sort | add test for multi-filter sorted query | contract |
+| SC-002 | implemented_unverified | existing list pagination tests cover tokens and count | add coverage that filtered/sorted requests keep count and token behavior | contract |
+| SC-003 | missing | no facet route | add facet test with values beyond current page via mocked Temporal page/count calls | contract |
+| SC-004 | missing | no facet route | add test that requested facet filter is excluded while other filters remain | unit + contract |
+| SC-005 | partial | validation errors exist for unknown scope and contradictory pairs | expand validation tests | unit |
+| SC-006 | partial | owner/task-scope tests exist for list | add facet authorization/scope test | unit + contract |
+| SC-007 | implemented_unverified | spec artifacts preserve Jira traceability | final verification | verify |
+| DESIGN-REQ-006 | partial | list route partially supports current request and count | complete list sort/filter validation | unit + contract |
+| DESIGN-REQ-019 | missing | no facet request surface | add facet contract and UI fallback notice | unit + contract + frontend |
+| DESIGN-REQ-020 | partial | canonical params exist for state/repo/runtime/skill but validation is incomplete | complete canonical raw-value validation and contradictory rejection | unit + contract |
+| DESIGN-REQ-025 | partial | list owner/task scope exists; facet path missing | ensure facets use same scoping and structured errors | unit + contract |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Tasks List client behavior  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async session fixtures, Temporal Python SDK client surface, React, TanStack Query, Zod, Vitest, Testing Library  
+**Storage**: Existing Temporal visibility/search attributes and canonical execution projection rows; no new persistent storage  
+**Unit Testing**: `./tools/test_unit.sh` with targeted pytest and Vitest during iteration  
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration suite; contract tests under `tests/contract/` provide API-boundary evidence  
+**Target Platform**: MoonMind FastAPI service and Mission Control Tasks List frontend  
+**Project Type**: Web service plus React frontend  
+**Performance Goals**: Bound list/facet request values and text lengths; avoid unbounded facet scans; preserve existing page-size limits  
+**Constraints**: Browser calls only MoonMind APIs; normal Tasks List remains task-run scoped; no direct Temporal or provider calls from browser; no raw query syntax exposed to users  
+**Scale/Scope**: One independently testable Tasks List list/facet API story for `MM-590`
+
+## Constitution Check
+
+| Principle | Gate | Status |
+| --- | --- | --- |
+| I Orchestrate, Don't Recreate | Extend MoonMind API boundaries without replacing Temporal or agent behavior | PASS |
+| II One-Click Agent Deployment | No new mandatory external dependency or storage | PASS |
+| III Avoid Vendor Lock-In | Temporal-specific query behavior stays behind the existing executions API boundary | PASS |
+| IV Own Your Data | Uses existing operator-controlled Temporal/projection data | PASS |
+| V Skills First-Class | No skill runtime changes | PASS |
+| VI Scientific Method | TDD tasks and final verification required | PASS |
+| VII Runtime Configurability | Reuses request parameters and existing config; no hardcoded deployment secrets | PASS |
+| VIII Modular Architecture | Changes remain in executions router/schema and Tasks List client boundary | PASS |
+| IX Resilient by Default | Structured validation and bounded inputs prevent raw backend failures | PASS |
+| X Continuous Improvement | Run ends with structured MoonSpec verification outcome | PASS |
+| XI Spec-Driven Development | This plan follows `spec.md` and creates tests before implementation | PASS |
+| XII Canonical Docs Desired State | No canonical docs changes planned; rollout stays in `specs/303-*` | PASS |
+| XIII Delete, Don't Deprecate | No compatibility shims beyond current explicit URL/filter compatibility | PASS |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/303-executions-list-facets/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── executions-list-facets.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/api/routers/executions.py
+moonmind/schemas/temporal_models.py
+frontend/src/entrypoints/tasks-list.tsx
+
+tests/unit/api/test_executions_temporal.py
+tests/contract/test_temporal_execution_api.py
+frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+**Structure Decision**: Use the existing FastAPI executions router and Temporal schema models for the backend API contract, and the existing Tasks List React entrypoint for client-facing fallback/error behavior. No new service package or persistence layer is needed.
+
+## Complexity Tracking
+
+No constitution violations require complexity exceptions.

--- a/specs/303-executions-list-facets/quickstart.md
+++ b/specs/303-executions-list-facets/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart: Executions List and Facet API Support for Column Filters
+
+## Targeted Unit Tests
+
+```bash
+./tools/test_unit.sh tests/unit/api/test_executions_temporal.py
+```
+
+Focused frontend iteration after dependencies are prepared:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+## Contract / Integration Evidence
+
+```bash
+./tools/test_unit.sh tests/contract/test_temporal_execution_api.py
+```
+
+Full final unit suite:
+
+```bash
+./tools/test_unit.sh
+```
+
+Hermetic integration suite when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Scenario Checks
+
+1. Request `/api/executions?source=temporal&scope=tasks&stateIn=executing,completed&targetRuntimeIn=codex_cli&sort=createdAt&sortDir=desc` and verify the generated query remains task-run and owner scoped.
+2. Request `/api/executions?source=temporal&stateIn=executing&stateNotIn=failed` and verify HTTP 422 with `invalid_execution_query`.
+3. Request `/api/executions/facets?source=temporal&facet=targetRuntime&stateIn=executing&targetRuntimeIn=codex_cli` and verify the target runtime filter is excluded from the facet universe while state and authorization constraints remain.
+4. Simulate facet API failure in the Tasks List test harness and verify the filter control shows a current-page-values fallback notice while the table remains usable.
+5. Confirm `MM-590` and DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-025 are preserved in verification evidence.

--- a/specs/303-executions-list-facets/research.md
+++ b/specs/303-executions-list-facets/research.md
@@ -1,0 +1,65 @@
+# Research: Executions List and Facet API Support for Column Filters
+
+## FR-001 / DESIGN-REQ-006: Server-Authoritative List Sorting And Filters
+
+Decision: Partial existing implementation; extend the current Temporal-backed `/api/executions` list route.
+Evidence: `api_service/api/routers/executions.py` already accepts canonical state/repo/runtime/skill/date params and builds Temporal visibility queries; it does not accept `sort`, `sortDir`, ID/title text filters, or repo contains filters.
+Rationale: The existing route is the product API the Tasks List already calls, so extending it keeps the browser on MoonMind APIs and avoids a second list contract.
+Alternatives considered: New list endpoint was rejected because the existing `/api/executions` response and frontend are already wired and tested.
+Test implications: Unit tests for query validation and contract tests for request/response behavior.
+
+## FR-002 / DESIGN-REQ-020: Canonical Include/Exclude/Text/Date/Blank Semantics
+
+Decision: Add shared bounded parsing helpers inside the executions router before query construction.
+Evidence: Current helper functions are nested inside `list_executions`, cover only some pairs, and do not enforce text length or value-list limits.
+Rationale: Router-local helpers keep validation close to the route until there is another consumer; they can be reused by the new facet route in the same module.
+Alternatives considered: A new standalone parser module was rejected for this story because only one router needs it and the blast radius would be larger.
+Test implications: Unit tests for contradictory pairs, oversize lists, invalid blank mode, invalid date range, unsupported sort/facet, and structured errors.
+
+## FR-003: Count And Pagination Metadata
+
+Decision: Preserve the existing Temporal `count_workflows` + `list_workflows` behavior and ensure new filters/sorts feed both count and list query construction.
+Evidence: `ExecutionListResponse` already includes `count`, `countMode`, `nextPageToken`, `degradedCount`, and `refreshedAt`.
+Rationale: Count and pagination are already established response fields; this story should not create new storage or count semantics.
+Alternatives considered: Estimating counts client-side was rejected because the source design requires full filtered result metadata when available.
+Test implications: Contract tests should assert filtered requests call both count and list with the same task-scoped query.
+
+## FR-004 / DESIGN-REQ-019: Facet Request Surface
+
+Decision: Add `GET /api/executions/facets` returning a Pydantic facet response model and deriving facet counts through trusted server-side Temporal queries.
+Evidence: No existing `/api/executions/facets` route or facet schema was found.
+Rationale: Facets are a public API boundary for the Tasks List; returning values, counts, blank count, count mode, truncation, and next token matches the source design while keeping the browser away from Temporal.
+Alternatives considered: Frontend-only current-page values were rejected because they do not satisfy counts beyond the current page.
+Test implications: Contract tests for dynamic facet values, status facet counts, filter-exclusion behavior, and task-scope authorization.
+
+## FR-005: Client Fallback Notice
+
+Decision: Keep current-page value fallback but expose it as a visible notice when authoritative facets fail or are unavailable.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` currently derives repository and skill options from `data.items` without a user-visible fallback notice.
+Rationale: This delivers the acceptance criterion without requiring the full future popover design in this backend-focused story.
+Alternatives considered: Building the complete Google Sheets-style filter popover was rejected as out of scope for MM-590.
+Test implications: Vitest coverage for facet fetch failure and visible current-page-values notice.
+
+## FR-006 / DESIGN-REQ-025: Authorization And System Values
+
+Decision: Reuse the same task-scope and owner enforcement for facets that list requests use.
+Evidence: Existing tests verify non-admin users are constrained to `WorkflowType="MoonMind.Run" AND mm_entry="run" AND mm_owner_id="user-123"` and system/all scopes fail safe for list.
+Rationale: Facets must not become a side channel for unauthorized values or counts.
+Alternatives considered: Client-side filtering of facet values was rejected because authorization must be a backend decision.
+Test implications: Unit/contract tests inspect generated facet queries for task scope and owner scope.
+
+## FR-007: Structured Validation
+
+Decision: Raise `TemporalExecutionValidationError` and convert it to existing `invalid_execution_query` 422 responses for list and facets.
+Evidence: The list route already maps `TemporalExecutionValidationError` to structured HTTP 422 details.
+Rationale: Reusing the established error code avoids a new error envelope while preventing raw backend query failures.
+Alternatives considered: Allowing Temporal RPC failures to surface was rejected by source security requirements.
+Test implications: Unit tests assert status code and error code/message for invalid inputs.
+
+## FR-008 / SC-007: Traceability
+
+Decision: Preserve `MM-590` and source design IDs in all MoonSpec artifacts and final reports.
+Evidence: `spec.md` already preserves the canonical Jira brief and source coverage IDs.
+Rationale: Verification and PR metadata need a stable trace back to the Jira story.
+Alternatives considered: None.
+Test implications: Final MoonSpec verification checks artifact traceability.

--- a/specs/303-executions-list-facets/spec.md
+++ b/specs/303-executions-list-facets/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Executions List and Facet API Support for Column Filters
+
+**Feature Branch**: `303-executions-list-facets`
+**Created**: 2026-05-05
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-590 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-590 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-590
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Executions list and facet API support for column filters
+- Labels: moonmind-workflow-mm-af73ac39-5c56-460e-bd77-712adac541f3
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Implement Jira issue MM-590: Executions list and facet API support for column filters.
+
+As the Tasks List UI, I need server-authoritative list and facet APIs for multi-column filtering so results, counts, pagination, and popover values reflect the authorized task universe beyond the current page.
+
+## Source Reference
+
+- Jira issue: MM-590
+- Issue type: Story
+- Summary: Executions list and facet API support for column filters
+- Status: In Progress
+- Source document: docs/UI/TasksListPage.md
+- Source title: Tasks List Page
+- Source sections:
+  - 5.4 Current API request
+  - 13. API and data requirements for column filtering
+  - 18. Security and privacy
+- Coverage IDs:
+  - DESIGN-REQ-006
+  - DESIGN-REQ-019
+  - DESIGN-REQ-020
+  - DESIGN-REQ-025
+
+## Acceptance Criteria
+
+- List results are sorted and filtered by the server for supported canonical fields.
+- Pagination remains deterministic under active filters.
+- Count and countMode describe the fully filtered result when available.
+- Facet requests include all active filters except the requested facet by default.
+- Static facets such as Status can use frontend enums plus server counts, while dynamic facets come from server data.
+- Facet failure does not break the table and can fall back to current-page values with a visible notice.
+- System-only values and unauthorized values never appear in list rows, facets, or counts for `/tasks/list`.
+
+## Requirements
+
+- Use raw canonical values rather than display labels for API filters.
+- Reject contradictory filters clearly.
+- Bound text lengths and value-list sizes.
+
+## Traceability Requirement
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve Jira issue key MM-590 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Server-Authoritative Column Filter Data
+
+**Summary**: As the Tasks List UI, I want server-authoritative list and facet data for task column filters so operators see accurate results, counts, pagination, and popover values across the authorized task universe rather than only the current page.
+
+**Goal**: Operators can apply supported column filters to the Tasks List and receive stable task rows, counts, pagination behavior, and facet values that are scoped to their authorized task executions.
+
+**Independent Test**: Can be fully tested by calling the task execution list and facet request surfaces with sort, include, exclude, text, date, blank, and contradictory filter combinations, then verifying returned rows, counts, pagination tokens, facet values, fallback behavior, and authorization boundaries.
+
+**Acceptance Scenarios**:
+
+1. **Given** task executions with different canonical field values, **When** a list request includes supported column filters and sort options, **Then** results are filtered and sorted by the server using raw canonical values rather than display labels.
+2. **Given** active filters and multiple result pages, **When** the list request is paginated, **Then** pagination remains deterministic and `count` plus `countMode` describe the fully filtered result when that count is available.
+3. **Given** an operator opens a filter popover for a facet, **When** the facet request is made, **Then** it applies all active filters except the requested facet by default and returns scoped facet values with counts beyond the current page where available.
+4. **Given** static and dynamic facet fields, **When** facet data is requested, **Then** static status facets can use the canonical status set with server counts while dynamic facets are derived from authorized server data.
+5. **Given** a facet request fails or cannot produce authoritative values, **When** the Tasks List uses fallback values from the current page, **Then** the table remains usable and exposes that fallback state to the user.
+6. **Given** filters reference system-only or unauthorized values, **When** list or facet requests are evaluated, **Then** unauthorized rows, values, and counts are never returned for the normal Tasks List.
+7. **Given** contradictory filters, unsupported values, overlong text, or excessive value lists, **When** the request is validated, **Then** the system returns a clear structured validation error without leaking raw backend query failures.
+
+### Edge Cases
+
+- Include and exclude filters for the same field are submitted together.
+- Text filters contain leading or trailing whitespace, empty strings, or values over the configured length limit.
+- Value-list filters contain duplicates, unknown values, comma-containing values, or more values than the request limit allows.
+- Date range filters have only one bound, reversed bounds, blank inclusion, or invalid date formats.
+- Facet requests are made for a field that is not facet-capable.
+- Active filters match no rows on the first page or on a later page.
+- System workflow scopes, workflow types, entries, or system-only facet values are attempted through normal task-list filters.
+
+## Assumptions
+
+- This story covers backend task-list and facet support plus minimal UI error/fallback integration needed for the existing Tasks List to consume those responses; the full column popover interaction model remains covered by separate UI stories.
+- The normal Tasks List remains bounded to user-visible task executions even if lower-level execution services can query broader workflow scopes.
+- Exact count may be unavailable for some backend sources, but the response must communicate count confidence through `countMode`.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-006** *(docs/UI/TasksListPage.md sections 5.4 and 13.1)*: The list request must support server-side filtering, sorting, deterministic pagination, and filtered count metadata for the normal task list. Scope: in scope. Mapped to FR-001, FR-002, FR-003.
+- **DESIGN-REQ-019** *(docs/UI/TasksListPage.md section 13.2)*: Facet requests must return scoped values and counts beyond the current page, applying all active filters except the requested facet by default. Scope: in scope. Mapped to FR-004, FR-005, FR-006.
+- **DESIGN-REQ-020** *(docs/UI/TasksListPage.md sections 12.2, 13.1, 13.2)*: API and URL-facing filter values must use raw canonical values, support include/exclude semantics, and reject contradictory filters clearly. Scope: in scope. Mapped to FR-002, FR-007.
+- **DESIGN-REQ-025** *(docs/UI/TasksListPage.md section 18)*: List and facet behavior must preserve security and privacy by scoping values to authorization, bounding untrusted input, rejecting invalid requests with structured errors, and rendering labels as text. Scope: in scope. Mapped to FR-006, FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST apply server-authoritative sorting and filtering for supported normal task-list canonical fields without relying on display labels for query behavior.
+- **FR-002**: The system MUST support multi-value include filters, multi-value exclude filters, text filters, date range filters, and meaningful blank/null filters with AND semantics across columns and OR semantics within a column.
+- **FR-003**: The system MUST keep pagination deterministic under active filters and return `count` plus `countMode` metadata that describes the fully filtered result when a count is available.
+- **FR-004**: The system MUST provide a facet request surface that returns authorized facet values, labels, counts when available, blank counts when meaningful, truncation state, count confidence, and pagination state for facet-capable fields.
+- **FR-005**: The Tasks List client-facing behavior MUST tolerate facet failures by keeping the table usable and exposing a visible fallback or error state when values are limited to the current page.
+- **FR-006**: The system MUST prevent system-only or unauthorized task values from appearing in normal task-list rows, facets, or counts regardless of submitted filters.
+- **FR-007**: The system MUST reject contradictory filters, unsupported fields or values, overlong text filters, excessive value lists, and invalid date ranges with clear structured validation errors.
+- **FR-008**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-590` and this canonical Jira preset brief for traceability.
+
+### Key Entities
+
+- **Execution List Query**: The task-list request state, including source, page size, pagination token, sort field, sort direction, canonical field filters, text filters, date ranges, and blank/null options.
+- **Execution List Result**: A page of authorized task rows plus pagination token, filtered count, and count confidence metadata.
+- **Facet Query**: A request for one facet field with the active filter context excluding the requested facet unless explicitly scoped otherwise.
+- **Facet Result**: Facet field identity, authorized facet values with labels and counts, blank count when meaningful, count confidence, truncation state, and facet pagination token.
+- **Filter Validation Error**: A structured failure describing invalid, contradictory, or oversized filter input without exposing raw backend query internals.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A list request with at least two active column filters and a supported sort returns only matching authorized task rows in deterministic order across repeated calls.
+- **SC-002**: Paginated filtered list requests preserve stable page traversal and report count metadata for the same filtered universe rather than the current page only.
+- **SC-003**: A facet request for a dynamic field returns values and counts from the authorized filtered result universe beyond the current page when matching rows exist outside the loaded page.
+- **SC-004**: A facet request applies all active filters except the requested facet by default, so changing another filter changes the returned facet values and counts predictably.
+- **SC-005**: Invalid or contradictory filter requests return structured validation errors instead of unhandled backend exceptions or raw query failures.
+- **SC-006**: Attempts to reveal system-only or unauthorized values through list or facet filters return no unauthorized rows, values, or counts.
+- **SC-007**: Verification evidence preserves `MM-590`, the canonical Jira preset brief, and DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, and DESIGN-REQ-025 in MoonSpec artifacts.

--- a/specs/303-executions-list-facets/tasks.md
+++ b/specs/303-executions-list-facets/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Executions List and Facet API Support for Column Filters
+
+**Input**: Design documents from `/specs/303-executions-list-facets/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/executions-list-facets.md
+
+**Tests**: Unit tests and integration/contract tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around one story: server-authoritative task-list and facet API data for column filters.
+
+**Source Traceability**: MM-590, DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-025.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py`
+- Frontend unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
+- Contract tests: `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify the existing web-service/frontend test surfaces and feature artifacts.
+
+- [X] T001 Verify active MoonSpec artifacts for MM-590 exist in specs/303-executions-list-facets/spec.md, specs/303-executions-list-facets/plan.md, specs/303-executions-list-facets/research.md, specs/303-executions-list-facets/data-model.md, specs/303-executions-list-facets/contracts/executions-list-facets.md, and specs/303-executions-list-facets/quickstart.md (FR-008, SC-007)
+- [X] T002 Verify existing ignore/test setup covers Python, frontend, and generated artifacts in .gitignore, package-lock.json, pytest.ini, and frontend/vitest config before story edits
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared parsing and response contracts before route and UI behavior.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T003 Add failing unit coverage for canonical list/facet query parsing, bounds, contradictory filters, blank modes, date ranges, and sort/facet validation in tests/unit/api/test_executions_temporal.py (FR-002, FR-007, DESIGN-REQ-020, DESIGN-REQ-025)
+- [X] T004 Add failing schema coverage for execution facet response shape in tests/unit/api/test_executions_temporal.py (FR-004, DESIGN-REQ-019)
+- [X] T005 Implement shared bounded filter parsing helpers and facet response models in api_service/api/routers/executions.py and moonmind/schemas/temporal_models.py (FR-002, FR-004, FR-007)
+- [X] T006 Run `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py` and confirm foundational tests pass after T005
+
+**Checkpoint**: Query parsing and schema foundations are ready for list, facet, and UI work.
+
+---
+
+## Phase 3: Story - Server-Authoritative Column Filter Data
+
+**Summary**: As the Tasks List UI, I want server-authoritative list and facet data for task column filters so operators see accurate results, counts, pagination, and popover values across the authorized task universe.
+
+**Independent Test**: Call list and facet request surfaces with supported filters, sort, pagination, invalid combinations, and authorization-sensitive values; render the Tasks List with facet failure and confirm usable fallback behavior.
+
+**Traceability**: FR-001 through FR-008, SC-001 through SC-007, DESIGN-REQ-006, DESIGN-REQ-019, DESIGN-REQ-020, DESIGN-REQ-025
+
+**Test Plan**:
+
+- Unit: query parsing, structured validation, task-scope query construction, facet filter exclusion, response schema.
+- Integration/Contract: `/api/executions` and `/api/executions/facets` request/response behavior at FastAPI boundary.
+- Frontend: facet failure fallback notice and table usability.
+
+### Unit Tests (write first)
+
+- [X] T007 [P] Add failing unit test for list requests combining multiple filters and supported sort query construction in tests/unit/api/test_executions_temporal.py (FR-001, FR-003, SC-001, DESIGN-REQ-006)
+- [X] T008 [P] Add failing unit test for facet query excluding the requested facet filter while retaining other active filters and owner/task scope in tests/unit/api/test_executions_temporal.py (FR-004, FR-006, SC-004, DESIGN-REQ-019, DESIGN-REQ-025)
+- [X] T009 [P] Add failing unit test for system/all workflow values not appearing through facet task-scope queries in tests/unit/api/test_executions_temporal.py (FR-006, SC-006, DESIGN-REQ-025)
+- [X] T010 Run `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py` to confirm T007-T009 fail for the expected missing implementation
+
+### Integration / Contract Tests (write first)
+
+- [X] T011 [P] Add failing contract test for filtered/sorted paginated list response count and token behavior in tests/contract/test_temporal_execution_api.py (FR-001, FR-003, SC-001, SC-002, DESIGN-REQ-006)
+- [X] T012 [P] Add failing contract test for `/api/executions/facets` dynamic values, counts, blank counts, and filter-exclusion behavior in tests/contract/test_temporal_execution_api.py (FR-004, SC-003, SC-004, DESIGN-REQ-019)
+- [X] T013 [P] Add failing frontend test for facet fetch failure showing a current-page-values fallback notice while table rows remain usable in frontend/src/entrypoints/tasks-list.test.tsx (FR-005, DESIGN-REQ-019)
+- [X] T014 Run `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` to confirm T011-T013 fail for the expected missing implementation
+
+### Implementation
+
+- [X] T015 Implement list route support for bounded `sort`, `sortDir`, `taskId`, `taskIdContains`, `titleContains`, `repoContains`, validated value-list bounds, blank modes, and date ranges in api_service/api/routers/executions.py (FR-001, FR-002, FR-003, FR-007, DESIGN-REQ-006, DESIGN-REQ-020)
+- [X] T016 Implement `GET /api/executions/facets` in api_service/api/routers/executions.py using the same task-scope, owner-scope, active-filter parsing, count metadata, and structured validation as the list route (FR-004, FR-006, FR-007, DESIGN-REQ-019, DESIGN-REQ-025)
+- [X] T017 Implement execution facet Pydantic response models in moonmind/schemas/temporal_models.py and wire them into the router response model (FR-004, DESIGN-REQ-019)
+- [X] T018 Implement Tasks List facet fetch/fallback state and visible current-page-values notice in frontend/src/entrypoints/tasks-list.tsx (FR-005, DESIGN-REQ-019)
+- [X] T019 Run `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py`, `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`; fix failures until the story passes end-to-end (FR-001-FR-007, SC-001-SC-006)
+
+**Checkpoint**: The story is functional, covered by backend unit, API contract, and frontend unit tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T020 Review validation messages and UI copy for secret-safe, user-facing wording in api_service/api/routers/executions.py and frontend/src/entrypoints/tasks-list.tsx (FR-007, DESIGN-REQ-025)
+- [X] T021 Update specs/303-executions-list-facets/tasks.md task statuses and preserve MM-590 traceability in final verification notes (FR-008, SC-007)
+- [X] T022 Run `./tools/test_unit.sh` for full unit-suite verification, or record the exact blocker if the full suite cannot run in this managed environment
+- [X] T023 Run `/speckit.verify` equivalent read-only verification against specs/303-executions-list-facets/spec.md, plan.md, tasks.md, source mappings, and test evidence (FR-008, SC-007)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion and blocks story work.
+- Story (Phase 3): depends on Foundational completion.
+- Polish (Phase 4): depends on story tests passing.
+
+### Within The Story
+
+- T007-T009 unit tests and T011-T013 contract/frontend tests must be written before T015-T018 implementation.
+- T010 and T014 confirm red-first failures before production code tasks.
+- T015 and T016 share router code and must be sequenced carefully with T017 schema wiring.
+- T018 frontend work can begin after the facet response contract from T017 is known.
+- T019 validates the complete story before polish.
+
+### Parallel Opportunities
+
+- T007, T008, and T009 can be authored in parallel within the same test file only if coordinated to avoid overlapping edits.
+- T011, T012, and T013 touch different files and can be authored in parallel.
+- Backend schema work T017 can be prepared alongside router implementation T015/T016 if imports and response names are coordinated.
+
+---
+
+## Implementation Strategy
+
+1. Preserve the MM-590 source brief and confirm feature artifacts.
+2. Add failing backend validation/query tests and schema tests.
+3. Implement shared parser/model foundations.
+4. Add failing list, facet, and frontend fallback tests.
+5. Implement list filters/sort, facet route, response schema, and Tasks List fallback notice.
+6. Run targeted backend and frontend suites until green.
+7. Run full unit verification where feasible.
+8. Run final MoonSpec verification and record any remaining evidence gaps.
+
+---
+
+## Notes
+
+- This task list covers exactly one story.
+- Do not implement the complete future Google Sheets-like popover interaction beyond the visible fallback/error behavior required by MM-590.
+- Do not expose system workflow browsing through `/tasks/list` or `/api/executions/facets`.
+- Do not send display labels as canonical filter values.
+- Preserve `MM-590` in verification, commit, and PR metadata.

--- a/specs/303-executions-list-facets/verification.md
+++ b/specs/303-executions-list-facets/verification.md
@@ -1,0 +1,72 @@
+# MoonSpec Verification Report
+
+**Feature**: Executions List and Facet API Support for Column Filters  
+**Spec**: `/work/agent_jobs/mm:31403231-2302-46f3-8253-b217f59aa8b2/repo/specs/303-executions-list-facets/spec.md`  
+**Original Request Source**: `spec.md` Input preserving canonical Jira preset brief for `MM-590`  
+**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Confidence**: MEDIUM
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Backend unit/router | `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` | PASS | 144 passed; warnings were pre-existing AsyncMock warnings. |
+| Temporal API unit | `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py` | PASS | 14 passed. |
+| API contract | `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` | PASS | 8 passed. |
+| Tasks List frontend | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` | PASS | 30 passed. |
+| Full unit suite | `./tools/test_unit.sh` | PASS | 4338 Python tests passed, 1 xpassed, 16 subtests passed; frontend 19 files / 299 tests passed with 223 skipped. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | Blocked: no Docker socket at `/var/run/docker.sock` in this managed runtime. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `api_service/api/routers/executions.py`; `tests/unit/api/routers/test_executions.py` | VERIFIED | List route supports bounded sort and canonical/text filters with unit evidence. |
+| FR-002 | `api_service/api/routers/executions.py`; query validation tests | VERIFIED | Include/exclude, text, date, blank, and bounds validation are covered. |
+| FR-003 | `ExecutionListResponse`; list route count/list query split; existing pagination tests | VERIFIED | Count metadata and pagination behavior remain covered by unit/contract evidence. |
+| FR-004 | `ExecutionFacetResponse`; `/api/executions/facets`; facet tests | VERIFIED | Facet response includes values, counts, blankCount, countMode, truncation, next token, and source. |
+| FR-005 | `frontend/src/entrypoints/tasks-list.tsx`; `tasks-list.test.tsx` | VERIFIED | Facet failures keep table usable and show current-page-values fallback notice. |
+| FR-006 | facet/list task-scope and owner query tests | VERIFIED | Facets reuse normal task and owner scoping; system/all scope does not widen ordinary visibility. |
+| FR-007 | structured 422 tests | VERIFIED | Invalid combinations and bounds return `invalid_execution_query`. |
+| FR-008 | `spec.md`, `plan.md`, `tasks.md`, this report | VERIFIED | MM-590 and source mappings are preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| SC-001 | list sort/text filter query tests | VERIFIED | Server query construction is validated. |
+| SC-002 | existing pagination/count contract tests plus full unit suite | VERIFIED | No regression in count/token behavior. |
+| SC-003 | dynamic facet test | VERIFIED | Dynamic facet response values and counts are covered at API boundary. |
+| SC-004 | requested-facet exclusion test | VERIFIED | Facet query excludes its own filter and retains other filters. |
+| SC-005 | invalid filter tests | VERIFIED | Structured validation errors are covered. |
+| SC-006 | task/owner scoped facet tests | VERIFIED | Unauthorized/system values are constrained by backend query scope. |
+| SC-007 | MoonSpec artifact traceability | VERIFIED | MM-590 and DESIGN-REQ IDs are preserved. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-006 | list route/query tests | VERIFIED | List sorting/filter/count behavior is represented. |
+| DESIGN-REQ-019 | facet route/schema/frontend fallback tests | VERIFIED | Facet data and fallback behavior are represented. |
+| DESIGN-REQ-020 | canonical filter validation tests | VERIFIED | Raw-value and contradictory-filter behavior are covered. |
+| DESIGN-REQ-025 | task/owner scope and structured validation | VERIFIED | Security/privacy constraints are implemented at backend boundary. |
+| Constitution XI | MoonSpec artifacts under `specs/303-executions-list-facets/` | VERIFIED | Spec, plan, tasks, and verification exist. |
+| Constitution IX | bounded validation and structured errors | VERIFIED | Invalid inputs fail safely before raw backend errors. |
+
+## Original Request Alignment
+
+- PASS: The implementation uses the MM-590 Jira preset brief as the canonical MoonSpec input and implements runtime behavior for server-authoritative list and facet API support.
+- PASS: The issue key `MM-590` is preserved in spec artifacts and verification evidence.
+- PARTIAL: Required hermetic integration execution could not be completed in this managed runtime because Docker is unavailable.
+
+## Gaps
+
+- Hermetic integration verification remains blocked by missing Docker socket access in this managed job.
+
+## Remaining Work
+
+- Run `./tools/test_integration.sh` in an environment with Docker available.
+
+## Decision
+
+- Code and unit/contract/frontend evidence support the MM-590 story, but final MoonSpec completion should remain `ADDITIONAL_WORK_NEEDED` until hermetic integration verification runs successfully.

--- a/specs/303-executions-list-facets/verification.md
+++ b/specs/303-executions-list-facets/verification.md
@@ -70,3 +70,13 @@
 ## Decision
 
 - Code and unit/contract/frontend evidence support the MM-590 story, but final MoonSpec completion should remain `ADDITIONAL_WORK_NEEDED` until hermetic integration verification runs successfully.
+
+## Implement-Stage Recheck - 2026-05-05
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Temporal API unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_executions_temporal.py` | PASS | 14 Python tests passed; the wrapper also completed the configured frontend suite with 19 files / 299 tests passed and 223 skipped. |
+| API contract | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` | PASS | 8 Python tests passed; the wrapper also completed the configured frontend suite with 19 files / 299 tests passed and 223 skipped. |
+| Focused frontend via test runner | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` | FAIL | The Python full-unit phase failed before focused Vitest execution because repo-local `.agents/skills` PR resolver and fix-comments files are absent from the active skill projection. Failures are outside MM-590 task-list/facet files. |
+
+Current blocker: full-suite verification in this managed skill-projection workspace is blocked by missing repo-local skill files referenced by `tests/unit/test_batch_pr_resolver.py`, `tests/unit/test_pr_resolver_tools.py`, and `tests/unit/workflows/test_skills_resolver.py`. The active instructions require using `.agents/skills` as the resolved active snapshot and not discovering local-only skill sources, so this recheck does not restore or rewrite those skill files.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -803,6 +804,76 @@ def test_execution_status_facet_counts_static_status_values_with_task_scope() ->
     assert 'mm_entry="run"' in first_count_query
     assert "mm_owner_id=" in first_count_query
     assert body["truncated"] is True
+
+def test_execution_status_facet_supports_real_pagination() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=False)
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=1)),
+        list_workflows=Mock(),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        first_page = test_client.get(
+            "/api/executions/facets",
+            params={"source": "temporal", "facet": "status", "pageSize": 2},
+        )
+        second_page = test_client.get(
+            "/api/executions/facets",
+            params={
+                "source": "temporal",
+                "facet": "status",
+                "pageSize": 2,
+                "nextPageToken": first_page.json()["nextPageToken"],
+            },
+        )
+
+    assert first_page.status_code == 200
+    assert first_page.json()["nextPageToken"] == base64.b64encode(b"2").decode("utf-8")
+    assert second_page.status_code == 200
+    assert second_page.json()["items"] == [
+        {
+            "value": "waiting_on_dependencies",
+            "label": "Waiting On Dependencies",
+            "count": 1,
+        },
+        {"value": "planning", "label": "Planning", "count": 1},
+    ]
+    assert second_page.json()["nextPageToken"] == base64.b64encode(b"4").decode("utf-8")
+    temporal_client.list_workflows.assert_not_called()
+
+def test_execution_facets_reject_malformed_next_page_token() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=False)
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/facets",
+            params={
+                "source": "temporal",
+                "facet": "targetRuntime",
+                "nextPageToken": "not base64",
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "invalid_execution_query",
+        "message": "nextPageToken must be a valid base64 token.",
+    }
+    temporal_client.list_workflows.assert_not_called()
 
 def test_list_executions_rejects_non_admin_owner_type_override() -> None:
     app = FastAPI()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -635,6 +635,175 @@ def test_list_executions_temporal_query_includes_blank_date_filter_semantics() -
     assert '(mm_scheduled_for IS NULL OR (mm_scheduled_for>="2026-05-01T00:00:00Z"))' in query
     assert "CloseTime IS NULL" in query
 
+def test_list_executions_temporal_query_supports_sort_and_text_filters() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scope": "tasks",
+                "repoContains": "Moon",
+                "taskIdContains": "wf-",
+                "titleContains": "release",
+                "sort": "createdAt",
+                "sortDir": "asc",
+            },
+        )
+
+    assert response.status_code == 200
+    count_query = temporal_client.count_workflows.await_args.kwargs["query"]
+    list_query = temporal_client.list_workflows.call_args.kwargs["query"]
+    assert 'mm_repo LIKE "%Moon%"' in count_query
+    assert 'WorkflowId LIKE "%wf-%"' in count_query
+    assert 'mm_title LIKE "%release%"' in count_query
+    assert "ORDER BY" not in count_query
+    assert list_query.endswith("ORDER BY StartTime ASC")
+
+def test_list_executions_temporal_query_rejects_invalid_filter_bounds() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+    temporal_client = SimpleNamespace(count_workflows=AsyncMock(), list_workflows=Mock())
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        invalid_blank = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scheduledBlank": "maybe",
+            },
+        )
+        invalid_range = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "createdFrom": "2026-05-06",
+                "createdTo": "2026-05-01",
+            },
+        )
+        invalid_sort = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "sort": "workflowType"},
+        )
+
+    assert invalid_blank.status_code == 422
+    assert invalid_blank.json()["detail"]["code"] == "invalid_execution_query"
+    assert "include, exclude" in invalid_blank.json()["detail"]["message"]
+    assert invalid_range.status_code == 422
+    assert "createdFrom must be before or equal to createdTo" in invalid_range.json()["detail"]["message"]
+    assert invalid_sort.status_code == 422
+    assert "sort must be one of" in invalid_sort.json()["detail"]["message"]
+    temporal_client.count_workflows.assert_not_called()
+
+def test_execution_facets_exclude_requested_facet_filter_and_keep_task_scope() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=False)
+
+    async def _memo():
+        return {}
+
+    workflow = SimpleNamespace(
+        search_attributes={
+            "mm_target_runtime": ["claude_code"],
+            "mm_state": "executing",
+        },
+        memo=_memo,
+    )
+
+    class _WorkflowIterator:
+        current_page = [workflow]
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(
+            side_effect=[SimpleNamespace(count=7), SimpleNamespace(count=0)]
+        ),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/facets",
+            params={
+                "source": "temporal",
+                "facet": "targetRuntime",
+                "stateIn": "executing",
+                "targetRuntimeIn": "codex_cli",
+            },
+        )
+
+    assert response.status_code == 200
+    base_query = temporal_client.list_workflows.call_args.kwargs["query"]
+    assert 'WorkflowType="MoonMind.Run"' in base_query
+    assert 'mm_entry="run"' in base_query
+    assert "mm_owner_id=" in base_query
+    assert 'mm_state="executing"' in base_query
+    assert "mm_target_runtime" not in base_query
+    body = response.json()
+    assert body["facet"] == "targetRuntime"
+    assert body["items"] == [{"value": "claude_code", "label": "Claude Code", "count": 7}]
+    assert body["blankCount"] == 0
+    assert body["source"] == "authoritative"
+
+def test_execution_status_facet_counts_static_status_values_with_task_scope() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=False)
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=1)),
+        list_workflows=Mock(),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/facets",
+            params={"source": "temporal", "facet": "status", "pageSize": 2},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == [
+        {"value": "scheduled", "label": "Scheduled", "count": 1},
+        {"value": "initializing", "label": "Initializing", "count": 1},
+    ]
+    first_count_query = temporal_client.count_workflows.await_args_list[0].kwargs["query"]
+    assert 'WorkflowType="MoonMind.Run"' in first_count_query
+    assert 'mm_entry="run"' in first_count_query
+    assert "mm_owner_id=" in first_count_query
+    assert body["truncated"] is True
+
 def test_list_executions_rejects_non_admin_owner_type_override() -> None:
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
Run Jira Orchestrate for MM-590.

Source story: STORY-006.
Source summary: Executions list and facet API support for column filters.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.