### PR TITLE
MM-591 Mobile accessibility and live-update stability

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_743
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_744

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_742
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_743

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_740
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_741

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_741
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_742

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:31403231-2302-46f3-8253-b217f59aa8b2_616
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_739

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_739
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_740

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/303-executions-list-facets"
+  "feature_directory": "specs/304-mobile-accessibility-live-update-stability"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,8 @@ Key diagnostics:
 - N/A; no persistence or data-store changes. (301-shared-additive-shimmer)
 - TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route tests. + React, TanStack Query, Zod, Vitest, Testing Library, FastAPI, pytest, Temporal visibility query helpers. (301-column-filter-popovers)
 - No new persistent storage; filter state is URL/query state and component state only. (301-column-filter-popovers)
+- TypeScript/React for Mission Control UI; Python 3.12 remains present but is not part of this story + React, TanStack Query, Zod, Vitest, Testing Library, existing Mission Control CSS (304-mobile-accessibility-live-update-stability)
+- N/A; filter state is URL/query state and component state only (304-mobile-accessibility-live-update-stability)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,27 @@
 [
   {
-    "id": 4377068969,
-    "disposition": "not-applicable",
-    "rationale": "Quota warning from Gemini bot; no repository action required."
-  },
-  {
-    "id": 3186528575,
+    "id": 3186820408,
     "disposition": "addressed",
-    "rationale": "Added base64 validation for facet nextPageToken so malformed dynamic facet tokens return structured invalid_execution_query 422 responses."
+    "rationale": "Restricted dialog Enter-to-apply handling so Enter on popover action buttons is not intercepted, with a regression test for staged filters remaining unapplied from action-button keydown."
   },
   {
-    "id": 3186528579,
-    "disposition": "addressed",
-    "rationale": "Added real offset pagination for static status facets using the filtered canonical status list and nextPageToken."
-  },
-  {
-    "id": 4225851317,
+    "id": 4226183005,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary wrapper; actionable child review comments are tracked separately."
+    "rationale": "Automated review summary wrapper; no standalone code action beyond the linked review comments."
+  },
+  {
+    "id": 3186821781,
+    "disposition": "addressed",
+    "rationale": "Excluded button targets from the popover Enter key apply path and covered the accessibility behavior in Tasks List tests."
+  },
+  {
+    "id": 3186821798,
+    "disposition": "addressed",
+    "rationale": "Guarded closeFilter focus restoration behind a non-null field target and added a mobile regression test to prevent stale desktop trigger focus."
+  },
+  {
+    "id": 4226184254,
+    "disposition": "not-applicable",
+    "rationale": "Broad review summary; the concrete keyboard and focus findings from the summary were addressed in the linked line comments."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -599,6 +599,41 @@ describe('Tasks List Entrypoint', () => {
     });
   });
 
+  it('does not apply staged filters when Enter is pressed on popover action buttons', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const baselineCalls = executionListCalls().length;
+
+    fireEvent.click(screen.getByRole('button', { name: /Filter Title\. No filter applied\./i }));
+    fireEvent.change(await screen.findByLabelText('Title filter value'), { target: { value: 'Example' } });
+    const clearButton = screen.getByRole('button', { name: 'Clear' });
+    clearButton.focus();
+
+    fireEvent.keyDown(clearButton, { key: 'Enter' });
+
+    expect(executionListCalls().length).toBe(baselineCalls);
+    expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50&scope=tasks');
+    expect(screen.getByRole('dialog', { name: 'Title filter' })).toBeTruthy();
+  });
+
+  it('keeps mobile filter focus from jumping to a stale desktop trigger', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const desktopStatusFilter = screen.getByRole('button', {
+      name: /Filter Status\. No filter applied\./i,
+    });
+    fireEvent.click(desktopStatusFilter);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Status filter' }));
+
+    const mobileStatusFilter = screen.getByLabelText('Mobile Status filter value') as HTMLSelectElement;
+    mobileStatusFilter.focus();
+    fireEvent.change(mobileStatusFilter, { target: { value: 'completed' } });
+
+    expect(document.activeElement).toBe(mobileStatusFilter);
+  });
+
   it('applies status exclude semantics and removes only the selected chip', async () => {
     window.history.pushState({}, 'Paged', '/tasks/list?nextPageToken=stale-token');
     renderWithClient(<TasksListPage payload={mockPayload} />);

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -99,11 +99,16 @@ describe('Tasks List Entrypoint', () => {
 
     await screen.findAllByText('Example task');
 
+    expect(screen.getByLabelText('Mobile ID filter value')).toBeTruthy();
     expect(screen.getByLabelText('Mobile Skill filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Mobile Title filter value')).toBeTruthy();
     expect(screen.getByLabelText('Mobile Scheduled from')).toBeTruthy();
     expect(screen.getByLabelText('Mobile Created from')).toBeTruthy();
     expect(screen.getByLabelText('Mobile Finished blank values')).toBeTruthy();
 
+    fireEvent.change(screen.getByLabelText('Mobile ID filter value'), {
+      target: { value: 'task-123' },
+    });
     fireEvent.change(screen.getByLabelText('Mobile Status filter value'), {
       target: { value: 'completed' },
     });
@@ -113,10 +118,13 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.change(screen.getByLabelText('Mobile Runtime filter value'), {
       target: { value: 'codex_cloud' },
     });
+    fireEvent.change(screen.getByLabelText('Mobile Title filter value'), {
+      target: { value: 'Example' },
+    });
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cloud',
+        '/api/executions?source=temporal&pageSize=50&scope=tasks&taskIdContains=task-123&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cloud&titleContains=Example',
       );
     });
   });
@@ -560,6 +568,35 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.mouseDown(document.body);
     expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
     expect(executionListCalls().length).toBe(baselineCalls);
+  });
+
+  it('moves focus into column filter dialogs and applies staged text filters with Enter', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const titleFilterButton = screen.getByRole('button', {
+      name: /Filter Title\. No filter applied\./i,
+    });
+
+    fireEvent.click(titleFilterButton);
+
+    const titleInput = (await screen.findByLabelText('Title filter value')) as HTMLInputElement;
+    await waitFor(() => {
+      expect(document.activeElement).toBe(titleInput);
+    });
+
+    fireEvent.change(titleInput, { target: { value: 'Example' } });
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Title filter' }), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(lastExecutionListUrl()).toBe(
+        '/api/executions?source=temporal&pageSize=50&scope=tasks&titleContains=Example',
+      );
+      expect(screen.queryByRole('dialog', { name: 'Title filter' })).toBeNull();
+      expect(
+        screen.getByRole('button', { name: /Filter Title\. Filter active: Example\./i }),
+      ).toBeTruthy();
+    });
   });
 
   it('applies status exclude semantics and removes only the selected chip', async () => {

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -58,19 +58,23 @@ const TABLE_COLUMNS = [
 ] as const;
 type TableColumn = (typeof TABLE_COLUMNS)[number];
 type FilterField =
+  | 'taskId'
   | 'status'
   | 'repository'
   | 'targetRuntime'
   | 'targetSkill'
+  | 'title'
   | 'scheduledFor'
   | 'createdAt'
   | 'closedAt';
 const VALID_TABLE_SORT_FIELDS = new Set<string>([...TABLE_COLUMNS.map((column) => column[0]), 'integration']);
 const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
+  'taskId',
   'status',
   'repository',
   'targetRuntime',
   'targetSkill',
+  'title',
   'scheduledFor',
   'createdAt',
   'closedAt',
@@ -80,12 +84,15 @@ function isFilterField(field: string): field is FilterField {
 }
 type ValueFilter = { mode: 'include' | 'exclude'; values: string[]; blank?: 'include' | 'exclude' | '' };
 type RepositoryFilter = ValueFilter & { exactText?: string };
+type TextFilter = { contains?: string };
 type DateFilter = { from?: string; to?: string; blank?: 'include' | 'exclude' | '' };
 type ColumnFilters = {
+  taskId: TextFilter;
   status: ValueFilter;
   repository: RepositoryFilter;
   targetRuntime: ValueFilter;
   targetSkill: ValueFilter;
+  title: TextFilter;
   scheduledFor: DateFilter;
   createdAt: DateFilter;
   closedAt: DateFilter;
@@ -235,10 +242,12 @@ function emptyValueFilter(): ValueFilter {
 
 function emptyFilters(): ColumnFilters {
   return {
+    taskId: {},
     status: emptyValueFilter(),
     repository: { ...emptyValueFilter(), exactText: '' },
     targetRuntime: emptyValueFilter(),
     targetSkill: emptyValueFilter(),
+    title: {},
     scheduledFor: {},
     createdAt: {},
     closedAt: {},
@@ -298,6 +307,8 @@ function parseInitialFilters(params: URLSearchParams): ColumnFilters {
   } else {
     filters.repository = { mode: 'include', values: repoIn, exactText: repoExact, blank: '' };
   }
+  filters.taskId = { contains: params.get('taskIdContains') || params.get('taskId') || '' };
+  filters.title = { contains: params.get('titleContains') || '' };
 
   const runtimeIn = splitParam(params, 'targetRuntimeIn');
   const runtimeNotIn = splitParam(params, 'targetRuntimeNotIn');
@@ -365,6 +376,7 @@ function appendDateParams(
 }
 
 function appendFilterParams(params: URLSearchParams, filters: ColumnFilters) {
+  if (filters.taskId.contains?.trim()) params.set('taskIdContains', filters.taskId.contains.trim());
   appendValueParams(params, filters.status, 'stateIn', 'stateNotIn');
   if (filters.repository.exactText?.trim()) {
     params.set('repoExact', filters.repository.exactText.trim());
@@ -372,6 +384,7 @@ function appendFilterParams(params: URLSearchParams, filters: ColumnFilters) {
   appendValueParams(params, filters.repository, 'repoIn', 'repoNotIn', 'repoBlank');
   appendValueParams(params, filters.targetRuntime, 'targetRuntimeIn', 'targetRuntimeNotIn', 'targetRuntimeBlank');
   appendValueParams(params, filters.targetSkill, 'targetSkillIn', 'targetSkillNotIn', 'targetSkillBlank');
+  if (filters.title.contains?.trim()) params.set('titleContains', filters.title.contains.trim());
   appendDateParams(params, filters.scheduledFor, 'scheduledFrom', 'scheduledTo', 'scheduledBlank');
   appendDateParams(params, filters.createdAt, 'createdFrom', 'createdTo');
   appendDateParams(params, filters.closedAt, 'finishedFrom', 'finishedTo', 'finishedBlank');
@@ -394,6 +407,7 @@ function filterSummary(field: FilterField, filters: ColumnFilters): string {
     const suffix = filter.values.length > 1 ? ` +${filter.values.length - 1}` : '';
     return `${filter.mode === 'exclude' ? 'not ' : ''}${first}${suffix}`;
   };
+  if (field === 'taskId') return filters.taskId.contains?.trim() || '';
   if (field === 'status') return summarizeValues(filters.status, formatStatusLabel);
   if (field === 'targetRuntime') return summarizeValues(filters.targetRuntime, formatRuntimeLabel);
   if (field === 'targetSkill') return summarizeValues(filters.targetSkill);
@@ -401,6 +415,7 @@ function filterSummary(field: FilterField, filters: ColumnFilters): string {
     if (filters.repository.exactText?.trim()) return filters.repository.exactText.trim();
     return summarizeValues(filters.repository);
   }
+  if (field === 'title') return filters.title.contains?.trim() || '';
   const dateFilter = field === 'scheduledFor' ? filters.scheduledFor : field === 'createdAt' ? filters.createdAt : filters.closedAt;
   if (dateFilter.blank === 'include' && !dateFilter.from && !dateFilter.to) return 'blank';
   if (dateFilter.blank === 'exclude' && !dateFilter.from && !dateFilter.to) return 'not blank';
@@ -428,7 +443,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
   const [hasEditedFilters, setHasEditedFilters] = useState(false);
   const [openFilter, setOpenFilter] = useState<FilterField | null>(null);
+  const [pendingFocusField, setPendingFocusField] = useState<FilterField | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const [pageSize, setPageSize] = useState(() => parsePageSize(initial.get('limit')));
   const [listCursor, setListCursor] = useState<string | null>(() =>
     ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
@@ -496,7 +513,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       }
       return ExecutionListResponseSchema.parse(await response.json());
     },
-    refetchInterval: liveUpdates && listEnabled ? listPollMs : false,
+    refetchInterval: liveUpdates && listEnabled && !openFilter ? listPollMs : false,
   });
 
   const openFacet = facetForFilterField(openFilter);
@@ -529,6 +546,37 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     setDraftFilters(filters);
   }, [openFilter, filters]);
 
+  const closeFilter = useCallback((nextDraftFilters = filters, fieldToFocus = openFilter) => {
+    const fallback = fieldToFocus
+      ? document.querySelector<HTMLButtonElement>(
+          `.task-list-column-filter-button[data-filter-field="${fieldToFocus}"]`,
+        )
+      : null;
+    (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
+    setOpenFilter(null);
+    setDraftFilters(nextDraftFilters);
+    setPendingFocusField(fieldToFocus);
+  }, [filters, openFilter]);
+
+  useEffect(() => {
+    if (openFilter || !pendingFocusField) return;
+    const fallback = document.querySelector<HTMLButtonElement>(
+      `.task-list-column-filter-button[data-filter-field="${pendingFocusField}"]`,
+    );
+    (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
+    setPendingFocusField(null);
+  }, [openFilter, pendingFocusField]);
+
+  useEffect(() => {
+    if (!openFilter) return;
+    window.requestAnimationFrame(() => {
+      const firstControl = popoverRef.current?.querySelector<HTMLElement>(
+        'input:not([disabled]), select:not([disabled]), button:not([disabled])',
+      );
+      firstControl?.focus();
+    });
+  }, [openFilter]);
+
   useEffect(() => {
     if (!openFilter) return;
     const onPointerDown = (event: MouseEvent) => {
@@ -536,12 +584,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       const targetElement = event.target as Element | null;
       if (target && popoverRef.current?.contains(target)) return;
       if (targetElement?.closest('.task-list-column-filter-button, .task-list-filter-chip-open')) return;
-      setOpenFilter(null);
-      setDraftFilters(filters);
+      closeFilter(filters, openFilter);
     };
     document.addEventListener('mousedown', onPointerDown);
     return () => document.removeEventListener('mousedown', onPointerDown);
-  }, [openFilter, filters]);
+  }, [closeFilter, openFilter, filters]);
 
   const sortedItems = useMemo(() => {
     const items = data?.items || [];
@@ -643,15 +690,22 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   }, []);
 
   const applyFilters = useCallback(
-    (nextFilters: ColumnFilters) => {
+    (nextFilters: ColumnFilters, focusField: FilterField | null = openFilter) => {
       setHasEditedFilters(true);
       setFilters(nextFilters);
       setDraftFilters(nextFilters);
-      setOpenFilter(null);
+      closeFilter(nextFilters, focusField);
       resetToFirstPage();
     },
-    [resetToFirstPage],
+    [closeFilter, openFilter, resetToFirstPage],
   );
+
+  const updateDraftText = (field: 'taskId' | 'title', value: string) => {
+    setDraftFilters((current) => ({
+      ...current,
+      [field]: { contains: value },
+    }));
+  };
 
   const updateDraftValue = (field: 'status' | 'targetRuntime' | 'targetSkill', value: string) => {
     setDraftFilters((current) => ({
@@ -764,6 +818,28 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
   const renderFilterControl = (field: FilterField, labelPrefix = '') => {
     const isMobile = Boolean(labelPrefix);
+    if (field === 'taskId' || field === 'title') {
+      const label = field === 'taskId' ? 'ID' : 'Title';
+      const draft = isMobile ? filters[field] : draftFilters[field];
+      return (
+        <div className="queue-inline-filter task-list-header-filter-control">
+          <label>
+            {labelPrefix}{label} filter value
+            <input
+              type="text"
+              value={draft.contains || ''}
+              disabled={!listEnabled}
+              placeholder={field === 'taskId' ? 'task id' : 'title text'}
+              onChange={(event) => {
+              if (isMobile) applyFilters({ ...filters, [field]: { contains: event.target.value } }, null);
+                else updateDraftText(field, event.target.value);
+              }}
+            />
+          </label>
+        </div>
+      );
+    }
+
     if (field === 'status') {
       const selected = isMobile ? filters.status.values[0] || '' : draftFilters.status.values[0] || '';
       return (
@@ -870,7 +946,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               disabled={!listEnabled}
               onChange={(event) => {
                 const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetRuntime: { ...filters.targetRuntime, mode } });
+                if (isMobile) applyFilters({ ...filters, targetRuntime: { ...filters.targetRuntime, mode } }, null);
                 else updateDraftValueMode('targetRuntime', mode);
               }}
             >
@@ -913,7 +989,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               disabled={!listEnabled}
               onChange={(event) => {
                 const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetSkill: { ...filters.targetSkill, mode } });
+                if (isMobile) applyFilters({ ...filters, targetSkill: { ...filters.targetSkill, mode } }, null);
                 else updateDraftValueMode('targetSkill', mode);
               }}
             >
@@ -933,7 +1009,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                     targetSkill: event.target.value
                       ? { ...filters.targetSkill, values: [event.target.value], blank: '' }
                       : emptyValueFilter(),
-                  });
+                  }, null);
                 } else {
                   updateDraftValue('targetSkill', event.target.value);
                 }
@@ -1021,8 +1097,14 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
         ref={popoverRef}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
-            setDraftFilters(filters);
-            setOpenFilter(null);
+            closeFilter(filters, field);
+          }
+          if (event.key === 'Enter' && event.target instanceof HTMLElement) {
+            const tagName = event.target.tagName.toLowerCase();
+            if (tagName !== 'textarea' && !event.defaultPrevented) {
+              event.preventDefault();
+              applyFilters(draftFilters, field);
+            }
           }
         }}
       >
@@ -1034,10 +1116,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               className="secondary"
               onClick={() => {
                 const next = { ...draftFilters };
-                if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
+                if (field === 'taskId' || field === 'title') next[field] = {};
+                else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
                 else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
                 else next[field] = emptyValueFilter();
-                applyFilters(next);
+                applyFilters(next, field);
               }}
               disabled={!listEnabled}
             >
@@ -1047,8 +1130,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               type="button"
               className="secondary"
               onClick={() => {
-                setDraftFilters(filters);
-                setOpenFilter(null);
+                closeFilter(filters, field);
               }}
               aria-label={`Cancel ${label} filter`}
             >
@@ -1056,7 +1138,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
             </button>
             <button
               type="button"
-              onClick={() => applyFilters(draftFilters)}
+              onClick={() => applyFilters(draftFilters, field)}
               disabled={!listEnabled}
               aria-label={`Apply ${label} filter`}
             >
@@ -1117,9 +1199,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                   <button
                     type="button"
                     className="task-list-filter-chip-open"
+                    data-filter-field={field}
                     onMouseDown={(event) => event.stopPropagation()}
                     onClick={(event) => {
                       event.stopPropagation();
+                      filterTriggerRef.current = event.currentTarget;
                       setOpenFilter(field);
                     }}
                     aria-label={`${label} filter: ${value}`}
@@ -1132,7 +1216,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                     className="task-list-filter-chip-remove"
                     onClick={() => {
                       const next = { ...filters };
-                      if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
+                      if (field === 'taskId' || field === 'title') next[field] = {};
+                      else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
                       else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
                       else next[field] = emptyValueFilter();
                       applyFilters(next);
@@ -1244,10 +1329,19 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                                 className={`task-list-column-filter-button${
                                   filterValueForField(field) ? ' is-active' : ''
                                 }`}
+                                data-filter-field={field}
+                                ref={
+                                  filterField && pendingFocusField === filterField
+                                    ? (node) => node?.focus()
+                                    : undefined
+                                }
                                 onMouseDown={(event) => event.stopPropagation()}
                                 onClick={(event) => {
                                   event.stopPropagation();
-                                  if (filterField) toggleFilter(filterField);
+                                  if (filterField) {
+                                    filterTriggerRef.current = event.currentTarget;
+                                    toggleFilter(filterField);
+                                  }
                                 }}
                                 aria-label={filterAccessibilityLabel(field, label)}
                                 aria-expanded={filterField ? openFilter === filterField : false}

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -552,7 +552,9 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           `.task-list-column-filter-button[data-filter-field="${fieldToFocus}"]`,
         )
       : null;
-    (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
+    if (fieldToFocus) {
+      (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
+    }
     setOpenFilter(null);
     setDraftFilters(nextDraftFilters);
     setPendingFocusField(fieldToFocus);
@@ -1101,7 +1103,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           }
           if (event.key === 'Enter' && event.target instanceof HTMLElement) {
             const tagName = event.target.tagName.toLowerCase();
-            if (tagName !== 'textarea' && !event.defaultPrevented) {
+            if (tagName !== 'textarea' && tagName !== 'button' && !event.defaultPrevented) {
               event.preventDefault();
               applyFilters(draftFilters, field);
             }

--- a/specs/304-mobile-accessibility-live-update-stability/checklists/requirements.md
+++ b/specs/304-mobile-accessibility-live-update-stability/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Mobile, Accessibility, and Live-Update Stability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: `MM-591` is preserved as the canonical Jira preset brief and the story is bounded to one runtime UI behavior surface.

--- a/specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md
+++ b/specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md
@@ -1,0 +1,58 @@
+# Contract: Tasks List Filter Behavior
+
+## Scope
+
+This contract covers the browser-visible Tasks List behavior for `MM-591`. The page remains bounded to ordinary task executions.
+
+## Request Contract
+
+The Tasks List page requests:
+
+```text
+GET /api/executions?source=temporal&pageSize=<size>&scope=tasks
+```
+
+Optional filter parameters used by this story:
+
+| Parameter | Meaning |
+| --- | --- |
+| `taskIdContains` | Task ID text contains filter |
+| `titleContains` | Task title text contains filter |
+| `stateIn` / `stateNotIn` | Status include/exclude values |
+| `repoExact` | Exact repository text filter |
+| `targetRuntimeIn` / `targetRuntimeNotIn` | Runtime include/exclude values |
+| `targetSkillIn` / `targetSkillNotIn` | Skill include/exclude values |
+| `scheduledFrom` / `scheduledTo` / `scheduledBlank` | Scheduled date filter |
+| `createdFrom` / `createdTo` | Created date filter |
+| `finishedFrom` / `finishedTo` / `finishedBlank` | Finished date filter |
+
+Rules:
+- Filter changes reset `nextPageToken`.
+- Empty text filters are omitted.
+- The page always sends `scope=tasks` for ordinary Tasks List requests.
+
+## Interaction Contract
+
+- Sort header buttons and filter buttons are separate keyboard targets.
+- Filter buttons expose `aria-expanded` and accessible names that include active filter state.
+- Opening a desktop filter dialog moves focus into the first enabled dialog control.
+- Cancel, Escape, outside click, Apply, and Enter-close paths return focus to the originating filter control.
+- Escape and outside click discard staged changes.
+- Enter applies staged changes when the focused target is not a multiline text input.
+- Live polling is paused while a desktop filter editor is open.
+
+## Mobile Contract
+
+Mobile task-card users can reach these filters without top dropdowns:
+
+- ID
+- Runtime
+- Skill
+- Repository
+- Status
+- Title
+- Scheduled
+- Created
+- Finished
+
+Mobile filters use the same task-scoped request contract as desktop filters.

--- a/specs/304-mobile-accessibility-live-update-stability/data-model.md
+++ b/specs/304-mobile-accessibility-live-update-stability/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Mobile, Accessibility, and Live-Update Stability
+
+This story does not add persistent storage or backend entities. It extends client-side filter state for the existing Tasks List page.
+
+## Client Filter State
+
+### TextFilter
+
+- `contains`: optional trimmed string used for text contains filtering.
+
+Validation rules:
+- Empty or whitespace-only values are normalized away before URL/API serialization.
+- Values are rendered as text only and are never interpreted as HTML.
+
+### ColumnFilters Additions
+
+- `taskId`: `TextFilter` serialized as `taskIdContains`.
+- `title`: `TextFilter` serialized as `titleContains`.
+
+Existing filter state remains unchanged:
+- `status`: value include/exclude filter serialized as `stateIn` or `stateNotIn`.
+- `repository`: exact text plus value include/exclude filters serialized as `repoExact`, `repoIn`, or `repoNotIn`.
+- `targetRuntime`: value include/exclude filter serialized as `targetRuntimeIn` or `targetRuntimeNotIn`.
+- `targetSkill`: value include/exclude filter serialized as `targetSkillIn` or `targetSkillNotIn`.
+- `scheduledFor`, `createdAt`, `closedAt`: date range filters with blank semantics where supported.
+
+## State Transitions
+
+1. Open desktop filter: copy applied filters into draft filters, store originating filter control, focus first enabled control.
+2. Edit desktop filter: update draft filters only.
+3. Cancel, Escape, or outside click: discard draft filters, close editor, return focus to originating control.
+4. Apply button or Enter: promote draft filters to applied filters, reset pagination, close editor, return focus to originating control.
+5. Mobile filter change: apply immediately through the same filter application path and reset pagination.
+6. Open editor with live updates enabled: execution-list polling interval is disabled until the editor closes.

--- a/specs/304-mobile-accessibility-live-update-stability/moonspec_align_report.md
+++ b/specs/304-mobile-accessibility-live-update-stability/moonspec_align_report.md
@@ -1,0 +1,21 @@
+# MoonSpec Alignment Report: Mobile, Accessibility, and Live-Update Stability
+
+MoonSpec alignment was run for `specs/304-mobile-accessibility-live-update-stability` after task generation.
+
+## Findings
+
+| Finding | Severity | Resolution |
+| --- | --- | --- |
+| The Jira brief requires a runtime implementation workflow and references `docs/UI/TasksListPage.md` as source requirements. | High | `spec.md` classifies the input as a single runtime UI story and maps sections 5.7, 14, 15, and 16 to DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023. |
+| The current page already implements much of the desired task-only column-filter model. | Medium | `plan.md` marks existing covered rows as implemented_verified or implemented_unverified and limits new work to ID/Title mobile parity, focus/Enter behavior, and polling pause while editors are open. |
+| Tasks must preserve TDD ordering even though implementation was executed in the same managed run. | Medium | `tasks.md` keeps test tasks before implementation tasks and records final validation tasks as remaining until test commands complete. |
+
+## Gate Results
+
+- Specify: PASS. `spec.md` contains one story, preserves `MM-591`, and maps all in-scope source design requirements.
+- Plan: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist and identify focused unit/UI validation.
+- Tasks: PASS. `tasks.md` covers one story with traceable test, implementation, and verification tasks.
+
+## Changes
+
+- No artifact rewrites were required after generation.

--- a/specs/304-mobile-accessibility-live-update-stability/moonspec_align_report.md
+++ b/specs/304-mobile-accessibility-live-update-stability/moonspec_align_report.md
@@ -1,21 +1,28 @@
 # MoonSpec Alignment Report: Mobile, Accessibility, and Live-Update Stability
 
-MoonSpec alignment was run for `specs/304-mobile-accessibility-live-update-stability` after task generation.
+MoonSpec alignment was rerun for `specs/304-mobile-accessibility-live-update-stability` after task regeneration for `MM-591`.
 
 ## Findings
 
 | Finding | Severity | Resolution |
 | --- | --- | --- |
-| The Jira brief requires a runtime implementation workflow and references `docs/UI/TasksListPage.md` as source requirements. | High | `spec.md` classifies the input as a single runtime UI story and maps sections 5.7, 14, 15, and 16 to DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023. |
-| The current page already implements much of the desired task-only column-filter model. | Medium | `plan.md` marks existing covered rows as implemented_verified or implemented_unverified and limits new work to ID/Title mobile parity, focus/Enter behavior, and polling pause while editors are open. |
-| Tasks must preserve TDD ordering even though implementation was executed in the same managed run. | Medium | `tasks.md` keeps test tasks before implementation tasks and records final validation tasks as remaining until test commands complete. |
+| The active task list was regenerated after `plan.md` and `research.md` were updated to current repo evidence. | Medium | `tasks.md` now consumes the updated `implemented_verified` statuses, preserves one story, keeps unit and UI integration tests before implementation tasks, includes red-first confirmation, and ends with `/speckit.verify`. |
+| The prior alignment report still claimed no artifact rewrites were required and referenced older mixed-status planning language. | Low | This report replaces the stale status summary and records the current artifact state. |
+| `plan.md` marks all tracked rows as `implemented_verified`, while `tasks.md` still includes replayable test and implementation tasks. | Low | Kept the tasks because the `moonspec-tasks` gate requires red-first unit tests, integration tests, implementation tasks, validation, and final verification; `tasks.md` explicitly says current execution should treat them as verification and traceability-preservation tasks. |
 
 ## Gate Results
 
-- Specify: PASS. `spec.md` contains one story, preserves `MM-591`, and maps all in-scope source design requirements.
-- Plan: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist and identify focused unit/UI validation.
-- Tasks: PASS. `tasks.md` covers one story with traceable test, implementation, and verification tasks.
+- Specify: PASS. `spec.md` contains exactly one story, preserves `MM-591`, and maps all in-scope source design requirements.
+- Plan: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist, include explicit unit and integration strategies, and show no unresolved planning status.
+- Tasks: PASS. `tasks.md` covers one story with sequential tasks T001 through T023, unit and UI integration tests before implementation, red-first confirmation, story validation, and final `/speckit.verify`.
+- Constitution: PASS. No conflict found with required spec-driven development, test discipline, runtime configurability, or canonical documentation separation.
 
 ## Changes
 
-- No artifact rewrites were required after generation.
+- Updated `moonspec_align_report.md` only.
+- No changes were required to `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, or `tasks.md` during this alignment pass.
+
+## Validation
+
+- `SPECIFY_FEATURE=304-mobile-accessibility-live-update-stability .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
+- Artifact scan found no unresolved clarification markers, stale requirement-status rows, multi-story task phases, or absent final `/speckit.verify` task.

--- a/specs/304-mobile-accessibility-live-update-stability/plan.md
+++ b/specs/304-mobile-accessibility-live-update-stability/plan.md
@@ -5,32 +5,32 @@
 
 ## Summary
 
-Complete the Tasks List runtime UI story for `MM-591` by closing the remaining gaps in mobile filter reachability, desktop filter keyboard/focus behavior, and live-update stability. Existing column-filter work already handles task-only visibility, legacy URL normalization, status/runtime/skill/repository/date filters, active chips, and desktop sort/filter separation. The implementation adds ID and Title text filters to the same column-filter model, exposes them in mobile controls, pauses list polling while a desktop filter editor is open, and returns focus after keyboard/dialog closure. Validation is focused in the existing Tasks List Vitest suite, with the full unit runner as final verification.
+Complete the Tasks List runtime UI story for `MM-591` by closing the remaining gaps in mobile filter reachability, desktop filter keyboard/focus behavior, and live-update stability. Current repo evidence shows the implementation now adds ID and Title text filters to the shared column-filter model, exposes them in mobile controls, pauses list polling while a desktop filter editor is open, and manages focus for keyboard/dialog closure. Validation is focused in the existing Tasks List Vitest suite, with the full unit runner as final verification.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | `frontend/src/entrypoints/tasks-list.tsx` had mobile status/runtime/skill/repository/date filters but no ID or Title filters | add ID and Title text filters to shared filter model and mobile controls | UI unit |
-| FR-002 | implemented_unverified | existing `applyFilters()` resets cursor stack; mobile controls use it | extend mobile filter test to include ID/Title and task-scoped request URL | UI unit |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` defines `taskId` and `title` text filters; `tasks-list.test.tsx` asserts mobile ID and Title controls plus canonical query params | preserve behavior | final UI validation |
+| FR-002 | implemented_verified | mobile filter test asserts task-scoped URL with ID/Title filters and no stale pagination cursor | preserve behavior | final UI validation |
 | FR-003 | implemented_verified | separate sort and filter buttons plus existing tests in `tasks-list.test.tsx` | preserve behavior | final UI validation |
-| FR-004 | partial | dialogs supported Escape/cancel but did not manage focus return | add focus-in/focus-return behavior and keyboard apply coverage | UI unit |
+| FR-004 | implemented_verified | `tasks-list.tsx` tracks the originating filter button and pending focus field; `tasks-list.test.tsx` verifies focus moves into the Title filter dialog | preserve behavior | final UI validation |
 | FR-005 | implemented_verified | existing staging tests cover cancel, Escape, outside click without requests | preserve behavior while changing close helper | final UI validation |
-| FR-006 | missing | no Enter-to-apply coverage found | add Enter handler for non-textarea dialog targets | UI unit |
-| FR-007 | partial | drafts are staged, but list polling continued while a popover was open | pause list refetch interval while a filter editor is open | UI unit / code inspection |
+| FR-006 | implemented_verified | `tasks-list.tsx` applies staged non-textarea filter edits on Enter; `tasks-list.test.tsx` verifies Title text filter Enter apply updates the URL | preserve behavior | final UI validation |
+| FR-007 | implemented_verified | `tasks-list.tsx` disables `refetchInterval` while `openFilter` is set, preserving staged editor state | preserve behavior | final UI validation / code inspection |
 | FR-008 | implemented_verified | active chips, filter accessible names, `aria-sort`, and status pill labels are covered by existing tests | preserve behavior | final UI validation |
 | FR-009 | implemented_verified | task scope normalization and absent workflow-kind controls are covered by existing tests | preserve behavior | final UI validation |
-| FR-010 | missing | no `MM-591` feature artifacts existed | create MoonSpec artifacts preserving Jira brief | artifact review |
-| SC-001 | partial | mobile controls test existed but missed ID/Title | extend mobile controls test | UI unit |
-| SC-002 | implemented_unverified | URL assertion covered status/repo/runtime | extend assertion for ID/Title and cursor omission | UI unit |
-| SC-003 | missing | no focus test found | add focus test | UI unit |
-| SC-004 | implemented_unverified | status staging covered Apply button only | add Enter apply text-filter test | UI unit |
+| FR-010 | implemented_verified | `spec.md`, `plan.md`, `tasks.md`, and `verification.md` preserve `MM-591` and the canonical Jira preset brief | preserve traceability | artifact review |
+| SC-001 | implemented_verified | mobile controls test asserts ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished controls | preserve behavior | final UI validation |
+| SC-002 | implemented_verified | mobile URL assertion includes task scope, ID/Title filters, status/runtime/repository filters, and omits stale cursor state | preserve behavior | final UI validation |
+| SC-003 | implemented_verified | focused UI test verifies a desktop Title filter dialog receives focus on open | preserve behavior | final UI validation |
+| SC-004 | implemented_verified | focused UI test verifies Enter applies staged Title text-filter changes | preserve behavior | final UI validation |
 | SC-005 | implemented_verified | existing workflow-kind tests | preserve behavior | final UI validation |
-| SC-006 | missing | no `MM-591` artifacts existed | preserve issue key in spec, plan, tasks, verification | artifact review |
+| SC-006 | implemented_verified | artifact review confirms `MM-591`, canonical preset brief, and source design IDs are preserved | preserve traceability | artifact review |
 | DESIGN-REQ-006 | implemented_verified | mobile card structure and details-action tests already exist | preserve behavior | final UI validation |
-| DESIGN-REQ-021 | partial | staged filters existed, polling pause missing | pause polling while editor is open | UI unit / code inspection |
-| DESIGN-REQ-022 | partial | sort/filter ARIA and Escape existed, focus/Enter gaps remained | add focus and Enter behavior | UI unit |
-| DESIGN-REQ-023 | partial | mobile parity existed for most fields, missing ID/Title | add ID/Title mobile filters | UI unit |
+| DESIGN-REQ-021 | implemented_verified | staged filters exist and polling is paused while a filter editor is open | preserve behavior | final UI validation / code inspection |
+| DESIGN-REQ-022 | implemented_verified | sort/filter ARIA, Escape/cancel staging, focus-in, focus-return helper, Enter apply, and non-color active indicators are present | preserve behavior | final UI validation |
+| DESIGN-REQ-023 | implemented_verified | mobile filters expose status, runtime, skill, repository, title, ID, and date filtering through task-scoped semantics | preserve behavior | final UI validation |
 
 ## Technical Context
 

--- a/specs/304-mobile-accessibility-live-update-stability/plan.md
+++ b/specs/304-mobile-accessibility-live-update-stability/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Mobile, Accessibility, and Live-Update Stability
+
+**Branch**: `304-mobile-accessibility-live-update-stability` | **Date**: 2026-05-05 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/304-mobile-accessibility-live-update-stability/spec.md`
+
+## Summary
+
+Complete the Tasks List runtime UI story for `MM-591` by closing the remaining gaps in mobile filter reachability, desktop filter keyboard/focus behavior, and live-update stability. Existing column-filter work already handles task-only visibility, legacy URL normalization, status/runtime/skill/repository/date filters, active chips, and desktop sort/filter separation. The implementation adds ID and Title text filters to the same column-filter model, exposes them in mobile controls, pauses list polling while a desktop filter editor is open, and returns focus after keyboard/dialog closure. Validation is focused in the existing Tasks List Vitest suite, with the full unit runner as final verification.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `frontend/src/entrypoints/tasks-list.tsx` had mobile status/runtime/skill/repository/date filters but no ID or Title filters | add ID and Title text filters to shared filter model and mobile controls | UI unit |
+| FR-002 | implemented_unverified | existing `applyFilters()` resets cursor stack; mobile controls use it | extend mobile filter test to include ID/Title and task-scoped request URL | UI unit |
+| FR-003 | implemented_verified | separate sort and filter buttons plus existing tests in `tasks-list.test.tsx` | preserve behavior | final UI validation |
+| FR-004 | partial | dialogs supported Escape/cancel but did not manage focus return | add focus-in/focus-return behavior and keyboard apply coverage | UI unit |
+| FR-005 | implemented_verified | existing staging tests cover cancel, Escape, outside click without requests | preserve behavior while changing close helper | final UI validation |
+| FR-006 | missing | no Enter-to-apply coverage found | add Enter handler for non-textarea dialog targets | UI unit |
+| FR-007 | partial | drafts are staged, but list polling continued while a popover was open | pause list refetch interval while a filter editor is open | UI unit / code inspection |
+| FR-008 | implemented_verified | active chips, filter accessible names, `aria-sort`, and status pill labels are covered by existing tests | preserve behavior | final UI validation |
+| FR-009 | implemented_verified | task scope normalization and absent workflow-kind controls are covered by existing tests | preserve behavior | final UI validation |
+| FR-010 | missing | no `MM-591` feature artifacts existed | create MoonSpec artifacts preserving Jira brief | artifact review |
+| SC-001 | partial | mobile controls test existed but missed ID/Title | extend mobile controls test | UI unit |
+| SC-002 | implemented_unverified | URL assertion covered status/repo/runtime | extend assertion for ID/Title and cursor omission | UI unit |
+| SC-003 | missing | no focus test found | add focus test | UI unit |
+| SC-004 | implemented_unverified | status staging covered Apply button only | add Enter apply text-filter test | UI unit |
+| SC-005 | implemented_verified | existing workflow-kind tests | preserve behavior | final UI validation |
+| SC-006 | missing | no `MM-591` artifacts existed | preserve issue key in spec, plan, tasks, verification | artifact review |
+| DESIGN-REQ-006 | implemented_verified | mobile card structure and details-action tests already exist | preserve behavior | final UI validation |
+| DESIGN-REQ-021 | partial | staged filters existed, polling pause missing | pause polling while editor is open | UI unit / code inspection |
+| DESIGN-REQ-022 | partial | sort/filter ARIA and Escape existed, focus/Enter gaps remained | add focus and Enter behavior | UI unit |
+| DESIGN-REQ-023 | partial | mobile parity existed for most fields, missing ID/Title | add ID/Title mobile filters | UI unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not part of this story  
+**Primary Dependencies**: React, TanStack Query, Zod, Vitest, Testing Library, existing Mission Control CSS  
+**Storage**: N/A; filter state is URL/query state and component state only  
+**Unit Testing**: Vitest via `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`; final repo runner `./tools/test_unit.sh`  
+**Integration Testing**: UI integration-style component tests in `frontend/src/entrypoints/tasks-list.test.tsx`; no compose-backed integration needed for this frontend-only story  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web frontend inside the MoonMind monorepo  
+**Performance Goals**: Preserve bounded polling and avoid refetching list data while an editor is open  
+**Constraints**: Ordinary `/tasks/list` must remain task-scoped and must not expose system workflows; mobile filters must not depend on desktop table headers  
+**Scale/Scope**: One Tasks List page entrypoint and its focused UI test file
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. This story changes Mission Control UI behavior only and does not replace agent orchestration.
+- II. One-Click Agent Deployment: PASS. No deployment or external prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. No provider-specific behavior.
+- IV. Own Your Data: PASS. Browser calls remain MoonMind API only.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill runtime changes.
+- VI. Replaceable Scaffolding: PASS. Behavior is covered by focused tests instead of brittle manual checks.
+- VII. Runtime Configurability: PASS. Existing poll interval config remains respected.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay inside the existing Tasks List UI module.
+- IX. Resilient by Default: PASS. Filter editing avoids live-update disruption.
+- X. Facilitate Continuous Improvement: PASS. Verification artifacts record outcome and test evidence.
+- XI. Spec-Driven Development: PASS. This spec, plan, tasks, and verification preserve the canonical `MM-591` input.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Canonical docs are read as source requirements and not rewritten.
+- XIII. Pre-Release Compatibility Policy: PASS. No internal compatibility aliases or deprecated paths are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/304-mobile-accessibility-live-update-stability/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── tasks-list-filter-behavior.md
+├── checklists/
+│   └── requirements.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+└── src/
+    ├── entrypoints/
+    │   ├── tasks-list.tsx
+    │   └── tasks-list.test.tsx
+    └── styles/
+        └── mission-control.css
+```
+
+**Structure Decision**: Use the existing Tasks List entrypoint and test file. No backend or persistent data model changes are required because this story uses existing execution-list query parameters and component state.
+
+## Complexity Tracking
+
+No constitution violations or added architectural complexity.

--- a/specs/304-mobile-accessibility-live-update-stability/quickstart.md
+++ b/specs/304-mobile-accessibility-live-update-stability/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Mobile, Accessibility, and Live-Update Stability
+
+## Focused Validation
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+Expected coverage:
+
+- Mobile ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished filters are reachable.
+- Mobile filter changes produce task-scoped list requests and reset pagination.
+- Desktop filter dialogs move focus into the editor and return focus to the originating control.
+- Escape/cancel/outside-click paths discard staged changes.
+- Enter applies staged text-filter changes.
+- Ordinary Tasks List users cannot expose workflow-kind browsing controls.
+
+## Final Validation
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected outcome:
+
+- Full unit suite passes, including Python unit coverage and frontend Vitest coverage.
+- `MM-591` remains preserved in `spec.md`, `plan.md`, `tasks.md`, and `verification.md`.

--- a/specs/304-mobile-accessibility-live-update-stability/research.md
+++ b/specs/304-mobile-accessibility-live-update-stability/research.md
@@ -2,35 +2,35 @@
 
 ## FR-001 / DESIGN-REQ-023 Mobile Filter Reachability
 
-Decision: Complete the existing mobile control set by adding ID and Title text filters to the shared column-filter model.
-Evidence: `frontend/src/entrypoints/tasks-list.tsx` already exposed mobile Status, Runtime, Skill, Repository, Scheduled, Created, and Finished controls; `docs/UI/TasksListPage.md` section 16 requires mobile access to status, runtime, skill, repository, title, ID, and date filters.
+Decision: Implemented and verified. The mobile control set now includes ID and Title text filters through the shared column-filter model.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` defines `taskId` and `title` text filters in the active filter fields, parsing, serialization, summaries, and mobile controls. `frontend/src/entrypoints/tasks-list.test.tsx` asserts `Mobile ID filter value` and `Mobile Title filter value`, changes both controls, and verifies canonical `taskIdContains` and `titleContains` query params.
 Rationale: Extending the existing filter model keeps desktop and mobile semantics aligned and avoids reintroducing removed top dropdowns.
 Alternatives considered: Add a separate mobile-only filter sheet state. Rejected because it would duplicate semantics already present in the column-filter model.
-Test implications: UI unit test must assert mobile ID and Title controls exist and submit canonical query params.
+Test implications: Final UI validation keeps the focused Tasks List Vitest coverage and full unit runner.
 
 ## FR-002 Pagination Reset
 
-Decision: Continue routing mobile filter changes through `applyFilters()`, which resets `listCursor` and `cursorStack`.
-Evidence: Existing code uses `applyFilters()` for mobile controls and existing pagination/filter tests cover cursor reset behavior.
+Decision: Implemented and verified. Mobile filter changes continue routing through `applyFilters()`, which resets `listCursor` and `cursorStack`.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` uses the shared mobile filter application path. `frontend/src/entrypoints/tasks-list.test.tsx` verifies the post-filter request URL is task-scoped and omits stale pagination cursor state while including the new ID and Title filters.
 Rationale: Reusing the existing path preserves desktop/mobile parity.
 Alternatives considered: Add a separate mobile reset helper. Rejected as unnecessary duplication.
-Test implications: Extended mobile filter URL assertion must omit `nextPageToken` after filter changes.
+Test implications: Final UI validation through the focused Tasks List Vitest test and `./tools/test_unit.sh`.
 
 ## FR-004 / FR-006 / DESIGN-REQ-022 Focus and Keyboard Dialog Behavior
 
-Decision: Track the originating filter button, focus the first dialog control after opening, return focus on close, and treat Enter as Apply for non-textarea targets.
-Evidence: Existing dialog supported Escape/cancel/apply but did not move focus into the dialog or return focus.
+Decision: Implemented and verified. The page tracks the originating filter button, focuses the first dialog control after opening, returns focus through the close helper, and treats Enter as Apply for non-textarea targets.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` includes `pendingFocusField`, `filterTriggerRef`, dialog focus handling, and an Enter key path that applies staged edits. `frontend/src/entrypoints/tasks-list.test.tsx` verifies the Title filter dialog receives focus and Enter applies the staged text filter to the request URL.
 Rationale: This directly satisfies the source accessibility requirements with small component-local state.
 Alternatives considered: Introduce a shared dialog component. Rejected because this page already owns a compact popover and no broader abstraction is required.
-Test implications: Add UI test for focus-in, Enter apply, URL update, and focus return.
+Test implications: Final UI validation through the focused Tasks List Vitest test and full unit runner.
 
 ## FR-007 / DESIGN-REQ-021 Live-Update Stability
 
-Decision: Disable the execution-list refetch interval while a desktop filter editor is open.
-Evidence: `useQuery` used `refetchInterval` whenever live updates were enabled; source design says live updates must not overwrite staged choices while an editor is open.
+Decision: Implemented and verified by code inspection plus staging tests. The execution-list refetch interval is disabled while a desktop filter editor is open.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` sets `refetchInterval` only when live updates are enabled, the list is enabled, and no filter editor is open. Existing staging tests continue to cover draft preservation and dismissal behavior.
 Rationale: Pausing the interval while the editor is open is deterministic and avoids changing active filters or option lists underneath the staged editor.
 Alternatives considered: Snapshot every facet and current-page value at open time while continuing polling. Rejected as higher complexity for the same user-visible guarantee.
-Test implications: Existing staging tests plus code inspection cover the guard; final UI tests ensure staging behavior remains intact.
+Test implications: Final UI validation combines focused Tasks List Vitest coverage with code inspection for the polling guard.
 
 ## FR-009 Task-Only Visibility
 

--- a/specs/304-mobile-accessibility-live-update-stability/research.md
+++ b/specs/304-mobile-accessibility-live-update-stability/research.md
@@ -1,0 +1,41 @@
+# Research: Mobile, Accessibility, and Live-Update Stability
+
+## FR-001 / DESIGN-REQ-023 Mobile Filter Reachability
+
+Decision: Complete the existing mobile control set by adding ID and Title text filters to the shared column-filter model.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` already exposed mobile Status, Runtime, Skill, Repository, Scheduled, Created, and Finished controls; `docs/UI/TasksListPage.md` section 16 requires mobile access to status, runtime, skill, repository, title, ID, and date filters.
+Rationale: Extending the existing filter model keeps desktop and mobile semantics aligned and avoids reintroducing removed top dropdowns.
+Alternatives considered: Add a separate mobile-only filter sheet state. Rejected because it would duplicate semantics already present in the column-filter model.
+Test implications: UI unit test must assert mobile ID and Title controls exist and submit canonical query params.
+
+## FR-002 Pagination Reset
+
+Decision: Continue routing mobile filter changes through `applyFilters()`, which resets `listCursor` and `cursorStack`.
+Evidence: Existing code uses `applyFilters()` for mobile controls and existing pagination/filter tests cover cursor reset behavior.
+Rationale: Reusing the existing path preserves desktop/mobile parity.
+Alternatives considered: Add a separate mobile reset helper. Rejected as unnecessary duplication.
+Test implications: Extended mobile filter URL assertion must omit `nextPageToken` after filter changes.
+
+## FR-004 / FR-006 / DESIGN-REQ-022 Focus and Keyboard Dialog Behavior
+
+Decision: Track the originating filter button, focus the first dialog control after opening, return focus on close, and treat Enter as Apply for non-textarea targets.
+Evidence: Existing dialog supported Escape/cancel/apply but did not move focus into the dialog or return focus.
+Rationale: This directly satisfies the source accessibility requirements with small component-local state.
+Alternatives considered: Introduce a shared dialog component. Rejected because this page already owns a compact popover and no broader abstraction is required.
+Test implications: Add UI test for focus-in, Enter apply, URL update, and focus return.
+
+## FR-007 / DESIGN-REQ-021 Live-Update Stability
+
+Decision: Disable the execution-list refetch interval while a desktop filter editor is open.
+Evidence: `useQuery` used `refetchInterval` whenever live updates were enabled; source design says live updates must not overwrite staged choices while an editor is open.
+Rationale: Pausing the interval while the editor is open is deterministic and avoids changing active filters or option lists underneath the staged editor.
+Alternatives considered: Snapshot every facet and current-page value at open time while continuing polling. Rejected as higher complexity for the same user-visible guarantee.
+Test implications: Existing staging tests plus code inspection cover the guard; final UI tests ensure staging behavior remains intact.
+
+## FR-009 Task-Only Visibility
+
+Decision: Preserve existing task-only scope enforcement and workflow-kind compatibility handling.
+Evidence: Existing tests cover absence of Scope, Workflow Type, Entry, and Kind controls and verify legacy workflow-scope URLs normalize to task-only visibility.
+Rationale: The source brief explicitly says system workflows remain unavailable from mobile task-card views.
+Alternatives considered: Add mobile diagnostics access. Rejected as out of scope and contrary to ordinary task-card visibility.
+Test implications: Existing UI tests remain final validation evidence.

--- a/specs/304-mobile-accessibility-live-update-stability/spec.md
+++ b/specs/304-mobile-accessibility-live-update-stability/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Mobile, Accessibility, and Live-Update Stability
+
+**Feature Branch**: `304-mobile-accessibility-live-update-stability`
+**Created**: 2026-05-05
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-591 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-591 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-591
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Mobile, accessibility, and live-update stability
+- Labels: `moonmind-workflow-mm-af73ac39-5c56-460e-bd77-712adac541f3`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-591 from MM project
+Summary: Mobile, accessibility, and live-update stability
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/UI/TasksListPage.md
+Source Title: Tasks List Page
+Source Sections:
+- 5.7 Current mobile cards
+- 14. Live updates and filter stability
+- 15. Accessibility requirements
+- 16. Mobile behavior
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-021
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+
+As an operator on any device or assistive technology, I want equivalent filters, accessible controls, and stable staged selections while live updates run so the Tasks List remains usable during active monitoring.
+
+Acceptance Criteria
+- Mobile users can reach status, runtime, skill, repository, title, ID, and date filters without the removed top dropdowns.
+- Mobile filter changes reset pagination just like desktop.
+- Focus moves into filter UI on open and returns to the originating control on close.
+- Escape cancels staged changes and Enter on Apply commits them.
+- Checkbox labels include value label and count when shown.
+- Color is not the only active sort/filter/status indicator.
+- When a popover or sheet editor is open, live updates do not overwrite staged selections.
+
+Requirements
+- Keep desktop and mobile filter semantics equivalent.
+- Show subtle update notices when facet values change after a filter editor opens if implemented.
+- Keep system workflows unavailable from mobile task-card views.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-591 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI behavior story from `docs/UI/TasksListPage.md`: Tasks List filters must remain reachable and accessible across desktop and mobile while live updates run.
+
+## User Story - Stable Accessible Task Filters
+
+**Summary**: As an operator on any device or assistive technology, I want equivalent filters, accessible controls, and stable staged selections while live updates run so that the Tasks List remains usable during active monitoring.
+
+**Goal**: The Tasks List page exposes the same task filter capabilities to mobile card users and desktop table users, keeps filter dialogs keyboard accessible, preserves task-only visibility, and prevents live polling from disrupting staged filter edits.
+
+**Independent Test**: Render the Tasks List page with mocked execution data, open and operate desktop filter dialogs by keyboard, operate the mobile filter controls for ID, title, status, runtime, skill, repository, and dates, and verify the resulting task-scoped API URLs and focus behavior without exposing workflow-kind controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile-width operator uses the Tasks List card view, **When** they need to filter tasks, **Then** status, runtime, skill, repository, title, ID, and date filters are reachable without the removed top dropdowns.
+2. **Given** any mobile filter changes, **When** the filter is applied, **Then** pagination resets to the first page and the API request remains bounded to task executions only.
+3. **Given** a desktop column filter is opened, **When** the dialog appears, **Then** focus moves into the filter UI and returns to the originating filter control when the dialog closes.
+4. **Given** a desktop filter has staged but unapplied changes, **When** the operator presses Escape or clicks outside, **Then** the staged changes are discarded and no filtered list request is sent.
+5. **Given** a desktop text filter has staged changes, **When** the operator presses Enter from inside the filter dialog, **Then** the changes are applied, pagination resets, and focus returns to the originating filter control.
+6. **Given** live updates are enabled while a filter editor is open, **When** the polling interval elapses, **Then** live polling does not overwrite the staged filter editor state.
+7. **Given** ordinary Tasks List users inspect mobile cards or column filters, **When** URL parameters or controls are manipulated, **Then** system workflows remain unavailable from the ordinary task-card view.
+
+### Edge Cases
+
+- Legacy task-list URLs that include workflow-kind parameters continue to fail safe into task-only visibility.
+- Empty text filters are normalized away instead of sending no-op filter parameters.
+- Active filters remain visible as chips so color is not the only indicator of filter state.
+- Facet values may be unavailable; the page can continue using current page values without blocking text/date filters.
+
+## Assumptions
+
+- The existing Tasks List page already owns the normal task-only query and desktop column-filter model; this story completes mobile parity and stability gaps rather than introducing a new diagnostics route.
+- The source brief says subtle update notices are optional, so the required behavior is stable staged selection; notices are not mandatory for this story.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mobile task-card users MUST be able to reach ID, runtime, skill, repository, status, title, scheduled, created, and finished filters without the removed top dropdown controls.
+- **FR-002**: Mobile filter changes MUST reset pagination to the first page using the same task-scoped query semantics as desktop filters.
+- **FR-003**: Desktop filter controls MUST be separately reachable from sort controls and expose accessible names that distinguish active and inactive filter state.
+- **FR-004**: Opening a desktop filter dialog MUST move focus into the dialog, and closing it through cancel, Escape, outside click, Enter apply, or apply button MUST return focus to the originating filter control.
+- **FR-005**: Escape and outside-click dismissal MUST discard staged filter changes without issuing a filtered list request.
+- **FR-006**: Enter from inside a desktop filter dialog MUST apply staged changes when the target is not a multiline text input.
+- **FR-007**: Live polling MUST NOT overwrite staged filter selections while a desktop filter editor is open.
+- **FR-008**: Active sort, active filter, and status state MUST remain communicated through text, accessible names, icons/glyphs, or chips rather than color alone.
+- **FR-009**: Ordinary mobile task-card views MUST NOT expose system workflow visibility or workflow-kind browsing controls.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-591` and this canonical Jira preset brief.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-006** (`docs/UI/TasksListPage.md` section 5.7): Mobile cards show task title, ID, runtime, skill, workflow metadata, status, repository, dates, dependency summary, and one full-width details action. Scope: in scope, mapped to FR-001 and FR-009.
+- **DESIGN-REQ-021** (`docs/UI/TasksListPage.md` section 14): Live updates must not disrupt staged filter choices; polling can continue only when it does not overwrite open editor state. Scope: in scope, mapped to FR-005 and FR-007.
+- **DESIGN-REQ-022** (`docs/UI/TasksListPage.md` section 15): Sort and filter controls must be separately keyboard reachable, expose correct ARIA state, move focus into and out of filter UI, support Escape/Enter behavior, and avoid color-only indicators. Scope: in scope, mapped to FR-003 through FR-006 and FR-008.
+- **DESIGN-REQ-023** (`docs/UI/TasksListPage.md` section 16): Mobile filter behavior must expose the same filterable task columns as desktop, reset pagination on changes, and keep system workflows out of ordinary task cards. Scope: in scope, mapped to FR-001, FR-002, and FR-009.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated UI tests verify mobile controls for ID, runtime, skill, repository, status, title, scheduled, created, and finished filters are present.
+- **SC-002**: Automated UI tests verify mobile filter changes produce task-scoped execution list requests and omit stale pagination cursors.
+- **SC-003**: Automated UI tests verify a desktop filter dialog receives focus on open and returns focus to its originating control after keyboard apply.
+- **SC-004**: Automated UI tests verify staged changes are not requested until Apply or Enter commits them.
+- **SC-005**: Automated UI tests verify ordinary Tasks List controls do not expose Scope, Workflow Type, Entry, Kind, or system workflow filters.
+- **SC-006**: Traceability review confirms `MM-591`, the canonical Jira preset brief, and DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023 remain preserved in MoonSpec artifacts and verification evidence.

--- a/specs/304-mobile-accessibility-live-update-stability/tasks.md
+++ b/specs/304-mobile-accessibility-live-update-stability/tasks.md
@@ -15,14 +15,14 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm `.specify/feature.json` points at `specs/304-mobile-accessibility-live-update-stability/` and that `specs/304-mobile-accessibility-live-update-stability/spec.md` preserves the `MM-591` Jira preset brief. (FR-010, SC-006)
-- [ ] T002 Confirm `specs/304-mobile-accessibility-live-update-stability/plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-filter-behavior.md` exist before story task execution. (FR-010, SC-006)
-- [ ] T003 Confirm `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` are the only source/test files required by the implementation plan. (FR-001 through FR-009)
+- [X] T001 Confirm `.specify/feature.json` points at `specs/304-mobile-accessibility-live-update-stability/` and that `specs/304-mobile-accessibility-live-update-stability/spec.md` preserves the `MM-591` Jira preset brief. (FR-010, SC-006)
+- [X] T002 Confirm `specs/304-mobile-accessibility-live-update-stability/plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-filter-behavior.md` exist before story task execution. (FR-010, SC-006)
+- [X] T003 Confirm `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` are the only source/test files required by the implementation plan. (FR-001 through FR-009)
 
 ## Phase 2: Foundational
 
-- [ ] T004 Inspect `docs/UI/TasksListPage.md` sections 5.7, 14, 15, and 16 and confirm the source mappings in `specs/304-mobile-accessibility-live-update-stability/spec.md`. (DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023)
-- [ ] T005 Inspect existing task-only query, filter parsing, URL serialization, and mobile card behavior in `frontend/src/entrypoints/tasks-list.tsx` before adding tests. (FR-001 through FR-009)
+- [X] T004 Inspect `docs/UI/TasksListPage.md` sections 5.7, 14, 15, and 16 and confirm the source mappings in `specs/304-mobile-accessibility-live-update-stability/spec.md`. (DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023)
+- [X] T005 Inspect existing task-only query, filter parsing, URL serialization, and mobile card behavior in `frontend/src/entrypoints/tasks-list.tsx` before adding tests. (FR-001 through FR-009)
 
 ## Phase 3: Story - Stable Accessible Task Filters
 
@@ -38,38 +38,38 @@
 
 ### Unit Tests
 
-- [ ] T006 Add or preserve the mobile filter reachability test in `frontend/src/entrypoints/tasks-list.test.tsx` for ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished controls. (FR-001, SC-001, DESIGN-REQ-023)
-- [ ] T007 Add or preserve the mobile filter URL test in `frontend/src/entrypoints/tasks-list.test.tsx` for task-scoped `taskIdContains`, `titleContains`, status, runtime, repository, and stale-cursor omission. (FR-002, SC-002, DESIGN-REQ-023)
-- [ ] T008 Add or preserve the desktop filter keyboard test in `frontend/src/entrypoints/tasks-list.test.tsx` for focus-in and Enter-to-apply behavior. (FR-004, FR-006, SC-003, SC-004, DESIGN-REQ-022)
-- [ ] T009 Preserve staging, Escape, outside-click, active-chip, status-label, workflow-kind, and mobile-card guardrail tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-005, FR-008, FR-009, DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022)
+- [X] T006 Add or preserve the mobile filter reachability test in `frontend/src/entrypoints/tasks-list.test.tsx` for ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished controls. (FR-001, SC-001, DESIGN-REQ-023)
+- [X] T007 Add or preserve the mobile filter URL test in `frontend/src/entrypoints/tasks-list.test.tsx` for task-scoped `taskIdContains`, `titleContains`, status, runtime, repository, and stale-cursor omission. (FR-002, SC-002, DESIGN-REQ-023)
+- [X] T008 Add or preserve the desktop filter keyboard test in `frontend/src/entrypoints/tasks-list.test.tsx` for focus-in and Enter-to-apply behavior. (FR-004, FR-006, SC-003, SC-004, DESIGN-REQ-022)
+- [X] T009 Preserve staging, Escape, outside-click, active-chip, status-label, workflow-kind, and mobile-card guardrail tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-005, FR-008, FR-009, DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022)
 
 ### Integration Tests
 
-- [ ] T010 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that renders the Tasks List, applies mobile filters, and verifies the resulting `/api/executions` request remains task-scoped. (Acceptance scenarios 1, 2, 7; FR-001, FR-002, FR-009)
-- [ ] T011 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that opens a desktop filter dialog, stages a text filter, applies it with Enter, and verifies the request URL. (Acceptance scenarios 3, 5; FR-004, FR-006)
-- [ ] T012 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that verifies cancel, Escape, and outside-click dismissal do not submit staged filter changes. (Acceptance scenario 4; FR-005)
+- [X] T010 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that renders the Tasks List, applies mobile filters, and verifies the resulting `/api/executions` request remains task-scoped. (Acceptance scenarios 1, 2, 7; FR-001, FR-002, FR-009)
+- [X] T011 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that opens a desktop filter dialog, stages a text filter, applies it with Enter, and verifies the request URL. (Acceptance scenarios 3, 5; FR-004, FR-006)
+- [X] T012 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that verifies cancel, Escape, and outside-click dismissal do not submit staged filter changes. (Acceptance scenario 4; FR-005)
 
 ### Red-First Confirmation
 
 - [ ] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` after T006-T012 and before T015-T018 to confirm newly authored or replayed tests fail for the intended reason on an unimplemented baseline. (FR-001 through FR-009)
-- [ ] T014 Record red-first or already-verified status in `specs/304-mobile-accessibility-live-update-stability/verification.md`; in the current workspace, cite the existing passing test evidence because `plan.md` marks all tracked rows `implemented_verified`. (SC-006)
+- [X] T014 Record red-first or already-verified status in `specs/304-mobile-accessibility-live-update-stability/verification.md`; in the current workspace, cite the existing passing test evidence because `plan.md` marks all tracked rows `implemented_verified`. (SC-006)
 
 ### Implementation
 
-- [ ] T015 Add or preserve `taskId` and `title` text filters in `frontend/src/entrypoints/tasks-list.tsx` across filter types, empty state, parsing, URL serialization, summaries, active chips, desktop popovers, and mobile controls. (FR-001, FR-002, DESIGN-REQ-023)
-- [ ] T016 Add or preserve desktop filter focus management and Enter-to-apply handling in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-006, DESIGN-REQ-022)
-- [ ] T017 Add or preserve the live-update stability guard in `frontend/src/entrypoints/tasks-list.tsx` so list refetch intervals pause while a filter editor is open. (FR-007, DESIGN-REQ-021)
-- [ ] T018 Preserve task-only scope enforcement, workflow-kind fail-safe behavior, active filter indicators, and mobile-card visibility in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-008, FR-009, DESIGN-REQ-006)
+- [X] T015 Add or preserve `taskId` and `title` text filters in `frontend/src/entrypoints/tasks-list.tsx` across filter types, empty state, parsing, URL serialization, summaries, active chips, desktop popovers, and mobile controls. (FR-001, FR-002, DESIGN-REQ-023)
+- [X] T016 Add or preserve desktop filter focus management and Enter-to-apply handling in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-006, DESIGN-REQ-022)
+- [X] T017 Add or preserve the live-update stability guard in `frontend/src/entrypoints/tasks-list.tsx` so list refetch intervals pause while a filter editor is open. (FR-007, DESIGN-REQ-021)
+- [X] T018 Preserve task-only scope enforcement, workflow-kind fail-safe behavior, active filter indicators, and mobile-card visibility in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-008, FR-009, DESIGN-REQ-006)
 
 ### Story Validation
 
-- [ ] T019 Run focused unit and UI integration validation with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` and record the result in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (FR-001 through FR-010, SC-001 through SC-006)
+- [X] T019 Run focused unit and UI integration validation with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` and record the result in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (FR-001 through FR-010, SC-001 through SC-006)
 - [ ] T020 Run final repository unit validation with `./tools/test_unit.sh` and record the result in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (FR-001 through FR-010, SC-001 through SC-006)
 
 ## Phase 4: Polish And Verification
 
-- [ ] T021 Review `specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md` against `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` to confirm public UI behavior remains aligned. (FR-001 through FR-009)
-- [ ] T022 Review `specs/304-mobile-accessibility-live-update-stability/quickstart.md` and confirm it lists the focused and final validation commands for the story. (SC-001 through SC-006)
+- [X] T021 Review `specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md` against `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` to confirm public UI behavior remains aligned. (FR-001 through FR-009)
+- [X] T022 Review `specs/304-mobile-accessibility-live-update-stability/quickstart.md` and confirm it lists the focused and final validation commands for the story. (SC-001 through SC-006)
 - [ ] T023 Run `/speckit.verify` and update `specs/304-mobile-accessibility-live-update-stability/verification.md` with final comparison against the original `MM-591` preset brief. (FR-010, SC-006)
 
 ## Dependencies and Execution Order

--- a/specs/304-mobile-accessibility-live-update-stability/tasks.md
+++ b/specs/304-mobile-accessibility-live-update-stability/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: Mobile, Accessibility, and Live-Update Stability
+
+**Input**: `specs/304-mobile-accessibility-live-update-stability/spec.md`  
+**Plan**: `specs/304-mobile-accessibility-live-update-stability/plan.md`  
+**Unit Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
+**Integration Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
+
+**Source Traceability**: The original `MM-591` Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-010, acceptance scenarios 1 through 7, SC-001 through SC-006, and DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm no existing `MM-591` MoonSpec artifact exists and assign global next spec prefix `304` under `specs/`.
+- [X] T002 Create `specs/304-mobile-accessibility-live-update-stability/` artifact structure and preserve the canonical Jira preset brief in `spec.md`.
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect `docs/UI/TasksListPage.md` sections 5.7, 14, 15, and 16 for source design requirements. (DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023)
+- [X] T004 Inspect current Tasks List implementation and tests in `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001 through FR-009)
+
+## Phase 3: Story - Stable Accessible Task Filters
+
+**Story Summary**: Operators on mobile, desktop, and assistive technologies can use equivalent task filters without live updates disrupting staged selections.
+
+**Independent Test**: Render the Tasks List page with mocked execution data, operate desktop filter dialogs by keyboard, operate mobile filters, and verify task-scoped API URLs and focus behavior.
+
+**Traceability IDs**: FR-001 through FR-010; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023.
+
+### Tests
+
+- [X] T005 Extend the mobile filter reachability test in `frontend/src/entrypoints/tasks-list.test.tsx` to cover ID and Title controls plus task-scoped URL serialization. (FR-001, FR-002, SC-001, SC-002, DESIGN-REQ-023)
+- [X] T006 Add a focused UI test in `frontend/src/entrypoints/tasks-list.test.tsx` proving desktop filter dialogs focus the first control, apply staged text filters with Enter, and return focus to the originating control. (FR-004, FR-006, SC-003, SC-004, DESIGN-REQ-022)
+- [X] T007 Preserve existing staging, Escape, outside-click, active-chip, workflow-kind, and mobile-card tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-005, FR-008, FR-009, DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022)
+
+### Implementation
+
+- [X] T008 Add `taskId` and `title` text filters to `ColumnFilters` parsing, URL serialization, summaries, active chips, desktop filter popovers, and mobile controls in `frontend/src/entrypoints/tasks-list.tsx`. (FR-001, FR-002, DESIGN-REQ-023)
+- [X] T009 Add desktop filter focus management and Enter-to-apply handling in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-006, DESIGN-REQ-022)
+- [X] T010 Pause Tasks List live refetch intervals while a desktop filter editor is open in `frontend/src/entrypoints/tasks-list.tsx`. (FR-007, DESIGN-REQ-021)
+- [X] T011 Preserve task-only scope enforcement and existing workflow-kind fail-safe behavior in `frontend/src/entrypoints/tasks-list.tsx`. (FR-009)
+
+### Validation
+
+- [X] T012 Run focused UI validation: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001 through FR-010)
+- [X] T013 Run final unit validation: `./tools/test_unit.sh`. (FR-001 through FR-010)
+- [X] T014 Produce final MoonSpec verification report in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (SC-006)
+
+## Dependencies and Execution Order
+
+1. T001-T004 establish artifacts and source understanding.
+2. T005-T007 define and preserve test coverage.
+3. T008-T011 implement the bounded UI changes.
+4. T012-T014 validate and publish final evidence.
+
+## Parallel Examples
+
+- T005 and T006 can be drafted independently because they cover different test scenarios in the same file, but final edits must be merged carefully.
+- T008 and T009 both touch `tasks-list.tsx`, so they should be applied serially.
+
+## Implementation Strategy
+
+The story is mostly implemented by existing Tasks List column-filter work. The remaining runtime work is narrowly scoped to missing text filters, focus/keyboard dialog behavior, and live-update stability while an editor is open.

--- a/specs/304-mobile-accessibility-live-update-stability/tasks.md
+++ b/specs/304-mobile-accessibility-live-update-stability/tasks.md
@@ -2,60 +2,93 @@
 
 **Input**: `specs/304-mobile-accessibility-live-update-stability/spec.md`  
 **Plan**: `specs/304-mobile-accessibility-live-update-stability/plan.md`  
+**Research**: `specs/304-mobile-accessibility-live-update-stability/research.md`  
+**Data Model**: `specs/304-mobile-accessibility-live-update-stability/data-model.md`  
+**Contract**: `specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md`  
 **Unit Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
-**Integration Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
+**Integration Test Command**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
+**Final Verification**: `/speckit.verify`
 
-**Source Traceability**: The original `MM-591` Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-010, acceptance scenarios 1 through 7, SC-001 through SC-006, and DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023.
+**Source Traceability**: The original `MM-591` Jira preset brief is preserved in `spec.md`. This task list covers exactly one story, FR-001 through FR-010, acceptance scenarios 1 through 7, SC-001 through SC-006, and DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, and DESIGN-REQ-023.
+
+**Requirement Status Summary**: `plan.md` currently marks all 20 tracked rows as `implemented_verified`. The tasks below preserve the red-first implementation sequence and identify the existing files that carry the verified evidence. When replaying from a clean baseline, execute the test tasks before implementation tasks; in the current workspace, use the validation and `/speckit.verify` tasks to preserve evidence.
 
 ## Phase 1: Setup
 
-- [X] T001 Confirm no existing `MM-591` MoonSpec artifact exists and assign global next spec prefix `304` under `specs/`.
-- [X] T002 Create `specs/304-mobile-accessibility-live-update-stability/` artifact structure and preserve the canonical Jira preset brief in `spec.md`.
+- [ ] T001 Confirm `.specify/feature.json` points at `specs/304-mobile-accessibility-live-update-stability/` and that `specs/304-mobile-accessibility-live-update-stability/spec.md` preserves the `MM-591` Jira preset brief. (FR-010, SC-006)
+- [ ] T002 Confirm `specs/304-mobile-accessibility-live-update-stability/plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-filter-behavior.md` exist before story task execution. (FR-010, SC-006)
+- [ ] T003 Confirm `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` are the only source/test files required by the implementation plan. (FR-001 through FR-009)
 
 ## Phase 2: Foundational
 
-- [X] T003 Inspect `docs/UI/TasksListPage.md` sections 5.7, 14, 15, and 16 for source design requirements. (DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023)
-- [X] T004 Inspect current Tasks List implementation and tests in `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001 through FR-009)
+- [ ] T004 Inspect `docs/UI/TasksListPage.md` sections 5.7, 14, 15, and 16 and confirm the source mappings in `specs/304-mobile-accessibility-live-update-stability/spec.md`. (DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023)
+- [ ] T005 Inspect existing task-only query, filter parsing, URL serialization, and mobile card behavior in `frontend/src/entrypoints/tasks-list.tsx` before adding tests. (FR-001 through FR-009)
 
 ## Phase 3: Story - Stable Accessible Task Filters
 
 **Story Summary**: Operators on mobile, desktop, and assistive technologies can use equivalent task filters without live updates disrupting staged selections.
 
-**Independent Test**: Render the Tasks List page with mocked execution data, operate desktop filter dialogs by keyboard, operate mobile filters, and verify task-scoped API URLs and focus behavior.
+**Independent Test**: Render the Tasks List page with mocked execution data, operate desktop filter dialogs by keyboard, operate mobile filters for ID, Title, status, runtime, skill, repository, and dates, and verify task-scoped API URLs plus focus behavior.
 
-**Traceability IDs**: FR-001 through FR-010; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023.
+**Traceability IDs**: FR-001 through FR-010; acceptance scenarios 1 through 7; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022, DESIGN-REQ-023.
 
-### Tests
+**Unit Test Plan**: Use `frontend/src/entrypoints/tasks-list.test.tsx` to verify filter state parsing, mobile control reachability, task-scoped URL serialization, staged filter behavior, Enter apply behavior, active chips, and workflow-kind guardrails.
 
-- [X] T005 Extend the mobile filter reachability test in `frontend/src/entrypoints/tasks-list.test.tsx` to cover ID and Title controls plus task-scoped URL serialization. (FR-001, FR-002, SC-001, SC-002, DESIGN-REQ-023)
-- [X] T006 Add a focused UI test in `frontend/src/entrypoints/tasks-list.test.tsx` proving desktop filter dialogs focus the first control, apply staged text filters with Enter, and return focus to the originating control. (FR-004, FR-006, SC-003, SC-004, DESIGN-REQ-022)
-- [X] T007 Preserve existing staging, Escape, outside-click, active-chip, workflow-kind, and mobile-card tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-005, FR-008, FR-009, DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022)
+**Integration Test Plan**: Use the same Testing Library component harness in `frontend/src/entrypoints/tasks-list.test.tsx` as the UI integration surface for the rendered Tasks List page; no compose-backed integration is required for this frontend-only story.
+
+### Unit Tests
+
+- [ ] T006 Add or preserve the mobile filter reachability test in `frontend/src/entrypoints/tasks-list.test.tsx` for ID, Runtime, Skill, Repository, Status, Title, Scheduled, Created, and Finished controls. (FR-001, SC-001, DESIGN-REQ-023)
+- [ ] T007 Add or preserve the mobile filter URL test in `frontend/src/entrypoints/tasks-list.test.tsx` for task-scoped `taskIdContains`, `titleContains`, status, runtime, repository, and stale-cursor omission. (FR-002, SC-002, DESIGN-REQ-023)
+- [ ] T008 Add or preserve the desktop filter keyboard test in `frontend/src/entrypoints/tasks-list.test.tsx` for focus-in and Enter-to-apply behavior. (FR-004, FR-006, SC-003, SC-004, DESIGN-REQ-022)
+- [ ] T009 Preserve staging, Escape, outside-click, active-chip, status-label, workflow-kind, and mobile-card guardrail tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-003, FR-005, FR-008, FR-009, DESIGN-REQ-006, DESIGN-REQ-021, DESIGN-REQ-022)
+
+### Integration Tests
+
+- [ ] T010 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that renders the Tasks List, applies mobile filters, and verifies the resulting `/api/executions` request remains task-scoped. (Acceptance scenarios 1, 2, 7; FR-001, FR-002, FR-009)
+- [ ] T011 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that opens a desktop filter dialog, stages a text filter, applies it with Enter, and verifies the request URL. (Acceptance scenarios 3, 5; FR-004, FR-006)
+- [ ] T012 Add or preserve UI integration-style component coverage in `frontend/src/entrypoints/tasks-list.test.tsx` that verifies cancel, Escape, and outside-click dismissal do not submit staged filter changes. (Acceptance scenario 4; FR-005)
+
+### Red-First Confirmation
+
+- [ ] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` after T006-T012 and before T015-T018 to confirm newly authored or replayed tests fail for the intended reason on an unimplemented baseline. (FR-001 through FR-009)
+- [ ] T014 Record red-first or already-verified status in `specs/304-mobile-accessibility-live-update-stability/verification.md`; in the current workspace, cite the existing passing test evidence because `plan.md` marks all tracked rows `implemented_verified`. (SC-006)
 
 ### Implementation
 
-- [X] T008 Add `taskId` and `title` text filters to `ColumnFilters` parsing, URL serialization, summaries, active chips, desktop filter popovers, and mobile controls in `frontend/src/entrypoints/tasks-list.tsx`. (FR-001, FR-002, DESIGN-REQ-023)
-- [X] T009 Add desktop filter focus management and Enter-to-apply handling in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-006, DESIGN-REQ-022)
-- [X] T010 Pause Tasks List live refetch intervals while a desktop filter editor is open in `frontend/src/entrypoints/tasks-list.tsx`. (FR-007, DESIGN-REQ-021)
-- [X] T011 Preserve task-only scope enforcement and existing workflow-kind fail-safe behavior in `frontend/src/entrypoints/tasks-list.tsx`. (FR-009)
+- [ ] T015 Add or preserve `taskId` and `title` text filters in `frontend/src/entrypoints/tasks-list.tsx` across filter types, empty state, parsing, URL serialization, summaries, active chips, desktop popovers, and mobile controls. (FR-001, FR-002, DESIGN-REQ-023)
+- [ ] T016 Add or preserve desktop filter focus management and Enter-to-apply handling in `frontend/src/entrypoints/tasks-list.tsx`. (FR-004, FR-006, DESIGN-REQ-022)
+- [ ] T017 Add or preserve the live-update stability guard in `frontend/src/entrypoints/tasks-list.tsx` so list refetch intervals pause while a filter editor is open. (FR-007, DESIGN-REQ-021)
+- [ ] T018 Preserve task-only scope enforcement, workflow-kind fail-safe behavior, active filter indicators, and mobile-card visibility in `frontend/src/entrypoints/tasks-list.tsx`. (FR-003, FR-008, FR-009, DESIGN-REQ-006)
 
-### Validation
+### Story Validation
 
-- [X] T012 Run focused UI validation: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001 through FR-010)
-- [X] T013 Run final unit validation: `./tools/test_unit.sh`. (FR-001 through FR-010)
-- [X] T014 Produce final MoonSpec verification report in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (SC-006)
+- [ ] T019 Run focused unit and UI integration validation with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` and record the result in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (FR-001 through FR-010, SC-001 through SC-006)
+- [ ] T020 Run final repository unit validation with `./tools/test_unit.sh` and record the result in `specs/304-mobile-accessibility-live-update-stability/verification.md`. (FR-001 through FR-010, SC-001 through SC-006)
+
+## Phase 4: Polish And Verification
+
+- [ ] T021 Review `specs/304-mobile-accessibility-live-update-stability/contracts/tasks-list-filter-behavior.md` against `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx` to confirm public UI behavior remains aligned. (FR-001 through FR-009)
+- [ ] T022 Review `specs/304-mobile-accessibility-live-update-stability/quickstart.md` and confirm it lists the focused and final validation commands for the story. (SC-001 through SC-006)
+- [ ] T023 Run `/speckit.verify` and update `specs/304-mobile-accessibility-live-update-stability/verification.md` with final comparison against the original `MM-591` preset brief. (FR-010, SC-006)
 
 ## Dependencies and Execution Order
 
-1. T001-T004 establish artifacts and source understanding.
-2. T005-T007 define and preserve test coverage.
-3. T008-T011 implement the bounded UI changes.
-4. T012-T014 validate and publish final evidence.
+1. T001-T003 confirm the active feature artifacts and source/test scope.
+2. T004-T005 establish source-design and implementation context.
+3. T006-T012 author or preserve unit and UI integration tests before implementation work.
+4. T013-T014 confirm red-first behavior on an unimplemented baseline, or preserve current already-verified evidence.
+5. T015-T018 implement or preserve the bounded UI changes.
+6. T019-T020 validate the story with focused and full unit runners.
+7. T021-T023 complete contract, quickstart, and final `/speckit.verify` evidence.
 
 ## Parallel Examples
 
-- T005 and T006 can be drafted independently because they cover different test scenarios in the same file, but final edits must be merged carefully.
-- T008 and T009 both touch `tasks-list.tsx`, so they should be applied serially.
+- T001 and T002 can run in parallel because they inspect different artifact files.
+- T006, T007, T008, and T009 all touch `frontend/src/entrypoints/tasks-list.test.tsx`; draft them independently only in separate workspaces, then merge serially.
+- T015, T016, T017, and T018 all touch `frontend/src/entrypoints/tasks-list.tsx` and must be applied serially.
+- T021 and T022 can run in parallel because they inspect different MoonSpec artifacts.
 
 ## Implementation Strategy
 
-The story is mostly implemented by existing Tasks List column-filter work. The remaining runtime work is narrowly scoped to missing text filters, focus/keyboard dialog behavior, and live-update stability while an editor is open.
+The updated `plan.md` marks all tracked requirement, scenario, success-criterion, and source-design rows as `implemented_verified`. For the current workspace, execute this task list as a verification and traceability-preservation workflow. For a clean replay, keep the TDD ordering: author unit and UI integration tests first, run the focused test command to confirm red-first failure, implement the Tasks List UI changes, run focused validation, run the full unit suite, then run `/speckit.verify`.

--- a/specs/304-mobile-accessibility-live-update-stability/verification.md
+++ b/specs/304-mobile-accessibility-live-update-stability/verification.md
@@ -1,0 +1,47 @@
+# MoonSpec Verification Report
+
+**Feature**: `specs/304-mobile-accessibility-live-update-stability`  
+**Original Request Source**: `spec.md` Input preserving `MM-591` Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED
+
+## Verification Summary
+
+The implementation satisfies the `MM-591` runtime UI story. Tasks List mobile controls now include ID and Title filters in addition to existing status, runtime, skill, repository, and date filters. Desktop filter dialogs focus the first control on open, support Enter-to-apply for staged filter edits, keep staged changes out of requests until committed, and pause list polling while a filter editor is open. Existing task-only visibility protections remain in place.
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `tasks-list.tsx` adds `taskId` and `title` filters; `tasks-list.test.tsx` verifies mobile ID, status, repository, runtime, skill, title, and date controls. |
+| FR-002 | VERIFIED | Mobile filter test verifies task-scoped URL serialization with no stale pagination cursor. |
+| FR-003 | VERIFIED | Existing sort/filter separation tests continue to pass. |
+| FR-004 | VERIFIED | Filter dialog test verifies focus moves into the title filter input on open; implementation returns focus to the originating control on close paths. |
+| FR-005 | VERIFIED | Existing staging test verifies cancel, Escape, and outside click discard changes without extra list requests. |
+| FR-006 | VERIFIED | New test verifies Enter applies the staged Title text filter and closes the dialog. |
+| FR-007 | VERIFIED | `tasks-list.tsx` disables the list refetch interval while `openFilter` is set. |
+| FR-008 | VERIFIED | Existing active chip, accessible filter label, `aria-sort`, and status pill tests continue to pass. |
+| FR-009 | VERIFIED | Existing workflow-kind tests continue to verify ordinary Tasks List remains task-scoped. |
+| FR-010 | VERIFIED | `MM-591` is preserved in `spec.md`, `plan.md`, `tasks.md`, and this report. |
+
+## Source Design Coverage
+
+| Source ID | Status | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-006 | VERIFIED | Mobile card structure and single full-width details action tests remain passing. |
+| DESIGN-REQ-021 | VERIFIED | Polling is paused while a filter editor is open and staged filter tests remain passing. |
+| DESIGN-REQ-022 | VERIFIED | Sort/filter separation, ARIA state, focus-in, Escape, Enter, active chips, and status label coverage pass. |
+| DESIGN-REQ-023 | VERIFIED | Mobile filter controls now include ID and Title along with existing task filters; workflow-kind controls remain unavailable. |
+
+## Test Evidence
+
+| Command | Result |
+| --- | --- |
+| `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` | PASS: 31 tests passed |
+| `./tools/test_unit.sh` | PASS: Python unit suite passed (`4344 passed, 1 xpassed, 16 subtests passed`); frontend Vitest passed (`20 files passed, 302 tests passed, 223 skipped`) |
+| `node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS |
+
+## Notes
+
+- The full unit runner emitted existing warnings, including `HTMLCanvasElement.getContext()` jsdom notices and Python deprecation warnings, but exited successfully.
+- `npm run ui:typecheck` could not find `tsc` through the npm script PATH in this managed shell; invoking the same local binary directly passed.
+- Compose-backed integration was not required for this frontend-only story.

--- a/specs/304-mobile-accessibility-live-update-stability/verification.md
+++ b/specs/304-mobile-accessibility-live-update-stability/verification.md
@@ -2,11 +2,13 @@
 
 **Feature**: `specs/304-mobile-accessibility-live-update-stability`  
 **Original Request Source**: `spec.md` Input preserving `MM-591` Jira preset brief  
-**Verdict**: FULLY_IMPLEMENTED
+**Verdict**: IMPLEMENTED_WITH_VALIDATION_BLOCKER
 
 ## Verification Summary
 
 The implementation satisfies the `MM-591` runtime UI story. Tasks List mobile controls now include ID and Title filters in addition to existing status, runtime, skill, repository, and date filters. Desktop filter dialogs focus the first control on open, support Enter-to-apply for staged filter edits, keep staged changes out of requests until committed, and pause list polling while a filter editor is open. Existing task-only visibility protections remain in place.
+
+Current direct story validation passes. The repository wrapper/full unit command is blocked in this managed run by unrelated tests that load repo `.agents/skills` files which are absent under the active managed skill snapshot.
 
 ## Requirement Coverage
 
@@ -37,11 +39,13 @@ The implementation satisfies the `MM-591` runtime UI story. Tasks List mobile co
 | Command | Result |
 | --- | --- |
 | `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` | PASS: 31 tests passed |
-| `./tools/test_unit.sh` | PASS: Python unit suite passed (`4344 passed, 1 xpassed, 16 subtests passed`); frontend Vitest passed (`20 files passed, 302 tests passed, 223 skipped`) |
+| `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` | FAIL: Python unit phase failed before UI target due unrelated missing `.agents/skills/*` files required by PR-resolver skill tests in this managed active-snapshot workspace. |
+| `./tools/test_unit.sh` | NOT RERUN after focused wrapper failure; expected to hit the same unrelated `.agents/skills/*` blocker until the active skill projection/test fixture mismatch is resolved. |
 | `node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS |
 
 ## Notes
 
-- The full unit runner emitted existing warnings, including `HTMLCanvasElement.getContext()` jsdom notices and Python deprecation warnings, but exited successfully.
+- Red-first failure evidence cannot be reproduced in the current workspace without reverting already-implemented behavior. The current `plan.md` marks all tracked rows `implemented_verified`, so this implementation pass preserves existing test evidence and records the managed-snapshot blocker.
+- The focused wrapper emitted existing Python warnings before failing on unrelated missing skill files.
 - `npm run ui:typecheck` could not find `tsc` through the npm script PATH in this managed shell; invoking the same local binary directly passed.
 - Compose-backed integration was not required for this frontend-only story.


### PR DESCRIPTION
Jira issue key: MM-591

Active MoonSpec feature path: specs/304-mobile-accessibility-live-update-stability

Verification verdict: NO_DETERMINATION

Summary:
- Adds mobile ID and Title filter coverage alongside existing status, runtime, skill, repository, and date filters.
- Preserves task-scoped URL serialization and workflow-kind guardrails.
- Adds/validates desktop filter focus behavior, Enter-to-apply handling, and live-update polling pause while a filter editor is open.

Tests run:
- PASS: node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx (31 tests)
- PASS: node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- FAIL: ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx failed before UI execution because unrelated PR-resolver tests load missing .agents/skills/* files under the active managed skill snapshot.
- NOT RUN: ./tools/test_unit.sh after the focused wrapper failure; expected to hit the same active-snapshot fixture blocker.

Remaining risks:
- Final MoonSpec verification is NO_DETERMINATION until the managed active-snapshot/test-fixture mismatch for .agents/skills/* is resolved and the required wrapper/full unit validation can pass.
- Local worktree contains unmanaged .agents/skills runtime projection changes that are intentionally excluded from the PR branch diff.
