### PR TITLE
MM-592 Empty/error states final rollout

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_875
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_876

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_873
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_874

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_871
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_872

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_872
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_873

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_874
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_875

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_876
+../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_744

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:d238eda5-24ef-4ab2-837a-0c5145d9de68_744
+../../runtime/skills_active/skillset_mm:c6f72093-3abd-4e85-9fde-6ed6806d700c_871

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/304-mobile-accessibility-live-update-stability"
+  "feature_directory": "specs/305-empty-error-states-rollout"
 }

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -41,6 +41,71 @@ describe('Tasks List Entrypoint', () => {
 
   const lastExecutionListUrl = () => executionListCalls().at(-1)?.[0];
 
+  it('shows the loading state while the task list request is pending', () => {
+    fetchSpy.mockReturnValue(new Promise(() => {}) as Promise<Response>);
+
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    expect(screen.getByText('Loading tasks...')).toBeTruthy();
+  });
+
+  it('shows structured API validation detail when the task list request fails', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      json: async () => ({
+        detail: {
+          code: 'execution_filter_validation_failed',
+          message: 'Cannot combine stateIn and stateNotIn.',
+        },
+      }),
+    } as Response);
+
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
+  });
+
+  it('keeps Clear filters available on an empty first page with active filters', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('stateIn=completed')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [], count: 0 }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              taskId: 'task-123',
+              source: 'temporal',
+              title: 'Example task',
+              status: 'completed',
+              state: 'completed',
+              rawState: 'completed',
+              createdAt: '2026-03-28T00:00:00Z',
+            },
+          ],
+        }),
+      } as Response);
+    });
+
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    fireEvent.change(await screen.findByLabelText('Status filter value'), {
+      target: { value: 'completed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+
+    expect(await screen.findByText('No tasks found for the current filters.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Clear filters' }).getAttribute('disabled')).toBeNull();
+  });
+
   it('announces the current sort state on table headers', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -236,6 +236,49 @@ function replaceUrlQuery(params: URLSearchParams) {
   window.history.replaceState({}, '', queryText ? `${path}?${queryText}` : path);
 }
 
+function sanitizeApiErrorMessage(message: string): string {
+  return message.replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function apiErrorMessageFromPayload(payload: unknown): string | null {
+  if (typeof payload === 'string') {
+    return sanitizeApiErrorMessage(payload) || null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.detail === 'string') {
+    return sanitizeApiErrorMessage(record.detail) || null;
+  }
+  if (record.detail && typeof record.detail === 'object' && !Array.isArray(record.detail)) {
+    const detail = record.detail as Record<string, unknown>;
+    if (typeof detail.message === 'string') {
+      return sanitizeApiErrorMessage(detail.message) || null;
+    }
+  }
+  if (Array.isArray(record.detail)) {
+    const firstMessage = record.detail
+      .map((item) => (item && typeof item === 'object' ? (item as Record<string, unknown>).msg : null))
+      .find((message): message is string => typeof message === 'string');
+    if (firstMessage) return sanitizeApiErrorMessage(firstMessage) || null;
+  }
+  if (typeof record.message === 'string') {
+    return sanitizeApiErrorMessage(record.message) || null;
+  }
+  return null;
+}
+
+async function taskListErrorMessage(response: Response): Promise<string> {
+  try {
+    const payload = await response.json();
+    const message = apiErrorMessageFromPayload(payload);
+    if (message) return message;
+  } catch {
+    // Fall back to status text below when the body is empty or not JSON.
+  }
+  const statusText = sanitizeApiErrorMessage(response.statusText || '');
+  return statusText ? `Failed to fetch: ${statusText}` : 'Failed to fetch tasks.';
+}
+
 function emptyValueFilter(): ValueFilter {
   return { mode: 'include', values: [], blank: '' };
 }
@@ -509,7 +552,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       appendFilterParams(params, filters);
       const response = await fetch(`${payload.apiBase}/executions?${params}`);
       if (!response.ok) {
-        throw new Error(`Failed to fetch: ${response.statusText}`);
+        throw new Error(await taskListErrorMessage(response));
       }
       return ExecutionListResponseSchema.parse(await response.json());
     },

--- a/specs/305-empty-error-states-rollout/checklists/requirements.md
+++ b/specs/305-empty-error-states-rollout/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Empty/Error States and Regression Coverage for Final Rollout
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is one Jira-selected runtime UI rollout story, so no MoonSpec breakdown was required.
+- PASS: The original MM-592 Jira preset brief is preserved verbatim in `spec.md`.
+- PASS: All in-scope DESIGN-REQ IDs map to functional requirements.

--- a/specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md
+++ b/specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md
@@ -1,0 +1,43 @@
+# Tasks List Empty/Error Rollout Contract
+
+Traceability: `MM-592`; FR-001 through FR-013; DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, DESIGN-REQ-028.
+
+## UI Contract
+
+The Tasks List page must expose these rollout recovery states:
+
+| State | Required behavior |
+| --- | --- |
+| Loading | Show `Loading tasks...`. |
+| List API failure | Show a visible error notice. Prefer structured API detail when provided. |
+| Empty first page | Show `No tasks found for the current filters.`. |
+| Empty first page with active filters | Keep an enabled `Clear filters` recovery action. |
+| Empty later page | Keep previous-page navigation enabled. |
+| Facet failure | Show an inline fallback notice inside the filter editor without hiding loaded rows. |
+| Invalid filters | Show structured validation messages and keep filter state editable or clearable. |
+| Final parity | Do not render old top Scope, Workflow Type, Status, Entry, or Repository controls. |
+
+## Error Detail Contract
+
+For non-OK list responses, the UI should derive a sanitized display message in this order:
+
+1. `detail.message` when the JSON body is an object with a string `message`.
+2. `detail` when the JSON body is a string.
+3. `message` when the JSON body is an object with a string `message`.
+4. `response.statusText` when no structured message exists.
+5. A generic list-fetch failure string as a final fallback.
+
+The UI must not print auth headers, cookies, tokens, or raw stack traces.
+
+## Non-Goal Guardrails
+
+The final rollout must not introduce:
+- spreadsheet-style editing;
+- arbitrary pivot tables;
+- multi-column sort;
+- user-authored raw Temporal Visibility SQL;
+- direct browser calls to Temporal;
+- saved filter views;
+- pagination replacement;
+- Live updates removal;
+- ordinary system workflow browsing from `/tasks/list`.

--- a/specs/305-empty-error-states-rollout/data-model.md
+++ b/specs/305-empty-error-states-rollout/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Empty/Error States and Regression Coverage for Final Rollout
+
+This story does not add persistent entities, database tables, or stored workflow payloads.
+
+## Runtime State Used by the UI
+
+### ColumnFilters
+
+Existing client-side query state representing active task-list filters.
+
+Fields used by this story:
+- `status`, `repository`, `targetRuntime`, `targetSkill`: value filters with include/exclude modes.
+- `taskId`, `title`: text contains filters.
+- `scheduledFor`, `createdAt`, `closedAt`: date filters with optional blank handling where supported.
+
+Validation rules:
+- Contradictory include and exclude filters for the same field are invalid.
+- Active filters must remain editable or clearable when validation fails.
+- Clearing filters resets pagination to the first page.
+
+### ListErrorMessage
+
+Derived display state for failed list requests.
+
+Fields:
+- `message`: sanitized operator-visible error message.
+
+Validation rules:
+- Prefer structured API `detail.message` when available.
+- Accept simple string `detail` responses.
+- Fall back to HTTP status text when structured detail is unavailable.
+- Do not render raw secrets, headers, or stack traces.
+
+### PaginationState
+
+Existing client-side pagination state.
+
+Fields:
+- `nextPageToken`: opaque cursor for the current page request.
+- `cursorStack`: previous-page cursor stack.
+- `pageSize`: selected page size.
+
+Validation rules:
+- Empty later pages retain previous-page recovery when `cursorStack` or `nextPageToken` indicates pagination context.
+- Filter changes clear stale cursor state.

--- a/specs/305-empty-error-states-rollout/moonspec_align_report.md
+++ b/specs/305-empty-error-states-rollout/moonspec_align_report.md
@@ -1,0 +1,25 @@
+# MoonSpec Align Report: Empty/Error States and Regression Coverage for Final Rollout
+
+## Summary
+
+PASS. The MoonSpec artifacts are aligned for a single runtime UI story sourced from `MM-592`. The spec preserves the canonical Jira preset brief, the plan identifies the current repo gap, and `tasks.md` orders missing regression tests before the structured API error implementation.
+
+## Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Single-story scope | PASS | `spec.md` contains exactly one `## User Story - Recoverable Final Column-Filter Rollout` section. |
+| Original input preservation | PASS | `spec.md` preserves `MM-592` and the canonical Jira preset brief. |
+| Source design mapping | PASS | DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028 map to FR rows in `spec.md`, status rows in `plan.md`, and tasks in `tasks.md`. |
+| TDD ordering | PASS | T006-T008 add missing tests before T012 implementation. |
+| Runtime intent | PASS | Artifacts describe Tasks List runtime behavior and tests, not documentation-only changes. |
+| Canonical docs boundary | PASS | `docs/UI/TasksListPage.md` is treated as source requirements; no canonical docs edits are planned. |
+
+## Decisions
+
+- Structured list API detail is the only production code gap identified during alignment; local validation, facet fallback, empty later-page recovery, old-control absence, and task-scope non-goals already have test evidence.
+- The UI component test harness is the integration-style surface for this frontend story; compose-backed integration is not required unless backend filter behavior changes.
+
+## Remaining Risks
+
+- Full `./tools/test_unit.sh` may remain blocked by the managed active-skill snapshot mismatch seen in nearby runs. Focused UI evidence is still required and sufficient for this frontend-only story if the full wrapper is blocked for unrelated reasons.

--- a/specs/305-empty-error-states-rollout/moonspec_align_report.md
+++ b/specs/305-empty-error-states-rollout/moonspec_align_report.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-PASS. The MoonSpec artifacts are aligned for a single runtime UI story sourced from `MM-592`. The spec preserves the canonical Jira preset brief, the plan identifies the current repo gap, and `tasks.md` orders missing regression tests before the structured API error implementation.
+PASS. The MoonSpec artifacts are aligned for a single runtime UI story sourced from `MM-592`. The spec preserves the canonical Jira preset brief, the plan and research artifacts reflect the current implemented-and-verified state, and `tasks.md` preserves the completed TDD order with final `/moonspec-verify` wording.
 
 ## Checks
 
@@ -10,16 +10,26 @@ PASS. The MoonSpec artifacts are aligned for a single runtime UI story sourced f
 | --- | --- | --- |
 | Single-story scope | PASS | `spec.md` contains exactly one `## User Story - Recoverable Final Column-Filter Rollout` section. |
 | Original input preservation | PASS | `spec.md` preserves `MM-592` and the canonical Jira preset brief. |
-| Source design mapping | PASS | DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028 map to FR rows in `spec.md`, status rows in `plan.md`, and tasks in `tasks.md`. |
-| TDD ordering | PASS | T006-T008 add missing tests before T012 implementation. |
+| Source design mapping | PASS | DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028 map to FR rows in `spec.md`, status rows in `plan.md`, tasks in `tasks.md`, and verification evidence in `verification.md`. |
+| TDD ordering | PASS | T006-T008 add tests before T012 implementation; T010-T011 preserve red-first evidence. |
+| Unit strategy | PASS | `tasks.md` and `quickstart.md` use the focused Vitest command and full unit runner. |
+| Integration strategy | PASS | The rendered Tasks List component harness is documented as the UI integration-style surface for this frontend story. |
 | Runtime intent | PASS | Artifacts describe Tasks List runtime behavior and tests, not documentation-only changes. |
 | Canonical docs boundary | PASS | `docs/UI/TasksListPage.md` is treated as source requirements; no canonical docs edits are planned. |
+| Final verification command | PASS | `tasks.md` uses `/moonspec-verify`; no legacy verify command references remain in task execution text. |
 
 ## Decisions
 
-- Structured list API detail is the only production code gap identified during alignment; local validation, facet fallback, empty later-page recovery, old-control absence, and task-scope non-goals already have test evidence.
-- The UI component test harness is the integration-style surface for this frontend story; compose-backed integration is not required unless backend filter behavior changes.
+- Updated research and alignment reporting from pre-implementation gap language to the current verified state because `plan.md`, `tasks.md`, and `verification.md` now show all tracked rows implemented and verified.
+- Kept the UI component test harness as the integration-style surface because this story is frontend-only and no backend contract or persistence behavior changed.
 
 ## Remaining Risks
 
-- Full `./tools/test_unit.sh` may remain blocked by the managed active-skill snapshot mismatch seen in nearby runs. Focused UI evidence is still required and sufficient for this frontend-only story if the full wrapper is blocked for unrelated reasons.
+None found.
+
+## Validation
+
+| Command | Result |
+| --- | --- |
+| Legacy verify command scan | PASS: no legacy verify command references remain outside this alignment report. |
+| Artifact gate script | PASS: one story, no clarification markers, no unchecked tasks, all required artifacts present. |

--- a/specs/305-empty-error-states-rollout/plan.md
+++ b/specs/305-empty-error-states-rollout/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Empty/Error States and Regression Coverage for Final Rollout
+
+**Branch**: `305-empty-error-states-rollout` | **Date**: 2026-05-05 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story runtime spec generated from the trusted Jira preset brief for `MM-592`.
+
+## Summary
+
+Complete the final Tasks List column-filter rollout story for `MM-592` by verifying and, where needed, tightening recoverable loading, API error, empty first-page, empty later-page, facet failure, invalid-filter, old-control removal, and non-goal safety behavior. Current repo evidence shows most behavior exists in `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`; the main gap is regression coverage for loading/API-error/empty-first-page recovery and structured API error detail rendering. Implementation will be TDD-first in the existing Tasks List Vitest suite, with no new persistence and no canonical docs changes.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `tasks-list.tsx` renders `Loading tasks...`; `tasks-list.test.tsx` covers the pending request state | complete | focused UI passed |
+| FR-002 | implemented_verified | `tasks-list.tsx` parses sanitized structured API error detail; `tasks-list.test.tsx` verifies `detail.message` display | complete | focused UI passed |
+| FR-003 | implemented_verified | `tasks-list.tsx` renders empty first-page text; `tasks-list.test.tsx` covers active-filter empty state | complete | focused UI passed |
+| FR-004 | implemented_verified | `tasks-list.test.tsx` verifies enabled Clear filters on empty first page with active filters | complete | focused UI passed |
+| FR-005 | implemented_verified | `tasks-list.test.tsx` covers previous-page enabled on empty later pages | preserve behavior | final UI validation |
+| FR-006 | implemented_verified | pagination tests cover next token and previous cursor stack behavior | preserve behavior | final UI validation |
+| FR-007 | implemented_verified | `tasks-list.test.tsx` covers facet failure fallback notice and table usability | preserve behavior | final UI validation |
+| FR-008 | implemented_verified | `tasks-list.test.tsx` covers contradictory canonical filter validation and Clear filters recovery | preserve behavior | final UI validation |
+| FR-009 | implemented_verified | structured API error detail is surfaced and active filter controls remain available | complete | focused UI passed |
+| FR-010 | implemented_verified | tests assert old control form and workflow-kind controls are absent | preserve behavior | final UI validation |
+| FR-011 | implemented_verified | task-scope and no workflow-kind browsing tests cover non-goal safety | preserve behavior | final UI validation |
+| FR-012 | implemented_verified | final rollout tests now cover loading, API error, empty first page, empty later page, facet fallback, invalid filters, old controls, and non-goals | complete | focused UI + full unit passed |
+| FR-013 | implemented_verified | `spec.md`, `plan.md`, `tasks.md`, and `verification.md` preserve MM-592 | complete | artifact review passed |
+| SC-001 | implemented_verified | pending request test asserts `Loading tasks...` | complete | focused UI passed |
+| SC-002 | implemented_verified | structured error test asserts API detail message | complete | focused UI passed |
+| SC-003 | implemented_verified | active-filter empty first page test asserts text and enabled Clear filters | complete | focused UI passed |
+| SC-004 | implemented_verified | existing UI test covers empty later-page previous button | preserve behavior | final UI validation |
+| SC-005 | implemented_verified | existing UI test covers facet fallback notice | preserve behavior | final UI validation |
+| SC-006 | implemented_verified | local contradictory validation and structured API detail are covered | complete | focused UI passed |
+| SC-007 | implemented_verified | old-control absence and workflow-kind safety tests exist | preserve behavior | final UI validation |
+| SC-008 | implemented_verified | MM-592 and source design IDs are preserved across feature artifacts | complete | traceability check passed |
+| DESIGN-REQ-006 | implemented_verified | loading, error, empty first-page, empty later-page, pagination, and page-size behavior are covered | complete | focused UI passed |
+| DESIGN-REQ-024 | implemented_verified | empty recovery, facet fallback, local validation, and API validation detail are covered | complete | focused UI passed |
+| DESIGN-REQ-026 | implemented_verified | final rollout regression set is present and passing | complete | focused UI + full unit passed |
+| DESIGN-REQ-027 | implemented_verified | normal page exposes no raw Temporal query, system browsing, saved views, pivot/spreadsheet controls, or pagination replacement | preserve non-goals | final UI validation |
+| DESIGN-REQ-028 | implemented_verified | old controls remain removed after parity tests; MM-592 feature-local artifacts and verification are complete | complete | artifact review passed |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected for production changes.  
+**Primary Dependencies**: React, TanStack Query, Zod, Vitest, Testing Library, existing Mission Control stylesheet.  
+**Storage**: No new persistent storage; state remains URL/query state and component state only.  
+**Unit Testing**: Focused UI validation with `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`; final runner `./tools/test_unit.sh` when feasible.  
+**Integration Testing**: UI integration-style component tests in the Tasks List entrypoint test file; no compose-backed integration is required for this frontend-only story.  
+**Target Platform**: Mission Control browser UI served by FastAPI.  
+**Project Type**: Web frontend inside the MoonMind monorepo.  
+**Performance Goals**: Error parsing must not add extra network calls; empty/error states must not remount the table in a way that loses filter recovery controls.  
+**Constraints**: Keep `/tasks/list` task-scoped, preserve old-control removal, avoid raw Temporal query authoring, keep browser calls to MoonMind APIs only, and preserve `MM-592` traceability.  
+**Scale/Scope**: One Tasks List React entrypoint and focused UI tests.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. This story changes Mission Control UI behavior only.
+- II. One-Click Agent Deployment: PASS. No deployment or external prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. No provider-specific behavior.
+- IV. Own Your Data: PASS. Browser calls remain MoonMind API calls only.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill runtime changes.
+- VI. Replaceable Scaffolding: PASS. Behavior is pinned by focused regression tests.
+- VII. Runtime Configurability: PASS. Existing poll/list config remains respected.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay inside the existing Tasks List UI module.
+- IX. Resilient by Default: PASS. Recoverable errors and empty states improve operator recovery.
+- X. Facilitate Continuous Improvement: PASS. Verification artifacts record evidence and blockers.
+- XI. Spec-Driven Development: PASS. This plan follows `spec.md` and preserves the canonical `MM-592` input.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Canonical docs are read as source requirements and not rewritten.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility aliases or internal contract shims are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/305-empty-error-states-rollout/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── tasks-list-empty-error-rollout.md
+├── checklists/
+│   └── requirements.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/tasks-list.tsx
+frontend/src/entrypoints/tasks-list.test.tsx
+frontend/src/styles/mission-control.css
+```
+
+**Structure Decision**: Use the existing Tasks List entrypoint and test file. No backend, database, generated dist asset, or canonical documentation changes are required.
+
+## Complexity Tracking
+
+No constitution violations or added architectural complexity.

--- a/specs/305-empty-error-states-rollout/plan.md
+++ b/specs/305-empty-error-states-rollout/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Complete the final Tasks List column-filter rollout story for `MM-592` by verifying and, where needed, tightening recoverable loading, API error, empty first-page, empty later-page, facet failure, invalid-filter, old-control removal, and non-goal safety behavior. Current repo evidence shows most behavior exists in `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`; the main gap is regression coverage for loading/API-error/empty-first-page recovery and structured API error detail rendering. Implementation will be TDD-first in the existing Tasks List Vitest suite, with no new persistence and no canonical docs changes.
+Complete the final Tasks List column-filter rollout story for `MM-592` by verifying recoverable loading, API error, empty first-page, empty later-page, facet failure, invalid-filter, old-control removal, and non-goal safety behavior. Current repo evidence now shows the story is implemented and verified in `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`: final regression coverage exists for loading/API-error/empty-first-page recovery, and structured API error detail rendering is implemented. The plan remains frontend-focused, with no new persistence and no canonical docs changes.
 
 ## Requirement Status
 

--- a/specs/305-empty-error-states-rollout/quickstart.md
+++ b/specs/305-empty-error-states-rollout/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: Empty/Error States and Regression Coverage for Final Rollout
+
+## Focused UI Validation
+
+```bash
+node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+Expected result: Tasks List UI tests pass, including MM-592 loading, structured API error, empty first-page recovery, empty later-page recovery, facet fallback, invalid-filter recovery, old-control absence, and non-goal safety coverage.
+
+## Full Unit Validation
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Expected result: full required unit suite passes. If this managed active-skill snapshot still blocks unrelated skill-file tests, record the exact blocker in `verification.md` and keep focused UI evidence.
+
+## Story Review
+
+1. Confirm `spec.md`, `plan.md`, `tasks.md`, and `verification.md` preserve `MM-592`.
+2. Confirm source IDs DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028 are preserved.
+3. Confirm `/tasks/list` has no old top Scope, Workflow Type, Status, Entry, or Repository controls.
+4. Confirm the final rollout does not add non-goal spreadsheet, pivot, raw Temporal query, direct Temporal browser calls, saved views, pagination replacement, Live updates removal, or system workflow browsing behavior.

--- a/specs/305-empty-error-states-rollout/research.md
+++ b/specs/305-empty-error-states-rollout/research.md
@@ -2,27 +2,27 @@
 
 ## FR-001 / SC-001 - Loading State
 
-Decision: Treat as implemented but unverified for MM-592 and add a focused UI regression test.
-Evidence: `frontend/src/entrypoints/tasks-list.tsx` renders `<p className="loading">Loading tasks...</p>` while the list query is loading.
-Rationale: The behavior exists, but MM-592 requires final rollout regression evidence.
-Alternatives considered: Code change was rejected unless the test exposes a regression.
-Test implications: UI unit.
+Decision: Treat as implemented and verified for MM-592.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` renders `<p className="loading">Loading tasks...</p>` while the list query is loading, and `frontend/src/entrypoints/tasks-list.test.tsx` verifies the pending request state.
+Rationale: MM-592 requires final rollout regression evidence, and focused UI validation now covers it.
+Alternatives considered: Additional code change was rejected because the existing behavior passed the new regression test.
+Test implications: UI unit covered and passing.
 
 ## FR-002 / FR-009 / SC-002 / SC-006 - Structured List API Errors
 
-Decision: Treat as partial and add structured API error parsing for failed list responses.
-Evidence: `tasks-list.tsx` currently throws `Failed to fetch: ${response.statusText}` for list failures. Local validation errors are already displayed, but structured API detail from failed list responses is discarded.
+Decision: Treat as implemented and verified after adding structured API error parsing for failed list responses.
+Evidence: `tasks-list.tsx` now derives sanitized messages from structured response payloads before falling back to status text, and `tasks-list.test.tsx` verifies `detail.message` rendering.
 Rationale: MM-592 requires visible API errors and invalid filter parameter recovery with structured messages when available.
 Alternatives considered: Keeping generic `statusText` was rejected because FastAPI validation responses already provide safer, more actionable detail.
-Test implications: UI unit with a red-first structured error response.
+Test implications: UI unit covered with red-first evidence and passing validation.
 
 ## FR-003 / FR-004 / SC-003 - Empty First Page Recovery
 
-Decision: Treat as implemented but unverified and add a focused test with active filters.
-Evidence: `tasks-list.tsx` renders `No tasks found for the current filters.` for an empty first page and keeps the control deck with `Clear filters` above the result state.
-Rationale: Existing tests cover empty later pages but not the first-page active-filter recovery path.
+Decision: Treat as implemented and verified with a focused active-filter empty-state test.
+Evidence: `tasks-list.tsx` renders `No tasks found for the current filters.` for an empty first page and keeps the control deck with `Clear filters` above the result state; `tasks-list.test.tsx` verifies the active-filter recovery path.
+Rationale: Existing tests covered empty later pages; MM-592 now also has first-page active-filter recovery evidence.
 Alternatives considered: Moving the Clear filters button into the empty panel was rejected because the current active filter row is already the consistent recovery location.
-Test implications: UI unit.
+Test implications: UI unit covered and passing.
 
 ## FR-005 / FR-006 / SC-004 - Empty Later Page and Pagination
 
@@ -58,16 +58,16 @@ Test implications: Final UI validation only.
 
 ## FR-012 / DESIGN-REQ-026 - Final Regression Gate
 
-Decision: Treat as partial until loading, API error, and empty-first-page tests are added and passing.
-Evidence: Existing tests already cover many final rollout behaviors, but MM-592-specific final recovery cases are incomplete.
-Rationale: The Jira brief explicitly makes regression evidence a rollout gate.
+Decision: Treat as implemented and verified.
+Evidence: Existing tests cover many final rollout behaviors, and MM-592-specific loading, structured API error, and empty-first-page recovery tests now pass.
+Rationale: The Jira brief explicitly makes regression evidence a rollout gate, and the focused plus full unit validation evidence satisfies that gate.
 Alternatives considered: Relying on code inspection alone was rejected.
-Test implications: UI unit plus final verification.
+Test implications: UI unit plus final verification completed.
 
 ## FR-013 / SC-008 / DESIGN-REQ-028 - Traceability
 
 Decision: Preserve MM-592 and source design IDs through all MoonSpec artifacts and final verification.
-Evidence: `spec.md` and `plan.md` preserve MM-592 and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028.
+Evidence: `spec.md`, `plan.md`, `tasks.md`, `verification.md`, and this research artifact preserve MM-592 and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028.
 Rationale: Downstream verification, commit text, and PR metadata need the Jira key.
 Alternatives considered: Referencing only the artifact path was rejected because final verification needs the source key visible in each artifact.
-Test implications: Artifact review.
+Test implications: Artifact review completed.

--- a/specs/305-empty-error-states-rollout/research.md
+++ b/specs/305-empty-error-states-rollout/research.md
@@ -1,0 +1,73 @@
+# Research: Empty/Error States and Regression Coverage for Final Rollout
+
+## FR-001 / SC-001 - Loading State
+
+Decision: Treat as implemented but unverified for MM-592 and add a focused UI regression test.
+Evidence: `frontend/src/entrypoints/tasks-list.tsx` renders `<p className="loading">Loading tasks...</p>` while the list query is loading.
+Rationale: The behavior exists, but MM-592 requires final rollout regression evidence.
+Alternatives considered: Code change was rejected unless the test exposes a regression.
+Test implications: UI unit.
+
+## FR-002 / FR-009 / SC-002 / SC-006 - Structured List API Errors
+
+Decision: Treat as partial and add structured API error parsing for failed list responses.
+Evidence: `tasks-list.tsx` currently throws `Failed to fetch: ${response.statusText}` for list failures. Local validation errors are already displayed, but structured API detail from failed list responses is discarded.
+Rationale: MM-592 requires visible API errors and invalid filter parameter recovery with structured messages when available.
+Alternatives considered: Keeping generic `statusText` was rejected because FastAPI validation responses already provide safer, more actionable detail.
+Test implications: UI unit with a red-first structured error response.
+
+## FR-003 / FR-004 / SC-003 - Empty First Page Recovery
+
+Decision: Treat as implemented but unverified and add a focused test with active filters.
+Evidence: `tasks-list.tsx` renders `No tasks found for the current filters.` for an empty first page and keeps the control deck with `Clear filters` above the result state.
+Rationale: Existing tests cover empty later pages but not the first-page active-filter recovery path.
+Alternatives considered: Moving the Clear filters button into the empty panel was rejected because the current active filter row is already the consistent recovery location.
+Test implications: UI unit.
+
+## FR-005 / FR-006 / SC-004 - Empty Later Page and Pagination
+
+Decision: Treat as implemented and verified by existing tests.
+Evidence: `frontend/src/entrypoints/tasks-list.test.tsx` includes `keeps the previous-page button enabled on empty pages after pagination` and page-size cursor reset coverage.
+Rationale: The existing test directly covers the MM-592 later-page recovery requirement.
+Alternatives considered: Adding a duplicate test was rejected.
+Test implications: Final UI validation only.
+
+## FR-007 / SC-005 - Facet Failure Fallback
+
+Decision: Treat as implemented and verified by existing tests.
+Evidence: `tasks-list.test.tsx` includes `shows a current-page values notice when facet values fail to load`, asserting the inline fallback notice and preserved table data.
+Rationale: This directly satisfies the facet-failure acceptance criterion.
+Alternatives considered: Adding retry behavior now was rejected because the design allows fallback or retry.
+Test implications: Final UI validation only.
+
+## FR-008 - Local Invalid Filter Recovery
+
+Decision: Treat as implemented and verified by existing tests.
+Evidence: `tasks-list.test.tsx` covers contradictory canonical URL filters and recovery after `Clear filters`.
+Rationale: The page preserves recovery without sending an invalid list request.
+Alternatives considered: Moving all validation to the server was rejected because local validation avoids unnecessary requests and keeps recovery immediate.
+Test implications: Final UI validation only.
+
+## FR-010 / FR-011 / SC-007 / DESIGN-REQ-027 - Old Controls and Non-Goals
+
+Decision: Treat as implemented and verified.
+Evidence: `tasks-list.test.tsx` asserts no Scope, Workflow Type, Entry, Kind, or old filter form controls exist and that task scope is forced.
+Rationale: The normal Tasks List remains task-scoped and does not expose system workflow browsing.
+Alternatives considered: Reintroducing compatibility top controls was rejected by the source design.
+Test implications: Final UI validation only.
+
+## FR-012 / DESIGN-REQ-026 - Final Regression Gate
+
+Decision: Treat as partial until loading, API error, and empty-first-page tests are added and passing.
+Evidence: Existing tests already cover many final rollout behaviors, but MM-592-specific final recovery cases are incomplete.
+Rationale: The Jira brief explicitly makes regression evidence a rollout gate.
+Alternatives considered: Relying on code inspection alone was rejected.
+Test implications: UI unit plus final verification.
+
+## FR-013 / SC-008 / DESIGN-REQ-028 - Traceability
+
+Decision: Preserve MM-592 and source design IDs through all MoonSpec artifacts and final verification.
+Evidence: `spec.md` and `plan.md` preserve MM-592 and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028.
+Rationale: Downstream verification, commit text, and PR metadata need the Jira key.
+Alternatives considered: Referencing only the artifact path was rejected because final verification needs the source key visible in each artifact.
+Test implications: Artifact review.

--- a/specs/305-empty-error-states-rollout/spec.md
+++ b/specs/305-empty-error-states-rollout/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: Empty/Error States and Regression Coverage for Final Rollout
+
+**Feature Branch**: `305-empty-error-states-rollout`  
+**Created**: 2026-05-05  
+**Status**: Draft  
+**Input**: User description: """
+Use the Jira preset brief for MM-592 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-592 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-592
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Empty/error states and regression coverage for final rollout
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-592-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-592 from MM project
+Summary: Empty/error states and regression coverage for final rollout
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-592 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-592: Empty/error states and regression coverage for final rollout
+
+Source Reference
+Source Document: docs/UI/TasksListPage.md
+Source Title: Tasks List Page
+Source Sections:
+- 5.8 Current empty, loading, error, and pagination states
+- 17. Empty and error states after column filters
+- 19. Testing contract
+- 20. Non-goals
+- 21. Desired implementation sequence
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-024
+- DESIGN-REQ-026
+- DESIGN-REQ-027
+- DESIGN-REQ-028
+
+As a MoonMind maintainer, I want the final column-filter rollout covered by regression tests and recoverable empty/error states so the old filter form can be removed without losing current behavior.
+
+Acceptance Criteria
+- Loading state still shows `Loading tasks...`.
+- API errors render a visible error notice.
+- Empty first pages show `No tasks found for the current filters.` and include Clear filters when filters are active.
+- Empty later pages keep previous-page navigation available.
+- Facet request failures show an inline retry/fallback path without breaking the table.
+- Invalid filter parameters show structured errors and preserve user filter state for editing.
+- The old top Scope, Workflow Type, Status, Entry, and Repository controls are absent after column-filter parity.
+- The documented regression tests pass before rollout is considered complete.
+
+Requirements
+- Treat TDD and regression evidence as required rollout gates.
+- Keep non-goals excluded from final UX.
+- Use the recommended implementation sequence without encoding a migration diary into canonical docs.
+
+## Relevant Implementation Notes
+
+- Source design path: `docs/UI/TasksListPage.md`.
+- Source sections from Jira brief are treated as runtime source requirements.
+- Coverage IDs: DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, DESIGN-REQ-028.
+- Jira Implementation plan field was empty or unavailable in the trusted response.
+- Jira Test plan field was empty or unavailable in the trusted response.
+
+## MoonSpec Classification Input
+
+Classify this as a single-story runtime feature request for the Tasks List page: complete the final column-filter rollout by preserving recoverable loading, API error, empty, pagination, facet-failure, invalid-filter, top-control-removal, non-goal, and regression-test behavior while preserving MM-592 traceability and the referenced Tasks List design requirements.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+## Classification
+
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI rollout story for the Tasks List page: final column-filter parity must keep recoverable loading, error, empty, pagination, facet-failure, invalid-filter, and regression-gate behavior while removing the old top filter form. The source document is a broader desired-state design, but the Jira brief narrows this run to the final rollout stability story and does not require MoonSpec breakdown.
+
+## User Story - Recoverable Final Column-Filter Rollout
+
+**Summary**: As a MoonMind maintainer, I want the final column-filter rollout covered by regression tests and recoverable empty/error states so the old filter form can be removed without losing current behavior.
+
+**Goal**: Operators can use the Tasks List after column-filter parity with clear loading, error, empty, pagination, facet fallback, and invalid-filter recovery behavior, while maintainers have regression evidence that the old top Scope, Workflow Type, Status, Entry, and Repository controls are absent and non-goals remain excluded.
+
+**Independent Test**: Render the Tasks List page with mocked loading, API error, empty first-page, empty later-page, facet-failure, invalid-filter, and populated responses, then verify visible recovery paths, preserved filter state, previous-page navigation, old-control absence, and documented regression coverage.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Tasks List request is loading, **When** the page renders, **Then** it shows `Loading tasks...`.
+2. **Given** the list API returns an error, **When** the page renders the failure, **Then** the operator sees a visible error notice with a useful sanitized message.
+3. **Given** active filters produce no rows on the first page, **When** the empty state is shown, **Then** it says `No tasks found for the current filters.` and keeps `Clear filters` available when filters are active.
+4. **Given** pagination has moved past the first page, **When** the later page returns no rows, **Then** the previous-page action remains available so the operator can recover.
+5. **Given** a facet request fails while the table data is still available, **When** a filter editor is opened, **Then** an inline retry or fallback notice appears without breaking the table.
+6. **Given** invalid or contradictory filter parameters are present, **When** validation runs locally or the API rejects them, **Then** structured errors are visible and the user's filter state remains editable or clearable.
+7. **Given** column-filter parity is active, **When** the control deck renders, **Then** the old top Scope, Workflow Type, Status, Entry, and Repository controls are absent.
+8. **Given** rollout validation is reviewed, **When** regression evidence is inspected, **Then** loading, error, empty, pagination, facet fallback, invalid-filter, old-control absence, non-goal safety, and traceability tests are present and passing or have exact blockers recorded.
+
+### Edge Cases
+
+- Empty later pages can occur after stale cursors or live updates and must not strand the operator without previous-page navigation.
+- Facet service failures must not hide already-loaded task rows or disable text/date filters that do not require facet values.
+- API validation responses may contain structured detail objects or simple strings; the UI must show a sanitized useful message.
+- Legacy URLs that attempt system or manifest browsing must fail safe without reintroducing old workflow-kind controls.
+- Empty states should not guess which filter is wrong when multiple active chips exist.
+
+## Assumptions
+
+- Prior column-filter stories already provide the column popovers, URL mapping, mobile parity, task-scoped visibility, and most active-chip behavior; this story owns final rollout recovery states and regression evidence.
+- Compose-backed integration is not required for this frontend-focused story unless backend filter validation behavior changes.
+- API error messages must be sanitized and must not expose credentials or raw provider details.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Tasks List page MUST show `Loading tasks...` while the list request is loading.
+- **FR-002**: List API failures MUST render a visible error notice with a sanitized message derived from structured API detail when available.
+- **FR-003**: Empty first pages MUST show `No tasks found for the current filters.`.
+- **FR-004**: Empty first pages with active filters MUST keep `Clear filters` available and enabled.
+- **FR-005**: Empty later pages MUST keep previous-page navigation available.
+- **FR-006**: Pagination MUST continue to use the opaque next-page token and client-side previous cursor stack behavior.
+- **FR-007**: Facet request failures MUST show an inline fallback, retry, or current-page-values notice inside the filter UI without breaking the table.
+- **FR-008**: Invalid or contradictory filter parameters detected before a list request MUST show structured validation errors and preserve recovery through editable filter state or Clear filters.
+- **FR-009**: Invalid filter parameters rejected by the list API MUST show structured validation detail when provided and preserve active filter state for editing or clearing.
+- **FR-010**: The old top Scope, Workflow Type, Status, Entry, and Repository controls MUST be absent after column-filter parity.
+- **FR-011**: Non-goals from the Tasks List design MUST remain excluded from the final rollout, including spreadsheet editing, pivot tables, multi-column sort, raw Temporal query authoring, direct browser calls to Temporal, saved views, pagination replacement, Live updates removal, and ordinary system workflow browsing.
+- **FR-012**: Regression tests MUST cover loading, API error, empty first-page, empty later-page, facet-failure, invalid-filter, old-control absence, and non-goal safety behavior before rollout is considered complete.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-592` and this canonical Jira preset brief.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | `docs/UI/TasksListPage.md` section 5.8 | Current loading, error, empty, pagination, page summary, and page-size behavior must remain recoverable after the rollout. | In scope | FR-001 through FR-006 |
+| DESIGN-REQ-024 | `docs/UI/TasksListPage.md` section 17 | Empty states, facet failures, list validation failures, and unsupported old URL combinations must provide recoverable user-visible paths. | In scope | FR-003, FR-004, FR-007, FR-008, FR-009 |
+| DESIGN-REQ-026 | `docs/UI/TasksListPage.md` section 19 | Regression coverage must prove final Tasks List behaviors, including old-control absence and recovery states, before rollout is complete. | In scope | FR-010, FR-012 |
+| DESIGN-REQ-027 | `docs/UI/TasksListPage.md` section 20 | The final rollout must not introduce non-goals such as spreadsheet editing, raw Temporal query authoring, direct Temporal browser calls, saved views, pagination replacement, Live updates removal, or system workflow browsing. | In scope | FR-011 |
+| DESIGN-REQ-028 | `docs/UI/TasksListPage.md` section 21 | The recommended sequence requires removing old top filter controls only after parity tests pass and preserving runtime source requirements in feature-local artifacts rather than canonical migration notes. | In scope | FR-010, FR-012, FR-013 |
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated UI tests verify `Loading tasks...` appears while the list request is pending.
+- **SC-002**: Automated UI tests verify list API errors render a visible sanitized error notice.
+- **SC-003**: Automated UI tests verify an empty first page with active filters shows `No tasks found for the current filters.` and an enabled `Clear filters` recovery action.
+- **SC-004**: Automated UI tests verify an empty later page keeps the previous-page button enabled.
+- **SC-005**: Automated UI tests verify facet failures show an inline fallback or current-page-values notice while table rows remain usable.
+- **SC-006**: Automated UI tests or API boundary tests verify invalid filter parameters produce structured errors while preserving recovery through editing or Clear filters.
+- **SC-007**: Automated UI tests verify the old top Scope, Workflow Type, Status, Entry, and Repository controls remain absent and non-goal workflow-kind browsing controls are unavailable.
+- **SC-008**: Traceability review confirms `MM-592`, the canonical Jira preset brief, and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028 remain preserved in MoonSpec artifacts and verification output.

--- a/specs/305-empty-error-states-rollout/tasks.md
+++ b/specs/305-empty-error-states-rollout/tasks.md
@@ -7,11 +7,11 @@
 **Contract**: `specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md`  
 **Unit Test Command**: `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
 **Integration Test Command**: `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
-**Final Verification**: `/speckit.verify`
+**Final Verification**: `/moonspec-verify`
 
 **Source Traceability**: The original `MM-592` Jira preset brief is preserved in `spec.md`. This task list covers exactly one story, FR-001 through FR-013, acceptance scenarios 1 through 8, SC-001 through SC-008, and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028.
 
-**Requirement Status Summary**: `plan.md` marks structured API error handling and final regression coverage as partial or implemented-unverified. The task sequence is TDD-first: add focused failing tests, confirm red-first for the structured API error gap, implement the error-detail parser, then run focused and final validation.
+**Requirement Status Summary**: `plan.md` marks all tracked requirement, scenario, success-criterion, and source-design rows as `implemented_verified`. The completed task sequence preserves TDD evidence: focused failing tests were added first, red-first behavior was confirmed for the structured API error gap, the error-detail parser was implemented, and focused plus full validation passed.
 
 ## Phase 1: Setup
 
@@ -65,7 +65,7 @@
 
 - [X] T016 Review `specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md` against `tasks-list.tsx` and `tasks-list.test.tsx`. (FR-001 through FR-012)
 - [X] T017 Run source traceability check for `MM-592` and DESIGN-REQ-006/DESIGN-REQ-024/DESIGN-REQ-026/DESIGN-REQ-027/DESIGN-REQ-028 across `specs/305-empty-error-states-rollout`. (FR-013, SC-008)
-- [X] T018 Run `/speckit.verify` and write `specs/305-empty-error-states-rollout/verification.md` with the final verdict against the original `MM-592` preset brief. (FR-013, SC-008)
+- [X] T018 Run `/moonspec-verify` and write `specs/305-empty-error-states-rollout/verification.md` with the final verdict against the original `MM-592` preset brief. (FR-013, SC-008)
 
 ## Dependencies and Execution Order
 

--- a/specs/305-empty-error-states-rollout/tasks.md
+++ b/specs/305-empty-error-states-rollout/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Empty/Error States and Regression Coverage for Final Rollout
+
+**Input**: `specs/305-empty-error-states-rollout/spec.md`  
+**Plan**: `specs/305-empty-error-states-rollout/plan.md`  
+**Research**: `specs/305-empty-error-states-rollout/research.md`  
+**Data Model**: `specs/305-empty-error-states-rollout/data-model.md`  
+**Contract**: `specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md`  
+**Unit Test Command**: `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
+**Integration Test Command**: `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`  
+**Final Verification**: `/speckit.verify`
+
+**Source Traceability**: The original `MM-592` Jira preset brief is preserved in `spec.md`. This task list covers exactly one story, FR-001 through FR-013, acceptance scenarios 1 through 8, SC-001 through SC-008, and DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, and DESIGN-REQ-028.
+
+**Requirement Status Summary**: `plan.md` marks structured API error handling and final regression coverage as partial or implemented-unverified. The task sequence is TDD-first: add focused failing tests, confirm red-first for the structured API error gap, implement the error-detail parser, then run focused and final validation.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm `.specify/feature.json` points at `specs/305-empty-error-states-rollout/` and `spec.md` preserves the `MM-592` Jira preset brief. (FR-013, SC-008)
+- [X] T002 Create planning artifacts `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-empty-error-rollout.md`. (FR-013, DESIGN-REQ-028)
+- [X] T003 Confirm the implementation scope is `frontend/src/entrypoints/tasks-list.tsx` and `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-001 through FR-012)
+
+## Phase 2: Foundational
+
+- [X] T004 Inspect `docs/UI/TasksListPage.md` sections 5.8, 17, 19, 20, and 21 and map them in `spec.md`. (DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, DESIGN-REQ-028)
+- [X] T005 Inspect existing Tasks List loading, error, empty, pagination, facet fallback, validation, and old-control tests before adding MM-592 coverage. (FR-001 through FR-012)
+
+## Phase 3: Story - Recoverable Final Column-Filter Rollout
+
+**Story Summary**: Operators keep recoverable loading, error, empty, pagination, facet fallback, invalid-filter, and final parity behavior after the old top filter form is removed.
+
+**Independent Test**: Render the Tasks List page with mocked loading, API error, empty first-page, empty later-page, facet-failure, invalid-filter, and populated responses, then verify visible recovery paths, preserved filter state, old-control absence, and final rollout regression evidence.
+
+**Traceability IDs**: FR-001 through FR-013; acceptance scenarios 1 through 8; SC-001 through SC-008; DESIGN-REQ-006, DESIGN-REQ-024, DESIGN-REQ-026, DESIGN-REQ-027, DESIGN-REQ-028.
+
+**Unit Test Plan**: Add focused Vitest/Testing Library tests in `frontend/src/entrypoints/tasks-list.test.tsx` for pending loading, structured API error detail, and empty first-page active-filter recovery.
+
+**Integration Test Plan**: Use the same rendered Tasks List component harness as the UI integration surface; existing tests already cover empty later-page pagination, facet fallback, local invalid-filter recovery, old-control absence, and workflow-kind non-goals.
+
+### Unit Tests
+
+- [X] T006 Add a loading-state regression test in `frontend/src/entrypoints/tasks-list.test.tsx` that holds the list request pending and asserts `Loading tasks...`. (FR-001, SC-001, DESIGN-REQ-006)
+- [X] T007 Add a structured API error regression test in `frontend/src/entrypoints/tasks-list.test.tsx` that returns a failed list response with `detail.message` and expects that message in a visible notice. (FR-002, FR-009, SC-002, SC-006, DESIGN-REQ-024)
+- [X] T008 Add an empty first-page active-filter recovery test in `frontend/src/entrypoints/tasks-list.test.tsx` that applies a filter, receives no rows, sees `No tasks found for the current filters.`, and has an enabled `Clear filters` action. (FR-003, FR-004, SC-003, DESIGN-REQ-006, DESIGN-REQ-024)
+- [X] T009 Preserve existing empty later-page pagination, facet fallback, invalid local filter recovery, old-control absence, and workflow-kind non-goal tests in `frontend/src/entrypoints/tasks-list.test.tsx`. (FR-005 through FR-008, FR-010, FR-011, SC-004, SC-005, SC-007, DESIGN-REQ-026, DESIGN-REQ-027)
+
+### Integration Tests
+
+- [X] T010 Run the focused Tasks List UI test file after T006-T008 to confirm the structured API error test fails before implementation and existing recovery tests remain stable. (FR-001 through FR-012)
+
+### Red-First Confirmation
+
+- [X] T011 Record the red-first failure for the structured API error message in `specs/305-empty-error-states-rollout/verification.md` or implementation notes before production changes. (FR-002, FR-009, SC-002, SC-006)
+
+### Implementation
+
+- [X] T012 Add a sanitized list-response error detail helper in `frontend/src/entrypoints/tasks-list.tsx` and use it when the list response is not OK. (FR-002, FR-009, DESIGN-REQ-024)
+- [X] T013 Keep the existing loading, empty first-page, empty later-page, facet fallback, local validation, old-control absence, and task-scope behavior unchanged while implementing T012. (FR-001, FR-003 through FR-008, FR-010, FR-011, DESIGN-REQ-006, DESIGN-REQ-026, DESIGN-REQ-027)
+
+### Story Validation
+
+- [X] T014 Run `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` and record the result in `verification.md`. (FR-001 through FR-013, SC-001 through SC-008)
+- [X] T015 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` when feasible and record pass/fail/blocker details in `verification.md`. (FR-001 through FR-013, SC-001 through SC-008)
+
+## Phase 4: Polish And Verification
+
+- [X] T016 Review `specs/305-empty-error-states-rollout/contracts/tasks-list-empty-error-rollout.md` against `tasks-list.tsx` and `tasks-list.test.tsx`. (FR-001 through FR-012)
+- [X] T017 Run source traceability check for `MM-592` and DESIGN-REQ-006/DESIGN-REQ-024/DESIGN-REQ-026/DESIGN-REQ-027/DESIGN-REQ-028 across `specs/305-empty-error-states-rollout`. (FR-013, SC-008)
+- [X] T018 Run `/speckit.verify` and write `specs/305-empty-error-states-rollout/verification.md` with the final verdict against the original `MM-592` preset brief. (FR-013, SC-008)
+
+## Dependencies and Execution Order
+
+1. T001-T003 establish active feature artifacts and source/test scope.
+2. T004-T005 establish source-design and repo behavior context.
+3. T006-T008 add missing UI tests before production changes.
+4. T010-T011 confirm red-first behavior for the structured API error gap.
+5. T012-T013 implement the bounded UI error-detail change without regressing existing recovery behavior.
+6. T014-T015 validate focused and full unit evidence.
+7. T016-T018 complete contract review, traceability, and final MoonSpec verification.
+
+## Parallel Examples
+
+- T006 and T008 can be drafted in parallel only in separate workspaces because they both touch `frontend/src/entrypoints/tasks-list.test.tsx`; merge serially.
+- T016 and T017 can run in parallel because one reviews behavior against the contract and one runs artifact traceability.
+
+## Implementation Strategy
+
+Add the missing regression tests first. The structured API error test should fail against the current generic `statusText` behavior, proving the implementation gap. Then add a small sanitized error-detail parser in `tasks-list.tsx` and rerun the focused Tasks List suite. Preserve all existing final rollout tests, especially old-control absence and task-scope non-goal safety.

--- a/specs/305-empty-error-states-rollout/verification.md
+++ b/specs/305-empty-error-states-rollout/verification.md
@@ -1,0 +1,54 @@
+# MoonSpec Verification Report
+
+**Feature**: `specs/305-empty-error-states-rollout`  
+**Original Request Source**: `spec.md` Input preserving the trusted `MM-592` Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED
+
+## Verification Summary
+
+The implementation satisfies the `MM-592` runtime UI story. The Tasks List final column-filter rollout now has regression coverage for loading, structured list API errors, empty first-page recovery with active filters, empty later-page previous navigation, facet failure fallback, invalid-filter recovery, old top-control absence, task-scope guardrails, and non-goal safety.
+
+A small frontend error-detail parser now prefers sanitized structured API response messages, including `detail.message`, before falling back to HTTP status text. This preserves useful validation feedback without changing the existing task-scoped list query, empty states, pagination model, facet fallback, or old-control removal behavior.
+
+## Requirement Coverage
+
+| ID | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `tasks-list.test.tsx` verifies `Loading tasks...` while the list request is pending. |
+| FR-002 | VERIFIED | `tasks-list.tsx` parses sanitized structured API detail; UI test verifies `detail.message` appears. |
+| FR-003 | VERIFIED | UI test verifies empty first page shows `No tasks found for the current filters.`. |
+| FR-004 | VERIFIED | UI test verifies `Clear filters` remains enabled on an empty first page with active filters. |
+| FR-005 | VERIFIED | Existing UI test verifies previous-page navigation remains enabled on empty later pages. |
+| FR-006 | VERIFIED | Existing pagination tests preserve next-token and previous cursor stack behavior. |
+| FR-007 | VERIFIED | Existing facet failure test verifies current-page fallback notice and preserved table data. |
+| FR-008 | VERIFIED | Existing contradictory-filter tests verify structured local validation and Clear filters recovery. |
+| FR-009 | VERIFIED | Structured API error test verifies API validation detail is shown while filter controls remain available for recovery. |
+| FR-010 | VERIFIED | Existing control deck tests verify old Scope, Workflow Type, Status, Entry, and Repository controls are absent. |
+| FR-011 | VERIFIED | Existing workflow-kind tests verify ordinary Tasks List remains task-scoped and does not expose system workflow browsing. |
+| FR-012 | VERIFIED | Focused Tasks List suite now covers loading, API error, empty first page, empty later page, facet failure, invalid filters, old controls, and non-goal safety. |
+| FR-013 | VERIFIED | `MM-592` is preserved in `spec.md`, `plan.md`, `tasks.md`, and this verification report. |
+
+## Source Design Coverage
+
+| Source ID | Status | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-006 | VERIFIED | Loading, visible API error, empty states, pagination, page summary, and page-size tests pass. |
+| DESIGN-REQ-024 | VERIFIED | Empty first-page recovery, facet failure fallback, local invalid-filter recovery, and API validation detail coverage pass. |
+| DESIGN-REQ-026 | VERIFIED | Final rollout regression coverage is present in `frontend/src/entrypoints/tasks-list.test.tsx`. |
+| DESIGN-REQ-027 | VERIFIED | Tests preserve non-goals: no workflow-kind controls, raw Temporal query authoring, system workflow browsing, saved views, or pagination replacement. |
+| DESIGN-REQ-028 | VERIFIED | Old top controls remain absent after parity tests, and MM-592 is preserved in feature-local artifacts rather than canonical docs. |
+
+## Test Evidence
+
+| Command | Result |
+| --- | --- |
+| `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` before implementation | RED-FIRST PASS: failed only on the new structured API error test; 35 passed, 1 failed. |
+| `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` after implementation | PASS: 36 tests passed. |
+| `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS: Python unit suite 4344 passed, 1 xpassed, 16 subtests passed; frontend suite 20 files passed, 307 tests passed, 223 skipped. |
+| `rg -n "MM-592\|DESIGN-REQ-006\|DESIGN-REQ-024\|DESIGN-REQ-026\|DESIGN-REQ-027\|DESIGN-REQ-028" specs/305-empty-error-states-rollout` | PASS: Jira key and all source design IDs are preserved across feature artifacts. |
+
+## Notes
+
+- `npm ci --no-fund --no-audit` was run to restore missing local JS dependencies before Vitest execution.
+- Full unit validation emitted existing warnings from deprecated packages, async mock cleanup, and jsdom canvas limitations; no test failed.
+- No compose-backed integration was required for this frontend-only story.


### PR DESCRIPTION
Jira issue key: MM-592

Active MoonSpec feature path: `specs/305-empty-error-states-rollout`

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` before implementation: red-first failure on the new structured API error test, with existing coverage passing.
- `node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` after implementation: PASS, 36 tests passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, Python unit suite 4344 passed, 1 xpassed, 16 subtests passed; frontend suite 20 files passed, 307 tests passed, 223 skipped.
- `rg -n "MM-592\|DESIGN-REQ-006\|DESIGN-REQ-024\|DESIGN-REQ-026\|DESIGN-REQ-027\|DESIGN-REQ-028" specs/305-empty-error-states-rollout`: PASS.

Remaining risks:
- No compose-backed integration was required for this frontend-only story.
- Full unit validation emitted existing warnings from deprecated packages, async mock cleanup, and jsdom canvas limitations; no test failed.
