### PR TITLE
[codex] Unify managed runtime GitHub clone auth

### DIFF
--- a/moonmind/workflows/temporal/runtime/git_auth.py
+++ b/moonmind/workflows/temporal/runtime/git_auth.py
@@ -1,0 +1,46 @@
+"""Shared host-side Git authentication helpers for managed runtimes."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+_GITHUB_TOKEN_GIT_CREDENTIAL_HELPER = (
+    '!f() { test "$1" = get || exit 0; '
+    'echo username=x-access-token; echo password="$GITHUB_TOKEN"; }; f'
+)
+
+
+def build_github_token_git_environment(
+    token: str | None,
+    *,
+    base_env: Mapping[str, str] | None = None,
+    terminal_prompt: str = "0",
+) -> dict[str, str]:
+    """Return a Git command environment that authenticates GitHub HTTPS.
+
+    Plain ``git`` does not consume ``gh`` auth state or ``GITHUB_TOKEN`` by
+    itself. This environment installs an in-memory credential helper through
+    Git's per-process config variables so host-side clone/fetch operations use
+    the same resolved GitHub token without writing the token to disk or argv.
+    """
+
+    env = {str(key): str(value) for key, value in (base_env or {}).items()}
+    normalized_token = str(token or "").strip()
+    if not normalized_token:
+        return env
+
+    env["GITHUB_TOKEN"] = normalized_token
+    env["GIT_TERMINAL_PROMPT"] = str(
+        env.get("GIT_TERMINAL_PROMPT") or terminal_prompt
+    )
+    env["GIT_CONFIG_COUNT"] = "2"
+    env["GIT_CONFIG_KEY_0"] = "credential.https://github.com.helper"
+    env["GIT_CONFIG_VALUE_0"] = ""
+    env["GIT_CONFIG_KEY_1"] = "credential.https://github.com.helper"
+    env["GIT_CONFIG_VALUE_1"] = _GITHUB_TOKEN_GIT_CREDENTIAL_HELPER
+    return env
+
+
+__all__ = [
+    "build_github_token_git_environment",
+]

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -96,7 +96,14 @@ class ManagedRuntimeLauncher:
     @staticmethod
     def _source_uses_github_https(source: str | None) -> bool:
         normalized = str(source or "").strip().lower()
-        return normalized.startswith(("https://github.com/", "http://github.com/"))
+        return normalized.startswith(
+            (
+                "https://github.com/",
+                "http://github.com/",
+                "https://www.github.com/",
+                "http://www.github.com/",
+            )
+        )
 
     @classmethod
     def _request_workspace_needs_github_https_auth(
@@ -717,7 +724,10 @@ class ManagedRuntimeLauncher:
             else None
         )
         git_host_env = (
-            build_github_token_git_environment(launch_github_token)
+            build_github_token_git_environment(
+                launch_github_token,
+                base_env=self._build_managed_runtime_base_env(),
+            )
             if launch_github_token
             else None
         )

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -23,6 +23,7 @@ from moonmind.schemas.agent_runtime_models import (
 from moonmind.utils.logging import SecretRedactor
 
 from .github_auth_broker import GitHubAuthBrokerManager
+from .git_auth import build_github_token_git_environment
 from .store import ManagedRunStore
 from .log_streamer import RuntimeLogStreamer
 from .managed_api_key_resolve import resolve_github_token_for_launch
@@ -91,6 +92,29 @@ class ManagedRuntimeLauncher:
         if repo_path.exists():
             return str(repo_path.resolve())
         return None
+
+    @staticmethod
+    def _source_uses_github_https(source: str | None) -> bool:
+        normalized = str(source or "").strip().lower()
+        return normalized.startswith(("https://github.com/", "http://github.com/"))
+
+    @classmethod
+    def _request_workspace_needs_github_https_auth(
+        cls,
+        request: AgentExecutionRequest,
+        workspace_path: str | Path | None,
+    ) -> bool:
+        if workspace_path is not None:
+            return False
+        workspace_spec = (
+            request.workspace_spec
+            if isinstance(request.workspace_spec, dict)
+            else {}
+        )
+        repo_ref = workspace_spec.get("repository") or workspace_spec.get("repo")
+        if not isinstance(repo_ref, str):
+            return False
+        return cls._source_uses_github_https(cls._normalize_clone_source(repo_ref))
 
     def _emit_system_annotation(
         self,
@@ -190,18 +214,22 @@ class ManagedRuntimeLauncher:
         args: list[str],
         *,
         allow_failure: bool = False,
+        env: dict[str, str] | None = None,
     ) -> bool:
         process = await asyncio.create_subprocess_exec(
             "git",
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         stdout, stderr = await process.communicate()
         if process.returncode == 0:
             return True
 
-        redactor = SecretRedactor.from_environ()
+        redactor = SecretRedactor.from_environ(
+            extra_secrets=[str((env or {}).get("GITHUB_TOKEN") or "")]
+        )
         self._logger.warning(
             "git %s failed rc=%s stdout=%s stderr=%s",
             redactor.scrub(" ".join(args)),
@@ -219,6 +247,7 @@ class ManagedRuntimeLauncher:
         run_id: str,
         request: AgentExecutionRequest,
         workspace_path: str | None,
+        git_env: dict[str, str] | None = None,
     ) -> str | None:
         if workspace_path:
             return workspace_path
@@ -244,11 +273,18 @@ class ManagedRuntimeLauncher:
 
         run_workspace.parent.mkdir(parents=True, exist_ok=True)
         branch = self._extract_workspace_branch(workspace_spec)
+        command_env = (
+            git_env if self._source_uses_github_https(clone_source) else None
+        )
         clone_args: list[str] = ["clone"]
         if branch and not Path(clone_source).exists():
             clone_args.extend(["--branch", branch, "--single-branch"])
         clone_args.extend(["--", clone_source, str(run_workspace)])
-        cloned = await self._run_git_command(clone_args, allow_failure=True)
+        cloned = await self._run_git_command(
+            clone_args,
+            allow_failure=True,
+            env=command_env,
+        )
         if not cloned:
             return None
 
@@ -256,15 +292,18 @@ class ManagedRuntimeLauncher:
             checkout_ok = await self._run_git_command(
                 ["-C", str(run_workspace), "checkout", branch],
                 allow_failure=True,
+                env=command_env,
             )
             if not checkout_ok:
                 await self._run_git_command(
                     ["-C", str(run_workspace), "fetch", "origin", branch],
                     allow_failure=True,
+                    env=command_env,
                 )
                 await self._run_git_command(
                     ["-C", str(run_workspace), "checkout", "-B", branch, f"origin/{branch}"],
                     allow_failure=True,
+                    env=command_env,
                 )
         return str(run_workspace)
 
@@ -288,12 +327,14 @@ class ManagedRuntimeLauncher:
         self,
         *cmd: str,
         cwd: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
+            env=env,
         )
         stdout, stderr = await process.communicate()
         return (
@@ -306,10 +347,12 @@ class ManagedRuntimeLauncher:
         self,
         *cmd: str,
         cwd: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> None:
         returncode, stdout_text, stderr_text = await self._run_command(
             *cmd,
             cwd=cwd,
+            env=env,
         )
         if returncode == 0:
             return
@@ -327,6 +370,7 @@ class ManagedRuntimeLauncher:
         run_id: str,
         request: AgentExecutionRequest,
         workspace_path: str | Path | None,
+        git_env: dict[str, str] | None = None,
     ) -> str | None:
         if workspace_path is not None:
             resolved = Path(workspace_path).expanduser().resolve()
@@ -359,12 +403,17 @@ class ManagedRuntimeLauncher:
             or workspace_spec.get("branch")
             or ""
         ).strip()
+        command_env = git_env if self._source_uses_github_https(source) else None
 
         clone_cmd = ["git", "clone"]
         if branch:
             clone_cmd.extend(["--branch", branch, "--single-branch"])
         clone_cmd.extend([source, str(repo_path)])
-        await self._run_checked_command(*clone_cmd, cwd=str(workspace_root))
+        await self._run_checked_command(
+            *clone_cmd,
+            cwd=str(workspace_root),
+            env=command_env,
+        )
 
         new_branch = str(workspace_spec.get("targetBranch") or "").strip()
         if new_branch:
@@ -374,6 +423,7 @@ class ManagedRuntimeLauncher:
                 str(repo_path),
                 "checkout",
                 new_branch,
+                env=command_env,
             )
             if returncode != 0:
                 failure_detail = (stderr_text or stdout_text).lower()
@@ -382,7 +432,11 @@ class ManagedRuntimeLauncher:
                     or "pathspec" in failure_detail
                 )
                 if not branch_missing:
-                    redactor = SecretRedactor.from_environ()
+                    redactor = SecretRedactor.from_environ(
+                        extra_secrets=[
+                            str((command_env or {}).get("GITHUB_TOKEN") or "")
+                        ]
+                    )
                     detail = redactor.scrub(stderr_text or stdout_text or "no output")
                     rendered_cmd = " ".join(
                         shlex.quote(part)
@@ -405,6 +459,7 @@ class ManagedRuntimeLauncher:
                     "checkout",
                     "-b",
                     new_branch,
+                    env=command_env,
                 )
 
         return str(repo_path)
@@ -653,16 +708,31 @@ class ManagedRuntimeLauncher:
 
         from moonmind.workflows.temporal.runtime.strategies import get_strategy
         strategy = get_strategy(profile.runtime_id)
+        launch_github_token = (
+            await resolve_github_token_for_launch()
+            if self._request_workspace_needs_github_https_auth(
+                request,
+                workspace_path,
+            )
+            else None
+        )
+        git_host_env = (
+            build_github_token_git_environment(launch_github_token)
+            if launch_github_token
+            else None
+        )
         resolved_workspace_path = await self._prepare_workspace_path(
             run_id=run_id,
             request=request,
             workspace_path=workspace_path,
+            git_env=git_host_env,
         )
         if resolved_workspace_path is None:
             resolved_workspace_path = await self._prepare_workspace(
                 run_id=run_id,
                 request=request,
                 workspace_path=workspace_path,
+                git_env=git_host_env,
             )
 
         # Phase 4 Materialization
@@ -808,6 +878,8 @@ class ManagedRuntimeLauncher:
             env_overrides.setdefault("GIT_COMMITTER_EMAIL", _git_email)
 
         github_token = await resolve_github_token_for_launch(env_overrides)
+        if not github_token:
+            github_token = launch_github_token
         cleanup_paths: list[str] = list(materializer.generated_files)
         cleanup_paths.extend(reversed(materializer.generated_dirs))
         deferred_cleanup_paths: list[str] = []

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -44,6 +44,7 @@ from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 
 from .github_auth_broker import GitHubAuthBrokerManager
+from .git_auth import build_github_token_git_environment
 from .managed_session_store import ManagedSessionStore
 from .managed_session_supervisor import ManagedSessionSupervisor
 
@@ -59,10 +60,6 @@ _SENSITIVE_ENV_KEY_PATTERN = re.compile(
     r"(?i)(?:token|secret|password|key|credential|auth)"
 )
 _GIT_COMMAND_LOCALE = {"LC_ALL": "C", "LANG": "C"}
-_GITHUB_TOKEN_GIT_CREDENTIAL_HELPER = (
-    '!f() { test "$1" = get || exit 0; '
-    'echo username=x-access-token; echo password="$GITHUB_TOKEN"; }; f'
-)
 _SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 _CONTAINER_LOG_EXCERPT_TAIL_LINES = 40
 _CONTAINER_LOG_EXCERPT_MAX_CHARS = 2000
@@ -783,18 +780,13 @@ class DockerCodexManagedSessionController:
             raise RuntimeError(str(exc)) from exc
         token = str(token or "").strip()
         if token:
-            env["GITHUB_TOKEN"] = token
-            env["GIT_TERMINAL_PROMPT"] = str(
-                request_env.get("GIT_TERMINAL_PROMPT") or "0"
-            )
             # Avoid depending on persistent per-user gh setup in the worker. The
             # clone happens before the managed agent container starts.
-            env["GIT_CONFIG_COUNT"] = "2"
-            env["GIT_CONFIG_KEY_0"] = "credential.https://github.com.helper"
-            env["GIT_CONFIG_VALUE_0"] = ""
-            env["GIT_CONFIG_KEY_1"] = "credential.https://github.com.helper"
-            env["GIT_CONFIG_VALUE_1"] = _GITHUB_TOKEN_GIT_CREDENTIAL_HELPER
-            return env
+            return build_github_token_git_environment(
+                token,
+                base_env=env,
+                terminal_prompt=str(request_env.get("GIT_TERMINAL_PROMPT") or "0"),
+            )
 
         terminal_prompt = str(request_env.get("GIT_TERMINAL_PROMPT") or "").strip()
         if terminal_prompt:

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import os
-from pathlib import Path
+import shutil
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -38,23 +39,30 @@ async def test_github_auth_broker_serves_token_and_cleans_socket():
     assert not Path(socket_path).exists()
 
 @pytest.mark.asyncio
-async def test_github_auth_broker_keeps_shared_mm_gh_root_traversable_only(tmp_path):
+async def test_github_auth_broker_keeps_shared_mm_gh_root_traversable_only():
     manager = GitHubAuthBrokerManager()
-    shared_root = tmp_path / "mm-gh"
+    # AF_UNIX socket paths are short on Linux; keep this test's path under /tmp
+    # so xdist's long per-worker tmp_path prefix does not exceed that limit.
+    short_base = Path("/tmp") / f"mm-gh-root-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    shared_root = short_base / "mm-gh"
     socket_dir = shared_root / "0123456789abcdef"
     socket_path = socket_dir / "github.sock"
 
-    await manager.start(
-        run_id="run-1",
-        token="ghp_testtoken123",
-        socket_path=str(socket_path),
-    )
+    try:
+        await manager.start(
+            run_id="run-1",
+            token="ghp_testtoken123",
+            socket_path=str(socket_path),
+        )
 
-    assert (shared_root.stat().st_mode & 0o777) == 0o711
-    assert (socket_dir.stat().st_mode & 0o777) == 0o700
-    assert (socket_path.stat().st_mode & 0o777) == 0o600
+        assert (shared_root.stat().st_mode & 0o777) == 0o711
+        assert (socket_dir.stat().st_mode & 0o777) == 0o700
+        assert (socket_path.stat().st_mode & 0o777) == 0o600
 
-    await manager.stop("run-1")
+        await manager.stop("run-1")
+    finally:
+        await manager.stop("run-1")
+        shutil.rmtree(short_base, ignore_errors=True)
 
 def test_run_gh_wrapper_clears_ambient_gh_token(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -236,6 +236,7 @@ async def test_launch_seeds_github_git_auth_before_initial_clone(
     token = "ghp_private_clone_token"
     store_root = tmp_path / "store"
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(store_root))
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example")
 
     async def _fake_resolve(*args, **kwargs):
         return token
@@ -309,8 +310,17 @@ async def test_launch_seeds_github_git_auth_before_initial_clone(
     assert clone_env["GIT_CONFIG_KEY_0"] == "credential.https://github.com.helper"
     assert clone_env["GIT_CONFIG_VALUE_0"] == ""
     assert clone_env["GIT_CONFIG_KEY_1"] == "credential.https://github.com.helper"
+    assert clone_env["HTTPS_PROXY"] == "http://proxy.example"
     assert "$GITHUB_TOKEN" in clone_env["GIT_CONFIG_VALUE_1"]
     assert token not in clone_env["GIT_CONFIG_VALUE_1"]
+
+def test_source_uses_github_https_includes_www_variant() -> None:
+    assert ManagedRuntimeLauncher._source_uses_github_https(
+        "https://www.github.com/MoonLadderStudios/Tactics.git"
+    )
+    assert ManagedRuntimeLauncher._source_uses_github_https(
+        "http://www.github.com/MoonLadderStudios/Tactics.git"
+    )
 
 @pytest.mark.asyncio
 async def test_launch_registers_generated_support_dir_for_cleanup(tmp_path, monkeypatch):

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -230,6 +230,89 @@ async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch)
     assert captured_env["GITHUB_TOKEN"] == "ghp-runtime"
 
 @pytest.mark.asyncio
+async def test_launch_seeds_github_git_auth_before_initial_clone(
+    tmp_path, monkeypatch
+):
+    token = "ghp_private_clone_token"
+    store_root = tmp_path / "store"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(store_root))
+
+    async def _fake_resolve(*args, **kwargs):
+        return token
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        pid = 779
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess()
+
+    clone_envs: list[dict[str, str]] = []
+    clone_commands: list[tuple[object, ...]] = []
+
+    async def _fake_run_checked_command(self, *cmd, **kwargs):
+        if cmd[:2] == ("git", "clone"):
+            clone_commands.append(cmd)
+            env = kwargs.get("env")
+            assert isinstance(env, dict)
+            clone_envs.append(dict(env))
+            repo_path = Path(cmd[-1])
+            (repo_path / ".git").mkdir(parents=True)
+            (repo_path / ".git" / "config").write_text(
+                "[core]\n\trepositoryformatversion = 0\n",
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._run_checked_command",
+        _fake_run_checked_command,
+    )
+
+    store = ManagedRunStore(store_root)
+    launcher = ManagedRuntimeLauncher(store)
+    profile = _make_profile(command_template=["echo", "hello"])
+    request = _make_request(
+        workspace_spec={
+            "repository": "MoonLadderStudios/Tactics",
+            "startingBranch": "main",
+        }
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-private-clone",
+        request=request,
+        profile=profile,
+    )
+    await process.wait()
+    await launcher.cleanup_run_support("run-private-clone")
+
+    assert len(clone_commands) == 1
+    assert token not in " ".join(str(part) for part in clone_commands[0])
+    clone_env = clone_envs[0]
+    assert clone_env["GITHUB_TOKEN"] == token
+    assert clone_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert clone_env["GIT_CONFIG_KEY_0"] == "credential.https://github.com.helper"
+    assert clone_env["GIT_CONFIG_VALUE_0"] == ""
+    assert clone_env["GIT_CONFIG_KEY_1"] == "credential.https://github.com.helper"
+    assert "$GITHUB_TOKEN" in clone_env["GIT_CONFIG_VALUE_1"]
+    assert token not in clone_env["GIT_CONFIG_VALUE_1"]
+
+@pytest.mark.asyncio
 async def test_launch_registers_generated_support_dir_for_cleanup(tmp_path, monkeypatch):
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")


### PR DESCRIPTION
## Summary
- Add a shared host-side GitHub HTTPS credential-helper environment for managed runtime Git commands.
- Use that shared helper for Claude/general managed runtime initial clones and Codex managed-session clones.
- Cover the private-repository clone ordering regression and make the GitHub auth broker socket permission test avoid AF_UNIX path-length failures.

## Root Cause
Claude Code agent runs cloned the workspace before the launcher installed MoonMind GitHub auth helpers. The worker had GitHub credentials, but plain `git clone https://github.com/...` does not consume `gh` auth state or `GITHUB_TOKEN` without a Git credential helper.

## Validation
- `./tools/test_unit.sh`
- Python: `4327 passed, 1 xpassed`
- Frontend: `19 passed`, `290 passed`, `223 skipped`
