### PR TITLE
[codex] Gate workflow completion on final outcomes

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,22 @@
 [
   {
-    "id": 3186820408,
+    "id": 3190605674,
     "disposition": "addressed",
-    "rationale": "Restricted dialog Enter-to-apply handling so Enter on popover action buttons is not intercepted, with a regression test for staged filters remaining unapplied from action-button keydown."
+    "rationale": "Simplified the branch publish unknown check by removing the redundant _branch_published() condition."
   },
   {
-    "id": 4226183005,
+    "id": 4230555974,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary wrapper; no standalone code action beyond the linked review comments."
+    "rationale": "Automated review summary; the actionable line comments are tracked separately."
   },
   {
-    "id": 3186821781,
+    "id": 3190620124,
     "disposition": "addressed",
-    "rationale": "Excluded button targets from the popover Enter key apply path and covered the accessibility behavior in Tasks List tests."
+    "rationale": "Recorded report refs from mapped agent-run outputs as well as metadata and added regression coverage."
   },
   {
-    "id": 3186821798,
-    "disposition": "addressed",
-    "rationale": "Guarded closeFilter focus restoration behind a non-null field target and added a mobile regression test to prevent stale desktop trigger focus."
-  },
-  {
-    "id": 4226184254,
+    "id": 4230570929,
     "disposition": "not-applicable",
-    "rationale": "Broad review summary; the concrete keyboard and focus findings from the summary were addressed in the linked line comments."
+    "rationale": "Automated review container comment; the actionable suggestions are tracked separately."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -273,6 +273,8 @@ class MoonMindRunWorkflow:
         self._last_diagnostics_ref: Optional[str] = None
         self._merge_automation_disposition: Optional[str] = None
         self._merge_automation_head_sha: Optional[str] = None
+        self._report_created: bool = False
+        self._report_ref: Optional[str] = None
         self._declared_dependencies: list[str] = []
         self._dependency_wait_occurred: bool = False
         self._dependency_wait_duration_ms: int = 0
@@ -1599,7 +1601,9 @@ class MoonMindRunWorkflow:
                 state=STATE_FAILED,
                 close_status=CLOSE_STATUS_FAILED,
                 summary=output_message,
-                error_category="execution_error",
+                error_category=(
+                    "user_error" if self._plan_blocked_message else "execution_error"
+                ),
             )
             raise exceptions.ApplicationError(
                 output_message,
@@ -3396,6 +3400,37 @@ class MoonMindRunWorkflow:
         if head_sha:
             self._publish_context["headSha"] = head_sha
 
+        self._record_report_result(execution_result)
+
+    def _record_report_result(self, execution_result: Any) -> None:
+        metadata = self._get_from_result(execution_result, "metadata")
+        if not isinstance(metadata, Mapping):
+            return
+
+        report_ref = self._coerce_text(
+            metadata.get("primaryReportRef")
+            or metadata.get("primary_report_ref"),
+            max_chars=200,
+        )
+        report_bundle = metadata.get("reportBundle") or metadata.get("report_bundle")
+        if not report_ref and isinstance(report_bundle, Mapping):
+            primary_ref = (
+                report_bundle.get("primary_report_ref")
+                or report_bundle.get("primaryReportRef")
+            )
+            if isinstance(primary_ref, Mapping):
+                report_ref = self._coerce_text(
+                    primary_ref.get("artifact_id")
+                    or primary_ref.get("artifactId"),
+                    max_chars=200,
+                )
+            else:
+                report_ref = self._coerce_text(primary_ref, max_chars=200)
+        if report_ref:
+            self._report_created = True
+            self._report_ref = report_ref
+            self._publish_context["reportRef"] = report_ref
+
     @staticmethod
     def _node_selected_skill(node: Mapping[str, Any]) -> str:
         inputs = node.get("inputs")
@@ -3543,16 +3578,9 @@ class MoonMindRunWorkflow:
         parameters: Mapping[str, Any],
     ) -> tuple[str, str, bool]:
         if self._plan_blocked_message:
-            return ("blocked", self._plan_blocked_message, False)
+            return ("failed", self._plan_blocked_message, True)
 
         publish_mode = self._publish_mode(parameters)
-        if publish_mode == "none":
-            return (
-                "success",
-                self._compose_success_completion_message(publish_mode=publish_mode),
-                False,
-            )
-
         if self._publish_status == "skipped":
             if publish_mode == "pr":
                 self._publish_status = "failed"
@@ -3564,6 +3592,29 @@ class MoonMindRunWorkflow:
                 )
             return ("no_changes", "Workflow completed with no local changes", False)
 
+        if self._publish_status == "failed":
+            return (
+                "failed",
+                self._publish_reason or "Publish failed",
+                True,
+            )
+
+        missing_outcome = self._missing_required_outcome_reason(
+            parameters=parameters,
+            publish_mode=publish_mode,
+        )
+        if missing_outcome:
+            self._publish_status = "failed"
+            self._publish_reason = missing_outcome
+            return ("failed", missing_outcome, True)
+
+        if publish_mode == "none":
+            return (
+                "success",
+                self._compose_success_completion_message(publish_mode=publish_mode),
+                False,
+            )
+
         if self._publish_status == "not_required":
             return (
                 "success",
@@ -3572,13 +3623,6 @@ class MoonMindRunWorkflow:
                     publish_mode=publish_mode,
                 ),
                 False,
-            )
-
-        if self._publish_status == "failed":
-            return (
-                "failed",
-                self._publish_reason or "Publish failed",
-                True,
             )
 
         if publish_mode == "branch" and self._publish_status is None:
@@ -3625,6 +3669,79 @@ class MoonMindRunWorkflow:
             self._compose_success_completion_message(publish_mode=publish_mode),
             False,
         )
+
+    def _missing_required_outcome_reason(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+        publish_mode: str,
+    ) -> str | None:
+        if publish_mode == "pr" and not self._pull_request_created():
+            return "publishMode 'pr' requested but no PR was created"
+        if (
+            publish_mode == "branch"
+            and self._publish_status is None
+            and not self._branch_published()
+        ):
+            return "branch publish outcome unknown"
+        if self._merge_automation_requested(parameters) and not self._merge_happened():
+            return "merge automation requested but PR was not merged"
+        if self._report_requested(parameters) and not self._report_created:
+            return "reportOutput requested but no final report was created"
+        return None
+
+    def _pull_request_created(self) -> bool:
+        if self._pull_request_url:
+            return True
+        pull_request_url = self._coerce_text(
+            self._publish_context.get("pullRequestUrl"),
+            max_chars=500,
+        )
+        if pull_request_url:
+            return True
+        pr_number = self._publish_context.get("pullRequestNumber")
+        return isinstance(pr_number, int) and pr_number > 0
+
+    def _branch_published(self) -> bool:
+        return self._publish_status == "published"
+
+    def _merge_happened(self) -> bool:
+        status = self._coerce_text(
+            self._publish_context.get("mergeAutomationStatus"),
+            max_chars=40,
+        )
+        if status in MERGE_AUTOMATION_SUCCESS_STATUSES:
+            return True
+        result = self._publish_context.get("mergeAutomationResult")
+        if isinstance(result, Mapping):
+            result_status = self._coerce_text(result.get("status"), max_chars=40)
+            return result_status in MERGE_AUTOMATION_SUCCESS_STATUSES
+        return False
+
+    def _merge_automation_requested(self, parameters: Mapping[str, Any]) -> bool:
+        return self._merge_automation_request(parameters) is not None
+
+    def _report_requested(self, parameters: Mapping[str, Any]) -> bool:
+        candidates = []
+        task_payload = self._mapping_value(parameters, "task")
+        if isinstance(task_payload, Mapping):
+            candidates.append(
+                task_payload.get("reportOutput") or task_payload.get("report_output")
+            )
+        candidates.append(
+            parameters.get("reportOutput") or parameters.get("report_output")
+        )
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            try:
+                enabled = _coerce_bool(candidate.get("enabled"), default=False)
+                required = _coerce_bool(candidate.get("required"), default=True)
+            except ValueError:
+                continue
+            if enabled and required:
+                return True
+        return False
 
     def _merge_automation_request(
         self,
@@ -5298,6 +5415,13 @@ class MoonMindRunWorkflow:
                 elif self._publish_status == "failed":
                     publish_status = "failed"
                     publish_reason = self._publish_reason or error or "publish failed"
+                elif status == "failed" and self._publish_status == "not_required":
+                    publish_status = "skipped"
+                    publish_reason = (
+                        self._publish_reason
+                        or error
+                        or "publish output not required"
+                    )
             else:
                 if status == "success":
                     if publish_mode == "pr":

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3404,15 +3404,26 @@ class MoonMindRunWorkflow:
 
     def _record_report_result(self, execution_result: Any) -> None:
         metadata = self._get_from_result(execution_result, "metadata")
-        if not isinstance(metadata, Mapping):
+        outputs = self._get_from_result(execution_result, "outputs")
+        report_sources = [
+            source
+            for source in (metadata, outputs)
+            if isinstance(source, Mapping)
+        ]
+        if not report_sources:
             return
 
-        report_ref = self._coerce_text(
-            metadata.get("primaryReportRef")
-            or metadata.get("primary_report_ref"),
-            max_chars=200,
-        )
-        report_bundle = metadata.get("reportBundle") or metadata.get("report_bundle")
+        report_ref = ""
+        report_bundle: Any = None
+        for source in report_sources:
+            report_ref = self._coerce_text(
+                source.get("primaryReportRef")
+                or source.get("primary_report_ref"),
+                max_chars=200,
+            )
+            report_bundle = source.get("reportBundle") or source.get("report_bundle")
+            if report_ref or isinstance(report_bundle, Mapping):
+                break
         if not report_ref and isinstance(report_bundle, Mapping):
             primary_ref = (
                 report_bundle.get("primary_report_ref")
@@ -3678,11 +3689,7 @@ class MoonMindRunWorkflow:
     ) -> str | None:
         if publish_mode == "pr" and not self._pull_request_created():
             return "publishMode 'pr' requested but no PR was created"
-        if (
-            publish_mode == "branch"
-            and self._publish_status is None
-            and not self._branch_published()
-        ):
+        if publish_mode == "branch" and self._publish_status is None:
             return "branch publish outcome unknown"
         if self._merge_automation_requested(parameters) and not self._merge_happened():
             return "merge automation requested but PR was not merged"

--- a/specs/296-workflow-blocked-outcomes/plan.md
+++ b/specs/296-workflow-blocked-outcomes/plan.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Add a replay-stable workflow helper that recognizes explicit structured blocked outcomes in step outputs. On detection, the parent `MoonMind.Run` workflow records the current step, skips remaining plan steps, suppresses publish handling, and completes with a blocked result message.
+Add a replay-stable workflow helper that recognizes explicit structured blocked outcomes in step outputs. On detection, the parent `MoonMind.Run` workflow records the current step, skips remaining plan steps, suppresses publish handling, and fails the parent run with the blocker as the terminal reason. Terminal success is evaluated from requested final outcomes: PR created for PR publishing, merge completed when merge automation is requested, and final report created when required report output is requested.
 
 ## Technical Context
 
@@ -34,4 +34,6 @@ Add a replay-stable workflow helper that recognizes explicit structured blocked 
 1. Add blocked outcome parsing for structured mappings and JSON summaries.
 2. Stop remaining plan execution and mark downstream steps skipped.
 3. Suppress publish handling for blocked outcomes.
-4. Add unit coverage for parsing, final publish outcome, and execution-stage stop behavior.
+4. Mark blocked parent runs as terminal `failed` so execution lists and dependency gates do not treat blocked work as successful completion.
+5. Track final outcome evidence for PR creation, merge automation success, and report artifact creation.
+6. Add unit coverage for parsing, final publish outcome, execution-stage stop behavior, parent terminal-state mapping, and final outcome gates.

--- a/specs/296-workflow-blocked-outcomes/spec.md
+++ b/specs/296-workflow-blocked-outcomes/spec.md
@@ -21,11 +21,18 @@ As a MoonMind operator, I want a workflow step that reports an explicit blocked 
 - **FR-003**: When a step reports a blocked outcome, the workflow MUST stop executing remaining plan steps.
 - **FR-004**: Remaining plan steps MUST be marked skipped in the step ledger.
 - **FR-005**: PR/branch publishing MUST be suppressed for blocked outcomes.
-- **FR-006**: The final workflow result MUST preserve the blocker summary without throwing a publish failure.
+- **FR-006**: The final workflow failure MUST preserve the blocker summary without throwing a misleading publish failure.
 - **FR-007**: Existing no-change PR publish behavior MUST still fail when no blocked outcome is present.
+- **FR-008**: The parent workflow MUST NOT publish `mm_state=completed` for a blocked outcome; it MUST publish a non-success terminal execution state.
+- **FR-009**: Parent workflow terminal state MUST be based on required final outcomes, not merely on whether intermediate plan steps were skipped.
+- **FR-010**: When `publishMode=pr`, successful completion MUST require evidence that a pull request was created or returned.
+- **FR-011**: When merge automation is requested, successful completion MUST require evidence that merge automation reached a successful merge outcome.
+- **FR-012**: When required report output is requested, successful completion MUST require evidence that a final report artifact was created.
 
 ## Success Criteria
 
 - **SC-001**: A structured `decision/status/outcome: blocked` report stops the plan after the reporting step.
 - **SC-002**: The blocked step is recorded, remaining steps are skipped, and no native PR creation is attempted.
-- **SC-003**: The final result status is `blocked` with the reported summary and `publish_failure` is false.
+- **SC-003**: The parent workflow reaches terminal `failed` state with the reported blocker summary, downstream steps skipped, and PR publishing suppressed.
+- **SC-004**: A workflow with skipped optional steps still completes when all requested final outcomes exist.
+- **SC-005**: A workflow fails when PR, merge, or required report output was requested but the corresponding final outcome is missing.

--- a/specs/296-workflow-blocked-outcomes/tasks.md
+++ b/specs/296-workflow-blocked-outcomes/tasks.md
@@ -4,7 +4,13 @@
 - [X] T002 Confirm the failure was caused by a structured blocker report being ignored before publish handling.
 - [X] T003 Add generic structured blocked-outcome detection in `moonmind/workflows/temporal/workflows/run.py`.
 - [X] T004 Stop remaining plan nodes and mark them skipped when a blocked outcome is detected.
-- [X] T005 Suppress PR publish failure and return a blocked final result.
+- [X] T005 Suppress PR publish failure and preserve the blocked terminal reason.
 - [X] T006 Add unit tests for structured blocker parsing and blocked publish completion.
 - [X] T007 Add unit test proving execution stops after a structured blocked outcome.
 - [X] T008 Run focused and broader unit verification.
+- [X] T009 Mark blocked parent runs as terminal failed instead of completed.
+- [X] T010 Add unit coverage for blocked parent terminal-state mapping.
+- [X] T011 Require PR-created evidence for `publishMode=pr` terminal success.
+- [X] T012 Require successful merge evidence when merge automation is requested.
+- [X] T013 Require final report artifact evidence when required report output is requested.
+- [X] T014 Add unit coverage for final outcome success and failure gates.

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1722,11 +1722,165 @@ def test_publish_completion_reports_blocked_outcome_without_pr_failure() -> None
         parameters={"publishMode": "pr"}
     )
 
-    assert status == "blocked"
+    assert status == "failed"
     assert reason == "Workflow blocked by plan step: blocked upstream."
-    assert failed is False
+    assert failed is True
 
-def test_publish_completion_accepts_jira_output_without_pr_url() -> None:
+@pytest.mark.asyncio
+async def test_run_marks_blocked_outcome_as_failed_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    blocker_summary = "Workflow blocked by plan step: blocked upstream."
+    finalizing_calls: list[dict[str, Any]] = []
+    terminal_calls: list[dict[str, Any]] = []
+    states: list[tuple[str, str | None]] = []
+
+    def fake_initialize(
+        _self: MoonMindRunWorkflow,
+        _payload: dict[str, Any],
+    ) -> tuple[str, dict[str, Any], None, str, None]:
+        _self._owner_type = "user"
+        _self._owner_id = "owner-1"
+        _self._entry = "run"
+        return (
+            "MoonMind.Run",
+            {"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+            None,
+            "art_plan_1",
+            None,
+        )
+
+    async def fake_run_execution_stage(
+        self: MoonMindRunWorkflow,
+        *,
+        parameters: dict[str, Any],
+        plan_ref: str | None,
+    ) -> None:
+        self._plan_blocked_message = blocker_summary
+        self._publish_status = "not_required"
+        self._publish_reason = blocker_summary
+
+    async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def fake_run_finalizing_stage(
+        self: MoonMindRunWorkflow,
+        *,
+        parameters: dict[str, Any],
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        finalizing_calls.append({"status": status, "error": error})
+
+    async def fake_record_terminal_state(
+        self: MoonMindRunWorkflow,
+        *,
+        state: str,
+        close_status: str,
+        summary: str | None,
+        error_category: str | None = None,
+    ) -> None:
+        terminal_calls.append(
+            {
+                "state": state,
+                "close_status": close_status,
+                "summary": summary,
+                "error_category": error_category,
+            }
+        )
+
+    original_set_state = MoonMindRunWorkflow._set_state
+
+    def capture_set_state(
+        self: MoonMindRunWorkflow,
+        state: str,
+        summary: str | None = None,
+    ) -> None:
+        states.append((state, summary))
+        original_set_state(self, state, summary)
+
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-blocked",
+            "run_id": "run-blocked",
+            "task_queue": "mm.workflow",
+            "search_attributes": {},
+        },
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: True,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_initialize_from_payload",
+        fake_initialize,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_noop_async,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_run_execution_stage",
+        fake_run_execution_stage,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_run_proposals_stage",
+        fake_noop_async,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_run_finalizing_stage",
+        fake_run_finalizing_stage,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_record_terminal_state",
+        fake_record_terminal_state,
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_set_state", capture_set_state)
+
+    with pytest.raises(run_workflow_module.exceptions.ApplicationError) as exc_info:
+        await workflow.run({"workflowType": "MoonMind.Run"})
+
+    assert str(exc_info.value) == blocker_summary
+    assert finalizing_calls == [{"status": "failed", "error": blocker_summary}]
+    assert terminal_calls == [
+        {
+            "state": "failed",
+            "close_status": "failed",
+            "summary": blocker_summary,
+            "error_category": "user_error",
+        }
+    ]
+    assert states[-1] == ("failed", blocker_summary)
+    assert workflow._close_status == "failed"
+
+def test_publish_completion_requires_pr_url_for_pr_publish_mode() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._publish_status = "published"
     workflow._publish_reason = "Jira issue output succeeded; no PR output required"
@@ -1736,9 +1890,9 @@ def test_publish_completion_accepts_jira_output_without_pr_url() -> None:
         parameters={"publishMode": "pr"}
     )
 
-    assert status == "success"
-    assert reason == "Workflow completed successfully"
-    assert failed is False
+    assert status == "failed"
+    assert reason == "publishMode 'pr' requested but no PR was created"
+    assert failed is True
 
 @pytest.mark.parametrize("story_status", ["jira_created", "jira_partial"])
 def test_jira_story_output_status_satisfies_pr_publish(story_status: str) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1289,6 +1289,35 @@ def test_record_execution_context_tracks_created_report(
     assert status == "success"
     assert publish_failure is False
 
+
+def test_record_execution_context_tracks_mapped_agent_run_report(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    execution_result = mock_run_workflow._map_agent_run_result(
+        {
+            "summary": "Report published.",
+            "metadata": {"primaryReportRef": "art_report_2"},
+        }
+    )
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result=execution_result,
+    )
+
+    status, _message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "none",
+            "reportOutput": {"enabled": True, "required": True},
+        }
+    )
+
+    assert mock_run_workflow._report_created is True
+    assert mock_run_workflow._report_ref == "art_report_2"
+    assert status == "success"
+    assert publish_failure is False
+
+
 def test_determine_publish_completion_includes_operator_summary_for_report_runs(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1187,7 +1187,7 @@ def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(
     assert message == "publishMode 'pr' requested but no PR was created"
     assert publish_failure is True
 
-def test_determine_publish_completion_allows_integration_pr_without_local_pr_url(
+def test_determine_publish_completion_requires_integration_pr_url(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
     mock_run_workflow._integration = "jules"
@@ -1196,8 +1196,97 @@ def test_determine_publish_completion_allows_integration_pr_without_local_pr_url
         parameters={"publishMode": "pr"}
     )
 
+    assert status == "failed"
+    assert message == "publishMode 'pr' requested but no PR was created"
+    assert publish_failure is True
+
+def test_determine_publish_completion_succeeds_when_pr_was_created_after_skips(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._integration = "jules"
+    mock_run_workflow._publish_status = "published"
+    mock_run_workflow._pull_request_url = "https://github.com/org/repo/pull/123"
+    mock_run_workflow._publish_context["pullRequestUrl"] = (
+        "https://github.com/org/repo/pull/123"
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
     assert status == "success"
-    assert message == "Workflow completed successfully"
+    assert "Pull request: https://github.com/org/repo/pull/123" in message
+    assert publish_failure is False
+
+def test_determine_publish_completion_requires_merge_when_requested(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._pull_request_url = "https://github.com/org/repo/pull/123"
+    mock_run_workflow._publish_status = "published"
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-1"},
+        }
+    )
+
+    assert status == "failed"
+    assert message == "merge automation requested but PR was not merged"
+    assert publish_failure is True
+
+def test_determine_publish_completion_accepts_completed_merge_outcome(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._pull_request_url = "https://github.com/org/repo/pull/123"
+    mock_run_workflow._publish_status = "published"
+    mock_run_workflow._publish_context["mergeAutomationStatus"] = "merged"
+
+    status, _message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-1"},
+        }
+    )
+
+    assert status == "success"
+    assert publish_failure is False
+
+def test_determine_publish_completion_requires_requested_report(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "none",
+            "reportOutput": {"enabled": True, "required": True},
+        }
+    )
+
+    assert status == "failed"
+    assert message == "reportOutput requested but no final report was created"
+    assert publish_failure is True
+
+def test_record_execution_context_tracks_created_report(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {"summary": "Report published."},
+            "metadata": {"primaryReportRef": "art_report_1"},
+        },
+    )
+
+    status, _message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "none",
+            "reportOutput": {"enabled": True, "required": True},
+        }
+    )
+
+    assert mock_run_workflow._report_created is True
+    assert mock_run_workflow._report_ref == "art_report_1"
+    assert status == "success"
     assert publish_failure is False
 
 def test_determine_publish_completion_includes_operator_summary_for_report_runs(


### PR DESCRIPTION
## Summary

This changes `MoonMind.Run` terminal success to depend on required final outcomes instead of intermediate step completion alone.

- require PR evidence when `publishMode=pr`
- require successful merge evidence when merge automation is requested
- require final report artifact evidence when required `reportOutput` is requested
- preserve blocked outcome summaries as failed parent workflow results

## Root Cause

Blocked or skipped downstream steps could previously still lead to a completed parent workflow because the terminal projection was driven too loosely by workflow completion rather than the requested business outcome.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `./tools/test_unit.sh -- --basetemp=/tmp/tfull2 tests/unit`
