### PR TITLE
Changes to the task details page: The header of the tasks list should remain in view as you scroll. The pagination navigation buttons and text should…

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,17 @@
 [
   {
-    "id": 3186820408,
+    "id": 3190760474,
     "disposition": "addressed",
-    "rationale": "Restricted dialog Enter-to-apply handling so Enter on popover action buttons is not intercepted, with a regression test for staged filters remaining unapplied from action-button keydown."
+    "rationale": "Factored the tasks-list results footer into a reusable control and rendered it for error and first-page empty states so the Live updates toggle remains available outside populated results. Added regression assertions for both states."
   },
   {
-    "id": 4226183005,
+    "id": 4230728001,
     "disposition": "not-applicable",
-    "rationale": "Automated review summary wrapper; no standalone code action beyond the linked review comments."
+    "rationale": "Automated review summary container with no separate actionable feedback beyond review comment 3190760474."
   },
   {
-    "id": 3186821781,
-    "disposition": "addressed",
-    "rationale": "Excluded button targets from the popover Enter key apply path and covered the accessibility behavior in Tasks List tests."
-  },
-  {
-    "id": 3186821798,
-    "disposition": "addressed",
-    "rationale": "Guarded closeFilter focus restoration behind a non-null field target and added a mobile regression test to prevent stale desktop trigger focus."
-  },
-  {
-    "id": 4226184254,
+    "id": 4230739851,
     "disposition": "not-applicable",
-    "rationale": "Broad review summary; the concrete keyboard and focus findings from the summary were addressed in the linked line comments."
+    "rationale": "Review explicitly states there is no feedback to address."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -64,6 +64,7 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
+    expect(screen.getByLabelText('Live updates')).toBeTruthy();
   });
 
   it('keeps active filter chips visible on an empty first page with active filters', async () => {
@@ -104,6 +105,7 @@ describe('Tasks List Entrypoint', () => {
 
     expect(await screen.findByText('No tasks found for the current filters.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
+    expect(screen.getByLabelText('Live updates')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   });
 

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -66,7 +66,7 @@ describe('Tasks List Entrypoint', () => {
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
   });
 
-  it('keeps Clear filters available on an empty first page with active filters', async () => {
+  it('keeps active filter chips visible on an empty first page with active filters', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('stateIn=completed')) {
@@ -103,7 +103,8 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
 
     expect(await screen.findByText('No tasks found for the current filters.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Clear filters' }).getAttribute('disabled')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   });
 
   it('announces the current sort state on table headers', async () => {
@@ -326,7 +327,7 @@ describe('Tasks List Entrypoint', () => {
     expect(executionListCalls().length).toBe(baselineCalls);
   });
 
-  it('recovers from contradictory canonical URL filters after filters are cleared', async () => {
+  it('does not render the removed clear-filters recovery action for contradictory canonical URL filters', async () => {
     const baselineCalls = executionListCalls().length;
     window.history.pushState(
       {},
@@ -338,17 +339,7 @@ describe('Tasks List Entrypoint', () => {
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
     expect(executionListCalls().length).toBe(baselineCalls);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
-
-    await waitFor(() => {
-      expect(executionListCalls().length).toBe(baselineCalls + 1);
-    });
-    expect(screen.queryByText('Cannot combine stateIn and stateNotIn.')).toBeNull();
-    expect(lastExecutionListUrl()).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks',
-    );
-    expect(window.location.search).toBe('?limit=50');
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   });
 
   it('renders active task-list pills with the shared shimmer selector contract while keeping inactive pills plain', async () => {
@@ -833,7 +824,7 @@ describe('Tasks List Entrypoint', () => {
     expect(screen.getAllByText('Example task').length).toBeGreaterThan(0);
   });
 
-  it('renders pagination as arrow buttons beside the table summary', async () => {
+  it('renders pagination controls in the table footer', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -856,6 +847,7 @@ describe('Tasks List Entrypoint', () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     expect(await screen.findByText('Page 1 · 1-1 · 21')).toBeTruthy();
+    expect(document.querySelector('.task-list-results-footer')?.textContent).toContain('Page 1 · 1-1 · 21');
     expect(screen.getByRole('button', { name: 'Previous page' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Next page' })).toBeTruthy();
   });
@@ -877,12 +869,13 @@ describe('Tasks List Entrypoint', () => {
     expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();
 
     expect(controlDeck?.classList.contains('panel--controls')).toBe(false);
-    expect(
-      controlDeck?.querySelector('.task-list-utility-cluster')?.contains(screen.getByLabelText('Live updates')),
-    ).toBe(true);
-    expect(screen.getByText('Showing all task executions.')).toBeTruthy();
+    expect(controlDeck?.querySelector('.task-list-utility-cluster')).toBeNull();
+    expect(dataSlab?.querySelector('.task-list-results-footer')?.contains(screen.getByLabelText('Live updates'))).toBe(
+      true,
+    );
+    expect(screen.queryByText('Showing all task executions.')).toBeNull();
     expect(dataSlab).toBeTruthy();
-    expect(dataSlab?.querySelector('.queue-results-toolbar')).toBeTruthy();
+    expect(dataSlab?.querySelector('.task-list-results-footer')).toBeTruthy();
     const pageSizeSelect = screen.getByLabelText('Show');
     const pageSizeLabel = pageSizeSelect.closest('label');
     expect(pageSizeLabel?.classList.contains('queue-page-size-selector')).toBe(true);
@@ -934,7 +927,7 @@ describe('Tasks List Entrypoint', () => {
     expect(tableWrapperStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   });
 
-  it('shows clickable active column filter chips and clears filters from the control deck', async () => {
+  it('shows clickable active column filter chips and removes individual filters from the chip row', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -965,7 +958,7 @@ describe('Tasks List Entrypoint', () => {
       );
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Status filter' }));
 
     await waitFor(() => {
       fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -704,6 +704,57 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   ]
     .filter(Boolean)
     .join(' · ');
+  const resultsFooter = (
+    <div className="queue-results-toolbar task-list-results-footer">
+      <div className="task-list-footer-summary">
+        <span className="small">{pageSummary}</span>
+        <span className="small">
+          {liveUpdates && listEnabled
+            ? `Polling every ${Math.round(listPollMs / 1000)}s`
+            : 'Updates paused to keep selections stable.'}
+        </span>
+      </div>
+      <div className="queue-pagination">
+        <label className="queue-inline-toggle toolbar-live-toggle task-list-footer-live-toggle">
+          <input
+            type="checkbox"
+            checked={liveUpdates}
+            disabled={!listEnabled}
+            onChange={(event) => setLiveUpdates(event.target.checked)}
+          />
+          Live updates
+        </label>
+        <PageSizeSelector
+          pageSize={pageSize}
+          disabled={!listEnabled}
+          onPageSizeChange={(size) => {
+            setPageSize(size);
+            resetToFirstPage();
+          }}
+        />
+        <nav aria-label="Pagination" style={{ display: 'inline-flex', gap: '0.45rem' }}>
+          <button
+            type="button"
+            className="secondary queue-pagination-button"
+            disabled={!listEnabled || cursorStack.length === 0}
+            onClick={goPrev}
+            aria-label="Previous page"
+          >
+            <span aria-hidden="true">&larr;</span>
+          </button>
+          <button
+            type="button"
+            className="secondary queue-pagination-button"
+            disabled={!listEnabled || !data?.nextPageToken}
+            onClick={goNext}
+            aria-label="Next page"
+          >
+            <span aria-hidden="true">&rarr;</span>
+          </button>
+        </nav>
+      </div>
+    </div>
+  );
   const filterValueForField = useCallback(
     (field: string): string => {
       if (!isFilterField(field)) return '';
@@ -1263,9 +1314,15 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
       {isLoading ? (
         <p className="loading">Loading tasks...</p>
       ) : isError ? (
-        <div className="notice error">{(error as Error).message}</div>
+        <>
+          <div className="notice error">{(error as Error).message}</div>
+          {resultsFooter}
+        </>
       ) : sortedItems.length === 0 && !hasPaginationContext ? (
-        <p className="small">No tasks found for the current filters.</p>
+        <>
+          <p className="small">No tasks found for the current filters.</p>
+          {resultsFooter}
+        </>
       ) : (
         <section className="queue-layouts panel--data task-list-data-slab" aria-label="Task results">
           {sortedItems.length === 0 ? (
@@ -1453,55 +1510,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               </ul>
             </>
           )}
-          <div className="queue-results-toolbar task-list-results-footer">
-            <div className="task-list-footer-summary">
-              <span className="small">{pageSummary}</span>
-              <span className="small">
-                {liveUpdates && listEnabled
-                  ? `Polling every ${Math.round(listPollMs / 1000)}s`
-                  : 'Updates paused to keep selections stable.'}
-              </span>
-            </div>
-            <div className="queue-pagination">
-              <label className="queue-inline-toggle toolbar-live-toggle task-list-footer-live-toggle">
-                <input
-                  type="checkbox"
-                  checked={liveUpdates}
-                  disabled={!listEnabled}
-                  onChange={(event) => setLiveUpdates(event.target.checked)}
-                />
-                Live updates
-              </label>
-              <PageSizeSelector
-                pageSize={pageSize}
-                disabled={!listEnabled}
-                onPageSizeChange={(size) => {
-                  setPageSize(size);
-                  resetToFirstPage();
-                }}
-              />
-              <nav aria-label="Pagination" style={{ display: 'inline-flex', gap: '0.45rem' }}>
-                <button
-                  type="button"
-                  className="secondary queue-pagination-button"
-                  disabled={!listEnabled || cursorStack.length === 0}
-                  onClick={goPrev}
-                  aria-label="Previous page"
-                >
-                  <span aria-hidden="true">&larr;</span>
-                </button>
-                <button
-                  type="button"
-                  className="secondary queue-pagination-button"
-                  disabled={!listEnabled || !data?.nextPageToken}
-                  onClick={goNext}
-                  aria-label="Next page"
-                >
-                  <span aria-hidden="true">&rarr;</span>
-                </button>
-              </nav>
-            </div>
-          </div>
+          {resultsFooter}
         </section>
       )}
     </div>

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -723,13 +723,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
     [filters],
   );
   const hasActiveFilters = activeFilters.length > 0;
-  const clearFilters = useCallback(() => {
-    setHasEditedFilters(true);
-    setFilters(emptyFilters());
-    setDraftFilters(emptyFilters());
-    setOpenFilter(null);
-    resetToFirstPage();
-  }, [resetToFirstPage]);
   const toggleFilter = useCallback((field: FilterField) => {
     setOpenFilter((current) => (current === field ? null : field));
   }, []);
@@ -1202,22 +1195,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           <div>
             <h2 className="page-title" id="task-list-title">Tasks List</h2>
           </div>
-          <div className="toolbar-controls task-list-utility-cluster">
-            <label className="queue-inline-toggle toolbar-live-toggle">
-              <input
-                type="checkbox"
-                checked={liveUpdates}
-                disabled={!listEnabled}
-                onChange={(event) => setLiveUpdates(event.target.checked)}
-              />
-              Live updates
-            </label>
-            <span className="small">
-              {liveUpdates && listEnabled
-                ? `Polling every ${Math.round(listPollMs / 1000)}s`
-                : 'Updates paused to keep selections stable.'}
-            </span>
-          </div>
         </div>
 
         {!listEnabled ? (
@@ -1236,8 +1213,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
           </div>
         ) : null}
 
-        <div className="task-list-filter-row" aria-live="polite">
-          {hasActiveFilters ? (
+        {hasActiveFilters ? (
+          <div className="task-list-filter-row" aria-live="polite">
             <div className="task-list-filter-chips" aria-label="Active filters">
               {activeFilters.map(({ field, label, value }) => (
                 <span className="task-list-filter-chip" key={`${label}:${value}`}>
@@ -1274,18 +1251,8 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                 </span>
               ))}
             </div>
-          ) : (
-            <span className="small">Showing all task executions.</span>
-          )}
-          <button
-            type="button"
-            className="secondary task-list-clear-filters"
-            disabled={!listEnabled || !hasActiveFilters}
-            onClick={clearFilters}
-          >
-            Clear filters
-          </button>
-        </div>
+          </div>
+        ) : null}
         <div className="task-list-mobile-filter-controls" aria-label="Mobile task filters">
           {TABLE_COLUMNS.map(([field]) =>
             isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
@@ -1301,39 +1268,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
         <p className="small">No tasks found for the current filters.</p>
       ) : (
         <section className="queue-layouts panel--data task-list-data-slab" aria-label="Task results">
-          <div className="queue-results-toolbar">
-            <span className="small">{pageSummary}</span>
-            <div className="queue-pagination">
-              <PageSizeSelector
-                pageSize={pageSize}
-                disabled={!listEnabled}
-                onPageSizeChange={(size) => {
-                  setPageSize(size);
-                  resetToFirstPage();
-                }}
-              />
-              <nav aria-label="Pagination" style={{ display: 'inline-flex', gap: '0.45rem' }}>
-                <button
-                  type="button"
-                  className="secondary queue-pagination-button"
-                  disabled={!listEnabled || cursorStack.length === 0}
-                  onClick={goPrev}
-                  aria-label="Previous page"
-                >
-                  <span aria-hidden="true">&larr;</span>
-                </button>
-                <button
-                  type="button"
-                  className="secondary queue-pagination-button"
-                  disabled={!listEnabled || !data?.nextPageToken}
-                  onClick={goNext}
-                  aria-label="Next page"
-                >
-                  <span aria-hidden="true">&rarr;</span>
-                </button>
-              </nav>
-            </div>
-          </div>
           {sortedItems.length === 0 ? (
             <div className="card small">No tasks found for the current filters.</div>
           ) : (
@@ -1391,7 +1325,14 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                                 aria-label={filterAccessibilityLabel(field, label)}
                                 aria-expanded={filterField ? openFilter === filterField : false}
                               >
-                                <span aria-hidden="true">Filter</span>
+                                <svg
+                                  aria-hidden="true"
+                                  className="task-list-column-filter-icon"
+                                  viewBox="0 0 16 16"
+                                  focusable="false"
+                                >
+                                  <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
+                                </svg>
                               </button>
                             </div>
                             {filterField ? renderFilterPopover(filterField, label) : null}
@@ -1512,6 +1453,55 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               </ul>
             </>
           )}
+          <div className="queue-results-toolbar task-list-results-footer">
+            <div className="task-list-footer-summary">
+              <span className="small">{pageSummary}</span>
+              <span className="small">
+                {liveUpdates && listEnabled
+                  ? `Polling every ${Math.round(listPollMs / 1000)}s`
+                  : 'Updates paused to keep selections stable.'}
+              </span>
+            </div>
+            <div className="queue-pagination">
+              <label className="queue-inline-toggle toolbar-live-toggle task-list-footer-live-toggle">
+                <input
+                  type="checkbox"
+                  checked={liveUpdates}
+                  disabled={!listEnabled}
+                  onChange={(event) => setLiveUpdates(event.target.checked)}
+                />
+                Live updates
+              </label>
+              <PageSizeSelector
+                pageSize={pageSize}
+                disabled={!listEnabled}
+                onPageSizeChange={(size) => {
+                  setPageSize(size);
+                  resetToFirstPage();
+                }}
+              />
+              <nav aria-label="Pagination" style={{ display: 'inline-flex', gap: '0.45rem' }}>
+                <button
+                  type="button"
+                  className="secondary queue-pagination-button"
+                  disabled={!listEnabled || cursorStack.length === 0}
+                  onClick={goPrev}
+                  aria-label="Previous page"
+                >
+                  <span aria-hidden="true">&larr;</span>
+                </button>
+                <button
+                  type="button"
+                  className="secondary queue-pagination-button"
+                  disabled={!listEnabled || !data?.nextPageToken}
+                  onClick={goNext}
+                  aria-label="Next page"
+                >
+                  <span aria-hidden="true">&rarr;</span>
+                </button>
+              </nav>
+            </div>
+          </div>
         </section>
       )}
     </div>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -584,7 +584,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 1.75rem;
+  width: 1.75rem;
   min-height: 1.65rem;
   padding: 0.12rem 0.32rem;
   border: 1px solid transparent;
@@ -606,6 +606,13 @@ h1 {
   box-shadow: var(--mm-control-focus-ring);
   transform: none;
   filter: none;
+}
+
+.task-list-column-filter-icon {
+  display: block;
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: currentColor;
 }
 
 .task-list-header-filter-popover {
@@ -965,6 +972,23 @@ tbody tr:hover {
 .task-list-data-slab .queue-results-toolbar {
   padding: 0.85rem 1rem;
   border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
+}
+
+.task-list-data-slab .task-list-results-footer {
+  border-top: 1px solid rgb(var(--mm-border) / 0.28);
+  border-bottom: 0;
+}
+
+.task-list-footer-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.task-list-footer-live-toggle {
+  flex: 0 0 auto;
 }
 
 .queue-pagination {
@@ -1374,6 +1398,10 @@ tr[data-proposal-id].proposal-consuming td {
   .queue-pagination {
     align-items: stretch;
     margin-left: 0;
+    width: 100%;
+  }
+
+  .task-list-footer-summary {
     width: 100%;
   }
 


### PR DESCRIPTION
Changes to the task details page: The header of the tasks list should remain in view as you scroll. The pagination navigation buttons and text should be moved to the bottom. The filter button should be replaced with an icon instead. The line "Showing all task executions." should be removed from the page. The clear filter button should be removed from the page. The live updates checkbox should get moved to the bottom of the table near the pagination information.