### PR TITLE
[codex] Make shimmer border glint visible

### DIFF
--- a/docs/UI/EffectShimmerSweep.md
+++ b/docs/UI/EffectShimmerSweep.md
@@ -88,6 +88,7 @@ layers:
   border_mask:
     role: border-ring glint where the shared light field crosses the pill edge
     source: shared_light_field
+    geometry: overlap the host border and a narrow inner edge while remaining clipped to the rounded pill bounds
     blend_intent: additive_light
 
   text_mask:
@@ -280,7 +281,7 @@ implementation_shape:
 
   overlay_elements:
     - ::before as fill_mask of shared_light_field
-    - ::after as border_mask of shared_light_field
+    - ::after as border_mask of shared_light_field, out-set and widened enough to overlap the physical border before clipping
 
   text_strategy:
     text_must_render_above_overlay: true
@@ -338,6 +339,9 @@ effect_tokens:
   --mm-executing-sweep-end-y: -160%
   --mm-executing-sweep-layer-offset-x: -12%
   --mm-executing-sweep-layer-offset-y: -10%
+  --mm-executing-border-glint-outset: 1px
+  --mm-executing-border-glint-width: 3px
+  --mm-executing-border-glint-opacity: 0.95
   --mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)
   --mm-executing-letter-sweep-start-ratio: 0.2
   --mm-executing-letter-sweep-travel-ratio: 0.18

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -429,6 +429,9 @@ describe('Mission Control shared entry', () => {
     expect(missionControlCss).toContain('--mm-executing-letter-sweep-direction: 1');
     expect(missionControlCss).toContain('--mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32)');
     expect(missionControlCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%)');
+    expect(missionControlCss).toContain('--mm-executing-border-glint-outset: 1px');
+    expect(missionControlCss).toContain('--mm-executing-border-glint-width: 3px');
+    expect(missionControlCss).toContain('--mm-executing-border-glint-opacity: 0.95');
     expect(missionControlCss).toContain('--mm-executing-moving-light-gradient:');
 
     const shimmerBlock = cssRuleBlocks(
@@ -480,6 +483,9 @@ describe('Mission Control shared entry', () => {
     expect(shimmerAfterBlock).toContain('mask-composite: exclude');
     expect(shimmerAfterBlock).toContain('-webkit-mask-composite: xor');
     expect(shimmerAfterBlock).toContain('z-index: 2');
+    expect(shimmerAfterBlock).toContain('inset: calc(-1 * var(--mm-executing-border-glint-outset))');
+    expect(shimmerAfterBlock).toContain('padding: var(--mm-executing-border-glint-width)');
+    expect(shimmerAfterBlock).toContain('opacity: var(--mm-executing-border-glint-opacity)');
     expect(cssRuleBlock(missionControlCss, '.status-letter-wave')).toContain('z-index: 3');
     const glyphBlock = cssRuleBlock(missionControlCss, '.status-letter-wave__glyph');
     expect(glyphBlock).toContain('--mm-letter-phase');

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -55,6 +55,9 @@
   --mm-executing-sweep-layer-offset-y: -10%;
   --mm-executing-sweep-core-opacity: 0.34;
   --mm-executing-sweep-halo-opacity: 0.14;
+  --mm-executing-border-glint-outset: 1px;
+  --mm-executing-border-glint-width: 3px;
+  --mm-executing-border-glint-opacity: 0.95;
   --mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration);
   --mm-executing-letter-sweep-start-ratio: 0.2;
   --mm-executing-letter-sweep-travel-ratio: 0.18;
@@ -1502,9 +1505,10 @@ tr[data-proposal-id].proposal-consuming td {
 .status-running.is-executing::after,
 .status-running.is-planning::after {
   z-index: 2;
+  inset: calc(-1 * var(--mm-executing-border-glint-outset));
   border-radius: inherit;
-  padding: 1px;
-  opacity: 0.82;
+  padding: var(--mm-executing-border-glint-width);
+  opacity: var(--mm-executing-border-glint-opacity);
   mask:
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);

--- a/specs/301-shared-additive-shimmer/contracts/status-pill-shimmer.md
+++ b/specs/301-shared-additive-shimmer/contracts/status-pill-shimmer.md
@@ -27,7 +27,7 @@ The shared light field is represented by:
 
 Required mask usage:
 - Fill mask: active host `::before` uses the shared gradient and keyframes.
-- Border mask: active host `::after` uses the same shared gradient and keyframes, clipped to the border ring.
+- Border mask: active host `::after` uses the same shared gradient and keyframes, clipped to a border ring that overlaps the physical border and a narrow inner edge.
 - Text mask: `.status-letter-wave::after` uses the same shared gradient and keyframes, clipped to visible label text.
 
 ## Text Contract
@@ -67,7 +67,7 @@ Forced colors:
 Unit CSS contract tests must assert:
 - Shared gradient token exists.
 - Fill, border, and text masks use the shared gradient and keyframes.
-- Border mask uses a ring mask.
+- Border mask uses a ring mask with explicit overlap geometry, not a purely interior hairline.
 - Text mask uses text clipping.
 - Glyph fallback is inactive by default and enabled only under unsupported text clipping.
 - Reduced-motion and forced-colors branches disable decorative animation.

--- a/specs/301-shared-additive-shimmer/data-model.md
+++ b/specs/301-shared-additive-shimmer/data-model.md
@@ -50,7 +50,7 @@ Purpose: A clipped visual region that exposes the shared light field.
 
 Fields:
 - `fill_mask`: Status-pill interior mask rendered through `::before`.
-- `border_mask`: Status-pill border ring mask rendered through `::after`.
+- `border_mask`: Status-pill border ring mask rendered through `::after`, widened to overlap the physical border plus a narrow inner edge while the host clips any outside extent.
 - `text_mask`: Label-shaped mask rendered through `.status-letter-wave::after`.
 - `glyph_pulse_fallback`: Existing per-glyph brightening fallback for unsupported text clipping.
 

--- a/specs/301-shared-additive-shimmer/verification.md
+++ b/specs/301-shared-additive-shimmer/verification.md
@@ -8,7 +8,7 @@
 
 | ID | Result | Evidence |
 | --- | --- | --- |
-| FR-001, SCN-001, SC-001, DESIGN-REQ-001 | PASS | `frontend/src/styles/mission-control.css` defines `--mm-executing-moving-light-gradient`; shared fill, border, and text mask selectors use that gradient and `mm-status-pill-shimmer`; `frontend/src/entrypoints/mission-control.test.tsx` passed. |
+| FR-001, SCN-001, SC-001, DESIGN-REQ-001 | PASS | `frontend/src/styles/mission-control.css` defines `--mm-executing-moving-light-gradient`; shared fill, border, and text mask selectors use that gradient and `mm-status-pill-shimmer`; the border mask now uses explicit out-set/width/opacity tokens so the glint overlaps the physical border instead of reading as an interior hairline; `frontend/src/entrypoints/mission-control.test.tsx` passed. |
 | FR-002, SCN-002, SC-002 | PASS | `ExecutionStatusPill.tsx` exposes `data-label`; `.status-letter-wave::after` clips the shared gradient to text; entrypoint render tests preserve glyph labels. |
 | FR-003, SCN-006, DESIGN-REQ-005 | PASS | `executionStatusPillProps()` remains the selector boundary; helper and render tests confirm active-only shimmer metadata. |
 | FR-004, SCN-004, SC-003, DESIGN-REQ-004 | PASS | Reduced-motion CSS disables decorative animation while preserving static active treatment; CSS contract tests passed. |


### PR DESCRIPTION
## Summary

- Widened the shared shimmer border mask so the additive light field visibly overlaps the pill border.
- Added explicit border glint tokens for outset, width, and opacity.
- Updated the shimmer design docs and feature artifacts to require overlap geometry instead of a 1px interior hairline.

## Root Cause

The existing border mask was present, but it used a 1px ring at the exact pill edge. In practice the shimmer read as restricted to the interior fill, so the border did not visibly brighten as the sweep passed.

## Validation

- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/mission-control.test.tsx frontend/src/utils/executionStatusPillClasses.test.ts
