### PR TITLE
The Tasks List title looks strangely separated from the actual table but should more clearly read as the Title OF the table on the tasks list page. Up

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,12 @@
 [
   {
-    "id": 3191819151,
+    "id": 3192062411,
     "disposition": "addressed",
-    "rationale": "Changed page range summary to show 0 - 0 when the current page has no sorted items."
+    "rationale": "Combined the two sortedItems.length === 0 branches into a single block that toggles the inner element on hasPaginationContext, removing the duplicated resultsFooter."
   },
   {
-    "id": 3191819160,
-    "disposition": "addressed",
-    "rationale": "Added flex-wrap to the task list footer pagination container for narrow layouts."
-  },
-  {
-    "id": 4231866388,
+    "id": 4232119181,
     "disposition": "not-applicable",
-    "rationale": "Bot review summary only; the actionable inline comments from that review were handled separately."
+    "rationale": "Summary review body referencing the inline suggestion already addressed; no additional action required."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -1317,14 +1317,13 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
             <div className="notice error task-list-empty-message">{(error as Error).message}</div>
             {resultsFooter}
           </>
-        ) : sortedItems.length === 0 && !hasPaginationContext ? (
-          <>
-            <p className="small task-list-empty-message">No tasks found for the current filters.</p>
-            {resultsFooter}
-          </>
         ) : sortedItems.length === 0 ? (
           <>
-            <div className="card small task-list-empty-message">No tasks found for the current filters.</div>
+            {!hasPaginationContext ? (
+              <p className="small task-list-empty-message">No tasks found for the current filters.</p>
+            ) : (
+              <div className="card small task-list-empty-message">No tasks found for the current filters.</div>
+            )}
             {resultsFooter}
           </>
         ) : (

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -1239,13 +1239,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
 
   return (
     <div className="stack">
-      <section className="task-list-control-deck" aria-labelledby="task-list-title">
-        <div className="toolbar">
-          <div>
-            <h2 className="page-title" id="task-list-title">Tasks List</h2>
-          </div>
-        </div>
-
+      <section className="task-list-control-deck" aria-label="Task list filters">
         {!listEnabled ? (
           <div className="notice error">Temporal task list is disabled in server configuration.</div>
         ) : null}
@@ -1309,25 +1303,33 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
         </div>
       </section>
 
-      {isLoading ? (
-        <p className="loading">Loading tasks...</p>
-      ) : isError ? (
-        <>
-          <div className="notice error">{(error as Error).message}</div>
-          {resultsFooter}
-        </>
-      ) : sortedItems.length === 0 && !hasPaginationContext ? (
-        <>
-          <p className="small">No tasks found for the current filters.</p>
-          {resultsFooter}
-        </>
-      ) : (
-        <section className="queue-layouts panel--data task-list-data-slab" aria-label="Task results">
-          {sortedItems.length === 0 ? (
-            <div className="card small">No tasks found for the current filters.</div>
-          ) : (
-            <>
-              <div className="queue-table-wrapper" data-layout="table">
+      <section
+        className="queue-layouts panel--data task-list-data-slab"
+        aria-labelledby="task-list-title"
+      >
+        <header className="task-list-results-header">
+          <h2 className="page-title" id="task-list-title">Tasks List</h2>
+        </header>
+        {isLoading ? (
+          <p className="loading task-list-empty-message">Loading tasks...</p>
+        ) : isError ? (
+          <>
+            <div className="notice error task-list-empty-message">{(error as Error).message}</div>
+            {resultsFooter}
+          </>
+        ) : sortedItems.length === 0 && !hasPaginationContext ? (
+          <>
+            <p className="small task-list-empty-message">No tasks found for the current filters.</p>
+            {resultsFooter}
+          </>
+        ) : sortedItems.length === 0 ? (
+          <>
+            <div className="card small task-list-empty-message">No tasks found for the current filters.</div>
+            {resultsFooter}
+          </>
+        ) : (
+          <>
+            <div className="queue-table-wrapper" data-layout="table">
                 <table>
                   <colgroup>
                     <col className="queue-table-column-id" />
@@ -1506,11 +1508,10 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                       );
                     })}
               </ul>
+              {resultsFooter}
             </>
           )}
-          {resultsFooter}
         </section>
-      )}
     </div>
   );
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -977,6 +977,26 @@ tbody tr:hover {
   border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
 }
 
+.task-list-results-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
+  background: rgb(var(--mm-panel) / 0.85);
+}
+
+.task-list-results-header .page-title {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+.task-list-empty-message {
+  margin: 0;
+  padding: 1rem;
+}
+
 .task-list-data-slab .task-list-results-footer {
   border-top: 1px solid rgb(var(--mm-border) / 0.28);
   border-bottom: 0;


### PR DESCRIPTION
The Tasks List title looks strangely separated from the actual table but should more clearly read as the Title OF the table on the tasks list page. Update the formatting to make this more clear and visually connected.