### PR TITLE
[codex] Fix Codex session skill projection ordering

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3192062411,
+    "id": 3192506969,
     "disposition": "addressed",
-    "rationale": "Combined the two sortedItems.length === 0 branches into a single block that toggles the inner element on hasPaginationContext, removing the duplicated resultsFooter."
+    "rationale": "Added launch metadata preflight that skips skill materialization so durable retrieval metadata is present at cold session launch while real skill projection still happens after launch."
   },
   {
-    "id": 4232119181,
+    "id": 4232619979,
     "disposition": "not-applicable",
-    "rationale": "Summary review body referencing the inline suggestion already addressed; no additional action required."
+    "rationale": "Review body summary only; no separate actionable request."
+  },
+  {
+    "id": 3192516052,
+    "disposition": "addressed",
+    "rationale": "Preserved preparation-produced durable retrieval metadata in launch request metadata and request parameters before sending the turn."
+  },
+  {
+    "id": 4232630020,
+    "disposition": "not-applicable",
+    "rationale": "Review body summary only; actionable retrieval metadata concern is covered by review comments 3192506969 and 3192516052."
   }
 ]

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -338,16 +338,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             raise ValueError(
                 "CodexSessionAdapter does not support inputRefs for managed session turns"
             )
-        instructions: str | None = None
-        preparation_error: Exception | None = None
-        try:
-            instructions = await self._instructions_for_request(
-                binding=binding,
-                request=request,
-                workspace_path=workspace_path,
-            )
-        except Exception as exc:
-            preparation_error = exc
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -392,14 +382,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         failed_state_persisted = False
 
         try:
-            if preparation_error is not None:
-                raise preparation_error
-            if instructions is None:
-                instructions = await self._instructions_for_request(
-                    binding=binding,
-                    request=request,
-                    workspace_path=workspace_path,
-                )
+            instructions = await self._instructions_for_request(
+                binding=binding,
+                request=request,
+                workspace_path=workspace_path,
+            )
             turn_response = await self._coerce_turn_response(
                 self._send_turn(
                     SendCodexManagedSessionTurnRequest(

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -338,6 +338,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             raise ValueError(
                 "CodexSessionAdapter does not support inputRefs for managed session turns"
             )
+        await self._prepare_launch_metadata_for_request(
+            request=request,
+            workspace_path=workspace_path,
+        )
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -989,6 +993,41 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
+
+    async def _prepare_launch_metadata_for_request(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        workspace_path: str,
+    ) -> None:
+        """Populate launch-safe durable metadata without installing skill projections."""
+
+        if self._prepare_turn_instructions is None:
+            return
+        metadata_request = request.model_copy(deep=True)
+        try:
+            prepared = await self._prepare_turn_instructions(
+                {
+                    "request": metadata_request.model_dump(
+                        by_alias=True,
+                        exclude_none=True,
+                    ),
+                    "workspacePath": workspace_path,
+                    "includePreparedRequestMetadata": True,
+                    "skipSkillMaterialization": True,
+                }
+            )
+        except Exception:
+            logger.debug(
+                "Launch metadata preflight failed; real turn preparation will run after session launch.",
+                exc_info=True,
+            )
+            return
+        if isinstance(prepared, Mapping):
+            _merge_durable_retrieval_metadata(
+                request,
+                prepared.get("durableRetrievalMetadata"),
+            )
 
     def _managed_session_launch_environment(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4029,10 +4029,16 @@ class TemporalAgentRuntimeActivities:
         workspace_path_raw = str(
             payload.get("workspace_path") or payload.get("workspacePath") or ""
         ).strip()
-        skill_snapshot_materialized = await self._materialize_selected_agent_skill_for_turn(
-            request=request,
-            workspace_path=workspace_path_raw,
+        skip_skill_materialization = bool(
+            payload.get("skipSkillMaterialization")
+            or payload.get("skip_skill_materialization")
         )
+        skill_snapshot_materialized = False
+        if not skip_skill_materialization:
+            skill_snapshot_materialized = await self._materialize_selected_agent_skill_for_turn(
+                request=request,
+                workspace_path=workspace_path_raw,
+            )
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
             if not workspace_path_raw:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5334,8 +5334,18 @@ class TemporalAgentRuntimeActivities:
         if workspace is not None and (
             normalized == ".agents/skills"
             or normalized.startswith(".agents/skills/")
+            or normalized == ".gemini/skills"
+            or normalized.startswith(".gemini/skills/")
+            or normalized == "skills_active"
+            or normalized.startswith("skills_active/")
         ):
-            projection = workspace.expanduser().resolve() / ".agents" / "skills"
+            root = normalized.split("/", 2)
+            if root[:2] == [".agents", "skills"]:
+                projection = workspace.expanduser().resolve() / ".agents" / "skills"
+            elif root[:2] == [".gemini", "skills"]:
+                projection = workspace.expanduser().resolve() / ".gemini" / "skills"
+            else:
+                projection = workspace.expanduser().resolve() / "skills_active"
             if projection.is_symlink():
                 return True
         return False

--- a/specs/307-codex-session-skill-projection/plan.md
+++ b/specs/307-codex-session-skill-projection/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan: Codex Session Skill Projection Stability
+
+## Summary
+
+Fix managed Codex session ordering so the final cloned workspace exists before selected skill materialization and instruction preparation. Harden publish filtering so runtime-only skill projection symlinks cannot leak into target repositories.
+
+## Technical Context
+
+- Python 3.12
+- Temporal workflow/activity boundaries
+- Managed Codex session adapter
+- Agent skill materialization under `.agents/skills`
+- Existing pytest unit coverage
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The fix preserves Codex as the agent runtime and adjusts orchestration order only.
+- **II. One-Click Agent Deployment**: PASS. No deployment prerequisites added.
+- **III. Avoid Vendor Lock-In**: PASS. Changes are isolated to Codex session adapter and generic publish filtering for skill projections.
+- **IV. Own Your Data**: PASS. Runtime artifacts remain local and inspectable.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Selected skills remain visible through the canonical `.agents/skills` path.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The result contract is unchanged; only runtime setup ordering is fixed.
+- **VII. Runtime Configurability**: PASS. No hardcoded operator-facing config added.
+- **VIII. Modular Architecture**: PASS. Changes stay inside adapter and activity boundaries.
+- **IX. Resilient by Default**: PASS. The run fails before turn send if selected skill projection cannot be materialized.
+- **X. Continuous Improvement**: PASS. Failure mode is covered by regression tests.
+- **XI. Spec-Driven Development**: PASS. This artifact records the bugfix contract.
+- **XII. Desired-State Docs**: PASS. Migration details remain in this feature artifact.
+- **XIII. Pre-release Compatibility**: PASS. No compatibility aliases or fallback semantics introduced.
+
+## Implementation Strategy
+
+1. Reorder `CodexSessionAdapter.start` so `_ensure_remote_session` runs before `_instructions_for_request`.
+2. Keep selected-skill materialization and validation inside `agent_runtime.prepare_turn_instructions`; now it runs against the final workspace.
+3. Extend publish path filtering to ignore `.gemini/skills` and root `skills_active` symlink projections.
+4. Add targeted tests for cold-session order and publish filtering.
+
+## Risk & Mitigation
+
+- **Risk**: Prepared retrieval metadata is no longer available to the launch request when it is produced by turn preparation.
+  **Mitigation**: Request metadata still receives prepared durable retrieval metadata before turn send; launch metadata continues to include metadata already present before preparation.
+
+## Verification
+
+- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`
+- `./tools/test_unit.sh` before finalizing.

--- a/specs/307-codex-session-skill-projection/plan.md
+++ b/specs/307-codex-session-skill-projection/plan.md
@@ -30,15 +30,16 @@ Fix managed Codex session ordering so the final cloned workspace exists before s
 
 ## Implementation Strategy
 
-1. Reorder `CodexSessionAdapter.start` so `_ensure_remote_session` runs before `_instructions_for_request`.
-2. Keep selected-skill materialization and validation inside `agent_runtime.prepare_turn_instructions`; now it runs against the final workspace.
-3. Extend publish path filtering to ignore `.gemini/skills` and root `skills_active` symlink projections.
-4. Add targeted tests for cold-session order and publish filtering.
+1. Add a launch metadata preflight that calls turn preparation with selected-skill materialization skipped.
+2. Reorder `CodexSessionAdapter.start` so `_ensure_remote_session` runs before the real `_instructions_for_request`.
+3. Keep selected-skill materialization and validation inside the real `agent_runtime.prepare_turn_instructions`; now it runs against the final workspace.
+4. Extend publish path filtering to ignore `.gemini/skills` and root `skills_active` symlink projections.
+5. Add targeted tests for cold-session order, launch metadata preservation, and publish filtering.
 
 ## Risk & Mitigation
 
-- **Risk**: Prepared retrieval metadata is no longer available to the launch request when it is produced by turn preparation.
-  **Mitigation**: Request metadata still receives prepared durable retrieval metadata before turn send; launch metadata continues to include metadata already present before preparation.
+- **Risk**: Preparing selected skills before launch can create a projection that is deleted by workspace clone.
+  **Mitigation**: The pre-launch preparation path skips selected-skill materialization and only harvests compact durable metadata.
 
 ## Verification
 

--- a/specs/307-codex-session-skill-projection/spec.md
+++ b/specs/307-codex-session-skill-projection/spec.md
@@ -1,0 +1,36 @@
+# Feature Specification: Codex Session Skill Projection Stability
+
+**Feature Branch**: `307-codex-session-skill-projection`
+**Created**: 2026-05-06
+**Status**: Draft
+**Input**: Managed Codex `pr-resolver` runs can receive instructions pointing to `.agents/skills/<skill>/SKILL.md` after the cold session launch has replaced the workspace and removed the active skill projection.
+
+## User Scenarios & Testing
+
+### User Story 1 - Selected Skills Survive Cold Session Launch (Priority: P1)
+
+As an operator running a managed Codex task with a selected MoonMind skill, I need Codex to see the resolved active skill snapshot at `.agents/skills` when the turn starts, even if the session launch has to clone or repair the workspace.
+
+**Independent Test**: Start a cold Codex managed session with a selected skill and verify turn preparation runs after session launch, so the prepared instructions are based on the final workspace state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a selected skill and a cold managed Codex session, **When** MoonMind launches the session and sends the first turn, **Then** `.agents/skills/<skill>/SKILL.md` is present in the runtime-visible workspace before Codex receives instructions to read it.
+2. **Given** the managed session launch creates or replaces the repo checkout, **When** turn instructions are prepared, **Then** preparation observes the post-launch workspace rather than a pre-launch placeholder.
+3. **Given** MoonMind-generated compatibility skill links exist in a workspace, **When** post-agent publishing stages changed files, **Then** projection-only skill symlinks are not committed to the target repository.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Managed Codex session startup MUST establish the final workspace before selected-skill turn instruction preparation materializes `.agents/skills`.
+- **FR-002**: Selected-skill instruction preparation MUST continue to validate the active `.agents/skills` projection before a turn is sent.
+- **FR-003**: Runtime-generated skill projection links under `.agents/skills`, `.gemini/skills`, and root `skills_active` MUST be excluded from publish staging when they are symlinks.
+- **FR-004**: Checked-in, non-symlink skill directories MUST remain publishable when they are user-authored content, not runtime projections.
+- **FR-005**: Existing pr-resolver result contract behavior MUST remain unchanged; missing `var/pr_resolver/result.json` still fails the run.
+
+## Success Criteria
+
+- **SC-001**: A regression test proves cold Codex sessions prepare turn instructions only after launch has completed.
+- **SC-002**: A regression test proves generated `.gemini/skills` and `skills_active` symlink projections are excluded from publish staging.
+- **SC-003**: Existing managed-session adapter and agent-runtime activity tests continue to pass.

--- a/specs/307-codex-session-skill-projection/spec.md
+++ b/specs/307-codex-session-skill-projection/spec.md
@@ -17,7 +17,8 @@ As an operator running a managed Codex task with a selected MoonMind skill, I ne
 
 1. **Given** a selected skill and a cold managed Codex session, **When** MoonMind launches the session and sends the first turn, **Then** `.agents/skills/<skill>/SKILL.md` is present in the runtime-visible workspace before Codex receives instructions to read it.
 2. **Given** the managed session launch creates or replaces the repo checkout, **When** turn instructions are prepared, **Then** preparation observes the post-launch workspace rather than a pre-launch placeholder.
-3. **Given** MoonMind-generated compatibility skill links exist in a workspace, **When** post-agent publishing stages changed files, **Then** projection-only skill symlinks are not committed to the target repository.
+3. **Given** preparation produces durable retrieval metadata, **When** a cold session is launched, **Then** launch metadata includes that compact durable metadata without relying on a pre-launch skill projection.
+4. **Given** MoonMind-generated compatibility skill links exist in a workspace, **When** post-agent publishing stages changed files, **Then** projection-only skill symlinks are not committed to the target repository.
 
 ## Requirements
 
@@ -25,12 +26,14 @@ As an operator running a managed Codex task with a selected MoonMind skill, I ne
 
 - **FR-001**: Managed Codex session startup MUST establish the final workspace before selected-skill turn instruction preparation materializes `.agents/skills`.
 - **FR-002**: Selected-skill instruction preparation MUST continue to validate the active `.agents/skills` projection before a turn is sent.
-- **FR-003**: Runtime-generated skill projection links under `.agents/skills`, `.gemini/skills`, and root `skills_active` MUST be excluded from publish staging when they are symlinks.
-- **FR-004**: Checked-in, non-symlink skill directories MUST remain publishable when they are user-authored content, not runtime projections.
-- **FR-005**: Existing pr-resolver result contract behavior MUST remain unchanged; missing `var/pr_resolver/result.json` still fails the run.
+- **FR-003**: Launch-safe preparation MUST be able to collect durable retrieval metadata before launch without installing selected-skill projections into a pre-launch workspace.
+- **FR-004**: Runtime-generated skill projection links under `.agents/skills`, `.gemini/skills`, and root `skills_active` MUST be excluded from publish staging when they are symlinks.
+- **FR-005**: Checked-in, non-symlink skill directories MUST remain publishable when they are user-authored content, not runtime projections.
+- **FR-006**: Existing pr-resolver result contract behavior MUST remain unchanged; missing `var/pr_resolver/result.json` still fails the run.
 
 ## Success Criteria
 
 - **SC-001**: A regression test proves cold Codex sessions prepare turn instructions only after launch has completed.
-- **SC-002**: A regression test proves generated `.gemini/skills` and `skills_active` symlink projections are excluded from publish staging.
-- **SC-003**: Existing managed-session adapter and agent-runtime activity tests continue to pass.
+- **SC-002**: A regression test proves launch metadata still includes durable retrieval metadata produced by preparation.
+- **SC-003**: A regression test proves generated `.gemini/skills` and `skills_active` symlink projections are excluded from publish staging.
+- **SC-004**: Existing managed-session adapter and agent-runtime activity tests continue to pass.

--- a/specs/307-codex-session-skill-projection/tasks.md
+++ b/specs/307-codex-session-skill-projection/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Codex Session Skill Projection Stability
+
+- [x] T001 Add a Codex session adapter regression test proving cold-session launch happens before turn preparation.
+- [x] T002 Reorder Codex managed-session start so turn instruction preparation runs after `_ensure_remote_session`.
+- [x] T003 Add publish filter coverage for `.gemini/skills` and root `skills_active` symlink projections.
+- [x] T004 Extend publish filtering to exclude generated compatibility skill symlinks while preserving real checked-in skill directories.
+- [x] T005 Run focused unit tests for the affected adapter and activity files.
+- [x] T006 Run the full unit suite before opening the PR.

--- a/specs/307-codex-session-skill-projection/tasks.md
+++ b/specs/307-codex-session-skill-projection/tasks.md
@@ -1,8 +1,10 @@
 # Tasks: Codex Session Skill Projection Stability
 
-- [x] T001 Add a Codex session adapter regression test proving cold-session launch happens before turn preparation.
-- [x] T002 Reorder Codex managed-session start so turn instruction preparation runs after `_ensure_remote_session`.
-- [x] T003 Add publish filter coverage for `.gemini/skills` and root `skills_active` symlink projections.
-- [x] T004 Extend publish filtering to exclude generated compatibility skill symlinks while preserving real checked-in skill directories.
-- [x] T005 Run focused unit tests for the affected adapter and activity files.
-- [x] T006 Run the full unit suite before opening the PR.
+- [x] T001 Add a Codex session adapter regression test proving cold-session launch happens before real turn preparation.
+- [x] T002 Add launch metadata regression coverage for preparation-produced durable retrieval metadata.
+- [x] T003 Add a pre-launch metadata preparation path that skips selected-skill materialization.
+- [x] T004 Reorder Codex managed-session start so real turn instruction preparation runs after `_ensure_remote_session`.
+- [x] T005 Add publish filter coverage for `.gemini/skills` and root `skills_active` symlink projections.
+- [x] T006 Extend publish filtering to exclude generated compatibility skill symlinks while preserving real checked-in skill directories.
+- [x] T007 Run focused unit tests for the affected adapter and activity files.
+- [x] T008 Run the full unit suite before opening the PR.

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -401,8 +401,12 @@ async def test_start_prepares_turn_instructions_after_cold_session_launch(
         )
 
     async def _prepare_after_launch(payload: dict[str, Any]) -> str:
-        call_order.append("prepare")
         assert payload["workspacePath"] == str(workspace_path)
+        if payload.get("skipSkillMaterialization") is True:
+            call_order.append("preflight")
+            assert not (workspace_path / ".launch-complete").exists()
+            return "metadata preflight\n\nManaged Codex CLI note:"
+        call_order.append("prepare")
         assert (workspace_path / ".launch-complete").is_file()
         return "prepared after launch\n\nManaged Codex CLI note:"
 
@@ -458,7 +462,7 @@ async def test_start_prepares_turn_instructions_after_cold_session_launch(
 
     await adapter.start(_request(binding, workspace_path=str(workspace_path)))
 
-    assert call_order == ["launch", "prepare", "send"]
+    assert call_order == ["preflight", "launch", "prepare", "send"]
     assert send_turn_calls[0].instructions.startswith("prepared after launch")
 
 async def test_start_passes_managed_session_dood_context(
@@ -2368,17 +2372,19 @@ async def test_start_delegates_turn_instruction_preparation_before_sending_turn(
     assert send_turn_calls[0].instructions.startswith("Injected context instruction")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
 
-async def test_start_updates_request_metadata_from_prepared_turn_request(
+async def test_start_populates_launch_metadata_from_prepared_turn_request(
     tmp_path: Path,
 ) -> None:
     binding = _binding()
     launch_calls: list[Any] = []
+    prepare_calls: list[bool] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(binding=binding)
 
     async def _prepare(payload: dict[str, Any]) -> dict[str, Any]:
         assert payload["includePreparedRequestMetadata"] is True
+        prepare_calls.append(bool(payload.get("skipSkillMaterialization")))
         return {
             "instructions": "Injected context instruction\n\nManaged Codex CLI note:",
             "durableRetrievalMetadata": {
@@ -2452,8 +2458,13 @@ async def test_start_updates_request_metadata_from_prepared_turn_request(
     await adapter.start(request)
 
     assert len(launch_calls) == 1
+    assert prepare_calls == [True, False]
     launch_request = launch_calls[0]["request"]
-    assert launch_request["metadata"] == {}
+    assert (
+        launch_request["metadata"]["latestContextPackRef"]
+        == "artifacts/context/rag-context-prepared.json"
+    )
+    assert launch_request["metadata"]["retrievalDurabilityAuthority"] == "artifact_ref"
     assert (
         request.parameters["metadata"]["moonmind"]["latestContextPackRef"]
         == "artifacts/context/rag-context-prepared.json"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -377,6 +377,90 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
 
+async def test_start_prepares_turn_instructions_after_cold_session_launch(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    call_order: list[str] = []
+    send_turn_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        call_order.append("launch")
+        workspace_path.mkdir(parents=True)
+        (workspace_path / ".git").mkdir()
+        (workspace_path / ".launch-complete").write_text("ready\n", encoding="utf-8")
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _prepare_after_launch(payload: dict[str, Any]) -> str:
+        call_order.append("prepare")
+        assert payload["workspacePath"] == str(workspace_path)
+        assert (workspace_path / ".launch-complete").is_file()
+        return "prepared after launch\n\nManaged Codex CLI note:"
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        call_order.append("send")
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_after_launch,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    assert call_order == ["launch", "prepare", "send"]
+    assert send_turn_calls[0].instructions.startswith("prepared after launch")
+
 async def test_start_passes_managed_session_dood_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -2284,7 +2368,7 @@ async def test_start_delegates_turn_instruction_preparation_before_sending_turn(
     assert send_turn_calls[0].instructions.startswith("Injected context instruction")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
 
-async def test_start_populates_launch_metadata_from_prepared_turn_request(
+async def test_start_updates_request_metadata_from_prepared_turn_request(
     tmp_path: Path,
 ) -> None:
     binding = _binding()
@@ -2369,14 +2453,14 @@ async def test_start_populates_launch_metadata_from_prepared_turn_request(
 
     assert len(launch_calls) == 1
     launch_request = launch_calls[0]["request"]
-    assert (
-        launch_request["metadata"]["latestContextPackRef"]
-        == "artifacts/context/rag-context-prepared.json"
-    )
-    assert launch_request["metadata"]["retrievalDurabilityAuthority"] == "artifact_ref"
+    assert launch_request["metadata"] == {}
     assert (
         request.parameters["metadata"]["moonmind"]["latestContextPackRef"]
         == "artifacts/context/rag-context-prepared.json"
+    )
+    assert (
+        request.parameters["metadata"]["moonmind"]["retrievalDurabilityAuthority"]
+        == "artifact_ref"
     )
 
 async def test_start_rejects_non_text_input_refs_for_session_turns(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3018,6 +3018,32 @@ async def test_publish_path_filter_normalizes_relative_workspace_path(
     )
 
 
+async def test_publish_path_filter_excludes_generated_compatibility_skill_links(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    backing = tmp_path / "runtime" / "skills_active"
+    backing.mkdir(parents=True)
+    gemini_projection = workspace / ".gemini" / "skills"
+    repo_projection = workspace / "skills_active"
+    gemini_projection.parent.mkdir(parents=True)
+    gemini_projection.symlink_to(backing, target_is_directory=True)
+    repo_projection.symlink_to(backing, target_is_directory=True)
+
+    assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        ".gemini/skills",
+        workspace=workspace,
+    )
+    assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        ".gemini/skills/pr-resolver/SKILL.md",
+        workspace=workspace,
+    )
+    assert TemporalAgentRuntimeActivities._should_exclude_publish_path(
+        "skills_active/pr-resolver/SKILL.md",
+        workspace=workspace,
+    )
+
+
 async def test_commit_workspace_changes_filters_skill_projection_from_string_workspace(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2670,6 +2670,55 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_can_skip_skill_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "agent_jobs" / "job-1" / "repo"
+    workspace.mkdir(parents=True)
+
+    class _FailingMaterializer:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("skill materializer should not be constructed")
+
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "AgentSkillMaterializer",
+        _FailingMaterializer,
+    )
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Resolve the PR.",
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "pr-resolver",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+            "includePreparedRequestMetadata": True,
+            "skipSkillMaterialization": True,
+        }
+    )
+
+    assert isinstance(result, dict)
+    assert result["instructions"].startswith("Resolve the PR.")
+    assert "Active MoonMind skill snapshot:" not in result["instructions"]
+    assert result["durableRetrievalMetadata"] == {}
+    assert not (workspace / ".agents").exists()
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_fails_before_launch_when_projection_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- launch cold Codex managed sessions before preparing selected-skill turn instructions so `.agents/skills` is materialized into the final workspace
- exclude generated `.gemini/skills` and root `skills_active` symlink projections from publish staging
- add MoonSpec traceability and regression coverage for the launch-order and publish-filter cases

## Root Cause
Selected-skill turn preparation ran before `agent_runtime.launch_session`. On cold sessions, launch cloned or replaced the workspace after `.agents/skills` had already been validated, deleting the projection before Codex received instructions to read it. Runtime compatibility symlinks could also leak into target repos during publish.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- `./tools/test_unit.sh`