### PR TITLE
Implement this mobile menu improvement: Yes — the current mobile dropdown feels a bit “menu inside a menu.” The outer rounded box plus each inner pill

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 3192384822,
+    "id": 3192536988,
     "disposition": "addressed",
-    "rationale": "Updated the popover label gap to 0.55rem so checkbox labels keep the same readable spacing as the global checkbox rule, and added a CSS regression assertion."
+    "rationale": "Changed the mobile route nav from fixed top offset to absolute positioning anchored below the masthead with top: 100%."
   },
   {
-    "id": 4232489257,
+    "id": 3192536991,
+    "disposition": "addressed",
+    "rationale": "Reworked mobile navigation CSS variables to derive from existing theme tokens and added dark theme overrides."
+  },
+  {
+    "id": 3192536992,
+    "disposition": "addressed",
+    "rationale": "Updated the Mission Control CSS structure test to assert absolute positioning and top: 100%."
+  },
+  {
+    "id": 4232652422,
+    "disposition": "addressed",
+    "rationale": "Top-level review summary is covered by the CSS positioning and token-first theme fixes."
+  },
+  {
+    "id": 3192540712,
+    "disposition": "addressed",
+    "rationale": "Added max-height and overflow-y:auto to keep the mobile top-sheet scrollable on constrained viewport heights."
+  },
+  {
+    "id": 4232656930,
     "disposition": "not-applicable",
-    "rationale": "Broad review summary only; the actionable spacing concern is tracked by review comment 3192384822 and was addressed."
+    "rationale": "Automated review metadata only; the actionable child comment was addressed separately."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -797,7 +797,8 @@ describe('Mission Control shared entry', () => {
     expect(
       navBlocks.some(
         (block) =>
-          block.includes('position: fixed;') &&
+          block.includes('position: absolute;') &&
+          block.includes('top: 100%;') &&
           block.includes('left: 0.875rem;') &&
           block.includes('right: 0.875rem;') &&
           block.includes('z-index: 50;'),
@@ -812,6 +813,8 @@ describe('Mission Control shared entry', () => {
         (block) =>
           block.includes('border-radius: 1.5rem;') &&
           block.includes('background: var(--mm-mobile-nav-fill);') &&
+          block.includes('max-height: min(28rem, calc(100dvh - 1rem));') &&
+          block.includes('overflow-y: auto;') &&
           block.includes('backdrop-filter: blur(18px);'),
       ),
     ).toBe(true);
@@ -836,6 +839,18 @@ describe('Mission Control shared entry', () => {
           block.includes('inset 3px 0 0 var(--mm-mobile-nav-active-edge)'),
       ),
     ).toBe(true);
+  });
+
+  it('derives mobile navigation colors from theme tokens', async () => {
+    const rootBlock = cssRuleBlock(missionControlCss, ':root');
+    const darkBlock = cssRuleBlock(missionControlCss, '.dark');
+
+    expect(rootBlock).toContain('--mm-mobile-nav-fill: var(--mm-glass-fill);');
+    expect(rootBlock).toContain('--mm-mobile-nav-border: var(--mm-glass-border);');
+    expect(rootBlock).toContain('--mm-mobile-nav-hover: var(--mm-control-shell-hover);');
+    expect(rootBlock).toContain('--mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.16);');
+    expect(darkBlock).toContain('--mm-mobile-nav-fill: var(--mm-glass-fill);');
+    expect(darkBlock).toContain('--mm-mobile-nav-active-edge: rgb(var(--mm-accent-2) / 0.86);');
   });
 
   it('keeps the wider masthead breakpoint isolated from the shared mobile layout rules', async () => {

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -796,7 +796,44 @@ describe('Mission Control shared entry', () => {
     const navBlocks = cssRuleBlocks(missionControlCss, '.route-nav');
     expect(
       navBlocks.some(
-        (block) => block.includes('position: absolute;') && block.includes('z-index: 30;'),
+        (block) =>
+          block.includes('position: fixed;') &&
+          block.includes('left: 0.875rem;') &&
+          block.includes('right: 0.875rem;') &&
+          block.includes('z-index: 50;'),
+      ),
+    ).toBe(true);
+  });
+
+  it('uses a mobile top-sheet navigation with row-style links', async () => {
+    const navBlocks = cssRuleBlocks(missionControlCss, '.route-nav');
+    expect(
+      navBlocks.some(
+        (block) =>
+          block.includes('border-radius: 1.5rem;') &&
+          block.includes('background: var(--mm-mobile-nav-fill);') &&
+          block.includes('backdrop-filter: blur(18px);'),
+      ),
+    ).toBe(true);
+
+    const linkBlocks = cssRuleBlocks(missionControlCss, '.route-nav a');
+    expect(
+      linkBlocks.some(
+        (block) =>
+          block.includes('min-height: 3.25rem;') &&
+          block.includes('border: 0;') &&
+          block.includes('border-radius: 1rem;') &&
+          block.includes('background: transparent;'),
+      ),
+    ).toBe(true);
+
+    const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');
+    expect(
+      activeBlocks.some(
+        (block) =>
+          block.includes('background: linear-gradient(') &&
+          block.includes('var(--mm-mobile-nav-active-start)') &&
+          block.includes('inset 3px 0 0 var(--mm-mobile-nav-active-edge)'),
       ),
     ).toBe(true);
   });

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -40,6 +40,15 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.78);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.12);
   --mm-control-border: rgb(var(--mm-border) / 0.78);
+  --mm-mobile-nav-fill: rgb(18 13 34 / 0.92);
+  --mm-mobile-nav-border: rgb(150 110 255 / 0.35);
+  --mm-mobile-nav-edge: rgb(255 255 255 / 0.06);
+  --mm-mobile-nav-shadow: 0 20px 50px rgb(0 0 0 / 0.45);
+  --mm-mobile-nav-text: rgb(235 230 255 / 0.78);
+  --mm-mobile-nav-hover: rgb(160 120 255 / 0.12);
+  --mm-mobile-nav-active-start: rgb(135 82 255 / 0.34);
+  --mm-mobile-nav-active-end: rgb(135 82 255 / 0.12);
+  --mm-mobile-nav-active-edge: rgb(165 120 255 / 0.95);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
   --mm-executing-sweep-angle: -18deg;
@@ -4127,23 +4136,25 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .route-nav {
-    position: absolute;
-    right: 1rem;
-    top: calc(100% + 0.4rem);
-    z-index: 30;
+    position: fixed;
+    top: 7rem;
+    left: 0.875rem;
+    right: 0.875rem;
+    z-index: 50;
     display: none;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.35rem;
-    padding: 0.55rem;
-    min-width: 14rem;
-    max-width: calc(100vw - 2rem);
-    border: 1px solid rgb(var(--mm-border));
-    border-radius: 0.85rem;
-    background: rgb(var(--mm-panel) / 0.98);
-    box-shadow: var(--mm-shadow);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    gap: 0.125rem;
+    padding: 0.625rem;
+    max-width: none;
+    border: 1px solid var(--mm-mobile-nav-border);
+    border-radius: 1.5rem;
+    background: var(--mm-mobile-nav-fill);
+    box-shadow:
+      var(--mm-mobile-nav-shadow),
+      inset 0 1px 0 var(--mm-mobile-nav-edge);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
   }
 
   .route-nav--open {
@@ -4151,8 +4162,46 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .route-nav a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-height: 3.25rem;
+    padding: 0 1rem;
+    border: 0;
+    border-radius: 1rem;
     text-align: left;
+    color: var(--mm-mobile-nav-text);
     background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    transform: none;
+  }
+
+  .route-nav a:hover {
+    color: white;
+    background: var(--mm-mobile-nav-hover);
+    box-shadow: none;
+    transform: none;
+  }
+
+  .route-nav a:focus-visible {
+    color: white;
+    background: var(--mm-mobile-nav-hover);
+    box-shadow: var(--mm-control-focus-ring);
+    transform: none;
+  }
+
+  .route-nav a.active {
+    color: white;
+    background: linear-gradient(
+      90deg,
+      var(--mm-mobile-nav-active-start),
+      var(--mm-mobile-nav-active-end)
+    );
+    box-shadow:
+      inset 3px 0 0 var(--mm-mobile-nav-active-edge),
+      inset 0 1px 0 var(--mm-mobile-nav-edge);
   }
 }
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -40,15 +40,15 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.78);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.12);
   --mm-control-border: rgb(var(--mm-border) / 0.78);
-  --mm-mobile-nav-fill: rgb(18 13 34 / 0.92);
-  --mm-mobile-nav-border: rgb(150 110 255 / 0.35);
-  --mm-mobile-nav-edge: rgb(255 255 255 / 0.06);
-  --mm-mobile-nav-shadow: 0 20px 50px rgb(0 0 0 / 0.45);
-  --mm-mobile-nav-text: rgb(235 230 255 / 0.78);
-  --mm-mobile-nav-hover: rgb(160 120 255 / 0.12);
-  --mm-mobile-nav-active-start: rgb(135 82 255 / 0.34);
-  --mm-mobile-nav-active-end: rgb(135 82 255 / 0.12);
-  --mm-mobile-nav-active-edge: rgb(165 120 255 / 0.95);
+  --mm-mobile-nav-fill: var(--mm-glass-fill);
+  --mm-mobile-nav-border: var(--mm-glass-border);
+  --mm-mobile-nav-edge: var(--mm-glass-edge);
+  --mm-mobile-nav-shadow: var(--mm-elevation-floating);
+  --mm-mobile-nav-text: rgb(var(--mm-muted));
+  --mm-mobile-nav-hover: var(--mm-control-shell-hover);
+  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.16);
+  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.06);
+  --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.74);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
   --mm-executing-sweep-angle: -18deg;
@@ -123,6 +123,15 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.82);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.18);
   --mm-control-border: rgb(var(--mm-border) / 0.76);
+  --mm-mobile-nav-fill: var(--mm-glass-fill);
+  --mm-mobile-nav-border: var(--mm-glass-border);
+  --mm-mobile-nav-edge: var(--mm-glass-edge);
+  --mm-mobile-nav-shadow: var(--mm-elevation-floating);
+  --mm-mobile-nav-text: rgb(var(--mm-muted));
+  --mm-mobile-nav-hover: var(--mm-control-shell-hover);
+  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.22);
+  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.10);
+  --mm-mobile-nav-active-edge: rgb(var(--mm-accent-2) / 0.86);
 }
 
 * {
@@ -4136,8 +4145,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .route-nav {
-    position: fixed;
-    top: 7rem;
+    position: absolute;
+    top: 100%;
     left: 0.875rem;
     right: 0.875rem;
     z-index: 50;
@@ -4147,6 +4156,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     gap: 0.125rem;
     padding: 0.625rem;
     max-width: none;
+    max-height: min(28rem, calc(100dvh - 1rem));
+    overflow-y: auto;
     border: 1px solid var(--mm-mobile-nav-border);
     border-radius: 1.5rem;
     background: var(--mm-mobile-nav-fill);


### PR DESCRIPTION
Implement this mobile menu improvement: Yes — the current mobile dropdown feels a bit “menu inside a menu.” The outer rounded box plus each inner pill border creates too many nested shapes, so it competes with the rest of the UI.

A better mobile look would be a top-sheet style menu with simple rows instead of bordered pills.

Something like:

┌──────────────────────────────┐
│  🛰  Tasks                   │
│  🚀  Create                  │  ← active row has soft purple fill
│  💿  Manifests               │
│  🌘  Schedules               │
│  🔭  Proposals               │
│  🛠  Skills                  │
│  ⚙️  Settings                │
└──────────────────────────────┘

The main change: keep the outer glass panel, but make the nav links feel like list items, not buttons.

I’d suggest:

.mobile-menu {
  position: fixed;
  top: 112px;
  left: 14px;
  right: 14px;
  z-index: 50;
  padding: 10px;
  border-radius: 24px;
  background: rgba(18, 13, 34, 0.92);
  backdrop-filter: blur(18px);
  border: 1px solid rgba(150, 110, 255, 0.35);
  box-shadow:
    0 20px 50px rgba(0, 0, 0, 0.45),
    inset 0 1px 0 rgba(255, 255, 255, 0.06);
}
.mobile-menu a {
  display: flex;
  align-items: center;
  gap: 12px;
  min-height: 52px;
  padding: 0 16px;
  border-radius: 16px;
  color: rgba(235, 230, 255, 0.78);
  text-decoration: none;
  border: 0;
  background: transparent;
}
.mobile-menu a:hover,
.mobile-menu a:focus-visible {
  background: rgba(160, 120, 255, 0.12);
  color: white;
}
.mobile-menu a.active {
  color: white;
  background:
    linear-gradient(
      90deg,
      rgba(135, 82, 255, 0.34),
      rgba(135, 82, 255, 0.12)
    );
  box-shadow:
    inset 3px 0 0 rgba(165, 120, 255, 0.95),
    inset 0 1px 0 rgba(255, 255, 255, 0.06);
}

Visually, I’d make the active item Create a soft filled row rather than a bordered pill. That will still preserve the neon sci-fi mood, but it will feel more native on mobile.

I’d also consider making the dropdown nearly full-width on mobile instead of a floating narrow card aligned to the hamburger. Since the rest of the screen already has strong cards and panels, a full-width top sheet would feel more deliberate and less like a desktop dropdown squeezed onto a phone.

Best direction for MoonMind, based on the screenshot:

Header
────────────────────────
[full-width dark glass menu]
  icon + label rows
  active row softly filled
  no individual borders
[content continues underneath]

That would look cleaner, more premium, and more consistent with the “Mission Control” aesthetic.