### PR TITLE
The mobile dropdown navigation menu looks bad as seen in the image. I need it improved following the recommendations from this analysis:

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -797,8 +797,8 @@ describe('Mission Control shared entry', () => {
     expect(
       navBlocks.some(
         (block) =>
-          block.includes('position: absolute;') &&
-          block.includes('top: 100%;') &&
+          block.includes('position: fixed;') &&
+          block.includes('top: 7rem;') &&
           block.includes('left: 0.875rem;') &&
           block.includes('right: 0.875rem;') &&
           block.includes('z-index: 50;'),
@@ -813,7 +813,7 @@ describe('Mission Control shared entry', () => {
         (block) =>
           block.includes('border-radius: 1.5rem;') &&
           block.includes('background: var(--mm-mobile-nav-fill);') &&
-          block.includes('max-height: min(28rem, calc(100dvh - 1rem));') &&
+          block.includes('max-height: min(28rem, calc(100dvh - 8rem));') &&
           block.includes('overflow-y: auto;') &&
           block.includes('backdrop-filter: blur(18px);'),
       ),
@@ -826,6 +826,7 @@ describe('Mission Control shared entry', () => {
           block.includes('min-height: 3.25rem;') &&
           block.includes('border: 0;') &&
           block.includes('border-radius: 1rem;') &&
+          block.includes('font-weight: 600;') &&
           block.includes('background: transparent;'),
       ),
     ).toBe(true);
@@ -845,12 +846,12 @@ describe('Mission Control shared entry', () => {
     const rootBlock = cssRuleBlock(missionControlCss, ':root');
     const darkBlock = cssRuleBlock(missionControlCss, '.dark');
 
-    expect(rootBlock).toContain('--mm-mobile-nav-fill: var(--mm-glass-fill);');
-    expect(rootBlock).toContain('--mm-mobile-nav-border: var(--mm-glass-border);');
-    expect(rootBlock).toContain('--mm-mobile-nav-hover: var(--mm-control-shell-hover);');
-    expect(rootBlock).toContain('--mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.16);');
-    expect(darkBlock).toContain('--mm-mobile-nav-fill: var(--mm-glass-fill);');
-    expect(darkBlock).toContain('--mm-mobile-nav-active-edge: rgb(var(--mm-accent-2) / 0.86);');
+    expect(rootBlock).toContain('--mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);');
+    expect(rootBlock).toContain('--mm-mobile-nav-border: rgb(var(--mm-accent) / 0.35);');
+    expect(rootBlock).toContain('--mm-mobile-nav-hover: rgb(var(--mm-accent) / 0.12);');
+    expect(rootBlock).toContain('--mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.30);');
+    expect(darkBlock).toContain('--mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);');
+    expect(darkBlock).toContain('--mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.95);');
   });
 
   it('keeps the wider masthead breakpoint isolated from the shared mobile layout rules', async () => {

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -850,7 +850,6 @@ describe('Mission Control shared entry', () => {
     expect(rootBlock).toContain('--mm-mobile-nav-border: rgb(var(--mm-accent) / 0.35);');
     expect(rootBlock).toContain('--mm-mobile-nav-hover: rgb(var(--mm-accent) / 0.12);');
     expect(rootBlock).toContain('--mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.30);');
-    expect(darkBlock).toContain('--mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);');
     expect(darkBlock).toContain('--mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.95);');
   });
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -123,8 +123,6 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.82);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.18);
   --mm-control-border: rgb(var(--mm-border) / 0.76);
-  --mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);
-  --mm-mobile-nav-border: rgb(var(--mm-accent) / 0.35);
   --mm-mobile-nav-edge: var(--mm-glass-edge);
   --mm-mobile-nav-shadow: 0 20px 50px rgb(0 0 0 / 0.45);
   --mm-mobile-nav-text: rgb(var(--mm-muted) / 0.78);

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -40,15 +40,15 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.78);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.12);
   --mm-control-border: rgb(var(--mm-border) / 0.78);
-  --mm-mobile-nav-fill: var(--mm-glass-fill);
-  --mm-mobile-nav-border: var(--mm-glass-border);
+  --mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);
+  --mm-mobile-nav-border: rgb(var(--mm-accent) / 0.35);
   --mm-mobile-nav-edge: var(--mm-glass-edge);
-  --mm-mobile-nav-shadow: var(--mm-elevation-floating);
-  --mm-mobile-nav-text: rgb(var(--mm-muted));
-  --mm-mobile-nav-hover: var(--mm-control-shell-hover);
-  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.16);
-  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.06);
-  --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.74);
+  --mm-mobile-nav-shadow: 0 20px 50px rgb(0 0 0 / 0.26);
+  --mm-mobile-nav-text: rgb(var(--mm-muted) / 0.86);
+  --mm-mobile-nav-hover: rgb(var(--mm-accent) / 0.12);
+  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.30);
+  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.10);
+  --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.88);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
   --mm-executing-sweep-angle: -18deg;
@@ -123,15 +123,15 @@
   --mm-control-shell: rgb(var(--mm-panel) / 0.82);
   --mm-control-shell-hover: rgb(var(--mm-accent) / 0.18);
   --mm-control-border: rgb(var(--mm-border) / 0.76);
-  --mm-mobile-nav-fill: var(--mm-glass-fill);
-  --mm-mobile-nav-border: var(--mm-glass-border);
+  --mm-mobile-nav-fill: rgb(var(--mm-panel) / 0.92);
+  --mm-mobile-nav-border: rgb(var(--mm-accent) / 0.35);
   --mm-mobile-nav-edge: var(--mm-glass-edge);
-  --mm-mobile-nav-shadow: var(--mm-elevation-floating);
-  --mm-mobile-nav-text: rgb(var(--mm-muted));
-  --mm-mobile-nav-hover: var(--mm-control-shell-hover);
-  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.22);
-  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.10);
-  --mm-mobile-nav-active-edge: rgb(var(--mm-accent-2) / 0.86);
+  --mm-mobile-nav-shadow: 0 20px 50px rgb(0 0 0 / 0.45);
+  --mm-mobile-nav-text: rgb(var(--mm-muted) / 0.78);
+  --mm-mobile-nav-hover: rgb(var(--mm-accent) / 0.12);
+  --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.34);
+  --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.12);
+  --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.95);
 }
 
 * {
@@ -4145,8 +4145,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .route-nav {
-    position: absolute;
-    top: 100%;
+    position: fixed;
+    top: 7rem;
     left: 0.875rem;
     right: 0.875rem;
     z-index: 50;
@@ -4156,7 +4156,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     gap: 0.125rem;
     padding: 0.625rem;
     max-width: none;
-    max-height: min(28rem, calc(100dvh - 1rem));
+    max-height: min(28rem, calc(100dvh - 8rem));
     overflow-y: auto;
     border: 1px solid var(--mm-mobile-nav-border);
     border-radius: 1.5rem;
@@ -4180,6 +4180,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     padding: 0 1rem;
     border: 0;
     border-radius: 1rem;
+    font-weight: 600;
     text-align: left;
     color: var(--mm-mobile-nav-text);
     background: transparent;


### PR DESCRIPTION
The mobile dropdown navigation menu looks bad as seen in the image. I need it improved following the recommendations from this analysis:

The current mobile dropdown feels a bit “menu inside a menu.” The outer rounded box plus each inner pill border creates too many nested shapes, so it competes with the rest of the UI.

A better mobile look would be a **top-sheet style menu** with simple rows instead of bordered pills.

Something like:

```text
┌──────────────────────────────┐
│  🛰  Tasks                   │
│  🚀  Create                  │  ← active row has soft purple fill
│  💿  Manifests               │
│  🌘  Schedules               │
│  🔭  Proposals               │
│  🛠  Skills                  │
│  ⚙️  Settings                │
└──────────────────────────────┘
```

The main change: keep the outer glass panel, but make the nav links feel like **list items**, not buttons.

I’d suggest:

```css
.mobile-menu {
  position: fixed;
  top: 112px;
  left: 14px;
  right: 14px;
  z-index: 50;

  padding: 10px;
  border-radius: 24px;

  background: rgba(18, 13, 34, 0.92);
  backdrop-filter: blur(18px);

  border: 1px solid rgba(150, 110, 255, 0.35);
  box-shadow:
    0 20px 50px rgba(0, 0, 0, 0.45),
    inset 0 1px 0 rgba(255, 255, 255, 0.06);
}

.mobile-menu a {
  display: flex;
  align-items: center;
  gap: 12px;

  min-height: 52px;
  padding: 0 16px;
  border-radius: 16px;

  color: rgba(235, 230, 255, 0.78);
  text-decoration: none;

  border: 0;
  background: transparent;
}

.mobile-menu a:hover,
.mobile-menu a:focus-visible {
  background: rgba(160, 120, 255, 0.12);
  color: white;
}

.mobile-menu a.active {
  color: white;
  background:
    linear-gradient(
      90deg,
      rgba(135, 82, 255, 0.34),
      rgba(135, 82, 255, 0.12)
    );
  box-shadow:
    inset 3px 0 0 rgba(165, 120, 255, 0.95),
    inset 0 1px 0 rgba(255, 255, 255, 0.06);
}
```

Visually, I’d make the active item **Create** a soft filled row rather than a bordered pill. That will still preserve the neon sci-fi mood, but it will feel more native on mobile.

I’d also consider making the dropdown nearly full-width on mobile instead of a floating narrow card aligned to the hamburger. Since the rest of the screen already has strong cards and panels, a full-width top sheet would feel more deliberate and less like a desktop dropdown squeezed onto a phone.

Best direction for MoonMind, based on the screenshot:

```text
Header
────────────────────────
[full-width dark glass menu]
  icon + label rows
  active row softly filled
  no individual borders
[content continues underneath]
```

That would look cleaner, more premium, and more consistent with the “Mission Control” aesthetic.