### PR TITLE
The position of the navigation buttons, e.g. tasks, create, manifests, etc., move a bit when you navigate from tasks to create page. This is not good.

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -792,10 +792,10 @@ describe('Mission Control shared entry', () => {
     expect(htmlBlock).toContain('scrollbar-gutter: stable;');
 
     const linkBlocks = cssRuleBlocks(missionControlCss, '.route-nav a');
-    expect(linkBlocks.join('\n')).not.toContain('transition: transform');
+    expect(linkBlocks.join('\n')).not.toMatch(/transition:[^;]*\btransform\b/);
 
     const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');
-    expect(activeBlocks.join('\n')).not.toContain('transform: scale');
+    expect(activeBlocks.join('\n')).not.toMatch(/transform:[^;]*\bscale\b/);
   });
 
   it('keeps the mobile navigation layer above route content panels', async () => {

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -787,6 +787,17 @@ describe('Mission Control shared entry', () => {
     );
   });
 
+  it('keeps navigation positions stable across route selection changes', async () => {
+    const htmlBlock = cssRuleBlock(missionControlCss, 'html');
+    expect(htmlBlock).toContain('scrollbar-gutter: stable;');
+
+    const linkBlocks = cssRuleBlocks(missionControlCss, '.route-nav a');
+    expect(linkBlocks.join('\n')).not.toContain('transition: transform');
+
+    const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');
+    expect(activeBlocks.join('\n')).not.toContain('transform: scale');
+  });
+
   it('keeps the mobile navigation layer above route content panels', async () => {
     const mastheadBlock = cssRuleBlock(missionControlCss, '.masthead');
     expect(mastheadBlock).toContain('position: relative;');

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -140,6 +140,7 @@
 
 html {
   font-family: var(--mm-font-sans);
+  scrollbar-gutter: stable;
 }
 
 body {
@@ -426,7 +427,7 @@ h1 {
   background: rgb(var(--mm-panel) / 0.65);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  transition: transform 130ms cubic-bezier(.2,.8,.2,1), border-color 130ms ease, background 130ms ease;
+  transition: border-color 130ms ease, background 130ms ease, box-shadow 130ms ease, color 130ms ease;
 }
 
 @supports not ((backdrop-filter: blur(2px)) or (-webkit-backdrop-filter: blur(2px))) {
@@ -441,7 +442,6 @@ h1 {
   background: rgb(var(--mm-accent) / 0.14);
   color: rgb(var(--mm-ink));
   box-shadow: 0 0 0 1px rgb(var(--mm-accent) / 0.35), 0 12px 30px -24px rgb(var(--mm-accent) / 0.85);
-  transform: scale(1.02);
 }
 
 .route-nav a:focus-visible {


### PR DESCRIPTION
The position of the navigation buttons, e.g. tasks, create, manifests, etc., move a bit when you navigate from tasks to create page. This is not good. They shouldn't shift no matter which page is selected.