### PR TITLE
The column names of the tasks list should remain in view as you scroll down

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -913,7 +913,9 @@ describe('Tasks List Entrypoint', () => {
     const controlDeck = document.querySelector<HTMLElement>('.task-list-control-deck');
     const dataSlab = document.querySelector<HTMLElement>('.task-list-data-slab.panel--data');
     const tableWrapper = dataSlab?.querySelector<HTMLElement>('.queue-table-wrapper[data-layout="table"]');
-    const scheduledHeader = tableWrapper?.querySelector<HTMLElement>('th');
+    const table = tableWrapper?.querySelector<HTMLElement>('table');
+    const tableHead = tableWrapper?.querySelector<HTMLElement>('thead');
+    const firstHeader = tableWrapper?.querySelector<HTMLElement>('th');
 
     expect(controlDeck).toBeTruthy();
     expect(controlDeck?.querySelector('form.task-list-control-grid')).toBeNull();
@@ -935,7 +937,13 @@ describe('Tasks List Entrypoint', () => {
     expect(pageSizeLabel?.classList.contains('queue-inline-filter')).toBe(false);
     expect(tableWrapper).toBeTruthy();
     expect(getComputedStyle(tableWrapper as HTMLElement).overflow).toBe('auto');
-    expect(getComputedStyle(scheduledHeader as HTMLElement).position).toBe('sticky');
+    expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');
+    expect(getComputedStyle(table as HTMLElement).borderCollapse).toBe('separate');
+    expect(getComputedStyle(tableHead as HTMLElement).position).toBe('sticky');
+    expect(getComputedStyle(tableHead as HTMLElement).top).toBe('0px');
+    expect(getComputedStyle(firstHeader as HTMLElement).position).toBe('sticky');
+    expect(getComputedStyle(firstHeader as HTMLElement).top).toBe('0px');
+    expect(Number(getComputedStyle(firstHeader as HTMLElement).zIndex)).toBeGreaterThan(1);
   });
 
   it('keeps the task list surfaces to one control deck and one data slab', async () => {

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -152,6 +152,7 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(repositoryFilterButton);
 
     expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
+    expect(repositoryFilterButton.closest('th')?.classList.contains('is-filter-open')).toBe(true);
     expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
 
     fireEvent.click(scheduledHeaderButton);
@@ -938,11 +939,13 @@ describe('Tasks List Entrypoint', () => {
     expect(tableWrapper).toBeTruthy();
     expect(getComputedStyle(tableWrapper as HTMLElement).overflow).toBe('auto');
     expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');
+    expect(getComputedStyle(tableWrapper as HTMLElement).minHeight).not.toBe('0px');
     expect(getComputedStyle(table as HTMLElement).borderCollapse).toBe('separate');
     expect(getComputedStyle(tableHead as HTMLElement).position).toBe('sticky');
     expect(getComputedStyle(tableHead as HTMLElement).top).toBe('0px');
     expect(getComputedStyle(firstHeader as HTMLElement).position).toBe('sticky');
     expect(getComputedStyle(firstHeader as HTMLElement).top).toBe('0px');
+    expect(getComputedStyle(firstHeader as HTMLElement).borderBottomWidth).toBe('0px');
     expect(Number(getComputedStyle(firstHeader as HTMLElement).zIndex)).toBeGreaterThan(1);
   });
 

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -1347,7 +1347,11 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                         const { ariaSort, ariaLabel, sortHint } = sortAccessibilityProps(field, label);
                         const filterField = isFilterField(field) ? field : null;
                         return (
-                          <th key={field} aria-sort={ariaSort} className="task-list-compound-header-cell">
+                          <th
+                            key={field}
+                            aria-sort={ariaSort}
+                            className={`task-list-compound-header-cell${filterField && openFilter === filterField ? " is-filter-open" : ""}`}
+                          >
                             <div className="task-list-compound-header">
                               <button
                                 type="button"

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1094,6 +1094,7 @@ tbody tr:hover {
   display: block;
   max-width: 100%;
   max-height: min(70vh, 58rem);
+  min-height: min(32rem, 70vh);
   overflow: auto;
   scroll-padding-top: 3.2rem;
   border-radius: 0.75rem;
@@ -1129,10 +1130,11 @@ tbody tr:hover {
   top: 0;
   z-index: 7;
   background: rgb(var(--mm-panel) / 0.98);
+  border-bottom: 0;
   box-shadow: 0 1px 0 rgb(var(--mm-border) / 0.72);
 }
 
-.queue-table-wrapper .task-list-compound-header-cell:has(.task-list-header-filter-popover) {
+.queue-table-wrapper .task-list-compound-header-cell.is-filter-open {
   z-index: 12;
 }
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1090,10 +1090,12 @@ tbody tr:hover {
 }
 
 .queue-table-wrapper {
+  position: relative;
   display: block;
   max-width: 100%;
   max-height: min(70vh, 58rem);
   overflow: auto;
+  scroll-padding-top: 3.2rem;
   border-radius: 0.75rem;
   border: 1px solid rgb(var(--mm-border) / 0.72);
   background: rgb(var(--mm-panel) / 0.92);
@@ -1107,6 +1109,8 @@ tbody tr:hover {
 
 .queue-table-wrapper table {
   border: 0;
+  border-collapse: separate;
+  border-spacing: 0;
   border-radius: 0;
   background: transparent;
   table-layout: fixed;
@@ -1114,10 +1118,22 @@ tbody tr:hover {
   margin: 0;
 }
 
+.queue-table-wrapper thead {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+}
+
 .queue-table-wrapper th {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 7;
+  background: rgb(var(--mm-panel) / 0.98);
+  box-shadow: 0 1px 0 rgb(var(--mm-border) / 0.72);
+}
+
+.queue-table-wrapper .task-list-compound-header-cell:has(.task-list-header-filter-popover) {
+  z-index: 12;
 }
 
 .queue-table-wrapper th,


### PR DESCRIPTION
The column names of the tasks list should remain in view as you scroll down