### PR TITLE
The column headers on the tasks list page should remain fixed in view as you scroll.

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -937,8 +937,9 @@ describe('Tasks List Entrypoint', () => {
     expect(pageSizeLabel?.classList.contains('queue-page-size-selector')).toBe(true);
     expect(pageSizeLabel?.classList.contains('queue-inline-filter')).toBe(false);
     expect(tableWrapper).toBeTruthy();
-    expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('visible');
-    expect(getComputedStyle(tableWrapper as HTMLElement).overflow).toBe('visible');
+    expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('hidden');
+    expect(getComputedStyle(tableWrapper as HTMLElement).overflowX).toBe('auto');
+    expect(getComputedStyle(tableWrapper as HTMLElement).overflowY).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');
     expect(getComputedStyle(table as HTMLElement).borderCollapse).toBe('separate');
     expect(getComputedStyle(tableHead as HTMLElement).position).toBe('sticky');
@@ -982,13 +983,15 @@ describe('Tasks List Entrypoint', () => {
 
     const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
-    expect(dataSlabStyles.overflow).toBe('visible');
+    expect(dataSlabStyles.overflow).toBe('hidden');
     expect(dataSlabStyles.paddingTop).toBe('0px');
 
     const tableWrapperStyles = getComputedStyle(tableWrapper as HTMLElement);
     expect(tableWrapperStyles.borderTopWidth).toBe('0px');
     expect(tableWrapperStyles.borderRadius).toBe('0px');
     expect(tableWrapperStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(tableWrapperStyles.overflowX).toBe('auto');
+    expect(tableWrapperStyles.overflowY).toBe('visible');
   });
 
   it('shows clickable active column filter chips and removes individual filters from the chip row', async () => {

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -937,9 +937,9 @@ describe('Tasks List Entrypoint', () => {
     expect(pageSizeLabel?.classList.contains('queue-page-size-selector')).toBe(true);
     expect(pageSizeLabel?.classList.contains('queue-inline-filter')).toBe(false);
     expect(tableWrapper).toBeTruthy();
-    expect(getComputedStyle(tableWrapper as HTMLElement).overflow).toBe('auto');
+    expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('visible');
+    expect(getComputedStyle(tableWrapper as HTMLElement).overflow).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');
-    expect(getComputedStyle(tableWrapper as HTMLElement).minHeight).not.toBe('0px');
     expect(getComputedStyle(table as HTMLElement).borderCollapse).toBe('separate');
     expect(getComputedStyle(tableHead as HTMLElement).position).toBe('sticky');
     expect(getComputedStyle(tableHead as HTMLElement).top).toBe('0px');
@@ -982,7 +982,7 @@ describe('Tasks List Entrypoint', () => {
 
     const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
-    expect(dataSlabStyles.overflow).toBe('hidden');
+    expect(dataSlabStyles.overflow).toBe('visible');
     expect(dataSlabStyles.paddingTop).toBe('0px');
 
     const tableWrapperStyles = getComputedStyle(tableWrapper as HTMLElement);

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1003,7 +1003,7 @@ tbody tr:hover {
 
 .task-list-data-slab {
   gap: 0;
-  overflow: visible;
+  overflow: hidden;
   padding: 0;
   border-color: rgb(var(--mm-border) / 0.45);
   background: rgb(var(--mm-panel) / 0.96);
@@ -1093,7 +1093,8 @@ tbody tr:hover {
   position: relative;
   display: block;
   max-width: 100%;
-  overflow: visible;
+  overflow-x: auto;
+  overflow-y: visible;
   scroll-padding-top: 3.2rem;
   border-radius: 0.75rem;
   border: 1px solid rgb(var(--mm-border) / 0.72);

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1003,7 +1003,7 @@ tbody tr:hover {
 
 .task-list-data-slab {
   gap: 0;
-  overflow: hidden;
+  overflow: visible;
   padding: 0;
   border-color: rgb(var(--mm-border) / 0.45);
   background: rgb(var(--mm-panel) / 0.96);
@@ -1093,9 +1093,7 @@ tbody tr:hover {
   position: relative;
   display: block;
   max-width: 100%;
-  max-height: min(70vh, 58rem);
-  min-height: min(32rem, 70vh);
-  overflow: auto;
+  overflow: visible;
   scroll-padding-top: 3.2rem;
   border-radius: 0.75rem;
   border: 1px solid rgb(var(--mm-border) / 0.72);


### PR DESCRIPTION
The column headers on the tasks list page should remain fixed in view as you scroll.