### PR TITLE
MM-594 Refresh Tasks List filter popover MoonSpec traceability

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/308-schema-driven-capability-inputs"
+  "feature_directory": "specs/301-column-filter-popovers"
 }

--- a/specs/301-column-filter-popovers/checklists/requirements.md
+++ b/specs/301-column-filter-popovers/checklists/requirements.md
@@ -36,5 +36,6 @@
 
 ## Notes
 
-- PASS: The input is a single runtime UI story selected by MM-588 and preserves the canonical Jira preset brief.
+- PASS: The input is a single runtime UI story selected by MM-588; MM-594 maps to the same story and is now preserved with its canonical Jira preset brief in `spec.md`.
 - PASS: The source document is broader than the selected story, but the source mapping includes every MM-588 coverage ID and maps each in-scope requirement to functional requirements.
+- PASS: The updated traceability requirement and success criterion preserve both MM-588 and MM-594 without adding a second user story or regenerating later-stage artifacts.

--- a/specs/301-column-filter-popovers/moonspec_align_report.md
+++ b/specs/301-column-filter-popovers/moonspec_align_report.md
@@ -2,25 +2,26 @@
 
 **Feature**: `301-column-filter-popovers`
 **Date**: 2026-05-05
-**Source**: `MM-588` canonical Jira preset brief preserved in `spec.md`
+**Source**: `MM-588` and `MM-594` canonical Jira preset briefs preserved in `spec.md`
 
 ## Updated
 
 - No specification, plan, task, or design artifact remediation was required in this alignment pass.
-- `moonspec_align_report.md`: refreshed to reflect that implementation and final verification have completed.
+- `moonspec_align_report.md`: refreshed to reflect MM-594 traceability, current task count, and pending final verification refresh work.
 
 ## Key Decisions
 
-- Preserve `spec.md` as the authoritative single-story MM-588 behavior contract; it still contains exactly one user story and the original Jira preset brief.
-- Keep `plan.md` as the planning-time gap analysis. Its pre-implementation `missing` and `partial` statuses are not artifact drift because `tasks.md` and `verification.md` now record completed execution evidence.
-- Keep `tasks.md` completed rather than regenerating it. It covers red-first unit tests, route-boundary integration tests, implementation, story validation, and final verification for the single MM-588 story.
+- Preserve `spec.md` as the authoritative single-story behavior contract; it still contains exactly one user story plus the original MM-588 brief and the additional MM-594 brief.
+- Keep `plan.md` as the current gap analysis. All tracked rows are `implemented_verified`, with MM-594 treated as traceability for the same value-list popover story rather than new product scope.
+- Keep `tasks.md` rather than regenerating it. It covers red-first unit tests, route-boundary integration tests, implementation, story validation, and final verification for the single story, with T034 added as the pending MM-594 final verification refresh.
 
 ## Validation
 
-- `SPECIFY_FEATURE=301-column-filter-popovers .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
-- Sequential task validation for `tasks.md`: PASS, 33 tasks from T001 through T033.
-- Requirement traceability: PASS. `spec.md`, `tasks.md`, and `verification.md` preserve `MM-588`, FR-001 through FR-025, SC-001 through SC-008, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027.
+- `SPECIFY_FEATURE=301-column-filter-popovers .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS, with the existing duplicate `301-*` prefix warning.
+- Structural artifact validation: PASS. `spec.md` has one story, task IDs are sequential, unit/integration/red-first sections precede implementation, and `/moonspec-verify` work is present.
+- Sequential task validation for `tasks.md`: PASS, 34 tasks from T001 through T034.
+- Requirement traceability: PASS. `spec.md`, `plan.md`, `research.md`, `quickstart.md`, and `tasks.md` preserve `MM-588`, `MM-594`, FR-001 through FR-025, SC-001 through SC-008, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027.
 
 ## Remaining Risks
 
-- None found in MoonSpec artifacts.
+- `verification.md` still records the earlier MM-588-only verification evidence until T034 runs `/moonspec-verify` and refreshes the report for MM-594 traceability.

--- a/specs/301-column-filter-popovers/plan.md
+++ b/specs/301-column-filter-popovers/plan.md
@@ -3,67 +3,67 @@
 **Branch**: `301-column-filter-popovers`
 **Date**: 2026-05-05
 **Spec**: `specs/301-column-filter-popovers/spec.md`
-**Input**: Single-story runtime spec generated from the trusted Jira preset brief for `MM-588`.
+**Input**: Single-story runtime spec generated from the trusted Jira preset briefs for `MM-588` and `MM-594`.
 
 ## Summary
 
-Tasks List already has the `MM-587` desktop column/header foundation: task-focused columns, separated sort/filter header targets, simple status/repository/runtime filtering, active chips, and task-scope API safety. This story will extend that surface into real column filter popovers with staged edits, include/exclude modes, blank handling, Skill and date filters, removable chips, pagination reset, and canonical filter URL/API encoding. Verification will be UI-first with Vitest/Testing Library coverage for interaction semantics and FastAPI route-boundary coverage for canonical task-scoped query filters.
+Tasks List already has the `MM-587` desktop column/header foundation and the completed `MM-588` column filter implementation: task-focused columns, separated sort/filter header targets, column filter popovers with staged edits, include/exclude modes, blank handling, Skill and date filters, removable chips, pagination reset, canonical URL/API encoding, and task-scope API safety. MM-594 maps to this same single story and adds traceability for the requirement that filter buttons open a box/popover with multi-select options instead of standard single-select dropdowns. No new implementation work is planned unless refreshed verification exposes a regression; verification remains UI-first with Vitest/Testing Library coverage for interaction semantics and Python route-boundary coverage for canonical task-scoped query filters.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | `frontend/src/entrypoints/tasks-list.tsx` has status/repository/runtime only | add Skill, Scheduled, Created, Finished filter controls | UI unit |
-| FR-002 | implemented_verified | top Status/Repository controls are absent; tests assert control deck has no old filter form | preserve behavior | UI unit |
-| FR-003 | missing | current select/input changes apply immediately | add staged draft state per popover and Apply | UI unit |
-| FR-004 | missing | popovers do not implement cancel/Escape/outside dismissal semantics | add non-applying dismissal paths | UI unit |
-| FR-005 | partial | empty select value approximates all state for simple filters | add Select all/no-filter model to value-list popovers | UI unit |
-| FR-006 | partial | current filters support one included status/repo/runtime value | add include arrays for value filters | UI unit + API route |
-| FR-007 | missing | no exclude filter state exists | add exclude arrays and status `not canceled` behavior | UI unit + API route |
-| FR-008 | partial | status options use canonical list, but query only supports one exact state | add lifecycle include/exclude mapping using row display precedence where possible | UI unit + API route |
-| FR-009 | implemented_unverified | runtime select stores raw value and displays `formatRuntimeLabel` | keep and extend to multi-value chips | UI unit |
-| FR-010 | missing | Skill filter has no active control | add Skill value-list filtering | UI unit + API route if supported |
-| FR-011 | partial | repository exact text behavior exists; value-list selection does not | add repository value selection while preserving exact text compatibility | UI unit + API route |
-| FR-012 | missing | date popovers are placeholders | add Scheduled/Finished bounds and blank handling | UI unit |
-| FR-013 | missing | Created date popover is placeholder | add Created bounds without blank filter | UI unit |
-| FR-014 | implemented_unverified | current runtime option list is bounded; dynamic long lists not yet needed | keep bounded value lists; document/server-search contingency | UI unit |
-| FR-015 | implemented_unverified | React text rendering escapes labels | keep labels as text; test malicious label rendering | UI unit |
-| FR-016 | partial | chips exist for three simple filters only | add chips for all active column filter types and modes | UI unit |
-| FR-017 | implemented_unverified | current chips reopen status/repository/runtime popovers | extend to all filters | UI unit |
-| FR-018 | missing | chips have no separate remove action | add remove button/action per chip | UI unit |
-| FR-019 | partial | Clear filters clears status/repo/runtime only | clear all new column filters and restore default task-run view | UI unit |
-| FR-020 | partial | existing changes reset pagination immediately | ensure Apply/remove/clear reset cursor pagination | UI unit |
-| FR-021 | implemented_verified | tests cover legacy `state=<value>` loading | preserve as Status include filter | UI unit |
-| FR-022 | implemented_verified | tests cover legacy `repo=<value>` loading | preserve as Repository exact include filter | UI unit |
-| FR-023 | partial | URL still writes legacy `state`, `repo`, `targetRuntime` names | add canonical filter encoding after new UI changes | UI unit |
-| FR-024 | implemented_verified | UI/API force `scope=tasks` and normalize unsafe workflow scope state | preserve task-scoped query | UI unit + API route |
-| FR-025 | partial | `spec.md` preserves MM-588 | carry MM-588 through plan/tasks/verification | final verify |
-| SC-001 | missing | no staged-edit test exists | add interaction test | UI unit |
-| SC-002 | missing | no cancel/Escape/outside test exists | add interaction test | UI unit |
-| SC-003 | missing | no exclude status chip exists | add exclude-mode test | UI unit + API route |
-| SC-004 | implemented_unverified | runtime display formatting test exists for simple select | extend to multi-value popover/chip | UI unit |
-| SC-005 | partial | legacy exact repo test exists | add repository value selection and exact mapping tests | UI unit |
-| SC-006 | partial | chip reopen and clear-all tests exist, no individual remove | add chip remove tests | UI unit |
-| SC-007 | partial | page reset happens on immediate changes | verify Apply/remove/clear reset pagination with task scope | UI unit + API route |
-| SC-008 | partial | MM-588 preserved in spec and plan | preserve through tasks and verification | final verify |
-| DESIGN-REQ-007 | partial | prior story covers header migration and chips for three filters | add all MM-588 filter semantics | UI unit |
-| DESIGN-REQ-012 | missing | current popovers are immediate simple controls | add staged, keyboard-accessible popover semantics | UI unit |
-| DESIGN-REQ-013 | missing | no include/exclude model | add AND-across-columns, OR-within-column state model | UI unit + API route |
-| DESIGN-REQ-014 | partial | current chips reopen filters, clear-all exists | add per-chip removal and all filter modes | UI unit |
-| DESIGN-REQ-015 | partial | status/runtime/repo simple behavior exists | add skill/date/blank/legacy/canonical behavior | UI unit + API route |
-| DESIGN-REQ-027 | implemented_verified | no raw Temporal query, direct Temporal call, or system browsing in current normal page | preserve non-goals | UI unit |
+| FR-001 | implemented_verified | `verification.md` maps filter controls to `frontend/src/entrypoints/tasks-list.tsx` and `tasks-list.test.tsx` | no new implementation; preserve behavior | UI unit final verify |
+| FR-002 | implemented_verified | `verification.md` confirms old top detached filters are replaced by column/mobile equivalents | no new implementation; preserve behavior | UI unit final verify |
+| FR-003 | implemented_verified | staged apply tests in `tasks-list.test.tsx` are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-004 | implemented_verified | Cancel/Escape/outside-click tests in `tasks-list.test.tsx` are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-005 | implemented_verified | status popover implementation/tests verify select-all/no-filter value-list behavior | no new implementation; preserve behavior | UI unit final verify |
+| FR-006 | implemented_verified | UI and route tests verify include arrays for value filters | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-007 | implemented_verified | UI and route tests verify exclude filters and `Status: not canceled` | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-008 | implemented_verified | lifecycle status order and route query tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-009 | implemented_verified | runtime tests verify raw stored values with readable labels | no new implementation; preserve behavior | UI unit final verify |
+| FR-010 | implemented_verified | skill filter UI/API evidence is cited by `verification.md` | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-011 | implemented_verified | repository value and exact text behavior are covered by UI/API tests | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-012 | implemented_verified | Scheduled/Finished date bounds and blank behavior are covered by UI/API tests | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-013 | implemented_verified | Created date bounds without blank filtering are covered by UI/API tests | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-014 | implemented_verified | bounded option derivation is cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-015 | implemented_verified | React text rendering and malicious-label coverage are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-016 | implemented_verified | active chip tests cover all active column filter summaries | no new implementation; preserve behavior | UI unit final verify |
+| FR-017 | implemented_verified | chip-open tests prove matching popovers reopen with applied state | no new implementation; preserve behavior | UI unit final verify |
+| FR-018 | implemented_verified | chip removal tests prove only the selected filter clears | no new implementation; preserve behavior | UI unit final verify |
+| FR-019 | implemented_verified | Clear filters behavior is covered by active chip tests | no new implementation; preserve behavior | UI unit final verify |
+| FR-020 | implemented_verified | pagination-reset assertions are cited by `verification.md` | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| FR-021 | implemented_verified | legacy `state=<value>` load mapping tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-022 | implemented_verified | legacy `repo=<value>` load mapping tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-023 | implemented_verified | canonical URL rewrite tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| FR-024 | implemented_verified | API scope/query tests verify task-scoped semantics | no new implementation; preserve behavior | route-boundary final verify |
+| FR-025 | implemented_verified | `spec.md` now preserves `MM-588` and `MM-594`; this plan carries both | no new implementation; preserve both keys downstream | final verify |
+| SC-001 | implemented_verified | staged apply tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| SC-002 | implemented_verified | cancel/Escape/outside-click tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| SC-003 | implemented_verified | exclude status chip tests and route assertions are cited by `verification.md` | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| SC-004 | implemented_verified | runtime and skill display tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| SC-005 | implemented_verified | repository selection and exact mapping tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| SC-006 | implemented_verified | chip reopen, individual removal, and clear-all tests are cited by `verification.md` | no new implementation; preserve behavior | UI unit final verify |
+| SC-007 | implemented_verified | API route tests verify canonical filters remain task-scoped | no new implementation; preserve behavior | route-boundary final verify |
+| SC-008 | implemented_verified | `spec.md` and this plan preserve `MM-588`, `MM-594`, and source design IDs | no new implementation; preserve both keys downstream | final verify |
+| DESIGN-REQ-007 | implemented_verified | `verification.md` maps layout/filter/chip behavior to implementation and tests | no new implementation; preserve behavior | UI unit final verify |
+| DESIGN-REQ-012 | implemented_verified | `verification.md` maps staged popover behavior to implementation and tests | no new implementation; preserve behavior | UI unit final verify |
+| DESIGN-REQ-013 | implemented_verified | include/exclude semantics are covered by UI and route tests | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| DESIGN-REQ-014 | implemented_verified | active chip behavior is covered by UI tests | no new implementation; preserve behavior | UI unit final verify |
+| DESIGN-REQ-015 | implemented_verified | field-specific status/runtime/repository/date behavior is covered by UI and route tests | no new implementation; preserve behavior | UI unit + route-boundary final verify |
+| DESIGN-REQ-027 | implemented_verified | task-scope route tests preserve non-goal safety | no new implementation; preserve behavior | route-boundary final verify |
 
 ## Technical Context
 
 **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route tests.
 **Primary Dependencies**: React, TanStack Query, Zod, Vitest, Testing Library, FastAPI, pytest, Temporal visibility query helpers.
 **Storage**: No new persistent storage; filter state is URL/query state and component state only.
-**Unit Testing**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` for focused UI coverage; targeted Python route tests through `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`.
-**Integration Testing**: Existing route-boundary tests for `/api/executions` plus UI entrypoint tests cover the task-list workflow without external credentials.
+**Unit Testing**: Focused UI unit coverage runs with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`. Focused Python route-boundary unit coverage runs with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`. Full required unit verification runs with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+**Integration Testing**: No compose-backed `integration_ci` coverage is required for this UI and route-planning refresh because no service topology, artifact store, worker routing, or external dependency contract changes are planned. The integration strategy is route-boundary validation for `/api/executions` task-scope query construction plus UI entrypoint workflow tests, both running without external credentials.
 **Target Platform**: Browser Mission Control Tasks List and MoonMind API.
 **Project Type**: Existing full-stack web app.
 **Performance Goals**: Popover interactions must not fetch until Apply/remove/clear; value lists remain bounded; no unbounded DOM rendering for long lists.
-**Constraints**: Preserve task-only visibility, avoid raw Temporal query authoring, keep direct browser calls to MoonMind APIs only, keep page size/pagination outside filters, and preserve `MM-588` traceability.
+**Constraints**: Preserve task-only visibility, avoid raw Temporal query authoring, keep direct browser calls to MoonMind APIs only, keep page size/pagination outside filters, and preserve `MM-588` and `MM-594` traceability.
 **Scale/Scope**: One Tasks List entrypoint, shared Mission Control CSS, and one API list route filter surface.
 
 ## Constitution Check

--- a/specs/301-column-filter-popovers/quickstart.md
+++ b/specs/301-column-filter-popovers/quickstart.md
@@ -3,31 +3,33 @@
 ## Preconditions
 
 - Use the active feature directory: `specs/301-column-filter-popovers`.
-- Preserve `MM-588` and the canonical Jira preset brief in downstream artifacts.
+- Preserve `MM-588`, `MM-594`, and their canonical Jira preset briefs in downstream artifacts.
 - Run frontend tests with local Node dependencies prepared by `./tools/test_unit.sh` or `npm ci --no-fund --no-audit` when needed.
 
-## Test-First Flow
+## Unit Test Strategy
 
-1. Add failing UI tests in `frontend/src/entrypoints/tasks-list.test.tsx` for staged Apply, Cancel, Escape/outside dismissal, include/exclude status, blank handling, Skill/date filters, chip remove, and canonical URL encoding.
-2. Add failing API route tests in `tests/unit/api/routers/test_executions.py` for canonical filter parameters remaining task-scoped.
-3. Implement the smallest Tasks List UI and API changes that satisfy those tests.
-4. Run focused UI tests:
+1. Use focused UI unit tests in `frontend/src/entrypoints/tasks-list.test.tsx` for staged Apply, Cancel, Escape/outside dismissal, include/exclude status, blank handling, Skill/date filters, chip remove, and canonical URL encoding.
+2. Run focused UI tests:
 
 ```bash
 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx
 ```
 
-5. Run focused API route tests:
+3. Run focused Python route-boundary unit tests:
 
 ```bash
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py
 ```
 
-6. Before finalizing, run the required full unit suite:
+4. Before finalizing, run the required full unit suite:
 
 ```bash
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
 ```
+
+## Integration Strategy
+
+No compose-backed `integration_ci` suite is required for this planning refresh because the mapped story changes only the Tasks List UI and task-scoped `/api/executions` query behavior. Integration coverage is the route-boundary test strategy above: focused API tests verify canonical filter parameters remain constrained to ordinary task scope without external credentials.
 
 ## End-to-End Story Check
 

--- a/specs/301-column-filter-popovers/research.md
+++ b/specs/301-column-filter-popovers/research.md
@@ -2,9 +2,9 @@
 
 ## Story Classification
 
-Decision: `MM-588` is a single-story runtime UI feature.
-Evidence: `specs/301-column-filter-popovers/spec.md` preserves one user story and the Jira preset brief names one operator goal.
-Rationale: The source design covers a broad desired Tasks List state, but Jira selected only popover filtering, selection semantics, chips, and reset behavior.
+Decision: `MM-588` and `MM-594` map to one single-story runtime UI feature.
+Evidence: `specs/301-column-filter-popovers/spec.md` preserves one user story, the original MM-588 Jira preset brief, and the additional MM-594 preset brief requiring filter buttons to open a box/popover with multi-select options.
+Rationale: The source design covers a broad desired Tasks List state, but the Jira briefs select only popover filtering, selection semantics, chips, and reset behavior. MM-594 is a narrower restatement of the value-list popover requirement, not a second independently testable story.
 Alternatives considered: Running MoonSpec breakdown was rejected because the Jira brief already narrows the source design to one independently testable story.
 Test implications: Unit and route-boundary tests are required before implementation.
 
@@ -12,7 +12,7 @@ Test implications: Unit and route-boundary tests are required before implementat
 
 Decision: Build on the `MM-587` implementation rather than replacing the Tasks List page.
 Evidence: `frontend/src/entrypoints/tasks-list.tsx` has `TABLE_COLUMNS`, compound header buttons, `renderFilterPopover`, status/repository/runtime controls, active chips, and `scope=tasks` API calls. `frontend/src/entrypoints/tasks-list.test.tsx` covers header sort/filter separation, legacy scope normalization, runtime filter options, and chips.
-Rationale: The current code already owns the correct entrypoint and basic controls; MM-588 is an extension of filter semantics.
+Rationale: The current code already owns the correct entrypoint and completed column filter behavior; MM-594 remains aligned with the same filter semantics.
 Alternatives considered: Creating a new filtering module first was rejected because the current behavior is localized and testable in one entrypoint.
 Test implications: Existing tests should remain, with new tests added around staged state and canonical semantics.
 
@@ -20,7 +20,7 @@ Test implications: Existing tests should remain, with new tests added around sta
 
 Decision: Add applied filter state plus popover-local draft state; only Apply/remove/clear mutate applied state and query state.
 Evidence: Current controls call `setTemporalState`, `setRepository`, and `setTargetRuntime` directly on change.
-Rationale: Staged editing is the central MM-588 gap and prevents live updates or accidental menu changes from changing results.
+Rationale: Staged editing is central to the story and prevents live updates or accidental menu changes from changing results.
 Alternatives considered: Debounced immediate application was rejected because the brief requires Apply.
 Test implications: UI tests must prove row fetches and URL state do not change until Apply, and Cancel/Escape/outside click discard draft changes.
 
@@ -29,7 +29,7 @@ Test implications: UI tests must prove row fetches and URL state do not change u
 Decision: Represent value-list filters as `{ mode: include|exclude, values: string[], includeBlank?: boolean, excludeBlank?: boolean }` per field.
 Evidence: `docs/UI/TasksListPage.md` section 10 requires AND across columns, OR within one column, and exclude mode when deselecting unwanted values from all.
 Rationale: This model expresses both `Status: completed OR failed` and `Status: not canceled`, while allowing new live-update values through exclude mode.
-Alternatives considered: Single `state` and `repo` strings were rejected because they cannot express MM-588 selection semantics.
+Alternatives considered: Single `state` and `repo` strings were rejected because they cannot express multi-select or exclude selection semantics.
 Test implications: UI and API tests must cover include arrays and `stateNotIn=canceled`.
 
 ## Canonical URL/API Encoding
@@ -44,7 +44,7 @@ Test implications: UI tests verify canonical URL rewrites after new UI changes; 
 
 Decision: Add Skill as a value-list filter from row task-skill metadata and add Scheduled/Created/Finished date filters with inclusive bounds; Scheduled and Finished support blank filtering.
 Evidence: `spec.md` FR-010 through FR-013 and `docs/UI/TasksListPage.md` sections 7 and 9.5.
-Rationale: These fields are part of the MM-588 acceptance scope and are not present in the simple current filters.
+Rationale: These fields are part of the accepted story scope and are not present in the simple pre-MM-588 filters.
 Alternatives considered: Deferring date filters was rejected because the Jira brief explicitly includes date bounds and blanks.
 Test implications: UI tests cover Skill labels, date bounds, Scheduled/Finished blanks, and Created without blanks.
 
@@ -58,8 +58,8 @@ Test implications: Route tests must assert canonical filters remain combined wit
 
 ## Requirement Status Summary
 
-Decision: Most MM-588 behavior is partial or missing, with task-scope safety and legacy load mappings already verified.
-Evidence: `specs/301-column-filter-popovers/plan.md` Requirement Status table.
-Rationale: Current code is a useful base but does not satisfy staged popover editing, include/exclude, blank handling, date filters, Skill filters, individual chip removal, or canonical URL/API encoding.
-Alternatives considered: Treating current simple filters as complete was rejected because they apply immediately and only express one included value.
-Test implications: Generate tasks in TDD order for missing and partial requirements.
+Decision: The current repository evidence marks the mapped MM-588/MM-594 story as implemented and verified.
+Evidence: `specs/301-column-filter-popovers/verification.md` reports `FULLY_IMPLEMENTED` with focused UI tests, focused API route tests, full unit verification, and whitespace evidence; `specs/301-column-filter-popovers/plan.md` now carries MM-594 traceability.
+Rationale: The earlier plan gaps have been closed by existing implementation and test evidence. The remaining planning need for MM-594 is traceability preservation, not new implementation.
+Alternatives considered: Regenerating tasks or reopening implementation work was rejected because existing verification already covers the behavior and this step is limited to planning artifacts.
+Test implications: Keep focused UI unit, focused Python route-boundary, and full unit commands explicit for final verification; no compose-backed integration suite is required for this UI/route-only traceability refresh.

--- a/specs/301-column-filter-popovers/spec.md
+++ b/specs/301-column-filter-popovers/spec.md
@@ -133,13 +133,6 @@ Acceptance Criteria
 - Filter controls must not be standard single-select dropdowns when the filter semantics allow multiple options.
 - Preserve existing tasks list behavior outside the filter interaction change.
 
-## Orchestration Constraints
-
-Selected mode: runtime.
-Default to runtime mode and only use docs mode when explicitly requested.
-If the brief points at an implementation document, treat it as runtime source requirements.
-Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
-Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
 """
 
 ## Classification

--- a/specs/301-column-filter-popovers/spec.md
+++ b/specs/301-column-filter-popovers/spec.md
@@ -97,11 +97,54 @@ Default to runtime mode and only use docs mode when explicitly requested.
 If the brief points at an implementation document, treat it as runtime source requirements.
 Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
 Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Additional canonical Jira preset brief for MM-594:
+
+# MM-594 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-594
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Filters on the tasks list page should be multi-select dropdowns
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-594-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-594 from MM project
+Summary: Filters on the tasks list page should be multi-select dropdowns
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-594 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-594: Filters on the tasks list page should be multi-select dropdowns
+
+When a filter button is pressed on the tasks list page, it should open a box which includes multi-select dropdown options. They should not be standard dropdowns that only allow the selection of one option.
+
+Acceptance Criteria
+- Pressing a filter button on the tasks list page opens a filter box/popover for that filter.
+- The filter box presents dropdown options that support selecting multiple values.
+- Filter controls must not be standard single-select dropdowns when the filter semantics allow multiple options.
+- Preserve existing tasks list behavior outside the filter interaction change.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
 """
 
 ## Classification
 
-Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI behavior story for the Tasks List page: operators can refine task rows through column-owned filter popovers, staged filter changes, include/exclude value semantics, blank handling, active chips, and default-view restoration. The source document is a broader design, but the Jira brief narrows the work to one story and does not require MoonSpec breakdown.
+Input classification: single-story feature request. The Jira brief selects one independently testable runtime UI behavior story for the Tasks List page: operators can refine task rows through column-owned filter popovers, staged filter changes, include/exclude value semantics, blank handling, active chips, and default-view restoration. The source document is a broader design, but the Jira brief narrows the work to one story and does not require MoonSpec breakdown. The additional MM-594 brief maps to this same single story because it specifically requires filter buttons to open a box with multi-select options instead of standard single-select dropdowns.
 
 ## User Story - Column Filter Refinement
 
@@ -166,7 +209,7 @@ Input classification: single-story feature request. The Jira brief selects one i
 - **FR-022**: Existing `repo=<value>` URLs MUST load as an equivalent exact Repository include filter for one value.
 - **FR-023**: After an operator changes filters in the new UI, shareable URL state SHOULD use canonical column filter encoding instead of legacy top-filter parameter names.
 - **FR-024**: Normal Tasks List filtering MUST remain task-scoped and MUST NOT expose system workflow browsing through column filters or legacy URL parameters.
-- **FR-025**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-588` and this canonical Jira preset brief.
+- **FR-025**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue keys `MM-588` and `MM-594` and their canonical Jira preset briefs.
 
 ## Source Design Requirements
 
@@ -190,4 +233,4 @@ Input classification: single-story feature request. The Jira brief selects one i
 - **SC-005**: UI tests prove Repository supports both selectable values and legacy exact repository text mapping.
 - **SC-006**: UI tests prove active chips reopen their column popovers, remove only their own filter, and Clear filters restores the default task-run view.
 - **SC-007**: Boundary tests prove filter application resets pagination and preserves task-scoped list semantics.
-- **SC-008**: Traceability evidence preserves `MM-588`, the canonical Jira preset brief, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027 in MoonSpec artifacts.
+- **SC-008**: Traceability evidence preserves `MM-588`, `MM-594`, their canonical Jira preset briefs, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027 in MoonSpec artifacts.

--- a/specs/301-column-filter-popovers/tasks.md
+++ b/specs/301-column-filter-popovers/tasks.md
@@ -5,14 +5,14 @@
 
 **Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
 
-**Source Traceability**: The canonical `MM-588` Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-025, acceptance scenarios 1 through 8, SC-001 through SC-008, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027.
+**Source Traceability**: The canonical `MM-588` and `MM-594` Jira preset briefs are preserved in `spec.md`. Tasks cover FR-001 through FR-025, acceptance scenarios 1 through 8, SC-001 through SC-008, and DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-015, and DESIGN-REQ-027.
 
 **Test Commands**:
 
 - Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
 - Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py`
 - Full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
 
 ## Format: `[ID] [P?] Description`
 
@@ -24,7 +24,7 @@
 
 **Purpose**: Confirm the existing Tasks List test harness and feature artifacts are ready.
 
-- [X] T001 Verify `specs/301-column-filter-popovers/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-column-filter-popovers.md` are present and preserve `MM-588`.
+- [X] T001 Verify `specs/301-column-filter-popovers/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/tasks-list-column-filter-popovers.md` are present and preserve `MM-588` and `MM-594`.
 - [X] T002 Confirm frontend test dependencies are prepared by running `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` before editing production code.
 - [X] T003 Confirm API route test dependencies are available by running `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` before editing production code.
 
@@ -86,7 +86,7 @@
 
 ### Story Validation
 
-- [X] T028 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` and fix failures until the MM-588 UI story passes.
+- [X] T028 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` and fix failures until the MM-588/MM-594 UI story passes.
 - [X] T029 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and fix failures until canonical filter route coverage passes.
 - [X] T030 Review `frontend/src/entrypoints/tasks-list.tsx` and `api_service/api/routers/executions.py` against `specs/301-column-filter-popovers/contracts/tasks-list-column-filter-popovers.md` for FR-024 and DESIGN-REQ-027 non-goal safety.
 
@@ -94,9 +94,10 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [X] T031 Update `specs/301-column-filter-popovers/tasks.md` to mark completed implementation tasks and preserve MM-588 traceability.
+- [X] T031 Update `specs/301-column-filter-popovers/tasks.md` to mark completed implementation tasks and preserve MM-588/MM-594 traceability.
 - [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full required unit verification.
-- [X] T033 Run final `/speckit.verify` equivalent and write `specs/301-column-filter-popovers/verification.md` with verdict, test evidence, requirement coverage, and MM-588 traceability.
+- [X] T033 Run final `/moonspec-verify` (`/speckit.verify` equivalent) and write `specs/301-column-filter-popovers/verification.md` with verdict, test evidence, requirement coverage, and MM-588 traceability.
+- [ ] T034 Run final `/moonspec-verify` (`/speckit.verify` equivalent) after the MM-594 traceability refresh and update `specs/301-column-filter-popovers/verification.md` with verdict, test evidence, requirement coverage, and MM-588/MM-594 traceability.
 
 ## Dependencies and Execution Order
 
@@ -112,7 +113,7 @@
 - T008-T017 must be written before implementation.
 - T018-T019 must confirm red-first failures before T020-T027.
 - T020-T027 implement the missing and partial behavior.
-- T028-T030 validate the story before final verification.
+- T028-T030 validate the story before final verification; T034 refreshes final verification evidence after MM-594 traceability is added.
 
 ### Parallel Opportunities
 
@@ -123,7 +124,7 @@
 ## Implementation Strategy
 
 1. Preserve existing `MM-587` table/header behavior and tests.
-2. Add failing tests for every missing MM-588 behavior before implementation.
+2. Add failing tests for every missing MM-588/MM-594 behavior before implementation.
 3. Introduce a compact filter state model in the Tasks List entrypoint instead of spreading independent strings across controls.
 4. Keep the API route fail-safe and task-scoped while adding canonical include/exclude query parameters.
 5. Validate focused UI and API tests, then run full unit verification and final MoonSpec verification.
@@ -132,5 +133,5 @@
 
 - This task list covers exactly one story.
 - `implemented_verified` rows from `plan.md` are preserved through validation tasks instead of unnecessary rewrites.
-- `implemented_unverified` rows are covered by verification tests and extended only where MM-588 requires new behavior.
+- `implemented_unverified` rows are covered by verification tests and extended only where MM-588/MM-594 requires new behavior.
 - Do not add saved views, multi-column sort, raw Temporal query authoring, direct browser calls to Temporal, or system workflow browsing.


### PR DESCRIPTION
## Summary
- Preserves Jira issue MM-594 in the existing MoonSpec feature for Tasks List column filter popovers.
- Maps MM-594 to the already implemented single-story feature at `specs/301-column-filter-popovers`.
- Refreshes specify, plan, tasks, and alignment artifacts so downstream Jira/MoonMind handling can reference MM-594.

## Jira issue
MM-594

## Active MoonSpec feature path
`specs/301-column-filter-popovers`

## Verification verdict
NO_DETERMINATION from the final `/moonspec-verify` gate. Feature-specific evidence passed, but full unit-suite evidence could not be completed in this managed workspace because the active `.agents/skills` projection masks tracked skill files and causes unrelated unit failures.

## Tests run
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` - passed targeted API route suite plus frontend runner suite
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` - passed 37 focused UI tests
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` - failed before reliable focused UI evidence because unrelated tracked `.agents/skills/*` files are masked by the active managed skill projection

## Remaining risks
- `specs/301-column-filter-popovers/verification.md` still contains the earlier MM-588-only report; T034 remains open to refresh final verification with MM-594 once the full unit environment is usable.
- Full unit verification is blocked in this workspace by the managed `.agents/skills` projection rather than by the MM-594 feature diff.
