### PR TITLE
Update documentation according to the guidance below:

### DIFF
--- a/docs/ManagedAgents/ClaudeAnthropicOAuth.md
+++ b/docs/ManagedAgents/ClaudeAnthropicOAuth.md
@@ -34,6 +34,11 @@ The OAuth path is the subject of this document. The API-key path is mentioned
 only to clarify that OAuth is not the only valid Claude Anthropic credential
 method.
 
+OAuth versus API-key authentication does not change managed-runtime
+rate-limit reporting requirements. Claude Code rate limits should flow through
+Provider Profiles and the shared managed-runtime retry/cooldown policy whenever
+the failure can be attributed to the selected profile.
+
 ## 2. OAuth Profile Shape
 
 The OAuth-backed `claude_anthropic` provider profile uses a volume-backed Claude

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -203,7 +203,20 @@ refs and related session observability. The transitional in-container
 fallback or bring-up helpers, but they are not the production publication path while
 they return empty publication refs.
 
-## 9. Non-goals for This Contract Slice
+## 9. Rate-limit retry behavior
+
+Codex managed-session turns must surface model-provider rate limits through the
+shared managed-runtime failure taxonomy. The session controller should retry
+rate-limit failures with bounded exponential backoff and jitter, honor provider
+retry hints when available, and keep attempt evidence bounded in summaries and
+diagnostics.
+
+If retries are exhausted, the session summary and diagnostics must explicitly
+state that the turn hit a model-provider rate limit. The terminal result should
+set the same `AgentRunResult` rate-limit metadata used by other managed
+runtimes.
+
+## 10. Non-goals for This Contract Slice
 
 This contract does not define:
 

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -688,6 +688,12 @@ On provider 429 or equivalent quota exhaustion:
 
 If another compatible profile exists, the run may continue on a different profile. Otherwise, it waits.
 
+Claude Code and Codex CLI rate limits must be reported against the selected
+provider profile whenever the failure can be attributed to that profile. The
+`AgentRun` should release the current slot, report cooldown, and retry through
+the same profile selector unless the request required an exact profile. If no
+compatible profile is available, the run waits in `awaiting_slot`.
+
 ---
 
 ## 11. Runtime Materialization Pipeline

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -435,6 +435,10 @@ All failures normalize to:
 * Activity retry policy is derived from ToolDefinition defaults.
 * `non_retryable_error_codes` stop retries immediately.
 * `retryable` is informative; the actual retry decision is policy-driven.
+* For model-provider rate limits in managed agent-runtime steps, see
+  [`docs/Temporal/ErrorTaxonomy.md`](../Temporal/ErrorTaxonomy.md),
+  [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md),
+  and [`docs/Temporal/StepLedgerAndProgressModel.md`](../Temporal/StepLedgerAndProgressModel.md).
 
 ---
 

--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -579,6 +579,13 @@ Typical defaults by family:
 - avoid retries that duplicate destructive sandbox side effects
 - ensure external starts are idempotent
 - ensure canonical contract normalization failures are treated as contract errors, not silently tolerated
+- treat model-provider rate limits as retryable-with-policy
+
+Activity-level retry for model-provider rate limits may be used only when it is
+bounded and safe. Managed agent runtimes should prefer orchestration-aware
+retry: classify the failure, back off with jitter, honor provider retry hints,
+persist bounded attempt metadata, and surface exhausted rate-limit failures in
+the step summary.
 
 ## 11.3 Heartbeats
 

--- a/docs/Temporal/ErrorTaxonomy.md
+++ b/docs/Temporal/ErrorTaxonomy.md
@@ -398,7 +398,7 @@ Model-provider rate limits include:
 Managed agent runtimes such as Claude Code and Codex CLI must treat these as
 retryable-with-policy failures. The runner should:
 
-1. classify the failure as `RATE_LIMITED`
+1. classify the normalized tool/step error code as `RATE_LIMITED`
 2. honor `Retry-After` when available
 3. retry with bounded exponential backoff and jitter
 4. report cooldown to the Provider Profile Manager when profile-scoped

--- a/docs/Temporal/ErrorTaxonomy.md
+++ b/docs/Temporal/ErrorTaxonomy.md
@@ -385,6 +385,28 @@ Examples of acceptable handling:
 
 The right response is usually orchestration-aware backoff, not aggressive activity-level repetition.
 
+## 8.3 Model-provider rate-limit handling
+
+Model-provider rate limits include:
+
+- HTTP `429`
+- provider-native `rate_limit_error` or `rate_limit_exceeded` codes
+- `Too Many Requests` responses
+- requests-per-minute exhaustion
+- tokens-per-minute exhaustion
+
+Managed agent runtimes such as Claude Code and Codex CLI must treat these as
+retryable-with-policy failures. The runner should:
+
+1. classify the failure as `RATE_LIMITED`
+2. honor `Retry-After` when available
+3. retry with bounded exponential backoff and jitter
+4. report cooldown to the Provider Profile Manager when profile-scoped
+5. stop after the configured maximum attempts
+6. persist bounded attempt metadata
+7. ensure the final operator summary explicitly says when retries were
+   exhausted due to a model-provider rate limit
+
 ---
 
 ## 9. Retry policy guidance
@@ -398,6 +420,12 @@ Even retryable failures should use:
 - maximum attempt caps
 
 Do not allow unbounded activity-level retry loops.
+
+For model-provider rate limits, bounded retry means the runtime or supervisor
+must make exhaustion observable rather than hiding it behind repeated process
+restarts. Attempts should preserve enough metadata to explain cooldowns and
+provider hints, but raw provider payloads and full stderr belong in diagnostics
+artifacts.
 
 ## 9.2 Prefer typed classification to string matching
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -343,6 +343,16 @@ Canonical fields:
 
 This result is the canonical terminal output surface for an agent run. Large data stays in artifacts referenced by `output_refs[]` or `diagnostics_ref`.
 
+For model-provider rate limits, terminal results should preserve bounded retry
+metadata:
+
+* `failure_class = "rate_limited"` when retry exhaustion caused failure
+* `provider_error_code` should preserve the stable provider code when known
+* `retry_recommendation` should indicate whether retrying later is useful
+* `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
+* `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted
+* `metadata.attempts[]` may contain bounded attempt summaries, not raw logs
+
 ## 4.5 Idempotency requirements
 
 Any start-like side effect must be idempotent with respect to a stable key such as:
@@ -529,6 +539,13 @@ They may:
 * need provider-specific concurrency and cooldown controls
 
 Because of that, they must be launched asynchronously and supervised durably.
+
+Claude Code and Codex CLI should not self-own MoonMind's provider rate-limit
+policy. Their CLI processes may expose provider errors, but the managed runtime
+runner or supervisor is responsible for classifying model-provider rate limits,
+honoring provider retry hints, coordinating profile cooldowns, enforcing bounded
+retry, and publishing terminal summaries through the canonical `AgentRunResult`
+and step-ledger surfaces.
 
 ## 8.2 Managed runtime lifecycle
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -346,8 +346,10 @@ This result is the canonical terminal output surface for an agent run. Large dat
 For model-provider rate limits, terminal results should preserve bounded retry
 metadata:
 
-* `failure_class = "rate_limited"` when retry exhaustion caused failure
-* `provider_error_code` should preserve the stable provider code when known
+* `failure_class = "integration_error"` when retry exhaustion caused provider
+  failure
+* `provider_error_code` should preserve the stable provider code when known,
+  and may use `RATE_LIMITED` when only the normalized classification is known
 * `retry_recommendation` should indicate whether retrying later is useful
 * `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
 * `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted

--- a/docs/Temporal/StepLedgerAndProgressModel.md
+++ b/docs/Temporal/StepLedgerAndProgressModel.md
@@ -203,6 +203,15 @@ Rules:
 - `summary` must stay bounded and display-safe
 - `lastError` is a summary only; large error details belong in artifacts
 
+If a step exhausts retries because of model-provider rate limits, the current
+step row must include a bounded operator-facing summary such as:
+
+> Failed after 5 attempts. The step hit a model-provider rate limit and
+> exhausted exponential-backoff retries.
+
+`lastError` should classify the failure as `RATE_LIMITED`. Detailed stderr,
+provider payloads, and diagnostics remain in artifacts.
+
 ## 8. Step status vocabulary
 
 The canonical v1 step statuses are:
@@ -259,6 +268,9 @@ Rules:
 - the authoritative key shape for derived storage is `(workflowId, runId, logicalStepId, attempt)`
 - the default task detail view may show a compact current row plus attempt count
 - detailed attempt history may be lazy-loaded later, but attempt identity must already be explicit
+- exhausted model-provider rate-limit retries must remain visible in the latest
+  attempt summary and `lastError`, with detailed attempt evidence linked through
+  artifacts rather than expanded inline
 
 ## 11. Parent/child refs and artifact refs
 

--- a/docs/Temporal/StepLedgerAndProgressModel.md
+++ b/docs/Temporal/StepLedgerAndProgressModel.md
@@ -209,8 +209,8 @@ step row must include a bounded operator-facing summary such as:
 > Failed after 5 attempts. The step hit a model-provider rate limit and
 > exhausted exponential-backoff retries.
 
-`lastError` should classify the failure as `RATE_LIMITED`. Detailed stderr,
-provider payloads, and diagnostics remain in artifacts.
+`lastError.error_code` should classify the failure as `RATE_LIMITED`. Detailed
+stderr, provider payloads, and diagnostics remain in artifacts.
 
 ## 8. Step status vocabulary
 


### PR DESCRIPTION
Update documentation according to the guidance below:

The best place is **MoonLadderStudios/MoonMind**, not `Tactics` or `MoonSpec`.

I’d update these docs in this order:

1. **`docs/Temporal/ErrorTaxonomy.md`** — primary source of truth
   This is the right canonical doc for the strategy. It already classifies `429` / provider rate limits as “retryable-with-policy,” says they should use cooldowns, slot release/reacquisition, and orchestration-aware backoff rather than naive tight-loop retries. Expand Sections **8. Rate limits and cooldowns** and **9. Retry policy guidance** here. 

   Add a subsection like:

   ```md
   ### 8.3 Model-provider rate-limit handling

   Model-provider rate limits include HTTP 429, `rate_limit_error`,
   `rate_limit_exceeded`, "Too Many Requests", requests-per-minute exhaustion,
   and tokens-per-minute exhaustion.

   Managed agent runtimes such as Claude Code and Codex CLI must treat these as
   retryable-with-policy failures. The runner should:

   1. classify the failure as `RATE_LIMITED`
   2. honor `Retry-After` when available
   3. retry with bounded exponential backoff and jitter
   4. report cooldown to the Provider Profile Manager when profile-scoped
   5. stop after the configured maximum attempts
   6. persist attempt metadata
   7. ensure the final operator summary explicitly says when retries were
      exhausted due to a model-provider rate limit
   ```

2. **`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`** — explain how Claude Code/Codex fit the execution model
   This doc owns `MoonMind.AgentRun`, managed runtimes, `AgentRunResult`, provider-profile slots, cooldown coordination, and runtime supervision. It already names `claude_code` and `codex_cli` as managed runtimes and defines `AgentRunResult` fields like `failure_class`, `provider_error_code`, `retry_recommendation`, and `metadata`. 

   Add to **4.4 `AgentRunResult`**:

   ```md
   For model-provider rate limits, terminal results should preserve bounded
   retry metadata:

   - `failure_class = "rate_limited"` when retry exhaustion caused failure
   - `provider_error_code` should preserve stable provider code when known
   - `retry_recommendation` should indicate whether retrying later is useful
   - `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
   - `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted
   - `metadata.attempts[]` may contain bounded attempt summaries, not raw logs
   ```

   Also add to **8. MoonMind-managed agents** that Claude Code and Codex should not self-own this policy; the managed runtime runner/supervisor should enforce it.

3. **`docs/Temporal/ActivityCatalogAndWorkerTopology.md`** — document where retries are enforced
   This doc owns activity routing, worker fleets, and retry policy rules. It already says retry policies should use bounded exponential backoff and that `agent_runtime.*` lives on the managed runtime fleet. 

   Update **11.2 Retry policy rules** with:

   ```md
   Model-provider rate limits are retryable-with-policy. Activity-level retry
   may be used only when bounded and safe, but managed agent runtimes should
   prefer orchestration-aware retry: classify, back off with jitter, honor
   provider retry hints, persist attempts, and surface exhausted rate-limit
   failures in the step summary.
   ```

4. **`docs/Security/ProviderProfiles.md`** — explain profile-level throttling/cooldown
   This doc owns provider-profile concurrency and cooldown policy. It already defines fields like `max_parallel_runs`, `cooldown_after_429_seconds`, and `rate_limit_policy`, plus `report_cooldown` behavior in the Provider Profile Manager. 

   Add a short subsection under **10.6 Cooldown behavior**:

   ```md
   Claude Code and Codex CLI rate limits must be reported against the selected
   provider profile whenever the failure can be attributed to that profile.
   The AgentRun should release the current slot, report cooldown, and retry
   through the same profile selector unless the request required an exact
   profile. If no compatible profile is available, the run waits in
   `awaiting_slot`.
   ```

5. **`docs/ManagedAgents/CodexCliManagedSessions.md`** — Codex-specific managed session behavior
   This doc is specifically for the Codex managed session plane and already states Codex sessions produce durable artifacts, diagnostics, and summaries. 

   Add a section such as:

   ```md
   ## Rate-limit retry behavior

   Codex managed-session turns must surface model-provider rate limits through
   the shared managed-runtime failure taxonomy. The session controller should
   retry rate-limit failures with bounded exponential backoff and jitter. If
   retries are exhausted, the session summary and diagnostics must explicitly
   state that the turn hit a model-provider rate limit.
   ```

6. **`docs/ManagedAgents/ClaudeAnthropicOAuth.md`** — only for Claude auth/provider nuance
   This doc is about Claude Code credential setup, not runtime retry policy. Use it only to clarify that OAuth vs API-key auth does not change the rate-limit reporting requirement; both should flow through Provider Profiles and managed-runtime policy. 

7. **`docs/Temporal/StepLedgerAndProgressModel.md`** — operator-facing summary behavior
   This is the right place to say how the UI/step ledger should display the exhausted-rate-limit outcome. It owns step status, attempt numbers, summaries, and `lastError`. 

   Add under **10. Attempts and retries** or **7. Step row contract**:

   ```md
   If a step exhausts retries because of model-provider rate limits, the current
   step row must include a bounded operator-facing summary such as:

   "Failed after 5 attempts. The step hit a model-provider rate limit and
   exhausted exponential-backoff retries."

   `lastError` should classify the failure as `RATE_LIMITED`; detailed stderr,
   provider payloads, and diagnostics remain in artifacts.
   ```

8. **`docs/Tasks/SkillAndPlanContracts.md`** — general plan/tool contract alignment
   This doc already defines `RATE_LIMITED` in the generic `ToolFailure` model and says retry decisions are policy-driven. 

   Add only a cross-reference here, not the full strategy:

   ```md
   For model-provider rate limits in managed agent-runtime steps, see
   `docs/Temporal/ErrorTaxonomy.md`,
   `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, and
   `docs/Temporal/StepLedgerAndProgressModel.md`.
   ```

My recommended minimum doc change set is:

```text
docs/Temporal/ErrorTaxonomy.md
docs/Temporal/ManagedAndExternalAgentExecutionModel.md
docs/Temporal/ActivityCatalogAndWorkerTopology.md
docs/Security/ProviderProfiles.md
docs/Temporal/StepLedgerAndProgressModel.md
docs/ManagedAgents/CodexCliManagedSessions.md
```

For Claude, I would not create a brand-new Claude runtime doc unless one already exists elsewhere. Put the shared Claude Code/Codex behavior in the Temporal/runtime docs, then add only a small note in `ClaudeAnthropicOAuth.md` if you want to make clear that credential mode does not change retry/cooldown semantics.