### PR TITLE
Update the documentation regarding rate limiting behavior in preparation for updating the code.

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,12 @@
 [
   {
-    "id": 3193823070,
+    "id": 3196972476,
     "disposition": "addressed",
-    "rationale": "Updated backend secret-like AWS access key detection to match the standard AKIA prefix plus 16-character key body."
+    "rationale": "Updated docs/Temporal/ManagedAndExternalAgentExecutionModel.md to use schema-valid failure_class = \"integration_error\" for exhausted provider rate limits while preserving rate-limit specificity in provider_error_code and metadata."
   },
   {
-    "id": 3193823074,
-    "disposition": "addressed",
-    "rationale": "Updated frontend secret-like AWS access key detection to match the standard AKIA prefix plus 16-character key body."
-  },
-  {
-    "id": 4234197184,
+    "id": 4238924098,
     "disposition": "not-applicable",
-    "rationale": "Review summary only; the actionable AWS regex line comments from this review were addressed separately."
-  },
-  {
-    "id": 3193830068,
-    "disposition": "addressed",
-    "rationale": "Merged schema-rendered Skill inputs into submitted tool and skill payload inputs, with regression coverage."
-  },
-  {
-    "id": 3193830071,
-    "disposition": "addressed",
-    "rationale": "Preserved cleared optional numeric schema fields as empty UI state and omitted them from resolved submission inputs."
-  },
-  {
-    "id": 4234205844,
-    "disposition": "not-applicable",
-    "rationale": "Review wrapper/informational body only; the actionable Codex review line comments were addressed separately."
+    "rationale": "Automated review summary body with no separate actionable request."
   }
 ]

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -346,7 +346,7 @@ This result is the canonical terminal output surface for an agent run. Large dat
 For model-provider rate limits, terminal results should preserve bounded retry
 metadata:
 
-* `failure_class = "rate_limited"` when retry exhaustion caused failure
+* `failure_class = "integration_error"` when retry exhaustion caused failure
 * `provider_error_code` should preserve the stable provider code when known,
   and may use `RATE_LIMITED` when only the normalized classification is known
 * `retry_recommendation` should indicate whether retrying later is useful

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -346,8 +346,7 @@ This result is the canonical terminal output surface for an agent run. Large dat
 For model-provider rate limits, terminal results should preserve bounded retry
 metadata:
 
-* `failure_class = "integration_error"` when retry exhaustion caused provider
-  failure
+* `failure_class = "rate_limited"` when retry exhaustion caused failure
 * `provider_error_code` should preserve the stable provider code when known,
   and may use `RATE_LIMITED` when only the normalized classification is known
 * `retry_recommendation` should indicate whether retrying later is useful


### PR DESCRIPTION
Update the documentation regarding rate limiting behavior in preparation for updating the code.

I’d update these docs in this order:

1. **`docs/Temporal/ErrorTaxonomy.md`** — primary source of truth
   This is the right canonical doc for the strategy. It already classifies `429` / provider rate limits as “retryable-with-policy,” says they should use cooldowns, slot release/reacquisition, and orchestration-aware backoff rather than naive tight-loop retries. Expand Sections **8. Rate limits and cooldowns** and **9. Retry policy guidance** here. 

   Add a subsection like:

   ```md
   ### 8.3 Model-provider rate-limit handling

   Model-provider rate limits include HTTP 429, `rate_limit_error`,
   `rate_limit_exceeded`, "Too Many Requests", requests-per-minute exhaustion,
   and tokens-per-minute exhaustion.

   Managed agent runtimes such as Claude Code and Codex CLI must treat these as
   retryable-with-policy failures. The runner should:

   1. classify the failure as `RATE_LIMITED`
   2. honor `Retry-After` when available
   3. retry with bounded exponential backoff and jitter
   4. report cooldown to the Provider Profile Manager when profile-scoped
   5. stop after the configured maximum attempts
   6. persist attempt metadata
   7. ensure the final operator summary explicitly says when retries were
      exhausted due to a model-provider rate limit
   ```

2. **`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`** — explain how Claude Code/Codex fit the execution model
   This doc owns `MoonMind.AgentRun`, managed runtimes, `AgentRunResult`, provider-profile slots, cooldown coordination, and runtime supervision. It already names `claude_code` and `codex_cli` as managed runtimes and defines `AgentRunResult` fields like `failure_class`, `provider_error_code`, `retry_recommendation`, and `metadata`. 

   Add to **4.4 `AgentRunResult`**:

   ```md
   For model-provider rate limits, terminal results should preserve bounded
   retry metadata:

   - `failure_class = "rate_limited"` when retry exhaustion caused failure
   - `provider_error_code` should preserve stable provider code when known
   - `retry_recommendation` should indicate whether retrying later is useful
   - `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
   - `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted
   - `metadata.attempts[]` may contain bounded attempt summaries, not raw logs
   ```

   Also add to **8. MoonMind-managed agents** that Claude Code and Codex should not self-own this policy; the managed runtime runner/supervisor should enforce it.

3. **`docs/Temporal/ActivityCatalogAndWorkerTopology.md`** — document where retries are enforced
   This doc owns activity routing, worker fleets, and retry policy rules. It already says retry policies should use bounded exponential backoff and that `agent_runtime.*` lives on the managed runtime fleet. 

   Update **11.2 Retry policy rules** with:

   ```md
   Model-provider rate limits are retryable-with-policy. Activity-level retry
   may be used only when bounded and safe, but managed agent runtimes should
   prefer orchestration-aware retry: classify, back off with jitter, honor
   provider retry hints, persist attempts, and surface exhausted rate-limit
   failures in the step summary.
   ```

4. **`docs/Security/ProviderProfiles.md`** — explain profile-level throttling/cooldown
   This doc owns provider-profile concurrency and cooldown policy. It already defines fields like `max_parallel_runs`, `cooldown_after_429_seconds`, and `rate_limit_policy`, plus `report_cooldown` behavior in the Provider Profile Manager. 

   Add a short subsection under **10.6 Cooldown behavior**:

   ```md
   Claude Code and Codex CLI rate limits must be reported against the selected
   provider profile whenever the failure can be attributed to that profile.
   The AgentRun should release the current slot, report cooldown, and retry
   through the same profile selector unless the request required an exact
   profile. If no compatible profile is available, the run waits in
   `awaiting_slot`.
   ```

5. **`docs/ManagedAgents/CodexCliManagedSessions.md`** — Codex-specific managed session behavior
   This doc is specifically for the Codex managed session plane and already states Codex sessions produce durable artifacts, diagnostics, and summaries. 

   Add a section such as:

   ```md
   ## Rate-limit retry behavior

   Codex managed-session turns must surface model-provider rate limits through
   the shared managed-runtime failure taxonomy. The session controller should
   retry rate-limit failures with bounded exponential backoff and jitter. If
   retries are exhausted, the session summary and diagnostics must explicitly
   state that the turn hit a model-provider rate limit.
   ```

6. **`docs/ManagedAgents/ClaudeAnthropicOAuth.md`** — only for Claude auth/provider nuance
   This doc is about Claude Code credential setup, not runtime retry policy. Use it only to clarify that OAuth vs API-key auth does not change the rate-limit reporting requirement; both should flow through Provider Profiles and managed-runtime policy. 

7. **`docs/Temporal/StepLedgerAndProgressModel.md`** — operator-facing summary behavior
   This is the right place to say how the UI/step ledger should display the exhausted-rate-limit outcome. It owns step status, attempt numbers, summaries, and `lastError`. 

   Add under **10. Attempts and retries** or **7. Step row contract**:

   ```md
   If a step exhausts retries because of model-provider rate limits, the current
   step row must include a bounded operator-facing summary such as:

   "Failed after 5 attempts. The step hit a model-provider rate limit and
   exhausted exponential-backoff retries."

   `lastError` should classify the failure as `RATE_LIMITED`; detailed stderr,
   provider payloads, and diagnostics remain in artifacts.
   ```

8. **`docs/Tasks/SkillAndPlanContracts.md`** — general plan/tool contract alignment
   This doc already defines `RATE_LIMITED` in the generic `ToolFailure` model and says retry decisions are policy-driven. 

   Add only a cross-reference here, not the full strategy:

   ```md
   For model-provider rate limits in managed agent-runtime steps, see
   `docs/Temporal/ErrorTaxonomy.md`,
   `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, and
   `docs/Temporal/StepLedgerAndProgressModel.md`.
   ```

My recommended minimum doc change set is:

```text
docs/Temporal/ErrorTaxonomy.md
docs/Temporal/ManagedAndExternalAgentExecutionModel.md
docs/Temporal/ActivityCatalogAndWorkerTopology.md
docs/Security/ProviderProfiles.md
docs/Temporal/StepLedgerAndProgressModel.md
docs/ManagedAgents/CodexCliManagedSessions.md
```

For Claude, I would not create a brand-new Claude runtime doc unless one already exists elsewhere. Put the shared Claude Code/Codex behavior in the Temporal/runtime docs, then add only a small note in `ClaudeAnthropicOAuth.md` if you want to make clear that credential mode does not change retry/cooldown semantics.