### PR TITLE
[codex] Tighten fix-ci post-push verification

### DIFF
--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -9,6 +9,7 @@ Run this workflow to diagnose and fix CI build and test failures on the active b
 
 ## Inputs
 - Optional: specific failing check name or local reproduction command.
+- Optional: `maxIterations` for post-push CI remediation loops. Default: `3`.
 
 If no inputs are provided, investigate the failing CI checks for the current branch PR.
 
@@ -30,6 +31,10 @@ If no inputs are provided, investigate the failing CI checks for the current bra
 4. Verify the fix locally.
 - Re-run the local reproduction command until it passes successfully.
 - If the command still fails, repeat step 3.
+- If the required local toolchain or service is unavailable, do not treat
+  weaker checks such as `git diff --check` as sufficient verification. Record
+  the missing prerequisite and default to post-push CI verification unless the
+  task explicitly forbids pushing; otherwise stop as blocked.
 
 5. Commit and push.
 - Ensure the working tree is clean except for the fixed files.
@@ -37,11 +42,26 @@ If no inputs are provided, investigate the failing CI checks for the current bra
 - Commit the changes using a descriptive message (e.g. `fix(ci): <short failure summary>`).
 - Push to the current branch with `git push`.
 
+6. Verify the pushed head in CI.
+- Record the exact local `HEAD` SHA after the push.
+- Confirm the PR branch on GitHub points at that same SHA. If it does not,
+  stop as blocked; do not report success.
+- Wait for required PR checks on that SHA to finish. Poll with bounded backoff.
+- If checks pass, finish successfully.
+- If checks fail, fetch the new failing logs and repeat steps 2-6, up to
+  `maxIterations`.
+- If checks remain queued/running beyond the wait cap, GitHub is unavailable,
+  or the task explicitly forbids pushing, stop as blocked with the current SHA,
+  check state, and next action. Do not report success while CI is running,
+  degraded, unknown, or failing.
+
 ## Output
 
 Provide:
 - The failing check name and a brief summary of the error.
 - The local reproduction command used.
 - Files changed to fix the issue.
-- Confirmation that the local verification command passed.
+- Confirmation that local verification passed, or a clear blocked reason if it
+  could not run.
+- Confirmation that the pushed PR-head CI passed for the exact fixed commit.
 - Commit hash and pushed branch.


### PR DESCRIPTION
## Summary

- Require `fix-ci` runs to verify the exact pushed PR head in CI before reporting success.
- Add a bounded post-push remediation loop for fresh CI failures.
- Default to post-push CI verification when local toolchains are unavailable, unless pushing is explicitly forbidden.

## Why

A recent CI-fix run completed after only `git diff --check` because the runtime did not have the target project toolchain installed. The skill should treat PR-head CI as the authoritative verification path in that case and avoid reporting success while checks are running, failing, degraded, or unknown.

## Validation

- `git diff --check -- .agents/skills/fix-ci/SKILL.md`