### PR TITLE
[codex] Fix Jira blocker preflight direction

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -43,7 +43,7 @@ steps:
     instructions: |-
       Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any MoonSpec implementation work starts.
 
-      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as inwardIssue and the link type says the inward relationship is "is blocked by", that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as outwardIssue and the link type says the outward relationship is "blocks", {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this orchestration.
+      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as outwardIssue and the link type says the outward relationship is "blocks", that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as inwardIssue and the link type says the inward relationship is "is blocked by", {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this orchestration.
 
       Ignore non-blocker issue links for the blocker decision.
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -121,8 +121,10 @@ def _blocking_issue_from_link(
             return outward_issue
         return None
 
-    if inward_issue and inward_key != target:
-        return inward_issue
+    # Jira issue GET responses include only the other side of the link. For a
+    # target blocked by another issue, Jira exposes that blocker as outwardIssue.
+    if outward_issue and outward_key != target:
+        return outward_issue
     return None
 
 def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:

--- a/specs/297-jira-blocker-direction/plan.md
+++ b/specs/297-jira-blocker-direction/plan.md
@@ -36,4 +36,4 @@ first-party executable tool that parses Jira `Blocks` link direction.
 1. Add deterministic Jira blocker-preflight parsing for `Blocks` link direction.
 2. Register the preflight as a first-party `mm.tool.execute` handler.
 3. Update Jira Orchestrate to use the deterministic tool step.
-4. Add regressions for outward-link continuation, inward-link blocking, status fetch, and preset seeding.
+4. Add regressions for inward-link continuation, outward-link blocking, status fetch, and preset seeding.

--- a/specs/297-jira-blocker-direction/spec.md
+++ b/specs/297-jira-blocker-direction/spec.md
@@ -23,8 +23,9 @@ link interpretation.
 - **FR-001**: `linear_blocker_chain` MUST continue to create links where each
   earlier story blocks the immediately later story.
 - **FR-002**: Jira Orchestrate preflight MUST only block a target issue when
-  trusted Jira link data shows the target is on the blocked/inward side of a
-  `Blocks` relationship.
+  trusted Jira GET issue data exposes the other issue as `outwardIssue`,
+  meaning the other issue is on the outward "blocks" side and the target is on
+  the blocked/inward side of a `Blocks` relationship.
 - **FR-003**: A `Blocks` relationship where the target issue blocks another
   issue MUST NOT block the target orchestration.
 - **FR-004**: Blocker status MUST be read from trusted Jira data, fetching the
@@ -38,9 +39,10 @@ link interpretation.
 
 - **SC-001**: A three-story chain creates `story1 -> story2` and
   `story2 -> story3` Jira blocker requests.
-- **SC-002**: Target issue `MM-1` with an outward `Blocks` link to `MM-2`
-  continues even when `MM-2` is not Done.
-- **SC-003**: Target issue `MM-2` with an inward `Blocks` link from `MM-1`
+- **SC-002**: Target issue `MM-1` whose Jira GET response exposes `MM-2` as
+  `inwardIssue` continues even when `MM-2` is not Done.
+- **SC-003**: Target issue `MM-2` whose Jira GET response exposes `MM-1` as
+  `outwardIssue`
   blocks when `MM-1` is not Done.
 - **SC-004**: The seeded Jira Orchestrate preset uses the deterministic
   blocker-preflight tool before MoonSpec implementation.

--- a/specs/297-jira-blocker-direction/tasks.md
+++ b/specs/297-jira-blocker-direction/tasks.md
@@ -2,8 +2,8 @@
 
 - [X] T001 Confirm existing `linear_blocker_chain` creation uses previous story as blocker and next story as blocked.
 - [X] T002 Add deterministic Jira blocker-preflight tool parsing raw Jira link direction.
-- [X] T003 Treat target `outwardIssue` Blocks links as non-blocking for the target.
-- [X] T004 Treat target `inwardIssue` Blocks links as blockers and fetch missing blocker status.
+- [X] T003 Treat target-response `inwardIssue` Blocks links as non-blocking for the target.
+- [X] T004 Treat target-response `outwardIssue` Blocks links as blockers and fetch missing blocker status.
 - [X] T005 Register the tool in the first-party tool dispatcher and registry payload.
 - [X] T006 Update Jira Orchestrate preset to execute the deterministic blocker preflight.
 - [X] T007 Add regression tests for link creation order and blocker direction.

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -779,7 +779,7 @@ async def test_create_jira_issues_linear_blocker_chain_creates_adjacent_links():
     assert [item["status"] for item in jira["linkResults"]] == ["created", "created"]
 
 @pytest.mark.asyncio
-async def test_check_jira_blockers_blocks_on_single_inward_unresolved_blocks_link():
+async def test_check_jira_blockers_blocks_on_single_outward_unresolved_blocks_link():
     service = _FakeJiraService()
     service.issue_responses["MM-2"] = {
         "key": "MM-2",
@@ -791,7 +791,7 @@ async def test_check_jira_blockers_blocks_on_single_inward_unresolved_blocks_lin
                         "outward": "blocks",
                         "inward": "is blocked by",
                     },
-                    "inwardIssue": {
+                    "outwardIssue": {
                         "key": "MM-1",
                         "fields": {"status": {"name": "Backlog"}},
                     },
@@ -822,7 +822,7 @@ async def test_check_jira_blockers_blocks_on_single_inward_unresolved_blocks_lin
     assert [request.issue_key for request in service.get_issue_requests] == ["MM-2"]
 
 @pytest.mark.asyncio
-async def test_check_jira_blockers_ignores_single_outward_links_from_target_issue():
+async def test_check_jira_blockers_ignores_single_inward_links_from_target_issue():
     service = _FakeJiraService()
     service.issue_responses["MM-1"] = {
         "key": "MM-1",
@@ -834,7 +834,7 @@ async def test_check_jira_blockers_ignores_single_outward_links_from_target_issu
                         "outward": "blocks",
                         "inward": "is blocked by",
                     },
-                    "outwardIssue": {
+                    "inwardIssue": {
                         "key": "MM-2",
                         "fields": {"status": {"name": "Backlog"}},
                     },
@@ -862,7 +862,7 @@ async def test_check_jira_blockers_fetches_missing_blocker_status_and_allows_don
             "issuelinks": [
                 {
                     "type": {"name": "Blocks"},
-                    "inwardIssue": {"key": "MM-1"},
+                    "outwardIssue": {"key": "MM-1"},
                 }
             ]
         },


### PR DESCRIPTION
## Summary

- Fix Jira blocker preflight parsing for single-sided Jira GET issue links.
- Update Jira Orchestrate preset instructions to match the observed Jira REST shape.
- Refresh MM-297 spec artifacts and regression tests for outward blocker detection and inward continuation.

## Root Cause

MoonMind created the Jira linear blocker chain correctly, but the deterministic preflight interpreted single-sided Jira issue links in the opposite direction. For a target issue blocked by another issue, Jira exposes the blocker as outwardIssue on the target issue GET response.

## Validation

- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh

## Notes

- Opened as non-draft per request.
