### PR TITLE
[codex] Fix preset skill submission

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12937,6 +12937,121 @@ describe("Task Create MM-578 Preset expansion", () => {
     fetchSpy.mockRestore();
   });
 
+  it("submits Jira Orchestrate preset runs with the executable first-step skill", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-orchestrate",
+                scope: "global",
+                title: "Jira Orchestrate",
+                description: "Run MoonSpec from a Jira issue.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/task-step-templates/jira-orchestrate?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "jira-orchestrate",
+            scope: "global",
+            title: "Jira Orchestrate",
+            description: "Run MoonSpec from a Jira issue.",
+            latestVersion: "1.0.0",
+            version: "1.0.0",
+            inputs: [
+              {
+                name: "jira_issue_key",
+                label: "Jira Issue Key",
+                type: "text",
+                required: true,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/task-step-templates/jira-orchestrate:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:jira-orchestrate:1.0.0:01",
+                title: "Move Jira issue",
+                instructions: "Transition THOR-352 to In Progress.",
+                skill: { id: "jira-issue-updater", args: {} },
+              },
+            ],
+            appliedTemplate: {
+              slug: "jira-orchestrate",
+              version: "1.0.0",
+              inputs: { jira_issue_key: "THOR-352" },
+              stepIds: ["tpl:jira-orchestrate:1.0.0:01"],
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(presetSelect.options).some(
+          (option) => option.text === "Jira Orchestrate (Global)",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-orchestrate" },
+    });
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    expect(
+      await screen.findByDisplayValue("Transition THOR-352 to In Progress."),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest();
+    const payload = request.payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(payload.publishMode).toBe("pr");
+    expect(task.publish).toEqual({ mode: "pr" });
+    expect(task.tool).toMatchObject({ type: "skill", name: "jira-issue-updater" });
+    expect(task.skill).toMatchObject({ id: "jira-issue-updater" });
+    expect(task.skills).toEqual({ include: [{ name: "jira-issue-updater" }] });
+    expect(task.appliedStepTemplates).toEqual([
+      expect.objectContaining({ slug: "jira-orchestrate" }),
+    ]);
+  });
+
   it("defaults parent publish mode to none when selecting Jira Breakdown and Orchestrate as a Preset step", async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6228,7 +6228,12 @@ describe.skip("Task Create Entrypoint", () => {
     expect(payload.publishMode).toBe("pr");
     expect(task.publish).toMatchObject({ mode: "pr" });
     expect(payload.mergeAutomation).toEqual({ enabled: true });
-    expect(task.skills).toEqual({ include: [{ name: "jira-orchestrate" }] });
+    expect(task.tool).toMatchObject({ type: "skill", name: "jira-issue-updater" });
+    expect(task.skill).toMatchObject({ id: "jira-issue-updater" });
+    expect(task.skills).toEqual({ include: [{ name: "jira-issue-updater" }] });
+    expect(task.appliedStepTemplates).toEqual([
+      expect.objectContaining({ slug: "jira-orchestrate" }),
+    ]);
   });
 
   it("shows only PR publish choices for the Jira Breakdown and Orchestrate preset inputs", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1378,12 +1378,8 @@ function isSelfManagedPublishSkill(skillId: string): boolean {
 
 function resolveEffectiveSkillId(
   primarySkillId: string,
-  appliedTemplates: AppliedTemplateState[],
+  _appliedTemplates: AppliedTemplateState[],
 ): string {
-  if (appliedTemplates.length > 0) {
-    const lastTemplate = appliedTemplates[appliedTemplates.length - 1];
-    return lastTemplate?.slug ?? primarySkillId;
-  }
   if (hasExplicitSkillSelection(primarySkillId)) {
     return primarySkillId;
   }

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1376,10 +1376,16 @@ function isSelfManagedPublishSkill(skillId: string): boolean {
   return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
 }
 
-function resolveEffectiveSkillId(
+function resolveEffectivePublishSkillId(
   primarySkillId: string,
-  _appliedTemplates: AppliedTemplateState[],
+  appliedTemplates: AppliedTemplateState[],
 ): string {
+  for (const template of [...appliedTemplates].reverse()) {
+    const slug = String(template.slug || "").trim();
+    if (slug && isSelfManagedPublishSkill(slug)) {
+      return slug;
+    }
+  }
   if (hasExplicitSkillSelection(primarySkillId)) {
     return primarySkillId;
   }
@@ -4337,7 +4343,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     : "Choose a preset to delete";
   const effectiveSkillId = useMemo(
     () =>
-      resolveEffectiveSkillId(
+      resolveEffectivePublishSkillId(
         String(steps[0]?.skillId || "").trim() || "auto",
         activeAppliedTemplatesForSteps(appliedTemplates, steps),
       ),
@@ -6629,12 +6635,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       submissionSteps,
     );
     submissionAppliedTemplates = activeSubmissionAppliedTemplates;
-    const effectiveSubmissionSkillId = resolveEffectiveSkillId(
+    const effectiveSubmissionSkillId = primarySkillId;
+    const effectivePublishSkillId = resolveEffectivePublishSkillId(
       primarySkillId,
       activeSubmissionAppliedTemplates,
     );
     const effectivePublishMode =
-      isSelfManagedPublishSkill(effectiveSubmissionSkillId)
+      isSelfManagedPublishSkill(effectivePublishSkillId)
         ? "none"
         : normalizedPublishMode;
     const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions
@@ -7311,7 +7318,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const shouldSubmitMergeAutomation =
       isMergeAutomationPublishMode(publishMode) &&
       effectivePublishMode === "pr" &&
-      !isSelfManagedPublishSkill(effectiveSubmissionSkillId);
+      !isSelfManagedPublishSkill(effectivePublishSkillId);
 
     const taskPayload: Record<string, unknown> = {
       instructions: objectiveInstructionsForSubmit,


### PR DESCRIPTION
## Summary
- Keep applied task preset slugs as provenance instead of replacing the executable skill selector.
- Submit the concrete first-step skill for `task.tool`, `task.skill`, and `task.skills.include` when a preset is applied.
- Update the Jira Orchestrate Create-page regression expectation to preserve `jira-orchestrate` in `appliedStepTemplates` while resolving `jira-issue-updater` for execution.

## Root Cause
The Create page promoted the applied preset slug into the runtime skill selector. For Jira Orchestrate, that submitted `jira-orchestrate` as the selected skill even though it is a task preset, not an agent skill bundle, causing Temporal skill resolution to fail before step one.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`