### PR TITLE
[codex] Make Codex session turn order replay-safe

### DIFF
--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -97,6 +97,31 @@ The rollout transcript remains a container-local runtime cache. MoonMind does no
 present the raw transcript as durable operator truth; it converts selected visible
 entries into artifact-backed output and observability events.
 
+### 3.2 Turn Instruction Preparation
+
+`MoonMind.AgentRun` prepares Codex managed-session turn instructions through
+`agent_runtime.prepare_turn_instructions` before `agent_runtime.send_turn`.
+Preparation is responsible for producing the final bounded prompt text, applying
+selected skill materialization, and attaching compact durable retrieval metadata
+needed by launch/session artifacts.
+
+The preferred command order for new histories is:
+
+1. perform a metadata-only preparation preflight when launch metadata may need
+   retrieval refs or skill context;
+2. launch or resume the task-scoped session;
+3. prepare the final turn instructions against the launched workspace/session
+   boundary;
+4. submit the turn through `agent_runtime.send_turn`.
+
+Workflow changes that move `prepare_turn_instructions` relative to session
+launch/resume or `send_turn` are replay-visible Temporal command-order changes.
+They must be protected by durable patch/version markers or Worker Versioning so
+in-flight `MoonMind.AgentRun` histories continue to replay the command order they
+already recorded. This is the automatic recovery boundary for old histories:
+existing runs replay their recorded preparation order, while new runs use the
+current preferred order.
+
 ## 4. Session Identity
 
 The canonical bounded session identity is:

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -435,6 +435,16 @@ For Codex task-scoped sessions:
 8. Session continuity artifacts, reset boundaries, stdout/stderr, diagnostics, control-event artifacts, and result artifacts are published.
 9. Clear/reset creates a new MoonMind session epoch and thread boundary inside the same task-scoped session policy. The epoch is MoonMind domain state and is independent of Temporal `RunId`.
 
+For Codex session-backed `AgentRun` steps, turn instruction preparation is a
+separate Agent Runtime activity (`agent_runtime.prepare_turn_instructions`) from
+turn submission (`agent_runtime.send_turn`). New histories should prepare final
+turn instructions after launch/resume so skill projection and retrieval metadata
+are evaluated against the active workspace/session boundary. Existing histories
+that recorded an earlier preparation order must remain replayable through
+Temporal patch/version markers; a workflow code change must not reorder
+`prepare_turn_instructions`, session launch/status, and `send_turn` for
+in-flight runs without such a marker.
+
 Current session-control vocabulary:
 
 | Canonical verb | Caller transport into workflow | Workflow action | Current activity / transport |
@@ -498,6 +508,14 @@ These workload containers do not own `session_id`, `session_epoch`, `thread_id`,
 All activity invocation should go through the canonical activity catalog. The route defines task queue, worker fleet, capability class, start-to-close timeout, schedule-to-close timeout, heartbeat timeout where required, retry policy, and non-retryable error types.
 
 Broad Workflow Retry Policies should not be the default for `MoonMind.Run`, `MoonMind.AgentRun`, or `MoonMind.AgentSession`, especially when a step may mutate a repository or external system. Retries should be explicit at the Activity or step-attempt level and must be workspace-safe and idempotent.
+
+Automatic recovery from activity timeout is different from recovery from
+workflow-task nondeterminism. Activity failures may be retried according to the
+activity catalog when the activity is idempotent or guarded by durable keys.
+Nondeterminism occurs during Temporal replay before workflow code can catch it;
+the recovery mechanism is replay-compatible workflow evolution, such as
+`workflow.patched(...)` markers, Worker Versioning, or an external reset/resume
+operation that starts from a safe workflow boundary.
 
 ### Idempotency keys
 

--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -444,6 +444,7 @@ Current implemented activities:
 
 - `agent_runtime.launch`
 - `agent_runtime.launch_session`
+- `agent_runtime.prepare_turn_instructions`
 - `agent_runtime.publish_artifacts`
 - `agent_runtime.session_status`
 - `agent_runtime.send_turn`
@@ -467,6 +468,7 @@ Worker queue: `mm.activity.agent_runtime`
 - `agent_runtime.cancel(...) -> AgentRunStatus`
 - `agent_runtime.launch_session(...) -> CodexManagedSessionHandle`
 - `agent_runtime.session_status(...) -> CodexManagedSessionHandle`
+- `agent_runtime.prepare_turn_instructions(...) -> str | prepared-instructions payload`
 - `agent_runtime.send_turn(...) -> CodexManagedSessionTurnResponse`
 - `agent_runtime.steer_turn(...) -> CodexManagedSessionTurnResponse`
 - `agent_runtime.interrupt_turn(...) -> CodexManagedSessionTurnResponse`
@@ -483,6 +485,14 @@ Worker queue: `mm.activity.agent_runtime`
 The session-oriented activities are remote-session contracts. They must delegate through a session controller or adapter boundary and must not fall back to the worker-local managed runtime launcher/process loop.
 
 The current session-oriented return types are Codex-specific because Codex is the live managed-session implementation. When a second runtime adopts task-scoped managed sessions, introduce a neutral managed-session request/response surface above runtime-specific adapters rather than spreading Codex contracts into the public workflow boundary.
+
+`agent_runtime.prepare_turn_instructions` is replay-visible when scheduled by
+`MoonMind.AgentRun`. Moving it before or after session launch/status activities,
+or before or after `agent_runtime.send_turn`, changes Temporal command order.
+Such changes must be guarded by Temporal patch/version markers or Worker
+Versioning so in-flight histories keep their recorded order while new histories
+use the current order. Activity retry cannot repair a workflow-task
+nondeterminism caused by an unguarded order change.
 
 ## 8.10 Proposal and review activities
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -165,6 +165,23 @@ Rules:
 * reruns reuse the original snapshot by default
 * explicit re-resolution is a separate action, not an implicit side effect of retry
 
+Replay compatibility is part of the retry boundary. A failed or timed-out
+activity can be retried only if the workflow can replay to the same activity
+command. If workflow code changes add, remove, or reorder activities in
+`MoonMind.AgentRun`, the change must use Temporal patch/version markers or Worker
+Versioning so in-flight histories continue on their recorded command path. For
+session-backed Codex runs this includes the relative order of
+`agent_runtime.prepare_turn_instructions`, session launch/status activities, and
+`agent_runtime.send_turn`.
+
+Automatic step recovery therefore has two layers:
+
+* activity-level retry for idempotent side-effecting work, controlled by the
+  activity catalog and durable idempotency keys;
+* workflow-level replay recovery for command-order changes, controlled by
+  Temporal versioning or a reset/resume operation from a safe parent/child
+  boundary.
+
 ---
 
 ## 3. Canonical contract rule

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -271,6 +271,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         apply_session_control_action: SessionControlSignaler,
         workspace_root: str,
         session_image_ref: str,
+        defer_turn_instructions_until_session_launch: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -288,6 +289,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._apply_session_control_action = apply_session_control_action
         self._workspace_root = Path(workspace_root).resolve()
         self._session_image_ref = str(session_image_ref).strip()
+        self._defer_turn_instructions_until_session_launch = bool(
+            defer_turn_instructions_until_session_launch
+        )
         self._run_states: dict[str, CodexSessionExecutionState] = {}
 
     async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
@@ -338,10 +342,18 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             raise ValueError(
                 "CodexSessionAdapter does not support inputRefs for managed session turns"
             )
-        await self._prepare_launch_metadata_for_request(
-            request=request,
-            workspace_path=workspace_path,
-        )
+        prepared_instructions: str | None = None
+        if self._defer_turn_instructions_until_session_launch:
+            await self._prepare_launch_metadata_for_request(
+                request=request,
+                workspace_path=workspace_path,
+            )
+        else:
+            prepared_instructions = await self._instructions_for_request(
+                binding=binding,
+                request=request,
+                workspace_path=workspace_path,
+            )
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -386,10 +398,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         failed_state_persisted = False
 
         try:
-            instructions = await self._instructions_for_request(
-                binding=binding,
-                request=request,
-                workspace_path=workspace_path,
+            instructions = (
+                prepared_instructions
+                if prepared_instructions is not None
+                else await self._instructions_for_request(
+                    binding=binding,
+                    request=request,
+                    workspace_path=workspace_path,
+                )
             )
             turn_response = await self._coerce_turn_response(
                 self._send_turn(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -125,6 +125,9 @@ STORY_BREAKDOWN_ARTIFACT_HANDOFF_PATCH_ID = (
 MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-prepare-turn-instructions-activity-v1"
 )
+MANAGED_SESSION_DEFER_TURN_INSTRUCTIONS_UNTIL_LAUNCH_PATCH_ID = (
+    "agent-run-managed-session-defer-turn-instructions-until-launch-v1"
+)
 PR_RESOLVER_PAYLOAD_SKILL_DETECTION_PATCH_ID = (
     "agent-run-pr-resolver-payload-skill-detection-v1"
 )
@@ -1573,6 +1576,9 @@ class MoonMindAgentRun:
                         use_prepare_turn_instructions_activity = workflow.patched(
                             MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID
                         )
+                        defer_turn_instructions_until_session_launch = workflow.patched(
+                            MANAGED_SESSION_DEFER_TURN_INSTRUCTIONS_UNTIL_LAUNCH_PATCH_ID
+                        )
                         if request.managed_session is None:
                             raise ApplicationError(
                                 "managedSession is required for Codex session-backed runs",
@@ -1706,6 +1712,9 @@ class MoonMindAgentRun:
                             workspace_root=_MANAGED_RUNTIME_STORE_ROOT,
                             session_image_ref=_DEFAULT_SESSION_IMAGE_REF,
                             launch_context_builder=_launch_context_builder,
+                            defer_turn_instructions_until_session_launch=(
+                                defer_turn_instructions_until_session_launch
+                            ),
                         )
                     else:
                         adapter = ManagedAgentAdapter(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -465,6 +465,91 @@ async def test_start_prepares_turn_instructions_after_cold_session_launch(
     assert call_order == ["preflight", "launch", "prepare", "send"]
     assert send_turn_calls[0].instructions.startswith("prepared after launch")
 
+async def test_start_can_preserve_pre_launch_instruction_preparation_order(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    call_order: list[str] = []
+    send_turn_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        call_order.append("load_snapshot")
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        call_order.append("launch")
+        workspace_path.mkdir(parents=True)
+        (workspace_path / ".launch-complete").write_text("ready\n", encoding="utf-8")
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _prepare_before_launch(payload: dict[str, Any]) -> str:
+        call_order.append("prepare")
+        assert payload.get("skipSkillMaterialization") is not True
+        assert not (workspace_path / ".launch-complete").exists()
+        return "prepared before launch\n\nManaged Codex CLI note:"
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        call_order.append("send")
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_before_launch,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+        defer_turn_instructions_until_session_launch=False,
+    )
+
+    await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    assert call_order == ["prepare", "load_snapshot", "launch", "send"]
+    assert send_turn_calls[0].instructions.startswith("prepared before launch")
+
 async def test_start_passes_managed_session_dood_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -192,6 +192,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     loaded_snapshots: list[dict[str, Any]] = []
     requested_snapshot_workflow_ids: list[str] = []
     prepared_instruction_results: list[str] = []
+    defer_instruction_flags: list[bool] = []
 
     _configure_workflow_runtime(monkeypatch)
 
@@ -203,6 +204,9 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
         def __init__(self, **kwargs: Any) -> None:
             self._load_session_snapshot = kwargs["load_session_snapshot"]
             self._prepare_turn_instructions = kwargs["prepare_turn_instructions"]
+            defer_instruction_flags.append(
+                kwargs["defer_turn_instructions_until_session_launch"]
+            )
 
         async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
             session_adapter_requests.append(request)
@@ -348,6 +352,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
         }
     ]
     assert prepared_instruction_results == ["Prepared session instructions"]
+    assert defer_instruction_flags == [True]
     assert run.run_id == "managed-session-run-1"
     assert result.summary == "Session-backed Codex step completed."
     assert result.metadata["resultSource"] == "agent-runtime-fetch-result"
@@ -1143,3 +1148,100 @@ async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_hist
     result = await run.run(_managed_session_request())
 
     assert result.summary == "Legacy instruction preparation path."
+
+async def test_agent_run_preserves_pre_launch_instruction_order_for_pre_defer_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    _configure_workflow_runtime(monkeypatch)
+
+    def _patched(patch_id: str) -> bool:
+        return (
+            patch_id
+            != agent_run_module.MANAGED_SESSION_DEFER_TURN_INSTRUCTIONS_UNTIL_LAUNCH_PATCH_ID
+        )
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **kwargs: Any) -> None:
+            assert kwargs["prepare_turn_instructions"] is not None
+            assert kwargs["defer_turn_instructions_until_session_launch"] is False
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-session-run-pre-defer",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+        async def fetch_result(
+            self,
+            run_id: str,
+            *,
+            pr_resolver_expected: bool = False,
+        ) -> AgentRunResult:
+            assert run_id == "managed-session-run-pre-defer"
+            assert pr_resolver_expected is False
+            return AgentRunResult(summary="Pre-defer instruction order path.")
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_id: str,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Pre-defer instruction order path.", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "patched", _patched)
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_managed_session_request())
+
+    assert result.summary == "Pre-defer instruction order path."


### PR DESCRIPTION
## Summary
- Add a Temporal patch gate for Codex managed-session turn instruction ordering so in-flight AgentRun histories replay their recorded command path.
- Preserve the existing prepare-after-launch behavior for new histories while allowing old histories to prepare before session launch/status.
- Document the replay-safe recovery boundary and add regression coverage for both command orders.

## Root cause
A Codex session-backed AgentRun history could record agent_runtime.send_turn, then replay with newer workflow code that attempted agent_runtime.prepare_turn_instructions at the same command slot. Temporal rejects that as nondeterminism before normal activity retry logic can run.

## Validation
- ./tools/test_unit.sh --python-only tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
- 59 passed

## Notes
- Existing local edits to .env-template and docker-compose.yaml were intentionally left out of this PR.
