### PR TITLE
Observe the navigation bar strategy used with both GitHub and Jira. They have a horizontal border line similar to MoonMind separating the top of the p

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -418,33 +418,37 @@ h1 {
 .route-nav a {
   text-decoration: none;
   color: rgb(var(--mm-ink) / 0.82);
-  border: 1px solid rgb(var(--mm-border) / 0.7);
-  border-radius: 999px;
+  border: 0;
+  border-radius: 0.5rem;
   padding: 0.48rem 0.82rem;
   font-size: 0.9rem;
-  background: rgb(var(--mm-panel) / 0.65);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  transition: border-color 130ms ease, background 130ms ease, box-shadow 130ms ease, color 130ms ease;
+  background: transparent;
+  box-shadow: inset 0 -2px 0 transparent;
+  transition: background 130ms ease, box-shadow 130ms ease, color 130ms ease;
 }
 
-@supports not ((backdrop-filter: blur(2px)) or (-webkit-backdrop-filter: blur(2px))) {
-  .route-nav a {
-    background: rgb(var(--mm-panel) / 0.92);
-  }
-}
-
-.route-nav a.active,
 .route-nav a:hover {
-  border-color: rgb(var(--mm-accent));
-  background: rgb(var(--mm-accent) / 0.14);
+  background: rgb(var(--mm-ink) / 0.06);
   color: rgb(var(--mm-ink));
-  box-shadow: 0 0 0 1px rgb(var(--mm-accent) / 0.35), 0 12px 30px -24px rgb(var(--mm-accent) / 0.85);
+}
+
+.route-nav a.active {
+  color: rgb(var(--mm-ink));
+  font-weight: 600;
+  box-shadow: inset 0 -2px 0 rgb(var(--mm-accent));
+}
+
+.route-nav a.active:hover {
+  background: rgb(var(--mm-ink) / 0.06);
 }
 
 .route-nav a:focus-visible {
   outline: none;
   box-shadow: var(--mm-control-focus-ring);
+}
+
+.route-nav a.active:focus-visible {
+  box-shadow: var(--mm-control-focus-ring), inset 0 -2px 0 rgb(var(--mm-accent));
 }
 
 .panel {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -416,6 +416,7 @@ h1 {
 }
 
 .route-nav a {
+  position: relative;
   text-decoration: none;
   color: rgb(var(--mm-ink) / 0.82);
   border: 0;
@@ -423,8 +424,18 @@ h1 {
   padding: 0.48rem 0.82rem;
   font-size: 0.9rem;
   background: transparent;
-  box-shadow: inset 0 -2px 0 transparent;
-  transition: background 130ms ease, box-shadow 130ms ease, color 130ms ease;
+  transition: background 130ms ease, color 130ms ease;
+}
+
+.route-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: transparent;
+  transition: background 130ms ease;
 }
 
 .route-nav a:hover {
@@ -434,8 +445,11 @@ h1 {
 
 .route-nav a.active {
   color: rgb(var(--mm-ink));
-  font-weight: 600;
-  box-shadow: inset 0 -2px 0 rgb(var(--mm-accent));
+  text-shadow: 0.5px 0 0 currentColor;
+}
+
+.route-nav a.active::after {
+  background: rgb(var(--mm-accent));
 }
 
 .route-nav a.active:hover {
@@ -445,10 +459,6 @@ h1 {
 .route-nav a:focus-visible {
   outline: none;
   box-shadow: var(--mm-control-focus-ring);
-}
-
-.route-nav a.active:focus-visible {
-  box-shadow: var(--mm-control-focus-ring), inset 0 -2px 0 rgb(var(--mm-accent));
 }
 
 .panel {
@@ -4236,6 +4246,11 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     box-shadow:
       inset 3px 0 0 var(--mm-mobile-nav-active-edge),
       inset 0 1px 0 var(--mm-mobile-nav-edge);
+  }
+
+  .route-nav a::after,
+  .route-nav a.active::after {
+    content: none;
   }
 }
 


### PR DESCRIPTION
Observe the navigation bar strategy used with both GitHub and Jira. They have a horizontal border line similar to MoonMind separating the top of the page from the rest of the page. However, they also use a thicker line segment underneath the tab that is selected with a color applied to it and then the font either tinted or bolded. They do not encircle the selected tab in a border. I want MoonMind to transition to this approach for the navigation bar on desktop and no longer use the constantly present pill borders with those buttons. However, they could still show the pill shape on hover if desired, as seen in the github images with a rounded corner gray highlight.