### PR TITLE
The purple underline under the selected navigation item in MoonMind should be touching the horizontal border as seen in the github and jira examples a

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -793,6 +793,13 @@ describe('Mission Control shared entry', () => {
 
     const linkBlocks = cssRuleBlocks(missionControlCss, '.route-nav a');
     expect(linkBlocks.join('\n')).not.toMatch(/transition:[^;]*\btransform\b/);
+    expect(
+      linkBlocks.some(
+        (block) =>
+          block.includes('padding: 0.48rem 0.82rem calc(0.48rem + 0.62rem);') &&
+          block.includes('margin-bottom: -0.62rem;'),
+      ),
+    ).toBe(true);
 
     const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');
     expect(activeBlocks.join('\n')).not.toMatch(/transform:[^;]*\bscale\b/);
@@ -835,6 +842,7 @@ describe('Mission Control shared entry', () => {
       linkBlocks.some(
         (block) =>
           block.includes('min-height: 3.25rem;') &&
+          block.includes('margin-bottom: 0;') &&
           block.includes('border: 0;') &&
           block.includes('border-radius: 1rem;') &&
           block.includes('font-weight: 600;') &&

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -793,12 +793,15 @@ describe('Mission Control shared entry', () => {
 
     const linkBlocks = cssRuleBlocks(missionControlCss, '.route-nav a');
     expect(linkBlocks.join('\n')).not.toMatch(/transition:[^;]*\btransform\b/);
+    const desktopLinkBlock = linkBlocks.find((block) =>
+      block.includes('padding: 0.48rem 0.82rem;'),
+    );
+    expect(desktopLinkBlock).toBeDefined();
+    expect(desktopLinkBlock).not.toMatch(/margin-bottom:\s*-/);
+
+    const underlineBlocks = cssRuleBlocks(missionControlCss, '.route-nav a::after');
     expect(
-      linkBlocks.some(
-        (block) =>
-          block.includes('padding: 0.48rem 0.82rem calc(0.48rem + 0.62rem);') &&
-          block.includes('margin-bottom: -0.62rem;'),
-      ),
+      underlineBlocks.some((block) => block.includes('bottom: -0.62rem;')),
     ).toBe(true);
 
     const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -421,7 +421,8 @@ h1 {
   color: rgb(var(--mm-ink) / 0.82);
   border: 0;
   border-radius: 0.5rem;
-  padding: 0.48rem 0.82rem;
+  padding: 0.48rem 0.82rem calc(0.48rem + 0.62rem);
+  margin-bottom: -0.62rem;
   font-size: 0.9rem;
   background: transparent;
   transition: background 130ms ease, color 130ms ease;
@@ -4215,6 +4216,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     gap: 0.75rem;
     min-height: 3.25rem;
     padding: 0 1rem;
+    margin-bottom: 0;
     border: 0;
     border-radius: 1rem;
     font-weight: 600;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -421,8 +421,7 @@ h1 {
   color: rgb(var(--mm-ink) / 0.82);
   border: 0;
   border-radius: 0.5rem;
-  padding: 0.48rem 0.82rem calc(0.48rem + 0.62rem);
-  margin-bottom: -0.62rem;
+  padding: 0.48rem 0.82rem;
   font-size: 0.9rem;
   background: transparent;
   transition: background 130ms ease, color 130ms ease;
@@ -433,7 +432,7 @@ h1 {
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: -0.62rem;
   height: 2px;
   background: transparent;
   transition: background 130ms ease;


### PR DESCRIPTION
The purple underline under the selected navigation item in MoonMind should be touching the horizontal border as seen in the github and jira examples and not floating above it. The navigation items can be moved a bit closer to the horizontal border if that makes it seem more natural.