### PR TITLE
Change Jira issue MM-598 to status In Progress before implementation starts.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,8 @@ Key diagnostics:
 - Existing `task_step_template_versions.inputs_schema` JSON and task draft/submission payloads; no new persistent tables planned (308-schema-driven-capability-inputs)
 - Python 3.12; TypeScript/React for Mission Control task details + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Zod, existing Temporal artifact service/helpers (310-resume-from-last-failed-step)
 - Existing Temporal execution records, canonical execution parameters/memo/search attributes, Temporal artifact metadata/content store, and existing workflow history; no new persistent database table is planned unless reverse related-run queries cannot be implemented safely from existing execution records (310-resume-from-last-failed-step)
+- Python 3.12 + Pydantic v2, SQLAlchemy async ORM, FastAPI, Temporal Python SDK activity boundaries, `httpx`, existing Jira trusted tool service, existing GitHub service/auth helpers, pytest (312-proposal-review-delivery)
+- Existing `task_proposals` table and `311_proposal_delivery_records` migration fields; no new persistent table planned unless provider decision audit cannot reuse existing proposal metadata/decision fields (312-proposal-review-delivery)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -160,6 +160,30 @@ def _serialize_similar(similar: list[TaskProposal] | None) -> list[dict[str, obj
         )
     return items
 
+def _serialize_review_delivery(proposal: TaskProposal) -> dict[str, object]:
+    provider_metadata = getattr(proposal, "provider_metadata", None)
+    delivery_node = (
+        provider_metadata.get("delivery")
+        if isinstance(provider_metadata, dict)
+        else None
+    )
+    delivery = dict(delivery_node) if isinstance(delivery_node, dict) else {}
+    status_value = str(delivery.get("status") or "").strip()
+    if not status_value:
+        status_value = "delivered" if getattr(proposal, "external_url", None) else "pending"
+    result: dict[str, object] = {
+        "provider": getattr(proposal, "provider", "github") or "github",
+        "status": status_value,
+        "externalKey": getattr(proposal, "external_key", None),
+        "externalUrl": getattr(proposal, "external_url", None),
+        "taskSnapshotRef": getattr(proposal, "task_snapshot_ref", None),
+        "storedSnapshotNotice": bool(delivery.get("storedSnapshotNotice")),
+    }
+    for key in ("created", "duplicateSource", "warnings"):
+        if key in delivery:
+            result[key] = delivery[key]
+    return result
+
 def _serialize_proposal(
     proposal: TaskProposal, *, similar: list[TaskProposal] | None = None
 ) -> TaskProposalModel:
@@ -190,6 +214,7 @@ def _serialize_proposal(
         "taskSnapshotRef": getattr(proposal, "task_snapshot_ref", None),
         "providerMetadata": getattr(proposal, "provider_metadata", None) or {},
         "resolvedPolicy": getattr(proposal, "resolved_policy", None) or {},
+        "reviewDelivery": _serialize_review_delivery(proposal),
         "reviewPriority": proposal.review_priority,
         "priorityOverrideReason": proposal.priority_override_reason,
         "proposedByWorkerId": proposal.proposed_by_worker_id,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6505,6 +6505,10 @@ export interface components {
             resolvedPolicy?: {
                 [key: string]: unknown;
             };
+            /** Reviewdelivery */
+            reviewDelivery?: {
+                [key: string]: unknown;
+            };
             /** @default normal */
             reviewPriority: components["schemas"]["TaskProposalReviewPriority"];
             /** Priorityoverridereason */

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -65,6 +65,7 @@ class TaskProposalModel(BaseModel):
     task_snapshot_ref: Optional[str] = Field(None, alias="taskSnapshotRef")
     provider_metadata: dict[str, Any] = Field(default_factory=dict, alias="providerMetadata")
     resolved_policy: dict[str, Any] = Field(default_factory=dict, alias="resolvedPolicy")
+    review_delivery: dict[str, Any] = Field(default_factory=dict, alias="reviewDelivery")
     review_priority: TaskProposalReviewPriority = Field(
         TaskProposalReviewPriority.NORMAL, alias="reviewPriority"
     )

--- a/moonmind/workflows/__init__.py
+++ b/moonmind/workflows/__init__.py
@@ -34,8 +34,20 @@ def get_task_proposal_repository(session: AsyncSession) -> TaskProposalRepositor
 def get_task_proposal_service(session: AsyncSession) -> TaskProposalService:
     """Factory helper returning the task proposal service."""
 
+    from moonmind.integrations.jira.tool import JiraToolService
+    from moonmind.workflows.adapters.github_service import GitHubService
+    from moonmind.workflows.task_proposals.delivery import (
+        GitHubProposalIssueProvider,
+        JiraProposalIssueProvider,
+        ProposalDeliveryService,
+    )
+
     return TaskProposalService(
         get_task_proposal_repository(session),
+        delivery_service=ProposalDeliveryService(
+            github=GitHubProposalIssueProvider(GitHubService()),
+            jira=JiraProposalIssueProvider(JiraToolService()),
+        ),
     )
 
 def get_temporal_execution_service(session: AsyncSession) -> TemporalExecutionService:

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -60,6 +60,18 @@ class PullRequestReadinessResult(BaseModel):
     blockers: list[dict[str, Any]] = Field(default_factory=list, alias="blockers")
 
 
+class GitHubIssueResult(BaseModel):
+    """Result from GitHub issue create/update operations."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    external_key: Optional[str] = Field(None, alias="externalKey")
+    external_url: Optional[str] = Field(None, alias="externalUrl")
+    created: bool = Field(False, alias="created")
+    updated: bool = Field(False, alias="updated")
+    summary: str = Field("", alias="summary")
+
+
 @dataclass(frozen=True, slots=True)
 class GitHubPermissionProfile:
     profile_id: str
@@ -467,6 +479,176 @@ class GitHubService:
                         }
                     )
         return result
+
+    # -- Issue operations -------------------------------------------------
+
+    async def search_issue_by_marker(
+        self,
+        *,
+        repo: str,
+        marker: str,
+        github_token: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Find an open GitHub Issue containing a deterministic proposal marker."""
+
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            logger.info("GitHub issue search skipped for %s: %s", repo, resolution_error)
+            return None
+        headers = self._github_headers(token)
+        query = f"repo:{repo} is:issue is:open {marker}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.get(
+                    "https://api.github.com/search/issues",
+                    headers=headers,
+                    params={"q": query, "per_page": 1},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except (
+                httpx.HTTPStatusError,
+                httpx.TransportError,
+                httpx.TimeoutException,
+            ) as exc:
+                logger.warning(
+                    "GitHub issue search failed for %s: %s",
+                    repo,
+                    exc.__class__.__name__,
+                )
+                return None
+        items = data.get("items") if isinstance(data, Mapping) else None
+        if not isinstance(items, list) or not items:
+            return None
+        issue = items[0]
+        if not isinstance(issue, Mapping):
+            return None
+        return {
+            "key": str(issue.get("number") or ""),
+            "url": str(issue.get("html_url") or ""),
+            "source": "provider_marker",
+        }
+
+    async def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+        github_token: str | None = None,
+    ) -> GitHubIssueResult:
+        """Create a GitHub Issue via REST API."""
+
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            return GitHubIssueResult(
+                created=False,
+                summary=resolution_error
+                or self._missing_auth_summary("create an issue"),
+            )
+        headers = self._github_headers(token)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.post(
+                    f"https://api.github.com/repos/{repo}/issues",
+                    headers=headers,
+                    json={"title": title, "body": body, "labels": labels or []},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPStatusError as exc:
+                summary = self._github_permission_summary(exc.response)
+                return GitHubIssueResult(
+                    created=False,
+                    summary=(
+                        f"GitHub create issue failed with HTTP {exc.response.status_code}"
+                        + (f" for {repo}. {summary}" if summary else f" for {repo}.")
+                    ),
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                return GitHubIssueResult(
+                    created=False,
+                    summary=(
+                        "GitHub create issue request failed: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                )
+        return GitHubIssueResult(
+            externalKey=str(data.get("number") or ""),
+            externalUrl=data.get("html_url"),
+            created=True,
+            summary=f"GitHub issue created: {data.get('html_url')}",
+        )
+
+    async def update_issue(
+        self,
+        *,
+        repo: str,
+        issue_number: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+        github_token: str | None = None,
+    ) -> GitHubIssueResult:
+        """Update a GitHub Issue via REST API."""
+
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            return GitHubIssueResult(
+                externalKey=issue_number,
+                updated=False,
+                summary=resolution_error
+                or self._missing_auth_summary("update an issue"),
+            )
+        headers = self._github_headers(token)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.patch(
+                    f"https://api.github.com/repos/{repo}/issues/{issue_number}",
+                    headers=headers,
+                    json={"title": title, "body": body, "labels": labels or []},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPStatusError as exc:
+                summary = self._github_permission_summary(exc.response)
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    updated=False,
+                    summary=(
+                        f"GitHub update issue failed with HTTP {exc.response.status_code}"
+                        + (
+                            f" for {repo}#{issue_number}. {summary}"
+                            if summary
+                            else f" for {repo}#{issue_number}."
+                        )
+                    ),
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    updated=False,
+                    summary=(
+                        "GitHub update issue request failed: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                )
+        return GitHubIssueResult(
+            externalKey=str(data.get("number") or issue_number),
+            externalUrl=data.get("html_url"),
+            updated=True,
+            summary=f"GitHub issue updated: {data.get('html_url')}",
+        )
 
     # -- PR operations ----------------------------------------------------
 

--- a/moonmind/workflows/task_proposals/__init__.py
+++ b/moonmind/workflows/task_proposals/__init__.py
@@ -2,6 +2,21 @@
 
 from .models import TaskProposal, TaskProposalOriginSource, TaskProposalStatus
 from .repositories import TaskProposalNotFoundError, TaskProposalRepository
+from .delivery import (
+    ProposalDeliveryError,
+    ProposalDeliveryRequest,
+    ProposalDeliveryResult,
+    ProposalDeliveryService,
+    GitHubProposalIssueProvider,
+    JiraProposalIssueProvider,
+    ProviderDecisionEvent,
+    ProviderDecisionResult,
+    RenderedProposalIssue,
+    parse_provider_decision,
+    render_github_issue,
+    render_jira_issue,
+    request_from_proposal,
+)
 from .service import (
     TaskProposalError,
     TaskProposalService,
@@ -15,6 +30,19 @@ __all__ = [
     "TaskProposalStatus",
     "TaskProposalRepository",
     "TaskProposalNotFoundError",
+    "ProposalDeliveryError",
+    "ProposalDeliveryRequest",
+    "ProposalDeliveryResult",
+    "ProposalDeliveryService",
+    "GitHubProposalIssueProvider",
+    "JiraProposalIssueProvider",
+    "ProviderDecisionEvent",
+    "ProviderDecisionResult",
+    "RenderedProposalIssue",
+    "parse_provider_decision",
+    "render_github_issue",
+    "render_jira_issue",
+    "request_from_proposal",
     "TaskProposalService",
     "TaskProposalError",
     "TaskProposalStatusError",

--- a/moonmind/workflows/task_proposals/delivery.py
+++ b/moonmind/workflows/task_proposals/delivery.py
@@ -1,0 +1,736 @@
+"""Provider-facing proposal delivery helpers.
+
+The executable proposal payload stays in MoonMind storage. External tracker
+issues are review artifacts with bounded controls and links back to evidence.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Mapping, Protocol
+
+from moonmind.utils.logging import SecretRedactor
+
+_GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SECRET_KEY_RE = re.compile(
+    r"(token|password|secret|authorization|cookie|private[_-]?key)",
+    re.IGNORECASE,
+)
+_COMMAND_RE = re.compile(
+    r"^\s*/moonmind\s+(?P<action>promote|dismiss|defer|priority)\b(?P<args>.*)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_SUPPORTED_ACTIONS = frozenset({"promote", "dismiss", "defer", "priority"})
+
+
+class ProposalDeliveryError(RuntimeError):
+    """Raised when proposal delivery cannot be attempted safely."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        destination: str,
+        retryable: bool = False,
+        next_action: str = "Review proposal delivery policy and provider configuration.",
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.destination = destination
+        self.retryable = retryable
+        self.next_action = next_action
+
+    def to_output(self, *, record_id: str | None = None) -> dict[str, Any]:
+        output: dict[str, Any] = {
+            "provider": self.provider,
+            "destination": self.destination,
+            "sanitizedReason": str(self),
+            "recoverableNextAction": self.next_action,
+            "retryable": self.retryable,
+        }
+        if record_id:
+            output["deliveryRecordId"] = record_id
+        return output
+
+
+@dataclass(frozen=True, slots=True)
+class RenderedProposalIssue:
+    """Provider-ready rendered review issue."""
+
+    title: str
+    body: str
+    labels: tuple[str, ...] = ()
+    fields: dict[str, Any] = field(default_factory=dict)
+    marker: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalDeliveryRequest:
+    """Compact delivery input built from a stored proposal record."""
+
+    record_id: str
+    provider: str
+    repository: str
+    title: str
+    summary: str
+    category: str | None
+    tags: tuple[str, ...]
+    priority: str
+    dedup_key: str
+    dedup_hash: str
+    task_snapshot_ref: str | None
+    task_create_request: Mapping[str, Any]
+    origin_metadata: Mapping[str, Any]
+    provider_metadata: Mapping[str, Any]
+    resolved_policy: Mapping[str, Any]
+    external_key: str | None = None
+    external_url: str | None = None
+
+    @property
+    def destination(self) -> str:
+        if self.provider == "jira":
+            jira = _provider_config(self.provider_metadata, "jira")
+            return _clean(jira.get("project_key") or jira.get("projectKey")) or self.repository
+        github = _provider_config(self.provider_metadata, "github")
+        return _clean(github.get("repository")) or self.repository
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalDeliveryResult:
+    """Sanitized result from provider delivery."""
+
+    provider: str
+    external_key: str
+    external_url: str
+    created: bool
+    duplicate_source: str | None = None
+    delivered_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    warnings: tuple[str, ...] = ()
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_decision(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "externalKey": self.external_key,
+            "externalUrl": self.external_url,
+            "created": self.created,
+            "duplicateSource": self.duplicate_source,
+            "deliveredAt": self.delivered_at.isoformat(),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDecisionEvent:
+    """Bounded reviewer decision observed from a provider issue."""
+
+    provider: str
+    external_key: str
+    provider_event_id: str
+    actor: str
+    body: str = ""
+    action: str | None = None
+    note: str | None = None
+    observed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDecisionResult:
+    """Normalized reviewer decision accepted from a provider event."""
+
+    accepted: bool
+    decision: str | None
+    note: str | None
+    actor: str
+    provider_event_id: str
+    reason: str | None = None
+    priority: str | None = None
+    defer_until: str | None = None
+
+
+class ProposalIssueProvider(Protocol):
+    """Provider port used by proposal delivery orchestration."""
+
+    async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, Any] | None:
+        ...
+
+    async def create_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+    ) -> dict[str, Any]:
+        ...
+
+    async def update_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+        issue: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        ...
+
+
+class GitHubProposalIssueProvider:
+    """Proposal issue provider backed by the trusted GitHub service."""
+
+    def __init__(self, github_service: Any) -> None:
+        self._github = github_service
+
+    async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, Any] | None:
+        if not hasattr(self._github, "search_issue_by_marker"):
+            return None
+        return await self._github.search_issue_by_marker(
+            repo=request.destination,
+            marker=request.dedup_hash,
+        )
+
+    async def create_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+    ) -> dict[str, Any]:
+        result = await self._github.create_issue(
+            repo=request.destination,
+            title=rendered.title,
+            body=rendered.body,
+            labels=list(rendered.labels),
+        )
+        if hasattr(result, "model_dump"):
+            return result.model_dump(by_alias=True)
+        return dict(result)
+
+    async def update_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+        issue: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        result = await self._github.update_issue(
+            repo=request.destination,
+            issue_number=_clean(issue.get("key") or issue.get("number")),
+            title=rendered.title,
+            body=rendered.body,
+            labels=list(rendered.labels),
+        )
+        if hasattr(result, "model_dump"):
+            return result.model_dump(by_alias=True)
+        return dict(result)
+
+
+class JiraProposalIssueProvider:
+    """Proposal issue provider backed by the trusted Jira tool service."""
+
+    def __init__(self, jira_service: Any) -> None:
+        self._jira = jira_service
+
+    async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, Any] | None:
+        from moonmind.integrations.jira.models import SearchIssuesRequest
+
+        marker = request.dedup_hash
+        project_key = request.destination
+        result = await self._jira.search_issues(
+            SearchIssuesRequest(
+                jql=f'text ~ "{marker}"',
+                projectKey=project_key,
+                fields=["summary"],
+                maxResults=1,
+            )
+        )
+        issues = result.get("issues") if isinstance(result, Mapping) else None
+        if not isinstance(issues, list) or not issues:
+            return None
+        issue = issues[0]
+        if not isinstance(issue, Mapping):
+            return None
+        key = _clean(issue.get("key"))
+        return {
+            "key": key,
+            "url": _clean(issue.get("url") or issue.get("self")),
+            "source": "provider_marker",
+        }
+
+    async def create_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+    ) -> dict[str, Any]:
+        from moonmind.integrations.jira.models import CreateIssueRequest
+
+        issue_type = _clean(rendered.fields.get("issueType")) or "Task"
+        result = await self._jira.create_issue(
+            CreateIssueRequest(
+                projectKey=request.destination,
+                issueTypeId=issue_type,
+                summary=rendered.title,
+                description=rendered.fields.get("description"),
+                fields={
+                    key: value
+                    for key, value in rendered.fields.items()
+                    if key not in {"projectKey", "issueType", "description"}
+                },
+            )
+        )
+        return {
+            "external_key": result.get("issueKey"),
+            "external_url": result.get("url") or result.get("self") or result.get("issueKey"),
+        }
+
+    async def update_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: RenderedProposalIssue,
+        issue: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        from moonmind.integrations.jira.models import EditIssueRequest
+
+        issue_key = _clean(issue.get("key"))
+        await self._jira.edit_issue(
+            EditIssueRequest(
+                issueKey=issue_key,
+                fields={
+                    key: value
+                    for key, value in rendered.fields.items()
+                    if key not in {"projectKey", "issueType"}
+                },
+                update={},
+            )
+        )
+        return {
+            "external_key": issue_key,
+            "external_url": _clean(issue.get("url") or issue.get("self") or issue_key),
+        }
+
+
+def _clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _provider_config(metadata: Mapping[str, Any], provider: str) -> dict[str, Any]:
+    node = metadata.get(provider)
+    return dict(node) if isinstance(node, Mapping) else {}
+
+
+def _iter_strings(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple, set)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
+
+
+def _contains_secret_key(value: object) -> bool:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if _SECRET_KEY_RE.search(str(key)):
+                return True
+            if _contains_secret_key(child):
+                return True
+    elif isinstance(value, (list, tuple, set)):
+        return any(_contains_secret_key(item) for item in value)
+    return False
+
+
+def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if _SECRET_KEY_RE.search(str(key)):
+            safe[str(key)] = "[REDACTED]"
+        elif isinstance(value, Mapping):
+            safe[str(key)] = _safe_metadata(value)
+        elif isinstance(value, list):
+            safe[str(key)] = [
+                _safe_metadata(item) if isinstance(item, Mapping) else item
+                for item in value
+            ]
+        else:
+            safe[str(key)] = value
+    return safe
+
+
+def _marker(request: ProposalDeliveryRequest) -> str:
+    snapshot = request.task_snapshot_ref or "stored-proposal-snapshot"
+    return (
+        "<!-- moonmind-proposal "
+        f"record={request.record_id} dedup={request.dedup_hash} "
+        f"snapshot={snapshot} -->"
+    )
+
+
+def _evidence_lines(request: ProposalDeliveryRequest) -> list[str]:
+    metadata = request.origin_metadata
+    lines: list[str] = []
+    for label, key in (
+        ("Workflow", "workflow_id"),
+        ("Temporal run", "temporal_run_id"),
+        ("Trigger repository", "trigger_repo"),
+        ("Trigger job", "trigger_job_id"),
+    ):
+        value = _clean(metadata.get(key))
+        if value:
+            lines.append(f"- {label}: `{value}`")
+    if request.task_snapshot_ref:
+        lines.append(f"- Stored proposal snapshot: `{request.task_snapshot_ref}`")
+    lines.append(f"- Dedup key: `{request.dedup_key}`")
+    lines.append(f"- Dedup hash: `{request.dedup_hash}`")
+    return lines
+
+
+def _review_controls() -> str:
+    return "\n".join(
+        [
+            "- `/moonmind promote` starts execution from the stored MoonMind snapshot.",
+            "- `/moonmind dismiss <reason>` dismisses the proposal.",
+            "- `/moonmind defer <date>` records a defer control.",
+            "- `/moonmind priority <low|normal|high|urgent>` updates triage priority.",
+        ]
+    )
+
+
+def _stored_snapshot_notice() -> str:
+    return (
+        "MoonMind executes the stored proposal snapshot. Edited issue text, "
+        "comments, labels, or fields are review artifacts and are never used as "
+        "replacement executable task payloads."
+    )
+
+
+def _text_to_adf_document(text: str) -> dict[str, Any]:
+    normalized = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
+    content: list[dict[str, Any]] = []
+    for raw_paragraph in normalized.split("\n\n"):
+        paragraph_content: list[dict[str, Any]] = []
+        lines = raw_paragraph.split("\n")
+        for index, line in enumerate(lines):
+            if line:
+                paragraph_content.append({"type": "text", "text": line})
+            if index < len(lines) - 1:
+                paragraph_content.append({"type": "hardBreak"})
+        content.append({"type": "paragraph", "content": paragraph_content})
+    return {"type": "doc", "version": 1, "content": content}
+
+
+def render_github_issue(
+    request: ProposalDeliveryRequest,
+    *,
+    redactor: SecretRedactor | None = None,
+) -> RenderedProposalIssue:
+    """Render a GitHub Issue body for proposal review."""
+
+    redactor = redactor or SecretRedactor.from_environ(placeholder="[REDACTED]")
+    provider_cfg = _provider_config(request.provider_metadata, "github")
+    configured_labels = _iter_strings(provider_cfg.get("labels"))
+    labels = tuple(dict.fromkeys(("moonmind-proposal", "proposal-review", *configured_labels)))
+    title = f"[MoonMind proposal] {request.title}".strip()
+    body = "\n\n".join(
+        [
+            _marker(request),
+            f"## Proposal\n\n{request.summary}",
+            (
+                "## Review Context\n\n"
+                f"- Repository: `{request.repository}`\n"
+                f"- Category: `{request.category or 'uncategorized'}`\n"
+                f"- Priority: `{request.priority}`\n"
+                f"- Tags: `{', '.join(request.tags) or 'none'}`"
+            ),
+            "## Evidence Links\n\n" + "\n".join(_evidence_lines(request)),
+            "## Reviewer Actions\n\n" + _review_controls(),
+            "## Stored Snapshot Notice\n\n" + _stored_snapshot_notice(),
+        ]
+    )
+    return RenderedProposalIssue(
+        title=redactor.scrub(title),
+        body=redactor.scrub(body),
+        labels=labels,
+        marker=_marker(request),
+    )
+
+
+def render_jira_issue(
+    request: ProposalDeliveryRequest,
+    *,
+    redactor: SecretRedactor | None = None,
+) -> RenderedProposalIssue:
+    """Render Jira issue fields and ADF description for proposal review."""
+
+    redactor = redactor or SecretRedactor.from_environ(placeholder="[REDACTED]")
+    provider_cfg = _provider_config(request.provider_metadata, "jira")
+    configured_labels = _iter_strings(provider_cfg.get("labels"))
+    labels = tuple(dict.fromkeys(("moonmind-proposal", "proposal-review", *configured_labels)))
+    summary = f"[MoonMind proposal] {request.title}".strip()
+    description_text = "\n\n".join(
+        [
+            _marker(request),
+            f"Proposal\n{request.summary}",
+            (
+                "Review Context\n"
+                f"Repository: {request.repository}\n"
+                f"Category: {request.category or 'uncategorized'}\n"
+                f"Priority: {request.priority}\n"
+                f"Tags: {', '.join(request.tags) or 'none'}"
+            ),
+            "Evidence Links\n" + "\n".join(_evidence_lines(request)),
+            "Reviewer Actions\n" + _review_controls(),
+            "Stored Snapshot Notice\n" + _stored_snapshot_notice(),
+        ]
+    )
+    fields: dict[str, Any] = {
+        "description": _text_to_adf_document(redactor.scrub(description_text)),
+        "labels": list(labels),
+    }
+    project_key = _clean(provider_cfg.get("project_key") or provider_cfg.get("projectKey"))
+    issue_type = _clean(provider_cfg.get("issue_type") or provider_cfg.get("issueType"))
+    if project_key:
+        fields["projectKey"] = project_key
+    if issue_type:
+        fields["issueType"] = issue_type
+    return RenderedProposalIssue(
+        title=redactor.scrub(summary),
+        body=redactor.scrub(description_text),
+        labels=labels,
+        fields=fields,
+        marker=_marker(request),
+    )
+
+
+def parse_provider_decision(event: ProviderDecisionEvent) -> ProviderDecisionResult:
+    """Parse only bounded reviewer controls from provider events."""
+
+    action = _clean(event.action).lower() or None
+    args = ""
+    if not action:
+        match = _COMMAND_RE.search(event.body or "")
+        if match:
+            action = match.group("action").lower()
+            args = _clean(match.group("args"))
+    if action not in _SUPPORTED_ACTIONS:
+        return ProviderDecisionResult(
+            accepted=False,
+            decision=None,
+            note=None,
+            actor=event.actor,
+            provider_event_id=event.provider_event_id,
+            reason="unsupported_action",
+        )
+    note = _clean(event.note) or args or None
+    priority: str | None = None
+    defer_until: str | None = None
+    if action == "priority":
+        candidate = _clean(args).lower()
+        if candidate not in {"low", "normal", "high", "urgent"}:
+            return ProviderDecisionResult(
+                accepted=False,
+                decision=None,
+                note=None,
+                actor=event.actor,
+                provider_event_id=event.provider_event_id,
+                reason="invalid_priority",
+            )
+        priority = candidate
+    if action == "defer":
+        defer_until = _clean(args) or None
+    return ProviderDecisionResult(
+        accepted=True,
+        decision=action,
+        note=note,
+        actor=event.actor,
+        provider_event_id=event.provider_event_id,
+        priority=priority,
+        defer_until=defer_until,
+    )
+
+
+def request_from_proposal(proposal: Any) -> ProposalDeliveryRequest:
+    """Build a delivery request from a TaskProposal-like object."""
+
+    return ProposalDeliveryRequest(
+        record_id=str(getattr(proposal, "id", "")),
+        provider=_clean(getattr(proposal, "provider", "github")).lower() or "github",
+        repository=_clean(getattr(proposal, "repository", "")),
+        title=_clean(getattr(proposal, "title", "")),
+        summary=_clean(getattr(proposal, "summary", "")),
+        category=getattr(proposal, "category", None),
+        tags=tuple(str(tag) for tag in (getattr(proposal, "tags", None) or ())),
+        priority=_clean(getattr(getattr(proposal, "review_priority", ""), "value", None))
+        or _clean(getattr(proposal, "review_priority", "normal"))
+        or "normal",
+        dedup_key=_clean(getattr(proposal, "dedup_key", "")),
+        dedup_hash=_clean(getattr(proposal, "dedup_hash", "")),
+        task_snapshot_ref=getattr(proposal, "task_snapshot_ref", None),
+        task_create_request=getattr(proposal, "task_create_request", None) or {},
+        origin_metadata=getattr(proposal, "origin_metadata", None) or {},
+        provider_metadata=getattr(proposal, "provider_metadata", None) or {},
+        resolved_policy=getattr(proposal, "resolved_policy", None) or {},
+        external_key=getattr(proposal, "external_key", None),
+        external_url=getattr(proposal, "external_url", None),
+    )
+
+
+class ProposalDeliveryService:
+    """Orchestrate dedup-first proposal delivery to provider issues."""
+
+    def __init__(
+        self,
+        *,
+        github: ProposalIssueProvider | None = None,
+        jira: ProposalIssueProvider | None = None,
+        redactor: SecretRedactor | None = None,
+    ) -> None:
+        self._providers = {"github": github, "jira": jira}
+        self._redactor = redactor or SecretRedactor.from_environ(
+            placeholder="[REDACTED]"
+        )
+
+    def _provider(self, provider: str) -> ProposalIssueProvider:
+        selected = self._providers.get(provider)
+        if selected is None:
+            raise ProposalDeliveryError(
+                f"{provider} proposal delivery is not configured",
+                provider=provider,
+                destination=provider,
+                retryable=True,
+                next_action="Configure the proposal delivery provider adapter.",
+            )
+        return selected
+
+    def _validate_policy(self, request: ProposalDeliveryRequest) -> None:
+        if request.provider not in {"github", "jira"}:
+            raise ProposalDeliveryError(
+                "provider must be github or jira",
+                provider=request.provider or "unknown",
+                destination=request.destination,
+            )
+        if _contains_secret_key(request.provider_metadata):
+            raise ProposalDeliveryError(
+                "provider metadata contains secret-like fields",
+                provider=request.provider,
+                destination=request.destination,
+                next_action="Move credentials to the trusted provider secret boundary.",
+            )
+        policy = request.resolved_policy
+        allowed_actions = set(_iter_strings(policy.get("allowedActions")))
+        if allowed_actions and not _SUPPORTED_ACTIONS.issubset(allowed_actions):
+            raise ProposalDeliveryError(
+                "proposal reviewer actions are not allowed by policy",
+                provider=request.provider,
+                destination=request.destination,
+            )
+        if request.provider == "github":
+            destination = request.destination
+            if not _GITHUB_REPO_RE.match(destination):
+                raise ProposalDeliveryError(
+                    "GitHub proposal destination must be owner/repo",
+                    provider=request.provider,
+                    destination=destination,
+                )
+            allowed_repositories = set(_iter_strings(policy.get("allowedRepositories")))
+            if allowed_repositories and destination.lower() not in {
+                repo.lower() for repo in allowed_repositories
+            }:
+                raise ProposalDeliveryError(
+                    "GitHub repository is not allowed by proposal delivery policy",
+                    provider=request.provider,
+                    destination=destination,
+                )
+            allowed_orgs = set(_iter_strings(policy.get("allowedOrganizations")))
+            org = destination.split("/", 1)[0].lower()
+            if allowed_orgs and org not in {item.lower() for item in allowed_orgs}:
+                raise ProposalDeliveryError(
+                    "GitHub organization is not allowed by proposal delivery policy",
+                    provider=request.provider,
+                    destination=destination,
+                )
+        else:
+            project = request.destination
+            allowed_projects = set(_iter_strings(policy.get("allowedProjects")))
+            if allowed_projects and project.upper() not in {
+                item.upper() for item in allowed_projects
+            }:
+                raise ProposalDeliveryError(
+                    "Jira project is not allowed by proposal delivery policy",
+                    provider=request.provider,
+                    destination=project,
+                )
+
+    def render(self, request: ProposalDeliveryRequest) -> RenderedProposalIssue:
+        if request.provider == "jira":
+            return render_jira_issue(request, redactor=self._redactor)
+        return render_github_issue(request, redactor=self._redactor)
+
+    async def deliver(self, request: ProposalDeliveryRequest) -> ProposalDeliveryResult:
+        self._validate_policy(request)
+        provider = self._provider(request.provider)
+        rendered = self.render(request)
+        existing: Mapping[str, Any] | None = None
+        if request.external_key or request.external_url:
+            existing = {
+                "key": request.external_key,
+                "url": request.external_url,
+                "source": "local_record",
+            }
+        if existing is None:
+            existing = await provider.search_issue(request)
+        if existing:
+            payload = await provider.update_issue(request, rendered, existing)
+            created = False
+            duplicate_source = _clean(existing.get("source")) or "provider"
+        else:
+            payload = await provider.create_issue(request, rendered)
+            created = True
+            duplicate_source = None
+        external_key = _clean(
+            payload.get("external_key")
+            or payload.get("externalKey")
+            or payload.get("key")
+            or payload.get("number")
+            or request.external_key
+        )
+        external_url = _clean(
+            payload.get("external_url")
+            or payload.get("externalUrl")
+            or payload.get("url")
+            or payload.get("html_url")
+            or request.external_url
+        )
+        if not external_key or not external_url:
+            raise ProposalDeliveryError(
+                "provider delivery did not return an external issue identity",
+                provider=request.provider,
+                destination=request.destination,
+                retryable=True,
+                next_action="Retry delivery after checking provider adapter response mapping.",
+            )
+        provider_metadata = _safe_metadata(
+            {
+                "marker": rendered.marker,
+                "labels": list(rendered.labels),
+                "created": created,
+                "duplicateSource": duplicate_source,
+            }
+        )
+        return ProposalDeliveryResult(
+            provider=request.provider,
+            external_key=external_key,
+            external_url=external_url,
+            created=created,
+            duplicate_source=duplicate_source,
+            provider_metadata=provider_metadata,
+        )
+
+
+__all__ = [
+    "ProposalDeliveryError",
+    "ProposalDeliveryRequest",
+    "ProposalDeliveryResult",
+    "ProposalDeliveryService",
+    "ProposalIssueProvider",
+    "GitHubProposalIssueProvider",
+    "JiraProposalIssueProvider",
+    "ProviderDecisionEvent",
+    "ProviderDecisionResult",
+    "RenderedProposalIssue",
+    "parse_provider_decision",
+    "render_github_issue",
+    "render_jira_issue",
+    "request_from_proposal",
+]

--- a/moonmind/workflows/task_proposals/delivery.py
+++ b/moonmind/workflows/task_proposals/delivery.py
@@ -155,14 +155,14 @@ class ProposalIssueProvider(Protocol):
     """Provider port used by proposal delivery orchestration."""
 
     async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, Any] | None:
-        ...
+        pass
 
     async def create_issue(
         self,
         request: ProposalDeliveryRequest,
         rendered: RenderedProposalIssue,
     ) -> dict[str, Any]:
-        ...
+        pass
 
     async def update_issue(
         self,
@@ -170,7 +170,7 @@ class ProposalIssueProvider(Protocol):
         rendered: RenderedProposalIssue,
         issue: Mapping[str, Any],
     ) -> dict[str, Any]:
-        ...
+        pass
 
 
 class GitHubProposalIssueProvider:
@@ -275,7 +275,7 @@ class JiraProposalIssueProvider:
         )
         return {
             "external_key": result.get("issueKey"),
-            "external_url": result.get("url") or result.get("self") or result.get("issueKey"),
+            "external_url": result.get("url") or result.get("self"),
         }
 
     async def update_issue(
@@ -300,7 +300,7 @@ class JiraProposalIssueProvider:
         )
         return {
             "external_key": issue_key,
-            "external_url": _clean(issue.get("url") or issue.get("self") or issue_key),
+            "external_url": _clean(issue.get("url") or issue.get("self")) or None,
         }
 
 
@@ -331,20 +331,21 @@ def _contains_secret_key(value: object) -> bool:
     return False
 
 
+def _safe_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _safe_metadata(value)
+    if isinstance(value, list):
+        return [_safe_value(item) for item in value]
+    return value
+
+
 def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     safe: dict[str, Any] = {}
     for key, value in metadata.items():
         if _SECRET_KEY_RE.search(str(key)):
             safe[str(key)] = "[REDACTED]"
-        elif isinstance(value, Mapping):
-            safe[str(key)] = _safe_metadata(value)
-        elif isinstance(value, list):
-            safe[str(key)] = [
-                _safe_metadata(item) if isinstance(item, Mapping) else item
-                for item in value
-            ]
         else:
-            safe[str(key)] = value
+            safe[str(key)] = _safe_value(value)
     return safe
 
 
@@ -516,7 +517,7 @@ def parse_provider_decision(event: ProviderDecisionEvent) -> ProviderDecisionRes
     priority: str | None = None
     defer_until: str | None = None
     if action == "priority":
-        candidate = _clean(args).lower()
+        candidate = _clean(args or event.note).lower()
         if candidate not in {"low", "normal", "high", "urgent"}:
             return ProviderDecisionResult(
                 accepted=False,
@@ -528,7 +529,7 @@ def parse_provider_decision(event: ProviderDecisionEvent) -> ProviderDecisionRes
             )
         priority = candidate
     if action == "defer":
-        defer_until = _clean(args) or None
+        defer_until = _clean(args or event.note) or None
     return ProviderDecisionResult(
         accepted=True,
         decision=action,
@@ -609,7 +610,7 @@ class ProposalDeliveryService:
             )
         policy = request.resolved_policy
         allowed_actions = set(_iter_strings(policy.get("allowedActions")))
-        if allowed_actions and not _SUPPORTED_ACTIONS.issubset(allowed_actions):
+        if allowed_actions and not allowed_actions.issubset(_SUPPORTED_ACTIONS):
             raise ProposalDeliveryError(
                 "proposal reviewer actions are not allowed by policy",
                 provider=request.provider,

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -26,6 +26,9 @@ from moonmind.workflows.task_proposals.models import (
 )
 from moonmind.workflows.task_proposals.delivery import (
     ProposalDeliveryError,
+    ProviderDecisionEvent,
+    ProviderDecisionResult,
+    parse_provider_decision,
     request_from_proposal,
 )
 from moonmind.workflows.task_proposals.repositories import (
@@ -897,6 +900,102 @@ class TaskProposalService:
         if not proposal.dedup_hash:
             return []
         return await self._repository.list_similar(proposal=proposal, limit=limit)
+
+    async def record_provider_decision_event(
+        self,
+        *,
+        proposal_id: UUID,
+        event: ProviderDecisionEvent,
+    ) -> ProviderDecisionResult:
+        """Record a bounded provider reviewer decision without trusting issue text."""
+
+        proposal = await self._repository.get_proposal_for_update(proposal_id)
+        provider_metadata = (
+            dict(getattr(proposal, "provider_metadata", {}))
+            if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
+            else {}
+        )
+        decision_rows = provider_metadata.get("providerDecisions")
+        decisions: list[dict[str, Any]] = (
+            list(decision_rows) if isinstance(decision_rows, list) else []
+        )
+        for row in decisions:
+            if not isinstance(row, Mapping):
+                continue
+            if row.get("providerEventId") == event.provider_event_id:
+                return ProviderDecisionResult(
+                    accepted=bool(row.get("accepted")),
+                    decision=self._clean_str(row.get("decision")) or None,
+                    note=self._clean_str(row.get("note")) or None,
+                    actor=self._clean_str(row.get("actor")),
+                    provider_event_id=event.provider_event_id,
+                    reason="duplicate_event",
+                    priority=self._clean_str(row.get("priority")) or None,
+                    defer_until=self._clean_str(row.get("deferUntil")) or None,
+                )
+
+        result = parse_provider_decision(event)
+        policy = (
+            dict(getattr(proposal, "resolved_policy", {}))
+            if isinstance(getattr(proposal, "resolved_policy", {}), Mapping)
+            else {}
+        )
+        allowed_actions = self._normalize_policy_tokens(
+            policy.get("allowedActions")
+            if isinstance(policy.get("allowedActions"), Sequence)
+            and not isinstance(policy.get("allowedActions"), (str, bytes))
+            else None
+        )
+        if result.accepted and allowed_actions and result.decision not in allowed_actions:
+            result = ProviderDecisionResult(
+                accepted=False,
+                decision=result.decision,
+                note=None,
+                actor=result.actor,
+                provider_event_id=result.provider_event_id,
+                reason="action_not_allowed",
+            )
+
+        resulting_state = result.decision or result.reason or "ignored"
+        if result.accepted and result.decision == "dismiss":
+            proposal.status = TaskProposalStatus.DISMISSED
+            proposal.decision_note = self._scrub_text(self._clean_str(result.note)) or None
+            resulting_state = TaskProposalStatus.DISMISSED.value
+        elif result.accepted and result.decision == "promote":
+            proposal.status = TaskProposalStatus.ACCEPTED
+            proposal.decision_note = self._scrub_text(self._clean_str(result.note)) or None
+            resulting_state = TaskProposalStatus.ACCEPTED.value
+        elif result.accepted and result.decision == "priority" and result.priority:
+            proposal.review_priority = self._normalize_review_priority(result.priority)
+            proposal.decision_note = self._scrub_text(self._clean_str(result.note)) or None
+            resulting_state = "priority"
+        elif result.accepted and result.decision == "defer":
+            proposal.decision_note = self._scrub_text(self._clean_str(result.note)) or None
+            resulting_state = "deferred"
+
+        decisions.append(
+            self._scrub_json(
+                {
+                    "provider": event.provider,
+                    "externalKey": event.external_key,
+                    "providerEventId": event.provider_event_id,
+                    "actor": event.actor,
+                    "decision": result.decision,
+                    "accepted": result.accepted,
+                    "note": result.note,
+                    "priority": result.priority,
+                    "deferUntil": result.defer_until,
+                    "observedAt": event.observed_at.isoformat(),
+                    "resultingExternalState": resulting_state,
+                    "reason": result.reason,
+                }
+            )
+        )
+        provider_metadata["providerDecisions"] = decisions
+        proposal.provider_metadata = provider_metadata
+        await self._repository.commit()
+        await self._repository.refresh(proposal)
+        return result
 
     async def promote_proposal(
         self,

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -24,6 +24,10 @@ from moonmind.workflows.task_proposals.models import (
     TaskProposalReviewPriority,
     TaskProposalStatus,
 )
+from moonmind.workflows.task_proposals.delivery import (
+    ProposalDeliveryError,
+    request_from_proposal,
+)
 from moonmind.workflows.task_proposals.repositories import (
     TaskProposalNotFoundError,
     TaskProposalRepository,
@@ -74,8 +78,10 @@ class TaskProposalService:
         repository: TaskProposalRepository,
         *,
         redactor: SecretRedactor | None = None,
+        delivery_service: object | None = None,
     ) -> None:
         self._repository = repository
+        self._delivery_service = delivery_service
         self._redactor = redactor or SecretRedactor.from_environ(
             placeholder="[REDACTED]"
         )
@@ -619,6 +625,39 @@ class TaskProposalService:
                     "Notification audit insert failed for proposal %s", proposal.id
                 )
 
+    async def _deliver_proposal_if_configured(self, proposal: TaskProposal) -> None:
+        if self._delivery_service is None:
+            return
+        existing_metadata = (
+            dict(getattr(proposal, "provider_metadata", {}))
+            if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
+            else {}
+        )
+        try:
+            result = await self._delivery_service.deliver(request_from_proposal(proposal))
+        except ProposalDeliveryError as exc:
+            existing_metadata["delivery"] = {
+                "status": "failed",
+                "error": self._scrub_json(exc.to_output(record_id=str(proposal.id))),
+            }
+            proposal.provider_metadata = existing_metadata
+            await self._repository.commit()
+            return
+        proposal.external_key = result.external_key
+        proposal.external_url = result.external_url
+        proposal.delivered_at = result.delivered_at
+        proposal.last_synced_at = result.delivered_at
+        delivery_metadata = {
+            "status": "delivered",
+            "created": result.created,
+            "duplicateSource": result.duplicate_source,
+            "storedSnapshotNotice": True,
+            **dict(result.provider_metadata or {}),
+        }
+        existing_metadata["delivery"] = self._scrub_json(delivery_metadata)
+        proposal.provider_metadata = existing_metadata
+        await self._repository.commit()
+
     async def create_proposal(
         self,
         *,
@@ -770,6 +809,7 @@ class TaskProposalService:
                     or cleaned_origin_external_id
                 )
                 await self._repository.commit()
+                await self._deliver_proposal_if_configured(duplicate)
                 refresh = getattr(self._repository, "refresh", None)
                 if callable(refresh):
                     refreshed = await refresh(duplicate)
@@ -804,6 +844,7 @@ class TaskProposalService:
             resolved_policy=scrubbed_resolved_policy,
         )
         await self._repository.commit()
+        await self._deliver_proposal_if_configured(proposal)
         await self._emit_notification(proposal)
         logger.info(
             "Created task proposal %s (repository=%s category=%s)",

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -646,6 +646,34 @@ class TaskProposalService:
             proposal.provider_metadata = existing_metadata
             await self._repository.commit()
             return
+        except Exception as exc:
+            provider = self._clean_str(getattr(proposal, "provider", "")) or "unknown"
+            destination = self._clean_str(getattr(proposal, "repository", "")) or "unknown"
+            logger.warning(
+                "Proposal delivery adapter failed for %s via %s: %s",
+                proposal.id,
+                provider,
+                type(exc).__name__,
+            )
+            existing_metadata["delivery"] = self._scrub_json(
+                {
+                    "status": "failed",
+                    "error": {
+                        "provider": provider,
+                        "destination": destination,
+                        "sanitizedReason": "provider delivery failed",
+                        "recoverableNextAction": (
+                            "Review trusted provider adapter logs and configuration."
+                        ),
+                        "retryable": True,
+                        "deliveryRecordId": str(proposal.id),
+                        "errorType": type(exc).__name__,
+                    },
+                }
+            )
+            proposal.provider_metadata = existing_metadata
+            await self._repository.commit()
+            return
         proposal.external_key = result.external_key
         proposal.external_url = result.external_url
         proposal.delivered_at = result.delivered_at
@@ -934,7 +962,26 @@ class TaskProposalService:
                     defer_until=self._clean_str(row.get("deferUntil")) or None,
                 )
 
-        result = parse_provider_decision(event)
+        proposal_provider = self._clean_str(getattr(proposal, "provider", "")).lower()
+        event_provider = self._clean_str(event.provider).lower()
+        proposal_external_key = self._clean_str(getattr(proposal, "external_key", ""))
+        event_external_key = self._clean_str(event.external_key)
+        if (
+            not proposal_provider
+            or not proposal_external_key
+            or event_provider != proposal_provider
+            or event_external_key != proposal_external_key
+        ):
+            result = ProviderDecisionResult(
+                accepted=False,
+                decision=None,
+                note=None,
+                actor=event.actor,
+                provider_event_id=event.provider_event_id,
+                reason="provider_identity_mismatch",
+            )
+        else:
+            result = parse_provider_decision(event)
         policy = (
             dict(getattr(proposal, "resolved_policy", {}))
             if isinstance(getattr(proposal, "resolved_policy", {}), Mapping)

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2978,6 +2978,8 @@ class TemporalProposalActivities:
         if self._proposal_service_factory is not None:
             try:
                 service_or_ctx = self._proposal_service_factory()
+                if inspect.isawaitable(service_or_ctx):
+                    service_or_ctx = await service_or_ctx
             except Exception as exc:
                 logger.warning(
                     "proposal.submit: failed to create proposal service: %s", exc
@@ -3104,7 +3106,7 @@ class TemporalProposalActivities:
                             "trigger_job_id": trigger_job_id,
                             "signal": {"severity": "normal", "type": "follow_up"},
                         }
-                        await service.create_proposal(
+                        proposal = await service.create_proposal(
                             title=title,
                             summary=summary,
                             category=candidate.get("category"),
@@ -3125,6 +3127,23 @@ class TemporalProposalActivities:
                                 "workflow_id": workflow_id,
                             },
                         )
+                        external_key = getattr(proposal, "external_key", None)
+                        external_url = getattr(proposal, "external_url", None)
+                        if external_key:
+                            decision["externalKey"] = external_key
+                        if external_url:
+                            decision["externalUrl"] = external_url
+                        delivery_metadata = getattr(
+                            proposal, "provider_metadata", {}
+                        )
+                        if isinstance(delivery_metadata, Mapping):
+                            delivery_node = delivery_metadata.get("delivery")
+                            if isinstance(delivery_node, Mapping):
+                                decision["deliveryStatus"] = delivery_node.get(
+                                    "status", "delivered"
+                                )
+                                if "created" in delivery_node:
+                                    decision["created"] = delivery_node["created"]
                         submitted_count += 1
                     else:
                         logger.info(

--- a/specs/312-proposal-review-delivery/checklists/requirements.md
+++ b/specs/312-proposal-review-delivery/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Proposal Review Delivery
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The original MM-598 Jira preset brief is preserved verbatim in `## Original Preset Brief`.
+- Runtime source mappings cover all in-scope MM-598 design IDs: DESIGN-REQ-001, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-027, and DESIGN-REQ-031.
+- No clarification markers remain; ready for `/speckit.plan`.

--- a/specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md
+++ b/specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md
@@ -1,5 +1,9 @@
 # Proposal Review Delivery Contract
 
+## Traceability
+
+This contract supports Jira issue `MM-598` and the external proposal delivery behavior mapped from DESIGN-REQ-001, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-027, and DESIGN-REQ-031.
+
 ## Delivery Input
 
 The proposal delivery boundary accepts a stored proposal delivery record or a validated proposal submission result with:

--- a/specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md
+++ b/specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md
@@ -1,0 +1,102 @@
+# Proposal Review Delivery Contract
+
+## Delivery Input
+
+The proposal delivery boundary accepts a stored proposal delivery record or a validated proposal submission result with:
+
+- delivery record ID
+- provider: `github` or `jira`
+- repository or Jira project destination
+- title, summary, category, tags, priority
+- dedup key/hash
+- stored proposal snapshot or `task_snapshot_ref`
+- origin run/workflow metadata
+- resolved policy metadata
+- provider metadata
+
+Rules:
+- Validate local delivery policy and allowlists before provider calls.
+- Search local open duplicates before provider delivery.
+- Search provider metadata when local state is stale or missing.
+- Do not send provider calls when the stored proposal snapshot is invalid.
+- Do not expose raw provider credentials in inputs, outputs, logs, issue bodies, or provider metadata.
+
+## GitHub Issue Delivery
+
+Create or update a GitHub Issue with:
+
+- title prefixed `[MoonMind proposal]`
+- canonical proposal labels or configured equivalents
+- category, priority, status, and dedup labels/metadata
+- hidden MoonMind marker containing delivery record ID, snapshot ref, and dedup hash
+- links to source run and relevant artifacts
+- reviewer action instructions
+- explicit stored-snapshot notice
+
+Duplicate behavior:
+- If an open issue matches the local delivery record or hidden marker, update it.
+- If an open issue matches dedup metadata, update or link it.
+- If no match exists, create a new issue.
+
+## Jira Issue Delivery
+
+Create or update a Jira issue with:
+
+- summary prefixed `[MoonMind proposal]`
+- ADF-rendered description with review context
+- configured labels/custom fields for category, priority, status, dedup hash, repository, origin, runtime, and snapshot ref when supported
+- configured workflow state or action triggers
+- source run and artifact links
+- issue links to duplicate or related proposals when applicable
+- explicit stored-snapshot notice
+
+Duplicate behavior:
+- Search local delivery record first.
+- Search Jira by configured custom fields, labels, or hidden marker metadata when available.
+- Update or link matching open Jira issues instead of creating duplicates.
+
+## Reviewer Decision Handling
+
+Accepted decisions:
+
+- promote
+- dismiss
+- defer
+- priority update
+
+Inputs:
+- provider
+- external issue identity
+- provider event ID
+- actor identity
+- decision source: comment command, workflow transition, field update, label update, or explicit provider event
+- bounded decision parameters: runtime, priority, max attempts, note, defer-until
+
+Rules:
+- Provider event IDs are idempotency keys.
+- Actor and action permissions are checked before mutation.
+- Only bounded controls are parsed.
+- Edited issue body/description text is never treated as a replacement task payload.
+- Promotion loads the stored proposal snapshot from MoonMind.
+
+## Delivery Output
+
+Successful delivery output includes:
+
+- delivery record ID
+- provider
+- external key
+- external URL
+- created or updated flag
+- duplicate source when reused
+- delivered or synced timestamp
+- sanitized warnings
+
+Failure output includes:
+
+- delivery record ID when available
+- provider
+- destination
+- sanitized reason
+- recoverable next action
+- no raw credentials, auth headers, cookies, tokens, private keys, or provider response dumps

--- a/specs/312-proposal-review-delivery/data-model.md
+++ b/specs/312-proposal-review-delivery/data-model.md
@@ -1,5 +1,9 @@
 # Data Model: Proposal Review Delivery
 
+## Traceability
+
+This data model supports Jira issue `MM-598` and the stored proposal delivery requirements mapped from DESIGN-REQ-001, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-027, and DESIGN-REQ-031.
+
 ## Proposal Delivery Record
 
 Represents one MoonMind proposal delivered or intended for delivery to an external review tracker.

--- a/specs/312-proposal-review-delivery/data-model.md
+++ b/specs/312-proposal-review-delivery/data-model.md
@@ -1,0 +1,90 @@
+# Data Model: Proposal Review Delivery
+
+## Proposal Delivery Record
+
+Represents one MoonMind proposal delivered or intended for delivery to an external review tracker.
+
+Fields:
+- `id`: stable delivery record identifier.
+- `provider`: `github` or `jira`.
+- `external_key`: provider issue number or Jira issue key when known.
+- `external_url`: provider issue URL when known.
+- `repository`: canonical repository target used for delivery and dedup.
+- `dedup_key`: human-inspectable dedup key from repository and normalized title.
+- `dedup_hash`: stable hash used for duplicate lookup.
+- `status`: proposal lifecycle state.
+- `title`, `summary`, `category`, `tags`, `review_priority`: reviewer-facing metadata.
+- `task_create_request`: stored validated proposal snapshot.
+- `task_snapshot_ref`: optional artifact-backed snapshot reference.
+- `origin_source`, `origin_id`, `origin_external_id`, `origin_metadata`: source run/workflow identity and compact evidence.
+- `provider_metadata`: provider-scoped metadata such as labels, issue properties, Jira project fields, hidden marker IDs, or sync cursors.
+- `resolved_policy`: resolved delivery provider, target, repository decision, defaulting evidence, and policy outcome.
+- `delivered_at`, `last_synced_at`: provider delivery/sync timestamps.
+- `promoted_at`, `promoted_by_user_id`, `decided_by_user_id`, `decision_note`: reviewer decision state.
+
+Validation rules:
+- `provider` must be `github` or `jira`.
+- Provider metadata must not contain raw credentials, auth headers, cookies, tokens, private keys, or plaintext secret refs.
+- Dedup identity is based on canonical repository target and normalized proposal title.
+- External key/url may be absent before delivery but must be present after confirmed provider creation/update.
+
+State transitions:
+- `open` -> provider delivered or updated while still reviewable.
+- `open` -> `promoted` after verified reviewer approval starts a new execution.
+- `open` -> `dismissed` after verified reviewer dismissal.
+- `open` -> deferred state representation through provider metadata or future status if implementation extends status vocabulary.
+- Terminal records are not treated as open duplicates.
+
+## External Proposal Issue
+
+Represents the GitHub Issue or Jira issue shown to reviewers.
+
+Fields:
+- Provider issue identity and URL.
+- Review title/summary.
+- Labels, fields, workflow state, or issue properties carrying proposal markers.
+- Human-readable body/description.
+- Dedup marker and delivery record marker.
+- Source run, artifact, and snapshot links.
+- Reviewer action controls.
+- Stored-snapshot notice.
+
+Validation rules:
+- Rendered text must not include raw executable payload replacement instructions.
+- Large logs, diagnostics, artifacts, and snapshots are linked by reference.
+- Hidden markers or issue properties must be deterministic enough for duplicate lookup.
+
+## Stored Proposal Snapshot
+
+Represents the executable source of truth for promotion.
+
+Fields:
+- Canonical task creation request or artifact ref.
+- Repository target.
+- Task instructions and compact runtime/skill/preset provenance.
+- Priority, max attempts, and bounded promotion controls.
+
+Validation rules:
+- Promotion uses this snapshot plus bounded reviewer controls only.
+- Edited external issue content cannot replace this snapshot.
+- Snapshot refs must not expose raw storage keys or presigned URLs.
+
+## Provider Decision Event
+
+Represents a reviewer action observed through GitHub or Jira.
+
+Fields:
+- Provider.
+- Provider event ID or equivalent idempotency key.
+- External issue key/URL.
+- Actor identity.
+- Decision: promote, dismiss, defer, or priority.
+- Optional note/reason.
+- Observed timestamp.
+- Resulting external issue state.
+
+Validation rules:
+- Duplicate provider event IDs are no-ops.
+- Actor and action must pass provider policy before mutation.
+- Event body text is untrusted except for explicit configured command fields.
+- Decision output must be redacted before persistence or user-visible reporting.

--- a/specs/312-proposal-review-delivery/plan.md
+++ b/specs/312-proposal-review-delivery/plan.md
@@ -53,8 +53,8 @@ Deliver MM-598 by extending the existing task proposal delivery-record foundatio
 **Language/Version**: Python 3.12  
 **Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, FastAPI, Temporal Python SDK activity boundaries, `httpx`, existing Jira trusted tool service, existing GitHub service/auth helpers, pytest  
 **Storage**: Existing `task_proposals` table and `311_proposal_delivery_records` migration fields; no new persistent table planned unless provider decision audit cannot reuse existing proposal metadata/decision fields  
-**Unit Testing**: pytest through `./tools/test_unit.sh`; focused iteration with `python -m pytest tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q`  
-**Integration Testing**: pytest boundary/integration coverage for proposal submit-to-delivery behavior and persisted delivery records; run `./tools/test_integration.sh` if `integration_ci` tests are added  
+**Unit Testing**: pytest through `./tools/test_unit.sh`; focused iteration with `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q`
+**Integration Testing**: pytest boundary/integration coverage for proposal submit-to-delivery behavior and persisted delivery records; focused iteration with `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`; run `./tools/test_integration.sh` if `integration_ci` tests are added
 **Target Platform**: MoonMind backend control plane and Temporal worker runtime on Linux  
 **Project Type**: Python backend workflow/runtime service with trusted external provider integrations  
 **Performance Goals**: Dedup lookup and rendering remain bounded per proposal candidate; provider delivery performs local validation and duplicate checks before external calls  

--- a/specs/312-proposal-review-delivery/plan.md
+++ b/specs/312-proposal-review-delivery/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: Proposal Review Delivery
+
+**Branch**: `312-proposal-review-delivery` | **Date**: 2026-05-07 | **Spec**: specs/312-proposal-review-delivery/spec.md
+**Input**: Single-story feature specification from `specs/312-proposal-review-delivery/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted but rejected the managed branch name `change-jira-issue-mm-598-to-status-in-pr-dd08a68f` because it is not in `001-feature-name` form. Planning continued with `.specify/feature.json` and the active feature directory.
+
+## Summary
+
+Deliver MM-598 by extending the existing task proposal delivery-record foundation into provider-facing GitHub Issue and Jira issue delivery. Current code already normalizes proposal policy, persists delivery-record fields, records provider metadata, performs local open-duplicate reuse, and exposes proposal fields through `/api/proposals`. The missing behavior is the external tracker delivery layer: provider-specific issue rendering, GitHub/Jira create-or-update adapters, stored-snapshot notices, safe reviewer controls, provider-event decision normalization, allowlist enforcement at the proposal delivery boundary, and existing task run/finish-summary visibility. The plan uses TDD with focused unit tests for rendering, policy, dedup, redaction, and provider adapters, plus hermetic boundary/integration coverage for proposal submit-to-delivery behavior and persisted delivery records.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `TaskProposalRepository.find_open_duplicate()` and `TaskProposalService.create_proposal()` reuse local open duplicates by provider/repository/dedup hash, but no provider issue create/update adapter exists | add provider delivery orchestration that creates or updates exactly one GitHub/Jira issue per destination and dedup target | unit + boundary/integration |
+| FR-002 | implemented_verified | `moonmind/workflows/task_proposals/models.py`, `repositories.py`, `api_service/migrations/versions/311_proposal_delivery_records.py`, and tests serialize provider/external/dedup/snapshot fields | preserve existing delivery-record fields and use them from the new delivery path | final verify |
+| FR-003 | implemented_verified | `TaskProposalService._compute_dedup_fields()` and `tests/unit/workflows/task_proposals/test_service.py` cover repository-aware normalized-title dedup | preserve current dedup identity and reuse it before provider delivery | final verify |
+| FR-004 | partial | local duplicate merge tests cover open record reuse, but provider metadata search/update and provider-side issue annotation are absent | add provider-side duplicate lookup/update/link behavior using local record and provider metadata before create | unit + boundary/integration |
+| FR-005 | missing | no proposal-specific GitHub Issue create/update renderer or adapter found; `GitHubService` is PR/readiness-oriented | add GitHub proposal issue renderer and trusted create/update path with labels, hidden marker, links, and reviewer instructions | unit + boundary |
+| FR-006 | partial | `JiraToolService.create_issue()`, `edit_issue()`, `search_issues()`, ADF helpers, and policy enforcement exist, but no proposal-specific Jira delivery adapter uses them | add Jira proposal issue renderer and trusted create/update path with ADF description, configured fields, states/triggers, links, and related issue metadata | unit + boundary |
+| FR-007 | missing | no external issue rendering layer currently emits stored-snapshot notices | include a stored-snapshot notice in both GitHub Markdown and Jira ADF renderers | unit |
+| FR-008 | partial | promotion uses stored `task_create_request` and API tests reject taskCreateRequest override; provider decision ingestion is not implemented | keep promotion snapshot-only and add provider command/event parsing that accepts only bounded controls | unit + boundary |
+| FR-009 | missing | no proposal-specific promote/dismiss/defer/priority provider command or workflow-state handler found | define and implement reviewer action controls for GitHub commands and Jira workflow/field/comment triggers | unit + boundary |
+| FR-010 | partial | `promote_proposal()` and `dismiss_proposal()` record user decisions; provider event identity and deferred/priority decisions are not modeled end to end | add provider decision event normalization and audit metadata for promote, dismiss, defer, and priority changes | unit + boundary/integration |
+| FR-011 | partial | Jira tool service enforces Jira project/action policy; GitHub permission profiles exist; proposal delivery itself has no destination/action allowlist gate | enforce repository/org/Jira site/project/action policy before provider issue delivery and decision handling | unit + boundary |
+| FR-012 | partial | proposal service scrubs stored metadata and trusted Jira/GitHub services keep credentials behind integration boundaries; no proposal provider adapter exists yet | ensure delivery adapters resolve credentials internally, redact errors, and never place credentials in issue text, logs, or API responses | unit + boundary |
+| FR-013 | partial | Jira/GitHub services expose sanitized summaries; proposal delivery path does not yet normalize provider errors | add sanitized proposal delivery error shape and persist/report recoverable next action | unit + boundary |
+| FR-014 | partial | delivery records can carry `task_snapshot_ref` and external URLs, but no issue renderer links run evidence/artifact refs | render links to stored snapshots, run evidence, logs, and diagnostics by reference only | unit |
+| FR-015 | partial | `/api/proposals` serializes external fields; no evidence found that task run details or finish summaries expose delivered proposal links | surface delivery status and external issue links in existing run detail/finish-summary outputs | unit + integration |
+| FR-016 | implemented_unverified | `spec.md` preserves MM-598 and original brief; this plan preserves it | preserve MM-598 through plan, tasks, verification, commit, and PR metadata | final verify |
+| SCN-001 | missing | no GitHub proposal issue create/update flow | add GitHub delivery scenario coverage | unit + boundary |
+| SCN-002 | partial | trusted Jira create/edit tools exist, but no proposal delivery flow | add Jira delivery scenario coverage | unit + boundary |
+| SCN-003 | partial | local duplicate record reuse exists; provider-side duplicate create/update is missing | add duplicate provider issue update/link coverage | unit + boundary |
+| SCN-004 | missing | no reviewer action rendering/handling from provider surfaces | add reviewer action instruction and decision handling tests | unit + boundary |
+| SCN-005 | partial | stored-snapshot promotion exists, but provider text/command ingestion is absent | add safety tests proving edited provider text cannot replace the stored snapshot | unit + boundary |
+| SCN-006 | partial | Jira/GitHub service-level policies exist; proposal delivery policy gate is absent | add blocked destination/action tests with sanitized output | unit + boundary |
+| SC-001 | partial | local dedup tests cover one record path, not provider surfaces | prove repeated proposals produce one open external issue in covered delivery tests | unit + boundary |
+| SC-002 | missing | no renderer tests for GitHub/Jira review context completeness | add renderer contract tests for required elements | unit |
+| SC-003 | implemented_unverified | promotion override rejection exists; provider edited-text safety lacks coverage | add provider decision safety tests; keep existing promotion tests | unit + boundary |
+| SC-004 | partial | redaction helpers and trusted services exist; no delivery-specific tests | add allowlist/redaction tests at proposal delivery boundary | unit + boundary |
+| SC-005 | partial | API proposal serialization exists; run detail/finish summary linkage not proven | add run detail or finish summary exposure tests | unit + integration |
+| SC-006 | implemented_unverified | `spec.md` and this plan preserve MM-598 and mapped source design IDs | preserve through tasks and final verification | final verify |
+| DESIGN-REQ-001 | partial | delivery records exist; external issue create/update does not | same as FR-001/FR-002/FR-015 | unit + boundary |
+| DESIGN-REQ-014 | partial | local dedup exists; provider duplicate lookup/update missing | same as FR-003/FR-004 | unit + boundary |
+| DESIGN-REQ-015 | missing | no GitHub proposal issue renderer/adapter | same as FR-005/FR-007/FR-009/FR-014 | unit + boundary |
+| DESIGN-REQ-016 | partial | trusted Jira create/edit/search and ADF exist; no proposal-specific adapter | same as FR-006/FR-007/FR-009/FR-014 | unit + boundary |
+| DESIGN-REQ-027 | partial | stored snapshot promotion exists; external rendered issue safety missing | same as FR-007/FR-008/FR-014 | unit + boundary |
+| DESIGN-REQ-031 | partial | trusted Jira/GitHub primitives exist; proposal provider adapter boundary missing | same as FR-010/FR-011/FR-012/FR-013 | unit + boundary |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, FastAPI, Temporal Python SDK activity boundaries, `httpx`, existing Jira trusted tool service, existing GitHub service/auth helpers, pytest  
+**Storage**: Existing `task_proposals` table and `311_proposal_delivery_records` migration fields; no new persistent table planned unless provider decision audit cannot reuse existing proposal metadata/decision fields  
+**Unit Testing**: pytest through `./tools/test_unit.sh`; focused iteration with `python -m pytest tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q`  
+**Integration Testing**: pytest boundary/integration coverage for proposal submit-to-delivery behavior and persisted delivery records; run `./tools/test_integration.sh` if `integration_ci` tests are added  
+**Target Platform**: MoonMind backend control plane and Temporal worker runtime on Linux  
+**Project Type**: Python backend workflow/runtime service with trusted external provider integrations  
+**Performance Goals**: Dedup lookup and rendering remain bounded per proposal candidate; provider delivery performs local validation and duplicate checks before external calls  
+**Constraints**: Provider credentials stay inside trusted integration boundaries; delivery is idempotent and retry-safe; external issue text is never executable; workflow/activity payload boundaries require regression tests; canonical docs stay desired-state only  
+**Scale/Scope**: One proposal delivery story covering GitHub Issues and Jira issues, dedup-first delivery, rendered review artifacts, safe decision controls, provider policy enforcement, and run-visible delivery links
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The plan adds provider adapter boundaries around external trackers and does not alter agent cognition.
+- II. One-Click Agent Deployment: PASS. Uses existing optional Jira/GitHub integrations and keeps local development available without mandatory external credentials.
+- III. Avoid Vendor Lock-In: PASS. GitHub and Jira behavior lives behind proposal provider adapters with a portable delivery-record contract.
+- IV. Own Your Data: PASS. Stored proposal snapshots and delivery records remain in operator-controlled storage.
+- V. Skills Are First-Class and Easy to Add: PASS. Proposal delivery preserves task payload and skill intent without re-expanding live presets.
+- VI. Design for Deletion / Thick Contracts: PASS. Renderer, adapter, and decision contracts make provider-specific code replaceable.
+- VII. Runtime Configurability: PASS. Delivery provider and metadata continue through task proposal policy and settings defaults.
+- VIII. Modular and Extensible Architecture: PASS. Changes are scoped to proposal delivery service/adapter boundaries and existing API/workflow surfaces.
+- IX. Resilient by Default: PASS. Dedup-first delivery, provider event idempotency, redacted failure summaries, and retry-safe updates are explicit requirements.
+- X. Facilitate Continuous Improvement: PASS. The feature makes generated follow-up work reviewable in external trackers.
+- XI. Spec-Driven Development: PASS. `spec.md`, `plan.md`, and design artifacts preserve MM-598 before implementation.
+- XII. Canonical Documentation Separation: PASS. Migration and execution details remain under `specs/312-*`; canonical docs remain source requirements.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility aliases are planned; internal proposal contracts should be updated consistently with tests.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/312-proposal-review-delivery/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── proposal-review-delivery-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # created by /speckit.tasks, not this step
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── integrations/
+│   └── jira/
+│       ├── adf.py
+│       ├── models.py
+│       └── tool.py
+├── workflows/
+│   ├── adapters/
+│   │   └── github_service.py
+│   ├── task_proposals/
+│   │   ├── models.py
+│   │   ├── repositories.py
+│   │   ├── service.py
+│   │   └── delivery.py          # planned provider adapter/rendering boundary
+│   └── temporal/
+│       └── activity_runtime.py
+
+api_service/
+├── api/routers/task_proposals.py
+├── api/routers/task_dashboard.py
+├── db/models.py
+└── migrations/versions/
+
+tests/
+├── unit/
+│   ├── api/routers/test_task_proposals.py
+│   ├── integrations/test_jira_tool_service.py
+│   └── workflows/
+│       ├── task_proposals/test_service.py
+│       ├── task_proposals/test_delivery.py
+│       └── temporal/test_proposal_activities.py
+└── integration/
+    └── temporal/ or service/API boundary tests as needed
+```
+
+**Structure Decision**: Reuse existing proposal service, repository, API, Temporal activity, Jira tool, and GitHub service boundaries. Add a proposal delivery module only if implementation needs a focused provider adapter/renderer boundary; add migrations only if existing delivery-record fields cannot carry required external issue and decision metadata.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| None | N/A | N/A |

--- a/specs/312-proposal-review-delivery/quickstart.md
+++ b/specs/312-proposal-review-delivery/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Proposal Review Delivery
+
+## Scope
+
+Validate MM-598 as a single runtime story: proposals are delivered to GitHub Issues or Jira issues as review artifacts while MoonMind keeps the stored proposal snapshot as the executable source of truth.
+
+## Focused Unit Iteration
+
+```bash
+python -m pytest \
+  tests/unit/workflows/task_proposals/test_service.py \
+  tests/unit/workflows/task_proposals/test_delivery.py \
+  tests/unit/workflows/temporal/test_proposal_activities.py \
+  tests/unit/api/routers/test_task_proposals.py \
+  -q
+```
+
+Expected coverage:
+- GitHub issue renderer includes title prefix, labels, hidden marker, evidence links, reviewer commands, dedup marker, and stored-snapshot notice.
+- Jira issue renderer emits ADF description, configured labels/fields, workflow/action trigger metadata, evidence links, dedup marker, and stored-snapshot notice.
+- Delivery service creates or updates one issue per provider/destination/dedup target.
+- Duplicate local records and provider metadata cause update/link/comment behavior, not duplicate issue creation.
+- Provider decision events accept only bounded controls and never replace the stored snapshot from edited issue text.
+- Provider policy denial and provider errors are sanitized.
+
+## Full Unit Suite
+
+```bash
+./tools/test_unit.sh
+```
+
+Use this before final implementation handoff to confirm the broader backend and frontend unit suite still passes.
+
+## Integration Strategy
+
+If implementation adds compose-backed persistence or activity/API boundary coverage, run:
+
+```bash
+./tools/test_integration.sh
+```
+
+Integration coverage should stay hermetic:
+- no real GitHub or Jira credentials
+- fake provider clients or trusted service stubs
+- local database fixtures only
+- `integration_ci` marker only when compose-backed dependencies are required
+
+## End-To-End Story Validation
+
+1. Seed or create a proposal candidate for a GitHub-configured destination.
+2. Run proposal submission/delivery with fake provider client.
+3. Confirm one GitHub Issue payload is created or updated and the delivery record stores external URL/key.
+4. Repeat the same proposal and confirm no duplicate issue is created.
+5. Seed or create a proposal candidate for a Jira-configured destination.
+6. Run proposal submission/delivery with fake Jira service.
+7. Confirm one Jira issue payload is created or updated with ADF review description and delivery metadata.
+8. Simulate provider reviewer commands or workflow-state events for promote, dismiss, defer, and priority.
+9. Confirm decisions are idempotent, actor/policy checked, redacted, and applied only to the stored MoonMind snapshot.
+10. Confirm task run details or finish summary expose proposal delivery status and external issue links.
+
+## Final Traceability Checks
+
+```bash
+rg -n "MM-598|DESIGN-REQ-001|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-016|DESIGN-REQ-027|DESIGN-REQ-031" specs/312-proposal-review-delivery
+```
+
+Expected result: all identifiers remain present in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, later `tasks.md`, and final verification evidence.

--- a/specs/312-proposal-review-delivery/research.md
+++ b/specs/312-proposal-review-delivery/research.md
@@ -1,0 +1,145 @@
+# Research: Proposal Review Delivery
+
+## Setup Script
+
+Decision: Proceed with manual planning artifacts in the active feature directory.
+Evidence: `.specify/scripts/bash/setup-plan.sh --json` failed because the managed branch name is `change-jira-issue-mm-598-to-status-in-pr-dd08a68f`, not `001-feature-name`; `.specify/feature.json` points at `specs/312-proposal-review-delivery`.
+Rationale: The active spec is valid and downstream artifacts can be created deterministically despite the helper's branch-name guard.
+Alternatives considered: Renaming the branch was rejected because this managed step is limited to planning artifacts and should not mutate branch state.
+Test implications: None beyond final artifact verification.
+
+## FR-001 / External Issue Create-Or-Update
+
+Decision: Add proposal delivery orchestration that performs local dedup lookup, then provider-specific GitHub/Jira issue create-or-update.
+Evidence: `TaskProposalService.create_proposal()` persists or reuses local delivery records, but no proposal-specific provider issue creation adapter was found.
+Rationale: Delivery records alone do not satisfy reviewer-facing GitHub/Jira delivery.
+Alternatives considered: Keeping proposals only in `/api/proposals` was rejected because the MM-598 story requires external trackers as the review surfaces.
+Test implications: Unit tests for delivery orchestration and provider adapter calls; boundary/integration tests for submit-to-record-to-delivery flow.
+
+## FR-002 / Delivery Record Shape
+
+Decision: Reuse the existing `task_proposals` delivery-record fields.
+Evidence: `TaskProposal` includes provider, external key/url, delivered/synced timestamps, snapshot ref, provider metadata, resolved policy, dedup fields, origin, and status; route tests serialize these fields.
+Rationale: The record shape already matches the desired audit/idempotency role closely enough for this story.
+Alternatives considered: A new delivery table was rejected unless implementation proves provider decision audit cannot fit the existing record/metadata fields.
+Test implications: Final verification plus regression tests when delivery updates these fields.
+
+## FR-003 / Dedup Identity
+
+Decision: Preserve repository-aware normalized-title dedup identity.
+Evidence: `TaskProposalService._compute_dedup_fields()` hashes `repository:slugified-title`; unit tests verify repository-aware and title-normalized behavior.
+Rationale: This matches source section 5.2 and avoids adding unrelated fields to the dedup identity.
+Alternatives considered: Including provider-specific issue type or category in the hash was rejected because it would reduce dedup effectiveness for the same review item.
+Test implications: Final verification plus duplicate delivery tests.
+
+## FR-004 / Provider Duplicate Update Path
+
+Decision: Extend duplicate handling beyond local records to provider issue metadata and update/link/comment behavior.
+Evidence: `find_open_duplicate()` and duplicate metadata merge exist locally; provider issue metadata search/update was not found.
+Rationale: A repeated proposal must not create duplicate reviewer-facing provider issues even when the local record is stale or provider metadata is authoritative.
+Alternatives considered: Relying only on local records was rejected because source section 5.2 explicitly includes provider-specific issue metadata.
+Test implications: Unit tests with mocked provider lookup/update and stale-local-record cases.
+
+## FR-005 / GitHub Proposal Issue Rendering
+
+Decision: Add a GitHub renderer and trusted issue adapter for `[MoonMind proposal]` issues.
+Evidence: `GitHubService` currently covers pull-request operations and issue-read permission evidence, but no proposal issue create/update method or renderer was found.
+Rationale: GitHub Issues are a required review surface with labels, hidden marker, evidence links, and reviewer instructions.
+Alternatives considered: Encoding proposal details in PR comments was rejected because the spec requires GitHub Issues.
+Test implications: Unit tests for Markdown body, labels, hidden marker, dedup marker, action instructions, and sanitized link rendering.
+
+## FR-006 / Jira Proposal Issue Rendering
+
+Decision: Add a Jira renderer that uses trusted Jira tool service primitives for create/update/search.
+Evidence: `JiraToolService` provides create, edit, search, transitions, comments, project/action policy, and ADF helpers; no proposal-specific Jira delivery adapter was found.
+Rationale: Jira delivery should reuse trusted Jira boundaries rather than raw REST or shell credentials.
+Alternatives considered: Calling Jira MCP tools from agent runtime was rejected for product implementation because delivery belongs in trusted control-plane/provider code.
+Test implications: Unit tests for ADF description, configured labels/fields, project/type metadata, stored-snapshot notice, and sanitized errors.
+
+## FR-007 / Stored-Snapshot Notice
+
+Decision: Include an explicit stored-snapshot notice in every rendered external issue.
+Evidence: Existing records can carry `task_snapshot_ref`, but no issue renderer currently emits a notice.
+Rationale: Reviewers must understand that issue text is a review artifact, not executable payload.
+Alternatives considered: Relying on docs alone was rejected because the notice must be visible at review time.
+Test implications: Renderer tests for GitHub Markdown and Jira ADF.
+
+## FR-008 / Snapshot-Only Promotion Safety
+
+Decision: Preserve existing promotion behavior and add provider decision parsing that only accepts bounded controls.
+Evidence: `promote_proposal()` uses stored `task_create_request`; API tests reject `taskCreateRequest` override on promotion. No provider command/event parser exists.
+Rationale: The strongest existing safety property should be extended to external tracker actions.
+Alternatives considered: Parsing full edited issue body into task payload was rejected by the source design and spec.
+Test implications: Unit tests proving edited issue content cannot replace the stored snapshot.
+
+## FR-009 / Reviewer Action Controls
+
+Decision: Implement explicit promote, dismiss, defer, and priority controls per provider.
+Evidence: Service supports promote, dismiss, and priority update API paths; no provider-originated command/workflow-state handler was found, and deferral is not end-to-end.
+Rationale: External trackers are the review surfaces, so reviewer actions must be available there.
+Alternatives considered: Keeping all actions in MoonMind API/UI was rejected because reviewers should not need a dedicated MoonMind proposal queue.
+Test implications: Command/state parsing tests and provider decision boundary tests.
+
+## FR-010 / Provider Decision Audit
+
+Decision: Add normalized provider decision event metadata with actor, provider event identity, decision, note/reason, timestamp, and resulting provider state.
+Evidence: `promote_proposal()` and `dismiss_proposal()` record MoonMind user decisions; provider event identity and deferred decisions are missing.
+Rationale: Provider webhooks and polling can repeat or arrive out of order, so decisions need stable audit and idempotency metadata.
+Alternatives considered: Treating provider events as anonymous service calls was rejected because source section 11 requires identity and event idempotency.
+Test implications: Unit/boundary tests for duplicate provider event no-op and decision metadata persistence.
+
+## FR-011 / Destination And Action Policy
+
+Decision: Enforce delivery destination and action policy before provider calls.
+Evidence: Jira tool service enforces Jira project/action policy; GitHub service resolves permissions for PR/readiness paths; proposal delivery has no dedicated allowlist gate yet.
+Rationale: The proposal delivery adapter is the correct place to stop blocked repositories, organizations, Jira sites/projects, and actions before side effects.
+Alternatives considered: Letting provider APIs reject unauthorized calls was rejected because operator-visible failures must be policy-aware and sanitized.
+Test implications: Unit tests for blocked GitHub repository/org, blocked Jira project/site, and blocked action outcomes.
+
+## FR-012 / Credential Boundary And Redaction
+
+Decision: Keep credential resolution inside trusted provider services and scrub all persisted/output text.
+Evidence: Proposal service uses `SecretRedactor`; Jira and GitHub services resolve credentials internally. Proposal delivery adapter does not exist yet.
+Rationale: External tracker delivery must not leak provider credentials to managed agents, issue text, logs, comments, or API responses.
+Alternatives considered: Passing raw provider tokens through proposal activity inputs was rejected by security guardrails.
+Test implications: Redaction tests for provider metadata, errors, rendered body, and logs where practical.
+
+## FR-013 / Sanitized Provider Errors
+
+Decision: Normalize provider errors into sanitized delivery outcomes with affected destination and recoverable next action.
+Evidence: Jira/GitHub services already sanitize several low-level errors; proposal delivery needs a story-specific error contract.
+Rationale: Operators need actionable status without secrets or raw provider dumps.
+Alternatives considered: Returning raw exceptions from provider clients was rejected by the spec and security rules.
+Test implications: Unit tests for Jira/GitHub permission failure, validation failure, transient failure, and policy denial summaries.
+
+## FR-014 / Evidence References
+
+Decision: Render evidence refs and artifact/snapshot links by reference only.
+Evidence: `task_snapshot_ref`, `external_url`, and origin metadata fields exist; no renderer links evidence yet.
+Rationale: Large logs and sensitive artifacts must stay behind artifact refs and operator-controlled access.
+Alternatives considered: Embedding full logs or snapshots in external issues was rejected by source section 5.5 and security constraints.
+Test implications: Renderer tests confirm links/refs are present and large raw payloads are absent.
+
+## FR-015 / Run Detail And Finish Summary Visibility
+
+Decision: Add or verify existing task run detail and finish summary surfaces expose proposal delivery status and external links.
+Evidence: `/api/proposals` serializes external fields; no direct evidence was found in task run details or finish summaries for delivered proposal links.
+Rationale: Operators should see external tracker delivery without switching to a dedicated proposal queue.
+Alternatives considered: Adding a new proposal page was rejected because the desired system avoids a primary MoonMind proposal queue.
+Test implications: API/router or workflow summary tests for delivery status and external URL projection.
+
+## Unit Test Strategy
+
+Decision: Use pytest unit tests for renderers, delivery orchestration, provider adapter decisions, redaction, and service/repository behavior.
+Evidence: Existing proposal tests live in `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/workflows/temporal/test_proposal_activities.py`, and `tests/unit/api/routers/test_task_proposals.py`.
+Rationale: The highest-risk behavior can be validated without live provider credentials.
+Alternatives considered: Provider verification tests were rejected for required coverage because this story should remain hermetic.
+Test implications: Run focused pytest during implementation, then `./tools/test_unit.sh`.
+
+## Integration / Boundary Test Strategy
+
+Decision: Add boundary-style tests for proposal submit-to-delivery flow and persisted record updates; use `integration_ci` only if compose-backed DB/API coverage is necessary.
+Evidence: The repo has hermetic integration taxonomy and existing proposal activity/service boundaries.
+Rationale: Provider delivery touches activity/service/repository/API contracts where mocks alone can miss shape drift.
+Alternatives considered: Testing only renderer helpers was rejected because delivery records and provider metadata must persist consistently.
+Test implications: Run `./tools/test_integration.sh` if integration_ci coverage is added; otherwise document why unit boundary tests are sufficient.

--- a/specs/312-proposal-review-delivery/research.md
+++ b/specs/312-proposal-review-delivery/research.md
@@ -1,5 +1,9 @@
 # Research: Proposal Review Delivery
 
+## Traceability
+
+This research artifact supports Jira issue `MM-598` and the single-story feature request "Deliver proposals to GitHub and Jira review surfaces". Source design coverage is preserved for DESIGN-REQ-001, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-027, and DESIGN-REQ-031.
+
 ## Setup Script
 
 Decision: Proceed with manual planning artifacts in the active feature directory.

--- a/specs/312-proposal-review-delivery/spec.md
+++ b/specs/312-proposal-review-delivery/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Proposal Review Delivery
+
+**Feature Branch**: `312-proposal-review-delivery`
+**Created**: 2026-05-07
+**Status**: Draft
+**Input**: Trusted Jira preset brief for MM-598 from `/work/agent_jobs/mm:615f63f1-adb1-406d-acf8-a3fce1b3a8e1/artifacts/moonspec-orchestration-input-MM-598.md`. Preserve `MM-598` and the original preset brief for final verification.
+
+Preserved source Jira preset brief: `MM-598` from the trusted Jira preset brief handoff, reproduced verbatim in `## Original Preset Brief` below for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response plus normalized trusted Jira issue detail `/api/jira/issues/MM-598?projectKey=MM`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-598` under `specs/` or `.specify`, so `Specify` is the first incomplete stage.
+
+## Original Preset Brief
+
+```text
+# MM-598 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-598
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Deliver proposals to GitHub and Jira review surfaces
+- Trusted fetch tool: `jira.get_issue`
+- Normalized detail source: `/api/jira/issues/MM-598?projectKey=MM`
+- Canonical source: `recommendedImports.presetInstructions` from the normalized trusted Jira issue detail response, with normalized acceptance criteria preserved below for MoonSpec coverage.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-598 from MM project
+Summary: Deliver proposals to GitHub and Jira review surfaces
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-598 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-598: Deliver proposals to GitHub and Jira review surfaces
+
+Source Reference
+Source Document: docs/Tasks/TaskProposalSystem.md
+Source Title: Task Proposal System
+Source Sections:
+- 5. External Proposal Delivery
+- 9.4 Provider adapters
+- 11. Security and Integrity
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-014
+- DESIGN-REQ-015
+- DESIGN-REQ-016
+- DESIGN-REQ-027
+- DESIGN-REQ-031
+
+As a reviewer, I need MoonMind proposals delivered as GitHub Issues or Jira issues with clear review context, canonical commands or workflow states, dedup markers, and safe links back to run evidence.
+
+Acceptance Criteria
+- GitHub issues are created or updated with [MoonMind proposal] titles, canonical labels, hidden markers, source links, dedup metadata, and reviewer action instructions.
+- Jira issues are created or updated with [MoonMind proposal] summaries, ADF descriptions, labels/custom fields, canonical workflow states, source links, and configured action triggers.
+- Issue bodies/descriptions include a clear stored-snapshot notice and never embed raw executable payload replacement instructions.
+- Provider adapters enforce repository, organization, Jira site, Jira project, and action allowlists.
+- Provider credentials and raw provider errors are never exposed to managed agent environments, logs, comments, or API responses.
+
+Requirements
+- Implement provider-specific delivery through adapter boundaries.
+- Render review artifacts from stored proposal snapshots and references.
+- Enforce delivery idempotency and security controls at the provider boundary.
+
+Implementation Notes
+- Preserve MM-598 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskProposalSystem.md` as the source design reference for external proposal delivery, provider adapter behavior, security, and integrity.
+- Scope implementation to delivering MoonMind proposals to GitHub Issues and Jira issues through provider-specific adapter boundaries.
+- Include clear review context, canonical commands or workflow states, dedup markers or metadata, safe links back to run evidence, and configured action triggers.
+- Render issue bodies/descriptions from stored proposal snapshots and references; do not embed raw executable payload replacement instructions.
+- Enforce repository, organization, Jira site, Jira project, and action allowlists at provider boundaries.
+- Keep provider credentials and raw provider errors out of managed agent environments, logs, comments, and API responses.
+```
+
+## User Story - Deliver Proposals To External Review Surfaces
+
+**Summary**: As a reviewer, I want MoonMind proposals delivered to GitHub Issues or Jira issues with clear review context, safe action controls, and evidence links so I can triage, approve, defer, or dismiss follow-up work in the tracker I already use.
+
+**Goal**: Reviewers can use configured GitHub or Jira review surfaces as the authoritative human triage location while MoonMind preserves the stored proposal snapshot as the executable source of truth.
+
+**Independent Test**: Can be validated end-to-end by submitting proposal candidates for one GitHub destination and one Jira destination, then confirming each destination receives a deduplicated external issue with review context, action instructions or workflow states, safe evidence links, and no executable payload replacement in the issue body.
+
+**Acceptance Scenarios**:
+
+1. **Given** a proposal is ready for a GitHub-configured repository, **When** MoonMind delivers the proposal, **Then** a GitHub Issue is created or updated with a `[MoonMind proposal]` title, canonical proposal labels, dedup metadata, source evidence links, reviewer action instructions, and a notice that execution uses the stored MoonMind snapshot.
+2. **Given** a proposal is ready for a Jira-configured project, **When** MoonMind delivers the proposal, **Then** a Jira issue is created or updated with a `[MoonMind proposal]` summary, rich review description, configured metadata, canonical workflow state or action triggers, source evidence links, and a stored-snapshot notice.
+3. **Given** a matching open proposal already exists for the same provider destination and dedup target, **When** MoonMind processes the repeated proposal, **Then** the existing external issue is updated or linked instead of creating a duplicate reviewer-facing issue.
+4. **Given** a reviewer reads the external issue, **When** they inspect available actions, **Then** they can identify the supported promote, dismiss, defer, or reprioritize controls without needing a MoonMind-hosted proposal queue.
+5. **Given** tracker content, comments, labels, fields, or descriptions are edited outside MoonMind, **When** promotion or decision handling evaluates the issue, **Then** MoonMind treats tracker text as untrusted and uses only the stored proposal snapshot plus bounded, validated reviewer controls.
+6. **Given** a provider destination, organization, repository, site, project, or action is not allowed by policy, **When** delivery or decision handling is attempted, **Then** MoonMind blocks the action with a sanitized operator-visible reason and does not expose provider credentials or raw provider errors.
+
+### Edge Cases
+
+- A matching issue exists in the provider but local delivery state is missing or stale.
+- Provider delivery succeeds but one optional metadata field, label, or custom field cannot be applied.
+- Provider delivery fails transiently after dedup lookup but before issue creation or update is confirmed.
+- A reviewer edits issue text to include replacement task instructions or unsafe commands.
+- Provider webhook or sync events are delivered more than once or arrive out of order.
+- Evidence links or large artifacts are unavailable, expired, or too large to embed directly.
+
+## Assumptions
+
+- GitHub or Jira delivery is selected by the existing proposal delivery policy and tracker binding for the proposal destination.
+- A validated stored proposal snapshot or snapshot reference exists before external delivery begins.
+- Review action names and workflow states use the configured provider conventions when a project customizes labels, fields, or workflow transitions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST create or update exactly one external GitHub Issue or Jira issue for each proposal destination and dedup target.
+- **FR-002**: MoonMind MUST maintain a durable delivery record that identifies the provider, external issue, destination, dedup identity, proposal status, source run, evidence references, and stored proposal snapshot or snapshot reference.
+- **FR-003**: MoonMind MUST compute and apply repository-aware dedup metadata before creating a new external issue.
+- **FR-004**: MoonMind MUST update or link to an existing matching open external issue instead of creating duplicate reviewer-facing issues.
+- **FR-005**: GitHub proposal issues MUST include a `[MoonMind proposal]` title, canonical proposal labels or equivalent metadata, a rendered review body, dedup marker, source evidence links, and reviewer action instructions.
+- **FR-006**: Jira proposal issues MUST include a `[MoonMind proposal]` summary, structured review description, configured labels or fields, canonical workflow state or action triggers, source evidence links, and related issue links when applicable.
+- **FR-007**: External issue content MUST clearly state that MoonMind executes the stored proposal snapshot rather than edited issue text.
+- **FR-008**: MoonMind MUST NOT accept arbitrary edited issue body text, Markdown, rich text, labels, fields, or comments as a replacement executable task payload.
+- **FR-009**: MoonMind MUST support reviewer promote, dismiss, defer, and priority controls through explicit configured commands, workflow states, fields, labels, or transitions.
+- **FR-010**: MoonMind MUST record reviewer decisions with actor identity, provider event identity, decision note or reason when supplied, timestamp, and resulting external issue state.
+- **FR-011**: Provider adapters MUST enforce configured repository, organization, Jira site, Jira project, and action allowlists before delivery or decision handling.
+- **FR-012**: Provider credentials and webhook secrets MUST remain inside trusted integration boundaries and MUST NOT appear in managed agent environments, external issue text, logs, comments, operator-facing responses, or spec-derived artifacts.
+- **FR-013**: Provider errors surfaced to users or operators MUST be sanitized while still identifying the affected provider, issue, destination, and recoverable next action.
+- **FR-014**: External issue rendering MUST link to large logs, diagnostics, artifacts, and run evidence by reference rather than embedding large or sensitive payloads directly.
+- **FR-015**: MoonMind MUST make proposal delivery status and external issue links visible from existing task run details or finish summaries without requiring a dedicated MoonMind proposal review page.
+- **FR-016**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-598` and this original Jira preset brief for final traceability.
+
+### Key Entities
+
+- **Proposal Delivery Record**: The audit and idempotency record for one proposal delivered to an external tracker; includes provider identity, destination, external issue reference, dedup data, status, origin, evidence refs, and snapshot ref.
+- **External Proposal Issue**: The GitHub Issue or Jira issue shown to reviewers; contains human-readable review context and bounded action controls but is not the executable proposal payload.
+- **Stored Proposal Snapshot**: The validated MoonMind proposal payload or artifact reference used for promotion; remains the executable source of truth.
+- **Provider Decision Event**: A normalized reviewer action from a provider command, workflow transition, field, label, or webhook event; includes actor, provider event identity, decision, note, and resulting state.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Tasks/TaskProposalSystem.md` §5.1 and §14): Each submitted proposal creates or updates a delivery record and exactly one GitHub or Jira issue per provider destination and dedup target. Scope: in scope. Maps to FR-001, FR-002, FR-015.
+- **DESIGN-REQ-014** (`docs/Tasks/TaskProposalSystem.md` §5.2): Delivery is dedup-first; matching open provider issues are updated, linked, or annotated rather than duplicated. Scope: in scope. Maps to FR-003, FR-004.
+- **DESIGN-REQ-015** (`docs/Tasks/TaskProposalSystem.md` §5.3): GitHub proposal issues include proposal-specific title, labels or equivalent metadata, rendered body, hidden marker, source links, dedup context, and reviewer action instructions. Scope: in scope. Maps to FR-005, FR-007, FR-009, FR-014.
+- **DESIGN-REQ-016** (`docs/Tasks/TaskProposalSystem.md` §5.4): Jira proposal issues include proposal-specific summary, structured review description, configured labels or fields, workflow states or approval triggers, source links, and related issue links. Scope: in scope. Maps to FR-006, FR-007, FR-009, FR-014.
+- **DESIGN-REQ-027** (`docs/Tasks/TaskProposalSystem.md` §5.5 and §11): Rendered external issue text is a review artifact; MoonMind executes the stored proposal snapshot and never treats edited issue content as replacement executable instructions. Scope: in scope. Maps to FR-007, FR-008, FR-014.
+- **DESIGN-REQ-031** (`docs/Tasks/TaskProposalSystem.md` §9.4 and §11): Provider adapters enforce destination and action policy, keep credentials inside trusted integration boundaries, normalize provider decisions, and redact errors or secrets. Scope: in scope. Maps to FR-010, FR-011, FR-012, FR-013.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a repeated proposal with the same destination and dedup target, review surfaces show one open external issue rather than two duplicate issues in 100% of covered delivery tests.
+- **SC-002**: GitHub and Jira delivery validation each confirms all required review context elements, action controls, dedup markers, source links, and stored-snapshot notices are present.
+- **SC-003**: Promotion and decision validation rejects arbitrary edited issue text as executable payload replacement in 100% of covered safety tests.
+- **SC-004**: Provider allowlist and credential-redaction tests confirm blocked destinations or actions return sanitized outcomes without exposing raw credentials or provider secrets.
+- **SC-005**: Task run details or finish summaries expose proposal delivery status and external issue links for delivered proposals without adding a dedicated MoonMind proposal queue.
+- **SC-006**: Traceability review confirms `MM-598`, the original Jira preset brief, and DESIGN-REQ-001, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-027, and DESIGN-REQ-031 remain preserved across MoonSpec artifacts and final evidence.

--- a/specs/312-proposal-review-delivery/tasks.md
+++ b/specs/312-proposal-review-delivery/tasks.md
@@ -16,6 +16,45 @@ This task plan implements exactly one story from MM-598. It preserves the Jira p
 - `DESIGN-REQ-027`: Stored-snapshot safety and no raw executable payload replacement from comments
 - `DESIGN-REQ-031`: Allowlisted providers, credential hygiene, and sanitized provider errors
 
+## Requirement Coverage
+
+| Requirement | Task Coverage |
+| --- | --- |
+| FR-001 | T007, T013, T021, T025, T032, T034 |
+| FR-002 | T002, T007, T010, T021, T025, T032, T034 |
+| FR-003 | T002, T007, T013, T021, T025, T034 |
+| FR-004 | T007, T010, T013, T021, T025, T034 |
+| FR-005 | T005, T013, T019, T022, T034 |
+| FR-006 | T006, T014, T020, T023, T034 |
+| FR-007 | T005, T006, T019, T020, T034 |
+| FR-008 | T008, T015, T024, T034 |
+| FR-009 | T005, T006, T008, T014, T015, T024, T034 |
+| FR-010 | T008, T015, T024, T025, T034 |
+| FR-011 | T009, T014, T021, T022, T023, T036 |
+| FR-012 | T009, T019, T020, T022, T023, T028, T036 |
+| FR-013 | T009, T014, T021, T022, T023, T028, T036 |
+| FR-014 | T005, T006, T019, T020, T034 |
+| FR-015 | T012, T027, T028, T032, T034 |
+| FR-016 | T040, T041 |
+| SC-001 | T007, T013, T032, T034 |
+| SC-002 | T005, T006, T013, T014, T034 |
+| SC-003 | T008, T015, T024, T034 |
+| SC-004 | T009, T014, T028, T036 |
+| SC-005 | T012, T027, T028, T034 |
+| SC-006 | T040, T041 |
+| SCN-001 | T005, T013, T019, T022, T034 |
+| SCN-002 | T006, T014, T020, T023, T034 |
+| SCN-003 | T007, T010, T013, T021, T025, T034 |
+| SCN-004 | T005, T006, T008, T015, T024, T034 |
+| SCN-005 | T008, T015, T024, T034 |
+| SCN-006 | T009, T014, T021, T028, T036 |
+| DESIGN-REQ-001 | T007, T010, T013, T021, T025, T027, T034 |
+| DESIGN-REQ-014 | T007, T010, T013, T021, T025, T034 |
+| DESIGN-REQ-015 | T005, T013, T019, T022, T034 |
+| DESIGN-REQ-016 | T006, T014, T020, T023, T034 |
+| DESIGN-REQ-027 | T005, T006, T008, T015, T019, T020, T024, T034 |
+| DESIGN-REQ-031 | T008, T009, T014, T021, T022, T023, T028, T036 |
+
 ## Test Commands
 
 - Focused unit red/green: `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q`
@@ -96,7 +135,7 @@ This task plan implements exactly one story from MM-598. It preserves the Jira p
 - [ ] T037 Run `./tools/test_unit.sh` and fix failures in the touched files
 - [ ] T038 Run `./tools/test_integration.sh` if `tests/integration/temporal/test_proposal_review_delivery.py` is marked `integration_ci`; otherwise run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
 - [ ] T039 Execute the manual quickstart validation in `specs/312-proposal-review-delivery/quickstart.md` against the implemented behavior
-- [ ] T040 Verify traceability for MM-598, all FR IDs, all scenario IDs, and all source-design coverage IDs in `specs/312-proposal-review-delivery/spec.md`, `specs/312-proposal-review-delivery/plan.md`, and `specs/312-proposal-review-delivery/tasks.md`
+- [ ] T040 Verify traceability for MM-598, all FR IDs, all scenario IDs, and all source-design coverage IDs across `specs/312-proposal-review-delivery/spec.md`, `specs/312-proposal-review-delivery/plan.md`, `specs/312-proposal-review-delivery/research.md`, `specs/312-proposal-review-delivery/data-model.md`, `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md`, `specs/312-proposal-review-delivery/quickstart.md`, and `specs/312-proposal-review-delivery/tasks.md`
 - [ ] T041 Run `/moonspec-verify` for `specs/312-proposal-review-delivery` and address any FAIL or PARTIAL findings before publishing implementation results
 
 ## Dependencies

--- a/specs/312-proposal-review-delivery/tasks.md
+++ b/specs/312-proposal-review-delivery/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Proposal Review Delivery
+
+**Input**: Design artifacts from `/specs/312-proposal-review-delivery/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/proposal-review-delivery-contract.md`, `quickstart.md`
+**Story**: Deliver Proposals To External Review Surfaces
+**Jira Traceability**: MM-598
+
+## Source Traceability
+
+This task plan implements exactly one story from MM-598. It preserves the Jira preset brief and source-design mappings carried in `spec.md`:
+
+- `DESIGN-REQ-001`: Proposal artifacts derived from workflow outputs and stored snapshots
+- `DESIGN-REQ-014`: Reviewer links back to canonical proposal/run evidence
+- `DESIGN-REQ-015`: GitHub issue delivery with review context and commands
+- `DESIGN-REQ-016`: Jira issue delivery with review context and commands
+- `DESIGN-REQ-027`: Stored-snapshot safety and no raw executable payload replacement from comments
+- `DESIGN-REQ-031`: Allowlisted providers, credential hygiene, and sanitized provider errors
+
+## Test Commands
+
+- Focused unit red/green: `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q`
+- Focused integration red/green: `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
+- Final unit suite: `./tools/test_unit.sh`
+- Final hermetic integration suite, if integration_ci coverage is added: `./tools/test_integration.sh`
+
+## Phase 1: Setup
+
+**Purpose**: Establish the single-story implementation surface and local test harness without changing behavior.
+
+- [ ] T001 Create the proposal delivery module and unit-test skeleton in `moonmind/workflows/task_proposals/delivery.py` and `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T002 Confirm existing delivery record fields before implementation in `api_service/migrations/versions/311_proposal_delivery_records.py` and `moonmind/workflows/task_proposals/models.py`
+- [ ] T003 [P] Add reusable fake GitHub, Jira, repository, and clock fixtures for proposal delivery tests in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T004 [P] Add fixture helpers for stored task snapshots, redaction probes, and reviewer command samples in `tests/unit/workflows/task_proposals/test_delivery.py`
+
+## Phase 2: Red-First Unit Tests
+
+**Purpose**: Write failing unit tests for the single MM-598 story before production behavior.
+
+- [ ] T005 [P] Add failing GitHub issue rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T006 [P] Add failing Jira ADF rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T007 [P] Add failing delivery orchestration tests for provider selection, stored snapshot usage, external key/url persistence, and local duplicate reuse in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T008 [P] Add failing reviewer decision parsing tests for approve, reject, dismiss, unknown commands, and immutable stored payload behavior in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T009 [P] Add failing allowlist, credential redaction, provider error sanitization, and retry classification tests in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T010 Update failing proposal service tests for post-create delivery invocation, duplicate delivery suppression, and existing open external issue reuse in `tests/unit/workflows/task_proposals/test_service.py`
+- [ ] T011 Update failing Temporal proposal activity tests for delivery decisions, provider metadata, sanitized failures, and task snapshot references in `tests/unit/workflows/temporal/test_proposal_activities.py`
+- [ ] T012 Update failing API visibility tests for reviewer delivery state, external issue links, stored-snapshot notices, and finish-summary fields in `tests/unit/api/routers/test_task_proposals.py`
+
+## Phase 3: Red-First Integration Tests
+
+**Purpose**: Capture provider-boundary behavior hermetically before implementation.
+
+- [ ] T013 Add a failing hermetic GitHub proposal delivery integration test with fake provider calls, dedup marker matching, and external issue update/create assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
+- [ ] T014 Add a failing hermetic Jira proposal delivery integration test with fake trusted Jira tool calls, ADF payload assertions, and sanitized error assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
+- [ ] T015 Add a failing reviewer decision ingestion integration test covering approve/reject/dismiss comments, immutable stored snapshots, and run evidence links in `tests/integration/temporal/test_proposal_review_delivery.py`
+
+## Phase 4: Red Confirmation
+
+**Purpose**: Verify the test suite fails for missing behavior before writing production code.
+
+- [ ] T016 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
+- [ ] T017 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
+
+## Phase 5: Implementation
+
+**Purpose**: Implement the one story after red-first evidence exists.
+
+- [ ] T018 Define proposal delivery request/result models, provider ports, renderer interfaces, and sanitized error types in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T019 Implement the GitHub issue Markdown renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T020 Implement the Jira ADF renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T021 Implement delivery orchestration for provider policy resolution, allowlist enforcement, local duplicate lookup, external create/update choice, retry classification, and delivery record updates in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T022 Extend the GitHub adapter boundary for proposal issue create/update/search calls and sanitized provider failures in `moonmind/workflows/adapters/github_service.py`
+- [ ] T023 Implement the trusted Jira delivery adapter through existing Jira tool orchestration and ADF helpers in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T024 Implement reviewer decision command parsing and normalized approve/reject/dismiss outcomes without mutating stored executable payloads in `moonmind/workflows/task_proposals/delivery.py`
+- [ ] T025 Wire `TaskProposalService` to invoke proposal delivery, persist external keys/urls/provider metadata, reuse open duplicates, and preserve stored task snapshots in `moonmind/workflows/task_proposals/service.py`
+- [ ] T026 Wire Temporal proposal submission activities to pass effective delivery policy, provider metadata, task snapshots, and sanitized delivery decisions in `moonmind/workflows/temporal/activity_runtime.py`
+- [ ] T027 Wire API and dashboard response fields for delivery provider, status, reviewer issue link, stored-snapshot notice, and finish-summary visibility in `api_service/api/routers/task_proposals.py`
+- [ ] T028 Extend task detail or run summary projection for delivered proposal review state and external links in `api_service/api/routers/task_dashboard.py`
+- [ ] T029 Export delivery types needed by service and activity tests in `moonmind/workflows/task_proposals/__init__.py`
+- [ ] T030 Apply conditional fallback updates if existing record fields are insufficient while avoiding new persistence unless required in `moonmind/workflows/task_proposals/models.py`
+- [ ] T031 Apply conditional fallback updates if reviewer delivery state cannot be represented by existing API contracts in `moonmind/workflows/task_contract.py`
+
+## Phase 6: Story Validation
+
+**Purpose**: Prove the single story works independently through unit and integration coverage.
+
+- [ ] T032 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and fix failures in the touched implementation and test files
+- [ ] T033 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and fix failures in the touched implementation and test files
+- [ ] T034 Validate the independent story criteria from `specs/312-proposal-review-delivery/spec.md` against GitHub delivery, Jira delivery, reviewer decisions, duplicate handling, and redaction behavior
+- [ ] T035 Validate the contract examples from `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md` against implemented response shapes and provider calls
+
+## Phase 7: Polish And Verification
+
+**Purpose**: Finish traceability, full-suite verification, and final Moon Spec verification.
+
+- [ ] T036 Add edge-case coverage for missing provider credentials, disallowed provider targets, transient provider errors, stale external records, and unknown reviewer commands in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [ ] T037 Run `./tools/test_unit.sh` and fix failures in the touched files
+- [ ] T038 Run `./tools/test_integration.sh` if `tests/integration/temporal/test_proposal_review_delivery.py` is marked `integration_ci`; otherwise run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
+- [ ] T039 Execute the manual quickstart validation in `specs/312-proposal-review-delivery/quickstart.md` against the implemented behavior
+- [ ] T040 Verify traceability for MM-598, all FR IDs, all scenario IDs, and all source-design coverage IDs in `specs/312-proposal-review-delivery/spec.md`, `specs/312-proposal-review-delivery/plan.md`, and `specs/312-proposal-review-delivery/tasks.md`
+- [ ] T041 Run `/moonspec-verify` for `specs/312-proposal-review-delivery` and address any FAIL or PARTIAL findings before publishing implementation results
+
+## Dependencies
+
+- Setup tasks T001-T004 must complete before red-first tests.
+- Unit tests T005-T012 must complete before integration tests T013-T015.
+- Red confirmation T016-T017 must complete before implementation tasks T018-T031.
+- Implementation tasks T018-T031 must complete before story validation T032-T035.
+- Story validation T032-T035 must complete before polish and final verification T036-T041.
+
+## Parallel Opportunities
+
+- T003 and T004 can run in parallel after T001.
+- T005-T009 can run in parallel once the unit-test skeleton exists.
+- T013-T015 can run in parallel after the unit red tests define the expected behavior.
+- T019 and T020 can run in parallel after T018.
+- T022 and T023 can run in parallel after T021 defines the provider port.
+- T036 can run in parallel with traceability review T040 after T032-T035 pass.
+
+## Completion Criteria
+
+- `tasks.md` covers exactly one story: Deliver Proposals To External Review Surfaces.
+- Red-first unit and integration tests are written and observed failing before implementation.
+- Production work is sequenced after failing tests and includes GitHub delivery, Jira delivery, reviewer decisions, deduplication, stored-snapshot safety, dashboard/API visibility, and redaction.
+- Final validation includes focused tests, full unit suite, applicable integration suite, quickstart validation, traceability review, and `/moonspec-verify`.

--- a/specs/312-proposal-review-delivery/tasks.md
+++ b/specs/312-proposal-review-delivery/tasks.md
@@ -66,76 +66,76 @@ This task plan implements exactly one story from MM-598. It preserves the Jira p
 
 **Purpose**: Establish the single-story implementation surface and local test harness without changing behavior.
 
-- [ ] T001 Create the proposal delivery module and unit-test skeleton in `moonmind/workflows/task_proposals/delivery.py` and `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T002 Confirm existing delivery record fields before implementation in `api_service/migrations/versions/311_proposal_delivery_records.py` and `moonmind/workflows/task_proposals/models.py`
-- [ ] T003 [P] Add reusable fake GitHub, Jira, repository, and clock fixtures for proposal delivery tests in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T004 [P] Add fixture helpers for stored task snapshots, redaction probes, and reviewer command samples in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T001 Create the proposal delivery module and unit-test skeleton in `moonmind/workflows/task_proposals/delivery.py` and `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T002 Confirm existing delivery record fields before implementation in `api_service/migrations/versions/311_proposal_delivery_records.py` and `moonmind/workflows/task_proposals/models.py`
+- [X] T003 [P] Add reusable fake GitHub, Jira, repository, and clock fixtures for proposal delivery tests in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T004 [P] Add fixture helpers for stored task snapshots, redaction probes, and reviewer command samples in `tests/unit/workflows/task_proposals/test_delivery.py`
 
 ## Phase 2: Red-First Unit Tests
 
 **Purpose**: Write failing unit tests for the single MM-598 story before production behavior.
 
-- [ ] T005 [P] Add failing GitHub issue rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T006 [P] Add failing Jira ADF rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T007 [P] Add failing delivery orchestration tests for provider selection, stored snapshot usage, external key/url persistence, and local duplicate reuse in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T008 [P] Add failing reviewer decision parsing tests for approve, reject, dismiss, unknown commands, and immutable stored payload behavior in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T009 [P] Add failing allowlist, credential redaction, provider error sanitization, and retry classification tests in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T010 Update failing proposal service tests for post-create delivery invocation, duplicate delivery suppression, and existing open external issue reuse in `tests/unit/workflows/task_proposals/test_service.py`
-- [ ] T011 Update failing Temporal proposal activity tests for delivery decisions, provider metadata, sanitized failures, and task snapshot references in `tests/unit/workflows/temporal/test_proposal_activities.py`
-- [ ] T012 Update failing API visibility tests for reviewer delivery state, external issue links, stored-snapshot notices, and finish-summary fields in `tests/unit/api/routers/test_task_proposals.py`
+- [X] T005 [P] Add failing GitHub issue rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T006 [P] Add failing Jira ADF rendering tests covering review context, evidence links, reviewer commands, stored-snapshot notice, and no executable payload replacement in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T007 [P] Add failing delivery orchestration tests for provider selection, stored snapshot usage, external key/url persistence, and local duplicate reuse in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T008 [P] Add failing reviewer decision parsing tests for approve, reject, dismiss, unknown commands, and immutable stored payload behavior in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T009 [P] Add failing allowlist, credential redaction, provider error sanitization, and retry classification tests in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T010 Update failing proposal service tests for post-create delivery invocation, duplicate delivery suppression, and existing open external issue reuse in `tests/unit/workflows/task_proposals/test_service.py`
+- [X] T011 Update failing Temporal proposal activity tests for delivery decisions, provider metadata, sanitized failures, and task snapshot references in `tests/unit/workflows/temporal/test_proposal_activities.py`
+- [X] T012 Update failing API visibility tests for reviewer delivery state, external issue links, stored-snapshot notices, and finish-summary fields in `tests/unit/api/routers/test_task_proposals.py`
 
 ## Phase 3: Red-First Integration Tests
 
 **Purpose**: Capture provider-boundary behavior hermetically before implementation.
 
-- [ ] T013 Add a failing hermetic GitHub proposal delivery integration test with fake provider calls, dedup marker matching, and external issue update/create assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
-- [ ] T014 Add a failing hermetic Jira proposal delivery integration test with fake trusted Jira tool calls, ADF payload assertions, and sanitized error assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
-- [ ] T015 Add a failing reviewer decision ingestion integration test covering approve/reject/dismiss comments, immutable stored snapshots, and run evidence links in `tests/integration/temporal/test_proposal_review_delivery.py`
+- [X] T013 Add a failing hermetic GitHub proposal delivery integration test with fake provider calls, dedup marker matching, and external issue update/create assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
+- [X] T014 Add a failing hermetic Jira proposal delivery integration test with fake trusted Jira tool calls, ADF payload assertions, and sanitized error assertions in `tests/integration/temporal/test_proposal_review_delivery.py`
+- [X] T015 Add a failing reviewer decision ingestion integration test covering approve/reject/dismiss comments, immutable stored snapshots, and run evidence links in `tests/integration/temporal/test_proposal_review_delivery.py`
 
 ## Phase 4: Red Confirmation
 
 **Purpose**: Verify the test suite fails for missing behavior before writing production code.
 
-- [ ] T016 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
-- [ ] T017 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
+- [X] T016 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
+- [X] T017 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and record the expected red failures in `specs/312-proposal-review-delivery/tasks.md`
 
 ## Phase 5: Implementation
 
 **Purpose**: Implement the one story after red-first evidence exists.
 
-- [ ] T018 Define proposal delivery request/result models, provider ports, renderer interfaces, and sanitized error types in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T019 Implement the GitHub issue Markdown renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T020 Implement the Jira ADF renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T021 Implement delivery orchestration for provider policy resolution, allowlist enforcement, local duplicate lookup, external create/update choice, retry classification, and delivery record updates in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T022 Extend the GitHub adapter boundary for proposal issue create/update/search calls and sanitized provider failures in `moonmind/workflows/adapters/github_service.py`
-- [ ] T023 Implement the trusted Jira delivery adapter through existing Jira tool orchestration and ADF helpers in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T024 Implement reviewer decision command parsing and normalized approve/reject/dismiss outcomes without mutating stored executable payloads in `moonmind/workflows/task_proposals/delivery.py`
-- [ ] T025 Wire `TaskProposalService` to invoke proposal delivery, persist external keys/urls/provider metadata, reuse open duplicates, and preserve stored task snapshots in `moonmind/workflows/task_proposals/service.py`
-- [ ] T026 Wire Temporal proposal submission activities to pass effective delivery policy, provider metadata, task snapshots, and sanitized delivery decisions in `moonmind/workflows/temporal/activity_runtime.py`
-- [ ] T027 Wire API and dashboard response fields for delivery provider, status, reviewer issue link, stored-snapshot notice, and finish-summary visibility in `api_service/api/routers/task_proposals.py`
-- [ ] T028 Extend task detail or run summary projection for delivered proposal review state and external links in `api_service/api/routers/task_dashboard.py`
-- [ ] T029 Export delivery types needed by service and activity tests in `moonmind/workflows/task_proposals/__init__.py`
-- [ ] T030 Apply conditional fallback updates if existing record fields are insufficient while avoiding new persistence unless required in `moonmind/workflows/task_proposals/models.py`
-- [ ] T031 Apply conditional fallback updates if reviewer delivery state cannot be represented by existing API contracts in `moonmind/workflows/task_contract.py`
+- [X] T018 Define proposal delivery request/result models, provider ports, renderer interfaces, and sanitized error types in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T019 Implement the GitHub issue Markdown renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T020 Implement the Jira ADF renderer with proposal summary, source context, evidence links, commands, dedup marker, stored-snapshot notice, and redacted metadata in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T021 Implement delivery orchestration for provider policy resolution, allowlist enforcement, local duplicate lookup, external create/update choice, retry classification, and delivery record updates in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T022 Extend the GitHub adapter boundary for proposal issue create/update/search calls and sanitized provider failures in `moonmind/workflows/adapters/github_service.py`
+- [X] T023 Implement the trusted Jira delivery adapter through existing Jira tool orchestration and ADF helpers in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T024 Implement reviewer decision command parsing and normalized approve/reject/dismiss outcomes without mutating stored executable payloads in `moonmind/workflows/task_proposals/delivery.py`
+- [X] T025 Wire `TaskProposalService` to invoke proposal delivery, persist external keys/urls/provider metadata, reuse open duplicates, and preserve stored task snapshots in `moonmind/workflows/task_proposals/service.py`
+- [X] T026 Wire Temporal proposal submission activities to pass effective delivery policy, provider metadata, task snapshots, and sanitized delivery decisions in `moonmind/workflows/temporal/activity_runtime.py`
+- [X] T027 Wire API and dashboard response fields for delivery provider, status, reviewer issue link, stored-snapshot notice, and finish-summary visibility in `api_service/api/routers/task_proposals.py`
+- [X] T028 Extend task detail or run summary projection for delivered proposal review state and external links in `api_service/api/routers/task_dashboard.py`
+- [X] T029 Export delivery types needed by service and activity tests in `moonmind/workflows/task_proposals/__init__.py`
+- [X] T030 Apply conditional fallback updates if existing record fields are insufficient while avoiding new persistence unless required in `moonmind/workflows/task_proposals/models.py`
+- [X] T031 Apply conditional fallback updates if reviewer delivery state cannot be represented by existing API contracts in `moonmind/workflows/task_contract.py`
 
 ## Phase 6: Story Validation
 
 **Purpose**: Prove the single story works independently through unit and integration coverage.
 
-- [ ] T032 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and fix failures in the touched implementation and test files
-- [ ] T033 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and fix failures in the touched implementation and test files
-- [ ] T034 Validate the independent story criteria from `specs/312-proposal-review-delivery/spec.md` against GitHub delivery, Jira delivery, reviewer decisions, duplicate handling, and redaction behavior
-- [ ] T035 Validate the contract examples from `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md` against implemented response shapes and provider calls
+- [X] T032 Run `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` and fix failures in the touched implementation and test files
+- [X] T033 Run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` and fix failures in the touched implementation and test files
+- [X] T034 Validate the independent story criteria from `specs/312-proposal-review-delivery/spec.md` against GitHub delivery, Jira delivery, reviewer decisions, duplicate handling, and redaction behavior
+- [X] T035 Validate the contract examples from `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md` against implemented response shapes and provider calls
 
 ## Phase 7: Polish And Verification
 
 **Purpose**: Finish traceability, full-suite verification, and final Moon Spec verification.
 
-- [ ] T036 Add edge-case coverage for missing provider credentials, disallowed provider targets, transient provider errors, stale external records, and unknown reviewer commands in `tests/unit/workflows/task_proposals/test_delivery.py`
-- [ ] T037 Run `./tools/test_unit.sh` and fix failures in the touched files
-- [ ] T038 Run `./tools/test_integration.sh` if `tests/integration/temporal/test_proposal_review_delivery.py` is marked `integration_ci`; otherwise run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
-- [ ] T039 Execute the manual quickstart validation in `specs/312-proposal-review-delivery/quickstart.md` against the implemented behavior
-- [ ] T040 Verify traceability for MM-598, all FR IDs, all scenario IDs, and all source-design coverage IDs across `specs/312-proposal-review-delivery/spec.md`, `specs/312-proposal-review-delivery/plan.md`, `specs/312-proposal-review-delivery/research.md`, `specs/312-proposal-review-delivery/data-model.md`, `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md`, `specs/312-proposal-review-delivery/quickstart.md`, and `specs/312-proposal-review-delivery/tasks.md`
+- [X] T036 Add edge-case coverage for missing provider credentials, disallowed provider targets, transient provider errors, stale external records, and unknown reviewer commands in `tests/unit/workflows/task_proposals/test_delivery.py`
+- [X] T037 Run `./tools/test_unit.sh` and fix failures in the touched files
+- [X] T038 Run `./tools/test_integration.sh` if `tests/integration/temporal/test_proposal_review_delivery.py` is marked `integration_ci`; otherwise run `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
+- [X] T039 Execute the manual quickstart validation in `specs/312-proposal-review-delivery/quickstart.md` against the implemented behavior
+- [X] T040 Verify traceability for MM-598, all FR IDs, all scenario IDs, and all source-design coverage IDs across `specs/312-proposal-review-delivery/spec.md`, `specs/312-proposal-review-delivery/plan.md`, `specs/312-proposal-review-delivery/research.md`, `specs/312-proposal-review-delivery/data-model.md`, `specs/312-proposal-review-delivery/contracts/proposal-review-delivery-contract.md`, `specs/312-proposal-review-delivery/quickstart.md`, and `specs/312-proposal-review-delivery/tasks.md`
 - [ ] T041 Run `/moonspec-verify` for `specs/312-proposal-review-delivery` and address any FAIL or PARTIAL findings before publishing implementation results
 
 ## Dependencies
@@ -145,6 +145,16 @@ This task plan implements exactly one story from MM-598. It preserves the Jira p
 - Red confirmation T016-T017 must complete before implementation tasks T018-T031.
 - Implementation tasks T018-T031 must complete before story validation T032-T035.
 - Story validation T032-T035 must complete before polish and final verification T036-T041.
+
+## Implementation Evidence
+
+- Red unit evidence for T016: `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` failed before service/API wiring with 3 expected failures: missing `TaskProposalService(delivery_service=...)` support and missing `reviewDelivery` serialization.
+- Red integration evidence for T017: `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` failed before service wiring with missing `TaskProposalService(delivery_service=...)` support.
+- Green focused unit evidence for T032: `python -m pytest tests/unit/workflows/task_proposals/test_delivery.py tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/api/routers/test_task_proposals.py -q` passed with 83 tests.
+- Green focused integration evidence for T033/T038: `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q` passed with 1 test.
+- Green full unit evidence for T037: `./tools/test_unit.sh` passed with 4458 Python tests, 16 subtests, and 20 frontend test files / 324 frontend tests.
+- Quickstart evidence for T039: provider behavior was validated through hermetic fake GitHub/Jira delivery paths and the focused integration test; no live provider credentials were used.
+- T041 remains for the subsequent `/moonspec-verify` managed step.
 
 ## Parallel Opportunities
 

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from moonmind.utils.logging import SecretRedactor
+from moonmind.workflows.task_proposals.models import (
+    TaskProposalOriginSource,
+    TaskProposalReviewPriority,
+    TaskProposalStatus,
+)
+from moonmind.workflows.task_proposals.service import TaskProposalService
+from moonmind.workflows.temporal.activity_runtime import TemporalProposalActivities
+
+
+class _Delivery:
+    def __init__(self, *, external_key: str = "42") -> None:
+        self.external_key = external_key
+        self.requests = []
+
+    async def deliver(self, request):
+        self.requests.append(request)
+        return SimpleNamespace(
+            provider=request.provider,
+            external_key=self.external_key,
+            external_url=f"https://tracker.example/issues/{self.external_key}",
+            created=True,
+            duplicate_source=None,
+            delivered_at=datetime(2026, 5, 7, 12, 30, tzinfo=UTC),
+            warnings=(),
+            provider_metadata={
+                "marker": "moonmind-proposal",
+                "storedSnapshotNotice": True,
+            },
+            to_decision=lambda: {
+                "provider": request.provider,
+                "externalKey": self.external_key,
+                "externalUrl": f"https://tracker.example/issues/{self.external_key}",
+                "created": True,
+            },
+        )
+
+
+def _record() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["artifact_gap"],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        priority_override_reason=None,
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={"workflow_id": "wf-1"},
+        origin_external_id="wf-1",
+        provider="github",
+        external_key=None,
+        external_url=None,
+        delivered_at=None,
+        last_synced_at=None,
+        task_snapshot_ref="artifact://snapshot",
+        provider_metadata={},
+        resolved_policy={"provider": "github"},
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_proposal_submit_persists_external_delivery_result() -> None:
+    repo = AsyncMock()
+    record = _record()
+    repo.find_open_duplicate.return_value = None
+    repo.create_proposal.return_value = record
+    delivery = _Delivery()
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "[REDACTED]"),
+        delivery_service=delivery,
+    )
+    service._emit_notification = AsyncMock()
+
+    async def factory():
+        return service
+
+    activities = TemporalProposalActivities(proposal_service_factory=factory)
+    result = await activities.proposal_submit(
+        {
+            "candidates": [
+                {
+                    "title": "Add tests",
+                    "summary": "Add follow-up",
+                    "tags": ["artifact_gap"],
+                    "taskCreateRequest": {
+                        "type": "task",
+                        "payload": {
+                            "repository": "Moon/Repo",
+                            "task": {"instructions": "Add tests"},
+                        },
+                    },
+                }
+            ],
+            "policy": {"delivery": {"provider": "github"}},
+            "origin": {
+                "workflow_id": "wf-1",
+                "temporal_run_id": "run-1",
+                "trigger_repo": "Moon/Repo",
+                "trigger_job_id": "job-1",
+            },
+        }
+    )
+
+    assert result["submitted_count"] == 1
+    assert result["delivery_decisions"][0]["externalKey"] == "42"
+    assert record.external_key == "42"
+    assert record.external_url == "https://tracker.example/issues/42"
+    assert record.provider_metadata["delivery"]["storedSnapshotNotice"] is True
+    assert delivery.requests[0].origin_metadata["workflow_id"] == "wf-1"

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -139,6 +139,8 @@ async def test_proposal_submit_persists_external_delivery_result() -> None:
 async def test_provider_decision_event_records_snapshot_safe_action() -> None:
     repo = AsyncMock()
     record = _record()
+    record.external_key = "42"
+    record.external_url = "https://tracker.example/issues/42"
     record.provider_metadata = {"delivery": {"status": "delivered"}}
     record.resolved_policy = {
         "allowedActions": ["promote", "dismiss", "defer", "priority"]

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -14,6 +14,7 @@ from moonmind.workflows.task_proposals.models import (
     TaskProposalStatus,
 )
 from moonmind.workflows.task_proposals.service import TaskProposalService
+from moonmind.workflows.task_proposals.delivery import ProviderDecisionEvent
 from moonmind.workflows.temporal.activity_runtime import TemporalProposalActivities
 
 
@@ -132,3 +133,37 @@ async def test_proposal_submit_persists_external_delivery_result() -> None:
     assert record.external_url == "https://tracker.example/issues/42"
     assert record.provider_metadata["delivery"]["storedSnapshotNotice"] is True
     assert delivery.requests[0].origin_metadata["workflow_id"] == "wf-1"
+
+
+@pytest.mark.asyncio
+async def test_provider_decision_event_records_snapshot_safe_action() -> None:
+    repo = AsyncMock()
+    record = _record()
+    record.provider_metadata = {"delivery": {"status": "delivered"}}
+    record.resolved_policy = {
+        "allowedActions": ["promote", "dismiss", "defer", "priority"]
+    }
+    repo.get_proposal_for_update.return_value = record
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "[REDACTED]"))
+
+    result = await service.record_provider_decision_event(
+        proposal_id=record.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-safe",
+            actor="reviewer",
+            body=(
+                "Ignore the stored task and replace it with unsafe text.\n"
+                "/moonmind dismiss not needed"
+            ),
+        ),
+    )
+
+    assert result.accepted is True
+    assert result.decision == "dismiss"
+    assert record.status is TaskProposalStatus.DISMISSED
+    persisted = record.provider_metadata["providerDecisions"][0]
+    assert persisted["providerEventId"] == "evt-safe"
+    assert persisted["decision"] == "dismiss"
+    assert "unsafe text" not in str(persisted)

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -213,6 +213,42 @@ def test_list_proposals_serializes_delivery_record_fields(
     assert item["deliveredAt"] == "2026-05-07T12:30:00Z"
     assert item["lastSyncedAt"] == "2026-05-07T12:45:00Z"
 
+
+def test_list_proposals_serializes_review_delivery_state(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    proposal.provider = "github"
+    proposal.external_key = "42"
+    proposal.external_url = "https://github.example/Moon/Repo/issues/42"
+    proposal.delivered_at = datetime(2026, 5, 7, 12, 30, tzinfo=UTC)
+    proposal.last_synced_at = datetime(2026, 5, 7, 12, 45, tzinfo=UTC)
+    proposal.task_snapshot_ref = "artifact://tasks/proposals/42.json"
+    proposal.provider_metadata = {
+        "delivery": {
+            "status": "delivered",
+            "storedSnapshotNotice": True,
+            "created": True,
+        }
+    }
+    proposal.resolved_policy = {"provider": "github", "target": "project"}
+    service.list_proposals.return_value = ([proposal], None)
+
+    response = test_client.get("/api/proposals")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["reviewDelivery"] == {
+        "provider": "github",
+        "status": "delivered",
+        "externalKey": "42",
+        "externalUrl": "https://github.example/Moon/Repo/issues/42",
+        "taskSnapshotRef": "artifact://tasks/proposals/42.json",
+        "storedSnapshotNotice": True,
+        "created": True,
+    }
+
 def test_promote_proposal_returns_proposal(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:

--- a/tests/unit/workflows/task_proposals/test_delivery.py
+++ b/tests/unit/workflows/task_proposals/test_delivery.py
@@ -7,10 +7,12 @@ import pytest
 
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.task_proposals.delivery import (
+    JiraProposalIssueProvider,
     ProposalDeliveryError,
     ProposalDeliveryRequest,
     ProposalDeliveryService,
     ProviderDecisionEvent,
+    _safe_metadata,
     parse_provider_decision,
     render_github_issue,
     render_jira_issue,
@@ -211,6 +213,25 @@ def test_provider_decision_parser_rejects_unknown_commands() -> None:
     assert result.reason == "unsupported_action"
 
 
+def test_provider_decision_parser_accepts_structured_priority_note() -> None:
+    result = parse_provider_decision(
+        ProviderDecisionEvent(
+            provider="jira",
+            external_key="MM-1",
+            provider_event_id="evt-3",
+            actor="reviewer",
+            body="",
+            action="priority",
+            note="urgent",
+        )
+    )
+
+    assert result.accepted is True
+    assert result.decision == "priority"
+    assert result.priority == "urgent"
+    assert result.note == "urgent"
+
+
 @pytest.mark.asyncio
 async def test_delivery_blocks_disallowed_github_repository() -> None:
     service = ProposalDeliveryService(github=FakeProvider())
@@ -222,6 +243,29 @@ async def test_delivery_blocks_disallowed_github_repository() -> None:
 
     assert "not allowed" in str(exc.value)
     assert exc.value.to_output()["sanitizedReason"] == str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_delivery_policy_allows_restricted_supported_actions() -> None:
+    provider = FakeProvider()
+    service = ProposalDeliveryService(github=provider)
+
+    result = await service.deliver(_request(resolved_policy={"allowedActions": ["dismiss"]}))
+
+    assert result.created is True
+    assert len(provider.creates) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_policy_rejects_unknown_allowed_action() -> None:
+    service = ProposalDeliveryService(github=FakeProvider())
+
+    with pytest.raises(ProposalDeliveryError) as exc:
+        await service.deliver(
+            _request(resolved_policy={"allowedActions": ["dismiss", "replace-task"]})
+        )
+
+    assert "reviewer actions are not allowed" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -246,3 +290,44 @@ async def test_delivery_requires_provider_identity_from_adapter() -> None:
 
     assert exc.value.retryable is True
     assert "external issue identity" in str(exc.value)
+
+
+def test_safe_metadata_redacts_secret_keys_inside_nested_lists() -> None:
+    safe = _safe_metadata(
+        {
+            "items": [
+                ["plain", {"token": "ghp_secret"}],
+                {"nested": [{"private_key": "secret-value"}]},
+            ]
+        }
+    )
+
+    assert safe == {
+        "items": [
+            ["plain", {"token": "[REDACTED]"}],
+            {"nested": [{"private_key": "[REDACTED]"}]},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_jira_provider_does_not_use_issue_key_as_external_url() -> None:
+    class FakeJira:
+        async def create_issue(self, request):
+            return {"issueKey": "MM-1"}
+
+        async def edit_issue(self, request):
+            return None
+
+    provider = JiraProposalIssueProvider(FakeJira())
+    rendered = render_jira_issue(_request(provider="jira", repository="MM"))
+
+    created = await provider.create_issue(_request(provider="jira", repository="MM"), rendered)
+    updated = await provider.update_issue(
+        _request(provider="jira", repository="MM"),
+        rendered,
+        {"key": "MM-1"},
+    )
+
+    assert created == {"external_key": "MM-1", "external_url": None}
+    assert updated == {"external_key": "MM-1", "external_url": None}

--- a/tests/unit/workflows/task_proposals/test_delivery.py
+++ b/tests/unit/workflows/task_proposals/test_delivery.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+
+from moonmind.utils.logging import SecretRedactor
+from moonmind.workflows.task_proposals.delivery import (
+    ProposalDeliveryError,
+    ProposalDeliveryRequest,
+    ProposalDeliveryService,
+    ProviderDecisionEvent,
+    parse_provider_decision,
+    render_github_issue,
+    render_jira_issue,
+)
+
+
+def _request(
+    *,
+    provider: str = "github",
+    repository: str = "Moon/Repo",
+    provider_metadata: dict[str, object] | None = None,
+    resolved_policy: dict[str, object] | None = None,
+    external_key: str | None = None,
+    external_url: str | None = None,
+) -> ProposalDeliveryRequest:
+    return ProposalDeliveryRequest(
+        record_id=str(uuid4()),
+        provider=provider,
+        repository=repository,
+        title="Add regression coverage",
+        summary="Follow-up proposal from workflow evidence.",
+        category="tests",
+        tags=("artifact_gap", "moonmind"),
+        priority="high",
+        dedup_key="moon/repo:add-regression-coverage",
+        dedup_hash="d" * 64,
+        task_snapshot_ref="artifact://task-snapshot.json",
+        task_create_request={
+            "payload": {
+                "repository": repository,
+                "task": {"instructions": "RAW EXECUTABLE PAYLOAD SHOULD NOT APPEAR"},
+            }
+        },
+        origin_metadata={
+            "workflow_id": "wf-123",
+            "temporal_run_id": "run-456",
+            "trigger_repo": repository,
+            "trigger_job_id": "job-789",
+        },
+        provider_metadata=provider_metadata or {},
+        resolved_policy=resolved_policy or {},
+        external_key=external_key,
+        external_url=external_url,
+    )
+
+
+@dataclass
+class FakeProvider:
+    existing: dict[str, object] | None = None
+    created_payload: dict[str, object] | None = None
+    updated_payload: dict[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.searches: list[ProposalDeliveryRequest] = []
+        self.creates: list[object] = []
+        self.updates: list[tuple[object, dict[str, object]]] = []
+
+    async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, object] | None:
+        self.searches.append(request)
+        return self.existing
+
+    async def create_issue(
+        self, request: ProposalDeliveryRequest, rendered: object
+    ) -> dict[str, object]:
+        self.creates.append(rendered)
+        return self.created_payload or {
+            "external_key": "42",
+            "external_url": "https://github.example/Moon/Repo/issues/42",
+        }
+
+    async def update_issue(
+        self,
+        request: ProposalDeliveryRequest,
+        rendered: object,
+        issue: dict[str, object],
+    ) -> dict[str, object]:
+        self.updates.append((rendered, issue))
+        return self.updated_payload or {
+            "external_key": str(issue.get("key") or "42"),
+            "external_url": str(issue.get("url") or "https://github.example/Moon/Repo/issues/42"),
+        }
+
+
+def test_github_renderer_includes_review_context_and_excludes_raw_payload() -> None:
+    rendered = render_github_issue(
+        _request(provider_metadata={"github": {"labels": ["custom"]}}),
+        redactor=SecretRedactor(["ghp_secret"], "[REDACTED]"),
+    )
+
+    assert rendered.title.startswith("[MoonMind proposal] Add regression coverage")
+    assert "moonmind-proposal" in rendered.labels
+    assert "custom" in rendered.labels
+    assert "<!-- moonmind-proposal" in rendered.body
+    assert "wf-123" in rendered.body
+    assert "artifact://task-snapshot.json" in rendered.body
+    assert "/moonmind promote" in rendered.body
+    assert "stored proposal snapshot" in rendered.body.lower()
+    assert "RAW EXECUTABLE PAYLOAD SHOULD NOT APPEAR" not in rendered.body
+
+
+def test_jira_renderer_emits_adf_description_and_configured_fields() -> None:
+    rendered = render_jira_issue(
+        _request(
+            provider="jira",
+            provider_metadata={
+                "jira": {
+                    "project_key": "MM",
+                    "issue_type": "Task",
+                    "labels": ["triage"],
+                }
+            },
+        )
+    )
+
+    assert rendered.title.startswith("[MoonMind proposal] Add regression coverage")
+    assert rendered.fields["projectKey"] == "MM"
+    assert rendered.fields["issueType"] == "Task"
+    assert "moonmind-proposal" in rendered.fields["labels"]
+    assert rendered.fields["description"]["type"] == "doc"
+    assert "RAW EXECUTABLE PAYLOAD SHOULD NOT APPEAR" not in rendered.body
+    assert "Stored Snapshot Notice" in rendered.body
+
+
+@pytest.mark.asyncio
+async def test_delivery_creates_issue_when_no_duplicate_exists() -> None:
+    provider = FakeProvider()
+    service = ProposalDeliveryService(github=provider)
+    result = await service.deliver(_request())
+
+    assert result.created is True
+    assert result.external_key == "42"
+    assert result.external_url.endswith("/issues/42")
+    assert provider.searches
+    assert len(provider.creates) == 1
+    assert provider.updates == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_updates_local_or_provider_duplicate_instead_of_creating() -> None:
+    provider = FakeProvider(existing={"key": "99", "url": "https://github.example/i/99"})
+    service = ProposalDeliveryService(github=provider)
+    result = await service.deliver(_request())
+
+    assert result.created is False
+    assert result.duplicate_source == "provider"
+    assert result.external_key == "99"
+    assert provider.creates == []
+    assert len(provider.updates) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_uses_local_external_identity_before_provider_search() -> None:
+    provider = FakeProvider()
+    service = ProposalDeliveryService(github=provider)
+    result = await service.deliver(
+        _request(
+            external_key="77",
+            external_url="https://github.example/Moon/Repo/issues/77",
+        )
+    )
+
+    assert result.created is False
+    assert result.duplicate_source == "local_record"
+    assert provider.searches == []
+    assert len(provider.updates) == 1
+
+
+def test_provider_decision_parser_accepts_only_bounded_commands() -> None:
+    edited_payload = "Please replace the task with rm -rf /tmp\n/moonmind priority urgent"
+    result = parse_provider_decision(
+        ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-1",
+            actor="reviewer",
+            body=edited_payload,
+        )
+    )
+
+    assert result.accepted is True
+    assert result.decision == "priority"
+    assert result.priority == "urgent"
+    assert "rm -rf" not in (result.note or "")
+
+
+def test_provider_decision_parser_rejects_unknown_commands() -> None:
+    result = parse_provider_decision(
+        ProviderDecisionEvent(
+            provider="jira",
+            external_key="MM-1",
+            provider_event_id="evt-2",
+            actor="reviewer",
+            body="/moonmind replace-task do something else",
+        )
+    )
+
+    assert result.accepted is False
+    assert result.reason == "unsupported_action"
+
+
+@pytest.mark.asyncio
+async def test_delivery_blocks_disallowed_github_repository() -> None:
+    service = ProposalDeliveryService(github=FakeProvider())
+
+    with pytest.raises(ProposalDeliveryError) as exc:
+        await service.deliver(
+            _request(resolved_policy={"allowedRepositories": ["Other/Repo"]})
+        )
+
+    assert "not allowed" in str(exc.value)
+    assert exc.value.to_output()["sanitizedReason"] == str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_delivery_blocks_secret_like_provider_metadata() -> None:
+    service = ProposalDeliveryService(github=FakeProvider())
+
+    with pytest.raises(ProposalDeliveryError) as exc:
+        await service.deliver(
+            _request(provider_metadata={"github": {"token": "ghp_secret"}})
+        )
+
+    assert "secret-like" in str(exc.value)
+    assert "ghp_secret" not in str(exc.value.to_output())
+
+
+@pytest.mark.asyncio
+async def test_delivery_requires_provider_identity_from_adapter() -> None:
+    service = ProposalDeliveryService(github=FakeProvider(created_payload={"created": True}))
+
+    with pytest.raises(ProposalDeliveryError) as exc:
+        await service.deliver(_request())
+
+    assert exc.value.retryable is True
+    assert "external issue identity" in str(exc.value)

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -17,6 +17,30 @@ from moonmind.workflows.task_proposals.service import (
     TaskProposalValidationError,
 )
 
+
+class _FakeDeliveryService:
+    def __init__(self) -> None:
+        self.requests = []
+
+    async def deliver(self, request):
+        self.requests.append(request)
+        return SimpleNamespace(
+            provider=request.provider,
+            external_key="42",
+            external_url="https://github.example/Moon/Repo/issues/42",
+            created=True,
+            duplicate_source=None,
+            delivered_at=datetime(2026, 5, 7, 12, 30, tzinfo=UTC),
+            warnings=(),
+            provider_metadata={"marker": "moonmind-proposal"},
+            to_decision=lambda: {
+                "provider": request.provider,
+                "externalKey": "42",
+                "externalUrl": "https://github.example/Moon/Repo/issues/42",
+                "created": True,
+            },
+        )
+
 @pytest.mark.asyncio
 async def test_create_proposal_defers_runtime_defaults_until_promotion() -> None:
     repo = AsyncMock()
@@ -947,3 +971,166 @@ def test_delivery_record_migration_declares_canonical_columns() -> None:
         "resolved_policy",
     ):
         assert column_name in text
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_invokes_delivery_and_persists_external_issue() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        priority_override_reason=None,
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={"workflow_id": "wf-1"},
+        origin_external_id="wf-1",
+        provider="github",
+        external_key=None,
+        external_url=None,
+        delivered_at=None,
+        last_synced_at=None,
+        task_snapshot_ref="artifact://snapshot",
+        provider_metadata={},
+        resolved_policy={"provider": "github"},
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+    )
+    repo.find_open_duplicate.return_value = None
+    repo.create_proposal.return_value = record
+    delivery = _FakeDeliveryService()
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=delivery,
+    )
+    service._emit_notification = AsyncMock()
+
+    proposal = await service.create_proposal(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["tests"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {"repository": "Moon/Repo"},
+        },
+        origin_source="workflow",
+        origin_id=None,
+        origin_external_id="wf-1",
+        origin_metadata={"workflow_id": "wf-1"},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        provider="github",
+        resolved_policy={"provider": "github"},
+        task_snapshot_ref="artifact://snapshot",
+    )
+
+    assert proposal.external_key == "42"
+    assert proposal.external_url == "https://github.example/Moon/Repo/issues/42"
+    assert proposal.delivered_at == datetime(2026, 5, 7, 12, 30, tzinfo=UTC)
+    assert proposal.last_synced_at == datetime(2026, 5, 7, 12, 30, tzinfo=UTC)
+    assert proposal.provider_metadata["delivery"]["marker"] == "moonmind-proposal"
+    assert delivery.requests[0].task_snapshot_ref == "artifact://snapshot"
+    assert repo.commit.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_records_sanitized_delivery_failure() -> None:
+    class FailingDelivery:
+        async def deliver(self, request):
+            from moonmind.workflows.task_proposals.delivery import ProposalDeliveryError
+
+            raise ProposalDeliveryError(
+                "provider rejected request",
+                provider=request.provider,
+                destination=request.destination,
+                retryable=False,
+            )
+
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        priority_override_reason=None,
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={"workflow_id": "wf-1"},
+        origin_external_id="wf-1",
+        provider="github",
+        external_key=None,
+        external_url=None,
+        delivered_at=None,
+        last_synced_at=None,
+        task_snapshot_ref="artifact://snapshot",
+        provider_metadata={},
+        resolved_policy={"provider": "github"},
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+    )
+    repo.find_open_duplicate.return_value = None
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=FailingDelivery(),
+    )
+    service._emit_notification = AsyncMock()
+
+    proposal = await service.create_proposal(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["tests"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {"repository": "Moon/Repo"},
+        },
+        origin_source="workflow",
+        origin_id=None,
+        origin_external_id="wf-1",
+        origin_metadata={"workflow_id": "wf-1"},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        provider="github",
+        resolved_policy={"provider": "github"},
+        task_snapshot_ref="artifact://snapshot",
+    )
+
+    assert proposal.provider_metadata["delivery"]["status"] == "failed"
+    assert proposal.provider_metadata["delivery"]["error"]["sanitizedReason"] == (
+        "provider rejected request"
+    )

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -16,6 +16,7 @@ from moonmind.workflows.task_proposals.service import (
     TaskProposalService,
     TaskProposalValidationError,
 )
+from moonmind.workflows.task_proposals.delivery import ProviderDecisionEvent
 
 
 class _FakeDeliveryService:
@@ -1134,3 +1135,97 @@ async def test_create_proposal_records_sanitized_delivery_failure() -> None:
     assert proposal.provider_metadata["delivery"]["error"]["sanitizedReason"] == (
         "provider rejected request"
     )
+
+
+@pytest.mark.asyncio
+async def test_record_provider_decision_event_persists_idempotent_metadata() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        provider="github",
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        provider_metadata={"delivery": {"status": "delivered"}},
+        resolved_policy={"allowedActions": ["promote", "dismiss", "defer", "priority"]},
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        decision_note=None,
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    result = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-1",
+            actor="reviewer",
+            body="/moonmind priority urgent",
+        ),
+    )
+
+    assert result.accepted is True
+    assert proposal.review_priority is TaskProposalReviewPriority.URGENT
+    decision_row = proposal.provider_metadata["providerDecisions"][0]
+    assert decision_row["provider"] == "github"
+    assert decision_row["externalKey"] == "42"
+    assert decision_row["providerEventId"] == "evt-1"
+    assert decision_row["actor"] == "reviewer"
+    assert decision_row["decision"] == "priority"
+    assert decision_row["accepted"] is True
+    assert decision_row["note"] == "urgent"
+    assert decision_row["priority"] == "urgent"
+    assert decision_row["deferUntil"] is None
+    assert decision_row["resultingExternalState"] == "priority"
+    assert decision_row["observedAt"]
+    repo.commit.assert_awaited_once()
+    repo.refresh.assert_awaited_once_with(proposal)
+
+    duplicate = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-1",
+            actor="reviewer",
+            body="/moonmind priority urgent",
+        ),
+    )
+
+    assert duplicate.accepted is True
+    assert len(proposal.provider_metadata["providerDecisions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_provider_decision_event_rejects_disallowed_action() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        provider="github",
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        provider_metadata={},
+        resolved_policy={"allowedActions": ["dismiss"]},
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        decision_note=None,
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    result = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-2",
+            actor="reviewer",
+            body="/moonmind promote",
+        ),
+    )
+
+    assert result.accepted is False
+    assert result.reason == "action_not_allowed"
+    assert proposal.status is TaskProposalStatus.OPEN
+    assert proposal.provider_metadata["providerDecisions"][0]["accepted"] is False

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -1138,6 +1138,84 @@ async def test_create_proposal_records_sanitized_delivery_failure() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_proposal_records_sanitized_unexpected_delivery_failure() -> None:
+    class FailingDelivery:
+        async def deliver(self, request):
+            raise RuntimeError("token=ghp_secret adapter exploded")
+
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        priority_override_reason=None,
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={"workflow_id": "wf-1"},
+        origin_external_id="wf-1",
+        provider="github",
+        external_key=None,
+        external_url=None,
+        delivered_at=None,
+        last_synced_at=None,
+        task_snapshot_ref="artifact://snapshot",
+        provider_metadata={},
+        resolved_policy={"provider": "github"},
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+    )
+    repo.find_open_duplicate.return_value = None
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor(["ghp_secret"], "***"),
+        delivery_service=FailingDelivery(),
+    )
+    service._emit_notification = AsyncMock()
+
+    proposal = await service.create_proposal(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["tests"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {"repository": "Moon/Repo"},
+        },
+        origin_source="workflow",
+        origin_id=None,
+        origin_external_id="wf-1",
+        origin_metadata={"workflow_id": "wf-1"},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        provider="github",
+        resolved_policy={"provider": "github"},
+        task_snapshot_ref="artifact://snapshot",
+    )
+
+    error = proposal.provider_metadata["delivery"]["error"]
+    assert error["sanitizedReason"] == "provider delivery failed"
+    assert error["errorType"] == "RuntimeError"
+    assert "ghp_secret" not in str(error)
+
+
+@pytest.mark.asyncio
 async def test_record_provider_decision_event_persists_idempotent_metadata() -> None:
     repo = AsyncMock()
     proposal = SimpleNamespace(
@@ -1229,3 +1307,39 @@ async def test_record_provider_decision_event_rejects_disallowed_action() -> Non
     assert result.reason == "action_not_allowed"
     assert proposal.status is TaskProposalStatus.OPEN
     assert proposal.provider_metadata["providerDecisions"][0]["accepted"] is False
+
+
+@pytest.mark.asyncio
+async def test_record_provider_decision_event_rejects_external_identity_mismatch() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        provider="github",
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        provider_metadata={},
+        resolved_policy={"allowedActions": ["promote", "dismiss", "defer", "priority"]},
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        decision_note=None,
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    result = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="99",
+            provider_event_id="evt-3",
+            actor="reviewer",
+            body="/moonmind promote",
+        ),
+    )
+
+    assert result.accepted is False
+    assert result.reason == "provider_identity_mismatch"
+    assert proposal.status is TaskProposalStatus.OPEN
+    decision_row = proposal.provider_metadata["providerDecisions"][0]
+    assert decision_row["accepted"] is False
+    assert decision_row["reason"] == "provider_identity_mismatch"


### PR DESCRIPTION
Change Jira issue MM-598 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.