### PR TITLE
For the navigation bar, the purple bar indicating the selected tab should be slightly thicker and actually cover that part of the horizontal gray line

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -780,7 +780,7 @@ describe('Mission Control shared entry', () => {
       /\.masthead-brand\s*\{[^}]*justify-self:\s*start;/s,
     );
     expect(missionControlCss).toMatch(
-      /\.masthead-nav\s*\{[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,
+      /\.masthead-nav\s*\{[^}]*align-self:\s*stretch;[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,
     );
     expect(missionControlCss).toMatch(
       /\.masthead-title-meta\s*\{[^}]*justify-self:\s*end;[^}]*justify-content:\s*flex-end;/s,
@@ -797,11 +797,15 @@ describe('Mission Control shared entry', () => {
       block.includes('padding: 0.48rem 0.82rem;'),
     );
     expect(desktopLinkBlock).toBeDefined();
+    expect(desktopLinkBlock).toContain('display: inline-flex;');
+    expect(desktopLinkBlock).toContain('align-items: center;');
     expect(desktopLinkBlock).not.toMatch(/margin-bottom:\s*-/);
 
     const underlineBlocks = cssRuleBlocks(missionControlCss, '.route-nav a::after');
     expect(
-      underlineBlocks.some((block) => block.includes('bottom: -0.46rem;')),
+      underlineBlocks.some((block) =>
+        block.includes('bottom: calc(-1 * var(--masthead-padding-block-end));'),
+      ),
     ).toBe(true);
     expect(underlineBlocks.some((block) => block.includes('height: 3px;'))).toBe(true);
 

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -801,8 +801,9 @@ describe('Mission Control shared entry', () => {
 
     const underlineBlocks = cssRuleBlocks(missionControlCss, '.route-nav a::after');
     expect(
-      underlineBlocks.some((block) => block.includes('bottom: -0.62rem;')),
+      underlineBlocks.some((block) => block.includes('bottom: -0.46rem;')),
     ).toBe(true);
+    expect(underlineBlocks.some((block) => block.includes('height: 3px;'))).toBe(true);
 
     const activeBlocks = cssRuleBlocks(missionControlCss, '.route-nav a.active');
     expect(activeBlocks.join('\n')).not.toMatch(/transform:[^;]*\bscale\b/);

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -192,6 +192,8 @@ samp {
 }
 
 .masthead {
+  --masthead-padding-block-end: 0.46rem;
+
   position: relative;
   z-index: 50;
   isolation: isolate;
@@ -199,7 +201,7 @@ samp {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   column-gap: 1rem;
-  padding: 0.65rem 1rem 0.46rem;
+  padding: 0.65rem 1rem var(--masthead-padding-block-end);
 }
 
 .masthead::before {
@@ -354,14 +356,14 @@ h1 {
 .route-nav {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: stretch;
   gap: 0.55rem;
 }
 
 .masthead-nav {
   position: relative;
-  z-index: 1;
   display: flex;
+  align-self: stretch;
   justify-content: center;
   justify-self: center;
   min-width: 0;
@@ -419,6 +421,8 @@ h1 {
 
 .route-nav a {
   position: relative;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
   color: rgb(var(--mm-ink) / 0.82);
   border: 0;
@@ -432,10 +436,9 @@ h1 {
 .route-nav a::after {
   content: "";
   position: absolute;
-  z-index: 1;
   left: 0;
   right: 0;
-  bottom: -0.46rem;
+  bottom: calc(-1 * var(--masthead-padding-block-end));
   height: 3px;
   background: transparent;
   transition: background 130ms ease;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -199,7 +199,7 @@ samp {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   column-gap: 1rem;
-  padding: 0.65rem 1rem 0.62rem;
+  padding: 0.65rem 1rem 0.46rem;
 }
 
 .masthead::before {
@@ -359,6 +359,8 @@ h1 {
 }
 
 .masthead-nav {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: center;
   justify-self: center;
@@ -430,10 +432,11 @@ h1 {
 .route-nav a::after {
   content: "";
   position: absolute;
+  z-index: 1;
   left: 0;
   right: 0;
-  bottom: -0.62rem;
-  height: 2px;
+  bottom: -0.46rem;
+  height: 3px;
   background: transparent;
   transition: background 130ms ease;
 }


### PR DESCRIPTION
For the navigation bar, the purple bar indicating the selected tab should be slightly thicker and actually cover that part of the horizontal gray line instead of hovering slightly above it with a gap. The navigation buttons should be slightly closer to the horizontal line so that there's less of a gap.