### PR TITLE
Change Jira issue MM-600 to status In Progress before implementation starts.

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1746,6 +1746,8 @@ def _serialize_execution(
     )
     resume_summary = _build_resume_summary(record, actions=actions)
     related_runs = _build_resume_related_runs(record, params=params)
+    proposal_summary = _proposal_summary_from_memo(memo)
+    proposal_outcomes = _proposal_outcomes_from_summary(proposal_summary)
 
     started_at = getattr(record, "started_at", None)
     created_at = getattr(record, "created_at", None) or started_at or record.updated_at
@@ -1832,6 +1834,8 @@ def _serialize_execution(
         actions=actions,
         resume=resume_summary,
         related_runs=related_runs,
+        proposal_summary=proposal_summary,
+        proposal_outcomes=proposal_outcomes,
         debug_fields=debug_fields,
         redirect_path=f"/tasks/{record.workflow_id}?source=temporal",
         integration=(
@@ -1855,6 +1859,40 @@ def _serialize_execution(
         stale_state=False,
         refreshed_at=_compatibility_refreshed_at(record),
     )
+
+
+def _proposal_summary_from_memo(memo: Mapping[str, Any]) -> dict[str, Any] | None:
+    direct = memo.get("proposals")
+    if isinstance(direct, Mapping):
+        return dict(direct)
+    finish_summary = memo.get("finishSummary") or memo.get("finish_summary")
+    if isinstance(finish_summary, Mapping):
+        proposals = finish_summary.get("proposals")
+        if isinstance(proposals, Mapping):
+            return dict(proposals)
+    return None
+
+
+def _proposal_outcomes_from_summary(
+    proposal_summary: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not proposal_summary:
+        return []
+    outcomes: list[dict[str, Any]] = []
+    for item in proposal_summary.get("externalLinks") or []:
+        if not isinstance(item, Mapping):
+            continue
+        outcome = dict(item)
+        outcome.setdefault("deliveryStatus", "delivered")
+        outcomes.append(outcome)
+    for item in proposal_summary.get("dedupUpdates") or []:
+        if not isinstance(item, Mapping):
+            continue
+        outcome = dict(item)
+        outcome.setdefault("deliveryStatus", "updated")
+        outcomes.append(outcome)
+    return outcomes
+
 
 def _resume_checkpoint_ref_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1879,18 +1879,41 @@ def _proposal_outcomes_from_summary(
     if not proposal_summary:
         return []
     outcomes: list[dict[str, Any]] = []
+    outcome_index: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def merge_outcome(item: Mapping[str, Any], *, default_status: str) -> None:
+        outcome = dict(item)
+        outcome.setdefault("deliveryStatus", default_status)
+        external_url = str(outcome.get("externalUrl") or "").strip()
+        external_key = str(outcome.get("externalKey") or "").strip()
+        keys: list[tuple[str, str]] = []
+        if external_url:
+            keys.append(("url", external_url))
+        if external_key:
+            keys.append(("key", external_key))
+        if not keys:
+            outcomes.append(outcome)
+            return
+        existing = next(
+            (outcome_index[key] for key in keys if key in outcome_index), None
+        )
+        if existing is None:
+            for key in keys:
+                outcome_index[key] = outcome
+            outcomes.append(outcome)
+            return
+        existing.update({k: v for k, v in outcome.items() if v is not None})
+        for key in keys:
+            outcome_index[key] = existing
+
     for item in proposal_summary.get("externalLinks") or []:
         if not isinstance(item, Mapping):
             continue
-        outcome = dict(item)
-        outcome.setdefault("deliveryStatus", "delivered")
-        outcomes.append(outcome)
+        merge_outcome(item, default_status="delivered")
     for item in proposal_summary.get("dedupUpdates") or []:
         if not isinstance(item, Mapping):
             continue
-        outcome = dict(item)
-        outcome.setdefault("deliveryStatus", "updated")
-        outcomes.append(outcome)
+        merge_outcome(item, default_status="updated")
     return outcomes
 
 

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -74,6 +74,8 @@ def _build_task_preview(
     runtime_mode = runtime.get("mode") or payload.get("targetRuntime")
     skill_id = skill.get("id")
     publish_mode = publish.get("mode")
+    priority = task_request.get("priority")
+    max_attempts = task_request.get("maxAttempts")
     starting_branch = git.get("startingBranch")
     target_branch = git.get("targetBranch")
     raw_skills = task.get("skills") or payload.get("skills")
@@ -141,6 +143,8 @@ def _build_task_preview(
         skillId=skill_value,
         taskSkills=task_skills,
         publishMode=publish_value,
+        priority=priority if isinstance(priority, int) else None,
+        maxAttempts=max_attempts if isinstance(max_attempts, int) else None,
         startingBranch=starting_value,
         targetBranch=target_branch_value,
         instructions=instructions_value,
@@ -182,13 +186,46 @@ def _serialize_review_delivery(proposal: TaskProposal) -> dict[str, object]:
         "status": status_value,
         "externalKey": getattr(proposal, "external_key", None),
         "externalUrl": getattr(proposal, "external_url", None),
+        "deliveredAt": getattr(proposal, "delivered_at", None),
+        "lastSyncedAt": getattr(proposal, "last_synced_at", None),
         "taskSnapshotRef": getattr(proposal, "task_snapshot_ref", None),
         "storedSnapshotNotice": bool(delivery.get("storedSnapshotNotice")),
     }
-    for key in ("created", "duplicateSource", "warnings"):
+    for key in ("created", "duplicateSource", "warnings", "error"):
         if key in delivery:
             result[key] = delivery[key]
     return result
+
+
+def _serialize_promotion_result(proposal: TaskProposal) -> dict[str, object] | None:
+    provider_metadata = getattr(proposal, "provider_metadata", None)
+    decision_rows = (
+        provider_metadata.get("providerDecisions")
+        if isinstance(provider_metadata, dict)
+        else None
+    )
+    if not isinstance(decision_rows, list):
+        return None
+    for row in reversed(decision_rows):
+        if not isinstance(row, dict):
+            continue
+        promoted_execution_id = str(row.get("promotedExecutionId") or "").strip()
+        if not promoted_execution_id:
+            continue
+        result: dict[str, object] = {
+            "promotedExecutionId": promoted_execution_id,
+            "promotedExecutionUrl": f"/tasks/temporal/{promoted_execution_id}",
+        }
+        for source_key, target_key in (
+            ("providerEventId", "providerEventId"),
+            ("resultingExternalState", "resultingExternalState"),
+            ("promotedAt", "promotedAt"),
+        ):
+            value = row.get(source_key)
+            if value not in (None, ""):
+                result[target_key] = value
+        return result
+    return None
 
 def _serialize_proposal(
     proposal: TaskProposal, *, similar: list[TaskProposal] | None = None
@@ -234,6 +271,7 @@ def _serialize_proposal(
         "origin": origin,
         "taskCreateRequest": proposal.task_create_request or {},
         "taskPreview": preview,
+        "promotionResult": _serialize_promotion_result(proposal),
         "similar": _serialize_similar(similar),
     }
     return TaskProposalModel.model_validate(data)

--- a/frontend/src/entrypoints/proposals.tsx
+++ b/frontend/src/entrypoints/proposals.tsx
@@ -189,7 +189,9 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
       <div className="toolbar">
         <div>
           <h2 className="page-title">Proposals</h2>
-          <p className="page-meta">Review and manage task proposals in the queue.</p>
+          <p className="page-meta">
+            Admin and recovery view for proposals delivered to GitHub or Jira.
+          </p>
         </div>
       </div>
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -257,6 +257,19 @@ const MergeAutomationSchema = z
   })
   .passthrough();
 
+const ProposalSummarySchema = z
+  .object({
+    requested: z.boolean().optional(),
+    generatedCount: z.number().optional(),
+    submittedCount: z.number().optional(),
+    deliveredCount: z.number().optional(),
+    validationErrors: z.array(z.record(z.string(), z.unknown())).default([]),
+    deliveryFailures: z.array(z.record(z.string(), z.unknown())).default([]),
+    externalLinks: z.array(z.record(z.string(), z.unknown())).default([]),
+    dedupUpdates: z.array(z.record(z.string(), z.unknown())).default([]),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string(),
@@ -284,6 +297,8 @@ const ExecutionDetailSchema = z
     failedDependencyId: z.string().nullable().optional(),
     blockedOnDependencies: z.boolean().optional(),
     dependencyOutcomes: z.array(DependencyOutcomeSchema).default([]),
+    proposalSummary: ProposalSummarySchema.nullable().optional(),
+    proposalOutcomes: z.array(z.record(z.string(), z.unknown())).default([]),
     prerequisites: z.array(DependencySummarySchema).default([]),
     dependents: z.array(DependencySummarySchema).default([]),
     attentionRequired: z.boolean().optional(),
@@ -785,6 +800,7 @@ const RunSummaryArtifactSchema = z
       .passthrough()
       .optional(),
     mergeAutomation: MergeAutomationSchema.optional(),
+    proposals: ProposalSummarySchema.optional(),
   })
   .passthrough();
 
@@ -3658,6 +3674,8 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const displayedMergeAutomation =
     execution?.mergeAutomation || runSummary?.mergeAutomation || null;
   const displayedSummary = runSummary?.operatorSummary || execution?.summary || '—';
+  const proposalSummary = runSummary?.proposals || execution?.proposalSummary || null;
+  const proposalOutcomes = execution?.proposalOutcomes || [];
   const prUrl =
     normalizeGitHubPullRequestUrl(execution?.prUrl) ||
     normalizeGitHubPullRequestUrl(runSummary?.publishContext?.pullRequestUrl);
@@ -4211,6 +4229,49 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                 </div>
               ) : null}
               {runSummary.nextAction ? <p className="small">{runSummary.nextAction}</p> : null}
+            </section>
+          ) : null}
+
+          {proposalSummary ? (
+            <section className="stack td-run-summary-region td-evidence-region">
+              <h3>Proposal Outcomes</h3>
+              <div className="grid-2">
+                <Card label="Requested">{proposalSummary.requested ? 'Yes' : 'No'}</Card>
+                <Card label="Generated">{String(proposalSummary.generatedCount ?? 0)}</Card>
+                <Card label="Submitted">{String(proposalSummary.submittedCount ?? 0)}</Card>
+                <Card label="Delivered">{String(proposalSummary.deliveredCount ?? 0)}</Card>
+              </div>
+              {proposalSummary.externalLinks.length > 0 ? (
+                <div className="stack">
+                  <strong>External Review Links</strong>
+                  {proposalSummary.externalLinks.map((item, index) => {
+                    const externalUrl = typeof item.externalUrl === 'string' ? item.externalUrl : '';
+                    const externalKey = typeof item.externalKey === 'string' ? item.externalKey : externalUrl || `Link ${index + 1}`;
+                    const provider = typeof item.provider === 'string' ? item.provider : 'tracker';
+                    return externalUrl ? (
+                      <a key={`${provider}-${externalKey}-${index}`} href={externalUrl}>
+                        {provider}: {externalKey}
+                      </a>
+                    ) : (
+                      <span key={`${provider}-${externalKey}-${index}`} className="small">
+                        {provider}: {externalKey}
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : null}
+              {proposalSummary.dedupUpdates.length > 0 ? (
+                <p className="small">{proposalSummary.dedupUpdates.length} dedup update(s)</p>
+              ) : null}
+              {proposalSummary.validationErrors.length > 0 ? (
+                <p className="small">{proposalSummary.validationErrors.length} validation error(s)</p>
+              ) : null}
+              {proposalSummary.deliveryFailures.length > 0 ? (
+                <p className="small">{proposalSummary.deliveryFailures.length} delivery failure(s)</p>
+              ) : null}
+              {proposalOutcomes.length > 0 && !runSummary?.proposals ? (
+                <p className="small">{proposalOutcomes.length} proposal outcome(s) available from execution detail.</p>
+              ) : null}
             </section>
           ) : null}
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4236,6 +4236,14 @@ export interface components {
             resume?: components["schemas"]["ExecutionResumeSummaryModel"] | null;
             /** Relatedruns */
             relatedRuns?: components["schemas"]["ExecutionRelatedRunModel"][];
+            /** Proposalsummary */
+            proposalSummary?: {
+                [key: string]: unknown;
+            } | null;
+            /** Proposaloutcomes */
+            proposalOutcomes?: {
+                [key: string]: unknown;
+            }[];
             debugFields?: components["schemas"]["ExecutionDebugFieldsModel"] | null;
             /** Redirectpath */
             redirectPath?: string | null;
@@ -6575,6 +6583,10 @@ export interface components {
                 [key: string]: unknown;
             };
             taskPreview?: components["schemas"]["TaskProposalTaskPreview"] | null;
+            /** Promotionresult */
+            promotionResult?: {
+                [key: string]: unknown;
+            } | null;
             /** Similar */
             similar?: components["schemas"]["TaskProposalSimilarModel"][];
         };
@@ -6752,6 +6764,10 @@ export interface components {
             taskSkills?: string[] | null;
             /** Publishmode */
             publishMode?: string | null;
+            /** Priority */
+            priority?: number | null;
+            /** Maxattempts */
+            maxAttempts?: number | null;
             /** Startingbranch */
             startingBranch?: string | null;
             /** Targetbranch */

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -1167,6 +1167,11 @@ class ProposalSubmissionReport:
     generated_count: int
     submitted_count: int
     errors: list[str]
+    delivered_count: int = 0
+    validation_errors: tuple[dict[str, Any], ...] = ()
+    delivery_failures: tuple[dict[str, Any], ...] = ()
+    external_links: tuple[dict[str, Any], ...] = ()
+    dedup_updates: tuple[dict[str, Any], ...] = ()
 
 @dataclass(frozen=True, slots=True)
 class FinishOutcome:
@@ -3685,6 +3690,11 @@ class CodexWorker:
                 "hookSkills": proposal_report.hook_skills,
                 "generatedCount": proposal_report.generated_count,
                 "submittedCount": proposal_report.submitted_count,
+                "deliveredCount": proposal_report.delivered_count,
+                "validationErrors": list(proposal_report.validation_errors),
+                "deliveryFailures": list(proposal_report.delivery_failures),
+                "externalLinks": list(proposal_report.external_links),
+                "dedupUpdates": list(proposal_report.dedup_updates),
                 "errors": proposal_report.errors,
             },
         }
@@ -11512,6 +11522,10 @@ class CodexWorker:
         approved_ci_tags = _MOONMIND_SIGNAL_TAGS
 
         submitted = 0
+        delivered_count = 0
+        delivery_failures: list[dict[str, Any]] = []
+        external_links: list[dict[str, Any]] = []
+        dedup_updates: list[dict[str, Any]] = []
         for candidate in proposals:
             if not isinstance(candidate, dict):
                 continue
@@ -11569,9 +11583,14 @@ class CodexWorker:
                     proposals_path=proposals_path,
                 ):
                     try:
-                        await self._queue_client.create_task_proposal(
+                        response = await self._queue_client.create_task_proposal(
                             proposal=project_payload
                         )
+                        outcome = self._proposal_submission_outcome(response)
+                        delivered_count += outcome["delivered_count"]
+                        external_links.extend(outcome["external_links"])
+                        dedup_updates.extend(outcome["dedup_updates"])
+                        delivery_failures.extend(outcome["delivery_failures"])
                         effective_policy.consume_project_slot()
                         submitted += 1
                     except Exception as exc:
@@ -11631,9 +11650,14 @@ class CodexWorker:
                     proposals_path=proposals_path,
                 ):
                     try:
-                        await self._queue_client.create_task_proposal(
+                        response = await self._queue_client.create_task_proposal(
                             proposal=moonmind_payload
                         )
+                        outcome = self._proposal_submission_outcome(response)
+                        delivered_count += outcome["delivered_count"]
+                        external_links.extend(outcome["external_links"])
+                        dedup_updates.extend(outcome["dedup_updates"])
+                        delivery_failures.extend(outcome["delivery_failures"])
                         effective_policy.consume_moonmind_slot()
                         submitted += 1
                     except Exception as exc:
@@ -11670,7 +11694,63 @@ class CodexWorker:
             generated_count=generated_count,
             submitted_count=submitted,
             errors=errors,
+            delivered_count=delivered_count,
+            validation_errors=tuple(
+                {"code": "proposal_validation_error", "message": error}
+                for error in errors
+                if "missing" in error or "invalid" in error
+            ),
+            delivery_failures=tuple(delivery_failures),
+            external_links=tuple(external_links),
+            dedup_updates=tuple(dedup_updates),
         )
+
+    @staticmethod
+    def _proposal_submission_outcome(response: Mapping[str, Any]) -> dict[str, Any]:
+        delivery = response.get("reviewDelivery")
+        delivery = delivery if isinstance(delivery, Mapping) else {}
+        status = str(delivery.get("status") or "").strip().lower()
+        external_url = str(delivery.get("externalUrl") or "").strip()
+        external_key = str(delivery.get("externalKey") or "").strip()
+        provider = str(
+            delivery.get("provider") or response.get("provider") or ""
+        ).strip()
+        delivered = bool(external_url and status in {"delivered", "updated", "deduped"})
+        external_links: list[dict[str, Any]] = []
+        if external_url:
+            link: dict[str, Any] = {"externalUrl": external_url}
+            if provider:
+                link["provider"] = provider
+            if external_key:
+                link["externalKey"] = external_key
+            external_links.append(link)
+        dedup_updates: list[dict[str, Any]] = []
+        if delivery.get("created") is False or delivery.get("duplicateSource"):
+            update: dict[str, Any] = {"created": bool(delivery.get("created"))}
+            if provider:
+                update["provider"] = provider
+            if external_key:
+                update["externalKey"] = external_key
+            if delivery.get("duplicateSource"):
+                update["duplicateSource"] = delivery["duplicateSource"]
+            dedup_updates.append(update)
+        delivery_failures: list[dict[str, Any]] = []
+        if status == "failed":
+            failure: dict[str, Any] = {}
+            if provider:
+                failure["provider"] = provider
+            error = delivery.get("error")
+            if isinstance(error, Mapping):
+                failure.update(dict(error))
+            else:
+                failure["message"] = "delivery failed"
+            delivery_failures.append(failure)
+        return {
+            "delivered_count": 1 if delivered else 0,
+            "external_links": external_links,
+            "dedup_updates": dedup_updates,
+            "delivery_failures": delivery_failures,
+        }
 
     async def _emit_event(
         self,

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -11698,7 +11698,12 @@ class CodexWorker:
             validation_errors=tuple(
                 {"code": "proposal_validation_error", "message": error}
                 for error in errors
-                if "missing" in error or "invalid" in error
+                if (
+                    "missing" in error
+                    or "invalid" in error
+                    or "malformed" in error
+                    or "skipped" in error
+                )
             ),
             delivery_failures=tuple(delivery_failures),
             external_links=tuple(external_links),
@@ -11742,8 +11747,15 @@ class CodexWorker:
             error = delivery.get("error")
             if isinstance(error, Mapping):
                 failure.update(dict(error))
-            else:
-                failure["message"] = "delivery failed"
+            failure.setdefault("code", "delivery_failed")
+            failure.setdefault(
+                "message",
+                str(
+                    failure.get("sanitizedReason")
+                    or failure.get("reason")
+                    or "delivery failed"
+                ),
+            )
             delivery_failures.append(failure)
         return {
             "delivered_count": 1 if delivered else 0,

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -33,6 +33,8 @@ class TaskProposalTaskPreview(BaseModel):
     skill_id: Optional[str] = Field(None, alias="skillId")
     task_skills: Optional[list[str]] = Field(None, alias="taskSkills")
     publish_mode: Optional[str] = Field(None, alias="publishMode")
+    priority: Optional[int] = Field(None, alias="priority")
+    max_attempts: Optional[int] = Field(None, alias="maxAttempts")
     starting_branch: Optional[str] = Field(None, alias="startingBranch")
     target_branch: Optional[str] = Field(None, alias="targetBranch")
     instructions: Optional[str] = Field(None, alias="instructions")
@@ -83,6 +85,7 @@ class TaskProposalModel(BaseModel):
     origin: TaskProposalOriginModel = Field(..., alias="origin")
     task_create_request: dict[str, Any] = Field(..., alias="taskCreateRequest")
     task_preview: Optional[TaskProposalTaskPreview] = Field(None, alias="taskPreview")
+    promotion_result: dict[str, Any] | None = Field(None, alias="promotionResult")
     similar: list["TaskProposalSimilarModel"] = Field(
         default_factory=list, alias="similar"
     )

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1283,6 +1283,10 @@ class ExecutionModel(BaseModel):
     related_runs: list[ExecutionRelatedRunModel] = Field(
         default_factory=list, alias="relatedRuns"
     )
+    proposal_summary: dict[str, Any] | None = Field(None, alias="proposalSummary")
+    proposal_outcomes: list[dict[str, Any]] = Field(
+        default_factory=list, alias="proposalOutcomes"
+    )
     debug_fields: Optional[ExecutionDebugFieldsModel] = Field(None, alias="debugFields")
     redirect_path: Optional[str] = Field(None, alias="redirectPath")
     manifest_artifact_ref: Optional[str] = Field(None, alias="manifestArtifactRef")

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3144,6 +3144,10 @@ class TemporalProposalActivities:
                                 )
                                 if "created" in delivery_node:
                                     decision["created"] = delivery_node["created"]
+                                if "duplicateSource" in delivery_node:
+                                    decision["duplicateSource"] = delivery_node[
+                                        "duplicateSource"
+                                    ]
                         submitted_count += 1
                     else:
                         logger.info(
@@ -3164,9 +3168,56 @@ class TemporalProposalActivities:
                         redacted_error,
                     )
 
+        delivered_count = 0
+        external_links: list[dict[str, Any]] = []
+        dedup_updates: list[dict[str, Any]] = []
+        delivery_failures: list[dict[str, Any]] = []
+        for decision in delivery_decisions:
+            if not isinstance(decision, Mapping) or not decision.get("accepted"):
+                continue
+            status = str(decision.get("deliveryStatus") or "").strip().lower()
+            external_url = str(decision.get("externalUrl") or "").strip()
+            external_key = str(decision.get("externalKey") or "").strip()
+            provider = str(decision.get("provider") or delivery_provider).strip()
+            if external_url:
+                link: dict[str, Any] = {"externalUrl": external_url}
+                if provider:
+                    link["provider"] = provider
+                if external_key:
+                    link["externalKey"] = external_key
+                external_links.append(link)
+            if external_url and status in {"", "delivered", "updated", "deduped"}:
+                delivered_count += 1
+            if decision.get("created") is False or decision.get("duplicateSource"):
+                dedup: dict[str, Any] = {"created": bool(decision.get("created"))}
+                if provider:
+                    dedup["provider"] = provider
+                if external_key:
+                    dedup["externalKey"] = external_key
+                if decision.get("duplicateSource"):
+                    dedup["duplicateSource"] = decision["duplicateSource"]
+                dedup_updates.append(dedup)
+            if status == "failed":
+                delivery_failures.append(
+                    {
+                        "provider": provider,
+                        "code": "delivery_failed",
+                        "message": "delivery failed",
+                    }
+                )
+
         return {
             "generated_count": generated_count,
             "submitted_count": submitted_count,
+            "deliveredCount": delivered_count,
+            "validationErrors": [
+                {"code": "proposal_validation_error", "message": error}
+                for error in errors
+                if "invalid" in error or "malformed" in error or "skipped" in error
+            ],
+            "deliveryFailures": delivery_failures,
+            "externalLinks": external_links,
+            "dedupUpdates": dedup_updates,
             "errors": errors,
             "delivery_decisions": delivery_decisions,
         }

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3148,6 +3148,8 @@ class TemporalProposalActivities:
                                     decision["duplicateSource"] = delivery_node[
                                         "duplicateSource"
                                     ]
+                                if "error" in delivery_node:
+                                    decision["error"] = delivery_node["error"]
                         submitted_count += 1
                     else:
                         logger.info(
@@ -3186,7 +3188,7 @@ class TemporalProposalActivities:
                 if external_key:
                     link["externalKey"] = external_key
                 external_links.append(link)
-            if external_url and status in {"", "delivered", "updated", "deduped"}:
+            if external_url and status in {"delivered", "updated", "deduped"}:
                 delivered_count += 1
             if decision.get("created") is False or decision.get("duplicateSource"):
                 dedup: dict[str, Any] = {"created": bool(decision.get("created"))}
@@ -3198,13 +3200,22 @@ class TemporalProposalActivities:
                     dedup["duplicateSource"] = decision["duplicateSource"]
                 dedup_updates.append(dedup)
             if status == "failed":
-                delivery_failures.append(
-                    {
-                        "provider": provider,
-                        "code": "delivery_failed",
-                        "message": "delivery failed",
-                    }
+                failure: dict[str, Any] = {}
+                if provider:
+                    failure["provider"] = provider
+                error = decision.get("error")
+                if isinstance(error, Mapping):
+                    failure.update(dict(error))
+                failure.setdefault("code", "delivery_failed")
+                failure.setdefault(
+                    "message",
+                    str(
+                        failure.get("sanitizedReason")
+                        or failure.get("reason")
+                        or "delivery failed"
+                    ),
                 )
+                delivery_failures.append(failure)
 
         return {
             "generated_count": generated_count,
@@ -3213,7 +3224,12 @@ class TemporalProposalActivities:
             "validationErrors": [
                 {"code": "proposal_validation_error", "message": error}
                 for error in errors
-                if "invalid" in error or "malformed" in error or "skipped" in error
+                if (
+                    "missing" in error
+                    or "invalid" in error
+                    or "malformed" in error
+                    or "skipped" in error
+                )
             ],
             "deliveryFailures": delivery_failures,
             "externalLinks": external_links,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -322,7 +322,12 @@ class MoonMindRunWorkflow:
         # Proposal tracking
         self._proposals_generated = 0
         self._proposals_submitted = 0
+        self._proposals_delivered = 0
         self._proposals_errors: list[str] = []
+        self._proposal_validation_errors: list[dict[str, Any]] = []
+        self._proposal_delivery_failures: list[dict[str, Any]] = []
+        self._proposal_external_links: list[dict[str, Any]] = []
+        self._proposal_dedup_updates: list[dict[str, Any]] = []
 
         # Auth profile slot tracking for managed agent runs.
         # Set when a child AgentRun acquires a slot so the parent can
@@ -3291,6 +3296,12 @@ class MoonMindRunWorkflow:
         else:
             return _coerce_bool(parameters.get("proposeTasks"), default=False)
 
+    @staticmethod
+    def _compact_proposal_rows(raw: Any) -> list[dict[str, Any]]:
+        if not isinstance(raw, list):
+            return []
+        return [dict(item) for item in raw if isinstance(item, dict)]
+
     def _resolve_task_body_instructions(self, task_payload: Mapping[str, Any]) -> str | None:
         instructions = self._coerce_text(task_payload.get("instructions"), flatten=False)
         if instructions:
@@ -5570,7 +5581,40 @@ class MoonMindRunWorkflow:
                 **self._execute_kwargs_for_route(submit_route),
             )
             if isinstance(submit_result, dict):
-                self._proposals_submitted = submit_result.get("submitted_count", 0)
+                self._proposals_submitted = int(
+                    submit_result.get("submitted_count")
+                    or submit_result.get("submittedCount")
+                    or 0
+                )
+                self._proposals_delivered = int(
+                    submit_result.get("delivered_count")
+                    or submit_result.get("deliveredCount")
+                    or 0
+                )
+                self._proposal_validation_errors.extend(
+                    self._compact_proposal_rows(
+                        submit_result.get("validation_errors")
+                        or submit_result.get("validationErrors")
+                    )
+                )
+                self._proposal_delivery_failures.extend(
+                    self._compact_proposal_rows(
+                        submit_result.get("delivery_failures")
+                        or submit_result.get("deliveryFailures")
+                    )
+                )
+                self._proposal_external_links.extend(
+                    self._compact_proposal_rows(
+                        submit_result.get("external_links")
+                        or submit_result.get("externalLinks")
+                    )
+                )
+                self._proposal_dedup_updates.extend(
+                    self._compact_proposal_rows(
+                        submit_result.get("dedup_updates")
+                        or submit_result.get("dedupUpdates")
+                    )
+                )
                 errors = submit_result.get("errors") or []
                 self._proposals_errors.extend(errors)
         except Exception as exc:
@@ -5688,6 +5732,11 @@ class MoonMindRunWorkflow:
                     "requested": self._proposal_generation_requested(parameters),
                     "generatedCount": self._proposals_generated,
                     "submittedCount": self._proposals_submitted,
+                    "deliveredCount": self._proposals_delivered,
+                    "validationErrors": self._proposal_validation_errors,
+                    "deliveryFailures": self._proposal_delivery_failures,
+                    "externalLinks": self._proposal_external_links,
+                    "dedupUpdates": self._proposal_dedup_updates,
                     "errors": self._proposals_errors,
                 },
                 "dependencies": {

--- a/specs/314-surface-proposal-outcomes/checklists/requirements.md
+++ b/specs/314-surface-proposal-outcomes/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Surface Proposal Outcomes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves Jira issue `MM-600`, the original Jira preset brief, one runtime user story, and source mappings for DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, and DESIGN-REQ-030.

--- a/specs/314-surface-proposal-outcomes/contracts/proposal-outcome-visibility-contract.md
+++ b/specs/314-surface-proposal-outcomes/contracts/proposal-outcome-visibility-contract.md
@@ -1,0 +1,101 @@
+# Contract: Proposal Outcome Visibility
+
+## Finish Summary Contract
+
+Run finish summaries and exported run summaries expose:
+
+```json
+{
+  "proposals": {
+    "requested": true,
+    "generatedCount": 2,
+    "submittedCount": 2,
+    "deliveredCount": 1,
+    "validationErrors": [
+      {"code": "proposal_missing_task", "message": "proposal skipped: task payload missing"}
+    ],
+    "deliveryFailures": [
+      {"provider": "jira", "code": "delivery_failed", "message": "delivery failed: [REDACTED]"}
+    ],
+    "externalLinks": [
+      {"provider": "jira", "externalKey": "MM-901", "externalUrl": "https://jira.example/browse/MM-901"}
+    ],
+    "dedupUpdates": [
+      {"provider": "github", "externalKey": "42", "created": false, "duplicateSource": "existing-open-issue"}
+    ]
+  }
+}
+```
+
+Rules:
+- Summary entries are compact.
+- Validation and delivery errors are redacted.
+- Full task snapshots and external issue body text are excluded.
+
+## Execution Detail / Mission Control Contract
+
+Execution detail and Mission Control surfaces expose proposal outcomes for the source run:
+
+```json
+{
+  "proposalOutcomes": [
+    {
+      "proposalId": "uuid",
+      "provider": "jira",
+      "externalKey": "MM-901",
+      "externalUrl": "https://jira.example/browse/MM-901",
+      "deliveryStatus": "delivered",
+      "lastSyncedAt": "2026-05-07T12:45:00Z",
+      "created": true,
+      "duplicateSource": null,
+      "taskSummary": {
+        "runtime": "codex",
+        "repository": "MoonMind/MoonMind",
+        "publishMode": "pr",
+        "priority": 0,
+        "maxAttempts": 3,
+        "skillContext": ["moonspec-implement"],
+        "presetProvenance": "preserved-binding"
+      },
+      "promotionResult": {
+        "promotedExecutionId": "wf-promoted-1",
+        "promotedExecutionUrl": "/tasks/temporal/wf-promoted-1"
+      }
+    }
+  ]
+}
+```
+
+Rules:
+- Missing source values are omitted or shown as unavailable.
+- The compact task summary is review information only.
+- Promotion links appear only when promotion has occurred.
+
+## State Compatibility Contract
+
+While proposals are being generated, submitted, or delivered:
+
+```json
+{
+  "mm_state": "proposals",
+  "dashboardStatus": "running"
+}
+```
+
+Rules:
+- API consumers can still identify the specific `proposals` state.
+- Dashboard compatibility continues to group `proposals` with running work.
+
+## Review Path Contract
+
+Normal proposal review uses:
+- GitHub Issues
+- Jira issues
+
+MoonMind UI may show:
+- source run finish summary
+- execution detail delivery links
+- compact delivery status cards
+- admin/recovery views
+
+MoonMind UI must not require a standalone proposal queue page as the normal Promote/Dismiss review path.

--- a/specs/314-surface-proposal-outcomes/data-model.md
+++ b/specs/314-surface-proposal-outcomes/data-model.md
@@ -1,0 +1,94 @@
+# Data Model: Surface Proposal Outcomes
+
+## Proposal Outcome Summary
+
+Operator-visible summary for one run's proposal stage.
+
+Fields:
+- `requested`: whether proposal generation was requested for the run.
+- `generatedCount`: number of generated proposal candidates.
+- `submittedCount`: number of candidates accepted for proposal submission.
+- `deliveredCount`: number of proposals delivered to external tracker issues.
+- `validationErrors`: redacted validation errors for skipped malformed candidates.
+- `deliveryFailures`: redacted provider-specific delivery failures.
+- `externalLinks`: compact list of delivered GitHub/Jira issue links.
+- `dedupUpdates`: compact list of proposals attached to or updating existing external issues.
+
+Validation rules:
+- Counts must be non-negative integers.
+- Error values must be redacted before artifact publication or UI exposure.
+- Links must identify provider and external key without embedding credentials.
+- Summary payloads must remain compact and must not embed full task snapshots or external issue bodies.
+
+## Proposal Delivery Outcome
+
+Run-scoped representation of one delivered or attempted proposal.
+
+Fields:
+- `proposalId`
+- `provider`
+- `externalKey`
+- `externalUrl`
+- `deliveryStatus`
+- `lastSyncedAt`
+- `created`
+- `duplicateSource`
+- `taskSnapshotRef`
+- `taskSummary`
+- `promotionResult`
+- `errors`
+
+Validation rules:
+- `provider`, `externalKey`, and `externalUrl` are present only when known.
+- `deliveryStatus` uses bounded proposal-delivery states such as `pending`, `delivered`, `failed`, `updated`, or `deduped`.
+- `duplicateSource` is present only when delivery reused or updated an existing issue.
+- `errors` are redacted and compact.
+
+## Compact Proposal Task Summary
+
+Small task-facing summary shown to operators without exposing the full task payload.
+
+Fields:
+- `runtime`
+- `repository`
+- `publishMode`
+- `priority`
+- `maxAttempts`
+- `skillContext`
+- `presetProvenance`
+
+Validation rules:
+- Fields may be omitted when the stored proposal lacks the source value.
+- The summary must never be used as the executable task contract.
+- Full stored proposal snapshots remain referenced by `taskSnapshotRef`.
+
+## Promotion Result
+
+Visibility record for an externally approved proposal that has been promoted.
+
+Fields:
+- `promotedExecutionId`
+- `promotedExecutionUrl`
+- `providerEventId`
+- `resultingExternalState`
+- `promotedAt`
+
+Validation rules:
+- Promotion links are shown only after a promotion result is known.
+- Duplicate provider approvals must not create duplicate promoted executions.
+
+## State Transitions
+
+Proposal-stage run state:
+- `scheduled|planning|executing -> proposals -> finalizing|completed|failed|canceled`
+
+Proposal delivery outcome:
+- `pending -> delivered`
+- `pending -> failed`
+- `delivered -> updated`
+- `delivered -> promoted`
+- `delivered -> dismissed|deferred|request_revision`
+
+Dedup outcome:
+- `new candidate -> new external issue`
+- `new candidate -> existing external issue update/link`

--- a/specs/314-surface-proposal-outcomes/moonspec_align_report.md
+++ b/specs/314-surface-proposal-outcomes/moonspec_align_report.md
@@ -1,0 +1,31 @@
+# MoonSpec Alignment Report: Surface Proposal Outcomes
+
+**Created**: 2026-05-07
+**Feature**: `specs/314-surface-proposal-outcomes`
+**Source**: MM-600 canonical Jira preset brief preserved in `spec.md`
+
+## Findings And Remediation
+
+| Area | Finding | Remediation | Status |
+| --- | --- | --- | --- |
+| Test strategy consistency | `tasks.md` referenced `tests/unit/agents/codex_worker/test_worker.py` and planned `frontend/src/entrypoints/proposals.test.tsx`, but `plan.md` and `quickstart.md` focused commands did not include both targets. | Updated `plan.md`, `quickstart.md`, and `tasks.md` so focused Python and frontend commands match the task list. | PASS |
+| Parallel markers | `tasks.md` marked multiple tasks as parallel even though they modify the same files: `tests/unit/workflows/temporal/workflows/test_run_proposals.py` and `tests/integration/temporal/test_proposal_review_delivery.py`. | Removed `[P]` from the conflicting verification/integration tasks and updated the parallel-opportunities notes. | PASS |
+| Traceability coverage | `FR-*`, `SC-*`, and `DESIGN-REQ-*` mappings needed re-check after task edits. | Verified every `FR-001` through `FR-014`, `SC-001` through `SC-008`, and `DESIGN-REQ-009/028/029/030` appears in `tasks.md`. | PASS |
+| Story shape | Alignment must preserve one independently testable story and avoid implementation work. | Verified exactly one story phase remains and only MoonSpec artifacts were edited. | PASS |
+
+## Gate Results
+
+- Specify gate: PASS - `spec.md` preserves MM-600, the original preset brief, one user story, and source mappings.
+- Plan gate: PASS - `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/` exist and have explicit unit/integration strategies.
+- Tasks gate: PASS - `tasks.md` has 45 sequential tasks, unit and integration tests before implementation, red-first confirmation tasks, conditional fallback tasks for implemented-unverified rows, and final `/moonspec-verify`.
+
+## Validation Evidence
+
+- `check-prerequisites.sh --json --require-tasks --include-tasks`: BLOCKED by managed branch name `change-jira-issue-mm-600-to-status-in-pr-39787ea8`; active feature was resolved from `.specify/feature.json`.
+- Artifact coverage script: PASS - no missing `FR-*`, `SC-*`, or `DESIGN-REQ-*` IDs in `tasks.md`.
+- Task format script: PASS - 45 tasks, `T001` through `T045`, sequential IDs, one story phase, no unresolved clarification markers, no sample placeholders.
+
+## Remaining Risks
+
+- No application tests were run because this alignment step edited MoonSpec artifacts only.
+- The prerequisite script still cannot resolve the managed branch name; downstream steps should continue using `.specify/feature.json` unless the branch is renamed by the orchestration environment.

--- a/specs/314-surface-proposal-outcomes/plan.md
+++ b/specs/314-surface-proposal-outcomes/plan.md
@@ -1,0 +1,144 @@
+# Implementation Plan: Surface Proposal Outcomes
+
+**Branch**: `314-surface-proposal-outcomes` | **Date**: 2026-05-07 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:0c314657-113e-4d5e-951f-7149150d8b9e/repo/specs/314-surface-proposal-outcomes/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted but rejected the managed branch name `change-jira-issue-mm-600-to-status-in-pr-39787ea8` because it is not in `001-feature-name` form. Planning continued manually from `.specify/feature.json` and the active feature directory.
+
+## Summary
+
+Deliver MM-600 by turning existing proposal-generation, proposal-delivery, and provider-decision records into operator-visible finish-summary, exported-summary, API, execution-detail, and Mission Control outcome surfaces. Current code already enters a `proposals` workflow state, records generated/submitted counts and errors in Temporal and Codex finish summaries, exposes proposal delivery-record fields through `/api/proposals`, computes dedup identities, records provider decision metadata and promoted execution IDs, and maps `proposals` to running for dashboard compatibility. The missing behavior is the complete visibility contract: delivered counts, issue links, dedup new-or-updated status, provider-specific failures, redacted validation errors, compact task summaries, promotion links, and proof that GitHub/Jira remain the normal proposal review path instead of a standalone MoonMind queue. The plan uses TDD with focused unit coverage for summary assembly, proposal-service serialization, API schemas, and UI rendering, plus integration/boundary coverage for a proposal-capable run that produces delivered, duplicate, malformed, failed-delivery, and promoted outcomes.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `moonmind/workflows/temporal/workflows/run.py` and `moonmind/agents/codex_worker/worker.py` include proposal `requested` in finish summaries | keep requested visibility and add coverage across Temporal/Codex summary paths | unit + integration |
+| FR-002 | partial | summaries include generated/submitted counts; delivered count is absent from both inspected summary builders | add delivered count to proposal-stage result and summaries | unit + integration |
+| FR-003 | partial | summaries include generic errors and summary payloads are redacted, but provider-specific delivery failures and validation-error categories are not exposed consistently | add structured redacted validation and provider-failure output | unit + integration |
+| FR-004 | partial | `/api/proposals` serializes `externalUrl`; finish summaries and execution detail do not yet expose delivered issue links | propagate external links into summaries and execution-detail/Mission Control surfaces | unit + integration |
+| FR-005 | partial | proposal service computes dedup fields and delivery metadata can carry `created`/`duplicateSource`; finish summaries and detail surfaces do not show dedup updates | surface new-or-updated/dedup attachment status in summaries and detail UI | unit + integration |
+| FR-006 | implemented_unverified | `MoonMindRunWorkflow._run_proposals_stage()` calls `_set_state(STATE_PROPOSALS)`; API status vocabulary includes `proposals` | add direct state exposure verification for proposal-stage execution | unit + integration |
+| FR-007 | implemented_verified | `tests/unit/api/routers/test_task_dashboard_view_model.py` proves Temporal `proposals` normalizes to `running`; task-list tests include `proposals` filter option | preserve dashboard compatibility mapping | final verify |
+| FR-008 | partial | `/api/proposals` serializes provider, external key/url, delivery status, delivered/synced timestamps, review delivery, and task snapshot refs; execution detail and Mission Control do not consume this as run outcome visibility | add proposal outcome payload to execution detail boot/API and render it in Mission Control/detail views | unit + integration |
+| FR-009 | partial | `_build_task_preview()` derives runtime, repository, publish mode, skills, and preset provenance for proposal records; max attempts/priority and run-detail visibility are incomplete | complete compact task summary fields and render them on run detail/Mission Control outcome surfaces | unit |
+| FR-010 | implemented_unverified | proposal submission skips malformed records such as missing title/task payload and records errors; provider-decision safety tests prevent edited text from replacing stored snapshots | add redacted visible-error tests for malformed candidates and no-promotion guarantee in outcome surfaces | unit + integration |
+| FR-011 | partial | delivery adapter and provider decision tests cover some retry/idempotency paths; summaries and diagnostics do not show external delivery failures end to end | add retry-safe delivery-failure metadata and visible diagnostics | unit + integration |
+| FR-012 | partial | external GitHub/Jira issue review path exists in delivery design, but `frontend/src/entrypoints/proposals.tsx` still presents a proposal queue-like page | ensure normal navigation and feature wording treat external trackers as primary; keep any MoonMind proposal page as admin/recovery only or remove normal review affordance | frontend unit |
+| FR-013 | partial | provider decision responses and delivery recovery expose `promotedExecutionId`; execution detail/Mission Control do not show promotion result links as proposal outcomes | surface promoted execution links in run detail and Mission Control | unit + integration |
+| FR-014 | implemented_unverified | `spec.md` preserves MM-600 and the original preset brief; this plan preserves MM-600 | preserve traceability through research, design artifacts, tasks, verification, commit, and PR metadata | final verify |
+| SCN-001 | partial | generated/submitted proposal counts exist in summaries | add delivered counts and external links to summary scenario | unit + integration |
+| SCN-002 | partial | dedup identity and duplicate-source metadata exist; run summary/detail visibility is missing | add duplicate delivery scenario coverage | unit + integration |
+| SCN-003 | partial | malformed candidates and provider failures are handled in service/worker paths; visible redacted outcome evidence is incomplete | add malformed and provider-failure scenario coverage | unit + integration |
+| SCN-004 | implemented_unverified | `STATE_PROPOSALS`, status vocabulary, and dashboard mapping exist | add proposal-stage state boundary test | unit + integration |
+| SCN-005 | partial | provider decision metadata can store promoted execution IDs; Mission Control/detail links are missing | add promoted proposal outcome scenario | unit + integration |
+| SCN-006 | partial | external tracker issue delivery is modeled; standalone proposal page remains visible as queue-like UI | adjust/reframe normal review path and add UI assertions | frontend unit |
+| SC-001 | partial | generated/submitted counts covered; requested/delivered full set not covered | add summary contract tests for all count fields | unit + integration |
+| SC-002 | partial | proposal API serializes external URLs; summary/detail parity missing | add parity test between delivered links and summary/detail outcome links | unit + integration |
+| SC-003 | implemented_unverified | malformed candidate handling exists but is not proven through visible outcome surfaces | add visible skipped/error and zero-promotion tests | unit + integration |
+| SC-004 | partial | redaction helpers and delivery/provider decision tests exist; provider-failure summary diagnostics not complete | add redacted provider-failure diagnostics tests | unit + integration |
+| SC-005 | implemented_verified | dashboard mapping test proves `proposals -> running`; status options include `proposals` | preserve existing coverage and add state exposure boundary if needed | final verify + integration |
+| SC-006 | partial | proposal API has most delivery/task-preview fields; UI run detail/Mission Control visibility missing | add API and frontend rendering tests for complete compact outcome fields | unit + frontend unit |
+| SC-007 | partial | existing `ProposalsPage` appears to be a normal queue page | add tests/changes so external trackers are primary and MoonMind proposal page is not the normal review path | frontend unit |
+| SC-008 | implemented_unverified | `spec.md` and this plan preserve MM-600 and source mappings | preserve through tasks and final verification | final verify |
+| DESIGN-REQ-009 | partial | finish summaries include requested/generated/submitted/errors but not delivered links/dedup updates | same as FR-001 through FR-005 | unit + integration |
+| DESIGN-REQ-028 | partial | `mm_state=proposals` and proposal record fields exist; execution detail/Mission Control outcome visibility incomplete | same as FR-006 through FR-009 and FR-013 | unit + integration + frontend unit |
+| DESIGN-REQ-029 | partial | malformed and delivery failure handling exists but visible redacted partial-success reporting is incomplete | same as FR-003, FR-010, and FR-011 | unit + integration |
+| DESIGN-REQ-030 | partial | external issue delivery exists, but a queue-like MoonMind proposals page remains exposed | same as FR-012 | frontend unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI  
+**Primary Dependencies**: Pydantic v2, FastAPI, SQLAlchemy async ORM, Temporal Python SDK, existing proposal service/repository, existing Temporal workflow/activity catalog, React, TanStack Query, Zod, Vitest, pytest  
+**Storage**: Existing `task_proposals` table and provider metadata fields; no new persistent table planned unless summary/detail visibility cannot safely derive from existing proposal delivery records and workflow artifacts  
+**Unit Testing**: pytest through `./tools/test_unit.sh`; focused Python iteration with `python -m pytest tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/api/routers/test_task_dashboard_view_model.py -q`; focused UI iteration with `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx` after JS deps are prepared  
+**Integration Testing**: pytest integration/boundary coverage, preferably extending `tests/integration/temporal/test_proposal_review_delivery.py`; run `./tools/test_integration.sh` when adding or changing `integration_ci` tests  
+**Target Platform**: MoonMind backend control plane, Temporal workflow/worker runtime, and Mission Control web UI on Linux  
+**Project Type**: Backend workflow/control-plane service plus frontend operational dashboard  
+**Performance Goals**: Proposal outcome rendering remains bounded by the delivered proposal count for one run; summary payloads stay compact and avoid embedding large task snapshots or external issue bodies  
+**Constraints**: Provider credentials stay inside trusted integration boundaries; errors and diagnostics must be redacted; proposal promotion uses stored snapshots only; no standalone proposal queue as the normal review path; workflow/activity payload changes need boundary regression coverage; no compatibility aliases for internal pre-release contracts  
+**Scale/Scope**: One runtime story for a proposal-capable run's outcome visibility across summaries, API state, execution detail, Mission Control, and external tracker links
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The plan surfaces proposal outcomes from existing orchestration and provider records without changing agent cognition.
+- II. One-Click Agent Deployment: PASS. Required tests stay hermetic; external provider credentials are not required for required CI.
+- III. Avoid Vendor Lock-In: PASS. GitHub/Jira links are represented through provider-neutral outcome fields and provider metadata.
+- IV. Own Your Data: PASS. Proposal snapshots, summaries, delivery records, and diagnostics remain in MoonMind-controlled storage/artifacts.
+- V. Skills Are First-Class and Easy to Add: PASS. Compact task summaries preserve skill context and preset provenance when present.
+- VI. Design for Deletion / Thick Contracts: PASS. Summary, API, and UI contracts are explicit and provider-specific details stay behind existing delivery boundaries.
+- VII. Runtime Configurability: PASS. Proposal generation and delivery continue to use existing workflow settings and task proposal policy.
+- VIII. Modular and Extensible Architecture: PASS. Planned changes are scoped to proposal workflow summaries, proposal service/API serialization, and Mission Control/detail rendering.
+- IX. Resilient by Default: PASS. Partial success, retry-safe delivery failures, dedup updates, and redacted diagnostics are explicit plan requirements.
+- X. Facilitate Continuous Improvement: PASS. Proposal outcomes become part of structured run outcomes and operator diagnostics.
+- XI. Spec-Driven Development: PASS. `spec.md`, this `plan.md`, and design artifacts preserve MM-600 before implementation.
+- XII. Canonical Documentation Separation: PASS. Planning and rollout details remain under `specs/314-*`; canonical docs remain desired-state source requirements.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility aliases are planned; internal proposal outcome payloads should be updated consistently with tests.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/314-surface-proposal-outcomes/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── proposal-outcome-visibility-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # created by moonspec-tasks, not this step
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── agents/codex_worker/worker.py                    # Codex finish summary/report payload
+├── schemas/task_proposal_models.py                  # proposal API/output schemas
+└── workflows/
+    ├── task_proposals/
+    │   ├── delivery.py                              # delivery result/decision metadata
+    │   ├── models.py                                # proposal delivery record fields
+    │   ├── repositories.py                          # proposal lookup/update persistence
+    │   └── service.py                               # dedup, validation, promotion, failure metadata
+    └── temporal/workflows/run.py                    # Temporal proposal stage state and finish summary
+
+api_service/
+└── api/routers/
+    ├── executions.py                                # execution detail/action/state payloads
+    └── task_proposals.py                            # proposal serialization and delivery recovery
+
+frontend/src/
+├── entrypoints/
+│   ├── task-detail.tsx                              # execution detail proposal outcome rendering
+│   ├── mission-control.test.tsx                     # Mission Control rendering tests
+│   ├── task-detail.test.tsx                         # detail rendering tests
+│   ├── tasks-list.tsx                               # status option and navigation behavior
+│   └── proposals.tsx                                # admin/recovery-only proposal surface if retained
+└── styles/mission-control.css                       # any compact outcome card/status styling
+
+tests/
+├── unit/
+│   ├── agents/codex_worker/test_worker.py
+│   ├── api/routers/test_task_proposals.py
+│   ├── api/routers/test_task_dashboard_view_model.py
+│   └── workflows/
+│       ├── task_proposals/test_service.py
+│       └── temporal/workflows/test_run_proposals.py
+└── integration/
+    └── temporal/test_proposal_review_delivery.py
+```
+
+**Structure Decision**: Reuse the existing proposal delivery record, proposal service, Temporal proposal stage, Codex finish summary builder, executions router, and Mission Control task-detail surfaces. Add fields and rendering at existing boundaries rather than introducing a new proposal queue or storage table.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| None | N/A | N/A |

--- a/specs/314-surface-proposal-outcomes/plan.md
+++ b/specs/314-surface-proposal-outcomes/plan.md
@@ -51,7 +51,7 @@ Deliver MM-600 by turning existing proposal-generation, proposal-delivery, and p
 **Language/Version**: Python 3.12; TypeScript/React for Mission Control UI  
 **Primary Dependencies**: Pydantic v2, FastAPI, SQLAlchemy async ORM, Temporal Python SDK, existing proposal service/repository, existing Temporal workflow/activity catalog, React, TanStack Query, Zod, Vitest, pytest  
 **Storage**: Existing `task_proposals` table and provider metadata fields; no new persistent table planned unless summary/detail visibility cannot safely derive from existing proposal delivery records and workflow artifacts  
-**Unit Testing**: pytest through `./tools/test_unit.sh`; focused Python iteration with `python -m pytest tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/api/routers/test_task_dashboard_view_model.py -q`; focused UI iteration with `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx` after JS deps are prepared  
+**Unit Testing**: pytest through `./tools/test_unit.sh`; focused Python iteration with `python -m pytest tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/agents/codex_worker/test_worker.py -q`; focused UI iteration with `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/proposals.test.tsx` after JS deps are prepared  
 **Integration Testing**: pytest integration/boundary coverage, preferably extending `tests/integration/temporal/test_proposal_review_delivery.py`; run `./tools/test_integration.sh` when adding or changing `integration_ci` tests  
 **Target Platform**: MoonMind backend control plane, Temporal workflow/worker runtime, and Mission Control web UI on Linux  
 **Project Type**: Backend workflow/control-plane service plus frontend operational dashboard  
@@ -120,6 +120,7 @@ frontend/src/
 │   ├── mission-control.test.tsx                     # Mission Control rendering tests
 │   ├── task-detail.test.tsx                         # detail rendering tests
 │   ├── tasks-list.tsx                               # status option and navigation behavior
+│   ├── proposals.test.tsx                           # proposal admin/recovery path guardrail tests
 │   └── proposals.tsx                                # admin/recovery-only proposal surface if retained
 └── styles/mission-control.css                       # any compact outcome card/status styling
 

--- a/specs/314-surface-proposal-outcomes/quickstart.md
+++ b/specs/314-surface-proposal-outcomes/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: Surface Proposal Outcomes
+
+## Prerequisites
+
+- Run from repository root.
+- Use local managed-agent test mode for unit tests:
+
+```bash
+export MOONMIND_FORCE_LOCAL_TESTS=1
+```
+
+## Focused Unit Test Plan
+
+Add failing tests first, then implement until they pass:
+
+```bash
+python -m pytest \
+  tests/unit/workflows/temporal/workflows/test_run_proposals.py \
+  tests/unit/workflows/task_proposals/test_service.py \
+  tests/unit/api/routers/test_task_proposals.py \
+  tests/unit/api/routers/test_task_dashboard_view_model.py \
+  tests/unit/agents/codex_worker/test_worker.py \
+  -q
+```
+
+Expected coverage:
+- requested/generated/submitted/delivered counts in proposal summaries
+- redacted validation errors and provider delivery failures
+- external issue links and dedup updates in summary/detail payloads
+- `mm_state=proposals` remains visible and maps to running
+- promoted execution IDs become run-detail-visible promotion links
+
+## Focused Frontend Test Plan
+
+After JS dependencies are prepared:
+
+```bash
+npm run ui:test -- \
+  frontend/src/entrypoints/task-detail.test.tsx \
+  frontend/src/entrypoints/mission-control.test.tsx \
+  frontend/src/entrypoints/tasks-list.test.tsx
+```
+
+Expected coverage:
+- execution detail and Mission Control show proposal provider, external key, delivery status, last sync timestamp, dedup status, compact task summary, and promotion link
+- task status filtering still includes `proposals`
+- normal UI copy/navigation does not make a standalone MoonMind proposal queue the primary review path
+
+## Focused Integration Test Plan
+
+Extend the hermetic proposal review delivery boundary:
+
+```bash
+python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q
+```
+
+Expected coverage:
+- one proposal-capable run produces delivered, duplicate, malformed, failed-delivery, and promoted outcomes
+- finish summary, exported run summary, API detail payload, and Mission Control-facing payloads expose matching compact outcome data
+- malformed candidates do not promote
+- duplicate provider delivery remains idempotent
+
+## Final Verification Commands
+
+Before completing implementation in a later step:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+If `./tools/test_integration.sh` is blocked by unavailable Docker in the managed environment, record the exact blocker and preserve focused integration evidence.
+
+## End-to-End Story Check
+
+1. Submit or simulate a proposal-capable run with proposal generation requested.
+2. Include one delivered proposal, one duplicate/dedup update, one malformed candidate, one provider delivery failure, and one promoted proposal.
+3. Confirm finish summary and exported run summary include requested/generated/submitted/delivered counts, links, dedup updates, and redacted failures.
+4. Confirm execution detail and Mission Control show provider, external key, delivery status, last sync, dedup status, compact task summary, and promotion result links.
+5. Confirm GitHub or Jira remains the normal human review surface.

--- a/specs/314-surface-proposal-outcomes/quickstart.md
+++ b/specs/314-surface-proposal-outcomes/quickstart.md
@@ -38,7 +38,8 @@ After JS dependencies are prepared:
 npm run ui:test -- \
   frontend/src/entrypoints/task-detail.test.tsx \
   frontend/src/entrypoints/mission-control.test.tsx \
-  frontend/src/entrypoints/tasks-list.test.tsx
+  frontend/src/entrypoints/tasks-list.test.tsx \
+  frontend/src/entrypoints/proposals.test.tsx
 ```
 
 Expected coverage:

--- a/specs/314-surface-proposal-outcomes/research.md
+++ b/specs/314-surface-proposal-outcomes/research.md
@@ -1,0 +1,121 @@
+# Research: Surface Proposal Outcomes
+
+## FR-001 / Proposal Requested Summary
+
+Decision: partial; preserve existing requested flag and add tests proving it appears in all required summary outputs.
+Evidence: `moonmind/workflows/temporal/workflows/run.py` writes `proposals.requested`; `moonmind/agents/codex_worker/worker.py` writes `proposals.requested` in `reports/run_summary.json`.
+Rationale: The core flag exists, but MM-600 requires the whole summary contract, so this stays partial until verified with delivered/failure/link fields.
+Alternatives considered: Treat as implemented; rejected because the success criteria require the full proposal outcome summary set.
+Test implications: unit + integration.
+
+## FR-002 / Generated Submitted Delivered Counts
+
+Decision: partial; generated/submitted counts exist, delivered count must be added to proposal submission results and finish summaries.
+Evidence: `run.py` stores `_proposals_generated` and `_proposals_submitted`; `worker.py` `ProposalSubmissionReport` has `generated_count` and `submitted_count` only.
+Rationale: Delivered count is a named acceptance criterion and is not represented in inspected summary builders.
+Alternatives considered: Derive delivered count in UI from proposal records only; rejected because finish summaries and exported summaries also require it.
+Test implications: unit + integration.
+
+## FR-003 / Redacted Provider Failures And Validation Errors
+
+Decision: partial; existing generic error arrays must become structured enough to distinguish redacted validation errors from provider-specific delivery failures.
+Evidence: `run.py` appends generation/submission errors; `worker.py` redacts finish summary payloads; proposal service and delivery tests use `SecretRedactor`.
+Rationale: Operators need partial-success diagnostics without secrets, and generic strings are insufficient for provider failure visibility.
+Alternatives considered: Leave provider diagnostics only in logs; rejected because the spec requires summaries, delivery records, and operator diagnostics.
+Test implications: unit + integration.
+
+## FR-004 / External Issue Links
+
+Decision: partial; proposal records expose external URLs but run summaries and execution detail must link delivered proposals.
+Evidence: `TaskProposalModel` serializes `externalUrl`; `task_proposals.py` returns review delivery external URLs; no task-detail references to proposal delivery URLs were found.
+Rationale: Delivered links are already persisted but not surfaced in the run-centric places required by MM-600.
+Alternatives considered: Use `/api/proposals` as the only link surface; rejected because execution detail and finish summaries are required.
+Test implications: unit + integration + frontend unit.
+
+## FR-005 / Dedup Updates
+
+Decision: partial; dedup calculation and duplicate metadata exist, but summary/detail outcome visibility is missing.
+Evidence: `TaskProposalRepository.find_open_duplicate()` and service dedup tests exist; review delivery serialization can include `created` and `duplicateSource`.
+Rationale: Operators must see whether a candidate created a new issue or updated/attached to an existing issue.
+Alternatives considered: Hide dedup status behind provider metadata; rejected because the spec calls for dedup updates in summaries and Mission Control.
+Test implications: unit + integration + frontend unit.
+
+## FR-006 / Proposal State Exposure
+
+Decision: implemented_unverified; workflow state-setting code exists but should gain a direct boundary test for active proposal-stage visibility.
+Evidence: `MoonMindRunWorkflow._run_proposals_stage()` calls `_set_state(STATE_PROPOSALS, summary="Generating task proposals.")`; executions router includes `proposals` in status vocabulary.
+Rationale: The behavior appears implemented, but current inspected tests focus on activity invocation and dashboard mapping rather than state exposure while in progress.
+Alternatives considered: Mark implemented_verified; rejected because no direct state exposure assertion was found.
+Test implications: unit + integration.
+
+## FR-007 / Dashboard Running Compatibility
+
+Decision: implemented_verified; preserve existing mapping.
+Evidence: `tests/unit/api/routers/test_task_dashboard_view_model.py` asserts `proposals` maps to `running`; task-list tests include `proposals` status filtering.
+Rationale: Current tests directly cover the compatibility mapping.
+Alternatives considered: Add more implementation; rejected because no code change is currently indicated beyond final verification.
+Test implications: none beyond final verify unless adjacent state payloads change.
+
+## FR-008 / Delivery Detail Visibility
+
+Decision: partial; API serialization exists for proposal records, but execution detail and Mission Control need run-scoped outcome visibility.
+Evidence: `TaskProposalModel` and `_serialize_review_delivery()` expose provider, status, external key/url, task snapshot, and created/duplicate fields; `task-detail.tsx` has no proposal outcome rendering references beyond URL parsing.
+Rationale: The required operator surface is run detail/Mission Control, not only the standalone proposal list.
+Alternatives considered: Link out to the proposal page; rejected because normal review must remain external-tracker-native.
+Test implications: unit + frontend unit + integration.
+
+## FR-009 / Compact Task Summary
+
+Decision: partial; task preview has many required fields but is incomplete and not rendered in required surfaces.
+Evidence: `_build_task_preview()` serializes repository, runtime, skill, publish mode, instructions, preset provenance, authored preset count, and step source metadata.
+Rationale: Priority and attempt policy are not visible, and the preview is not attached to run detail/Mission Control proposal outcomes.
+Alternatives considered: Show full task payload; rejected because large task snapshots must stay out of workflow/UI summary payloads.
+Test implications: unit + frontend unit.
+
+## FR-010 / Malformed Candidate Handling
+
+Decision: implemented_unverified; existing submission code skips malformed proposals but must prove visible redacted outcome data and no promotion.
+Evidence: `worker.py` and `TaskProposalService` paths skip missing title/task payload candidates and record errors; provider decision tests prove edited issue text does not replace stored snapshots.
+Rationale: The safety behavior exists in service layers, but MM-600 requires operator-visible redacted errors and no silent semantic drops.
+Alternatives considered: Treat as implemented; rejected because outcome-surface proof is missing.
+Test implications: unit + integration.
+
+## FR-011 / Retry-Safe Delivery Failures
+
+Decision: partial; provider delivery and decision paths have idempotency foundations, but delivery-failure visibility across summaries/diagnostics is incomplete.
+Evidence: delivery service tests cover external delivery result persistence and duplicate provider event handling; summary builders do not include delivery failure categories.
+Rationale: External delivery failures must be visible and retry-safe across multiple surfaces.
+Alternatives considered: Rely on provider logs only; rejected for operator diagnostics.
+Test implications: unit + integration.
+
+## FR-012 / External Tracker Primary Review
+
+Decision: partial; the architecture is external-tracker-native, but the current UI exposes a queue-like `ProposalsPage`.
+Evidence: `frontend/src/entrypoints/proposals.tsx` labels the page "Review and manage task proposals in the queue"; source docs require no standalone proposal page as the normal review path.
+Rationale: The implementation must ensure GitHub/Jira is the normal path and any MoonMind surface is status/admin/recovery only.
+Alternatives considered: Delete all proposal UI; rejected because status/admin/recovery views remain valid source-design surfaces.
+Test implications: frontend unit.
+
+## FR-013 / Promotion Result Links
+
+Decision: partial; provider decision responses can store promoted execution IDs, but run detail/Mission Control outcome links are missing.
+Evidence: `TaskProposalProviderDecisionResponse` includes `promotedExecutionId`; tests cover provider decision promotion through canonical execution path and delivery recovery exposes provider decisions.
+Rationale: Promotion outcome is known but not yet surfaced where MM-600 requires it.
+Alternatives considered: Keep promotion links only in provider metadata; rejected because operators need run detail/Mission Control visibility.
+Test implications: unit + integration + frontend unit.
+
+## FR-014 / MM-600 Traceability
+
+Decision: implemented_unverified; preserve through all downstream artifacts.
+Evidence: `spec.md` preserves the canonical Jira preset brief and this plan preserves MM-600.
+Rationale: Verification must compare against the preserved Jira source.
+Alternatives considered: none.
+Test implications: final verify.
+
+## Test Strategy
+
+Decision: use test-first backend unit tests, frontend unit tests, and hermetic integration coverage.
+Evidence: Repo instructions require `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for `integration_ci`. Existing focused tests live in `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, and frontend Mission Control/task detail tests.
+Rationale: The story crosses workflow summary, API serialization, and UI rendering boundaries, so isolated tests alone are insufficient.
+Alternatives considered: UI-only validation; rejected because summary/report contracts and workflow state are backend-owned.
+Test implications: unit + integration + frontend unit.

--- a/specs/314-surface-proposal-outcomes/spec.md
+++ b/specs/314-surface-proposal-outcomes/spec.md
@@ -1,0 +1,160 @@
+# Feature Specification: Surface Proposal Outcomes
+
+**Feature Branch**: `314-surface-proposal-outcomes`
+**Created**: 2026-05-07
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-600 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-600 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-600
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Surface proposal outcomes in summaries and Mission Control
+- Priority: Medium
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or any non-empty recommended/preset custom field; potentially related custom fields `Implementation plan`, `Backout plan`, and `Test plan` were present but empty.
+- Trusted response artifact: `/work/agent_jobs/mm:0c314657-113e-4d5e-951f-7149150d8b9e/artifacts/moonspec-inputs/MM-600-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-600 from MM project
+Summary: Surface proposal outcomes in summaries and Mission Control
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-600 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-600: Surface proposal outcomes in summaries and Mission Control
+
+Source Reference
+Source Document: docs/Tasks/TaskProposalSystem.md
+Source Title: Task Proposal System
+Source Sections:
+- 3.6 Finish summary integration
+- 10. Observability and UI Contract
+- 14. Acceptance Criteria
+Coverage IDs:
+- DESIGN-REQ-009
+- DESIGN-REQ-028
+- DESIGN-REQ-029
+- DESIGN-REQ-030
+
+As a MoonMind operator, I need proposal generation, delivery, dedup, failure, and promotion outcomes visible in finish summaries, reports, APIs, execution detail, and Mission Control without creating a new primary proposal queue.
+
+Acceptance Criteria
+- Finish summaries and reports/run_summary.json include requested/generated/submitted/delivered counts, provider failures, redacted validation errors, issue links, and dedup updates.
+- Execution detail and Mission Control show provider, external key, delivery status, last sync timestamp, dedup new-or-updated status, compact task summary, and promotion result links.
+- mm_state=proposals is visible and mapped to running for dashboard compatibility.
+- Malformed candidates are skipped with visible redacted errors and do not promote or silently drop semantically important fields.
+- External delivery failures are retried idempotently and visible in summaries, delivery records, and operator diagnostics.
+- No standalone proposal queue page becomes the normal review path.
+
+Requirements
+- Publish proposal-stage observability across run summaries, APIs, and Mission Control.
+- Represent partial success and redacted failures clearly.
+- Preserve external tracker review as the primary workflow.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+## User Story - Proposal Outcome Visibility
+
+**Summary**: As a MoonMind operator, I want proposal generation, delivery, deduplication, failure, and promotion outcomes visible in run summaries and Mission Control so I can understand proposal-stage results without using a separate proposal queue.
+
+**Goal**: Operators can inspect one completed or in-progress proposal-capable run and see whether proposals were requested, generated, submitted, delivered, deduplicated, failed validation or delivery, and later promoted, with external tracker links available for human review.
+
+**Independent Test**: Can be fully tested by running or simulating one proposal-capable task with generated, delivered, duplicate, malformed, delivery-failed, and promoted proposal outcomes, then verifying the finish summary, exported run summary, execution detail, API-visible state, and Mission Control surfaces expose the expected redacted outcome data while review remains anchored in GitHub or Jira.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run requests proposal generation and proposals are generated and delivered, **When** an operator opens the run finish summary or exported run summary, **Then** the operator sees requested, generated, submitted, and delivered counts plus external tracker links.
+2. **Given** generated proposals include duplicates of existing external tracker issues, **When** the run summary and execution detail are inspected, **Then** the operator sees which proposals updated or linked to existing issues instead of appearing as new deliveries.
+3. **Given** proposal generation or delivery encounters provider failures or malformed candidates, **When** the operator reviews summaries, delivery records, execution detail, or Mission Control, **Then** redacted validation and delivery errors are visible and no malformed candidate is promoted or silently changed into a different task.
+4. **Given** a run is in the proposal generation or delivery stage, **When** API consumers or Mission Control read its state, **Then** `mm_state=proposals` is visible and dashboard compatibility treats it as a running state.
+5. **Given** a proposal has an external tracker record and is later approved for promotion, **When** the operator views execution detail or Mission Control, **Then** provider, external key, delivery status, last sync timestamp, dedup status, compact task summary, and promotion result links are visible.
+6. **Given** an operator needs to review proposal work, **When** the normal review path is used, **Then** GitHub or Jira remains the primary review surface and no standalone MoonMind proposal queue page becomes required.
+
+### Edge Cases
+
+- Proposal generation is requested but produces zero candidates.
+- Proposal generation is disabled globally or not requested for the run.
+- A delivery provider partially succeeds, producing delivered proposals and provider-specific failures in the same run.
+- A candidate is malformed, contains invalid skill-selection meaning, or omits required task meaning.
+- A retry attempts to deliver the same proposal after a previous partial failure.
+- A delivered proposal is attached to an existing dedup target rather than creating a new issue.
+- A proposal is promoted after the source run has completed.
+
+## Assumptions
+
+- Existing GitHub and Jira tracker issues remain the primary human review destinations for proposal triage.
+- Operator-visible errors should be redacted while still preserving enough context to diagnose the proposal-stage outcome.
+- Dashboard compatibility can continue to classify `proposals` as running while still exposing the more specific underlying state.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-009**: Source `docs/Tasks/TaskProposalSystem.md` section 3.6. Finish summaries and exported run summaries must record whether proposal generation was requested, generated candidate count, submitted and delivered counts, provider-specific delivery failures, redacted validation errors, external GitHub or Jira issue links, and dedup updates. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, and FR-005.
+- **DESIGN-REQ-028**: Source `docs/Tasks/TaskProposalSystem.md` sections 10.1 and 10.2. Proposal state and delivery visibility must be exposed across API, execution detail, and Mission Control, including `mm_state=proposals`, dashboard compatibility mapping to running, proposal counts and errors, external issue links, provider, external key, delivery status, last sync timestamp, dedup new-or-updated status, compact task summary, and promotion result links. Scope: in scope. Maps to FR-006, FR-007, FR-008, and FR-009.
+- **DESIGN-REQ-029**: Source `docs/Tasks/TaskProposalSystem.md` sections 10.4 and 14. Proposal generation, submission, and delivery failures must be represented as retry-safe, redacted, operator-visible partial outcomes; malformed candidates must be skipped and must not be promoted or silently altered in ways that change execution meaning. Scope: in scope. Maps to FR-003, FR-004, FR-010, and FR-011.
+- **DESIGN-REQ-030**: Source `docs/Tasks/TaskProposalSystem.md` sections 10.3 and 14. GitHub Issues and Jira issues must remain the normal proposal review surfaces, while MoonMind may show delivery status and links but must not require or introduce a standalone proposal queue page as the primary review path. Scope: in scope. Maps to FR-012.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST indicate in run finish summaries whether proposal generation was requested for the run.
+- **FR-002**: System MUST expose generated candidate, submitted proposal, and delivered proposal counts in both the finish summary and exported run summary.
+- **FR-003**: System MUST include provider-specific delivery failures and redacted validation errors in proposal-stage summaries when they occur.
+- **FR-004**: System MUST include external GitHub Issue or Jira issue links for delivered proposals in summary and detail surfaces.
+- **FR-005**: System MUST identify dedup updates where a new proposal candidate was attached to or updated an existing external issue.
+- **FR-006**: System MUST expose `mm_state=proposals` while proposal generation, submission, or delivery is in progress.
+- **FR-007**: System MUST map proposal-stage runs to the running dashboard compatibility category while preserving the specific proposal state for operators.
+- **FR-008**: System MUST show proposal delivery details in execution detail and Mission Control, including provider, external key, delivery status, last sync timestamp, and whether delivery created a new issue or updated an existing one.
+- **FR-009**: System MUST show a compact task summary for delivered proposals, including runtime, repository, publish mode, priority, attempt policy, skill context, and preset provenance when those values are present in the stored proposal.
+- **FR-010**: System MUST skip malformed or semantically invalid proposal candidates with redacted visible errors rather than promoting them.
+- **FR-011**: System MUST make external delivery failures retry-safe and visible in summaries, delivery records, and operator diagnostics.
+- **FR-012**: System MUST preserve GitHub Issues or Jira issues as the primary proposal review workflow and MUST NOT require a standalone MoonMind proposal queue page for normal review.
+- **FR-013**: System MUST show promotion result links after approved proposals are promoted.
+- **FR-014**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-600` and this original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Proposal Outcome Summary**: Operator-visible summary for one run's proposal-stage request, generation, submission, delivery, dedup, validation, and failure outcomes.
+- **Proposal Delivery Record**: Review and audit representation of one delivered or attempted proposal, including provider, external key, delivery status, sync timing, dedup status, errors, and links.
+- **Proposal Candidate Error**: Redacted validation or provider error explaining why a candidate was skipped, failed delivery, or requires operator attention.
+- **Promotion Result**: Linkage from an approved external proposal review item to the resulting promoted work outcome.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a proposal-capable run with generated and delivered proposals, 100% of requested, generated, submitted, and delivered proposal counts are visible in finish summary output and the exported run summary.
+- **SC-002**: For delivered proposals, 100% of external GitHub or Jira issue links visible in execution detail are also represented in proposal-stage summary data.
+- **SC-003**: For malformed candidates in validation coverage, 100% are skipped with redacted visible errors and 0 are promoted.
+- **SC-004**: For provider delivery failure coverage, 100% of failures are visible in summaries, delivery records, and operator diagnostics without exposing secret values.
+- **SC-005**: During proposal-stage execution, API-visible state includes `mm_state=proposals` and dashboard compatibility categorizes the run as running in 100% of covered cases.
+- **SC-006**: Mission Control and execution detail show provider, external key, delivery status, last sync timestamp, dedup status, compact task summary, and promotion result links for 100% of covered delivered-or-promoted proposals where those values exist.
+- **SC-007**: Verification confirms no standalone MoonMind proposal queue page is required for normal proposal review.
+- **SC-008**: Traceability evidence preserves `MM-600`, the original Jira preset brief, and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, and DESIGN-REQ-030 in MoonSpec artifacts.

--- a/specs/314-surface-proposal-outcomes/tasks.md
+++ b/specs/314-surface-proposal-outcomes/tasks.md
@@ -1,0 +1,185 @@
+# Tasks: Surface Proposal Outcomes
+
+**Input**: Design documents from `/work/agent_jobs/mm:0c314657-113e-4d5e-951f-7149150d8b9e/repo/specs/314-surface-proposal-outcomes/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/proposal-outcome-visibility-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Source Traceability**: Original Jira preset brief `MM-600` is preserved in `spec.md`. Tasks cover one story: Proposal Outcome Visibility. Traceability spans FR-001 through FR-014, acceptance scenarios 1-6, edge cases, SC-001 through SC-008, and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030.
+
+**Requirement Status Summary**: 24 partial rows require code-and-test work, 6 implemented_unverified rows require verification-first tests with conditional fallback implementation, and 2 implemented_verified rows require preservation through final validation only.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Focused Python unit tests: `python -m pytest tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/agents/codex_worker/test_worker.py -q`
+- Focused frontend unit tests: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx`
+- Integration tests: `./tools/test_integration.sh`
+- Focused integration tests: `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active one-story feature artifacts and testing entry points before writing tests.
+
+- [ ] T001 Confirm active feature artifacts exist and preserve `MM-600` in `specs/314-surface-proposal-outcomes/spec.md`, `specs/314-surface-proposal-outcomes/plan.md`, `specs/314-surface-proposal-outcomes/research.md`, `specs/314-surface-proposal-outcomes/data-model.md`, `specs/314-surface-proposal-outcomes/contracts/proposal-outcome-visibility-contract.md`, and `specs/314-surface-proposal-outcomes/quickstart.md`.
+- [ ] T002 Confirm the one-story scope and no existing `tasks.md` implementation state drift in `specs/314-surface-proposal-outcomes/spec.md` and `specs/314-surface-proposal-outcomes/plan.md`.
+- [ ] T003 [P] Confirm Python-focused proposal tests can be collected in `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`.
+- [ ] T004 [P] Confirm frontend-focused proposal visibility tests can be collected in `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and planned `frontend/src/entrypoints/proposals.test.tsx`.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared fixtures and contract anchors needed before story test authoring.
+
+**Blocking Rule**: No production implementation work begins until Phase 2 is complete.
+
+- [ ] T005 Add shared proposal outcome fixture helpers for delivered, duplicate, malformed, failed-delivery, and promoted outcomes in `tests/unit/workflows/task_proposals/test_service.py` covering FR-002, FR-003, FR-005, FR-010, FR-011, FR-013, SC-001 through SC-006, DESIGN-REQ-009, DESIGN-REQ-028, and DESIGN-REQ-029.
+- [ ] T006 [P] Add shared UI fixture payloads for proposal outcomes in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [ ] T007 [P] Add integration fixture helpers for a proposal-capable run outcome in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 1-6 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030.
+
+**Checkpoint**: Shared fixtures and contract anchors are ready; story tests can be written.
+
+---
+
+## Phase 3: Story - Proposal Outcome Visibility
+
+**Summary**: As a MoonMind operator, I want proposal generation, delivery, deduplication, failure, and promotion outcomes visible in run summaries and Mission Control so I can understand proposal-stage results without using a separate proposal queue.
+
+**Independent Test**: Run or simulate one proposal-capable task with generated, delivered, duplicate, malformed, delivery-failed, and promoted proposal outcomes, then verify finish summary, exported run summary, execution detail, API-visible state, and Mission Control surfaces expose expected redacted outcome data while GitHub/Jira remain the normal review path.
+
+**Traceability**: FR-001 through FR-014; acceptance scenarios 1-6; SC-001 through SC-008; DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030.
+
+**Unit Test Plan**: Summary builders, proposal service serialization, API payloads, state mapping, redaction, malformed-candidate handling, provider-failure metadata, compact task summary, promotion links, and UI rendering.
+
+**Integration Test Plan**: Proposal-capable run boundary covering delivered, duplicate, malformed, failed-delivery, and promoted outcomes across summary, exported summary, API/detail payload, and Mission Control-facing data.
+
+### Unit Tests
+
+- [ ] T008 [P] Add failing unit tests for Temporal proposal summary requested/generated/submitted/delivered counts, redacted validation errors, delivery failures, external links, and dedup updates in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, SC-001, SC-002, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
+- [ ] T009 [P] Add failing unit tests for Codex worker `reports/run_summary.json` proposal outcome fields and redaction in `tests/unit/agents/codex_worker/test_worker.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, SC-001, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
+- [ ] T010 [P] Add verification-first unit tests for proposal-stage state exposure in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-006, SCN-004, SC-005, DESIGN-REQ-028.
+- [ ] T011 [P] Add failing unit tests for proposal service delivery outcome aggregation, malformed candidate visible errors, failed delivery metadata, dedup new-or-updated status, and zero-promotion guarantee in `tests/unit/workflows/task_proposals/test_service.py` covering FR-003, FR-005, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
+- [ ] T012 [P] Add failing API serialization tests for proposal outcome payloads, compact task summaries, review delivery details, and promotion result links in `tests/unit/api/routers/test_task_proposals.py` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [ ] T013 [P] Add preservation unit tests for dashboard compatibility mapping in `tests/unit/api/routers/test_task_dashboard_view_model.py` covering FR-007, SC-005.
+- [ ] T014 [P] Add failing frontend unit tests for execution detail proposal outcome rendering in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [ ] T015 [P] Add failing frontend unit tests for Mission Control proposal outcome/status rendering in `frontend/src/entrypoints/mission-control.test.tsx` covering FR-008, FR-009, FR-013, SC-006, DESIGN-REQ-028.
+- [ ] T016 [P] Add failing frontend unit tests proving normal navigation/copy does not make a standalone proposal queue the primary review path in `frontend/src/entrypoints/tasks-list.test.tsx` and `frontend/src/entrypoints/proposals.test.tsx` covering FR-012, SCN-006, SC-007, DESIGN-REQ-030.
+
+### Integration Tests
+
+- [ ] T017 [P] Add failing integration test for a proposal-capable run with delivered and duplicate proposal outcomes in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 1-2, FR-001, FR-002, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-009.
+- [ ] T018 [P] Add failing integration test for malformed candidate and provider delivery failure visibility in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 3, FR-003, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
+- [ ] T019 [P] Add failing integration test for proposal-stage state, detail payload, compact task summary, and promotion result links in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 4-5, FR-006, FR-008, FR-009, FR-013, SC-005, SC-006, DESIGN-REQ-028.
+- [ ] T020 [P] Add failing integration or UI-boundary test proving external GitHub/Jira tracker review remains primary and MoonMind proposal UI is admin/recovery-only if retained in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 6, FR-012, SC-007, DESIGN-REQ-030.
+
+### Red-First Confirmation
+
+- [ ] T021 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; confirm new tests from T008-T013 fail for the expected missing proposal outcome behavior.
+- [ ] T022 Run focused frontend unit tests for `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and `frontend/src/entrypoints/proposals.test.tsx`; confirm new tests from T014-T016 fail for the expected missing proposal outcome UI behavior.
+- [ ] T023 Run focused integration tests for `tests/integration/temporal/test_proposal_review_delivery.py`; confirm new tests from T017-T020 fail for the expected missing end-to-end proposal outcome behavior.
+
+### Conditional Fallback Implementation For Implemented-Unverified Rows
+
+- [ ] T024 If T010 shows proposal-stage state exposure is not already complete, update `moonmind/workflows/temporal/workflows/run.py` and `api_service/api/routers/executions.py` for FR-006, SCN-004, SC-005, DESIGN-REQ-028.
+- [ ] T025 If T011 shows malformed candidate skip/no-promotion behavior is incomplete, update `moonmind/workflows/task_proposals/service.py` and `moonmind/agents/codex_worker/worker.py` for FR-010, SC-003, DESIGN-REQ-029.
+- [ ] T026 If final traceability checks fail, update `specs/314-surface-proposal-outcomes/spec.md`, `specs/314-surface-proposal-outcomes/plan.md`, `specs/314-surface-proposal-outcomes/tasks.md`, and later verification artifacts to preserve MM-600, FR-014, SC-008.
+
+### Implementation
+
+- [ ] T027 Extend proposal outcome summary models and payload shapes in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/agents/codex_worker/worker.py`, and `moonmind/schemas/task_proposal_models.py` for FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, DESIGN-REQ-009, DESIGN-REQ-029.
+- [ ] T028 Implement delivered count, external links, dedup updates, redacted validation errors, and provider delivery failures in `moonmind/workflows/task_proposals/service.py` and `moonmind/workflows/temporal/activity_runtime.py` for FR-002, FR-003, FR-004, FR-005, FR-011, SC-001 through SC-004.
+- [ ] T029 Implement compact proposal task summary fields, including priority and max attempts where present, in `api_service/api/routers/task_proposals.py` and `moonmind/schemas/task_proposal_models.py` for FR-008, FR-009, SC-006, DESIGN-REQ-028.
+- [ ] T030 Implement run-scoped proposal outcome exposure for execution detail and Mission Control consumers in `api_service/api/routers/executions.py` and any required schema helpers in `api_service/api/schemas.py` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [ ] T031 Implement promotion result link derivation from provider decision metadata in `api_service/api/routers/task_proposals.py`, `api_service/api/routers/executions.py`, and `moonmind/workflows/task_proposals/service.py` for FR-013, SCN-005, SC-006.
+- [ ] T032 Implement execution detail proposal outcome rendering in `frontend/src/entrypoints/task-detail.tsx` and any required styling in `frontend/src/styles/mission-control.css` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006.
+- [ ] T033 Implement Mission Control proposal outcome rendering or task-detail handoff in `frontend/src/entrypoints/mission-control.tsx`, `frontend/src/entrypoints/mission-control-app.tsx`, and `frontend/src/styles/mission-control.css` for FR-008, FR-009, FR-013, SC-006.
+- [ ] T034 Reframe, restrict, or remove normal proposal queue affordances in `frontend/src/entrypoints/proposals.tsx`, `frontend/src/entrypoints/mission-control-app.tsx`, and `frontend/src/entrypoints/tasks-list.tsx` so GitHub/Jira remain the primary review path for FR-012, SCN-006, SC-007, DESIGN-REQ-030.
+- [ ] T035 Wire integration boundary behavior for proposal outcome summaries, detail payloads, and UI-facing fields in `tests/integration/temporal/test_proposal_review_delivery.py`, `moonmind/workflows/temporal/workflows/run.py`, and `api_service/api/routers/executions.py` for acceptance scenarios 1-6 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030.
+
+### Story Validation
+
+- [ ] T036 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; fix failures until FR-001 through FR-014 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030 pass in the focused backend scope.
+- [ ] T037 Run focused frontend unit tests for `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and `frontend/src/entrypoints/proposals.test.tsx`; fix failures until Mission Control and execution detail satisfy FR-008, FR-009, FR-012, FR-013.
+- [ ] T038 Run focused integration tests for `tests/integration/temporal/test_proposal_review_delivery.py`; fix failures until acceptance scenarios 1-6 and SC-001 through SC-007 pass.
+- [ ] T039 Run quickstart validation from `specs/314-surface-proposal-outcomes/quickstart.md` and record exact blockers if Docker-backed integration execution is unavailable in the managed environment.
+
+**Checkpoint**: The single story is implemented, covered by unit and integration tests, and independently validated against MM-600.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [ ] T040 [P] Review proposal outcome payloads for compactness and secret redaction in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/agents/codex_worker/worker.py`, `moonmind/workflows/task_proposals/service.py`, and `api_service/api/routers/executions.py` covering FR-003, FR-011, SC-004.
+- [ ] T041 [P] Review UI accessibility and text fit for proposal outcome rendering in `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/mission-control.tsx`, and `frontend/src/styles/mission-control.css` covering FR-008, FR-009, FR-013.
+- [ ] T042 [P] Preserve MM-600 traceability in `specs/314-surface-proposal-outcomes/verification.md` when final verification is produced, covering FR-014, SC-008.
+- [ ] T043 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` using the command documented in `specs/314-surface-proposal-outcomes/quickstart.md` for final unit verification and record failures or environment blockers.
+- [ ] T044 Run `./tools/test_integration.sh` using the command documented in `specs/314-surface-proposal-outcomes/quickstart.md` for final `integration_ci` verification when Docker is available and record failures or environment blockers.
+- [ ] T045 Run `/moonspec-verify` for `specs/314-surface-proposal-outcomes/` after implementation and tests pass, preserving MM-600 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030 in verification evidence.
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- Phase 1 Setup has no dependencies.
+- Phase 2 Foundational depends on Phase 1 and blocks story tests.
+- Phase 3 Story depends on Phase 2.
+- Phase 4 Polish and Verification depends on story implementation and focused validation passing.
+
+### Within The Story
+
+- T008-T016 unit/frontend tests must be written before T027-T034 implementation.
+- T017-T020 integration tests must be written before T035 integration wiring.
+- T021-T023 red-first confirmation must complete before production implementation tasks T027-T035.
+- T024-T026 are conditional fallback tasks for implemented_unverified rows and should run only when verification tests expose a gap.
+- T027-T031 backend contracts and services should complete before T032-T034 UI rendering.
+- T036-T039 validate the story after implementation.
+- T045 `/moonspec-verify` runs only after implementation and test evidence is available.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel after T001-T002.
+- T006 and T007 can run in parallel after T005.
+- T008-T016 can be authored in parallel because they touch different test files.
+- T017-T020 can be authored in parallel within the same integration file only with careful non-overlapping test additions.
+- T024-T026 are conditional and independent by file set.
+- T040-T042 can run in parallel during polish.
+
+## Parallel Example
+
+```bash
+# After Phase 2, launch independent test authoring:
+Task: "T008 add Temporal summary tests in tests/unit/workflows/temporal/workflows/test_run_proposals.py"
+Task: "T012 add API serialization tests in tests/unit/api/routers/test_task_proposals.py"
+Task: "T014 add task detail UI tests in frontend/src/entrypoints/task-detail.test.tsx"
+
+# After backend outcome fields exist, launch UI/admin-path work separately:
+Task: "T032 implement execution detail rendering in frontend/src/entrypoints/task-detail.tsx"
+Task: "T034 reframe proposal queue affordances in frontend/src/entrypoints/proposals.tsx"
+```
+
+## Implementation Strategy
+
+1. Preserve the single-story MM-600 traceability from `spec.md`.
+2. Complete setup and shared fixtures.
+3. Write unit, frontend, and integration tests first.
+4. Run red-first commands and confirm failures identify missing proposal outcome behavior.
+5. Execute conditional fallback tasks only where verification-first tests fail.
+6. Implement backend summary/service/API contracts.
+7. Implement frontend Mission Control and execution-detail surfaces.
+8. Validate focused Python, frontend, and integration test suites.
+9. Run full unit and integration commands when available.
+10. Run final `/moonspec-verify`.
+
+## Notes
+
+- This task list covers exactly one story: Proposal Outcome Visibility.
+- Do not create a standalone proposal-review workflow as normal UX; GitHub/Jira remain the normal review path.
+- Do not embed full task snapshots or provider issue bodies in workflow summaries or UI outcome cards.
+- Keep all redacted errors compact and secret-safe.
+- Do not create commits, pull requests, Jira transitions, or implementation outside this task list during task generation.

--- a/specs/314-surface-proposal-outcomes/tasks.md
+++ b/specs/314-surface-proposal-outcomes/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
 - Focused Python unit tests: `python -m pytest tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/agents/codex_worker/test_worker.py -q`
-- Focused frontend unit tests: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx`
+- Focused frontend unit tests: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/proposals.test.tsx`
 - Integration tests: `./tools/test_integration.sh`
 - Focused integration tests: `python -m pytest tests/integration/temporal/test_proposal_review_delivery.py -q`
 - Final verification: `/moonspec-verify`
@@ -59,7 +59,7 @@
 
 - [ ] T008 [P] Add failing unit tests for Temporal proposal summary requested/generated/submitted/delivered counts, redacted validation errors, delivery failures, external links, and dedup updates in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, SC-001, SC-002, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
 - [ ] T009 [P] Add failing unit tests for Codex worker `reports/run_summary.json` proposal outcome fields and redaction in `tests/unit/agents/codex_worker/test_worker.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, SC-001, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
-- [ ] T010 [P] Add verification-first unit tests for proposal-stage state exposure in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-006, SCN-004, SC-005, DESIGN-REQ-028.
+- [ ] T010 Add verification-first unit tests for proposal-stage state exposure in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-006, SCN-004, SC-005, DESIGN-REQ-028.
 - [ ] T011 [P] Add failing unit tests for proposal service delivery outcome aggregation, malformed candidate visible errors, failed delivery metadata, dedup new-or-updated status, and zero-promotion guarantee in `tests/unit/workflows/task_proposals/test_service.py` covering FR-003, FR-005, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
 - [ ] T012 [P] Add failing API serialization tests for proposal outcome payloads, compact task summaries, review delivery details, and promotion result links in `tests/unit/api/routers/test_task_proposals.py` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
 - [ ] T013 [P] Add preservation unit tests for dashboard compatibility mapping in `tests/unit/api/routers/test_task_dashboard_view_model.py` covering FR-007, SC-005.
@@ -69,10 +69,10 @@
 
 ### Integration Tests
 
-- [ ] T017 [P] Add failing integration test for a proposal-capable run with delivered and duplicate proposal outcomes in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 1-2, FR-001, FR-002, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-009.
-- [ ] T018 [P] Add failing integration test for malformed candidate and provider delivery failure visibility in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 3, FR-003, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
-- [ ] T019 [P] Add failing integration test for proposal-stage state, detail payload, compact task summary, and promotion result links in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 4-5, FR-006, FR-008, FR-009, FR-013, SC-005, SC-006, DESIGN-REQ-028.
-- [ ] T020 [P] Add failing integration or UI-boundary test proving external GitHub/Jira tracker review remains primary and MoonMind proposal UI is admin/recovery-only if retained in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 6, FR-012, SC-007, DESIGN-REQ-030.
+- [ ] T017 Add failing integration test for a proposal-capable run with delivered and duplicate proposal outcomes in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 1-2, FR-001, FR-002, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-009.
+- [ ] T018 Add failing integration test for malformed candidate and provider delivery failure visibility in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 3, FR-003, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
+- [ ] T019 Add failing integration test for proposal-stage state, detail payload, compact task summary, and promotion result links in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenarios 4-5, FR-006, FR-008, FR-009, FR-013, SC-005, SC-006, DESIGN-REQ-028.
+- [ ] T020 Add failing integration or UI-boundary test proving external GitHub/Jira tracker review remains primary and MoonMind proposal UI is admin/recovery-only if retained in `tests/integration/temporal/test_proposal_review_delivery.py` covering acceptance scenario 6, FR-012, SC-007, DESIGN-REQ-030.
 
 ### Red-First Confirmation
 
@@ -146,7 +146,7 @@
 - T003 and T004 can run in parallel after T001-T002.
 - T006 and T007 can run in parallel after T005.
 - T008-T016 can be authored in parallel because they touch different test files.
-- T017-T020 can be authored in parallel within the same integration file only with careful non-overlapping test additions.
+- T017-T020 are ordered because they all modify `tests/integration/temporal/test_proposal_review_delivery.py`.
 - T024-T026 are conditional and independent by file set.
 - T040-T042 can run in parallel during polish.
 

--- a/specs/314-surface-proposal-outcomes/tasks.md
+++ b/specs/314-surface-proposal-outcomes/tasks.md
@@ -22,10 +22,10 @@
 
 **Purpose**: Confirm the active one-story feature artifacts and testing entry points before writing tests.
 
-- [ ] T001 Confirm active feature artifacts exist and preserve `MM-600` in `specs/314-surface-proposal-outcomes/spec.md`, `specs/314-surface-proposal-outcomes/plan.md`, `specs/314-surface-proposal-outcomes/research.md`, `specs/314-surface-proposal-outcomes/data-model.md`, `specs/314-surface-proposal-outcomes/contracts/proposal-outcome-visibility-contract.md`, and `specs/314-surface-proposal-outcomes/quickstart.md`.
-- [ ] T002 Confirm the one-story scope and no existing `tasks.md` implementation state drift in `specs/314-surface-proposal-outcomes/spec.md` and `specs/314-surface-proposal-outcomes/plan.md`.
-- [ ] T003 [P] Confirm Python-focused proposal tests can be collected in `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`.
-- [ ] T004 [P] Confirm frontend-focused proposal visibility tests can be collected in `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and planned `frontend/src/entrypoints/proposals.test.tsx`.
+- [X] T001 Confirm active feature artifacts exist and preserve `MM-600` in `specs/314-surface-proposal-outcomes/spec.md`, `specs/314-surface-proposal-outcomes/plan.md`, `specs/314-surface-proposal-outcomes/research.md`, `specs/314-surface-proposal-outcomes/data-model.md`, `specs/314-surface-proposal-outcomes/contracts/proposal-outcome-visibility-contract.md`, and `specs/314-surface-proposal-outcomes/quickstart.md`.
+- [X] T002 Confirm the one-story scope and no existing `tasks.md` implementation state drift in `specs/314-surface-proposal-outcomes/spec.md` and `specs/314-surface-proposal-outcomes/plan.md`.
+- [X] T003 [P] Confirm Python-focused proposal tests can be collected in `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`.
+- [X] T004 [P] Confirm frontend-focused proposal visibility tests can be collected in `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and planned `frontend/src/entrypoints/proposals.test.tsx`.
 
 ---
 
@@ -57,12 +57,12 @@
 
 ### Unit Tests
 
-- [ ] T008 [P] Add failing unit tests for Temporal proposal summary requested/generated/submitted/delivered counts, redacted validation errors, delivery failures, external links, and dedup updates in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, SC-001, SC-002, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
-- [ ] T009 [P] Add failing unit tests for Codex worker `reports/run_summary.json` proposal outcome fields and redaction in `tests/unit/agents/codex_worker/test_worker.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, SC-001, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
+- [X] T008 [P] Add failing unit tests for Temporal proposal summary requested/generated/submitted/delivered counts, redacted validation errors, delivery failures, external links, and dedup updates in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, SC-001, SC-002, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
+- [X] T009 [P] Add failing unit tests for Codex worker `reports/run_summary.json` proposal outcome fields and redaction in `tests/unit/agents/codex_worker/test_worker.py` covering FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, SC-001, SC-004, DESIGN-REQ-009, DESIGN-REQ-029.
 - [ ] T010 Add verification-first unit tests for proposal-stage state exposure in `tests/unit/workflows/temporal/workflows/test_run_proposals.py` covering FR-006, SCN-004, SC-005, DESIGN-REQ-028.
 - [ ] T011 [P] Add failing unit tests for proposal service delivery outcome aggregation, malformed candidate visible errors, failed delivery metadata, dedup new-or-updated status, and zero-promotion guarantee in `tests/unit/workflows/task_proposals/test_service.py` covering FR-003, FR-005, FR-010, FR-011, SC-003, SC-004, DESIGN-REQ-029.
-- [ ] T012 [P] Add failing API serialization tests for proposal outcome payloads, compact task summaries, review delivery details, and promotion result links in `tests/unit/api/routers/test_task_proposals.py` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
-- [ ] T013 [P] Add preservation unit tests for dashboard compatibility mapping in `tests/unit/api/routers/test_task_dashboard_view_model.py` covering FR-007, SC-005.
+- [X] T012 [P] Add failing API serialization tests for proposal outcome payloads, compact task summaries, review delivery details, and promotion result links in `tests/unit/api/routers/test_task_proposals.py` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [X] T013 [P] Add preservation unit tests for dashboard compatibility mapping in `tests/unit/api/routers/test_task_dashboard_view_model.py` covering FR-007, SC-005.
 - [ ] T014 [P] Add failing frontend unit tests for execution detail proposal outcome rendering in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
 - [ ] T015 [P] Add failing frontend unit tests for Mission Control proposal outcome/status rendering in `frontend/src/entrypoints/mission-control.test.tsx` covering FR-008, FR-009, FR-013, SC-006, DESIGN-REQ-028.
 - [ ] T016 [P] Add failing frontend unit tests proving normal navigation/copy does not make a standalone proposal queue the primary review path in `frontend/src/entrypoints/tasks-list.test.tsx` and `frontend/src/entrypoints/proposals.test.tsx` covering FR-012, SCN-006, SC-007, DESIGN-REQ-030.
@@ -76,7 +76,7 @@
 
 ### Red-First Confirmation
 
-- [ ] T021 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; confirm new tests from T008-T013 fail for the expected missing proposal outcome behavior.
+- [X] T021 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; confirm new tests from T008-T013 fail for the expected missing proposal outcome behavior.
 - [ ] T022 Run focused frontend unit tests for `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and `frontend/src/entrypoints/proposals.test.tsx`; confirm new tests from T014-T016 fail for the expected missing proposal outcome UI behavior.
 - [ ] T023 Run focused integration tests for `tests/integration/temporal/test_proposal_review_delivery.py`; confirm new tests from T017-T020 fail for the expected missing end-to-end proposal outcome behavior.
 
@@ -88,21 +88,21 @@
 
 ### Implementation
 
-- [ ] T027 Extend proposal outcome summary models and payload shapes in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/agents/codex_worker/worker.py`, and `moonmind/schemas/task_proposal_models.py` for FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, DESIGN-REQ-009, DESIGN-REQ-029.
-- [ ] T028 Implement delivered count, external links, dedup updates, redacted validation errors, and provider delivery failures in `moonmind/workflows/task_proposals/service.py` and `moonmind/workflows/temporal/activity_runtime.py` for FR-002, FR-003, FR-004, FR-005, FR-011, SC-001 through SC-004.
-- [ ] T029 Implement compact proposal task summary fields, including priority and max attempts where present, in `api_service/api/routers/task_proposals.py` and `moonmind/schemas/task_proposal_models.py` for FR-008, FR-009, SC-006, DESIGN-REQ-028.
-- [ ] T030 Implement run-scoped proposal outcome exposure for execution detail and Mission Control consumers in `api_service/api/routers/executions.py` and any required schema helpers in `api_service/api/schemas.py` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
-- [ ] T031 Implement promotion result link derivation from provider decision metadata in `api_service/api/routers/task_proposals.py`, `api_service/api/routers/executions.py`, and `moonmind/workflows/task_proposals/service.py` for FR-013, SCN-005, SC-006.
-- [ ] T032 Implement execution detail proposal outcome rendering in `frontend/src/entrypoints/task-detail.tsx` and any required styling in `frontend/src/styles/mission-control.css` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006.
+- [X] T027 Extend proposal outcome summary models and payload shapes in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/agents/codex_worker/worker.py`, and `moonmind/schemas/task_proposal_models.py` for FR-001, FR-002, FR-003, FR-004, FR-005, FR-011, DESIGN-REQ-009, DESIGN-REQ-029.
+- [X] T028 Implement delivered count, external links, dedup updates, redacted validation errors, and provider delivery failures in `moonmind/workflows/task_proposals/service.py` and `moonmind/workflows/temporal/activity_runtime.py` for FR-002, FR-003, FR-004, FR-005, FR-011, SC-001 through SC-004.
+- [X] T029 Implement compact proposal task summary fields, including priority and max attempts where present, in `api_service/api/routers/task_proposals.py` and `moonmind/schemas/task_proposal_models.py` for FR-008, FR-009, SC-006, DESIGN-REQ-028.
+- [X] T030 Implement run-scoped proposal outcome exposure for execution detail and Mission Control consumers in `api_service/api/routers/executions.py` and any required schema helpers in `api_service/api/schemas.py` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006, DESIGN-REQ-028.
+- [X] T031 Implement promotion result link derivation from provider decision metadata in `api_service/api/routers/task_proposals.py`, `api_service/api/routers/executions.py`, and `moonmind/workflows/task_proposals/service.py` for FR-013, SCN-005, SC-006.
+- [X] T032 Implement execution detail proposal outcome rendering in `frontend/src/entrypoints/task-detail.tsx` and any required styling in `frontend/src/styles/mission-control.css` for FR-004, FR-008, FR-009, FR-013, SC-002, SC-006.
 - [ ] T033 Implement Mission Control proposal outcome rendering or task-detail handoff in `frontend/src/entrypoints/mission-control.tsx`, `frontend/src/entrypoints/mission-control-app.tsx`, and `frontend/src/styles/mission-control.css` for FR-008, FR-009, FR-013, SC-006.
-- [ ] T034 Reframe, restrict, or remove normal proposal queue affordances in `frontend/src/entrypoints/proposals.tsx`, `frontend/src/entrypoints/mission-control-app.tsx`, and `frontend/src/entrypoints/tasks-list.tsx` so GitHub/Jira remain the primary review path for FR-012, SCN-006, SC-007, DESIGN-REQ-030.
+- [X] T034 Reframe, restrict, or remove normal proposal queue affordances in `frontend/src/entrypoints/proposals.tsx`, `frontend/src/entrypoints/mission-control-app.tsx`, and `frontend/src/entrypoints/tasks-list.tsx` so GitHub/Jira remain the primary review path for FR-012, SCN-006, SC-007, DESIGN-REQ-030.
 - [ ] T035 Wire integration boundary behavior for proposal outcome summaries, detail payloads, and UI-facing fields in `tests/integration/temporal/test_proposal_review_delivery.py`, `moonmind/workflows/temporal/workflows/run.py`, and `api_service/api/routers/executions.py` for acceptance scenarios 1-6 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030.
 
 ### Story Validation
 
-- [ ] T036 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; fix failures until FR-001 through FR-014 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030 pass in the focused backend scope.
-- [ ] T037 Run focused frontend unit tests for `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and `frontend/src/entrypoints/proposals.test.tsx`; fix failures until Mission Control and execution detail satisfy FR-008, FR-009, FR-012, FR-013.
-- [ ] T038 Run focused integration tests for `tests/integration/temporal/test_proposal_review_delivery.py`; fix failures until acceptance scenarios 1-6 and SC-001 through SC-007 pass.
+- [X] T036 Run focused Python unit tests for `tests/unit/workflows/temporal/workflows/test_run_proposals.py`, `tests/unit/workflows/task_proposals/test_service.py`, `tests/unit/api/routers/test_task_proposals.py`, `tests/unit/api/routers/test_task_dashboard_view_model.py`, and `tests/unit/agents/codex_worker/test_worker.py`; fix failures until FR-001 through FR-014 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030 pass in the focused backend scope.
+- [X] T037 Run focused frontend unit tests for `frontend/src/entrypoints/task-detail.test.tsx`, `frontend/src/entrypoints/mission-control.test.tsx`, `frontend/src/entrypoints/tasks-list.test.tsx`, and `frontend/src/entrypoints/proposals.test.tsx`; fix failures until Mission Control and execution detail satisfy FR-008, FR-009, FR-012, FR-013.
+- [X] T038 Run focused integration tests for `tests/integration/temporal/test_proposal_review_delivery.py`; fix failures until acceptance scenarios 1-6 and SC-001 through SC-007 pass.
 - [ ] T039 Run quickstart validation from `specs/314-surface-proposal-outcomes/quickstart.md` and record exact blockers if Docker-backed integration execution is unavailable in the managed environment.
 
 **Checkpoint**: The single story is implemented, covered by unit and integration tests, and independently validated against MM-600.
@@ -116,7 +116,7 @@
 - [ ] T040 [P] Review proposal outcome payloads for compactness and secret redaction in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/agents/codex_worker/worker.py`, `moonmind/workflows/task_proposals/service.py`, and `api_service/api/routers/executions.py` covering FR-003, FR-011, SC-004.
 - [ ] T041 [P] Review UI accessibility and text fit for proposal outcome rendering in `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/mission-control.tsx`, and `frontend/src/styles/mission-control.css` covering FR-008, FR-009, FR-013.
 - [ ] T042 [P] Preserve MM-600 traceability in `specs/314-surface-proposal-outcomes/verification.md` when final verification is produced, covering FR-014, SC-008.
-- [ ] T043 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` using the command documented in `specs/314-surface-proposal-outcomes/quickstart.md` for final unit verification and record failures or environment blockers.
+- [X] T043 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` using the command documented in `specs/314-surface-proposal-outcomes/quickstart.md` for final unit verification and record failures or environment blockers.
 - [ ] T044 Run `./tools/test_integration.sh` using the command documented in `specs/314-surface-proposal-outcomes/quickstart.md` for final `integration_ci` verification when Docker is available and record failures or environment blockers.
 - [ ] T045 Run `/moonspec-verify` for `specs/314-surface-proposal-outcomes/` after implementation and tests pass, preserving MM-600 and DESIGN-REQ-009, DESIGN-REQ-028, DESIGN-REQ-029, DESIGN-REQ-030 in verification evidence.
 

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1270,6 +1270,35 @@ async def test_worker_submission_report_aggregates_delivery_outcomes(
         },
     )
 
+
+async def test_worker_submission_outcome_preserves_delivery_failure_details() -> None:
+    outcome = CodexWorker._proposal_submission_outcome(
+        {
+            "provider": "jira",
+            "reviewDelivery": {
+                "provider": "jira",
+                "status": "failed",
+                "error": {
+                    "code": "provider_rejected",
+                    "sanitizedReason": "provider rejected delivery",
+                    "retryable": False,
+                },
+            },
+        }
+    )
+
+    assert outcome["delivered_count"] == 0
+    assert outcome["delivery_failures"] == [
+        {
+            "provider": "jira",
+            "code": "provider_rejected",
+            "sanitizedReason": "provider rejected delivery",
+            "retryable": False,
+            "message": "provider rejected delivery",
+        }
+    ]
+
+
 async def test_task_proposal_request_uses_task_flag_with_config_gate(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1172,6 +1172,104 @@ async def test_worker_submits_task_proposals(tmp_path: Path) -> None:
     assert first["origin"]["metadata"]["workingBranch"] == "feature/proposal-tests"
     assert not proposals_path.exists()
 
+
+async def test_worker_submission_report_aggregates_delivery_outcomes(
+    tmp_path: Path,
+) -> None:
+    class OutcomeQueue(FakeQueueClient):
+        async def create_task_proposal(self, *, proposal):
+            self.submitted_proposals.append(dict(proposal))
+            return {
+                "id": str(uuid4()),
+                "reviewDelivery": {
+                    "provider": "jira",
+                    "status": "updated",
+                    "externalKey": "MM-901",
+                    "externalUrl": "https://jira.example/browse/MM-901",
+                    "created": False,
+                    "duplicateSource": "existing-open-issue",
+                },
+            }
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    queue = OutcomeQueue()
+    worker = CodexWorker(
+        config=config,
+        queue_client=queue,
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="ok", error_message=None)
+        ),
+    )  # type: ignore[arg-type]
+
+    job = ClaimedJob(id=uuid4(), type="task", payload={"repository": "moon/org"})
+    context_dir = tmp_path / "context"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "task_proposals.json").write_text(
+        json.dumps(
+            [
+                {
+                    "title": "Add regression tests",
+                    "summary": "Cover auth flow edge cases",
+                    "taskCreateRequest": {
+                        "type": "task",
+                        "priority": 0,
+                        "maxAttempts": 3,
+                        "payload": {
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "task": {"instructions": "Add tests"},
+                        },
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / "job",
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=context_dir,
+        publish_result_path=tmp_path / "publish-result.log",
+        default_branch="main",
+        starting_branch="main",
+        new_branch=None,
+        working_branch="feature/proposal-tests",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+
+    report = await worker._maybe_submit_task_proposals(job=job, prepared=prepared)
+
+    assert report.submitted_count == 1
+    assert report.delivered_count == 1
+    assert report.external_links == (
+        {
+            "provider": "jira",
+            "externalKey": "MM-901",
+            "externalUrl": "https://jira.example/browse/MM-901",
+        },
+    )
+    assert report.dedup_updates == (
+        {
+            "provider": "jira",
+            "externalKey": "MM-901",
+            "created": False,
+            "duplicateSource": "existing-open-issue",
+        },
+    )
+
 async def test_task_proposal_request_uses_task_flag_with_config_gate(
     tmp_path: Path,
 ) -> None:
@@ -6986,6 +7084,89 @@ async def test_finish_reports_include_jules_runtime_artifact(
     assert runtime_payload["tasks"][0]["taskId"] == "task-123"
     assert runtime_payload["tasks"][0]["status"] == "completed"
     assert runtime_payload["tasks"][0]["providerStatus"] == "completed"
+
+
+async def test_finish_summary_includes_proposal_outcome_contract(
+    tmp_path: Path,
+) -> None:
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    queue = FakeQueueClient(jobs=[])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    started_at = datetime.now(UTC)
+    proposals = ProposalSubmissionReport(
+        requested=True,
+        hook_skills=["fix-proposal"],
+        generated_count=2,
+        submitted_count=2,
+        errors=["legacy validation error"],
+        delivered_count=1,
+        validation_errors=(
+            {"code": "proposal_missing_task", "message": "proposal skipped: [REDACTED]"},
+        ),
+        delivery_failures=(
+            {
+                "provider": "jira",
+                "code": "delivery_failed",
+                "message": "delivery failed: [REDACTED]",
+            },
+        ),
+        external_links=(
+            {
+                "provider": "jira",
+                "externalKey": "MM-901",
+                "externalUrl": "https://jira.example/browse/MM-901",
+            },
+        ),
+        dedup_updates=(
+            {
+                "provider": "github",
+                "externalKey": "42",
+                "created": False,
+                "duplicateSource": "existing-open-issue",
+            },
+        ),
+    )
+
+    finish_summary = worker._build_finish_summary(
+        job=ClaimedJob(id=uuid4(), type="task", payload={}, attempt=1, max_attempts=3),
+        canonical_payload={"repository": "owner/repo"},
+        runtime_mode="codex",
+        started_at=started_at,
+        finished_at=started_at,
+        stages=worker._new_finish_stages(),
+        finish_outcome=FinishOutcome(
+            code="COMPLETED", stage="finalize", reason="completed"
+        ),
+        prepared=None,
+        publish_mode="none",
+        publish_status="not_run",
+        publish_reason="publish mode is none",
+        publish_pr_url=None,
+        publish_base_branch=None,
+        publish_working_branch=None,
+        proposal_report=proposals,
+    )
+
+    proposal_summary = finish_summary["proposals"]
+    assert proposal_summary["requested"] is True
+    assert proposal_summary["generatedCount"] == 2
+    assert proposal_summary["submittedCount"] == 2
+    assert proposal_summary["deliveredCount"] == 1
+    assert proposal_summary["validationErrors"][0]["message"] == "proposal skipped: [REDACTED]"
+    assert proposal_summary["deliveryFailures"][0]["message"] == "delivery failed: [REDACTED]"
+    assert proposal_summary["externalLinks"][0]["externalKey"] == "MM-901"
+    assert proposal_summary["dedupUpdates"][0]["duplicateSource"] == "existing-open-issue"
 
 async def test_jules_worker_multiplexes_inflight_jobs_without_llm_execution(
     tmp_path: Path,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2432,7 +2432,45 @@ def test_serialize_execution_exposes_proposal_outcome_summary() -> None:
     assert payload["proposalSummary"]["deliveredCount"] == 1
     assert payload["proposalSummary"]["externalLinks"][0]["externalKey"] == "MM-901"
     assert payload["proposalOutcomes"][0]["provider"] == "jira"
-    assert payload["proposalOutcomes"][0]["externalUrl"] == "https://jira.example/browse/MM-901"
+    assert (
+        payload["proposalOutcomes"][0]["externalUrl"]
+        == "https://jira.example/browse/MM-901"
+    )
+
+
+def test_serialize_execution_deduplicates_proposal_outcomes_by_external_key() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.PROPOSALS)
+    record.memo["proposals"] = {
+        "externalLinks": [
+            {
+                "provider": "jira",
+                "externalKey": "MM-901",
+                "externalUrl": "https://jira.example/browse/MM-901",
+            }
+        ],
+        "dedupUpdates": [
+            {
+                "provider": "jira",
+                "externalKey": "MM-901",
+                "created": False,
+                "duplicateSource": "existing-open-issue",
+            }
+        ],
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["proposalOutcomes"] == [
+        {
+            "provider": "jira",
+            "externalKey": "MM-901",
+            "externalUrl": "https://jira.example/browse/MM-901",
+            "deliveryStatus": "updated",
+            "created": False,
+            "duplicateSource": "existing-open-issue",
+        }
+    ]
+
 
 def test_serialize_execution_exposes_snake_case_publish_merge_automation() -> None:
     record = _build_execution_record()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2389,7 +2389,50 @@ def test_serialize_execution_exposes_merge_automation_selection() -> None:
     payload = _serialize_execution(record)
 
     assert payload.merge_automation_selected is True
-    assert payload.model_dump(by_alias=True)["mergeAutomationSelected"] is True
+
+
+def test_serialize_execution_exposes_proposal_outcome_summary() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.PROPOSALS)
+    record.memo["proposals"] = {
+        "requested": True,
+        "generatedCount": 2,
+        "submittedCount": 2,
+        "deliveredCount": 1,
+        "validationErrors": [
+            {"code": "proposal_missing_task", "message": "proposal skipped: [REDACTED]"}
+        ],
+        "deliveryFailures": [
+            {
+                "provider": "jira",
+                "code": "delivery_failed",
+                "message": "delivery failed: [REDACTED]",
+            }
+        ],
+        "externalLinks": [
+            {
+                "provider": "jira",
+                "externalKey": "MM-901",
+                "externalUrl": "https://jira.example/browse/MM-901",
+            }
+        ],
+        "dedupUpdates": [
+            {
+                "provider": "github",
+                "externalKey": "42",
+                "created": False,
+                "duplicateSource": "existing-open-issue",
+            }
+        ],
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["state"] == "proposals"
+    assert payload["dashboardStatus"] == "running"
+    assert payload["proposalSummary"]["deliveredCount"] == 1
+    assert payload["proposalSummary"]["externalLinks"][0]["externalKey"] == "MM-901"
+    assert payload["proposalOutcomes"][0]["provider"] == "jira"
+    assert payload["proposalOutcomes"][0]["externalUrl"] == "https://jira.example/browse/MM-901"
 
 def test_serialize_execution_exposes_snake_case_publish_merge_automation() -> None:
     record = _build_execution_record()

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -244,6 +244,8 @@ def test_list_proposals_serializes_review_delivery_state(
         "status": "delivered",
         "externalKey": "42",
         "externalUrl": "https://github.example/Moon/Repo/issues/42",
+        "deliveredAt": "2026-05-07T12:30:00Z",
+        "lastSyncedAt": "2026-05-07T12:45:00Z",
         "taskSnapshotRef": "artifact://tasks/proposals/42.json",
         "storedSnapshotNotice": True,
         "created": True,
@@ -424,6 +426,72 @@ def test_get_proposal_preview_includes_preset_provenance(
             "originalStepId": "add-regression-test",
         }
     ]
+
+
+def test_get_proposal_preview_includes_operator_outcome_fields(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    proposal.provider = "jira"
+    proposal.external_key = "MM-901"
+    proposal.external_url = "https://jira.example/browse/MM-901"
+    proposal.delivered_at = datetime(2026, 5, 7, 12, 30, tzinfo=UTC)
+    proposal.last_synced_at = datetime(2026, 5, 7, 12, 45, tzinfo=UTC)
+    proposal.task_snapshot_ref = "artifact://tasks/proposals/MM-901.json"
+    proposal.provider_metadata = {
+        "delivery": {
+            "status": "updated",
+            "storedSnapshotNotice": True,
+            "created": False,
+            "duplicateSource": "existing-open-issue",
+        },
+        "providerDecisions": [
+            {
+                "providerEventId": "evt-promote",
+                "accepted": True,
+                "decision": "promote",
+                "promotedExecutionId": "wf-promoted-1",
+                "resultingExternalState": "promoted",
+            }
+        ],
+    }
+    proposal.task_create_request = {
+        "type": "task",
+        "priority": 1,
+        "maxAttempts": 3,
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "Add regression coverage",
+                "runtime": {"mode": "codex"},
+                "publish": {"mode": "pr"},
+                "skills": ["moonspec-implement"],
+                "authoredPresets": [{"presetId": "runtime-quality-followup"}],
+            },
+        },
+    }
+    service.get_proposal.return_value = proposal
+    service.get_similar_proposals.return_value = []
+
+    response = test_client.get(f"/api/proposals/{proposal.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reviewDelivery"]["status"] == "updated"
+    assert payload["reviewDelivery"]["lastSyncedAt"] == "2026-05-07T12:45:00Z"
+    assert payload["reviewDelivery"]["duplicateSource"] == "existing-open-issue"
+    assert payload["taskPreview"]["runtimeMode"] == "codex"
+    assert payload["taskPreview"]["publishMode"] == "pr"
+    assert payload["taskPreview"]["priority"] == 1
+    assert payload["taskPreview"]["maxAttempts"] == 3
+    assert payload["taskPreview"]["taskSkills"] == ["moonspec-implement"]
+    assert payload["promotionResult"] == {
+        "promotedExecutionId": "wf-promoted-1",
+        "promotedExecutionUrl": "/tasks/temporal/wf-promoted-1",
+        "providerEventId": "evt-promote",
+        "resultingExternalState": "promoted",
+    }
 
 def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
     test_client, service, _execution_service = client

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -655,6 +655,94 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result["errors"]), 1)
         self.assertIn("DB down", result["errors"][0])
 
+    async def test_delivery_summary_preserves_failure_details_and_validation_keywords(
+        self,
+    ) -> None:
+        mock_service = AsyncMock()
+        mock_service.create_proposal.return_value = SimpleNamespace(
+            external_key="MM-901",
+            external_url="https://jira.example/browse/MM-901",
+            provider_metadata={
+                "delivery": {
+                    "status": "failed",
+                    "error": {
+                        "code": "provider_rejected",
+                        "sanitizedReason": "provider rejected delivery",
+                        "retryable": False,
+                    },
+                }
+            },
+        )
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "",
+                        "summary": "Missing title",
+                        "taskCreateRequest": {},
+                    },
+                    {
+                        "title": "Deliver proposal",
+                        "summary": "Exercise failed delivery summaries",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    },
+                ],
+                "policy": {},
+                "origin": {},
+            }
+        )
+
+        self.assertEqual(result["deliveredCount"], 0)
+        self.assertEqual(
+            result["deliveryFailures"],
+            [
+                {
+                    "provider": "github",
+                    "code": "provider_rejected",
+                    "sanitizedReason": "provider rejected delivery",
+                    "retryable": False,
+                    "message": "provider rejected delivery",
+                }
+            ],
+        )
+        self.assertIn("malformed", result["validationErrors"][0]["message"])
+
+    async def test_blank_delivery_status_is_not_counted_as_delivered(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.create_proposal.return_value = SimpleNamespace(
+            external_key="MM-901",
+            external_url="https://jira.example/browse/MM-901",
+            provider_metadata={"delivery": {"status": ""}},
+        )
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Deliver proposal",
+                        "summary": "Blank status should not count as delivered",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    },
+                ],
+                "policy": {},
+                "origin": {},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        self.assertEqual(result["deliveredCount"], 0)
+
 class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
     async def test_default_runtime_stamped_into_candidate(self) -> None:
         """When default_runtime is set and candidate has no runtime, stamp it."""

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -93,6 +93,89 @@ async def test_run_proposals_stage_propagates_policy(
     assert mock_run_workflow._proposals_generated == 1
     assert mock_run_workflow._proposals_submitted == 1
 
+
+@pytest.mark.asyncio
+async def test_run_proposals_stage_records_operator_visible_outcomes(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "proposal.generate":
+            return [{"title": "Generated proposal 1"}, {"title": "Generated proposal 2"}]
+        if activity_type == "proposal.submit":
+            return {
+                "submitted_count": 2,
+                "deliveredCount": 1,
+                "validationErrors": [
+                    {
+                        "code": "proposal_missing_task",
+                        "message": "proposal skipped: [REDACTED]",
+                    }
+                ],
+                "deliveryFailures": [
+                    {
+                        "provider": "jira",
+                        "code": "delivery_failed",
+                        "message": "delivery failed: [REDACTED]",
+                    }
+                ],
+                "externalLinks": [
+                    {
+                        "provider": "jira",
+                        "externalKey": "MM-901",
+                        "externalUrl": "https://jira.example/browse/MM-901",
+                    }
+                ],
+                "dedupUpdates": [
+                    {
+                        "provider": "github",
+                        "externalKey": "42",
+                        "created": False,
+                        "duplicateSource": "existing-open-issue",
+                    }
+                ],
+            }
+        return {}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    await mock_run_workflow._run_proposals_stage(
+        parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
+    )
+
+    assert mock_run_workflow._proposals_generated == 2
+    assert mock_run_workflow._proposals_submitted == 2
+    assert mock_run_workflow._proposals_delivered == 1
+    assert mock_run_workflow._proposal_validation_errors == [
+        {"code": "proposal_missing_task", "message": "proposal skipped: [REDACTED]"}
+    ]
+    assert mock_run_workflow._proposal_delivery_failures == [
+        {
+            "provider": "jira",
+            "code": "delivery_failed",
+            "message": "delivery failed: [REDACTED]",
+        }
+    ]
+    assert mock_run_workflow._proposal_external_links == [
+        {
+            "provider": "jira",
+            "externalKey": "MM-901",
+            "externalUrl": "https://jira.example/browse/MM-901",
+        }
+    ]
+    assert mock_run_workflow._proposal_dedup_updates == [
+        {
+            "provider": "github",
+            "externalKey": "42",
+            "created": False,
+            "duplicateSource": "existing-open-issue",
+        }
+    ]
+
 @pytest.mark.asyncio
 async def test_run_proposals_stage_ignores_flattened_legacy_policy_fields(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
Change Jira issue MM-600 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.