### PR TITLE
[codex] Fix deployment update stack execution

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -100,6 +100,7 @@ MINIO_API_PORT=9000
 MINIO_ROOT_USER="minioadmin"
 MINIO_ROOT_PASSWORD="minioadmin"
 MINIO_CONSOLE_PORT=9001
+MOONMIND_IMAGE="ghcr.io/moonladderstudios/moonmind:latest"
 WORKFLOW_USE_SKILLS="true"
 # Legacy aliases:
 # WORKFLOW_USE_SKILLS="true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     ports:
       - "8000:8000"
     environment:
@@ -257,7 +257,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-workflow:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -311,7 +311,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-artifacts:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -365,7 +365,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-llm:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -421,7 +421,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-sandbox:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -505,7 +505,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-agent-runtime:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -597,7 +597,7 @@ services:
     restart: unless-stopped
 
   temporal-worker-integrations:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -662,7 +662,7 @@ services:
       - local-network
 
   init-db:
-    image: ghcr.io/moonladderstudios/moonmind:latest
+    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-moonmind-api-db}:5432/${POSTGRES_DB:-moonmind}
       - PYTHONPATH=/app

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -226,8 +226,9 @@ describe('OperationsSettingsSection deployment update card', () => {
     renderOperations();
 
     const card = await screen.findByRole('region', { name: /deployment update/i });
-    const reference = (await within(card).findByLabelText(/target reference/i)) as HTMLSelectElement;
+    const reference = (await within(card).findByLabelText(/target reference/i)) as HTMLInputElement;
     expect(reference.value).toBe('20260425.1234');
+    expect(within(card).getByDisplayValue('20260425.1234')).toBeTruthy();
 
     fireEvent.change(reference, { target: { value: 'latest' } });
     expect(within(card).getByText(/latest may resolve differently/i)).toBeTruthy();
@@ -286,7 +287,7 @@ describe('OperationsSettingsSection deployment update card', () => {
     const card = await screen.findByRole('region', { name: /deployment update/i });
 
     fireEvent.change(await within(card).findByLabelText(/target reference/i), {
-      target: { value: 'latest' },
+      target: { value: 'v20260507.2470' },
     });
     fireEvent.click(
       await within(card).findByRole('button', { name: /submit deployment update/i }),
@@ -294,11 +295,10 @@ describe('OperationsSettingsSection deployment update card', () => {
 
     await waitFor(() => {
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Current image: ghcr.io/moonladderstudios/moonmind:stable'));
-      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Target image: ghcr.io/moonladderstudios/moonmind:latest'));
+      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Target image: ghcr.io/moonladderstudios/moonmind:v20260507.2470'));
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Mode: Restart changed services'));
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Stack: moonmind'));
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Expected affected services: api, worker'));
-      expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Mutable tag warning'));
       expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Services may restart'));
     });
 
@@ -309,7 +309,7 @@ describe('OperationsSettingsSection deployment update card', () => {
         stack: 'moonmind',
         image: {
           repository: 'ghcr.io/moonladderstudios/moonmind',
-          reference: 'latest',
+          reference: 'v20260507.2470',
         },
         mode: 'changed_services',
         removeOrphans: true,

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -875,17 +875,19 @@ export function OperationsSettingsSection({
               </label>
               <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-300">
                 <span>Target reference</span>
-                <select
+                <input
                   className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                  list="deployment-target-references"
                   value={targetReference}
                   onChange={(event) => setTargetReference(event.target.value)}
-                >
+                />
+                <datalist id="deployment-target-references">
                   {referenceOptions.map((reference) => (
                     <option key={reference} value={reference}>
                       {reference}
                     </option>
                   ))}
-                </select>
+                </datalist>
               </label>
               {isMutableReference(targetReference) ? (
                 <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-300">

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -18,6 +18,7 @@ def _build_proposal_service_factory():
 """Temporal worker runtime entrypoint."""
 
 import asyncio
+from copy import deepcopy
 import json
 import logging
 import os
@@ -1030,6 +1031,7 @@ def _build_runtime_planner():
         explicit_plan = task_payload.get("plan")
         if isinstance(explicit_plan, list) and explicit_plan:
             nodes: list[dict[str, Any]] = []
+            node_ids: set[str] = set()
             for idx, plan_entry in enumerate(explicit_plan, start=1):
                 if not isinstance(plan_entry, Mapping):
                     raise RuntimeError("task.plan entries must be objects")
@@ -1057,9 +1059,14 @@ def _build_runtime_planner():
                     node_inputs = _coerce_mapping(
                         tool_payload.get("inputs") or tool_payload.get("args")
                     )
+                node_id = str(plan_entry.get("id") or f"node-{idx}").strip()
+                if not node_id:
+                    node_id = f"node-{idx}"
+                if node_id in node_ids:
+                    raise RuntimeError(f"task.plan duplicate node id: {node_id}")
+                node_ids.add(node_id)
                 node: dict[str, Any] = {
-                    "id": str(plan_entry.get("id") or f"node-{idx}").strip()
-                    or f"node-{idx}",
+                    "id": node_id,
                     "tool": {
                         "type": tool_type,
                         "name": tool_name,
@@ -1070,6 +1077,10 @@ def _build_runtime_planner():
                 options = _coerce_mapping(plan_entry.get("options"))
                 if options:
                     node["options"] = dict(options)
+                for key, value in plan_entry.items():
+                    if key in {"id", "tool", "skill", "inputs", "options"}:
+                        continue
+                    node[str(key)] = deepcopy(value)
                 nodes.append(node)
 
             explicit_edges = task_payload.get("edges")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1027,6 +1027,72 @@ def _build_runtime_planner():
         if failure_mode not in {"FAIL_FAST", "CONTINUE"}:
             failure_mode = "FAIL_FAST"
 
+        explicit_plan = task_payload.get("plan")
+        if isinstance(explicit_plan, list) and explicit_plan:
+            nodes: list[dict[str, Any]] = []
+            for idx, plan_entry in enumerate(explicit_plan, start=1):
+                if not isinstance(plan_entry, Mapping):
+                    raise RuntimeError("task.plan entries must be objects")
+                tool_payload = _coerce_mapping(
+                    plan_entry.get("tool")
+                ) or _coerce_mapping(plan_entry.get("skill"))
+                if not tool_payload:
+                    raise RuntimeError("task.plan entries require a tool object")
+                tool_type = str(
+                    tool_payload.get("type") or tool_payload.get("kind") or "skill"
+                ).strip() or "skill"
+                tool_name = str(
+                    tool_payload.get("name") or tool_payload.get("id") or ""
+                ).strip()
+                if not tool_name:
+                    raise RuntimeError("task.plan tool name is required")
+                tool_version = str(
+                    tool_payload.get("version")
+                    or ("1.0.0" if tool_type == "skill" else "1.0")
+                ).strip()
+                if not tool_version:
+                    raise RuntimeError("task.plan tool version is required")
+                node_inputs = _coerce_mapping(plan_entry.get("inputs"))
+                if not node_inputs:
+                    node_inputs = _coerce_mapping(
+                        tool_payload.get("inputs") or tool_payload.get("args")
+                    )
+                node: dict[str, Any] = {
+                    "id": str(plan_entry.get("id") or f"node-{idx}").strip()
+                    or f"node-{idx}",
+                    "tool": {
+                        "type": tool_type,
+                        "name": tool_name,
+                        "version": tool_version,
+                    },
+                    "inputs": dict(node_inputs),
+                }
+                options = _coerce_mapping(plan_entry.get("options"))
+                if options:
+                    node["options"] = dict(options)
+                nodes.append(node)
+
+            explicit_edges = task_payload.get("edges")
+            edges = (
+                [dict(edge) for edge in explicit_edges if isinstance(edge, Mapping)]
+                if isinstance(explicit_edges, list)
+                else []
+            )
+            return {
+                "plan_version": "1.0",
+                "metadata": {
+                    "title": title,
+                    "created_at": created_at,
+                    "registry_snapshot": {
+                        "digest": snapshot.digest,
+                        "artifact_ref": snapshot.artifact_ref,
+                    },
+                },
+                "policy": {"failure_mode": failure_mode, "max_concurrency": 1},
+                "nodes": nodes,
+                "edges": edges,
+            }
+
         story_output_payload = _coerce_mapping(
             task_payload.get("storyOutput")
             or task_payload.get("story_output")

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -84,6 +84,36 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"
 
 
+def test_moonmind_application_services_use_deployment_image_variable():
+    """Deployment updates must be able to change the app image without YAML edits."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    application_services = [
+        "api",
+        "init-db",
+        "temporal-worker-workflow",
+        "temporal-worker-artifacts",
+        "temporal-worker-llm",
+        "temporal-worker-sandbox",
+        "temporal-worker-agent-runtime",
+        "temporal-worker-integrations",
+    ]
+
+    for service_name in application_services:
+        service_config = services.get(service_name)
+        assert isinstance(service_config, dict), (
+            f"{service_name} service is missing from docker-compose.yaml"
+        )
+        assert service_config.get("image") == (
+            "${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}"
+        ), f"{service_name} must use MOONMIND_IMAGE for deployment updates"
+
+
 def test_agent_runtime_worker_mounts_agent_skill_catalog():
     """Selected managed-session skills resolve from the deployment skill catalog."""
     compose_path = Path("docker-compose.yaml")

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -289,6 +289,71 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
         "originalStepId": "fetch-jira-issue",
     }
 
+def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={},
+        parameters={
+            "failurePolicy": "fail_fast",
+            "task": {
+                "title": "Update deployment stack moonmind",
+                "instructions": (
+                    "Run the policy-gated deployment update operation for stack "
+                    "'moonmind' using the typed deployment.update_compose_stack "
+                    "tool contract."
+                ),
+                "plan": [
+                    {
+                        "id": "update-moonmind-deployment",
+                        "tool": {
+                            "type": "skill",
+                            "name": "deployment.update_compose_stack",
+                            "version": "1.0.0",
+                        },
+                        "inputs": {
+                            "stack": "moonmind",
+                            "image": {
+                                "repository": (
+                                    "ghcr.io/moonladderstudios/moonmind"
+                                ),
+                                "reference": "v20260507.2470",
+                            },
+                            "mode": "changed_services",
+                        },
+                    }
+                ],
+            },
+        },
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"] == [
+        {
+            "id": "update-moonmind-deployment",
+            "tool": {
+                "type": "skill",
+                "name": "deployment.update_compose_stack",
+                "version": "1.0.0",
+            },
+            "inputs": {
+                "stack": "moonmind",
+                "image": {
+                    "repository": "ghcr.io/moonladderstudios/moonmind",
+                    "reference": "v20260507.2470",
+                },
+                "mode": "changed_services",
+            },
+        }
+    ]
+    assert plan["policy"]["failure_mode"] == "FAIL_FAST"
+    registry_snapshot = plan["metadata"]["registry_snapshot"]
+    assert registry_snapshot["artifact_ref"] == "art_registry_123"
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -354,6 +354,88 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
     registry_snapshot = plan["metadata"]["registry_snapshot"]
     assert registry_snapshot["artifact_ref"] == "art_registry_123"
 
+
+def test_runtime_planner_preserves_authored_task_plan_node_metadata():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={},
+        parameters={
+            "task": {
+                "instructions": "Run the authored deployment plan.",
+                "plan": [
+                    {
+                        "id": "update-moonmind-deployment",
+                        "title": "Update MoonMind deployment",
+                        "description": "Use the deployment operations service.",
+                        "tool": {
+                            "type": "skill",
+                            "name": "deployment.update_compose_stack",
+                            "version": "1.0.0",
+                        },
+                        "inputs": {
+                            "stack": "moonmind",
+                            "image": {
+                                "repository": (
+                                    "ghcr.io/moonladderstudios/moonmind"
+                                ),
+                                "reference": "v20260507.2470",
+                            },
+                        },
+                    }
+                ],
+            },
+        },
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+    assert node["title"] == "Update MoonMind deployment"
+    assert node["description"] == "Use the deployment operations service."
+
+
+def test_runtime_planner_rejects_duplicate_authored_task_plan_node_ids():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    with pytest.raises(RuntimeError, match="task\\.plan duplicate node id: node-2"):
+        planner(
+            inputs={},
+            parameters={
+                "task": {
+                    "instructions": "Run the authored deployment plan.",
+                    "plan": [
+                        {
+                            "id": "node-2",
+                            "tool": {
+                                "type": "skill",
+                                "name": "deployment.update_compose_stack",
+                                "version": "1.0.0",
+                            },
+                            "inputs": {"stack": "moonmind"},
+                        },
+                        {
+                            "tool": {
+                                "type": "skill",
+                                "name": "deployment.update_compose_stack",
+                                "version": "1.0.0",
+                            },
+                            "inputs": {"stack": "moonmind"},
+                        },
+                    ],
+                },
+            },
+            snapshot=snapshot,
+        )
+
+
 @pytest.mark.parametrize(
     "source",
     [


### PR DESCRIPTION
## Summary

Fix the deployment update flow so policy-gated stack updates execute the typed `deployment.update_compose_stack` tool instead of being rewritten into a generic agent runtime step.

This also makes the MoonMind application image configurable through `MOONMIND_IMAGE`, and lets Settings Operations submit exact release tags such as `v20260507.2470` instead of only choosing from the suggested references list.

## Root Cause

The failed deployment task generated a generic `agent_runtime` plan node from an authored `task.plan`, so Codex queued another deployment operation rather than the workflow executing the typed deployment tool. The compose stack also hardcoded `ghcr.io/moonladderstudios/moonmind:latest`, so a requested release tag could not be represented by compose desired state.

## Changes

- Preserve authored `task.plan` tool nodes in the runtime planner.
- Parameterize MoonMind app service images with `MOONMIND_IMAGE`.
- Add `MOONMIND_IMAGE` to `.env-template`.
- Change the deployment target reference control to a free text input with suggestions.
- Add planner, compose, and UI regression coverage.

## Validation

- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_deployment_operations.py tests/unit/workflows/skills/test_deployment_update_execution.py tests/integration/temporal/test_deployment_update_execution_contract.py tests/test_local_dev.py -q` -> 113 passed
- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_preserves_authored_task_plan_tool_nodes tests/test_local_dev.py::test_moonmind_application_services_use_deployment_image_variable -q` -> 2 passed
- `npm run ui:test -- frontend/src/components/settings/OperationsSettingsSection.test.tsx` -> 8 passed
- `git diff --check` -> clean
- `MOONMIND_IMAGE=ghcr.io/moonladderstudios/moonmind:v20260507.2470 docker compose config --format json ...` resolved all MoonMind app services to the requested tag

Note: the full `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` run was attempted but hung near the end in existing managed-session fake app server tests, so I terminated it and relied on the affected suites above.