### PR TITLE
[codex] Propagate story output handoff to agent runs

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4747,6 +4747,12 @@ class MoonMindRunWorkflow:
             "stepCount",
             "maxAttempts",
             "steps",
+            "storyOutput",
+            "story_output",
+            "storyBreakdownPath",
+            "story_breakdown_path",
+            "storyBreakdownMarkdownPath",
+            "story_breakdown_markdown_path",
         ):
             param_val = runtime_block.get(param_key) or node_inputs.get(param_key)
             if param_val is not None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -698,6 +698,54 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             {"id": "step-2", "instructions": "Do part B"}
         ])
 
+    def test_build_agent_execution_request_propagates_story_output_handoff(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        story_output = {
+            "mode": "jira",
+            "handoff": "artifact",
+            "requiresStoryBreakdownArtifactRef": True,
+            "storyBreakdownPath": "artifacts/story-breakdowns/demo/stories.json",
+            "storyBreakdownMarkdownPath": (
+                "artifacts/story-breakdowns/demo/stories.md"
+            ),
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {"mode": "codex_cli"},
+                    "storyOutput": story_output,
+                    "storyBreakdownPath": (
+                        "artifacts/story-breakdowns/demo/stories.json"
+                    ),
+                    "storyBreakdownMarkdownPath": (
+                        "artifacts/story-breakdowns/demo/stories.md"
+                    ),
+                },
+                node_id="node-story-output",
+                tool_name="moonspec-breakdown",
+            )
+
+        self.assertEqual(request.parameters["storyOutput"], story_output)
+        self.assertEqual(
+            request.parameters["storyBreakdownPath"],
+            "artifacts/story-breakdowns/demo/stories.json",
+        )
+        self.assertEqual(
+            request.parameters["storyBreakdownMarkdownPath"],
+            "artifacts/story-breakdowns/demo/stories.md",
+        )
+
     def test_build_agent_execution_request_marks_hyphenated_codex_runtime_managed(self) -> None:
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- propagate story-output handoff fields into managed agent run requests
- add a regression test covering story breakdown artifact handoff propagation

## Root Cause
The runtime planner generated the Jira story breakdown path and artifact handoff contract, but MoonMind.Run dropped those fields while constructing AgentExecutionRequest.parameters. The managed agent could write the files, but the artifact publication step could not publish a durable storyBreakdownArtifactRef for the following Jira tool step.

## Validation
- ./tools/test_unit.sh
- Re-ran the failed workflow successfully as mm:7bdf3ad6-c14c-4add-bc67-7352bceee655; it created Jira issues MM-612 through MM-616, blocker links, and dependent Jira Orchestrate tasks.