### PR TITLE
[codex] Fix deployment update latest image execution

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,4 +1,11 @@
 # Deployment Settings
+MOONMIND_IMAGE="ghcr.io/moonladderstudios/moonmind:latest"
+# Deployment update operations run Docker Compose from the trusted agent-runtime
+# worker. Keep this as the absolute host path to this checkout so bind mounts in
+# docker-compose.yaml resolve to the same path on the Docker host.
+MOONMIND_DEPLOYMENT_PROJECT_DIR=""
+MOONMIND_DEPLOYMENT_COMPOSE_FILE=""
+MOONMIND_DEPLOYMENT_PROJECT_NAME="moonmind"
 FASTAPI_RELOAD=""
 INIT_DATABASE="true"
 JWT_SECRET_KEY="replace_with_a_strong_random_jwt_secret"

--- a/api_service/services/deployment_operations.py
+++ b/api_service/services/deployment_operations.py
@@ -279,6 +279,23 @@ class DeploymentOperationsService:
             plan_inputs["rollbackSourceActionId"] = submission.rollback_source_action_id
         if submission.confirmation:
             plan_inputs["confirmation"] = submission.confirmation
+        deployment_step = {
+            "id": "update-moonmind-deployment",
+            "type": "tool",
+            "title": "Update MoonMind deployment",
+            "instructions": (
+                "Run the policy-gated deployment update operation for "
+                f"stack '{policy.stack}' using the typed "
+                f"{DEPLOYMENT_UPDATE_TOOL_NAME} tool contract."
+            ),
+            "tool": {
+                "type": "skill",
+                "name": DEPLOYMENT_UPDATE_TOOL_NAME,
+                "id": DEPLOYMENT_UPDATE_TOOL_NAME,
+                "version": DEPLOYMENT_UPDATE_TOOL_VERSION,
+                "inputs": plan_inputs,
+            },
+        }
         return {
             "task": {
                 "instructions": (
@@ -293,10 +310,13 @@ class DeploymentOperationsService:
                     "kind": submission.operation_kind,
                     "rollbackSourceActionId": submission.rollback_source_action_id,
                 },
+                "steps": [deployment_step],
+                # Keep the legacy projection shape until deployment action
+                # readers are fully migrated to task.steps.
                 "plan": [
                     {
-                        "id": "update-moonmind-deployment",
-                        "title": "Update MoonMind deployment",
+                        "id": deployment_step["id"],
+                        "title": deployment_step["title"],
                         "tool": {
                             "type": "skill",
                             "name": DEPLOYMENT_UPDATE_TOOL_NAME,
@@ -315,11 +335,11 @@ class DeploymentOperationsService:
         submission: DeploymentUpdateSubmission,
     ) -> str:
         normalized_reason = str(submission.reason or "").strip()
-        explicit_action_key = (
-            uuid4().hex
-            if submission.operation_kind == "rollback"
-            else normalized_reason
-        )
+        explicit_action_key = normalized_reason
+        if submission.operation_kind == "rollback" or _is_mutable_reference(
+            policy=policy, reference=submission.reference
+        ):
+            explicit_action_key = uuid4().hex
         return "|".join(
             [
                 "deployment-update",
@@ -330,3 +350,10 @@ class DeploymentOperationsService:
                 explicit_action_key,
             ]
         )[:128]
+
+
+def _is_mutable_reference(*, policy: DeploymentStackPolicy, reference: str) -> bool:
+    normalized = str(reference or "").strip()
+    if not normalized or normalized.startswith("sha256:"):
+        return False
+    return policy.allow_mutable_tags and normalized in policy.allowed_references

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - TEMPORAL_TASK_EDITING_ENABLED=${TEMPORAL_TASK_EDITING_ENABLED:-true}
       - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
-      - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+      - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
       # OIDC specific variables for API service
       - AUTH_PROVIDER=${AUTH_PROVIDER:-disabled} # local, google, or disabled
@@ -516,7 +516,7 @@ services:
       - TEMPORAL_ACTIVITY_AGENT_RUNTIME_TASK_QUEUE=${TEMPORAL_ACTIVITY_AGENT_RUNTIME_TASK_QUEUE:-mm.activity.agent_runtime}
       - TEMPORAL_AGENT_RUNTIME_WORKER_CONCURRENCY=${TEMPORAL_AGENT_RUNTIME_WORKER_CONCURRENCY:-4}
       - MOONMIND_URL=${MOONMIND_URL:-http://api:8000}
-      - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+      - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}}
       - CODEX_VOLUME_PATH=${CODEX_VOLUME_PATH:-/home/app/.codex}
       - CODEX_HOME=${CODEX_VOLUME_PATH:-/home/app/.codex}
       - CODEX_CONFIG_HOME=${CODEX_VOLUME_PATH:-/home/app/.codex}
@@ -547,10 +547,14 @@ services:
       - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - MOONMIND_DOCKER_PROXY_NETWORK=${MOONMIND_DOCKER_PROXY_NETWORK:-moonmind_docker-proxy-network}
+      - MOONMIND_DEPLOYMENT_PROJECT_DIR=${MOONMIND_DEPLOYMENT_PROJECT_DIR:-${PWD}}
+      - MOONMIND_DEPLOYMENT_COMPOSE_FILE=${MOONMIND_DEPLOYMENT_COMPOSE_FILE:-${PWD}/docker-compose.yaml}
+      - MOONMIND_DEPLOYMENT_PROJECT_NAME=${MOONMIND_DEPLOYMENT_PROJECT_NAME:-moonmind}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
     env_file:
       - .env
     volumes:
+      - ${MOONMIND_DEPLOYMENT_PROJECT_DIR:-${PWD}}:${MOONMIND_DEPLOYMENT_PROJECT_DIR:-${PWD}}:ro
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
       - ./services:/app/services:ro

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Mapping, Protocol
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
 
 from .deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
@@ -67,10 +70,22 @@ class ComposeRunner(Protocol):
     async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
         """Capture before/after state for a deployment stack."""
 
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
         """Run the pull command."""
 
-    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def up(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
         """Run the up command."""
 
     async def verify(
@@ -172,7 +187,13 @@ class DisabledComposeRunner:
             },
         )
 
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
         raise ToolFailure(
             error_code="POLICY_VIOLATION",
             message="Deployment update runner is not configured for this worker.",
@@ -184,7 +205,13 @@ class DisabledComposeRunner:
             },
         )
 
-    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def up(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
         raise ToolFailure(
             error_code="POLICY_VIOLATION",
             message="Deployment update runner is not configured for this worker.",
@@ -214,6 +241,273 @@ class DisabledComposeRunner:
                 "failureClass": "policy_violation",
             },
         )
+
+
+@dataclass(frozen=True, slots=True)
+class HostDockerComposeRunner:
+    """Docker Compose runner for a trusted deployment-control worker."""
+
+    project_dir: str
+    compose_file: str | None = None
+    project_name: str = "moonmind"
+    command_timeout_seconds: int = 900
+
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        services = await self._run_compose_json(("ps", "--format", "json"))
+        images = await self._run_compose_json(("images", "--format", "json"))
+        return {
+            "stack": stack,
+            "phase": phase,
+            "projectName": self.project_name,
+            "services": services,
+            "images": images,
+            "capturedAt": _utc_now(),
+        }
+
+    async def pull(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
+        return await self._run_compose_command(command, requested_image=requested_image)
+
+    async def up(
+        self,
+        *,
+        stack: str,
+        command: tuple[str, ...],
+        requested_image: str,
+    ) -> Mapping[str, Any]:
+        return await self._run_compose_command(command, requested_image=requested_image)
+
+    async def verify(
+        self,
+        *,
+        stack: str,
+        requested_image: str,
+        resolved_digest: str | None,
+    ) -> ComposeVerification:
+        target = await self._inspect_image(requested_image)
+        target_id = str(target.get("Id") or "").strip()
+        images = await self._run_compose_json(("images", "--format", "json"))
+        services = await self._run_compose_json(("ps", "--format", "json"))
+        repository, reference = _split_requested_image(requested_image)
+        matched_images = [
+            image
+            for image in images
+            if isinstance(image, Mapping)
+            and str(image.get("Repository") or image.get("repository") or "").strip()
+            == repository
+        ]
+        mismatches: list[dict[str, Any]] = []
+        updated_services: list[str] = []
+        for image in matched_images:
+            image_id = str(
+                image.get("ID")
+                or image.get("Id")
+                or image.get("ImageID")
+                or image.get("image_id")
+                or ""
+            ).strip()
+            service_name = str(
+                image.get("Service") or image.get("Name") or image.get("Container")
+                or ""
+            ).strip()
+            tag = str(image.get("Tag") or image.get("tag") or "").strip()
+            if service_name:
+                updated_services.append(service_name)
+            if target_id and image_id and image_id != target_id:
+                mismatches.append(
+                    {
+                        "service": service_name or None,
+                        "repository": repository,
+                        "tag": tag or None,
+                        "imageId": image_id,
+                        "expectedImageId": target_id,
+                    }
+                )
+        succeeded = bool(matched_images) and not mismatches
+        details = {
+            "requestedImage": requested_image,
+            "resolvedDigest": resolved_digest,
+            "targetImageId": target_id or None,
+            "targetRepoDigests": target.get("RepoDigests") or [],
+            "matchedImageCount": len(matched_images),
+            "failedChecks": mismatches,
+            "requestedReference": reference,
+        }
+        if not matched_images:
+            details["failureReason"] = (
+                "No running Compose services were found for the requested image "
+                f"repository {repository}."
+            )
+        elif mismatches:
+            details["failureReason"] = (
+                "One or more Compose services are not running the pulled target image."
+            )
+        return ComposeVerification(
+            succeeded=succeeded,
+            updated_services=tuple(sorted(set(updated_services))),
+            running_services=tuple(
+                service for service in services if isinstance(service, Mapping)
+            ),
+            details=details,
+        )
+
+    def _compose_base_command(self) -> list[str]:
+        project_dir = Path(self.project_dir).expanduser()
+        if not project_dir.is_absolute():
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message="Deployment compose project directory must be absolute.",
+                retryable=False,
+                details={
+                    "project_dir": str(project_dir),
+                    "failureClass": "policy_violation",
+                },
+            )
+        if not project_dir.exists():
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message="Deployment compose project directory is not mounted.",
+                retryable=False,
+                details={
+                    "project_dir": str(project_dir),
+                    "failureClass": "policy_violation",
+                },
+            )
+        compose_file = Path(self.compose_file).expanduser() if self.compose_file else (
+            project_dir / "docker-compose.yaml"
+        )
+        if not compose_file.is_absolute():
+            compose_file = project_dir / compose_file
+        if not compose_file.exists():
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message="Deployment compose file is not mounted.",
+                retryable=False,
+                details={
+                    "compose_file": str(compose_file),
+                    "failureClass": "policy_violation",
+                },
+            )
+        return [
+            "docker",
+            "compose",
+            "--project-name",
+            self.project_name,
+            "--project-directory",
+            str(project_dir),
+            "-f",
+            str(compose_file),
+        ]
+
+    def _compose_command(self, command: Sequence[str]) -> list[str]:
+        parts = list(command)
+        if len(parts) < 3 or parts[0:2] != ["docker", "compose"]:
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message="Deployment command must use docker compose.",
+                retryable=False,
+                details={
+                    "command": parts,
+                    "failureClass": "policy_violation",
+                },
+            )
+        return [*self._compose_base_command(), *parts[2:]]
+
+    async def _run_compose_command(
+        self,
+        command: Sequence[str],
+        *,
+        requested_image: str | None = None,
+        max_output_chars: int = 512,
+    ) -> Mapping[str, Any]:
+        resolved = self._compose_command(command)
+        env = os.environ.copy()
+        if requested_image:
+            env["MOONMIND_IMAGE"] = requested_image
+        process = await asyncio.create_subprocess_exec(
+            *resolved,
+            cwd=str(Path(self.project_dir).expanduser()),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.command_timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Deployment compose command timed out.",
+                retryable=False,
+                details={
+                    "command": resolved,
+                    "timeoutSeconds": self.command_timeout_seconds,
+                    "failureClass": "compose_config_validation_failure",
+                },
+            ) from exc
+        return {
+            "command": resolved,
+            "exitCode": process.returncode,
+            "stdout": _tail_text(stdout, max_chars=max_output_chars),
+            "stderr": _tail_text(stderr, max_chars=max_output_chars),
+        }
+
+    async def _run_compose_json(self, args: Sequence[str]) -> list[Mapping[str, Any]]:
+        result = await self._run_compose_command(
+            ("docker", "compose", *args),
+            max_output_chars=20000,
+        )
+        _ensure_command_succeeded("config", result)
+        payload = "\n".join(
+            part
+            for part in (str(result.get("stdout") or ""), str(result.get("stderr") or ""))
+            if part.strip()
+        )
+        return _parse_json_records(payload)
+
+    async def _inspect_image(self, requested_image: str) -> Mapping[str, Any]:
+        process = await asyncio.create_subprocess_exec(
+            "docker",
+            "image",
+            "inspect",
+            requested_image,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Pulled deployment image could not be inspected.",
+                retryable=False,
+                details={
+                    "requestedImage": requested_image,
+                    "stderr": _tail_text(stderr),
+                    "failureClass": "image_pull_failure",
+                },
+            )
+        parsed = json.loads(stdout.decode("utf-8"))
+        if not isinstance(parsed, list) or not parsed or not isinstance(parsed[0], Mapping):
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Docker image inspect returned an invalid payload.",
+                retryable=False,
+                details={
+                    "requestedImage": requested_image,
+                    "failureClass": "image_pull_failure",
+                },
+            )
+        return dict(parsed[0])
 
 
 @dataclass(slots=True)
@@ -341,7 +635,9 @@ class DeploymentUpdateExecutor:
                     progress_events, "PULLING_IMAGES", "Pulling requested images."
                 )
                 pull_result = await self.runner.pull(
-                    stack=parsed["stack"], command=command_plan.pull_args
+                    stack=parsed["stack"],
+                    command=command_plan.pull_args,
+                    requested_image=requested_image,
                 )
                 command_log["pull"]["result"] = pull_result
                 _ensure_command_succeeded("pull", pull_result)
@@ -352,7 +648,9 @@ class DeploymentUpdateExecutor:
                     "Recreating deployment services.",
                 )
                 up_result = await self.runner.up(
-                    stack=parsed["stack"], command=command_plan.up_args
+                    stack=parsed["stack"],
+                    command=command_plan.up_args,
+                    requested_image=requested_image,
                 )
                 command_log["up"]["result"] = up_result
                 _ensure_command_succeeded("up", up_result)
@@ -853,6 +1151,39 @@ def _record_command_exception(command_log: dict[str, Any], exc: Exception) -> No
         }
 
 
+def _parse_json_records(payload: str) -> list[Mapping[str, Any]]:
+    text = str(payload or "").strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        records: list[Mapping[str, Any]] = []
+        for line in text.splitlines():
+            candidate = line.strip()
+            if not candidate:
+                continue
+            parsed_line = json.loads(candidate)
+            if isinstance(parsed_line, Mapping):
+                records.append(dict(parsed_line))
+        return records
+    if isinstance(parsed, list):
+        return [dict(item) for item in parsed if isinstance(item, Mapping)]
+    if isinstance(parsed, Mapping):
+        return [dict(parsed)]
+    return []
+
+
+def _split_requested_image(requested_image: str) -> tuple[str, str]:
+    if "@" in requested_image:
+        repository, reference = requested_image.rsplit("@", 1)
+        return repository, reference
+    repository, separator, reference = requested_image.rpartition(":")
+    if not separator or "/" not in repository:
+        return requested_image, ""
+    return repository, reference
+
+
 def _stable_ref(kind: str, payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
     digest = hashlib.sha256(kind.encode("utf-8") + b"\0" + encoded).hexdigest()
@@ -872,6 +1203,7 @@ __all__ = [
     "DEPLOYMENT_UPDATE_STACKS",
     "DEPLOYMENT_UPDATE_MODES",
     "DisabledComposeRunner",
+    "HostDockerComposeRunner",
     "InMemoryDesiredStateStore",
     "InMemoryEvidenceWriter",
     "build_compose_command_plan",

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -45,6 +45,11 @@ from api_service.db.models import (
 )
 from moonmind.config.settings import settings
 from moonmind.workflows.skills.deployment_execution import (
+    DeploymentUpdateExecutor,
+    DeploymentUpdateLockManager,
+    HostDockerComposeRunner,
+    InMemoryDesiredStateStore,
+    InMemoryEvidenceWriter,
     register_deployment_update_tool_handler,
 )
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
@@ -490,6 +495,37 @@ _CODEX_CONFIG_FLEETS = frozenset({SANDBOX_FLEET, AGENT_RUNTIME_FLEET})
 # ``automationMode`` / ``AUTO_CREATE_PR``), not by appending ``gh pr create``
 # to plan instructions.
 _TOOLS_WITH_AUTO_PR_CREATION = frozenset({"jules", "jules_api"})
+
+
+def _build_deployment_update_executor() -> DeploymentUpdateExecutor | None:
+    project_dir = str(os.environ.get("MOONMIND_DEPLOYMENT_PROJECT_DIR") or "").strip()
+    if not project_dir:
+        return None
+    compose_file = (
+        str(os.environ.get("MOONMIND_DEPLOYMENT_COMPOSE_FILE") or "").strip() or None
+    )
+    project_name = (
+        str(os.environ.get("MOONMIND_DEPLOYMENT_PROJECT_NAME") or "").strip()
+        or "moonmind"
+    )
+    timeout_raw = str(
+        os.environ.get("MOONMIND_DEPLOYMENT_COMMAND_TIMEOUT_SECONDS") or ""
+    ).strip()
+    try:
+        timeout_seconds = int(timeout_raw) if timeout_raw else 900
+    except ValueError:
+        timeout_seconds = 900
+    return DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=HostDockerComposeRunner(
+            project_dir=project_dir,
+            compose_file=compose_file,
+            project_name=project_name,
+            command_timeout_seconds=timeout_seconds,
+        ),
+    )
 
 def _coerce_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
@@ -1679,7 +1715,10 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 launcher=workload_launcher,
                 workflow_docker_mode=settings.workflow.workflow_docker_mode,
             )
-            register_deployment_update_tool_handler(dispatcher)
+            register_deployment_update_tool_handler(
+                dispatcher,
+                executor=_build_deployment_update_executor(),
+            )
 
         bindings = build_worker_activity_bindings(
             fleet=topology.fleet,

--- a/tests/integration/temporal/test_deployment_update_execution_contract.py
+++ b/tests/integration/temporal/test_deployment_update_execution_contract.py
@@ -35,11 +35,15 @@ class HermeticRunner:
     async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
         return {"stack": stack, "phase": phase}
 
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.commands.append(("pull", command))
         return {"ok": True}
 
-    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def up(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.commands.append(("up", command))
         return {"ok": True}
 

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -198,9 +198,14 @@ def test_admin_can_submit_policy_valid_deployment_update(
     parameters = request["initial_parameters"]
     assert isinstance(parameters, dict)
     plan = parameters["task"]["plan"]
+    steps = parameters["task"]["steps"]
     assert plan[0]["tool"]["name"] == DEPLOYMENT_UPDATE_TOOL_NAME
     assert plan[0]["tool"]["version"] == DEPLOYMENT_UPDATE_TOOL_VERSION
     assert plan[0]["inputs"]["stack"] == "moonmind"
+    assert steps[0]["type"] == "tool"
+    assert steps[0]["tool"]["name"] == DEPLOYMENT_UPDATE_TOOL_NAME
+    assert steps[0]["tool"]["version"] == DEPLOYMENT_UPDATE_TOOL_VERSION
+    assert steps[0]["tool"]["inputs"]["stack"] == "moonmind"
 
 
 def test_deployment_update_uses_canonical_policy_stack_for_queued_run(
@@ -265,6 +270,34 @@ def test_repeated_update_submission_without_reason_reuses_idempotency_key(
     assert second.status_code == 202
     assert len(execution_service.requests) == 2
     assert execution_service.requests[0]["idempotency_key"] == (
+        execution_service.requests[1]["idempotency_key"]
+    )
+
+
+def test_mutable_tag_update_submission_without_reason_is_not_stale_idempotent(
+    admin_client: tuple[TestClient, _FakeExecutionService],
+) -> None:
+    client, execution_service = admin_client
+    payload = _valid_update_payload()
+    payload["image"] = {
+        "repository": "ghcr.io/moonladderstudios/moonmind",
+        "reference": "latest",
+    }
+    payload.pop("reason")
+
+    first = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+    second = client.post(
+        "/api/v1/operations/deployment/update",
+        json=payload,
+    )
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert len(execution_service.requests) == 2
+    assert execution_service.requests[0]["idempotency_key"] != (
         execution_service.requests[1]["idempotency_key"]
     )
 

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -66,15 +66,29 @@ class RecordingRunner:
             await self._release_event.wait()
         return {"stack": stack, "phase": phase, "services": ["api"]}
 
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.events.append("runner:pull")
         self.commands.append(("pull", command))
-        return {"stack": stack, "command": list(command), "exitCode": 0}
+        return {
+            "stack": stack,
+            "command": list(command),
+            "requestedImage": requested_image,
+            "exitCode": 0,
+        }
 
-    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def up(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.events.append("runner:up")
         self.commands.append(("up", command))
-        return {"stack": stack, "command": list(command), "exitCode": 0}
+        return {
+            "stack": stack,
+            "command": list(command),
+            "requestedImage": requested_image,
+            "exitCode": 0,
+        }
 
     async def verify(
         self,
@@ -155,14 +169,18 @@ def _executor(
 
 
 class FailingUpRunner(RecordingRunner):
-    async def up(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def up(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.events.append("runner:up")
         self.commands.append(("up", command))
         return {"stack": stack, "command": list(command), "exitCode": 17}
 
 
 class FailingPullRunner(RecordingRunner):
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.events.append("runner:pull")
         self.commands.append(("pull", command))
         return {"stack": stack, "command": list(command), "exitCode": 23}
@@ -183,7 +201,9 @@ class SecretRecordingRunner(RecordingRunner):
             },
         }
 
-    async def pull(self, *, stack: str, command: tuple[str, ...]) -> Mapping[str, Any]:
+    async def pull(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
         self.events.append("runner:pull")
         self.commands.append(("pull", command))
         return {

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -27,6 +27,7 @@ from moonmind.workflows.temporal.worker_runtime import (
     OpenTelemetryLoggingFilter,
     _OPENTELEMETRY_LOG_FORMAT,
     _build_agent_runtime_deps,
+    _build_deployment_update_executor,
     _enforce_codex_config_for_managed_fleet,
     _expand_task_template_for_child_run,
     _persist_child_run_task_input_snapshot,
@@ -398,6 +399,56 @@ def test_runtime_planner_preserves_authored_task_plan_node_metadata():
     assert node["description"] == "Use the deployment operations service."
 
 
+def test_runtime_planner_maps_deployment_update_step_to_typed_tool_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={},
+        parameters={
+            "task": {
+                "instructions": "Run deployment update.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "update-moonmind-deployment",
+                        "type": "tool",
+                        "instructions": "Update MoonMind deployment.",
+                        "tool": {
+                            "type": "skill",
+                            "name": "deployment.update_compose_stack",
+                            "version": "1.0.0",
+                            "inputs": {
+                                "stack": "moonmind",
+                                "image": {
+                                    "repository": (
+                                        "ghcr.io/moonladderstudios/moonmind"
+                                    ),
+                                    "reference": "latest",
+                                },
+                            },
+                        },
+                    }
+                ],
+            }
+        },
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["tool"] == {
+        "type": "skill",
+        "name": "deployment.update_compose_stack",
+        "version": "1.0.0",
+    }
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == (
+        "deployment.update_compose_stack"
+    )
+    assert plan["nodes"][0]["inputs"]["image"]["reference"] == "latest"
+
+
 def test_runtime_planner_rejects_duplicate_authored_task_plan_node_ids():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
@@ -434,6 +485,27 @@ def test_runtime_planner_rejects_duplicate_authored_task_plan_node_ids():
             },
             snapshot=snapshot,
         )
+
+
+def test_deployment_update_executor_is_enabled_only_with_project_mount(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("MOONMIND_DEPLOYMENT_PROJECT_DIR", raising=False)
+
+    assert _build_deployment_update_executor() is None
+
+    compose_file = tmp_path / "docker-compose.yaml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setenv("MOONMIND_DEPLOYMENT_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("MOONMIND_DEPLOYMENT_COMPOSE_FILE", str(compose_file))
+    monkeypatch.setenv("MOONMIND_DEPLOYMENT_PROJECT_NAME", "moonmind-test")
+
+    executor = _build_deployment_update_executor()
+
+    assert executor is not None
+    assert executor.runner.project_dir == str(tmp_path)
+    assert executor.runner.compose_file == str(compose_file)
+    assert executor.runner.project_name == "moonmind-test"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Queue deployment update submissions as typed tool steps while preserving the legacy plan projection.
- Prevent mutable references like `latest` from reusing stale idempotency keys.
- Register a host Docker Compose deployment runner for the agent-runtime worker and expose the compose project mount/config.

## Root Cause
The update request for task `mm:1cbaf386-8eb1-43b1-807b-8ab2f20d62ee` was stored as `task.plan`, so the runtime planner treated it as agent instructions instead of invoking `deployment.update_compose_stack` directly. Repeated `latest` updates also reused the same idempotency key, allowing an old run pinned to the previous digest to be reused instead of pulling the current image.

## Impact
Future `latest` deployment updates execute through the typed deployment tool path, pull the requested image, recreate the stack through Compose, and avoid stale idempotent reuse for mutable tags. The local stack was also updated and verified at build `20260508.2476`.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_deployment_operations.py tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'deployment_update or explicit_tool_step'`
- `./tools/test_unit.sh --python-only tests/integration/temporal/test_deployment_update_execution_contract.py`
- `docker exec moonmind-api-1 sh -lc 'cat /app/.moonmind-build-id'` -> `20260508.2476`
- `curl -fsS http://localhost:8000/healthz`