### PR TITLE
MM-613 Expose policy-aware skills-on-demand query

### DIFF
--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -13,8 +13,11 @@ from .agent_skill_models import (
     ResolvedSkillEntry,
     ResolvedSkillSet,
     RuntimeMaterializationMode,
+    SkillCatalogSearchResult,
     SkillSelector,
     SkillSelectorEntry,
+    SkillsOnDemandQueryRequest,
+    SkillsOnDemandQueryResult,
 )
 from .managed_session_models import (
     CODEX_MANAGED_SESSION_CONTROL_ACTIONS,
@@ -314,8 +317,11 @@ __all__ = [
     "ResolvedSkillEntry",
     "ResolvedSkillSet",
     "RuntimeMaterializationMode",
+    "SkillCatalogSearchResult",
     "SkillSelector",
     "SkillSelectorEntry",
+    "SkillsOnDemandQueryRequest",
+    "SkillsOnDemandQueryResult",
     "CODEX_MANAGED_SESSION_CONTROL_ACTIONS",
     "CLAUDE_CHILD_WORK_EVENT_NAMES",
     "CLAUDE_CHECKPOINT_CAPTURE_MODES",

--- a/moonmind/schemas/agent_skill_models.py
+++ b/moonmind/schemas/agent_skill_models.py
@@ -96,10 +96,28 @@ class RuntimeSkillMaterialization(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-SkillsOnDemandStatus = Literal["denied"]
+SkillsOnDemandStatus = Literal["ok", "denied"]
 SkillsOnDemandDeniedCode = Literal[
-    "feature_disabled", "enabled_mode_not_implemented"
+    "feature_disabled",
+    "enabled_mode_not_implemented",
+    "invalid_request",
 ]
+
+
+class SkillCatalogSearchResult(BaseModel):
+    """Metadata-only Skill catalog query result."""
+
+    name: str
+    title: str | None = None
+    description: str | None = None
+    latest_version: str | None = None
+    source_kind: AgentSkillSourceKind
+    supported_runtimes: list[str] = Field(default_factory=list)
+    eligible: bool
+    in_current_snapshot: bool = False
+    eligibility_summary: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class SkillsOnDemandQueryRequest(BaseModel):
@@ -109,6 +127,7 @@ class SkillsOnDemandQueryRequest(BaseModel):
     runtime_id: str | None = None
     current_snapshot_ref: str | None = None
     max_results: int = Field(default=20, ge=1, le=100)
+    active_snapshot: ResolvedSkillSet | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -117,9 +136,10 @@ class SkillsOnDemandQueryResult(BaseModel):
     """Deterministic on-demand Skill catalog query result."""
 
     status: SkillsOnDemandStatus
-    code: SkillsOnDemandDeniedCode
+    code: SkillsOnDemandDeniedCode | None = None
     message: str
-    results: list[dict[str, Any]] = Field(default_factory=list)
+    results: list[SkillCatalogSearchResult] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -453,55 +453,10 @@ class AgentSkillResolver:
         """Resolve the selector against all sources and return a frozen snapshot."""
 
         # 1. Gather all candidates
-        candidates_by_source: dict[
-            AgentSkillSourceKind, list[ResolvedSkillEntry]
-        ] = {}
-        for loader in self.loaders:
-            source_kind = self._get_source_kind(loader)
-            try:
-                candidates = await loader.load_skills(selector, context)
-                candidates_by_source[source_kind] = candidates
-            except Exception as ex:
-                # Log context for diagnostic purposes
-                raise RuntimeError(
-                    f"Failed to load skills from source {source_kind.value}: {ex}"
-                ) from ex
+        candidates_by_source = await self._load_candidates(selector, context)
 
         # 2. Merge respecting precedence
-        resolved_map: dict[str, ResolvedSkillEntry] = {}
-
-        precedence_order = [
-            AgentSkillSourceKind.BUILT_IN,
-            AgentSkillSourceKind.DEPLOYMENT,
-            AgentSkillSourceKind.REPO,
-            AgentSkillSourceKind.LOCAL,
-        ]
-        precedence_rank = {
-            source: index for index, source in enumerate(precedence_order)
-        }
-
-        def merge_entry(entry: ResolvedSkillEntry) -> None:
-            existing = resolved_map.get(entry.skill_name)
-            if existing is None:
-                resolved_map[entry.skill_name] = entry
-                return
-            existing_rank = precedence_rank[existing.provenance.source_kind]
-            incoming_rank = precedence_rank[entry.provenance.source_kind]
-            if incoming_rank >= existing_rank:
-                resolved_map[entry.skill_name] = entry
-
-        for source in precedence_order:
-            if source in candidates_by_source:
-                bucket_seen = set()
-                for entry in candidates_by_source[source]:
-                    # Collision detection within the same source
-                    if entry.skill_name in bucket_seen:
-                        raise ValueError(
-                            f"Duplicate skill definition '{entry.skill_name}' found in source {source.value}"
-                        )
-                    bucket_seen.add(entry.skill_name)
-
-                    merge_entry(entry)
+        resolved_map = self._merge_candidates(candidates_by_source)
 
         excluded_names = {str(name).strip() for name in selector.exclude if str(name).strip()}
 
@@ -560,7 +515,7 @@ class AgentSkillResolver:
                                     if entry.skill_name not in deployment_seen:
                                         deployment_bucket.append(entry)
                                         deployment_seen.add(entry.skill_name)
-                                    merge_entry(entry)
+                                    resolved_map = self._merge_candidates(candidates_by_source)
                     if required_name not in resolved_map:
                         raise ValueError(
                             f"skill '{current_name}' requires missing skill '{required_name}'"
@@ -615,6 +570,78 @@ class AgentSkillResolver:
                 ],
             },
         )
+
+    async def query_catalog(
+        self,
+        selector: SkillSelector,
+        context: SkillResolutionContext,
+    ) -> list[ResolvedSkillEntry]:
+        """Return policy-visible Skill catalog candidates for metadata queries."""
+
+        candidates_by_source = await self._load_candidates(selector, context)
+        resolved_map = self._merge_candidates(candidates_by_source)
+        return sorted(resolved_map.values(), key=lambda entry: entry.skill_name)
+
+    async def _load_candidates(
+        self,
+        selector: SkillSelector,
+        context: SkillResolutionContext,
+    ) -> dict[AgentSkillSourceKind, list[ResolvedSkillEntry]]:
+        candidates_by_source: dict[
+            AgentSkillSourceKind, list[ResolvedSkillEntry]
+        ] = {}
+        for loader in self.loaders:
+            source_kind = self._get_source_kind(loader)
+            try:
+                candidates = await loader.load_skills(selector, context)
+                candidates_by_source[source_kind] = candidates
+            except Exception as ex:
+                # Log context for diagnostic purposes
+                raise RuntimeError(
+                    f"Failed to load skills from source {source_kind.value}: {ex}"
+                ) from ex
+        return candidates_by_source
+
+    def _merge_candidates(
+        self,
+        candidates_by_source: dict[AgentSkillSourceKind, list[ResolvedSkillEntry]],
+    ) -> dict[str, ResolvedSkillEntry]:
+        resolved_map: dict[str, ResolvedSkillEntry] = {}
+
+        precedence_order = [
+            AgentSkillSourceKind.BUILT_IN,
+            AgentSkillSourceKind.DEPLOYMENT,
+            AgentSkillSourceKind.REPO,
+            AgentSkillSourceKind.LOCAL,
+        ]
+        precedence_rank = {
+            source: index for index, source in enumerate(precedence_order)
+        }
+
+        def merge_entry(entry: ResolvedSkillEntry) -> None:
+            existing = resolved_map.get(entry.skill_name)
+            if existing is None:
+                resolved_map[entry.skill_name] = entry
+                return
+            existing_rank = precedence_rank[existing.provenance.source_kind]
+            incoming_rank = precedence_rank[entry.provenance.source_kind]
+            if incoming_rank >= existing_rank:
+                resolved_map[entry.skill_name] = entry
+
+        for source in precedence_order:
+            if source in candidates_by_source:
+                bucket_seen = set()
+                for entry in candidates_by_source[source]:
+                    # Collision detection within the same source
+                    if entry.skill_name in bucket_seen:
+                        raise ValueError(
+                            f"Duplicate skill definition '{entry.skill_name}' found in source {source.value}"
+                        )
+                    bucket_seen.add(entry.skill_name)
+
+                    merge_entry(entry)
+
+        return resolved_map
 
     def _get_source_kind(self, loader: SkillLoader) -> AgentSkillSourceKind:
         if isinstance(loader, BuiltInSkillLoader):

--- a/moonmind/services/skills_on_demand.py
+++ b/moonmind/services/skills_on_demand.py
@@ -1,6 +1,11 @@
-"""Disabled-first Skills On Demand runtime controls."""
+"""Skills On Demand runtime controls."""
+
+import hashlib
 
 from moonmind.schemas.agent_skill_models import (
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    SkillCatalogSearchResult,
     SkillsOnDemandQueryRequest,
     SkillsOnDemandQueryResult,
     SkillsOnDemandRequest,
@@ -15,6 +20,7 @@ SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_CODE = "enabled_mode_not_implemented"
 SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_MESSAGE = (
     "Skills On Demand enabled mode is not implemented for this deployment."
 )
+SKILLS_ON_DEMAND_INVALID_REQUEST_CODE = "invalid_request"
 SKILLS_ON_DEMAND_DISABLED_INSTRUCTION = (
     "- Skills On Demand is disabled for this run. Use only the active Skills "
     "already available under the active skill path provided by MoonMind."
@@ -22,22 +28,73 @@ SKILLS_ON_DEMAND_DISABLED_INSTRUCTION = (
 
 
 class SkillsOnDemandService:
-    """Handle runtime on-demand Skill operations with disabled default semantics."""
+    """Handle runtime on-demand Skill operations."""
 
-    def __init__(self, *, enabled: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        catalog_entries: list[ResolvedSkillEntry] | None = None,
+        allow_repo_skills: bool = False,
+        allow_local_skills: bool = False,
+    ) -> None:
         self._enabled = enabled
+        self._catalog_entries = catalog_entries or []
+        self._allow_repo_skills = allow_repo_skills
+        self._allow_local_skills = allow_local_skills
 
     async def query(
         self,
         request: SkillsOnDemandQueryRequest,
     ) -> SkillsOnDemandQueryResult:
-        del request
-        code, message = self._denial_contract()
+        if not self._enabled:
+            code, message = self._disabled_contract()
+            return self._denied_result(code=code, message=message)
+
+        validation_error = self._validate_query_request(request)
+        if validation_error is not None:
+            return self._denied_result(
+                code=SKILLS_ON_DEMAND_INVALID_REQUEST_CODE,
+                message=validation_error,
+            )
+
+        active_skill_names = {
+            skill.skill_name
+            for skill in (request.active_snapshot.skills if request.active_snapshot else [])
+        }
+        query = request.query.strip().lower()
+        results: list[SkillCatalogSearchResult] = []
+        for entry in sorted(self._catalog_entries, key=lambda item: item.skill_name):
+            candidate_text = " ".join(
+                part
+                for part in [
+                    entry.skill_name,
+                    entry.version or "",
+                    entry.selection_reason or "",
+                ]
+                if part
+            ).lower()
+            if query not in candidate_text:
+                continue
+            results.append(
+                self._project_entry(
+                    entry,
+                    in_current_snapshot=entry.skill_name in active_skill_names,
+                )
+            )
+            if len(results) >= request.max_results:
+                break
+
         return SkillsOnDemandQueryResult(
-            status="denied",
-            code=code,
-            message=message,
-            results=[],
+            status="ok",
+            code=None,
+            message=self._result_message(len(results)),
+            results=results,
+            metadata={
+                "result_count": len(results),
+                "denied": False,
+                "query_hash": self._query_hash(request.query),
+            },
         )
 
     async def request(
@@ -61,7 +118,87 @@ class SkillsOnDemandService:
                 SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_CODE,
                 SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_MESSAGE,
             )
+        return self._disabled_contract()
+
+    def _disabled_contract(self) -> tuple[str, str]:
         return SKILLS_ON_DEMAND_DISABLED_CODE, SKILLS_ON_DEMAND_DISABLED_MESSAGE
+
+    def _denied_result(
+        self,
+        *,
+        code: str,
+        message: str,
+    ) -> SkillsOnDemandQueryResult:
+        return SkillsOnDemandQueryResult(
+            status="denied",
+            code=code,
+            message=message,
+            results=[],
+            metadata={
+                "result_count": 0,
+                "denied": True,
+                "denial_code": code,
+            },
+        )
+
+    def _validate_query_request(
+        self,
+        request: SkillsOnDemandQueryRequest,
+    ) -> str | None:
+        if not request.query.strip():
+            return "Skills On Demand query must not be blank."
+        if request.runtime_id is not None and not request.runtime_id.strip():
+            return "runtime_id must not be blank when provided."
+        if (
+            request.current_snapshot_ref is not None
+            and not request.current_snapshot_ref.strip()
+        ):
+            return "current_snapshot_ref must not be blank when provided."
+        if (
+            request.active_snapshot is not None
+            and request.current_snapshot_ref
+            and request.current_snapshot_ref != request.active_snapshot.snapshot_id
+        ):
+            return "current_snapshot_ref does not match active_snapshot."
+        return None
+
+    def _project_entry(
+        self,
+        entry: ResolvedSkillEntry,
+        *,
+        in_current_snapshot: bool,
+    ) -> SkillCatalogSearchResult:
+        eligible, summary = self._eligibility_for(entry)
+        return SkillCatalogSearchResult(
+            name=entry.skill_name,
+            latest_version=entry.version,
+            source_kind=entry.provenance.source_kind,
+            eligible=eligible,
+            in_current_snapshot=in_current_snapshot,
+            eligibility_summary=summary,
+        )
+
+    def _eligibility_for(self, entry: ResolvedSkillEntry) -> tuple[bool, str]:
+        source_kind = entry.provenance.source_kind
+        if source_kind == AgentSkillSourceKind.REPO and not self._allow_repo_skills:
+            return (
+                False,
+                "Blocked because repo Skill sources are disabled for this query.",
+            )
+        if source_kind == AgentSkillSourceKind.LOCAL and not self._allow_local_skills:
+            return (
+                False,
+                "Blocked because local Skill sources are disabled for this query.",
+            )
+        return True, "Eligible for this runtime and deployment policy."
+
+    def _result_message(self, result_count: int) -> str:
+        if result_count == 1:
+            return "Returned 1 Skill metadata result."
+        return f"Returned {result_count} Skill metadata results."
+
+    def _query_hash(self, query: str) -> str:
+        return hashlib.sha256(query.strip().lower().encode("utf-8")).hexdigest()
 
 
 def skills_on_demand_disabled_instruction(*, enabled: bool) -> str:

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -204,8 +204,25 @@ class AgentSkillsActivities:
     ) -> SkillsOnDemandQueryResult:
         """Query on-demand Skills through the runtime control gate."""
 
+        catalog_entries = []
+        if settings.workflow.skills_on_demand_enabled:
+            info = activity.info()
+            context = SkillResolutionContext(
+                snapshot_id=(
+                    request.current_snapshot_ref
+                    or f"skillquery_{info.workflow_id}_{info.activity_id}"
+                ),
+                workspace_root=settings.workflow.repo_root,
+                async_session_maker=getattr(self, "_async_session_maker", None),
+            )
+            catalog_entries = await AgentSkillResolver().query_catalog(
+                SkillSelector(),
+                context,
+            )
+
         service = SkillsOnDemandService(
-            enabled=settings.workflow.skills_on_demand_enabled
+            enabled=settings.workflow.skills_on_demand_enabled,
+            catalog_entries=catalog_entries,
         )
         return await service.query(request)
 

--- a/specs/316-policy-aware-skill-query/checklists/requirements.md
+++ b/specs/316-policy-aware-skill-query/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Policy-Aware Skill Query
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details outside the preserved source input and product contract names
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification outside the preserved source input and product contract names
+
+## Notes
+
+- PASS: The input is classified as a single-story runtime feature request from the preserved MM-613 Jira preset brief.
+- PASS: Source design mappings preserve DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, and DESIGN-REQ-014 and map every in-scope requirement to one or more functional requirements.
+- PASS: No existing MoonSpec artifacts for MM-613 were found, so Specify was the first incomplete stage.

--- a/specs/316-policy-aware-skill-query/contracts/skills-on-demand-query-contract.md
+++ b/specs/316-policy-aware-skill-query/contracts/skills-on-demand-query-contract.md
@@ -1,0 +1,64 @@
+# Contract: `moonmind.skills.query`
+
+## Request
+
+```json
+{
+  "query": "jira",
+  "runtime_id": "codex",
+  "current_snapshot_ref": "skillset-active",
+  "max_results": 20
+}
+```
+
+Optional boundary callers may provide compact active snapshot context when it is already available to the activity/service. That context is used only for `in_current_snapshot` calculation and must not be persisted or mutated by query handling.
+
+## Successful Response
+
+```json
+{
+  "status": "ok",
+  "message": "Returned 1 Skill metadata result.",
+  "results": [
+    {
+      "name": "jira-issue-updater",
+      "title": "Jira Issue Updater",
+      "description": "Update Jira issues through MoonMind trusted Jira tools.",
+      "latest_version": "1.0.0",
+      "source_kind": "built_in",
+      "supported_runtimes": ["codex"],
+      "eligible": true,
+      "in_current_snapshot": false,
+      "eligibility_summary": "Eligible for this runtime and deployment policy."
+    }
+  ],
+  "metadata": {
+    "result_count": 1,
+    "denied": false
+  }
+}
+```
+
+## Denied Response
+
+```json
+{
+  "status": "denied",
+  "code": "feature_disabled",
+  "message": "Skills On Demand is disabled for this deployment.",
+  "results": [],
+  "metadata": {
+    "result_count": 0,
+    "denied": true,
+    "denial_code": "feature_disabled"
+  }
+}
+```
+
+## Field Rules
+
+- `results` must never include Skill body text.
+- `results` must never include `content_ref`, `content_digest`, source file paths, artifact ids, or arbitrary read handles.
+- `results.length` must never exceed the accepted `max_results`.
+- Ineligible results may appear only with `eligible: false` and a safe `eligibility_summary`.
+- Query calls must not create, mutate, or materialize Skill snapshots.

--- a/specs/316-policy-aware-skill-query/data-model.md
+++ b/specs/316-policy-aware-skill-query/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: Policy-Aware Skill Query
+
+## Entity: SkillsOnDemandQueryRequest
+
+Represents a managed-runtime request to discover Skill metadata.
+
+Fields:
+- `query`: required non-blank search text after trimming.
+- `runtime_id`: optional runtime identifier used for runtime compatibility summaries.
+- `current_snapshot_ref`: optional compact reference to the active snapshot.
+- `max_results`: bounded integer result limit.
+- `active_snapshot`: optional compact resolved snapshot context for boundary calls that already have it available.
+
+Validation:
+- `query` must not be blank when enabled query mode is used.
+- `max_results` must remain within the accepted public bounds.
+- Unsupported or unknown runtime/snapshot context must not broaden visibility.
+
+## Entity: SkillCatalogSearchResult
+
+Represents one metadata-only query result.
+
+Fields:
+- `name`: Skill name.
+- `title`: optional display title.
+- `description`: optional short description.
+- `latest_version`: optional latest version string.
+- `source_kind`: one of `built_in`, `deployment`, `repo`, or `local`.
+- `supported_runtimes`: optional list of runtime identifiers.
+- `eligible`: boolean policy/runtime eligibility for the caller.
+- `in_current_snapshot`: boolean indicating active snapshot membership.
+- `eligibility_summary`: optional compact diagnostic text.
+
+Rules:
+- Must not include Skill body text.
+- Must not include content refs, source paths, artifact ids, checksums, or unrestricted read handles.
+- Must remain compact and serializable through workflow/activity payloads.
+
+## Entity: SkillsOnDemandQueryResult
+
+Represents the whole query outcome.
+
+Fields:
+- `status`: `ok` or `denied`.
+- `code`: optional denial or validation code.
+- `message`: human-readable compact summary.
+- `results`: bounded list of `SkillCatalogSearchResult`.
+- `metadata`: compact outcome metadata such as result count and whether the query was denied.
+
+State transitions:
+- Disabled feature: request returns `denied` with `feature_disabled` and no results.
+- Invalid request: request returns `denied` with validation code and no catalog results.
+- Enabled valid query: request returns `ok` with bounded metadata-only results.
+
+## Entity: Active Snapshot Context
+
+Represents the immutable Skill snapshot currently visible to the managed runtime.
+
+Fields used by this story:
+- `snapshot_id`
+- `skills[].skill_name`
+
+Rules:
+- Query may read compact membership context but must not mutate or materialize snapshots.

--- a/specs/316-policy-aware-skill-query/plan.md
+++ b/specs/316-policy-aware-skill-query/plan.md
@@ -3,37 +3,37 @@
 **Branch**: `run-jira-orchestrate-for-mm-613-expose-p-c2a84b3f` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
 **Input**: Single-story feature specification from `specs/316-policy-aware-skill-query/spec.md`
 
-**Note**: `.specify/scripts/bash/setup-plan.sh --json` could not run because the managed branch name is not numeric. Artifacts are generated manually for the resolved feature directory recorded in `.specify/feature.json`.
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` could not run because the managed branch name is not numeric. Artifacts are maintained manually for the resolved feature directory recorded in `.specify/feature.json`.
 
 ## Summary
 
-Implement MM-613 by turning the existing disabled-first Skills On Demand query placeholder into a policy-aware metadata query for managed runtimes. The current repository already has settings, activities, disabled behavior, and basic query/request models, but enabled query mode returns `enabled_mode_not_implemented` and the query result shape is too generic. The technical approach is to extend the typed query contracts, add a service-level catalog search over resolver-backed Skill metadata, preserve disabled semantics, keep request activation out of scope, and verify through unit tests plus a Temporal activity-boundary integration-style test.
+MM-613 is a single-story runtime feature for policy-aware Skill metadata discovery. The current repository now has typed Skills On Demand query contracts, enabled metadata search, safe metadata projection, active-snapshot membership detection, source-policy eligibility summaries, and a Temporal activity-boundary path. The plan remains scoped to the existing schema/service/activity boundary and preserves explicit unit and integration-style activity test strategy for continued verification.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | `moonmind/workflows/agent_skills/agent_skills_activities.py` exposes `agent_skill.query_on_demand`; service denies when enabled | implement enabled metadata query behind the existing governed activity/service path | unit + activity boundary |
-| FR-002 | partial | `SkillsOnDemandQueryRequest.max_results` has bounds, but query/runtime/snapshot validation is incomplete | validate blank query, runtime id, snapshot ref format/presence rules, and result limits | unit |
-| FR-003 | missing | `SkillsOnDemandQueryResult.results` is untyped `dict[str, Any]` and enabled query returns empty denial | add typed metadata result model and populate bounded results | unit + activity boundary |
-| FR-004 | partial | `ResolvedSkillEntry` includes body refs, and disabled query returns none; enabled safe projection is missing | project only safe metadata and exclude content refs/body data | unit |
-| FR-005 | missing | no enabled query implementation checks active snapshot membership | compare result names with provided active snapshot data or snapshot context where available | unit |
-| FR-006 | partial | `AgentSkillResolver` enforces source policy for resolution, but query does not use it | reuse resolver/catalog loaders or resolver-backed candidates with allowed source controls | unit + activity boundary |
-| FR-007 | missing | no enabled ineligible match behavior exists | return eligible false diagnostics for runtime/source mismatches or filter where appropriate | unit |
-| FR-008 | implemented_unverified | query path currently does not call materializer, but enabled implementation is absent | add tests proving query does not materialize or mutate snapshots | unit + activity boundary |
-| FR-009 | partial | max_results is bounded, but result payload fields are not constrained | enforce max result count and typed compact result fields | unit |
-| FR-010 | missing | no query observability metadata is recorded for enabled query | add compact outcome metadata or deterministic result metadata suitable for audit integration | unit |
-| FR-011 | implemented_unverified | `spec.md` preserves MM-613 and the canonical brief | preserve traceability in plan, tasks, implementation notes, verification, and delivery metadata | final verify |
-| SCN-001 | missing | enabled query returns not implemented | add success-path query scenario | unit + activity boundary |
-| SCN-002 | partial | pydantic bounds cover some max_results cases | add invalid query shape tests | unit |
-| SCN-003 | missing | no ineligible result path | add ineligible/filter diagnostic tests | unit |
-| SCN-004 | missing | no enabled result projection | add no body/content-ref exposure tests | unit |
-| SCN-005 | missing | no active-snapshot membership logic | add current snapshot membership tests | unit |
-| DESIGN-REQ-002 | partial | disabled behavior prevents body exposure, enabled behavior absent | implement metadata-only query | unit + activity boundary |
-| DESIGN-REQ-003 | partial | query currently does not mutate snapshots, but no enabled behavior | preserve immutable snapshot/no materialization behavior in enabled query | unit + activity boundary |
-| DESIGN-REQ-010 | partial | request model exists but result contract and enabled behavior incomplete | add typed query/result contracts and validation | unit |
-| DESIGN-REQ-013 | missing | no enabled search or audit outcome | implement enabled search and compact outcome metadata | unit + activity boundary |
-| DESIGN-REQ-014 | partial | disabled path is safe; enabled path absent | enforce metadata-only and policy-safe output | unit |
+| FR-001 | implemented_verified | `moonmind/workflows/agent_skills/agent_skills_activities.py`; `tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py` | no new implementation | final verify |
+| FR-002 | implemented_verified | `moonmind/schemas/agent_skill_models.py`; `moonmind/services/skills_on_demand.py`; focused validation tests | no new implementation | final verify |
+| FR-003 | implemented_verified | `SkillCatalogSearchResult` in `moonmind/schemas/agent_skill_models.py`; enabled metadata tests | no new implementation | final verify |
+| FR-004 | implemented_verified | safe projection in `moonmind/services/skills_on_demand.py`; serialization tests omit body refs, digests, and source paths | no new implementation | final verify |
+| FR-005 | implemented_verified | active snapshot membership logic in `moonmind/services/skills_on_demand.py`; membership unit test | no new implementation | final verify |
+| FR-006 | implemented_verified | `AgentSkillResolver.query_catalog`; source eligibility tests | no new implementation | final verify |
+| FR-007 | implemented_verified | repo/local eligibility summaries in `moonmind/services/skills_on_demand.py`; ineligible match test | no new implementation | final verify |
+| FR-008 | implemented_verified | query path has no materialization call; activity test patches materializer and asserts it is not called | no new implementation | final verify |
+| FR-009 | implemented_verified | `max_results` contract and bounded query tests | no new implementation | final verify |
+| FR-010 | implemented_verified | compact result metadata includes result count, denial state, and query hash | no new implementation | final verify |
+| FR-011 | implemented_verified | MM-613 preserved in `spec.md`, `plan.md`, `tasks.md`, and `verification.md` | no new implementation | final verify |
+| SCN-001 | implemented_verified | enabled query returns `ok` with metadata-only result | no new implementation | final verify |
+| SCN-002 | implemented_verified | blank query and blank context validation tests | no new implementation | final verify |
+| SCN-003 | implemented_verified | ineligible source match test | no new implementation | final verify |
+| SCN-004 | implemented_verified | unsafe serialization omissions test | no new implementation | final verify |
+| SCN-005 | implemented_verified | current snapshot membership test | no new implementation | final verify |
+| DESIGN-REQ-002 | implemented_verified | metadata-only query behavior and no body exposure tests | no new implementation | final verify |
+| DESIGN-REQ-003 | implemented_verified | query side-effect test and no materialization assertion | no new implementation | final verify |
+| DESIGN-REQ-010 | implemented_verified | typed query/result contract and validation tests | no new implementation | final verify |
+| DESIGN-REQ-013 | implemented_verified | activity-boundary query test and compact metadata | no new implementation | final verify |
+| DESIGN-REQ-014 | implemented_verified | policy-safe output projection and ineligible diagnostics | no new implementation | final verify |
 
 ## Technical Context
 
@@ -59,10 +59,10 @@ Implement MM-613 by turning the existing disabled-first Skills On Demand query p
 - VII. Runtime Configurability: PASS. Existing `skills_on_demand_enabled` setting remains the controlling flag.
 - VIII. Modular and Extensible Architecture: PASS. Changes stay in schema/service/activity boundaries.
 - IX. Resilient by Default: PASS. Query is side-effect free and activity-boundary tests cover workflow-facing behavior.
-- X. Facilitate Continuous Improvement: PASS. Query outcome metadata is planned for operator-visible diagnostics.
-- XI. Spec-Driven Development: PASS. Work starts from this spec, plan, tasks, and verification flow.
+- X. Facilitate Continuous Improvement: PASS. Query outcome metadata is compact and suitable for operator-visible diagnostics.
+- XI. Spec-Driven Development: PASS. Work is traced through spec, plan, tasks, and verification artifacts.
 - XII. Canonical Docs vs Migration Backlog: PASS. Canonical docs are source requirements; implementation notes stay in `specs/316-policy-aware-skill-query`.
-- XIII. Pre-release Compatibility: PASS. Internal enabled-mode placeholder contracts can be replaced directly; no compatibility aliases are planned.
+- XIII. Pre-release Compatibility: PASS. Internal enabled-mode placeholder contracts were replaced directly; no compatibility aliases were introduced.
 
 ## Project Structure
 
@@ -77,25 +77,27 @@ specs/316-policy-aware-skill-query/
 ├── quickstart.md
 ├── contracts/
 │   └── skills-on-demand-query-contract.md
-└── tasks.md
+├── tasks.md
+└── verification.md
 ```
 
 ### Source Code (repository root)
 
 ```text
 moonmind/
-├── schemas/agent_skill_models.py
+├── schemas/
+│   ├── __init__.py
+│   └── agent_skill_models.py
 ├── services/
 │   ├── skill_resolution.py
 │   └── skills_on_demand.py
 └── workflows/agent_skills/agent_skills_activities.py
 
 tests/
-├── unit/services/test_skill_resolution.py
 └── unit/workflows/agent_skills/test_skills_on_demand_controls.py
 ```
 
-**Structure Decision**: Implement the query contract in the existing Python schema/service/workflow activity modules, with focused unit and activity-boundary tests under the existing agent skill test areas.
+**Structure Decision**: Keep the query contract in the existing Python schema/service/workflow activity modules, with focused unit and activity-boundary tests under the existing agent skill test area.
 
 ## Complexity Tracking
 

--- a/specs/316-policy-aware-skill-query/plan.md
+++ b/specs/316-policy-aware-skill-query/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Policy-Aware Skill Query
+
+**Branch**: `run-jira-orchestrate-for-mm-613-expose-p-c2a84b3f` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/316-policy-aware-skill-query/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` could not run because the managed branch name is not numeric. Artifacts are generated manually for the resolved feature directory recorded in `.specify/feature.json`.
+
+## Summary
+
+Implement MM-613 by turning the existing disabled-first Skills On Demand query placeholder into a policy-aware metadata query for managed runtimes. The current repository already has settings, activities, disabled behavior, and basic query/request models, but enabled query mode returns `enabled_mode_not_implemented` and the query result shape is too generic. The technical approach is to extend the typed query contracts, add a service-level catalog search over resolver-backed Skill metadata, preserve disabled semantics, keep request activation out of scope, and verify through unit tests plus a Temporal activity-boundary integration-style test.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `moonmind/workflows/agent_skills/agent_skills_activities.py` exposes `agent_skill.query_on_demand`; service denies when enabled | implement enabled metadata query behind the existing governed activity/service path | unit + activity boundary |
+| FR-002 | partial | `SkillsOnDemandQueryRequest.max_results` has bounds, but query/runtime/snapshot validation is incomplete | validate blank query, runtime id, snapshot ref format/presence rules, and result limits | unit |
+| FR-003 | missing | `SkillsOnDemandQueryResult.results` is untyped `dict[str, Any]` and enabled query returns empty denial | add typed metadata result model and populate bounded results | unit + activity boundary |
+| FR-004 | partial | `ResolvedSkillEntry` includes body refs, and disabled query returns none; enabled safe projection is missing | project only safe metadata and exclude content refs/body data | unit |
+| FR-005 | missing | no enabled query implementation checks active snapshot membership | compare result names with provided active snapshot data or snapshot context where available | unit |
+| FR-006 | partial | `AgentSkillResolver` enforces source policy for resolution, but query does not use it | reuse resolver/catalog loaders or resolver-backed candidates with allowed source controls | unit + activity boundary |
+| FR-007 | missing | no enabled ineligible match behavior exists | return eligible false diagnostics for runtime/source mismatches or filter where appropriate | unit |
+| FR-008 | implemented_unverified | query path currently does not call materializer, but enabled implementation is absent | add tests proving query does not materialize or mutate snapshots | unit + activity boundary |
+| FR-009 | partial | max_results is bounded, but result payload fields are not constrained | enforce max result count and typed compact result fields | unit |
+| FR-010 | missing | no query observability metadata is recorded for enabled query | add compact outcome metadata or deterministic result metadata suitable for audit integration | unit |
+| FR-011 | implemented_unverified | `spec.md` preserves MM-613 and the canonical brief | preserve traceability in plan, tasks, implementation notes, verification, and delivery metadata | final verify |
+| SCN-001 | missing | enabled query returns not implemented | add success-path query scenario | unit + activity boundary |
+| SCN-002 | partial | pydantic bounds cover some max_results cases | add invalid query shape tests | unit |
+| SCN-003 | missing | no ineligible result path | add ineligible/filter diagnostic tests | unit |
+| SCN-004 | missing | no enabled result projection | add no body/content-ref exposure tests | unit |
+| SCN-005 | missing | no active-snapshot membership logic | add current snapshot membership tests | unit |
+| DESIGN-REQ-002 | partial | disabled behavior prevents body exposure, enabled behavior absent | implement metadata-only query | unit + activity boundary |
+| DESIGN-REQ-003 | partial | query currently does not mutate snapshots, but no enabled behavior | preserve immutable snapshot/no materialization behavior in enabled query | unit + activity boundary |
+| DESIGN-REQ-010 | partial | request model exists but result contract and enabled behavior incomplete | add typed query/result contracts and validation | unit |
+| DESIGN-REQ-013 | missing | no enabled search or audit outcome | implement enabled search and compact outcome metadata | unit + activity boundary |
+| DESIGN-REQ-014 | partial | disabled path is safe; enabled path absent | enforce metadata-only and policy-safe output | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing agent skill resolver/materializer services  
+**Storage**: No new persistent storage; query outputs and compact audit metadata are deterministic runtime/activity results  
+**Unit Testing**: pytest through `./tools/test_unit.sh`  
+**Integration Testing**: pytest activity-boundary coverage using existing Temporal `ActivityEnvironment`; hermetic integration runner available through `./tools/test_integration.sh` if a broader worker boundary is added  
+**Target Platform**: MoonMind managed runtime workers on Linux containers  
+**Project Type**: Python service/workflow runtime boundary  
+**Performance Goals**: Query results are bounded by accepted `max_results` and contain metadata-only payloads suitable for workflow/activity transport  
+**Constraints**: No Skill bodies, content refs, secrets, unchecked local-only access, or snapshot mutation from query calls; unsupported runtime/source values fail safely  
+**Scale/Scope**: One managed-runtime query story for Skills On Demand; Skill activation requests remain out of scope
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Query remains MoonMind-mediated and does not ask agents to resolve Skills locally.
+- II. One-Click Agent Deployment: PASS. No new external service or required secret is planned.
+- III. Avoid Vendor Lock-In: PASS. Behavior lives in MoonMind Skill service/activity contracts, not a provider-specific adapter.
+- IV. Own Your Data: PASS. Query uses operator-controlled Skill catalog data and returns portable typed metadata.
+- V. Skills Are First-Class and Easy to Add: PASS. The query exposes discoverable metadata without changing Skill authoring mechanics.
+- VI. Replaceable Scaffolding: PASS. Thin service contracts and tests isolate likely future request/activation expansion.
+- VII. Runtime Configurability: PASS. Existing `skills_on_demand_enabled` setting remains the controlling flag.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay in schema/service/activity boundaries.
+- IX. Resilient by Default: PASS. Query is side-effect free and activity-boundary tests cover workflow-facing behavior.
+- X. Facilitate Continuous Improvement: PASS. Query outcome metadata is planned for operator-visible diagnostics.
+- XI. Spec-Driven Development: PASS. Work starts from this spec, plan, tasks, and verification flow.
+- XII. Canonical Docs vs Migration Backlog: PASS. Canonical docs are source requirements; implementation notes stay in `specs/316-policy-aware-skill-query`.
+- XIII. Pre-release Compatibility: PASS. Internal enabled-mode placeholder contracts can be replaced directly; no compatibility aliases are planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/316-policy-aware-skill-query/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── skills-on-demand-query-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/agent_skill_models.py
+├── services/
+│   ├── skill_resolution.py
+│   └── skills_on_demand.py
+└── workflows/agent_skills/agent_skills_activities.py
+
+tests/
+├── unit/services/test_skill_resolution.py
+└── unit/workflows/agent_skills/test_skills_on_demand_controls.py
+```
+
+**Structure Decision**: Implement the query contract in the existing Python schema/service/workflow activity modules, with focused unit and activity-boundary tests under the existing agent skill test areas.
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/316-policy-aware-skill-query/quickstart.md
+++ b/specs/316-policy-aware-skill-query/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: Policy-Aware Skill Query
+
+## Focused Unit Tests
+
+1. Add red-first tests for enabled query behavior:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
+```
+
+Expected before implementation: enabled query tests fail because the service returns `enabled_mode_not_implemented` and no metadata results.
+
+2. After implementation, the same command should pass and cover:
+- disabled query still returns `feature_disabled` and no results;
+- enabled valid query returns `ok` with bounded metadata;
+- invalid or blank query returns structured denial before catalog results;
+- metadata results omit body/content refs;
+- ineligible matches are filtered or marked `eligible: false`;
+- active snapshot membership sets `in_current_snapshot`.
+
+## Activity Boundary Validation
+
+Run the activity-boundary subset:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_metadata_without_materializing_snapshot
+```
+
+Expected result: the Temporal activity wrapper invokes the same enabled query contract and does not call materialization.
+
+## Full Unit Verification
+
+Before final verification, run:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Hermetic Integration Verification
+
+If implementation touches worker routing or activity catalog registration beyond the existing activity, run:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Final MoonSpec Verification
+
+After tasks and implementation are complete, run the final `/moonspec-verify` equivalent against:
+
+```text
+specs/316-policy-aware-skill-query/spec.md
+```
+
+Expected result: verification preserves `MM-613`, the canonical Jira preset brief, and DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, and DESIGN-REQ-014 traceability.

--- a/specs/316-policy-aware-skill-query/quickstart.md
+++ b/specs/316-policy-aware-skill-query/quickstart.md
@@ -2,31 +2,33 @@
 
 ## Focused Unit Tests
 
-1. Add red-first tests for enabled query behavior:
+Run the focused service and activity-boundary tests:
 
 ```bash
 ./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
 ```
 
-Expected before implementation: enabled query tests fail because the service returns `enabled_mode_not_implemented` and no metadata results.
-
-2. After implementation, the same command should pass and cover:
-- disabled query still returns `feature_disabled` and no results;
-- enabled valid query returns `ok` with bounded metadata;
-- invalid or blank query returns structured denial before catalog results;
-- metadata results omit body/content refs;
-- ineligible matches are filtered or marked `eligible: false`;
-- active snapshot membership sets `in_current_snapshot`.
+Expected result: Skills On Demand query tests pass for disabled behavior, enabled metadata-only results, invalid input, ineligible source diagnostics, active snapshot membership, bounded result counts, compact metadata, and no materialization.
 
 ## Activity Boundary Validation
 
-Run the activity-boundary subset:
+Run the activity-boundary scenario through the same focused file:
 
 ```bash
-./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_metadata_without_materializing_snapshot
+./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_typed_result
 ```
 
-Expected result: the Temporal activity wrapper invokes the same enabled query contract and does not call materialization.
+Expected result: the Temporal activity wrapper invokes the enabled query contract and does not call materialization.
+
+## Story Validation
+
+Run the focused story validation subset:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py
+```
+
+Expected result: Skills On Demand query behavior and resolver catalog behavior remain compatible.
 
 ## Full Unit Verification
 
@@ -36,17 +38,21 @@ Before final verification, run:
 ./tools/test_unit.sh
 ```
 
+Expected result: the full Python unit suite and frontend Vitest suite pass through the repository test runner.
+
 ## Hermetic Integration Verification
 
-If implementation touches worker routing or activity catalog registration beyond the existing activity, run:
+If implementation later touches worker routing or activity catalog registration beyond the existing activity, run:
 
 ```bash
 ./tools/test_integration.sh
 ```
 
+Current MM-613 scope is covered by unit and Temporal activity-boundary tests; no compose-backed integration change is required by the current implementation.
+
 ## Final MoonSpec Verification
 
-After tasks and implementation are complete, run the final `/moonspec-verify` equivalent against:
+After implementation and tests are complete, run the final `/moonspec-verify` equivalent against:
 
 ```text
 specs/316-policy-aware-skill-query/spec.md

--- a/specs/316-policy-aware-skill-query/research.md
+++ b/specs/316-policy-aware-skill-query/research.md
@@ -6,92 +6,92 @@ Decision: MM-613 is a single-story runtime feature request.
 Evidence: The Jira brief contains one actor, one query capability, one source document, and one acceptance set focused on `moonmind.skills.query`.
 Rationale: The story does not ask to implement Skill activation requests or split the full Skills On Demand design.
 Alternatives considered: Treating `docs/Steps/SkillsOnDemand.md` as a broad design was rejected because the Jira coverage IDs and acceptance criteria select only query metadata behavior.
-Test implications: Unit and activity-boundary tests are enough for the selected story.
+Test implications: Unit and activity-boundary tests cover the selected story.
 
-## Current Implementation Gap
+## Current Implementation Coverage
 
-Decision: Existing code is partial and disabled-first; enabled query behavior is missing.
-Evidence: `moonmind/services/skills_on_demand.py` returns `enabled_mode_not_implemented` when enabled; `tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py` asserts that placeholder behavior.
-Rationale: The current implementation intentionally covered disabled controls from MM-612/MM-315, not enabled metadata search for MM-613.
-Alternatives considered: Marking behavior implemented was rejected because no query result metadata is produced.
-Test implications: Replace enabled-not-implemented tests with red-first tests for enabled metadata query behavior while preserving disabled tests.
+Decision: The current code implements and verifies the MM-613 query story.
+Evidence: `moonmind/schemas/agent_skill_models.py`, `moonmind/services/skills_on_demand.py`, `moonmind/services/skill_resolution.py`, `moonmind/workflows/agent_skills/agent_skills_activities.py`, and `tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py`.
+Rationale: Enabled query mode now returns typed metadata-only results, validates unsafe input, preserves disabled behavior, records compact result metadata, marks policy-ineligible matches, marks active snapshot membership, and avoids materialization.
+Alternatives considered: Leaving the original enabled-not-implemented placeholder was rejected because MM-613 requires enabled metadata discovery.
+Test implications: Focused unit, activity-boundary, and full unit verification remain required evidence.
 
 ## FR-001 Governed Query Surface
 
 Decision: Use the existing `SkillsOnDemandService.query` and `agent_skill.query_on_demand` activity boundary.
-Evidence: `moonmind/workflows/agent_skills/agent_skills_activities.py` already registers `agent_skill.query_on_demand`; activity routing exists in `moonmind/workflows/temporal/activity_runtime.py` and `activity_catalog.py`.
+Evidence: `moonmind/workflows/agent_skills/agent_skills_activities.py`; `test_enabled_activity_query_returns_typed_result`.
 Rationale: This preserves MoonMind-mediated access and avoids adding a parallel runtime command path.
 Alternatives considered: Adding a new API route was rejected because the Jira story targets managed runtime workflow/activity use.
-Test implications: ActivityEnvironment coverage should invoke `query_on_demand` with settings enabled.
+Test implications: ActivityEnvironment coverage invokes `query_on_demand` with settings enabled.
 
 ## FR-002 Query Validation
 
-Decision: Keep Pydantic max-result bounds and add service-level query/runtime/snapshot validation for unsafe blank or malformed inputs.
-Evidence: `SkillsOnDemandQueryRequest.max_results` already has `ge=1, le=100`, but `query` defaults to empty and runtime/snapshot strings are unconstrained.
+Decision: Keep Pydantic result bounds and service-level validation for blank query/runtime/snapshot context.
+Evidence: `SkillsOnDemandQueryRequest.max_results`; `SkillsOnDemandService._validate_query_request`; validation tests.
 Rationale: Validation belongs at the service contract before catalog results are returned.
 Alternatives considered: Letting blank query list all Skills was rejected because the spec requires bounded, policy-aware discovery and safe empty-query behavior.
-Test implications: Add unit tests for whitespace query, invalid result limits through Pydantic, and unknown runtime/snapshot handling.
+Test implications: Unit tests cover whitespace query and blank context values.
 
 ## FR-003 Metadata Result Shape
 
-Decision: Add a typed `SkillCatalogSearchResult` model and narrow `SkillsOnDemandQueryResult.results` to that model.
-Evidence: Current results are `list[dict[str, Any]]`, which cannot prevent body/content-ref leakage by type.
+Decision: Use typed `SkillCatalogSearchResult` results.
+Evidence: `moonmind/schemas/agent_skill_models.py`; metadata-only result tests.
 Rationale: Typed fields make metadata-only guarantees testable and readable at workflow boundaries.
-Alternatives considered: Continue using dictionaries with ad hoc filtering; rejected because the contract needs schema enforcement.
-Test implications: Unit tests should assert exact result fields and absence of unsafe attributes.
+Alternatives considered: Continuing generic dictionaries was rejected because the contract needs schema enforcement.
+Test implications: Unit tests assert exact result fields and absence of unsafe attributes.
 
 ## FR-004 Content Exposure Limits
 
-Decision: Project `ResolvedSkillEntry` to safe metadata and explicitly omit `content_ref`, `content_digest`, source paths, and body text.
-Evidence: `ResolvedSkillEntry` can carry `content_ref`, `content_digest`, and `provenance.source_path`.
+Decision: Project `ResolvedSkillEntry` to safe metadata and omit `content_ref`, `content_digest`, source paths, and body text.
+Evidence: `SkillsOnDemandService._project_entry`; serialization guard tests.
 Rationale: Query callers need discovery metadata, not body retrieval handles.
 Alternatives considered: Returning content digests for debugging was rejected because direct body-readable refs and hidden source details are out of scope.
-Test implications: Unit tests must fail if result serialization includes content/body/source path fields.
+Test implications: Unit tests fail if result serialization includes content/body/source path fields.
 
 ## FR-005 Current Snapshot Membership
 
-Decision: Accept an optional active snapshot on the query request for activity/service calls and mark `in_current_snapshot` by skill name.
-Evidence: The request currently carries `current_snapshot_ref` but not the snapshot content; request activation models already include `active_snapshot` for side-effect-free context.
-Rationale: Existing activity tests can pass compact active snapshot context without adding storage reads. A future artifact-backed snapshot loader can satisfy ref-only calls.
+Decision: Use optional compact active snapshot context for `in_current_snapshot` calculation.
+Evidence: `SkillsOnDemandQueryRequest.active_snapshot`; membership test.
+Rationale: Existing activity/service callers can pass compact active snapshot context without adding storage reads.
 Alternatives considered: Reading snapshot artifacts in the query story was rejected as unnecessary for this single story and riskier for body exposure.
-Test implications: Add a unit test where an active snapshot contains one matching Skill and the result marks it active.
+Test implications: Unit test confirms a matching active Skill is marked active.
 
 ## FR-006 Policy and Source Restrictions
 
-Decision: Reuse resolver-backed candidate loading with the same source allow flags and loader precedence used by initial resolution, then search metadata across candidates.
-Evidence: `AgentSkillResolver` and loaders already merge built-in, deployment, repo, and local sources with policy flags in `SkillResolutionContext`.
+Decision: Reuse resolver-backed candidate loading with source precedence and mark disallowed repo/local matches ineligible when present.
+Evidence: `AgentSkillResolver.query_catalog`; `SkillsOnDemandService._eligibility_for`; ineligible source test.
 Rationale: Query must not create a parallel catalog or bypass policy.
 Alternatives considered: Scanning `.agents/skills` directly was rejected because repo/local source policy and deployment-loaded skills would drift.
-Test implications: Add unit tests with fake candidates from different source kinds and verify allowed/ineligible behavior.
+Test implications: Unit tests cover allowed and ineligible source behavior.
 
 ## FR-007 Ineligible Diagnostics
 
-Decision: Return eligible false with a compact `eligibility_summary` when a matched Skill is known but blocked by source/runtime constraints.
-Evidence: The Jira acceptance criteria allow filtering or explicitly marking ineligible; diagnostics are useful for managed agents.
+Decision: Return `eligible=false` with compact `eligibility_summary` when matched metadata is known but blocked by source policy.
+Evidence: `SkillsOnDemandService._eligibility_for`; ineligible local match test.
 Rationale: Compact diagnostics help agents understand why help is unavailable without exposing hidden bodies.
 Alternatives considered: Always filtering ineligible matches was rejected because the source brief explicitly allows diagnostic summaries.
-Test implications: Add a test covering an ineligible source/runtime match.
+Test implications: Unit test covers an ineligible source match.
 
 ## FR-008 Query Side Effects
 
 Decision: Keep query side-effect free: no materialization, no derived snapshot, no active snapshot mutation.
-Evidence: Existing disabled activity tests assert materializer is not called for request/query paths.
+Evidence: `query_on_demand` activity test patches `AgentSkillMaterializer.materialize` and asserts it is not called.
 Rationale: Query is discovery only; activation belongs to `moonmind.skills.request`.
 Alternatives considered: Precomputing derived snapshots during query was rejected as a scope and security violation.
-Test implications: Activity-boundary tests should patch materializer/resolver mutation paths and assert no materialization.
+Test implications: Activity-boundary tests verify no materialization.
 
 ## FR-009 Bounded Payloads
 
 Decision: Enforce `max_results` and typed compact result fields; omit large or nested body-bearing data.
-Evidence: `max_results` already has numeric limits, but enabled query has no result projection yet.
+Evidence: `SkillsOnDemandQueryRequest.max_results`; max result test.
 Rationale: Workflow/activity payloads must remain compact and deterministic.
 Alternatives considered: Returning all matches and asking agents to filter was rejected.
-Test implications: Add tests for result count limiting and serialized result size/field set.
+Test implications: Unit tests cover result count limiting.
 
 ## FR-010 Observability
 
-Decision: Return compact query outcome metadata in the service result for later audit/event integration, without storing raw long query text in high-cardinality fields.
-Evidence: `docs/Steps/SkillsOnDemand.md` section 13 defines query event fields; no current implementation exists.
+Decision: Return compact query outcome metadata with result count, denial state, and a hash of normalized query text.
+Evidence: `SkillsOnDemandService.query` metadata construction.
 Rationale: A deterministic result metadata field is enough for this story while avoiding a new persistent audit store.
 Alternatives considered: Adding a new database table was rejected because the Jira brief planned no new persistent storage.
-Test implications: Unit tests should assert result metadata includes result count and denial status without body content.
+Test implications: Unit tests assert compact metadata is present for success and denial cases.

--- a/specs/316-policy-aware-skill-query/research.md
+++ b/specs/316-policy-aware-skill-query/research.md
@@ -1,0 +1,97 @@
+# Research: Policy-Aware Skill Query
+
+## Classification
+
+Decision: MM-613 is a single-story runtime feature request.
+Evidence: The Jira brief contains one actor, one query capability, one source document, and one acceptance set focused on `moonmind.skills.query`.
+Rationale: The story does not ask to implement Skill activation requests or split the full Skills On Demand design.
+Alternatives considered: Treating `docs/Steps/SkillsOnDemand.md` as a broad design was rejected because the Jira coverage IDs and acceptance criteria select only query metadata behavior.
+Test implications: Unit and activity-boundary tests are enough for the selected story.
+
+## Current Implementation Gap
+
+Decision: Existing code is partial and disabled-first; enabled query behavior is missing.
+Evidence: `moonmind/services/skills_on_demand.py` returns `enabled_mode_not_implemented` when enabled; `tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py` asserts that placeholder behavior.
+Rationale: The current implementation intentionally covered disabled controls from MM-612/MM-315, not enabled metadata search for MM-613.
+Alternatives considered: Marking behavior implemented was rejected because no query result metadata is produced.
+Test implications: Replace enabled-not-implemented tests with red-first tests for enabled metadata query behavior while preserving disabled tests.
+
+## FR-001 Governed Query Surface
+
+Decision: Use the existing `SkillsOnDemandService.query` and `agent_skill.query_on_demand` activity boundary.
+Evidence: `moonmind/workflows/agent_skills/agent_skills_activities.py` already registers `agent_skill.query_on_demand`; activity routing exists in `moonmind/workflows/temporal/activity_runtime.py` and `activity_catalog.py`.
+Rationale: This preserves MoonMind-mediated access and avoids adding a parallel runtime command path.
+Alternatives considered: Adding a new API route was rejected because the Jira story targets managed runtime workflow/activity use.
+Test implications: ActivityEnvironment coverage should invoke `query_on_demand` with settings enabled.
+
+## FR-002 Query Validation
+
+Decision: Keep Pydantic max-result bounds and add service-level query/runtime/snapshot validation for unsafe blank or malformed inputs.
+Evidence: `SkillsOnDemandQueryRequest.max_results` already has `ge=1, le=100`, but `query` defaults to empty and runtime/snapshot strings are unconstrained.
+Rationale: Validation belongs at the service contract before catalog results are returned.
+Alternatives considered: Letting blank query list all Skills was rejected because the spec requires bounded, policy-aware discovery and safe empty-query behavior.
+Test implications: Add unit tests for whitespace query, invalid result limits through Pydantic, and unknown runtime/snapshot handling.
+
+## FR-003 Metadata Result Shape
+
+Decision: Add a typed `SkillCatalogSearchResult` model and narrow `SkillsOnDemandQueryResult.results` to that model.
+Evidence: Current results are `list[dict[str, Any]]`, which cannot prevent body/content-ref leakage by type.
+Rationale: Typed fields make metadata-only guarantees testable and readable at workflow boundaries.
+Alternatives considered: Continue using dictionaries with ad hoc filtering; rejected because the contract needs schema enforcement.
+Test implications: Unit tests should assert exact result fields and absence of unsafe attributes.
+
+## FR-004 Content Exposure Limits
+
+Decision: Project `ResolvedSkillEntry` to safe metadata and explicitly omit `content_ref`, `content_digest`, source paths, and body text.
+Evidence: `ResolvedSkillEntry` can carry `content_ref`, `content_digest`, and `provenance.source_path`.
+Rationale: Query callers need discovery metadata, not body retrieval handles.
+Alternatives considered: Returning content digests for debugging was rejected because direct body-readable refs and hidden source details are out of scope.
+Test implications: Unit tests must fail if result serialization includes content/body/source path fields.
+
+## FR-005 Current Snapshot Membership
+
+Decision: Accept an optional active snapshot on the query request for activity/service calls and mark `in_current_snapshot` by skill name.
+Evidence: The request currently carries `current_snapshot_ref` but not the snapshot content; request activation models already include `active_snapshot` for side-effect-free context.
+Rationale: Existing activity tests can pass compact active snapshot context without adding storage reads. A future artifact-backed snapshot loader can satisfy ref-only calls.
+Alternatives considered: Reading snapshot artifacts in the query story was rejected as unnecessary for this single story and riskier for body exposure.
+Test implications: Add a unit test where an active snapshot contains one matching Skill and the result marks it active.
+
+## FR-006 Policy and Source Restrictions
+
+Decision: Reuse resolver-backed candidate loading with the same source allow flags and loader precedence used by initial resolution, then search metadata across candidates.
+Evidence: `AgentSkillResolver` and loaders already merge built-in, deployment, repo, and local sources with policy flags in `SkillResolutionContext`.
+Rationale: Query must not create a parallel catalog or bypass policy.
+Alternatives considered: Scanning `.agents/skills` directly was rejected because repo/local source policy and deployment-loaded skills would drift.
+Test implications: Add unit tests with fake candidates from different source kinds and verify allowed/ineligible behavior.
+
+## FR-007 Ineligible Diagnostics
+
+Decision: Return eligible false with a compact `eligibility_summary` when a matched Skill is known but blocked by source/runtime constraints.
+Evidence: The Jira acceptance criteria allow filtering or explicitly marking ineligible; diagnostics are useful for managed agents.
+Rationale: Compact diagnostics help agents understand why help is unavailable without exposing hidden bodies.
+Alternatives considered: Always filtering ineligible matches was rejected because the source brief explicitly allows diagnostic summaries.
+Test implications: Add a test covering an ineligible source/runtime match.
+
+## FR-008 Query Side Effects
+
+Decision: Keep query side-effect free: no materialization, no derived snapshot, no active snapshot mutation.
+Evidence: Existing disabled activity tests assert materializer is not called for request/query paths.
+Rationale: Query is discovery only; activation belongs to `moonmind.skills.request`.
+Alternatives considered: Precomputing derived snapshots during query was rejected as a scope and security violation.
+Test implications: Activity-boundary tests should patch materializer/resolver mutation paths and assert no materialization.
+
+## FR-009 Bounded Payloads
+
+Decision: Enforce `max_results` and typed compact result fields; omit large or nested body-bearing data.
+Evidence: `max_results` already has numeric limits, but enabled query has no result projection yet.
+Rationale: Workflow/activity payloads must remain compact and deterministic.
+Alternatives considered: Returning all matches and asking agents to filter was rejected.
+Test implications: Add tests for result count limiting and serialized result size/field set.
+
+## FR-010 Observability
+
+Decision: Return compact query outcome metadata in the service result for later audit/event integration, without storing raw long query text in high-cardinality fields.
+Evidence: `docs/Steps/SkillsOnDemand.md` section 13 defines query event fields; no current implementation exists.
+Rationale: A deterministic result metadata field is enough for this story while avoiding a new persistent audit store.
+Alternatives considered: Adding a new database table was rejected because the Jira brief planned no new persistent storage.
+Test implications: Unit tests should assert result metadata includes result count and denial status without body content.

--- a/specs/316-policy-aware-skill-query/spec.md
+++ b/specs/316-policy-aware-skill-query/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Policy-Aware Skill Query
+
+**Feature Branch**: `316-policy-aware-skill-query`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-613 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-613 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-613
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Expose policy-aware Skill metadata query for managed runtimes
+- Priority: Medium
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+- Trusted response artifact: `/work/agent_jobs/mm:c890dc23-df31-428f-bf72-53621ff56aa0/artifacts/moonspec-inputs/MM-613-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-613 from MM project
+Summary: Expose policy-aware Skill metadata query for managed runtimes
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-613 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-613: Expose policy-aware Skill metadata query for managed runtimes
+
+Source Reference
+Source Document: docs/Steps/SkillsOnDemand.md
+Source Title: Skills On Demand
+Source Sections:
+- 5.2 On-Demand Skill Query
+- 6. Core Invariants
+- 8.1 moonmind.skills.query
+- 9.2 On-demand query
+- 14. Security Rules
+Coverage IDs:
+- DESIGN-REQ-002
+- DESIGN-REQ-003
+- DESIGN-REQ-010
+- DESIGN-REQ-013
+- DESIGN-REQ-014
+
+As a managed agent, I want to ask MoonMind for bounded metadata about available Skills so I can discover relevant help without receiving hidden Skill bodies or bypassing deployment policy.
+
+Acceptance Criteria
+- moonmind.skills.query validates query, runtime_id, current_snapshot_ref, and max_results inputs.
+- Results include metadata fields such as name, title, description, latest_version, source_kind, supported_runtimes, eligible, in_current_snapshot, and eligibility_summary where available.
+- Results never include full Skill bodies or direct content refs that permit body reads.
+- Ineligible matches are either filtered or explicitly marked eligible false with diagnostic summaries.
+- Query payloads and results remain bounded for workflow/activity use.
+
+Requirements
+- Add SkillsOnDemandQuery and SkillsOnDemandQueryResult contracts.
+- Reuse existing Skill resolver/catalog primitives instead of creating a parallel catalog.
+- Enforce source-kind restrictions, runtime compatibility summaries, and content exposure limits on query results.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Policy-Aware Skill Metadata Discovery
+
+**Summary**: As a managed agent, I want to query MoonMind for bounded metadata about available Skills so that I can discover relevant help without receiving hidden Skill bodies or bypassing deployment policy.
+
+**Goal**: Managed runtimes can perform a governed Skill metadata query that validates caller input, returns only safe metadata, reflects eligibility and active-snapshot context, and preserves all existing Skill policy boundaries.
+
+**Independent Test**: This can be tested independently by enabling Skills On Demand for a managed-runtime query path, submitting valid and invalid Skill metadata queries, and confirming that successful results are bounded metadata-only responses while denied or ineligible cases do not expose Skill bodies or alter active snapshots.
+
+**Acceptance Scenarios**:
+
+1. **Given** Skills On Demand query support is enabled and a managed runtime submits a valid query with runtime and snapshot context, **When** MoonMind evaluates the query, **Then** the response includes only bounded Skill metadata fields and marks whether each result is eligible and already in the current snapshot.
+2. **Given** a managed runtime submits a query with missing, blank, malformed, or excessive input values, **When** MoonMind validates the request, **Then** the request is rejected or constrained with a structured failure that identifies the invalid input without returning catalog contents.
+3. **Given** a matching Skill is blocked by source policy or runtime compatibility, **When** the managed runtime queries for it, **Then** MoonMind either filters the match from results or returns it with `eligible` set to false and a compact diagnostic summary.
+4. **Given** a Skill has body content, artifact refs, or hidden source details, **When** it appears in query results, **Then** the response omits full bodies and direct content refs that would permit unmanaged body reads.
+5. **Given** a managed runtime includes the current snapshot reference, **When** query results overlap with already active Skills, **Then** each overlapping result identifies that it is already present in the current snapshot.
+
+### Edge Cases
+
+- Queries with an empty or whitespace-only search term are handled deterministically without returning an unbounded catalog dump.
+- Requests with `max_results` below or above supported bounds are rejected or constrained according to the public query contract.
+- Unknown runtime identifiers or invalid current snapshot references do not bypass policy or expose hidden catalog details.
+- Ineligible results include only diagnostic metadata that is safe for operators and managed agents to see.
+- No query outcome creates, mutates, or materializes a new active Skill snapshot.
+
+## Assumptions
+
+- The query story is limited to metadata discovery; activating additional Skills remains a separate on-demand request story.
+- Runtime intent is required because the source brief asks for product behavior, not documentation-only alignment.
+- The existing Skill catalog and resolver policy remain the authoritative source of eligibility and metadata.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-002** (`docs/Steps/SkillsOnDemand.md` section 5.2 On-Demand Skill Query): Managed runtimes may query for available Skill metadata but must not directly fetch or inspect hidden Skill bodies. Scope: in scope. Mapped to FR-001, FR-004, FR-005.
+- **DESIGN-REQ-003** (`docs/Steps/SkillsOnDemand.md` section 6 Core Invariants): MoonMind must resolve and police Skill access, keep snapshots immutable, keep workflow payloads compact, and avoid exposing large Skill bodies in runtime-visible data. Scope: in scope. Mapped to FR-004, FR-006, FR-008, FR-009.
+- **DESIGN-REQ-010** (`docs/Steps/SkillsOnDemand.md` section 8.1 moonmind.skills.query): The query contract must validate query, runtime, snapshot, and result limit inputs and return metadata-only search results with eligibility and current-snapshot indicators. Scope: in scope. Mapped to FR-001, FR-002, FR-003, FR-005, FR-007.
+- **DESIGN-REQ-013** (`docs/Steps/SkillsOnDemand.md` section 9.2 On-demand query): Query handling must check feature availability, identify runtime and active snapshot context, search allowed Skill metadata, return bounded results, and record the query for observability. Scope: in scope. Mapped to FR-001, FR-002, FR-003, FR-006, FR-010.
+- **DESIGN-REQ-014** (`docs/Steps/SkillsOnDemand.md` section 14 Security Rules): Query responses must preserve security boundaries by preventing secret exposure, hidden body exposure, arbitrary content reads, and source-policy bypass. Scope: in scope. Mapped to FR-004, FR-006, FR-008, FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a managed-runtime Skill metadata query capability only through MoonMind-governed control paths.
+- **FR-002**: System MUST validate query text, runtime identity, current snapshot reference, and requested result limit before returning Skill metadata.
+- **FR-003**: System MUST return bounded query results that include, when available, Skill name, title, description, latest version, source kind, supported runtimes, eligibility, current-snapshot membership, and eligibility summary.
+- **FR-004**: System MUST NOT return full Skill bodies, unrestricted content references, secrets, or hidden catalog details in query responses.
+- **FR-005**: System MUST identify whether each returned Skill is already present in the current active snapshot when snapshot context is supplied.
+- **FR-006**: System MUST apply the same source-kind restrictions, runtime compatibility checks, and deployment policy constraints used for normal Skill resolution.
+- **FR-007**: System MUST handle ineligible matches by either filtering them from results or marking them ineligible with safe diagnostic summaries.
+- **FR-008**: System MUST ensure Skill metadata queries do not create, mutate, materialize, or activate Skill snapshots.
+- **FR-009**: System MUST keep query payloads and results compact enough for managed workflow and activity boundaries.
+- **FR-010**: System MUST record enough query outcome information for operator observability without storing unsafe high-cardinality or sensitive body content in runtime-visible results.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-613` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Skill Metadata Query**: A managed-runtime request containing query text, optional runtime identity, optional current snapshot reference, and a bounded maximum result count.
+- **Skill Metadata Result**: A metadata-only representation of a matching Skill, including display fields, source and runtime compatibility indicators, eligibility, and current-snapshot membership.
+- **Eligibility Summary**: A compact explanation of why a Skill is eligible or ineligible for the requesting runtime and deployment policy.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid query responses contain only metadata fields and no full Skill body content or direct body-readable refs.
+- **SC-002**: 100% of invalid query-shape cases return a structured denial or validation failure before catalog results are returned.
+- **SC-003**: Query responses never return more results than the accepted result limit.
+- **SC-004**: At least one validation path confirms that ineligible matches are filtered or marked `eligible: false` with a safe diagnostic summary.
+- **SC-005**: At least one validation path confirms that a Skill already active in the current snapshot is marked as present in that snapshot.
+- **SC-006**: Final verification confirms `MM-613` and DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, and DESIGN-REQ-014 remain traceable across MoonSpec artifacts.

--- a/specs/316-policy-aware-skill-query/tasks.md
+++ b/specs/316-policy-aware-skill-query/tasks.md
@@ -4,7 +4,7 @@
 **Prerequisites**: Existing Skills On Demand settings, service, schema, resolver, and activity registrations.
 **Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py`
 **Integration Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_typed_result`
-**Final Verification**: `/speckit.verify`
+**Final Verification**: `/moonspec-verify`
 
 ## Source Traceability Summary
 
@@ -60,7 +60,7 @@
 
 - [X] T018 Review query result serialization for unsafe fields using tests and code inspection in moonmind/schemas/agent_skill_models.py and moonmind/services/skills_on_demand.py (FR-004, SC-001, DESIGN-REQ-014)
 - [X] T019 Run full unit verification with `./tools/test_unit.sh` and record result in specs/316-policy-aware-skill-query/verification.md (FR-001 through FR-011)
-- [X] T020 Run `/speckit.verify` equivalent and write specs/316-policy-aware-skill-query/verification.md with MM-613, acceptance scenario coverage, DESIGN-REQ coverage, test evidence, and final verdict (FR-011, SC-006)
+- [X] T020 Run `/moonspec-verify` equivalent and write specs/316-policy-aware-skill-query/verification.md with MM-613, acceptance scenario coverage, DESIGN-REQ coverage, test evidence, and final verdict (FR-011, SC-006)
 
 ## Dependencies And Execution Order
 

--- a/specs/316-policy-aware-skill-query/tasks.md
+++ b/specs/316-policy-aware-skill-query/tasks.md
@@ -1,9 +1,9 @@
 # Tasks: Policy-Aware Skill Query
 
 **Input**: `specs/316-policy-aware-skill-query/spec.md`, `specs/316-policy-aware-skill-query/plan.md`, `specs/316-policy-aware-skill-query/research.md`, `specs/316-policy-aware-skill-query/data-model.md`, `specs/316-policy-aware-skill-query/contracts/skills-on-demand-query-contract.md`
-**Prerequisites**: Existing disabled-first Skills On Demand settings, service, schema, and activity registrations.
+**Prerequisites**: Existing Skills On Demand settings, service, schema, resolver, and activity registrations.
 **Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py`
-**Integration Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_metadata_without_materializing_snapshot`
+**Integration Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_typed_result`
 **Final Verification**: `/speckit.verify`
 
 ## Source Traceability Summary
@@ -11,8 +11,9 @@
 - Jira issue: MM-613
 - Source design: `docs/Steps/SkillsOnDemand.md`
 - Coverage IDs: DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
-- Code-and-test rows: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-009, FR-010, SCN-001 through SCN-005, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
-- Verification/traceability rows: FR-008, FR-011, SC-006
+- Upstream plan status: all FR, SCN, and in-scope DESIGN-REQ rows are `implemented_verified` in `plan.md`.
+- Completed code-and-test rows: FR-001 through FR-010, SCN-001 through SCN-005, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
+- Completed verification/traceability rows: FR-011, SC-006
 
 ## Phase 1: Setup
 
@@ -78,4 +79,4 @@
 
 ## Implementation Strategy
 
-Start with tests that replace the enabled-not-implemented placeholder expectations. Keep disabled behavior unchanged. Add typed metadata result contracts first, then implement service-level validation and projection from resolver-backed Skill entries. Activity wiring should remain thin and must not materialize snapshots. Preserve `MM-613` and source coverage IDs in verification evidence.
+The completed task sequence followed TDD: red-first tests replaced enabled-not-implemented placeholder expectations, then typed metadata result contracts, service-level validation/projection, resolver-backed catalog search, and activity wiring were implemented. Disabled behavior remained unchanged, query activity wiring stayed thin, and materialization is explicitly guarded by tests. `MM-613` and source coverage IDs are preserved in verification evidence.

--- a/specs/316-policy-aware-skill-query/tasks.md
+++ b/specs/316-policy-aware-skill-query/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Policy-Aware Skill Query
+
+**Input**: `specs/316-policy-aware-skill-query/spec.md`, `specs/316-policy-aware-skill-query/plan.md`, `specs/316-policy-aware-skill-query/research.md`, `specs/316-policy-aware-skill-query/data-model.md`, `specs/316-policy-aware-skill-query/contracts/skills-on-demand-query-contract.md`
+**Prerequisites**: Existing disabled-first Skills On Demand settings, service, schema, and activity registrations.
+**Unit Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py`
+**Integration Test Command**: `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py::test_enabled_activity_query_returns_metadata_without_materializing_snapshot`
+**Final Verification**: `/speckit.verify`
+
+## Source Traceability Summary
+
+- Jira issue: MM-613
+- Source design: `docs/Steps/SkillsOnDemand.md`
+- Coverage IDs: DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
+- Code-and-test rows: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-009, FR-010, SCN-001 through SCN-005, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
+- Verification/traceability rows: FR-008, FR-011, SC-006
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature artifacts exist for MM-613 in specs/316-policy-aware-skill-query/spec.md, specs/316-policy-aware-skill-query/plan.md, specs/316-policy-aware-skill-query/research.md, specs/316-policy-aware-skill-query/data-model.md, specs/316-policy-aware-skill-query/quickstart.md, and specs/316-policy-aware-skill-query/contracts/skills-on-demand-query-contract.md
+- [X] T002 Confirm existing test harness paths for Skills On Demand unit and activity-boundary coverage in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
+
+## Phase 2: Foundational
+
+- [X] T003 Review existing query/request schema, service, and activity boundaries in moonmind/schemas/agent_skill_models.py, moonmind/services/skills_on_demand.py, and moonmind/workflows/agent_skills/agent_skills_activities.py for MM-613 scope
+- [X] T004 Add or update shared fake Skill catalog fixtures for query tests in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-006, DESIGN-REQ-002, DESIGN-REQ-014)
+
+## Phase 3: Story - Policy-Aware Skill Metadata Discovery
+
+**Summary**: Managed runtimes can query for bounded, policy-aware Skill metadata without receiving Skill bodies or changing active snapshots.
+**Independent Test**: Enable Skills On Demand query mode, issue valid and invalid query requests through service and activity boundaries, and verify metadata-only results, eligibility diagnostics, active-snapshot membership, bounded results, and no materialization.
+**Traceability IDs**: FR-001 through FR-011, SCN-001 through SCN-005, SC-001 through SC-006, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-013, DESIGN-REQ-014
+
+### Unit Test Plan
+
+- Validate typed query/result contracts and input failures.
+- Validate enabled query metadata projection, source/runtime eligibility, current snapshot membership, and bounded result count.
+- Validate body/content-ref/source-path omissions.
+- Preserve disabled query behavior.
+
+### Integration Test Plan
+
+- Use Temporal `ActivityEnvironment` to exercise `agent_skill.query_on_demand` with settings enabled and assert the service contract is preserved at the activity boundary with no materialization.
+
+- [X] T005 Add failing unit tests for enabled query returning `ok` with metadata-only results in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-001, FR-003, FR-004, SCN-001, SCN-004, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-014)
+- [X] T006 Add failing unit tests for blank query, invalid request shape, and max result bounds in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-002, FR-009, SCN-002, DESIGN-REQ-010)
+- [X] T007 Add failing unit tests for ineligible source/runtime matches and safe `eligibility_summary` behavior in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-006, FR-007, SCN-003, DESIGN-REQ-013, DESIGN-REQ-014)
+- [X] T008 Add failing unit tests for `in_current_snapshot` membership from active snapshot context in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-005, SCN-005, DESIGN-REQ-010)
+- [X] T009 Add failing unit tests proving enabled query does not materialize or mutate snapshots in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-008, DESIGN-REQ-003)
+- [X] T010 Add failing activity-boundary test for enabled `agent_skill.query_on_demand` metadata results without materialization in tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py (FR-001, FR-003, FR-008, DESIGN-REQ-013)
+- [X] T011 Run red-first focused tests with `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py` and record expected failures in specs/316-policy-aware-skill-query/tasks.md (FR-001 through FR-010) - initial result failed during collection because `SkillCatalogSearchResult` was missing, confirming the new contract gap.
+- [X] T012 Update query status, denial codes, `SkillCatalogSearchResult`, `SkillsOnDemandQueryRequest`, and `SkillsOnDemandQueryResult` contracts in moonmind/schemas/agent_skill_models.py (FR-002, FR-003, FR-009, DESIGN-REQ-010)
+- [X] T013 Implement enabled metadata query search, validation, safe projection, eligibility summaries, active snapshot membership, bounded results, and compact metadata in moonmind/services/skills_on_demand.py (FR-001, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-013, DESIGN-REQ-014)
+- [X] T014 Wire `AgentSkillsActivities.query_on_demand` to pass resolver-backed catalog context without enabling materialization in moonmind/workflows/agent_skills/agent_skills_activities.py (FR-001, FR-006, FR-008, DESIGN-REQ-013)
+- [X] T015 Update or add resolver helper behavior only if needed for policy-aware candidate search in moonmind/services/skill_resolution.py (FR-006, DESIGN-REQ-002)
+- [X] T016 Run focused green tests with `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py` (FR-001 through FR-010)
+- [X] T017 Run story validation command `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py` and confirm MM-613 behavior remains bounded and metadata-only (SC-001 through SC-005)
+
+## Final Phase: Polish And Verification
+
+- [X] T018 Review query result serialization for unsafe fields using tests and code inspection in moonmind/schemas/agent_skill_models.py and moonmind/services/skills_on_demand.py (FR-004, SC-001, DESIGN-REQ-014)
+- [X] T019 Run full unit verification with `./tools/test_unit.sh` and record result in specs/316-policy-aware-skill-query/verification.md (FR-001 through FR-011)
+- [X] T020 Run `/speckit.verify` equivalent and write specs/316-policy-aware-skill-query/verification.md with MM-613, acceptance scenario coverage, DESIGN-REQ coverage, test evidence, and final verdict (FR-011, SC-006)
+
+## Dependencies And Execution Order
+
+1. T001-T004 establish artifact and fixture foundations.
+2. T005-T010 add red-first unit and activity-boundary tests.
+3. T011 confirms the tests fail for the missing enabled query behavior.
+4. T012-T015 implement the minimal schema, service, activity, and resolver changes required by the failing tests.
+5. T016-T018 validate focused story behavior and metadata safety.
+6. T019-T020 complete final unit and MoonSpec verification.
+
+## Parallel Opportunities
+
+- T005 through T010 touch the same test file and should be ordered carefully rather than parallelized.
+- T012 and T013 can be drafted together only after red-first tests are established, but final schema changes must land before service changes are validated.
+- T018 can run after T016 while broader unit verification T019 is prepared.
+
+## Implementation Strategy
+
+Start with tests that replace the enabled-not-implemented placeholder expectations. Keep disabled behavior unchanged. Add typed metadata result contracts first, then implement service-level validation and projection from resolver-backed Skill entries. Activity wiring should remain thin and must not materialize snapshots. Preserve `MM-613` and source coverage IDs in verification evidence.

--- a/specs/316-policy-aware-skill-query/verification.md
+++ b/specs/316-policy-aware-skill-query/verification.md
@@ -22,7 +22,7 @@ MM-613 is implemented for the selected single story. Managed-runtime Skills On D
 | FR-007 | VERIFIED | Ineligible local matches return `eligible=false` and a compact safe diagnostic. |
 | FR-008 | VERIFIED | Activity-boundary test patches materializer and asserts query does not materialize. |
 | FR-009 | VERIFIED | Query result count honors accepted `max_results`; metadata reports result count. |
-| FR-010 | VERIFIED | Query result includes compact metadata with result count and denial state. |
+| FR-010 | VERIFIED | Query result includes compact metadata with result count, denial state, and normalized query hash. |
 | FR-011 | VERIFIED | `MM-613` and canonical Jira preset brief are preserved in spec, plan, tasks, and this verification report. |
 
 ## Source Design Coverage

--- a/specs/316-policy-aware-skill-query/verification.md
+++ b/specs/316-policy-aware-skill-query/verification.md
@@ -1,0 +1,48 @@
+# Verification: Policy-Aware Skill Query
+
+**Feature**: `specs/316-policy-aware-skill-query`
+**Jira**: MM-613
+**Verdict**: FULLY_IMPLEMENTED
+**Verified**: 2026-05-08
+
+## Summary
+
+MM-613 is implemented for the selected single story. Managed-runtime Skills On Demand query support now returns policy-aware, metadata-only Skill catalog results when enabled, preserves disabled behavior, validates blank input, marks source-policy ineligible matches, marks current snapshot membership when active snapshot context is supplied, keeps results bounded, and does not materialize or mutate Skill snapshots.
+
+## Requirement Coverage
+
+| ID | Verdict | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | `AgentSkillsActivities.query_on_demand` remains the governed activity path and delegates to `SkillsOnDemandService.query`. |
+| FR-002 | VERIFIED | `SkillsOnDemandQueryRequest` preserves bounded `max_results`; service rejects blank queries and snapshot mismatches. |
+| FR-003 | VERIFIED | `SkillCatalogSearchResult` provides typed metadata-only result fields; enabled query returns `status="ok"`. |
+| FR-004 | VERIFIED | Tests assert result serialization omits body refs, content digests, and source paths. |
+| FR-005 | VERIFIED | Active snapshot membership is derived from supplied compact snapshot context. |
+| FR-006 | VERIFIED | Resolver-backed `query_catalog` reuses source loaders and precedence; service marks repo/local sources ineligible when disabled. |
+| FR-007 | VERIFIED | Ineligible local matches return `eligible=false` and a compact safe diagnostic. |
+| FR-008 | VERIFIED | Activity-boundary test patches materializer and asserts query does not materialize. |
+| FR-009 | VERIFIED | Query result count honors accepted `max_results`; metadata reports result count. |
+| FR-010 | VERIFIED | Query result includes compact metadata with result count and denial state. |
+| FR-011 | VERIFIED | `MM-613` and canonical Jira preset brief are preserved in spec, plan, tasks, and this verification report. |
+
+## Source Design Coverage
+
+| Source ID | Verdict | Evidence |
+| --- | --- | --- |
+| DESIGN-REQ-002 | VERIFIED | Query discovers Skill metadata without body/content-ref exposure. |
+| DESIGN-REQ-003 | VERIFIED | Query is side-effect free and does not mutate/materialize snapshots. |
+| DESIGN-REQ-010 | VERIFIED | Query/result contracts validate input and return metadata with eligibility and snapshot indicators. |
+| DESIGN-REQ-013 | VERIFIED | Activity-boundary query checks enabled mode, searches resolver-backed metadata, and returns bounded results. |
+| DESIGN-REQ-014 | VERIFIED | Security guardrails are covered by metadata-only projection and ineligible diagnostics tests. |
+
+## Test Evidence
+
+- `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py`: PASS, 12 Python tests passed; frontend suite also passed through the unit runner.
+- `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py`: PASS, 39 Python tests passed; frontend suite also passed through the unit runner.
+- `./tools/test_unit.sh`: PASS, 4509 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest suite passed with 20 files and 324 tests passed, 223 skipped.
+
+## Notes
+
+- Red-first evidence: the first focused run failed during collection because `SkillCatalogSearchResult` was missing, confirming the new typed result contract gap before implementation.
+- `python -m ruff check ...` was attempted for touched files, but `ruff` is not installed in this runtime.
+- `.specify/scripts/bash/setup-plan.sh --json` and `.specify/scripts/bash/update-agent-context.sh codex` could not run because this managed branch name is not in numeric MoonSpec branch format; artifacts were created under the resolved `specs/316-policy-aware-skill-query` directory instead.

--- a/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
+++ b/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
@@ -9,6 +9,7 @@ from moonmind.schemas.agent_skill_models import (
     AgentSkillSourceKind,
     ResolvedSkillEntry,
     ResolvedSkillSet,
+    SkillCatalogSearchResult,
     SkillsOnDemandQueryRequest,
     SkillsOnDemandRequest,
     SkillsOnDemandRequestedSkill,
@@ -22,6 +23,26 @@ from moonmind.services.skills_on_demand import (
 from moonmind.workflows.agent_skills.agent_skills_activities import AgentSkillsActivities
 
 pytestmark = [pytest.mark.asyncio]
+
+
+def _entry(
+    name: str,
+    *,
+    source_kind: AgentSkillSourceKind = AgentSkillSourceKind.BUILT_IN,
+    version: str | None = "1.0.0",
+    content_ref: str | None = None,
+    source_path: str | None = None,
+) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name=name,
+        version=version,
+        content_ref=content_ref,
+        content_digest="sha256:secret-digest" if content_ref else None,
+        provenance=AgentSkillProvenance(
+            source_kind=source_kind,
+            source_path=source_path,
+        ),
+    )
 
 
 async def test_disabled_query_returns_denied_without_catalog_results() -> None:
@@ -66,14 +87,126 @@ async def test_disabled_request_returns_denied_without_snapshot_mutation() -> No
     assert result.active_snapshot_id == "skillset-active"
 
 
-async def test_enabled_query_returns_structured_not_implemented_result() -> None:
-    result = await SkillsOnDemandService(enabled=True).query(
-        SkillsOnDemandQueryRequest(query="jira")
+async def test_enabled_query_returns_metadata_only_results() -> None:
+    result = await SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[
+            _entry(
+                "jira-issue-updater",
+                content_ref="artifact-body-ref",
+                source_path="/hidden/SKILL.md",
+            ),
+            _entry("moonspec-plan"),
+        ],
+    ).query(
+        SkillsOnDemandQueryRequest(query="jira", runtime_id="codex", max_results=5)
     )
 
+    assert result.status == "ok"
+    assert result.code is None
+    assert result.metadata["result_count"] == 1
+    assert result.results == [
+        SkillCatalogSearchResult(
+            name="jira-issue-updater",
+            latest_version="1.0.0",
+            source_kind=AgentSkillSourceKind.BUILT_IN,
+            eligible=True,
+            in_current_snapshot=False,
+            eligibility_summary="Eligible for this runtime and deployment policy.",
+        )
+    ]
+    serialized = result.model_dump(mode="json")
+    assert "artifact-body-ref" not in str(serialized)
+    assert "secret-digest" not in str(serialized)
+    assert "/hidden/SKILL.md" not in str(serialized)
+
+
+async def test_enabled_query_validates_blank_query() -> None:
+    result = await SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[_entry("jira-issue-updater")],
+    ).query(SkillsOnDemandQueryRequest(query="   "))
+
     assert result.status == "denied"
-    assert result.code == SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_CODE
+    assert result.code == "invalid_request"
     assert result.results == []
+    assert result.metadata["denied"] is True
+
+
+async def test_enabled_query_validates_blank_context_values() -> None:
+    service = SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[_entry("jira-issue-updater")],
+    )
+
+    runtime_result = await service.query(
+        SkillsOnDemandQueryRequest(query="jira", runtime_id=" ")
+    )
+    snapshot_result = await service.query(
+        SkillsOnDemandQueryRequest(query="jira", current_snapshot_ref=" ")
+    )
+
+    assert runtime_result.status == "denied"
+    assert runtime_result.code == "invalid_request"
+    assert snapshot_result.status == "denied"
+    assert snapshot_result.code == "invalid_request"
+
+
+async def test_enabled_query_marks_policy_ineligible_matches() -> None:
+    result = await SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[
+            _entry(
+                "local-jira-helper",
+                source_kind=AgentSkillSourceKind.LOCAL,
+            )
+        ],
+        allow_local_skills=False,
+    ).query(SkillsOnDemandQueryRequest(query="jira"))
+
+    assert result.status == "ok"
+    assert len(result.results) == 1
+    assert result.results[0].eligible is False
+    assert result.results[0].eligibility_summary == (
+        "Blocked because local Skill sources are disabled for this query."
+    )
+
+
+async def test_enabled_query_marks_current_snapshot_membership() -> None:
+    active_snapshot = ResolvedSkillSet(
+        snapshot_id="skillset-active",
+        resolved_at=datetime.now(UTC),
+        skills=[_entry("jira-issue-updater")],
+    )
+
+    result = await SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[_entry("jira-issue-updater")],
+    ).query(
+        SkillsOnDemandQueryRequest(
+            query="jira",
+            current_snapshot_ref="skillset-active",
+            active_snapshot=active_snapshot,
+        )
+    )
+
+    assert result.status == "ok"
+    assert result.results[0].in_current_snapshot is True
+
+
+async def test_enabled_query_respects_max_results() -> None:
+    result = await SkillsOnDemandService(
+        enabled=True,
+        catalog_entries=[
+            _entry("jira-a"),
+            _entry("jira-b"),
+            _entry("jira-c"),
+        ],
+    ).query(SkillsOnDemandQueryRequest(query="jira", max_results=2))
+
+    assert result.status == "ok"
+    assert [entry.name for entry in result.results] == ["jira-a", "jira-b"]
+    assert result.metadata["result_count"] == 2
 
 
 async def test_enabled_request_returns_structured_not_implemented_result() -> None:
@@ -165,10 +298,26 @@ async def test_enabled_activity_query_returns_typed_result(
     activities = AgentSkillsActivities()
     env = ActivityEnvironment()
 
-    result = await env.run(
-        activities.query_on_demand,
-        SkillsOnDemandQueryRequest(query="jira"),
-    )
+    async def fake_query_catalog(*args, **kwargs):
+        return [_entry("jira-issue-updater", content_ref="artifact-body-ref")]
 
-    assert result.status == "denied"
-    assert result.code == SKILLS_ON_DEMAND_ENABLED_NOT_IMPLEMENTED_CODE
+    with (
+        patch(
+            "moonmind.workflows.agent_skills.agent_skills_activities.AgentSkillResolver.query_catalog",
+            side_effect=fake_query_catalog,
+        ) as mock_query_catalog,
+        patch(
+            "moonmind.workflows.agent_skills.agent_skills_activities.AgentSkillMaterializer.materialize"
+        ) as mock_materialize,
+    ):
+        result = await env.run(
+            activities.query_on_demand,
+            SkillsOnDemandQueryRequest(query="jira"),
+        )
+
+    assert result.status == "ok"
+    assert result.results[0].name == "jira-issue-updater"
+    assert result.results[0].eligible is True
+    assert "artifact-body-ref" not in str(result.model_dump(mode="json"))
+    mock_query_catalog.assert_awaited_once()
+    mock_materialize.assert_not_called()


### PR DESCRIPTION
Jira issue key: MM-613

Active MoonSpec feature path: `specs/316-policy-aware-skill-query`

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py`
- `./tools/test_unit.sh tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/services/test_skill_resolution.py`
- `./tools/test_unit.sh`

Remaining risks:
- The final verification report notes the MoonSpec prerequisite helper could not run in this managed checkout because the branch name is non-numeric.
- The checkout has a runtime `.gemini/skills` projection symlink modification that is intentionally excluded from the PR.