### PR TITLE
MM-618 Build bounded remediation evidence context

### DIFF
--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -232,7 +232,8 @@ class RemediationContextBuilder:
         unavailable_classes = [
             item["class"]
             for item in availability
-            if item.get("status") in {"missing", "partial", "denied", "unavailable"}
+            if item.get("status")
+            in {"missing", "partial", "denied", "unavailable", "unsupported"}
         ]
 
         return {
@@ -858,18 +859,23 @@ def _match_step_evidence(
     selector_task_run_id = _string_or_none(selector.get("taskRunId"))
     selector_logical_step_id = _string_or_none(selector.get("logicalStepId"))
     selector_attempt = _positive_int_or_none(selector.get("attempt"))
+    if (
+        not selector_task_run_id
+        and not selector_logical_step_id
+        and selector_attempt is None
+    ):
+        return None
     for item in evidence_steps:
         task_run_id = _string_or_none(item.get("taskRunId"))
-        if selector_task_run_id and task_run_id == selector_task_run_id:
-            return item
+        if selector_task_run_id and task_run_id != selector_task_run_id:
+            continue
         logical_step_id = _string_or_none(item.get("logicalStepId"))
+        if selector_logical_step_id and logical_step_id != selector_logical_step_id:
+            continue
         attempt = _positive_int_or_none(item.get("attempt"))
-        if (
-            selector_logical_step_id
-            and logical_step_id == selector_logical_step_id
-            and (selector_attempt is None or attempt == selector_attempt)
-        ):
-            return item
+        if selector_attempt is not None and attempt != selector_attempt:
+            continue
+        return item
     return None
 
 def _has_task_run_evidence(item: Mapping[str, Any], field_name: str) -> bool:

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -61,6 +61,14 @@ REMEDIATION_RESOLUTIONS = frozenset(
 )
 MAX_REMEDIATION_CONTEXT_TAIL_LINES = 2000
 MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS = 20
+TARGET_EVIDENCE_CLASSES = (
+    ("stdout", "stdoutRef"),
+    ("stderr", "stderrRef"),
+    ("merged_logs", "mergedLogsRef"),
+    ("diagnostics", "diagnosticsRef"),
+    ("provider_snapshot", "providerSnapshotRef"),
+    ("continuity", "continuityRefs"),
+)
 SECRET_LIKE_POLICY_KEY_PARTS = (
     "api_key",
     "apikey",
@@ -197,11 +205,35 @@ class RemediationContextBuilder:
         target = remediation.get("target") if isinstance(remediation, Mapping) else {}
         target_mapping = target if isinstance(target, Mapping) else {}
         task_run_ids = self._normalize_task_run_ids(target_mapping.get("taskRunIds"))
+        target_evidence = self._target_evidence_payload(target_record)
+        if not task_run_ids:
+            task_run_ids = self._task_run_ids_from_evidence(target_evidence)
         evidence_policy = self._normalize_evidence_policy(
             remediation.get("evidencePolicy")
             if isinstance(remediation, Mapping)
             else None
         )
+        task_runs = self._normalize_task_run_evidence(
+            task_run_ids=task_run_ids,
+            target_evidence=target_evidence,
+        )
+        live_follow = self._live_follow_payload(
+            link=link,
+            target_record=target_record,
+            task_run_ids=task_run_ids,
+            task_runs=task_runs,
+            target_evidence=target_evidence,
+            evidence_policy=evidence_policy,
+        )
+        availability = self._evidence_availability(
+            task_runs=task_runs,
+            live_follow=live_follow,
+        )
+        unavailable_classes = [
+            item["class"]
+            for item in availability
+            if item.get("status") in {"missing", "partial", "denied", "unavailable"}
+        ]
 
         return {
             "schemaVersion": REMEDIATION_CONTEXT_SCHEMA_VERSION,
@@ -209,18 +241,18 @@ class RemediationContextBuilder:
             "generatedAt": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             "target": self._target_payload(target_record, link=link),
             "selectedSteps": self._normalize_step_selectors(
-                target_mapping.get("stepSelectors")
+                target_mapping.get("stepSelectors"),
+                target_evidence=target_evidence,
             ),
             "evidence": {
                 "targetArtifactRefs": self._target_artifact_refs(target_record),
-                "taskRuns": [{"taskRunId": item} for item in task_run_ids],
+                "taskRuns": task_runs,
+                "availability": availability,
+                "evidenceDegraded": bool(unavailable_classes),
+                "unavailableEvidenceClasses": unavailable_classes,
+                **self._diagnosis_hints_payload(target_evidence),
             },
-            "liveFollow": {
-                "mode": link.mode,
-                "supported": False,
-                "taskRunId": task_run_ids[0] if task_run_ids else None,
-                "resumeCursor": None,
-            },
+            "liveFollow": live_follow,
             "policies": {
                 "authorityMode": link.authority_mode,
                 "actionPolicyRef": self._string_or_none(
@@ -259,6 +291,20 @@ class RemediationContextBuilder:
         return remediation if isinstance(remediation, Mapping) else {}
 
     @staticmethod
+    def _target_evidence_payload(
+        record: db_models.TemporalExecutionCanonicalRecord,
+    ) -> Mapping[str, Any]:
+        for source in (record.memo, record.parameters, record.integration_state):
+            if not isinstance(source, Mapping):
+                continue
+            evidence = source.get("remediationEvidence") or source.get(
+                "remediation_evidence"
+            )
+            if isinstance(evidence, Mapping):
+                return evidence
+        return {}
+
+    @staticmethod
     def _target_payload(
         record: db_models.TemporalExecutionCanonicalRecord,
         *,
@@ -275,9 +321,14 @@ class RemediationContextBuilder:
         }
 
     @staticmethod
-    def _normalize_step_selectors(value: Any) -> list[dict[str, Any]]:
+    def _normalize_step_selectors(
+        value: Any,
+        *,
+        target_evidence: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
         if not isinstance(value, list):
             return []
+        evidence_steps = _mapping_list(target_evidence.get("selectedSteps"))
         selectors: list[dict[str, Any]] = []
         for item in value[:MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS]:
             if not isinstance(item, Mapping):
@@ -294,6 +345,15 @@ class RemediationContextBuilder:
             task_run_id = _string_or_none(item.get("taskRunId") or item.get("task_run_id"))
             if task_run_id:
                 selector["taskRunId"] = task_run_id
+            evidence_step = _match_step_evidence(selector, evidence_steps)
+            if evidence_step is not None:
+                if status := _safe_optional_string(evidence_step.get("status")):
+                    selector["status"] = status
+                if summary := _safe_optional_string(evidence_step.get("summary")):
+                    selector["summary"] = summary
+                artifact_refs = _artifact_ref_list(evidence_step.get("artifactRefs"))
+                if artifact_refs:
+                    selector["artifactRefs"] = artifact_refs
             if selector:
                 selectors.append(selector)
         return selectors
@@ -313,6 +373,165 @@ class RemediationContextBuilder:
             if len(task_run_ids) >= MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS:
                 break
         return task_run_ids
+
+    @staticmethod
+    def _task_run_ids_from_evidence(target_evidence: Mapping[str, Any]) -> list[str]:
+        task_run_ids: list[str] = []
+        seen: set[str] = set()
+        for item in _mapping_list(target_evidence.get("taskRuns")):
+            task_run_id = _string_or_none(item.get("taskRunId"))
+            if not task_run_id or task_run_id in seen:
+                continue
+            seen.add(task_run_id)
+            task_run_ids.append(task_run_id)
+            if len(task_run_ids) >= MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS:
+                break
+        return task_run_ids
+
+    @staticmethod
+    def _normalize_task_run_evidence(
+        *,
+        task_run_ids: Sequence[str],
+        target_evidence: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        source_by_id = {
+            task_run_id: item
+            for item in _mapping_list(target_evidence.get("taskRuns"))
+            if (task_run_id := _string_or_none(item.get("taskRunId")))
+        }
+        task_runs: list[dict[str, Any]] = []
+        for task_run_id in task_run_ids[:MAX_REMEDIATION_CONTEXT_TASK_RUN_IDS]:
+            entry: dict[str, Any] = {"taskRunId": task_run_id}
+            source = source_by_id.get(task_run_id, {})
+            for field in (
+                "observabilitySummaryRef",
+                "stdoutRef",
+                "stderrRef",
+                "mergedLogsRef",
+                "diagnosticsRef",
+                "providerSnapshotRef",
+            ):
+                if ref := _artifact_ref_payload(source.get(field), kind=None):
+                    entry[field] = ref
+            continuity_refs = _artifact_ref_list(source.get("continuityRefs"))
+            if continuity_refs:
+                entry["continuityRefs"] = continuity_refs
+            task_runs.append(entry)
+        return task_runs
+
+    @staticmethod
+    def _evidence_availability(
+        *,
+        task_runs: Sequence[Mapping[str, Any]],
+        live_follow: Mapping[str, Any],
+    ) -> list[dict[str, str]]:
+        has_merged = any(isinstance(item.get("mergedLogsRef"), Mapping) for item in task_runs)
+        availability: list[dict[str, str]] = []
+        for class_name, field_name in TARGET_EVIDENCE_CLASSES:
+            available = any(_has_task_run_evidence(item, field_name) for item in task_runs)
+            if available:
+                availability.append({"class": class_name, "status": "available"})
+            else:
+                record = {"class": class_name, "status": "missing"}
+                if has_merged:
+                    record["fallback"] = "merged_logs"
+                availability.append(record)
+
+        live_status = _string_or_none(live_follow.get("status")) or "unsupported"
+        if live_status == "active":
+            availability.append({"class": "live_follow", "status": "available"})
+        else:
+            status = "denied" if live_status == "policy_denied" else live_status
+            record = {"class": "live_follow", "status": status}
+            if reason := _string_or_none(live_follow.get("reason")):
+                record["reason"] = reason
+            fallbacks = live_follow.get("fallbacks")
+            if isinstance(fallbacks, Sequence) and not isinstance(
+                fallbacks, (str, bytes, bytearray)
+            ):
+                if fallback := _string_or_none(next(iter(fallbacks), None)):
+                    record["fallback"] = fallback
+            availability.append(record)
+        return availability
+
+    @staticmethod
+    def _live_follow_payload(
+        *,
+        link: db_models.TemporalExecutionRemediationLink,
+        target_record: db_models.TemporalExecutionCanonicalRecord,
+        task_run_ids: Sequence[str],
+        task_runs: Sequence[Mapping[str, Any]],
+        target_evidence: Mapping[str, Any],
+        evidence_policy: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        mode = link.mode
+        task_run_id = task_run_ids[0] if task_run_ids else None
+        live_evidence = target_evidence.get("liveFollow")
+        live_mapping = live_evidence if isinstance(live_evidence, Mapping) else {}
+        resume_cursor = _safe_policy_mapping(live_mapping.get("resumeCursor"))
+        fallbacks = _durable_fallback_classes(task_runs)
+
+        if _live_follow_denied_by_policy(evidence_policy):
+            return {
+                "status": "policy_denied",
+                "mode": mode,
+                "supported": False,
+                "taskRunId": task_run_id,
+                "resumeCursor": resume_cursor,
+                "reason": "policy denies live observation",
+                "fallbacks": fallbacks,
+            }
+        if mode not in {"follow", "snapshot_then_follow"}:
+            return {
+                "status": "unsupported",
+                "mode": mode,
+                "supported": False,
+                "taskRunId": task_run_id,
+                "resumeCursor": resume_cursor,
+                "reason": "remediation mode does not request live observation",
+                "fallbacks": fallbacks,
+            }
+        if _enum_value(target_record.state) not in {
+            "executing",
+            "awaiting_external",
+            "awaiting_slot",
+            "finalizing",
+        }:
+            return {
+                "status": "unavailable",
+                "mode": mode,
+                "supported": False,
+                "taskRunId": task_run_id,
+                "resumeCursor": resume_cursor,
+                "reason": "target is terminal",
+                "fallbacks": fallbacks,
+            }
+        if not _task_run_supports_live_follow(
+            task_run_id=task_run_id,
+            target_evidence=target_evidence,
+        ):
+            return {
+                "status": "unsupported",
+                "mode": mode,
+                "supported": False,
+                "taskRunId": task_run_id,
+                "resumeCursor": resume_cursor,
+                "reason": "task run does not support live follow",
+                "fallbacks": fallbacks,
+            }
+        return {
+            "status": "active",
+            "mode": mode,
+            "supported": True,
+            "taskRunId": task_run_id,
+            "resumeCursor": resume_cursor,
+            "fallbacks": fallbacks,
+        }
+
+    @staticmethod
+    def _diagnosis_hints_payload(target_evidence: Mapping[str, Any]) -> dict[str, Any]:
+        hints = _safe_string_list(target_evidence.get("diagnosisHints") or [])
+        return {"diagnosisHints": hints} if hints else {}
 
     @staticmethod
     def _normalize_evidence_policy(value: Any) -> dict[str, Any]:
@@ -598,13 +817,104 @@ def build_target_remediation_linkage_summary(
     return summary
 
 def _artifact_ref_payload(raw_ref: Any, *, kind: str | None) -> dict[str, str] | None:
-    ref = _string_or_none(raw_ref)
+    source_kind = kind
+    if isinstance(raw_ref, Mapping):
+        source_kind = kind or _safe_optional_string(raw_ref.get("kind"))
+        ref = _string_or_none(raw_ref.get("artifact_id") or raw_ref.get("artifactId"))
+    else:
+        ref = _string_or_none(raw_ref)
     if not ref or not ref.startswith("art_"):
         return None
     payload: dict[str, str] = {"artifact_id": ref}
-    if kind:
-        payload["kind"] = kind
+    if source_kind:
+        payload["kind"] = source_kind
     return payload
+
+def _artifact_ref_list(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    refs: list[dict[str, str]] = []
+    seen: set[tuple[str, str | None]] = set()
+    for item in value[:50]:
+        ref = _artifact_ref_payload(item, kind=None)
+        if ref is None:
+            continue
+        key = (ref.get("artifact_id") or "", ref.get("kind"))
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(ref)
+    return refs
+
+def _mapping_list(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+def _match_step_evidence(
+    selector: Mapping[str, Any],
+    evidence_steps: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    selector_task_run_id = _string_or_none(selector.get("taskRunId"))
+    selector_logical_step_id = _string_or_none(selector.get("logicalStepId"))
+    selector_attempt = _positive_int_or_none(selector.get("attempt"))
+    for item in evidence_steps:
+        task_run_id = _string_or_none(item.get("taskRunId"))
+        if selector_task_run_id and task_run_id == selector_task_run_id:
+            return item
+        logical_step_id = _string_or_none(item.get("logicalStepId"))
+        attempt = _positive_int_or_none(item.get("attempt"))
+        if (
+            selector_logical_step_id
+            and logical_step_id == selector_logical_step_id
+            and (selector_attempt is None or attempt == selector_attempt)
+        ):
+            return item
+    return None
+
+def _has_task_run_evidence(item: Mapping[str, Any], field_name: str) -> bool:
+    value = item.get(field_name)
+    if field_name == "continuityRefs":
+        return isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ) and any(isinstance(ref, Mapping) for ref in value)
+    return isinstance(value, Mapping)
+
+def _durable_fallback_classes(task_runs: Sequence[Mapping[str, Any]]) -> list[str]:
+    classes: list[str] = []
+    for class_name, field_name in (
+        ("merged_logs", "mergedLogsRef"),
+        ("stdout", "stdoutRef"),
+        ("stderr", "stderrRef"),
+        ("diagnostics", "diagnosticsRef"),
+    ):
+        if any(_has_task_run_evidence(item, field_name) for item in task_runs):
+            classes.append(class_name)
+    return classes
+
+def _live_follow_denied_by_policy(evidence_policy: Mapping[str, Any]) -> bool:
+    for key in ("allowLiveFollow", "liveFollowAllowed", "includeLiveFollow"):
+        if evidence_policy.get(key) is False:
+            return True
+    return False
+
+def _task_run_supports_live_follow(
+    *,
+    task_run_id: str | None,
+    target_evidence: Mapping[str, Any],
+) -> bool:
+    live_follow = target_evidence.get("liveFollow")
+    if isinstance(live_follow, Mapping) and live_follow.get("supported") is True:
+        return True
+    if not task_run_id:
+        return False
+    for item in _mapping_list(target_evidence.get("taskRuns")):
+        if _string_or_none(item.get("taskRunId")) == task_run_id:
+            return bool(
+                item.get("liveFollowSupported") is True
+                or item.get("supportsLiveFollow") is True
+            )
+    return False
 
 def _safe_policy_mapping(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):

--- a/specs/318-bounded-remediation-evidence/checklists/requirements.md
+++ b/specs/318-bounded-remediation-evidence/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Bounded Remediation Evidence Context
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is classified as a single-story runtime feature request from the trusted MM-618 Jira preset brief.
+- PASS: `spec.md` preserves MM-618, the canonical preset brief, linked issue context, and source coverage IDs DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-025.
+- PASS: No existing MoonSpec artifacts matched MM-618, so Specify was the first incomplete stage.

--- a/specs/318-bounded-remediation-evidence/contracts/remediation-evidence.md
+++ b/specs/318-bounded-remediation-evidence/contracts/remediation-evidence.md
@@ -1,0 +1,266 @@
+# Contract: Remediation Evidence Context and Tools
+
+## Context Artifact Contract
+
+Artifact metadata:
+
+```json
+{
+  "artifact_type": "remediation.context",
+  "name": "reports/remediation_context.json",
+  "schemaVersion": "v1",
+  "targetWorkflowId": "mm:target",
+  "targetRunId": "run-target"
+}
+```
+
+Payload shape:
+
+```json
+{
+  "schemaVersion": "v1",
+  "remediationWorkflowId": "mm:remediation",
+  "generatedAt": "2026-05-08T00:00:00Z",
+  "target": {
+    "workflowId": "mm:target",
+    "runId": "run-target",
+    "title": "Failed target task",
+    "summary": "Needs remediation",
+    "state": "failed",
+    "closeStatus": "FAILED"
+  },
+  "selectedSteps": [
+    {
+      "logicalStepId": "run-tests",
+      "attempt": 1,
+      "taskRunId": "task-run-1",
+      "status": "failed",
+      "summary": "Integration test failed"
+    }
+  ],
+  "evidence": {
+    "targetArtifactRefs": [
+      { "artifact_id": "art_run_summary", "kind": "run_summary" }
+    ],
+    "taskRuns": [
+      {
+        "taskRunId": "task-run-1",
+        "observabilitySummaryRef": { "artifact_id": "art_observability" },
+        "stdoutRef": { "artifact_id": "art_stdout" },
+        "stderrRef": { "artifact_id": "art_stderr" },
+        "mergedLogsRef": { "artifact_id": "art_merged" },
+        "diagnosticsRef": { "artifact_id": "art_diagnostics" },
+        "providerSnapshotRef": { "artifact_id": "art_provider" }
+      }
+    ],
+    "availability": [
+      {
+        "class": "live_follow",
+        "status": "unavailable",
+        "reason": "target is terminal",
+        "fallback": "merged_logs"
+      }
+    ]
+  },
+  "liveFollow": {
+    "status": "unavailable",
+    "mode": "snapshot_then_follow",
+    "supported": false,
+    "taskRunId": "task-run-1",
+    "resumeCursor": null,
+    "reason": "target is terminal",
+    "fallbacks": ["merged_logs", "diagnostics"]
+  },
+  "policies": {
+    "authorityMode": "approval_gated",
+    "actionPolicyRef": "admin_healer_default",
+    "evidencePolicy": {
+      "includeStepLedger": true,
+      "includeDiagnostics": true,
+      "tailLines": 2000
+    },
+    "approvalPolicy": {
+      "mode": "risk_gated",
+      "autoAllowedRisk": "medium"
+    },
+    "lockPolicy": {
+      "scope": "target_execution",
+      "mode": "exclusive"
+    }
+  },
+  "boundedness": {
+    "maxTailLines": 2000,
+    "maxTaskRunIds": 20,
+    "rawLogBodiesIncluded": false,
+    "artifactContentsIncluded": false
+  }
+}
+```
+
+Forbidden payload content:
+- Presigned storage URLs.
+- Storage backend keys.
+- Absolute local filesystem paths.
+- Raw secret values or secret-bearing config bundles.
+- Unbounded log bodies or full diagnostics.
+
+## Typed Tool Surface
+
+These are internal/service contracts. Transport may be Temporal activity, adapter method, or MCP-style tool, but the inputs and outputs stay bounded.
+
+### `remediation.get_context`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation"
+}
+```
+
+Output:
+
+```json
+{
+  "context": "<remediation.context payload>"
+}
+```
+
+Errors:
+- `context_missing`: no linked context artifact.
+- `context_invalid`: linked artifact is not valid remediation context JSON.
+- `permission_denied`: requester cannot read this remediation evidence.
+
+### `remediation.read_target_artifact`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "artifactRef": { "artifact_id": "art_stdout" },
+  "readMode": "preview"
+}
+```
+
+Output:
+
+```json
+{
+  "artifactRef": { "artifact_id": "art_stdout" },
+  "contentType": "text/plain",
+  "payloadRef": "server-mediated-response"
+}
+```
+
+Rules:
+- The artifact ID must appear in the linked context.
+- The read goes through normal artifact authorization.
+- The tool never returns backend storage coordinates.
+
+### `remediation.read_target_logs`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "taskRunId": "task-run-1",
+  "stream": "merged",
+  "cursor": null,
+  "tailLines": 200
+}
+```
+
+Output:
+
+```json
+{
+  "taskRunId": "task-run-1",
+  "stream": "merged",
+  "lines": ["bounded log line"],
+  "nextCursor": "cursor-2"
+}
+```
+
+Rules:
+- `taskRunId` must appear in the linked context.
+- `stream` is one of `stdout`, `stderr`, `merged`, or `diagnostics`.
+- `tailLines` is capped by the context evidence policy.
+
+### `remediation.follow_target_logs`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "taskRunId": "task-run-1",
+  "fromSequence": 3842
+}
+```
+
+Output:
+
+```json
+{
+  "taskRunId": "task-run-1",
+  "events": [
+    {
+      "sequence": 3843,
+      "stream": "stdout",
+      "text": "bounded live line",
+      "timestamp": "2026-05-08T00:00:00Z"
+    }
+  ],
+  "resumeCursor": { "sequence": 3843 }
+}
+```
+
+Rules:
+- Context live-follow state must be active/supported and policy-allowed.
+- The requested task run must match the context live-follow task run.
+- Durable logs and artifacts remain available if the stream disconnects.
+
+### `remediation.prepare_action_request`
+
+Input:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "actionKind": "session.interrupt_turn"
+}
+```
+
+Output:
+
+```json
+{
+  "remediationWorkflowId": "mm:remediation",
+  "actionKind": "session.interrupt_turn",
+  "target": {
+    "workflowId": "mm:target",
+    "pinnedRunId": "run-target",
+    "currentRunId": "run-target",
+    "state": "running",
+    "closeStatus": null,
+    "targetRunChanged": false
+  }
+}
+```
+
+Rules:
+- Must reread target health before side-effecting action execution.
+- Does not execute the action.
+- If `targetRunChanged` is true, downstream action authority must evaluate whether the action is still safe.
+
+## Mission Control Presentation Contract
+
+For each remediation relationship, Mission Control should expose:
+- Context artifact link when `contextArtifactRef` is present.
+- Explicit missing/degraded message when `contextArtifactRef` is absent or evidence availability is degraded.
+- Live observation state when present, with durable artifact/log fallback messaging.
+- Links or labeled entries for decision log, action request/result, verification, target logs, diagnostics, and summaries when those artifacts are present.
+
+Operator-facing labels must not expose raw storage paths, backend keys, or secret-bearing details.

--- a/specs/318-bounded-remediation-evidence/data-model.md
+++ b/specs/318-bounded-remediation-evidence/data-model.md
@@ -1,0 +1,151 @@
+# Data Model: Bounded Remediation Evidence Context
+
+## Remediation Context Artifact
+
+Represents the stable evidence entrypoint for one remediation task.
+
+Fields:
+- `schemaVersion`: version string, currently `v1`.
+- `remediationWorkflowId`: logical workflow ID of the remediation run.
+- `generatedAt`: ISO timestamp for context generation.
+- `target`: `TargetExecutionSnapshot`.
+- `selectedSteps`: ordered list of `SelectedStepEvidence`.
+- `evidence`: `EvidenceBundle`.
+- `liveFollow`: `LiveFollowState`.
+- `policies`: `RemediationPolicySnapshot`.
+- `boundedness`: limits and booleans proving raw logs/artifact bodies are not embedded.
+
+Validation rules:
+- Must be valid JSON and linked as artifact type `remediation.context`.
+- Must be linked to the remediation execution with label `reports/remediation_context.json`.
+- Must not include presigned URLs, storage backend keys, absolute local paths, or secret values.
+- Must include refs and compact summaries only; full evidence bodies remain behind server-mediated reads.
+
+## TargetExecutionSnapshot
+
+Compact target identity pinned for remediation diagnosis.
+
+Fields:
+- `workflowId`: target logical execution ID.
+- `runId`: pinned target run ID for the context.
+- `title`: compact title when available.
+- `summary`: compact summary when available.
+- `state`: current lifecycle state at context generation.
+- `closeStatus`: terminal close status when available.
+
+Validation rules:
+- `workflowId` and `runId` are required.
+- `runId` is the pinned target run, not a mutable latest-run alias.
+
+## SelectedStepEvidence
+
+Optional bounded selector for evidence the remediation task should prioritize.
+
+Fields:
+- `logicalStepId`: optional logical step identifier.
+- `attempt`: optional positive attempt number.
+- `taskRunId`: optional task-run identifier for logs/diagnostics/live follow.
+- `status`: optional compact step status when available.
+- `summary`: optional compact step summary when available.
+- `artifactRefs`: optional list of step-scoped `EvidenceRef` values.
+
+Validation rules:
+- At least one identifying field must be present.
+- Total selected task-run IDs must remain capped by the context builder.
+
+## EvidenceBundle
+
+Collection of server-mediated refs and availability records.
+
+Fields:
+- `targetArtifactRefs`: refs to target-level artifacts such as input, plan, manifest, run summaries, provider snapshots, and continuity artifacts.
+- `taskRuns`: list of `TaskRunEvidence` entries.
+- `availability`: list of `EvidenceAvailabilityRecord` entries.
+- `diagnosisHints`: optional compact hints derived from known state, never raw logs.
+
+Validation rules:
+- All refs are identifiers, not access grants.
+- Missing or unavailable evidence is recorded explicitly rather than causing context generation to deadlock when other evidence remains available.
+
+## TaskRunEvidence
+
+Evidence refs for one target task run.
+
+Fields:
+- `taskRunId`: task-run ID.
+- `observabilitySummaryRef`: optional artifact ref.
+- `stdoutRef`: optional artifact ref.
+- `stderrRef`: optional artifact ref.
+- `mergedLogsRef`: optional artifact ref.
+- `diagnosticsRef`: optional artifact ref.
+- `providerSnapshotRef`: optional artifact ref.
+- `continuityRefs`: optional continuity or control-boundary refs.
+
+Validation rules:
+- `taskRunId` is required.
+- Each ref must be readable only through server-mediated artifact/log surfaces.
+
+## EvidenceAvailabilityRecord
+
+Records evidence class status.
+
+Fields:
+- `class`: evidence class such as `stdout`, `stderr`, `merged_logs`, `diagnostics`, `provider_snapshot`, `continuity`, or `live_follow`.
+- `status`: `available`, `missing`, `partial`, `denied`, `unavailable`, or `fallback_used`.
+- `reason`: compact operator-safe reason when unavailable or degraded.
+- `fallback`: optional fallback evidence class.
+
+Validation rules:
+- Missing, partial, denied, and unavailable evidence must not include sensitive backend details.
+- Historical merged-log-only targets set degraded evidence when richer evidence is absent.
+
+## LiveFollowState
+
+Best-effort live observation state for the target.
+
+Fields:
+- `status`: `active`, `unavailable`, `unsupported`, or `policy_denied`.
+- `mode`: remediation mode, for example `snapshot`, `follow`, or `snapshot_then_follow`.
+- `supported`: boolean compatibility field for the typed evidence tool.
+- `taskRunId`: live-follow target task run when active or selected.
+- `resumeCursor`: compact cursor such as last seen sequence when available.
+- `reason`: compact reason when not active.
+- `fallbacks`: durable fallback evidence classes.
+
+Validation rules:
+- Live follow may be active only when target run is active, target task run supports live follow, and policy permits it.
+- Live follow never replaces durable artifact/log evidence.
+- Cursor state must be compact and safe to carry across retries or continue-as-new boundaries.
+
+## RemediationPolicySnapshot
+
+Compact policy state captured for evidence access and action decisions.
+
+Fields:
+- `authorityMode`: remediation authority mode.
+- `actionPolicyRef`: action policy identifier when present.
+- `evidencePolicy`: bounded evidence policy such as log tail limit and included classes.
+- `approvalPolicy`: compact approval policy.
+- `lockPolicy`: compact target mutation lock policy.
+
+Validation rules:
+- Secret-like keys and values are removed.
+- Unsupported authority/action policy values fail fast elsewhere; context does not invent fallbacks.
+
+## State Transitions
+
+Context generation:
+1. Remediation link exists with target workflow and pinned run.
+2. Builder resolves target record, selected steps, evidence refs, policy snapshots, and live-follow state.
+3. Builder writes restricted `remediation.context` artifact and stores `context_artifact_ref` on the remediation link.
+4. Remediation task uses typed evidence tools to read context, artifacts, logs, or live-follow batches.
+
+Live follow:
+1. `unsupported`, `unavailable`, or `policy_denied` states use durable fallback evidence.
+2. `active` state may advance `resumeCursor` as events are consumed.
+3. Disconnects or retries resume from durable cursor when available.
+
+Action preparation:
+1. Remediation task requests an action.
+2. Typed evidence service rereads current target health.
+3. Action execution proceeds only through a separate authorized action path and publishes bounded lifecycle artifacts.

--- a/specs/318-bounded-remediation-evidence/moonspec_align_report.md
+++ b/specs/318-bounded-remediation-evidence/moonspec_align_report.md
@@ -1,0 +1,42 @@
+# MoonSpec Alignment Report: Bounded Remediation Evidence Context
+
+**Feature**: `318-bounded-remediation-evidence`  
+**Date**: 2026-05-08  
+**Source**: MM-618 canonical Jira preset brief preserved in `spec.md`
+
+## Verdict
+
+PASS. The MoonSpec artifacts are aligned for the next implementation step.
+
+## Checks
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Active feature | PASS | `.specify/feature.json` points to `specs/318-bounded-remediation-evidence`. |
+| Prerequisites | PASS with managed-branch caveat | `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/remediation-evidence.md`, and `tasks.md` all exist. The repository prerequisite script failed because the managed branch name is not numeric. |
+| Single story | PASS | `spec.md` contains exactly one `## User Story - Diagnose With Bounded Evidence` section. |
+| Source preservation | PASS | `spec.md` preserves MM-618 and the canonical Jira preset brief in the Input block. |
+| Clarifications/placeholders | PASS | No unresolved clarification markers or template placeholders were found in the active artifacts. |
+| Requirement coverage | PASS | All 14 `FR-*`, 6 `SC-*`, and 4 `DESIGN-REQ-*` IDs from `spec.md` are referenced in `tasks.md`. |
+| Task format | PASS | `tasks.md` has 45 tasks, all using the required `- [ ] T### [P?] ...` format with sequential IDs. |
+| TDD ordering | PASS | Unit test tasks, integration test tasks, and red-first confirmation tasks precede implementation tasks. |
+| Final verification | PASS | `tasks.md` includes final `/moonspec-verify` work. |
+| Constitution alignment | PASS | `plan.md` records PASS for all constitution gates and no complexity exceptions. |
+
+## Decisions
+
+- **Prerequisite script failure**: Used `.specify/feature.json` as the active feature locator because `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` failed on the managed branch name `run-jira-orchestrate-for-mm-618-build-bo-5fae104f`.
+- **No artifact regeneration**: Chose not to regenerate `spec.md`, `plan.md`, design artifacts, or `tasks.md` because validation found complete coverage, coherent ordering, and no higher-authority conflicts.
+- **Integration command specificity**: Kept `./tools/test_integration.sh` as the canonical integration command because repo instructions identify it as the required hermetic integration runner; focused integration targets remain described as task intent rather than replacing the canonical command.
+
+## Remaining Risks
+
+- Implementation has not started; `plan.md` intentionally marks live-follow capability resolution, real task-run evidence adapter binding, degraded evidence records, and full Mission Control evidence presentation as partial.
+- The prerequisite scripts remain branch-name sensitive in this managed run. Downstream stages should continue using `.specify/feature.json` when the scripts fail for the same reason.
+
+## Validation Evidence
+
+- Direct artifact existence check: PASS.
+- Direct coverage check for `FR-*`, `SC-*`, and `DESIGN-REQ-*` IDs in `tasks.md`: PASS.
+- Direct task format and ordering check: PASS.
+- Prerequisite script: BLOCKED by managed branch name before artifact validation.

--- a/specs/318-bounded-remediation-evidence/plan.md
+++ b/specs/318-bounded-remediation-evidence/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Bounded Remediation Evidence Context
+
+**Branch**: `318-bounded-remediation-evidence` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:a6d63116-cfbf-4474-90db-6af6f461079b/repo/specs/318-bounded-remediation-evidence/spec.md`
+
+## Summary
+
+Deliver MM-618 by completing the remediation evidence story around a bounded `reports/remediation_context.json` artifact, typed remediation evidence tools, policy-gated live follow, durable fallbacks, and Mission Control evidence presentation. Repo analysis found substantial existing implementation in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_tools.py`, task-run observability routes, and Mission Control remediation panels. Remaining work should focus on closing partial behavior and proof gaps: real task-run log/live-follow adapter binding, live-follow capability state generation, explicit unavailable-evidence/degraded-evidence recording in context payloads, and hermetic integration coverage across remediation creation, context artifact publication, typed evidence reads, and UI evidence presentation.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `RemediationContextBuilder.build_context()` creates and links `reports/remediation_context.json`; `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_context_builder_creates_bounded_linked_artifact` | preserve behavior; add end-to-end integration proof | integration |
+| FR-002 | partial | Context payload includes target, selected steps, task run IDs, target artifact refs, policies, and liveFollow stub in `remediation_context.py`; observability refs/compact summaries are not fully resolved from task-run surfaces | extend builder to resolve observability summary/log/diagnostic refs and compact availability metadata | unit + integration |
+| FR-003 | implemented_verified | Builder stores refs and `boundedness.rawLogBodiesIncluded = False`; unit assertions cover bounded payload | preserve behavior; include regression in integration artifact payload check | integration |
+| FR-004 | implemented_verified | Sanitization helpers and tests reject presigned URLs, local paths, secret-like policy keys, and secret-bearing payloads | preserve behavior | none beyond final verify |
+| FR-005 | implemented_verified | `RemediationEvidenceToolService` gates context, artifact, log, live-follow, and action-prep access through typed methods and context membership checks | preserve behavior; expose through worker/activity boundary if not already bound | integration |
+| FR-006 | partial | `read_target_artifact()` and `read_target_logs()` exist and unit tests use injected readers; real task-run log reader adapter is not proven in repo evidence | bind remediation log reader to existing task-run observability/log services without raw storage exposure | unit + integration |
+| FR-007 | partial | `follow_target_logs()` enforces context support/policy, but builder currently emits `supported: False` and does not compute live capability from target activity/task run state | add live-follow capability resolution from target task-run support and policy | unit + integration |
+| FR-008 | partial | Live follower supports resume cursors and cursor recorder in service-level tests; durable fallback remains separate from live-follow state generation | persist/resume live cursor through remediation context or compact runtime state and document fallback path | unit + integration |
+| FR-009 | partial | Task-run routes expose stdout/stderr/merged/diagnostics and Mission Control shows fallback messaging; remediation tool fallback orchestration is not fully proven | ensure non-live paths return durable merged/stdout/stderr/diagnostics refs or read results when live follow is unavailable | unit + integration |
+| FR-010 | partial | Summary helpers can record `evidenceDegraded`, unavailable evidence, and fallbacks; builder does not yet compute missing evidence classes consistently | compute and persist evidence availability records in context payload and tool responses | unit + integration |
+| FR-011 | partial | Summary helpers model degraded evidence and UI has degraded-state coverage; historical target context generation with merged-log-only evidence is not proven | add historical target case with merged logs and partial artifacts | unit + integration |
+| FR-012 | partial | Mission Control renders remediation evidence bundle, degraded state, approval, and links; referenced target logs/diagnostics/decision/action/verification artifacts are only partially exercised | expand UI/API contract evidence to cover all remediation evidence artifact classes and live observation state | unit + integration |
+| FR-013 | implemented_verified | `prepare_action_request()` rereads target execution state before action and unit test covers target run changes | preserve behavior; include in action-boundary integration test if action execution is touched | integration |
+| FR-014 | implemented_verified | `spec.md` preserves MM-618 and canonical preset brief; this plan preserves traceability | preserve MM-618 in all downstream artifacts and PR metadata | final verify |
+| Scenario 1 | partial | Context builder publishes linked artifact after remediation link exists | ensure artifact is generated before diagnostic work starts in real run lifecycle | integration |
+| Scenario 2 | implemented_verified | Unit tests prove context contains refs/summaries and excludes raw logs/secrets | preserve with integration payload assertion | integration |
+| Scenario 3 | partial | Live-follow service can follow only when context says supported; builder does not yet set support dynamically | implement capability resolver and test active supported target | unit + integration |
+| Scenario 4 | partial | UI and task-run routes support durable fallback messaging/reads; remediation service fallback flow needs proof | add unavailable/denied/disconnected live-follow cases | unit + integration |
+| Scenario 5 | partial | Degraded evidence summary helpers and UI messages exist; context builder does not compute degraded evidence for historical/partial targets | add evidence availability/degraded fields and tests | unit + integration |
+| Scenario 6 | partial | Mission Control renders context artifact link and degraded state; all evidence classes are not yet covered | expand API/UI tests for decision, action, verification, diagnostics, and live observation links | unit + integration |
+| SC-001 | partial | Builder creates artifact when called; lifecycle timing before diagnostics is not proven | wire or verify builder invocation at remediation startup | integration |
+| SC-002 | implemented_verified | Unit tests assert no raw logs, presigned URLs, local paths, or secrets in context/lifecycle payloads | preserve behavior | none beyond final verify |
+| SC-003 | partial | Live-follow states are not fully normalized in context builder | add explicit active/unavailable/unsupported/policy_denied state contract | unit + integration |
+| SC-004 | partial | Degraded state helpers exist; builder/tool outputs do not consistently list missing classes | add availability records and historical partial-evidence tests | unit + integration |
+| SC-005 | partial | UI links context artifact; all referenced evidence classes need coverage | expand Mission Control evidence rendering tests | unit + integration |
+| SC-006 | implemented_verified | Spec and plan preserve MM-618 and source IDs | preserve in tasks, verification, commit, and PR metadata | final verify |
+| DESIGN-REQ-008 | partial | Context builder exists but needs richer evidence refs and compact summaries | complete evidence resolution and availability metadata | unit + integration |
+| DESIGN-REQ-009 | implemented_verified | Artifact/log access remains server-mediated and restricted; typed tools enforce context membership | preserve; add adapter-boundary coverage | integration |
+| DESIGN-REQ-010 | partial | Live-follow tool exists but capability/policy state generation is incomplete | implement live-follow state resolution and cursor persistence proof | unit + integration |
+| DESIGN-REQ-025 | partial | UI/degraded helpers exist but historical/partial evidence path is incomplete | add degraded evidence and presentation coverage | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control evidence presentation  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK activity/workflow boundaries, existing Temporal artifact service, existing task-run observability/log routes, React, TanStack Query, Zod  
+**Storage**: Existing `execution_remediation_links`, `temporal_execution_sources`/canonical execution records, Temporal artifact metadata/content store, managed-run observability artifacts; no new persistent database table planned  
+**Unit Testing**: `pytest` through `./tools/test_unit.sh`; focused Python tests under `tests/unit/workflows/temporal/test_remediation_context.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`; focused frontend tests through `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` or `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` after dependencies are prepared  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci`; add targeted integration coverage under `tests/integration/temporal/` or `tests/integration/workflows/temporal/` only when it can run within CI constraints  
+**Target Platform**: Linux server/container deployment with FastAPI API service, Temporal workers, local artifact store, and Mission Control web UI  
+**Project Type**: Full-stack orchestration feature touching backend services, Temporal activity/service boundaries, artifact/log contracts, and Mission Control task detail UI  
+**Performance Goals**: Context artifacts remain bounded; default log tail stays capped at 2000 lines; no unbounded log bodies or rich diagnostics enter workflow history  
+**Constraints**: Server-mediated artifact/log access only; no presigned URLs, storage keys, local paths, or secrets in durable context; live follow is best effort and never authoritative; workflow history carries refs and compact metadata only  
+**Scale/Scope**: One remediation task targets one logical execution and selected task-run evidence; cap selected task run IDs and evidence summaries to bounded payload size
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Result | Notes |
+| --- | --- | --- |
+| I. Orchestrate, Don't Recreate | PASS | Uses MoonMind orchestration services and existing agent/runtime observability, not a new agent engine. |
+| II. One-Click Agent Deployment | PASS | Plans reuse existing FastAPI/Temporal/artifact services and local test paths; no new mandatory external SaaS. |
+| III. Avoid Vendor Lock-In | PASS | Evidence contracts are MoonMind-owned refs and typed surfaces, not provider-specific storage URLs. |
+| IV. Own Your Data | PASS | Evidence remains in MoonMind artifacts/log stores on operator-controlled infrastructure. |
+| V. Skills Are First-Class and Easy to Add | PASS | No skill runtime mutation is planned; remediation evidence surfaces remain adapter/service boundaries. |
+| VI. Scientific Method / Replaceable Scaffolding | PASS | Plan requires unit and integration proof before implementation claims. |
+| VII. Runtime Configurability | PASS | Live-follow and policy decisions derive from request/runtime policy rather than hardcoded unrestricted access. |
+| VIII. Modular and Extensible Architecture | PASS | Work stays in remediation context/tool services, Temporal artifact boundary, task-run observability, and UI contracts. |
+| IX. Resilient by Default | PASS | Context and cursor state are durable/bounded; missing evidence degrades explicitly instead of deadlocking. |
+| X. Continuous Improvement | PASS | Remediation evidence and decision artifacts support structured outcomes and follow-up analysis. |
+| XI. Spec-Driven Development | PASS | `spec.md` is present and this plan preserves MM-618 traceability. |
+| XII. Canonical Docs vs Migration Backlog | PASS | Implementation details remain in this feature plan/artifacts, not canonical docs. |
+| XIII. Pre-Release Velocity | PASS | Plan avoids compatibility aliases for internal remediation contracts; unsupported values should fail fast. |
+
+Post-design re-check: PASS. The Phase 1 artifacts below preserve the same boundaries and introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/318-bounded-remediation-evidence/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-evidence.md
+└── tasks.md              # Phase 2 output; not created by this step
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── remediation_context.py
+├── remediation_tools.py
+├── remediation_actions.py
+├── artifacts.py
+└── runtime/
+
+api_service/
+├── api/routers/
+│   ├── executions.py
+│   ├── task_runs.py
+│   └── temporal_artifacts.py
+├── db/models.py
+└── migrations/versions/
+
+frontend/src/
+├── entrypoints/task-detail.tsx
+├── entrypoints/task-detail.test.tsx
+└── styles/mission-control.css
+
+tests/
+├── unit/workflows/temporal/
+├── unit/api/routers/
+├── unit/api/
+└── integration/temporal/
+```
+
+**Structure Decision**: Use the existing full-stack MoonMind structure. Backend remediation evidence logic belongs at service/activity boundaries under `moonmind/workflows/temporal/`, API read/projection contracts stay under `api_service/api/routers/`, persistence remains in existing SQLAlchemy models and migrations, Mission Control evidence presentation stays in `frontend/src/entrypoints/task-detail.tsx`, and tests follow the existing unit plus hermetic integration taxonomy.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are planned.

--- a/specs/318-bounded-remediation-evidence/quickstart.md
+++ b/specs/318-bounded-remediation-evidence/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Bounded Remediation Evidence Context
+
+## Prerequisites
+
+- Python 3.12 environment for backend tests.
+- Node/npm dependencies prepared by `./tools/test_unit.sh` when frontend tests are enabled.
+- No external credentials are required for the planned unit and hermetic integration tests.
+
+## Test-First Flow
+
+1. Confirm the active feature:
+
+   ```bash
+   sed -n '1,40p' .specify/feature.json
+   ```
+
+2. Add or update focused backend unit tests first:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+   ```
+
+   Expected red-first targets:
+   - context builder resolves observability/log/diagnostic/provider refs into `evidence.taskRuns`;
+   - context builder records unavailable evidence classes and degraded historical targets;
+   - live-follow state reports `active`, `unavailable`, `unsupported`, or `policy_denied`;
+   - remediation log reader adapter reads only task runs declared by context;
+   - `prepare_action_request` continues to reread target health before side effects.
+
+3. Add or update API/router unit tests where serialization or permissions change:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py
+   ```
+
+4. Add or update Mission Control tests for evidence presentation:
+
+   ```bash
+   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+   ```
+
+   Expected red-first targets:
+   - all remediation evidence artifact classes are discoverable from the remediation panel;
+   - live observation state is distinct from durable fallback evidence;
+   - degraded evidence messages remain visible and accessible.
+
+5. Implement the smallest backend/UI changes needed to pass the focused tests.
+
+6. Run the full unit suite:
+
+   ```bash
+   ./tools/test_unit.sh
+   ```
+
+7. Add hermetic integration coverage for the full evidence path when code changes cross service boundaries:
+
+   ```bash
+   ./tools/test_integration.sh
+   ```
+
+   Integration proof should cover:
+   - remediation task creation with a target execution;
+   - context artifact publication and `context_artifact_ref` linkage before diagnostic work;
+   - typed read of declared target artifacts/logs through server-mediated surfaces;
+   - live-follow unavailable fallback to durable logs/artifacts;
+   - no presigned URLs, storage keys, local paths, or secrets in context payload.
+
+## End-to-End Validation
+
+For a seeded or test-created target execution:
+
+1. Create a remediation task with `mode = snapshot_then_follow`.
+2. Confirm the remediation link has `contextArtifactRef`.
+3. Download/read the linked `remediation.context` artifact through the artifact API.
+4. Confirm the payload includes target identity, selected task-run evidence, policy snapshots, availability records, and live-follow state.
+5. Confirm the payload excludes raw log bodies, storage paths, presigned URLs, and secrets.
+6. Confirm declared logs/artifacts can be read through typed remediation evidence surfaces.
+7. Confirm an undeclared artifact or task run is rejected.
+8. Confirm Mission Control renders the context, evidence classes, degraded state, and live-follow/fallback messaging.
+
+## Requirement Status Reflection
+
+- `missing`: none identified.
+- `partial`: FR-002, FR-006 through FR-012, scenarios involving live follow/degraded evidence/presentation, SC-001, SC-003 through SC-005, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-025.
+- `implemented_verified`: FR-001, FR-003, FR-004, FR-005, FR-013, FR-014, SC-002, SC-006, DESIGN-REQ-009.
+
+Do not proceed to `/speckit.tasks` until `plan.md`, `research.md`, `data-model.md`, this quickstart, and `contracts/remediation-evidence.md` remain mutually consistent.

--- a/specs/318-bounded-remediation-evidence/research.md
+++ b/specs/318-bounded-remediation-evidence/research.md
@@ -1,0 +1,81 @@
+# Research: Bounded Remediation Evidence Context
+
+## Scope Classification
+
+Decision: MM-618 remains one runtime story, not a broad design needing breakdown.
+Evidence: `/work/agent_jobs/mm:a6d63116-cfbf-4474-90db-6af6f461079b/repo/specs/318-bounded-remediation-evidence/spec.md` contains exactly one `## User Story - Diagnose With Bounded Evidence` and preserves MM-618 as the canonical Jira preset brief.
+Rationale: The Jira brief selects one independently testable remediation evidence behavior from `docs/Tasks/TaskRemediation.md`: bounded context plus typed evidence/live-follow access.
+Alternatives considered: Running `moonspec-breakdown` was rejected because no multiple independently testable stories are required by MM-618.
+Test implications: none beyond final traceability verification.
+
+## Existing Remediation Context Builder
+
+Decision: Mark context creation as implemented for basic linked artifact creation, but partial for rich evidence resolution.
+Evidence: `moonmind/workflows/temporal/remediation_context.py` defines `RemediationContextBuilder`, `REMEDIATION_CONTEXT_ARTIFACT_NAME = "reports/remediation_context.json"`, restricted artifact creation, link update through `context_artifact_ref`, boundedness flags, target artifact refs, selected steps, task run IDs, and policy snapshots. `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_context_builder_creates_bounded_linked_artifact` verifies artifact creation, linkage, metadata, persisted refs, and bounded payload.
+Rationale: The core artifact-builder shape exists, but the current payload does not yet prove full observability-summary, stdout/stderr/merged/diagnostic refs, provider snapshot refs, compact summaries, or unavailable-evidence records for all target evidence classes.
+Alternatives considered: Treating the builder as complete was rejected because MM-618 requires typed evidence availability and degraded evidence, not only a linked context artifact.
+Test implications: add unit tests for richer context payload construction and an integration test proving artifact generation before remediation diagnostic work.
+
+## Boundedness And Redaction
+
+Decision: Mark boundedness and secret-safety requirements as implemented_verified.
+Evidence: `remediation_context.py` stores refs instead of artifact bodies, sets `rawLogBodiesIncluded` and `artifactContentsIncluded` false, restricts redaction level, and sanitizes policy/lifecycle payloads. Unit tests in `test_remediation_context.py` assert no presigned URLs, raw secrets, or raw local paths are serialized in context, lifecycle, audit, and guard payloads.
+Rationale: Current implementation and tests directly cover the strongest safety constraints in MM-618.
+Alternatives considered: Adding new persistent redaction storage was rejected; the artifact service metadata and sanitized JSON payloads are enough for this story.
+Test implications: preserve unit coverage and include one integration payload assertion that the generated context contains no forbidden raw access values.
+
+## Typed Evidence Access Surface
+
+Decision: Mark typed evidence tools as implemented_verified for service-level membership checks, partial for real log/live-follow adapter binding.
+Evidence: `moonmind/workflows/temporal/remediation_tools.py` provides `get_context`, `read_target_artifact`, `read_target_logs`, `follow_target_logs`, `prepare_action_request`, and `execute_action`. The service reads only the linked context artifact, rejects artifacts and task run IDs not listed in context, normalizes log streams, caps tail lines from context policy, and rereads target health before actions. Unit tests cover declared evidence reads, live-follow gating, action prep, and action lifecycle artifacts.
+Rationale: The typed API boundary exists, but injected log/live-follow readers remain runtime adapters. The plan must prove or implement binding to existing `/api/task-runs` observability/log surfaces or equivalent internal services.
+Alternatives considered: Giving remediation tasks raw URLs or filesystem paths was rejected by the spec and constitution.
+Test implications: add adapter-boundary unit tests plus hermetic integration exercising target log/diagnostic reads through the real server-mediated path.
+
+## Live Follow Semantics
+
+Decision: Mark live-follow requirements partial.
+Evidence: `RemediationEvidenceToolService.follow_target_logs()` requires context `liveFollow.supported is True`, allowed mode, declared taskRunId membership, and resumes from a sequence cursor. `api_service/api/routers/task_runs.py` exposes live SSE via `/task-runs/{id}/logs/stream` with `since` support and terminal-run fallback behavior. Mission Control tests cover live logs and artifact fallback.
+Rationale: The follow primitive and task-run stream exist, but `RemediationContextBuilder` currently emits `supported: False` and does not compute `active`, `unavailable`, `unsupported`, or `policy_denied` state from target activity, taskRun support, and policy. Cursor persistence is service-injectable but not yet proven in a remediation lifecycle integration.
+Alternatives considered: Treating live-follow as authoritative was rejected; durable artifacts/logs remain the fallback and source of truth.
+Test implications: add unit cases for each live-follow state and integration coverage for active supported and unavailable fallback paths.
+
+## Evidence Availability And Degraded Targets
+
+Decision: Mark degraded evidence support partial.
+Evidence: `build_remediation_summary_block()` supports `evidenceDegraded`, `unavailableEvidenceClasses`, and `fallbacksUsed`; Mission Control tests render degraded remediation states. The context builder does not yet compute missing stdout/stderr/diagnostics/provider snapshot/continuity classes into a first-class availability record.
+Rationale: MM-618 requires every missing evidence class to be recorded without deadlock. Existing helpers are useful, but the context artifact and typed tool responses need consistent availability semantics.
+Alternatives considered: Failing remediation when evidence is incomplete was rejected because historical and degraded targets must remain diagnosable.
+Test implications: add unit tests for historical merged-log-only target, partial artifact refs, and unavailable live follow; add integration proof that diagnosis can proceed with degraded evidence.
+
+## Mission Control Evidence Presentation
+
+Decision: Mark Mission Control presentation partial.
+Evidence: `frontend/src/entrypoints/task-detail.tsx` renders remediation relationship panels, evidence bundle status, context artifact download links, approval summaries, and degraded messages. `frontend/src/entrypoints/task-detail.test.tsx` covers evidence link rendering, degraded states, approval controls, and containment/accessibility styling.
+Rationale: UI coverage demonstrates the context artifact and degraded states, but MM-618 calls out direct access to target logs, diagnostics, decision logs, action request/results, verification artifacts, and live observation state. The existing UI should be expanded or verified for all remediation evidence artifact classes.
+Alternatives considered: Relying only on artifact list generic rendering was rejected because operators need evidence classes to be discoverable from the remediation panel.
+Test implications: add focused UI tests for all evidence artifact classes and live observation/fallback state.
+
+## Unit Test Strategy
+
+Decision: Use focused `pytest` unit tests for backend service models/builders/tools and frontend Vitest tests for task detail evidence presentation.
+Evidence: Existing unit coverage lives in `tests/unit/workflows/temporal/test_remediation_context.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, and `frontend/src/entrypoints/task-detail.test.tsx`.
+Rationale: The story spans deterministic builders, typed access services, API serialization, and React rendering, which are all suitable for focused unit tests.
+Alternatives considered: Only broad integration tests were rejected because they would make failure diagnosis slower and would not prove small contract details.
+Test implications: run `./tools/test_unit.sh` before final verification; for focused frontend iteration use `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`.
+
+## Integration Test Strategy
+
+Decision: Add hermetic integration coverage for the real remediation context/evidence boundary only where it can stay within required CI timeouts.
+Evidence: Repo instructions require `./tools/test_integration.sh` for tests marked `integration_ci`; existing high-risk seams include artifacts, worker topology, and live logs.
+Rationale: MM-618 crosses artifact publication, execution records, task-run evidence, and UI/API contracts. Unit tests alone are insufficient for final proof that context artifacts are linked before diagnostic work and that evidence reads remain server-mediated.
+Alternatives considered: Temporal time-skipping workflow tests were rejected for required CI because repo instructions say those are not marked `integration_ci` due timeout risk.
+Test implications: create or update hermetic integration tests under `tests/integration/temporal/` and run `./tools/test_integration.sh` when integration coverage is added.
+
+## No New Persistent Storage
+
+Decision: Reuse existing remediation link, execution record, artifact metadata/content, and managed-run observability stores.
+Evidence: `api_service/db/models.py` already has `TemporalExecutionRemediationLink.context_artifact_ref`; migration `221_remediation_context_artifacts.py` adds the context artifact ref; artifact service stores context/lifecycle payloads.
+Rationale: MM-618 requires durable evidence artifacts, not a new database table. Availability and live-follow cursor state can live in bounded artifacts or existing compact remediation state.
+Alternatives considered: A new remediation evidence table was rejected because it would duplicate artifact-backed context and increase migration scope.
+Test implications: tests should verify existing DB rows and artifact refs rather than new persistence.

--- a/specs/318-bounded-remediation-evidence/spec.md
+++ b/specs/318-bounded-remediation-evidence/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Bounded Remediation Evidence Context
+
+**Feature Branch**: `318-bounded-remediation-evidence`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-618 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-618 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-618
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Build bounded remediation evidence context and live follow tools
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or recommended preset instructions.
+- Trusted response artifact: `/work/agent_jobs/mm:a6d63116-cfbf-4474-90db-6af6f461079b/artifacts/moonspec-inputs/MM-618-trusted-jira-get-issue-sanitized.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-618 from MM project
+Summary: Build bounded remediation evidence context and live follow tools
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-618 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-618: Build bounded remediation evidence context and live follow tools
+
+Source Reference
+Source Document: docs/Tasks/TaskRemediation.md
+Source Title: Task Remediation
+Source Sections:
+- 9. Evidence and context model
+- 10.5 Artifact and log access mediation
+- 15.4 Evidence presentation
+- 15.5 Live follow behavior
+- 16.3 Historical target has only merged logs
+- 16.4 Missing or partial artifact refs
+- 16.5 Live follow unavailable
+Coverage IDs:
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-025
+
+As a remediation task, I receive a bounded artifact-first context bundle plus typed evidence and live-follow access so that I can diagnose a target without scraping Mission Control, importing unbounded logs, or receiving raw storage access.
+
+Acceptance Criteria
+- reports/remediation_context.json is generated up front and linked to the remediation task.
+- The context artifact contains refs and compact summaries, not unbounded logs, presigned URLs, raw storage keys, local paths, or secrets.
+- Live follow starts only when target activity, taskRun support, and policy permit it; otherwise logs and artifacts remain available.
+- Evidence access is through typed MoonMind-owned surfaces, and every missing evidence class is recorded without deadlock.
+
+Requirements
+- Evidence is artifact-first and server-mediated.
+- Live follow is optional, cursor-resumable, and not authoritative.
+- Remediation can diagnose historical or degraded targets.
+
+## Relevant Linked Issues
+
+- MM-617 (blocks): Create canonical remediation submissions with durable target links [Story, Done]
+- MM-619 (is blocked by): Enforce remediation authority, policy profiles, and secret-safe access [Story, Backlog]
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+## Classification
+
+Input classification: single-story runtime feature request. The Jira brief selects one independently testable remediation behavior from `docs/Tasks/TaskRemediation.md`: provide a bounded evidence context and optional live-follow access for remediation tasks. It does not require story splitting.
+
+Resume decision: no existing Moon Spec feature directory or later-stage artifacts matched `MM-618` under `specs/`, so Specify is the first incomplete stage.
+
+## User Story - Diagnose With Bounded Evidence
+
+**Summary**: As a remediation task, I want a bounded artifact-first context bundle with typed evidence access and optional live-follow state so I can diagnose a target execution without scraping Mission Control, importing unbounded logs, or receiving raw storage access.
+
+**Goal**: Remediation starts with a stable context artifact that identifies the target, selected evidence, policy snapshots, compact summaries, and degraded evidence state, while all detailed artifacts and logs remain available only through server-mediated references or typed access surfaces.
+
+**Independent Test**: Create a remediation run for a target execution that has step evidence, artifact refs, and managed-run observability, then verify the remediation context artifact is linked before the remediation task begins, contains only bounded refs and summaries, exposes typed evidence access including optional live-follow state when allowed, and records missing evidence without blocking diagnosis.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid remediation task is created for a target execution, **When** the remediation task starts, **Then** it has a linked `reports/remediation_context.json` context artifact containing target identity, selected steps, compact summaries, evidence refs, policy snapshots, and current evidence availability.
+2. **Given** target logs, diagnostics, provider snapshots, and continuity artifacts are available, **When** the context artifact is generated, **Then** it stores refs and bounded summaries instead of unbounded log bodies, presigned URLs, storage backend keys, absolute local paths, or secret-bearing config.
+3. **Given** the target is active, its task run supports live follow, and policy permits live observation, **When** remediation evidence is prepared, **Then** the context includes live-follow support and a resumable cursor while durable logs and artifacts remain available as the authoritative fallback.
+4. **Given** live follow is unavailable, disconnected, unsupported, or denied by policy, **When** the remediation task reads evidence, **Then** it can continue through durable logs, diagnostics, summaries, and artifact refs, with the unavailable evidence class recorded.
+5. **Given** the target is historical or evidence is partial, **When** the remediation task diagnoses the target, **Then** degraded evidence is represented explicitly and does not deadlock remediation.
+6. **Given** an operator inspects remediation evidence in Mission Control, **When** the detail view is rendered, **Then** the operator can reach the context artifact, referenced target logs and diagnostics, decision log, action result evidence, verification evidence, and live observation state when present.
+
+### Edge Cases
+
+- Historical targets with only merged logs are still diagnosable and are marked as degraded evidence.
+- Missing stdout, stderr, diagnostics, continuity, or provider snapshot refs are recorded by evidence class while available evidence remains usable.
+- Live follow can disconnect, restart, or cross a managed-session epoch boundary; the user-visible state preserves the last durable sequence position when available.
+- Unauthorized artifact or log access does not leak raw storage details or target existence beyond the requester's permitted scope.
+- A remediation task that later considers a side-effecting action must refresh the target health view instead of relying only on the initial context snapshot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST generate and link a remediation context artifact before the remediation task starts diagnostic work.
+- **FR-002**: The remediation context artifact MUST identify the remediation run, target execution, target run, selected steps, evidence refs, compact summaries, live-follow capability state, action policy snapshot, approval policy snapshot, and lock policy snapshot when those values are available.
+- **FR-003**: The remediation context artifact MUST remain bounded by storing refs, compact summaries, compact diagnosis hints, and availability metadata instead of unbounded full logs or raw diagnostic bodies.
+- **FR-004**: The remediation context artifact MUST NOT contain presigned storage URLs, storage backend keys, absolute local filesystem paths, raw secret-bearing config bundles, or secret values.
+- **FR-005**: Remediation evidence access MUST be artifact-first and server-mediated through typed MoonMind-owned surfaces rather than Mission Control page scraping or raw storage access.
+- **FR-006**: Remediation tasks MUST be able to read referenced target artifacts and bounded target logs through policy-enforced access surfaces.
+- **FR-007**: Live follow MUST start only when the target run is active, the target task run supports live follow, and policy permits live observation.
+- **FR-008**: Live follow MUST be optional, best effort, cursor-resumable when possible, and never the only available evidence path.
+- **FR-009**: When live follow is unavailable, System MUST fall back to durable merged logs, stdout logs, stderr logs, diagnostics, summaries, or artifact refs as available.
+- **FR-010**: System MUST record unavailable, missing, partial, or denied evidence classes in the remediation context or evidence read result without blocking diagnosis when enough other evidence remains available.
+- **FR-011**: Historical target diagnosis MUST support merged logs and partial artifacts, and MUST expose an explicit degraded-evidence indicator when evidence is incomplete.
+- **FR-012**: Mission Control MUST present direct operator access to the remediation context artifact, referenced target logs and diagnostics, remediation decision log, action request or result artifacts, verification artifacts, and live observation state when available.
+- **FR-013**: Before a remediation task performs a side-effecting action, System MUST require a fresh bounded target health view so actions are not based only on stale initial evidence.
+- **FR-014**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-618` and this canonical Jira preset brief.
+
+### Key Entities
+
+- **Remediation Context Artifact**: The stable evidence entrypoint linked to a remediation task; contains target identity, selected steps, evidence refs, bounded summaries, policy snapshots, live-follow state, and evidence availability.
+- **Evidence Ref**: A server-mediated reference to target logs, diagnostics, summaries, provider snapshots, continuity artifacts, decision logs, action results, or verification evidence.
+- **Live Follow State**: Best-effort observation metadata for an active target task run, including support state, policy allowance, task-run identity, reconnect state, epoch boundary information when relevant, and resume cursor when available.
+- **Evidence Availability Record**: A compact record of evidence classes that are available, missing, partial, denied, degraded, or replaced by fallback evidence.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-008** (`docs/Tasks/TaskRemediation.md` section 9, Evidence and context model): Remediation must receive a MoonMind-owned context bundle containing target identity, selected steps, observability refs, bounded summaries, live-follow state when applicable, and policy snapshots. Scope: in scope. Mapped to FR-001, FR-002, FR-003, FR-010.
+- **DESIGN-REQ-009** (`docs/Tasks/TaskRemediation.md` section 10.5, Artifact and log access mediation): Remediation evidence and logs must remain server-mediated and must not expose raw storage URLs, backend keys, local paths, or secret-bearing config. Scope: in scope. Mapped to FR-004, FR-005, FR-006.
+- **DESIGN-REQ-010** (`docs/Tasks/TaskRemediation.md` sections 9.6 and 15.5, Live follow semantics and behavior): Live follow must be optional, policy-gated, cursor-resumable when possible, clearly observable, and backed by durable evidence fallbacks. Scope: in scope. Mapped to FR-007, FR-008, FR-009, FR-012.
+- **DESIGN-REQ-025** (`docs/Tasks/TaskRemediation.md` sections 15.4, 16.3, 16.4, and 16.5, Evidence presentation and degraded evidence): Operators and remediation tasks must be able to use context artifacts, logs, diagnostics, decision evidence, partial artifacts, and merged-log fallbacks while recording degraded or missing evidence. Scope: in scope. Mapped to FR-010, FR-011, FR-012, FR-013.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of accepted remediation tasks receive a linked remediation context artifact before diagnostic work starts.
+- **SC-002**: Context artifacts generated for targets with logs contain refs and bounded summaries, and contain zero unbounded log bodies, presigned URLs, storage backend keys, absolute local paths, or secret values.
+- **SC-003**: Live-follow setup reports one of the explicit states `active`, `unavailable`, `unsupported`, or `policy_denied`, and every non-active state includes durable fallback evidence when available.
+- **SC-004**: Historical or partial-evidence targets produce an explicit degraded-evidence indicator and list each missing evidence class without blocking diagnosis.
+- **SC-005**: Operator-facing evidence presentation links the context artifact and every available referenced evidence class for the remediation task.
+- **SC-006**: Traceability evidence preserves `MM-618`, the canonical Jira preset brief, and DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-025 in downstream MoonSpec artifacts.

--- a/specs/318-bounded-remediation-evidence/tasks.md
+++ b/specs/318-bounded-remediation-evidence/tasks.md
@@ -18,10 +18,10 @@
 
 **Purpose**: Confirm the active MoonSpec artifacts and test surfaces before story work.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/318-bounded-remediation-evidence` and that `specs/318-bounded-remediation-evidence/spec.md` contains exactly one `## User Story - Diagnose With Bounded Evidence` section for MM-618.
-- [ ] T002 Confirm planning artifacts exist and are mutually consistent in `specs/318-bounded-remediation-evidence/plan.md`, `specs/318-bounded-remediation-evidence/research.md`, `specs/318-bounded-remediation-evidence/data-model.md`, `specs/318-bounded-remediation-evidence/contracts/remediation-evidence.md`, and `specs/318-bounded-remediation-evidence/quickstart.md`.
-- [ ] T003 [P] Confirm Python unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` is available for `tests/unit/workflows/temporal/test_remediation_context.py`, `tests/unit/api/routers/test_executions.py`, and `tests/unit/api/routers/test_task_runs.py`.
-- [ ] T004 [P] Confirm frontend unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` is available.
+- [X] T001 Confirm `.specify/feature.json` points to `specs/318-bounded-remediation-evidence` and that `specs/318-bounded-remediation-evidence/spec.md` contains exactly one `## User Story - Diagnose With Bounded Evidence` section for MM-618.
+- [X] T002 Confirm planning artifacts exist and are mutually consistent in `specs/318-bounded-remediation-evidence/plan.md`, `specs/318-bounded-remediation-evidence/research.md`, `specs/318-bounded-remediation-evidence/data-model.md`, `specs/318-bounded-remediation-evidence/contracts/remediation-evidence.md`, and `specs/318-bounded-remediation-evidence/quickstart.md`.
+- [X] T003 [P] Confirm Python unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` is available for `tests/unit/workflows/temporal/test_remediation_context.py`, `tests/unit/api/routers/test_executions.py`, and `tests/unit/api/routers/test_task_runs.py`.
+- [X] T004 [P] Confirm frontend unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` is available.
 - [ ] T005 [P] Confirm hermetic integration test tooling for `./tools/test_integration.sh` is available and identify the target integration file under `tests/integration/temporal/test_remediation_evidence_context.py`.
 
 ---
@@ -32,7 +32,7 @@
 
 **CRITICAL**: No production implementation work starts until foundational fixtures and red-first tests are in place.
 
-- [ ] T006 Extend remediation context unit-test fixtures for target task-run evidence, observability refs, log refs, diagnostics refs, provider snapshots, continuity refs, and historical partial-evidence targets in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
+- [X] T006 Extend remediation context unit-test fixtures for target task-run evidence, observability refs, log refs, diagnostics refs, provider snapshots, continuity refs, and historical partial-evidence targets in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
 - [ ] T007 [P] Add reusable fake log/live-follow reader fixtures in `tests/unit/workflows/temporal/test_remediation_context.py` for declared task-run log reads, cursor resume, unavailable live follow, and policy-denied live follow covering FR-006, FR-007, FR-008, FR-009, and DESIGN-REQ-010.
 - [ ] T008 [P] Add API/router test fixtures for task-run log/diagnostic authorization and bounded read responses in `tests/unit/api/routers/test_task_runs.py` for FR-006, FR-009, and DESIGN-REQ-009.
 - [ ] T009 [P] Add Mission Control mock payload fixtures for remediation evidence classes, degraded evidence, and live observation states in `frontend/src/entrypoints/task-detail.test.tsx` for FR-012, Scenario 6, and SC-005.
@@ -56,14 +56,14 @@
 
 ### Unit Tests
 
-- [ ] T011 [P] Add failing unit tests for enriched `evidence.taskRuns` refs and compact selected-step summaries in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-002, Scenario 1, DESIGN-REQ-008, and SC-001.
-- [ ] T012 [P] Add failing unit tests for context `availability` records, degraded historical targets, partial artifact refs, and merged-log fallback in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, FR-011, Scenario 5, SC-004, and DESIGN-REQ-025.
-- [ ] T013 [P] Add failing unit tests for live-follow state normalization values `active`, `unavailable`, `unsupported`, and `policy_denied` in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-007, FR-008, Scenario 3, SC-003, and DESIGN-REQ-010.
+- [X] T011 [P] Add failing unit tests for enriched `evidence.taskRuns` refs and compact selected-step summaries in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-002, Scenario 1, DESIGN-REQ-008, and SC-001.
+- [X] T012 [P] Add failing unit tests for context `availability` records, degraded historical targets, partial artifact refs, and merged-log fallback in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, FR-011, Scenario 5, SC-004, and DESIGN-REQ-025.
+- [X] T013 [P] Add failing unit tests for live-follow state normalization values `active`, `unavailable`, `unsupported`, and `policy_denied` in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-007, FR-008, Scenario 3, SC-003, and DESIGN-REQ-010.
 - [ ] T014 [P] Add failing unit tests for typed log read adapter binding, stream normalization, tail-line caps, and undeclared task-run rejection in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-006, FR-009, Scenario 4, and DESIGN-REQ-009.
 - [ ] T015 [P] Add failing unit tests preserving forbidden payload exclusions for enriched context fields in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-003, FR-004, Scenario 2, and SC-002.
 - [ ] T016 [P] Add failing API/router unit tests for server-mediated task-run log/diagnostic reads usable by remediation evidence adapters in `tests/unit/api/routers/test_task_runs.py` covering FR-006, FR-009, and DESIGN-REQ-009.
 - [ ] T017 [P] Add failing Mission Control unit tests for context, target logs, diagnostics, decision log, action request/result, verification artifact links, degraded evidence state, and live observation state in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-012, Scenario 6, and SC-005.
-- [ ] T018 Confirm implemented-verified guardrail unit coverage still passes for linked artifact creation, boundedness, typed membership checks, fresh target health reread, and MM-618 traceability in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-001, FR-003, FR-004, FR-005, FR-013, FR-014, SC-002, SC-006, and DESIGN-REQ-009.
+- [X] T018 Confirm implemented-verified guardrail unit coverage still passes for linked artifact creation, boundedness, typed membership checks, fresh target health reread, and MM-618 traceability in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-001, FR-003, FR-004, FR-005, FR-013, FR-014, SC-002, SC-006, and DESIGN-REQ-009.
 
 ### Integration Tests
 
@@ -81,21 +81,21 @@
 
 ### Implementation
 
-- [ ] T027 Update `moonmind/workflows/temporal/remediation_context.py` to resolve observability summary refs, stdout/stderr/merged log refs, diagnostics refs, provider snapshot refs, continuity refs, compact selected-step summaries, and target evidence availability for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
-- [ ] T028 Update `moonmind/workflows/temporal/remediation_context.py` to compute live-follow state values `active`, `unavailable`, `unsupported`, and `policy_denied`, plus durable fallbacks and resume cursor state when available, for FR-007, FR-008, FR-009, SC-003, and DESIGN-REQ-010.
+- [X] T027 Update `moonmind/workflows/temporal/remediation_context.py` to resolve observability summary refs, stdout/stderr/merged log refs, diagnostics refs, provider snapshot refs, continuity refs, compact selected-step summaries, and target evidence availability for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
+- [X] T028 Update `moonmind/workflows/temporal/remediation_context.py` to compute live-follow state values `active`, `unavailable`, `unsupported`, and `policy_denied`, plus durable fallbacks and resume cursor state when available, for FR-007, FR-008, FR-009, SC-003, and DESIGN-REQ-010.
 - [ ] T029 Update `moonmind/workflows/temporal/remediation_tools.py` to bind or expose real task-run log/live-follow reader adapters while preserving context membership checks, tail-line caps, cursor handling, and server-mediated access for FR-005, FR-006, FR-008, FR-009, and DESIGN-REQ-009.
 - [ ] T030 Update `api_service/api/routers/task_runs.py` only if required by T016/T020 to provide bounded server-mediated log/diagnostic reads for remediation evidence without exposing storage paths, presigned URLs, or secret-bearing details for FR-006, FR-009, and DESIGN-REQ-009.
 - [ ] T031 Update `api_service/api/routers/executions.py` only if required by T023 to serialize remediation evidence artifact classes, live observation state, and degraded evidence summaries for Mission Control without broadening MM-618 scope for FR-012 and SC-005.
 - [ ] T032 Update `frontend/src/entrypoints/task-detail.tsx` to render context, target logs, diagnostics, decision log, action request/result, verification artifacts, degraded evidence, and live observation/fallback state for FR-012, Scenario 6, and SC-005.
 - [ ] T033 Update `frontend/src/styles/mission-control.css` only if T017 requires evidence presentation layout, containment, or accessibility styling changes for FR-012 and Scenario 6.
-- [ ] T034 Preserve existing fresh target health reread behavior in `moonmind/workflows/temporal/remediation_tools.py` and adjust only if T018 exposes a regression for FR-013.
-- [ ] T035 Preserve MM-618 traceability in `specs/318-bounded-remediation-evidence/tasks.md`, future `specs/318-bounded-remediation-evidence/verification.md`, commit text, pull request metadata, and Jira-visible handoff for FR-014 and SC-006.
+- [X] T034 Preserve existing fresh target health reread behavior in `moonmind/workflows/temporal/remediation_tools.py` and adjust only if T018 exposes a regression for FR-013.
+- [X] T035 Preserve MM-618 traceability in `specs/318-bounded-remediation-evidence/tasks.md`, future `specs/318-bounded-remediation-evidence/verification.md`, commit text, pull request metadata, and Jira-visible handoff for FR-014 and SC-006.
 
 ### Story Validation
 
-- [ ] T036 Run focused backend unit tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py` and fix failures in the files touched by T027-T031.
-- [ ] T037 Run focused frontend tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx` or `frontend/src/styles/mission-control.css`.
-- [ ] T038 Run hermetic integration validation with `./tools/test_integration.sh` and confirm MM-618 integration tests pass or record the exact environment blocker in `specs/318-bounded-remediation-evidence/verification.md`.
+- [X] T036 Run focused backend unit tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py` and fix failures in the files touched by T027-T031.
+- [X] T037 Run focused frontend tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx` or `frontend/src/styles/mission-control.css`.
+- [X] T038 Run hermetic integration validation with `./tools/test_integration.sh` and confirm MM-618 integration tests pass or record the exact environment blocker in `specs/318-bounded-remediation-evidence/verification.md`.
 - [ ] T039 Validate the independent story criteria from `specs/318-bounded-remediation-evidence/quickstart.md` against implemented behavior and record command evidence for FR-001 through FR-014, Scenarios 1-6, SC-001 through SC-006, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-025.
 
 **Checkpoint**: The MM-618 story is fully functional, covered by unit and integration tests, and independently testable.
@@ -108,8 +108,8 @@
 
 - [ ] T040 [P] Review `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py` for duplicated evidence-normalization logic and refactor only within the MM-618 boundaries.
 - [ ] T041 [P] Review `specs/318-bounded-remediation-evidence/plan.md`, `research.md`, `data-model.md`, `contracts/remediation-evidence.md`, `quickstart.md`, and `tasks.md` for traceability drift after implementation.
-- [ ] T042 [P] Run forbidden-content checks or focused assertions to ensure remediation context/lifecycle payloads still exclude presigned URLs, storage keys, absolute local paths, and secrets in `tests/unit/workflows/temporal/test_remediation_context.py`.
-- [ ] T043 Run full unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` after focused backend and frontend tests pass.
+- [X] T042 [P] Run forbidden-content checks or focused assertions to ensure remediation context/lifecycle payloads still exclude presigned URLs, storage keys, absolute local paths, and secrets in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [X] T043 Run full unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` after focused backend and frontend tests pass.
 - [ ] T044 Run quickstart validation from `specs/318-bounded-remediation-evidence/quickstart.md` and record exact commands and results in `specs/318-bounded-remediation-evidence/verification.md`.
 - [ ] T045 Run final `/moonspec-verify` for `specs/318-bounded-remediation-evidence` after implementation and tests pass, and record the verdict in `specs/318-bounded-remediation-evidence/verification.md`.
 

--- a/specs/318-bounded-remediation-evidence/tasks.md
+++ b/specs/318-bounded-remediation-evidence/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: Bounded Remediation Evidence Context
+
+**Input**: Design documents from `/work/agent_jobs/mm:a6d63116-cfbf-4474-90db-6af6f461079b/repo/specs/318-bounded-remediation-evidence/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/remediation-evidence.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended MM-618 reason, then implement the production code until they pass. Rows marked `implemented_verified` in `plan.md` keep traceability and final validation coverage without unnecessary implementation tasks.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_task_runs.py`
+- Frontend unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+**Source Traceability**: Original Jira issue `MM-618` and the canonical Jira preset brief are preserved in `spec.md`. This task list covers the single story "Diagnose With Bounded Evidence", FR-001 through FR-014, acceptance scenarios 1-6, edge cases, SC-001 through SC-006, and DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-025. Plan status summary: 10 rows `implemented_verified`, 20 rows `partial`, 0 `missing`, and 0 `implemented_unverified`.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active MoonSpec artifacts and test surfaces before story work.
+
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/318-bounded-remediation-evidence` and that `specs/318-bounded-remediation-evidence/spec.md` contains exactly one `## User Story - Diagnose With Bounded Evidence` section for MM-618.
+- [ ] T002 Confirm planning artifacts exist and are mutually consistent in `specs/318-bounded-remediation-evidence/plan.md`, `specs/318-bounded-remediation-evidence/research.md`, `specs/318-bounded-remediation-evidence/data-model.md`, `specs/318-bounded-remediation-evidence/contracts/remediation-evidence.md`, and `specs/318-bounded-remediation-evidence/quickstart.md`.
+- [ ] T003 [P] Confirm Python unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` is available for `tests/unit/workflows/temporal/test_remediation_context.py`, `tests/unit/api/routers/test_executions.py`, and `tests/unit/api/routers/test_task_runs.py`.
+- [ ] T004 [P] Confirm frontend unit test tooling for `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` is available.
+- [ ] T005 [P] Confirm hermetic integration test tooling for `./tools/test_integration.sh` is available and identify the target integration file under `tests/integration/temporal/test_remediation_evidence_context.py`.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared test fixtures and adapters that block the story tests and implementation.
+
+**CRITICAL**: No production implementation work starts until foundational fixtures and red-first tests are in place.
+
+- [ ] T006 Extend remediation context unit-test fixtures for target task-run evidence, observability refs, log refs, diagnostics refs, provider snapshots, continuity refs, and historical partial-evidence targets in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
+- [ ] T007 [P] Add reusable fake log/live-follow reader fixtures in `tests/unit/workflows/temporal/test_remediation_context.py` for declared task-run log reads, cursor resume, unavailable live follow, and policy-denied live follow covering FR-006, FR-007, FR-008, FR-009, and DESIGN-REQ-010.
+- [ ] T008 [P] Add API/router test fixtures for task-run log/diagnostic authorization and bounded read responses in `tests/unit/api/routers/test_task_runs.py` for FR-006, FR-009, and DESIGN-REQ-009.
+- [ ] T009 [P] Add Mission Control mock payload fixtures for remediation evidence classes, degraded evidence, and live observation states in `frontend/src/entrypoints/task-detail.test.tsx` for FR-012, Scenario 6, and SC-005.
+- [ ] T010 Create hermetic integration fixture scaffolding for remediation creation, context artifact publication, declared evidence reads, unavailable live follow fallback, and forbidden payload checks in `tests/integration/temporal/test_remediation_evidence_context.py` for Scenario 1, Scenario 4, SC-001, SC-002, and DESIGN-REQ-009.
+
+**Checkpoint**: Foundation ready; story test authoring can proceed.
+
+---
+
+## Phase 3: Story - Diagnose With Bounded Evidence
+
+**Summary**: As a remediation task, I want a bounded artifact-first context bundle with typed evidence access and optional live-follow state so I can diagnose a target execution without scraping Mission Control, importing unbounded logs, or receiving raw storage access.
+
+**Independent Test**: Create a remediation run for a target execution that has step evidence, artifact refs, and managed-run observability, then verify the remediation context artifact is linked before the remediation task begins, contains only bounded refs and summaries, exposes typed evidence access including optional live-follow state when allowed, and records missing evidence without blocking diagnosis.
+
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013, FR-014, Scenarios 1-6, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-025.
+
+**Unit Test Plan**: Add focused unit tests for context payload enrichment, evidence availability, live-follow state normalization, real log/live adapter behavior, server-mediated access guardrails, fresh target health reread, and UI presentation of evidence classes.
+
+**Integration Test Plan**: Add hermetic integration coverage for remediation context publication, linked artifact metadata, typed evidence reads, live-follow fallback behavior, and secret/path/URL exclusion from context payloads.
+
+### Unit Tests
+
+- [ ] T011 [P] Add failing unit tests for enriched `evidence.taskRuns` refs and compact selected-step summaries in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-002, Scenario 1, DESIGN-REQ-008, and SC-001.
+- [ ] T012 [P] Add failing unit tests for context `availability` records, degraded historical targets, partial artifact refs, and merged-log fallback in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-010, FR-011, Scenario 5, SC-004, and DESIGN-REQ-025.
+- [ ] T013 [P] Add failing unit tests for live-follow state normalization values `active`, `unavailable`, `unsupported`, and `policy_denied` in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-007, FR-008, Scenario 3, SC-003, and DESIGN-REQ-010.
+- [ ] T014 [P] Add failing unit tests for typed log read adapter binding, stream normalization, tail-line caps, and undeclared task-run rejection in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-006, FR-009, Scenario 4, and DESIGN-REQ-009.
+- [ ] T015 [P] Add failing unit tests preserving forbidden payload exclusions for enriched context fields in `tests/unit/workflows/temporal/test_remediation_context.py` covering FR-003, FR-004, Scenario 2, and SC-002.
+- [ ] T016 [P] Add failing API/router unit tests for server-mediated task-run log/diagnostic reads usable by remediation evidence adapters in `tests/unit/api/routers/test_task_runs.py` covering FR-006, FR-009, and DESIGN-REQ-009.
+- [ ] T017 [P] Add failing Mission Control unit tests for context, target logs, diagnostics, decision log, action request/result, verification artifact links, degraded evidence state, and live observation state in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-012, Scenario 6, and SC-005.
+- [ ] T018 Confirm implemented-verified guardrail unit coverage still passes for linked artifact creation, boundedness, typed membership checks, fresh target health reread, and MM-618 traceability in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-001, FR-003, FR-004, FR-005, FR-013, FR-014, SC-002, SC-006, and DESIGN-REQ-009.
+
+### Integration Tests
+
+- [ ] T019 [P] Add failing hermetic integration test for remediation context artifact publication and `context_artifact_ref` linkage before diagnostic work in `tests/integration/temporal/test_remediation_evidence_context.py` covering FR-001, Scenario 1, and SC-001.
+- [ ] T020 [P] Add failing hermetic integration test for declared target artifact/log reads through typed server-mediated surfaces and undeclared evidence rejection in `tests/integration/temporal/test_remediation_evidence_context.py` covering FR-005, FR-006, Scenario 2, and DESIGN-REQ-009.
+- [ ] T021 [P] Add failing hermetic integration test for live-follow unavailable fallback to durable merged/stdout/stderr/diagnostics refs in `tests/integration/temporal/test_remediation_evidence_context.py` covering FR-007, FR-008, FR-009, Scenario 4, and DESIGN-REQ-010.
+- [ ] T022 [P] Add failing hermetic integration test for historical or partial target diagnosis with explicit degraded evidence and missing evidence classes in `tests/integration/temporal/test_remediation_evidence_context.py` covering FR-010, FR-011, Scenario 5, SC-004, and DESIGN-REQ-025.
+- [ ] T023 [P] Add failing integration or contract test for Mission Control/API evidence artifact class exposure in `tests/integration/temporal/test_remediation_evidence_context.py` or `tests/unit/api/routers/test_executions.py` covering FR-012, Scenario 6, and SC-005.
+
+### Red-First Confirmation
+
+- [ ] T024 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py` and confirm T011-T016 fail for the intended MM-618 gaps before production implementation.
+- [ ] T025 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T017 fails for the intended MM-618 evidence-presentation gaps before production implementation.
+- [ ] T026 Run the focused integration command for `tests/integration/temporal/test_remediation_evidence_context.py` through `./tools/test_integration.sh` or the repo-supported integration runner and confirm T019-T023 fail for the intended MM-618 gaps before production implementation.
+
+### Implementation
+
+- [ ] T027 Update `moonmind/workflows/temporal/remediation_context.py` to resolve observability summary refs, stdout/stderr/merged log refs, diagnostics refs, provider snapshot refs, continuity refs, compact selected-step summaries, and target evidence availability for FR-002, FR-010, FR-011, DESIGN-REQ-008, and DESIGN-REQ-025.
+- [ ] T028 Update `moonmind/workflows/temporal/remediation_context.py` to compute live-follow state values `active`, `unavailable`, `unsupported`, and `policy_denied`, plus durable fallbacks and resume cursor state when available, for FR-007, FR-008, FR-009, SC-003, and DESIGN-REQ-010.
+- [ ] T029 Update `moonmind/workflows/temporal/remediation_tools.py` to bind or expose real task-run log/live-follow reader adapters while preserving context membership checks, tail-line caps, cursor handling, and server-mediated access for FR-005, FR-006, FR-008, FR-009, and DESIGN-REQ-009.
+- [ ] T030 Update `api_service/api/routers/task_runs.py` only if required by T016/T020 to provide bounded server-mediated log/diagnostic reads for remediation evidence without exposing storage paths, presigned URLs, or secret-bearing details for FR-006, FR-009, and DESIGN-REQ-009.
+- [ ] T031 Update `api_service/api/routers/executions.py` only if required by T023 to serialize remediation evidence artifact classes, live observation state, and degraded evidence summaries for Mission Control without broadening MM-618 scope for FR-012 and SC-005.
+- [ ] T032 Update `frontend/src/entrypoints/task-detail.tsx` to render context, target logs, diagnostics, decision log, action request/result, verification artifacts, degraded evidence, and live observation/fallback state for FR-012, Scenario 6, and SC-005.
+- [ ] T033 Update `frontend/src/styles/mission-control.css` only if T017 requires evidence presentation layout, containment, or accessibility styling changes for FR-012 and Scenario 6.
+- [ ] T034 Preserve existing fresh target health reread behavior in `moonmind/workflows/temporal/remediation_tools.py` and adjust only if T018 exposes a regression for FR-013.
+- [ ] T035 Preserve MM-618 traceability in `specs/318-bounded-remediation-evidence/tasks.md`, future `specs/318-bounded-remediation-evidence/verification.md`, commit text, pull request metadata, and Jira-visible handoff for FR-014 and SC-006.
+
+### Story Validation
+
+- [ ] T036 Run focused backend unit tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py` and fix failures in the files touched by T027-T031.
+- [ ] T037 Run focused frontend tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx` or `frontend/src/styles/mission-control.css`.
+- [ ] T038 Run hermetic integration validation with `./tools/test_integration.sh` and confirm MM-618 integration tests pass or record the exact environment blocker in `specs/318-bounded-remediation-evidence/verification.md`.
+- [ ] T039 Validate the independent story criteria from `specs/318-bounded-remediation-evidence/quickstart.md` against implemented behavior and record command evidence for FR-001 through FR-014, Scenarios 1-6, SC-001 through SC-006, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, and DESIGN-REQ-025.
+
+**Checkpoint**: The MM-618 story is fully functional, covered by unit and integration tests, and independently testable.
+
+---
+
+## Final Phase: Polish And Verification
+
+**Purpose**: Strengthen the completed MM-618 story without adding hidden scope.
+
+- [ ] T040 [P] Review `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py` for duplicated evidence-normalization logic and refactor only within the MM-618 boundaries.
+- [ ] T041 [P] Review `specs/318-bounded-remediation-evidence/plan.md`, `research.md`, `data-model.md`, `contracts/remediation-evidence.md`, `quickstart.md`, and `tasks.md` for traceability drift after implementation.
+- [ ] T042 [P] Run forbidden-content checks or focused assertions to ensure remediation context/lifecycle payloads still exclude presigned URLs, storage keys, absolute local paths, and secrets in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [ ] T043 Run full unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` after focused backend and frontend tests pass.
+- [ ] T044 Run quickstart validation from `specs/318-bounded-remediation-evidence/quickstart.md` and record exact commands and results in `specs/318-bounded-remediation-evidence/verification.md`.
+- [ ] T045 Run final `/moonspec-verify` for `specs/318-bounded-remediation-evidence` after implementation and tests pass, and record the verdict in `specs/318-bounded-remediation-evidence/verification.md`.
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- Setup T001-T005 can start immediately.
+- Foundational T006-T010 depends on Setup completion and blocks story implementation.
+- Story tests T011-T023 depend on foundational fixtures.
+- Red-first confirmation T024-T026 depends on story tests being written.
+- Implementation T027-T035 depends on red-first confirmation.
+- Story validation T036-T039 depends on implementation.
+- Polish and final verification T040-T045 depends on story validation.
+
+### Within The Story
+
+- Unit tests T011-T018 must be written before implementation tasks T027-T035.
+- Integration tests T019-T023 must be written before implementation tasks T027-T035.
+- Red-first confirmation T024-T026 must complete before production code changes.
+- Context/data-model implementation T027-T028 must precede evidence tool adapter work T029 where adapter behavior depends on enriched context shape.
+- Backend service/API work T027-T031 must precede frontend rendering work T032-T033.
+- Story validation T036-T039 must pass before final polish T040-T045.
+
+## Parallel Opportunities
+
+- T003, T004, and T005 can run in parallel because they inspect different test tooling.
+- T007, T008, T009, and T010 can run in parallel after T006 when fixture ownership is coordinated.
+- T011 through T017 can be authored in parallel where each task edits its named test file area without conflicting changes.
+- T019 through T023 can be authored in parallel if they use separate test functions in `tests/integration/temporal/test_remediation_evidence_context.py`.
+- T030 and T031 can run in parallel with T032 after T027-T029 stabilize the backend contract.
+- T040, T041, and T042 can run in parallel after story validation.
+
+## Parallel Example
+
+```bash
+# Backend and frontend red-first test authoring can proceed together:
+Task: "T011 Add failing context evidence refs unit tests in tests/unit/workflows/temporal/test_remediation_context.py"
+Task: "T017 Add failing Mission Control evidence presentation tests in frontend/src/entrypoints/task-detail.test.tsx"
+
+# Independent implementation follow-ups after context shape stabilizes:
+Task: "T030 Update task-run router bounded reads in api_service/api/routers/task_runs.py"
+Task: "T032 Update Mission Control evidence rendering in frontend/src/entrypoints/task-detail.tsx"
+```
+
+## Implementation Strategy
+
+1. Complete setup and foundational fixture tasks.
+2. Write all focused unit and integration tests first.
+3. Run red-first confirmation and verify failures are for the MM-618 partial requirements from `plan.md`.
+4. Implement enriched context generation, live-follow state, typed evidence adapter binding, API serialization, and UI presentation in that order.
+5. Preserve already-verified behavior for artifact linkage, boundedness, secret safety, typed membership checks, fresh target health reread, and MM-618 traceability.
+6. Run focused backend, frontend, and integration tests.
+7. Run full unit validation and quickstart validation.
+8. Finish with `/moonspec-verify`.
+
+## Requirement Status Coverage Summary
+
+- Code-and-test work for `partial` rows: FR-002, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, Scenarios 1 and 3-6, SC-001, SC-003, SC-004, SC-005, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-025.
+- Integration reinforcement for implemented rows: FR-001, FR-003, FR-005, FR-013, Scenario 2, DESIGN-REQ-009.
+- Already-verified final validation only: FR-004, FR-014, SC-002, SC-006.
+- Conditional fallback rows: none, because `plan.md` has no `implemented_unverified` rows.
+- Missing rows: none.
+
+## Notes
+
+- This task list covers exactly one story: MM-618 "Diagnose With Bounded Evidence".
+- Do not create new specs, run `/moonspec-breakdown`, or broaden into remediation action-authority behavior beyond the fresh-health guard already in FR-013.
+- Do not create `tasks.md` work for future MM-619 authority/policy scope except preserving linked-issue awareness in traceability.

--- a/specs/318-bounded-remediation-evidence/verification.md
+++ b/specs/318-bounded-remediation-evidence/verification.md
@@ -1,0 +1,36 @@
+# Verification: Bounded Remediation Evidence Context
+
+## Implementation Step Evidence
+
+- Jira issue: MM-618
+- Feature directory: `specs/318-bounded-remediation-evidence`
+- Implemented scope: bounded remediation context enrichment for target task-run evidence refs, compact selected-step summaries, evidence availability/degraded metadata, and live-follow state normalization.
+
+## Red-First Evidence
+
+- Command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q`
+- Initial result before production changes: failed as expected.
+- Expected failures:
+  - `test_remediation_context_builder_enriches_task_run_evidence_and_live_follow` showed selected steps lacked `status`, `summary`, and `artifactRefs`, and task-run evidence lacked typed refs.
+  - `test_remediation_context_builder_records_historical_degraded_evidence` showed task-run evidence lacked `mergedLogsRef`.
+
+## Passing Unit Evidence
+
+- Command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q`
+- Result: passed, 35 tests.
+
+- Command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py -q`
+- Result: passed for the focused Python unit targets and the bundled frontend unit run invoked by the test runner.
+
+- Command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- Result: passed, including full Python unit suite (`4521 passed`, `1 xpassed`, `16 subtests passed`) and focused frontend task-detail tests (`87 passed`).
+
+## Integration Evidence
+
+- Command: `./tools/test_integration.sh`
+- Result: blocked by managed runtime Docker access.
+- Exact blocker: Docker Compose attempted to build `repo-pytest`, then Docker returned `403 Forbidden` with `Request forbidden by administrative rules`.
+
+## Remaining Verify Step
+
+- Final `/moonspec-verify` is intentionally not run in this implementation step because the current managed step boundary authorizes `moonspec-implement` only.

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -633,6 +633,92 @@ async def test_remediation_context_builder_enriches_task_run_evidence_and_live_f
         }
 
 @pytest.mark.asyncio
+async def test_remediation_context_builder_matches_selected_step_by_full_identity(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+        )
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.memo = {
+            **target_source.memo,
+            "remediationEvidence": {
+                "selectedSteps": [
+                    {
+                        "logicalStepId": "plan",
+                        "attempt": 1,
+                        "taskRunId": "tr_shared",
+                        "status": "succeeded",
+                        "summary": "Plan passed",
+                        "artifactRefs": [
+                            {"artifact_id": "art_plan", "kind": "step.summary"}
+                        ],
+                    },
+                    {
+                        "logicalStepId": "implement",
+                        "attempt": 2,
+                        "taskRunId": "tr_shared",
+                        "status": "failed",
+                        "summary": "Implementation failed",
+                        "artifactRefs": [
+                            {"artifact_id": "art_implement", "kind": "step.summary"}
+                        ],
+                    },
+                ]
+            },
+        }
+        remediation_source = await session.get(
+            TemporalExecutionCanonicalRecord, remediation.workflow_id
+        )
+        assert remediation_source is not None
+        remediation_source.parameters = {
+            **remediation_source.parameters,
+            "task": {
+                "remediation": {
+                    "target": {
+                        "workflowId": target.workflow_id,
+                        "stepSelectors": [
+                            {
+                                "logicalStepId": "implement",
+                                "attempt": 2,
+                                "taskRunId": "tr_shared",
+                            }
+                        ],
+                        "taskRunIds": ["tr_shared"],
+                    }
+                }
+            },
+        }
+        await session.commit()
+
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        result = await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        assert result.payload["selectedSteps"] == [
+            {
+                "logicalStepId": "implement",
+                "attempt": 2,
+                "taskRunId": "tr_shared",
+                "status": "failed",
+                "summary": "Implementation failed",
+                "artifactRefs": [
+                    {"artifact_id": "art_implement", "kind": "step.summary"}
+                ],
+            }
+        ]
+
+@pytest.mark.asyncio
 async def test_remediation_context_builder_records_historical_degraded_evidence(
     tmp_path, mock_client_adapter
 ):
@@ -742,6 +828,89 @@ async def test_remediation_context_builder_records_historical_degraded_evidence(
             "resumeCursor": None,
             "reason": "policy denies live observation",
             "fallbacks": ["merged_logs"],
+        }
+
+@pytest.mark.asyncio
+async def test_remediation_context_builder_marks_unsupported_live_follow_degraded(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+        )
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.state = MoonMindWorkflowState.EXECUTING
+        target_source.memo = {
+            **target_source.memo,
+            "remediationEvidence": {
+                "taskRuns": [
+                    {
+                        "taskRunId": "tr_no_live",
+                        "stdoutRef": {"artifact_id": "art_stdout"},
+                        "stderrRef": {"artifact_id": "art_stderr"},
+                        "mergedLogsRef": {"artifact_id": "art_merged"},
+                        "diagnosticsRef": {"artifact_id": "art_diag"},
+                        "providerSnapshotRef": {"artifact_id": "art_provider"},
+                        "continuityRefs": [
+                            {
+                                "artifact_id": "art_session_summary",
+                                "kind": "session.summary",
+                            }
+                        ],
+                    }
+                ],
+                "liveFollow": {"resumeCursor": {"sequence": 42}},
+            },
+        }
+        remediation_source = await session.get(
+            TemporalExecutionCanonicalRecord, remediation.workflow_id
+        )
+        assert remediation_source is not None
+        remediation_source.parameters = {
+            **remediation_source.parameters,
+            "task": {
+                "remediation": {
+                    "target": {
+                        "workflowId": target.workflow_id,
+                        "taskRunIds": ["tr_no_live"],
+                    },
+                    "mode": "snapshot_then_follow",
+                }
+            },
+        }
+        await session.commit()
+
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        result = await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        assert result.payload["evidence"]["evidenceDegraded"] is True
+        assert result.payload["evidence"]["unavailableEvidenceClasses"] == [
+            "live_follow"
+        ]
+        assert result.payload["evidence"]["availability"][-1] == {
+            "class": "live_follow",
+            "status": "unsupported",
+            "reason": "task run does not support live follow",
+            "fallback": "merged_logs",
+        }
+        assert result.payload["liveFollow"] == {
+            "status": "unsupported",
+            "mode": "snapshot_then_follow",
+            "supported": False,
+            "taskRunId": "tr_no_live",
+            "resumeCursor": {"sequence": 42},
+            "reason": "task run does not support live follow",
+            "fallbacks": ["merged_logs", "stdout", "stderr", "diagnostics"],
         }
 
 def test_remediation_lifecycle_summary_audit_and_continuation_are_bounded():

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -446,10 +446,13 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
         assert payload["policies"]["approvalPolicy"]["reviewers"] == [{"user": "ops"}]
         assert payload["policies"]["lockPolicy"]["mode"] == "exclusive"
         assert payload["liveFollow"] == {
+            "status": "unavailable",
             "mode": "snapshot_then_follow",
             "supported": False,
             "taskRunId": "tr_00",
             "resumeCursor": None,
+            "reason": "target is terminal",
+            "fallbacks": [],
         }
         assert payload["boundedness"] == {
             "maxTailLines": 2000,
@@ -468,6 +471,278 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
         assert "raw-api-key" not in serialized
         assert "password" not in serialized.lower()
         assert "token=" not in serialized.lower()
+
+@pytest.mark.asyncio
+async def test_remediation_context_builder_enriches_task_run_evidence_and_live_follow(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        mock_client_adapter.start_workflow.side_effect = [
+            SimpleNamespace(run_id="target-run"),
+            SimpleNamespace(run_id="remediation-run"),
+        ]
+        execution_service = TemporalExecutionService(
+            session, client_adapter=mock_client_adapter
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+
+        target = await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target with evidence",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+            summary="Target summary",
+        )
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.state = MoonMindWorkflowState.EXECUTING
+        target_source.memo = {
+            **target_source.memo,
+            "remediationEvidence": {
+                "selectedSteps": [
+                    {
+                        "logicalStepId": "run-tests",
+                        "attempt": 2,
+                        "taskRunId": "tr_live",
+                        "status": "failed",
+                        "summary": "Integration tests failed",
+                        "artifactRefs": [
+                            {"artifact_id": "art_step_summary", "kind": "step.summary"}
+                        ],
+                    }
+                ],
+                "taskRuns": [
+                    {
+                        "taskRunId": "tr_live",
+                        "observabilitySummaryRef": {"artifact_id": "art_obs"},
+                        "stdoutRef": {"artifact_id": "art_stdout"},
+                        "stderrRef": {"artifact_id": "art_stderr"},
+                        "mergedLogsRef": {"artifact_id": "art_merged"},
+                        "diagnosticsRef": {"artifact_id": "art_diag"},
+                        "providerSnapshotRef": {"artifact_id": "art_provider"},
+                        "continuityRefs": [
+                            {
+                                "artifact_id": "art_session_summary",
+                                "kind": "session.summary",
+                            }
+                        ],
+                        "liveFollowSupported": True,
+                    }
+                ],
+                "diagnosisHints": ["Prefer diagnostics before merged logs"],
+                "liveFollow": {"resumeCursor": {"sequence": 12}},
+            },
+        }
+        await session.commit()
+
+        remediation = await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {
+                    "remediation": {
+                        "target": {
+                            "workflowId": target.workflow_id,
+                            "stepSelectors": [
+                                {
+                                    "logicalStepId": "run-tests",
+                                    "attempt": "2",
+                                    "taskRunId": "tr_live",
+                                }
+                            ],
+                            "taskRunIds": ["tr_live"],
+                        },
+                        "mode": "snapshot_then_follow",
+                        "evidencePolicy": {
+                            "tailLines": 250,
+                            "allowLiveFollow": True,
+                        },
+                    }
+                }
+            },
+            idempotency_key=None,
+        )
+
+        result = await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        assert result.payload["selectedSteps"] == [
+            {
+                "logicalStepId": "run-tests",
+                "attempt": 2,
+                "taskRunId": "tr_live",
+                "status": "failed",
+                "summary": "Integration tests failed",
+                "artifactRefs": [
+                    {"artifact_id": "art_step_summary", "kind": "step.summary"}
+                ],
+            }
+        ]
+        assert result.payload["evidence"]["taskRuns"] == [
+            {
+                "taskRunId": "tr_live",
+                "observabilitySummaryRef": {"artifact_id": "art_obs"},
+                "stdoutRef": {"artifact_id": "art_stdout"},
+                "stderrRef": {"artifact_id": "art_stderr"},
+                "mergedLogsRef": {"artifact_id": "art_merged"},
+                "diagnosticsRef": {"artifact_id": "art_diag"},
+                "providerSnapshotRef": {"artifact_id": "art_provider"},
+                "continuityRefs": [
+                    {"artifact_id": "art_session_summary", "kind": "session.summary"}
+                ],
+            }
+        ]
+        assert result.payload["evidence"]["availability"] == [
+            {"class": "stdout", "status": "available"},
+            {"class": "stderr", "status": "available"},
+            {"class": "merged_logs", "status": "available"},
+            {"class": "diagnostics", "status": "available"},
+            {"class": "provider_snapshot", "status": "available"},
+            {"class": "continuity", "status": "available"},
+            {"class": "live_follow", "status": "available"},
+        ]
+        assert result.payload["evidence"]["evidenceDegraded"] is False
+        assert result.payload["evidence"]["diagnosisHints"] == [
+            "Prefer diagnostics before merged logs"
+        ]
+        assert result.payload["liveFollow"] == {
+            "status": "active",
+            "mode": "snapshot_then_follow",
+            "supported": True,
+            "taskRunId": "tr_live",
+            "resumeCursor": {"sequence": 12},
+            "fallbacks": ["merged_logs", "stdout", "stderr", "diagnostics"],
+        }
+
+@pytest.mark.asyncio
+async def test_remediation_context_builder_records_historical_degraded_evidence(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+        )
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.state = MoonMindWorkflowState.FAILED
+        target_source.memo = {
+            **target_source.memo,
+            "remediationEvidence": {
+                "taskRuns": [
+                    {
+                        "taskRunId": "tr_history",
+                        "mergedLogsRef": {"artifact_id": "art_merged"},
+                    }
+                ]
+            },
+        }
+        remediation_source = await session.get(
+            TemporalExecutionCanonicalRecord, remediation.workflow_id
+        )
+        assert remediation_source is not None
+        remediation_source.parameters = {
+            **remediation_source.parameters,
+            "task": {
+                "remediation": {
+                    "target": {
+                        "workflowId": target.workflow_id,
+                        "taskRunIds": ["tr_history"],
+                    },
+                    "mode": "snapshot_then_follow",
+                    "evidencePolicy": {"allowLiveFollow": False},
+                }
+            },
+        }
+        await session.commit()
+
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        result = await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        assert result.payload["evidence"]["taskRuns"] == [
+            {
+                "taskRunId": "tr_history",
+                "mergedLogsRef": {"artifact_id": "art_merged"},
+            }
+        ]
+        assert result.payload["evidence"]["evidenceDegraded"] is True
+        assert result.payload["evidence"]["unavailableEvidenceClasses"] == [
+            "stdout",
+            "stderr",
+            "diagnostics",
+            "provider_snapshot",
+            "continuity",
+            "live_follow",
+        ]
+        assert result.payload["evidence"]["availability"] == [
+            {
+                "class": "stdout",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {
+                "class": "stderr",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {"class": "merged_logs", "status": "available"},
+            {
+                "class": "diagnostics",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {
+                "class": "provider_snapshot",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {
+                "class": "continuity",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {
+                "class": "live_follow",
+                "status": "denied",
+                "reason": "policy denies live observation",
+                "fallback": "merged_logs",
+            },
+        ]
+        assert result.payload["liveFollow"] == {
+            "status": "policy_denied",
+            "mode": "snapshot_then_follow",
+            "supported": False,
+            "taskRunId": "tr_history",
+            "resumeCursor": None,
+            "reason": "policy denies live observation",
+            "fallbacks": ["merged_logs"],
+        }
 
 def test_remediation_lifecycle_summary_audit_and_continuation_are_bounded():
     assert normalize_remediation_phase("diagnosing") == "diagnosing"


### PR DESCRIPTION
## Summary

Implements the backend portion of MM-618 by enriching bounded remediation context artifacts with selected-step summaries, typed task-run evidence refs, explicit evidence availability/degraded metadata, and normalized live-follow state.

## Jira

- Jira issue key: MM-618

## MoonSpec

- Active MoonSpec feature path: `specs/318-bounded-remediation-evidence`
- Verification verdict: `ADDITIONAL_WORK_NEEDED`

## Tests run

- Red-first: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q` failed before production changes for the intended MM-618 context enrichment gaps.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q` passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py -q` passed for focused backend/API targets and the bundled frontend run invoked by the runner.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` passed, including full Python unit suite and focused task-detail UI tests.
- `./tools/test_integration.sh` was attempted but blocked by Docker daemon administrative rules in the managed runtime.

## Remaining risks

- Final MoonSpec verification returned `ADDITIONAL_WORK_NEEDED`, not `FULLY_IMPLEMENTED`.
- Hermetic integration evidence is missing because Docker returned a managed-runtime 403 during compose setup.
- Real task-run log/live-follow adapter binding and full Mission Control evidence-class presentation remain partial verification gaps.
- Verify preflight flagged the managed `.gemini/skills` symlink projection shape as an environment concern.
