### PR TITLE
Add document-update-orchestrate preset with alignment check and Jira fallback

### DIFF
--- a/.agents/skills/document-update/SKILL.md
+++ b/.agents/skills/document-update/SKILL.md
@@ -57,32 +57,53 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
    - Record concise evidence for every `stale`, `missing`, or `ambiguous` item.
    - If the implementation appears internally inconsistent, document the inconsistency in the ledger and avoid inventing a new contract.
 
-5. Edit the document.
+5. Determine if the document is out-of-date or not fully implemented.
+   - Compare the drift ledger against the current codebase. If all claims are `accurate` and nothing is `missing`, the document is up-to-date; stop and report that no update is needed.
+   - If the document is `stale` or `missing`, check whether the needed update aligns with the project's declared direction.
+   - Read the constitution (`.specify/memory/constitution.md`), `README.md`, and the main architecture document under `docs/`.
+   - Assess whether the drift-correcting update would move the document toward or away from those canonical sources.
+   - If the update is clearly aligned with the constitution, README, and architecture, proceed to edit the document.
+   - If the update appears to contradict the project's declared direction, or if the correct direction is uncertain, do **not** edit the document. Instead, proceed to step 8 (Jira fallback).
+
+6. Edit the document.
    - Update only the sections needed to correct the drift.
    - Describe the current behavior directly and concretely.
    - Remove obsolete compatibility language, stale migration framing, and contradicted examples.
    - Preserve the document's existing voice, heading structure, and terminology where they remain accurate.
    - Add or update cross-references only when they help readers find the canonical contract.
 
-6. Verify the update.
+7. Verify the update.
    - Re-read the changed sections and compare them against the drift ledger.
    - Run targeted documentation checks if available.
    - Run the repository-mandated programmatic checks from `AGENTS.md`, even for documentation-only updates.
    - Add any extra targeted code tests needed when the documentation change depends on behavior that is not already evident from existing tests or source inspection.
    - If verification cannot be run, record the exact blocker.
 
-7. Finalize the evidence.
+8. Jira fallback for misaligned updates.
+   - If step 5 determined that the document update is not aligned with the project's direction, create a Jira issue instead of editing the document.
+   - Read `.agents/skills/jira-issue-creator/SKILL.md` and follow its workflow.
+   - The Jira issue must include:
+     - A clear summary naming the document and the planned update.
+     - A description that explains the drift found in the drift ledger.
+     - An explicit statement of why the update may conflict with the constitution, README, or main architecture document.
+     - The specific document path and relevant implementation evidence.
+   - Do not edit the document when creating the Jira fallback issue.
+   - Report the created Jira issue key and URL as the primary output.
+
+9. Finalize the evidence.
    - Summarize which document changed, what drift was corrected, and the implementation evidence used.
    - Include validation commands and results.
+   - If a Jira fallback issue was created, include its key, URL, and rationale.
    - If requested by the task, commit the documentation update with a concise message.
 
 ## Outputs
 
-- Updated document path(s).
+- Updated document path(s), or the reason no update was performed.
 - Drift ledger summary with each corrected or intentionally deferred claim.
 - Implementation evidence references, including file paths and relevant tests or schemas.
 - Validation commands run and their result, or the reason validation was not run.
 - Commit hash when the user requested a commit.
+- Jira issue key and URL when a misaligned update triggered the Jira fallback.
 
 ## Failure Modes
 
@@ -92,3 +113,5 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
 - The document describes intended behavior that code does not implement: report the gap clearly and update only if the user's goal is to document actual behavior.
 - Required verification cannot run: keep the doc update if source evidence is sufficient, but report the blocked command and reason.
 - Secret-like content appears in examples or copied logs: redact it before writing or reporting.
+- Document update contradicts the constitution, README, or architecture: do not edit; create a Jira issue and report the misalignment.
+- Jira fallback blocked: report the exact blocker and preserve the drift ledger for manual review.

--- a/api_service/data/task_step_templates/document-update-orchestrate.yaml
+++ b/api_service/data/task_step_templates/document-update-orchestrate.yaml
@@ -1,0 +1,61 @@
+slug: document-update-orchestrate
+title: Document Update Orchestrate
+description: Scan a document directory for .md, .txt, and .tex files, then create a document-update task for each discovered document.
+scope: global
+version: 1.0.0
+tags:
+  - documentation
+  - document-update
+  - orchestration
+requiredCapabilities:
+  - git
+annotations:
+  sourceSkill: document-update-orchestrate
+  output: document-update-tasks
+inputs:
+  - name: document_directory
+    label: Document Directory
+    type: text
+    required: true
+    default: ""
+  - name: publish_mode
+    label: Publish Mode
+    type: enum
+    required: true
+    default: pr_with_merge_automation
+    options:
+      - pr
+      - pr_with_merge_automation
+steps:
+  - title: Discover documents
+    type: tool
+    instructions: |-
+      Run a python script to discover all .md, .txt, and .tex files in the document directory:
+      {{ inputs.document_directory }}
+
+      Return the discovered file paths as a structured list.
+    tool:
+      id: document.discover
+      args:
+        directory: "{{ inputs.document_directory }}"
+  - title: Create document update tasks
+    type: tool
+    instructions: |-
+      Create one document-update task for each document discovered in the previous step.
+      Each task must use the document-update skill and target the specific document path.
+      Preserve the document order from the discovery step.
+      Report created tasks, skipped documents, dependency edges, and any partial failures honestly.
+    documentUpdateOrchestration:
+      task:
+        repository: "{{ context.repository }}"
+        runtime:
+          mode: "{{ context.targetRuntime }}"
+        publish:
+          mode: "pr"
+          mergeAutomation:
+            enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+      traceability:
+        sourceDirectory: "{{ inputs.document_directory }}"
+    tool:
+      id: story.create_document_update_tasks
+      args: {}

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -6,7 +6,9 @@ import base64
 import hashlib
 import inspect
 import json
+import os
 import re
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Sequence
 
 import httpx
@@ -36,6 +38,9 @@ JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN = "linear_blocker_chain"
 JIRA_DEPENDENCY_MODES = frozenset(
     {JIRA_DEPENDENCY_MODE_NONE, JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN}
 )
+
+DOCUMENT_DISCOVER_TOOL_NAME = "document.discover"
+DOCUMENT_UPDATE_TASKS_TOOL_NAME = "story.create_document_update_tasks"
 
 StoryFetcher = Callable[
     [str, str, str],
@@ -1597,6 +1602,282 @@ async def check_jira_blockers(
         },
     )
 
+async def discover_documents(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+) -> ToolResult:
+    """Discover .md, .txt, and .tex files in a directory."""
+
+    directory = _string(inputs.get("directory") or inputs.get("path"))
+    if not directory:
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "documentPaths": [],
+                "error": "Missing required input: directory or path.",
+            },
+        )
+
+    root = Path(directory).expanduser().resolve()
+    if not root.exists() or not root.is_dir():
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "documentPaths": [],
+                "error": f"Directory does not exist or is not a directory: {directory}",
+            },
+        )
+
+    extensions = frozenset(
+        _list(
+            inputs.get("extensions")
+            or [".md", ".txt", ".tex"]
+        )
+    )
+    if not extensions:
+        extensions = frozenset({".md", ".txt", ".tex"})
+
+    document_paths: list[str] = []
+    for ext in extensions:
+        pattern = f"*{ext}"
+        for path in root.rglob(pattern):
+            if path.is_file():
+                document_paths.append(str(path))
+
+    document_paths = sorted(document_paths)
+
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "directory": str(root),
+            "extensions": sorted(extensions),
+            "documentCount": len(document_paths),
+            "documentPaths": document_paths,
+        },
+    )
+
+def _document_update_task_payload(
+    *,
+    document_path: str,
+    task_payload: Mapping[str, Any],
+    traceability: Mapping[str, Any],
+    depends_on: Sequence[str],
+    source_directory: str,
+) -> tuple[str, dict[str, Any]]:
+    instructions = (
+        f"Update the technical document at {document_path} to align with the current "
+        "codebase implementation. Follow the document-update skill workflow."
+    )
+    runtime = _mapping(task_payload.get("runtime"))
+    publish = _mapping(task_payload.get("publish"))
+    repository = _string(task_payload.get("repository") or task_payload.get("repo"))
+    task: dict[str, Any] = {
+        "title": f"Document update: {Path(document_path).name}",
+        "instructions": instructions,
+        "inputs": {
+            "document_path": document_path,
+            "source_directory": source_directory,
+        },
+        "taskTemplate": {
+            "slug": "document-update",
+            "version": "1.0.0",
+        },
+    }
+    if runtime:
+        task["runtime"] = runtime
+    if publish:
+        task["publish"] = publish
+    if repository:
+        task["repository"] = repository
+    if depends_on:
+        task["dependsOn"] = list(depends_on)
+    selected_skill = _string(traceability.get("selectedSkill") or traceability.get("selected_skill"))
+    if selected_skill:
+        metadata = task.setdefault("metadata", {})
+        moonmind = metadata.setdefault("moonmind", {})
+        moonmind["selectedSkill"] = selected_skill
+        metadata["moonmind"] = moonmind
+        task["metadata"] = metadata
+    return task["title"], task
+
+async def create_document_update_tasks_from_paths(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    execution_creator: ExecutionCreator | None = None,
+) -> ToolResult:
+    """Create document-update tasks from a list of document paths."""
+
+    if execution_creator is None:
+        raise ValueError("execution_creator is required for document update task creation.")
+
+    context = _context or {}
+    previous_outputs = _mapping(context.get("previousOutputs") or context.get("previous_outputs"))
+    document_paths: list[str] = []
+    raw_paths = inputs.get("documentPaths") or inputs.get("document_paths")
+    if isinstance(raw_paths, Sequence) and not isinstance(raw_paths, (str, bytes, bytearray)):
+        document_paths = [str(p) for p in raw_paths if _string(p)]
+    if not document_paths and previous_outputs:
+        raw_paths = previous_outputs.get("documentPaths") or previous_outputs.get("document_paths")
+        if isinstance(raw_paths, Sequence) and not isinstance(raw_paths, (str, bytes, bytearray)):
+            document_paths = [str(p) for p in raw_paths if _string(p)]
+
+    orchestration_payload = _mapping(
+        inputs.get("documentUpdateOrchestration")
+        or inputs.get("document_update_orchestration")
+    )
+    task_payload = _mapping(
+        orchestration_payload.get("task")
+        or inputs.get("task")
+    )
+    traceability = _mapping(
+        orchestration_payload.get("traceability")
+        or inputs.get("traceability")
+    )
+    source_directory = _string(
+        traceability.get("sourceDirectory")
+        or traceability.get("source_directory")
+        or inputs.get("sourceDirectory")
+        or inputs.get("source_directory")
+        or ""
+    )
+    repository = _string(task_payload.get("repository") or task_payload.get("repo"))
+    owner_id = (
+        _string(task_payload.get("ownerId") or task_payload.get("owner_id"))
+        or _string(inputs.get("ownerId") or inputs.get("owner_id"))
+        or _string(context.get("ownerId") or context.get("owner_id"))
+        or None
+    )
+    owner_type = (
+        _string(task_payload.get("ownerType") or task_payload.get("owner_type"))
+        or _string(inputs.get("ownerType") or inputs.get("owner_type"))
+        or _string(context.get("ownerType") or context.get("owner_type"))
+        or None
+    )
+
+    tasks: list[dict[str, Any]] = []
+    dependencies: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    previous_workflow_id = ""
+
+    for index, document_path in enumerate(document_paths, start=1):
+        base_result = {
+            "documentIndex": index,
+            "documentPath": document_path,
+        }
+        depends_on = [previous_workflow_id] if previous_workflow_id else []
+        title, task = _document_update_task_payload(
+            document_path=document_path,
+            task_payload=task_payload,
+            traceability=traceability,
+            depends_on=depends_on,
+            source_directory=source_directory,
+        )
+        idempotency_key = _stable_idempotency_key(
+            source_issue_key=source_directory,
+            story_id=f"doc-{index:03d}",
+            issue_key=document_path,
+        )
+        try:
+            created = execution_creator(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                owner_type=owner_type,
+                title=title,
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "requestType": "task",
+                    "repository": repository or None,
+                    "targetRuntime": _string(_mapping(task.get("runtime")).get("mode")) or None,
+                    "publishMode": _string(_mapping(task.get("publish")).get("mode")) or None,
+                    "task": task,
+                    "traceability": {
+                        "sourceDirectory": source_directory,
+                    },
+                },
+                idempotency_key=idempotency_key,
+                repository=repository or None,
+                integration="document_update",
+                summary=f"Document update task for {document_path}.",
+            )
+            if inspect.isawaitable(created):
+                created = await created  # type: ignore[assignment]
+        except Exception as exc:
+            failures.append(
+                {
+                    **base_result,
+                    "errorCode": "task_creation_failed",
+                    "message": str(exc) or "Downstream task creation failed.",
+                    "dependsOn": depends_on,
+                }
+            )
+            remaining = document_paths[index:]
+            for skipped_path in remaining:
+                failures.append(
+                    {
+                        "documentIndex": document_paths.index(skipped_path) + 1,
+                        "documentPath": skipped_path,
+                        "errorCode": "dependency_not_created",
+                        "message": "Earlier downstream task creation failed.",
+                    }
+                )
+            break
+
+        created_mapping = dict(created)
+        workflow_id = _string(
+            created_mapping.get("workflowId") or created_mapping.get("workflow_id")
+        )
+        task_result = {
+            **base_result,
+            "workflowId": workflow_id,
+            "runId": _string(created_mapping.get("runId") or created_mapping.get("run_id")),
+            "title": _string(created_mapping.get("title")) or title,
+            "created": not bool(created_mapping.get("existing")),
+            "existing": bool(created_mapping.get("existing")),
+            "dependsOn": depends_on,
+            "idempotencyKey": idempotency_key,
+        }
+        tasks.append(task_result)
+        if depends_on:
+            dependencies.append(
+                {
+                    "fromWorkflowId": depends_on[0],
+                    "toWorkflowId": workflow_id,
+                    "fromDocumentPath": tasks[-2]["documentPath"] if len(tasks) > 1 else "",
+                    "toDocumentPath": document_path,
+                    "status": "created",
+                }
+            )
+        previous_workflow_id = workflow_id
+
+    if not document_paths:
+        status = "no_downstream_tasks"
+    elif failures:
+        status = "partial" if tasks else "no_downstream_tasks"
+    else:
+        status = "completed"
+
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "documentUpdateOrchestration": {
+                "status": status,
+                "documentCount": len(document_paths),
+                "createdTaskCount": len(tasks),
+                "dependencyCount": len(dependencies),
+                "tasks": tasks,
+                "dependencies": dependencies,
+                "failures": failures,
+                "traceability": {
+                    "sourceDirectory": source_directory,
+                },
+            }
+        },
+    )
+
 def register_story_output_tool_handlers(
     dispatcher: Any,
     *,
@@ -1647,11 +1928,43 @@ def register_story_output_tool_handlers(
         handler=_check_jira_blockers,
     )
 
+    async def _discover_documents(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await discover_documents(inputs, context)
+
+    dispatcher.register_skill(
+        skill_name=DOCUMENT_DISCOVER_TOOL_NAME,
+        version="1.0",
+        handler=_discover_documents,
+    )
+
+    async def _create_document_update_tasks(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await create_document_update_tasks_from_paths(
+            inputs,
+            context,
+            execution_creator=execution_creator,
+        )
+
+    dispatcher.register_skill(
+        skill_name=DOCUMENT_UPDATE_TASKS_TOOL_NAME,
+        version="1.0",
+        handler=_create_document_update_tasks,
+    )
+
 __all__ = [
     "JIRA_CHECK_BLOCKERS_TOOL_NAME",
     "JIRA_STORY_TOOL_NAMES",
     "check_jira_blockers",
     "create_jira_issues_from_stories",
     "create_jira_orchestrate_tasks_from_issue_mappings",
+    "discover_documents",
+    "create_document_update_tasks_from_paths",
+    "DOCUMENT_DISCOVER_TOOL_NAME",
+    "DOCUMENT_UPDATE_TASKS_TOOL_NAME",
     "register_story_output_tool_handlers",
 ]

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import inspect
 import json
-import os
 import re
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Sequence
@@ -1638,11 +1637,13 @@ async def discover_documents(
         extensions = frozenset({".md", ".txt", ".tex"})
 
     document_paths: list[str] = []
+    workspace_root = Path.cwd().resolve()
+    output_base = workspace_root if root.is_relative_to(workspace_root) else root
     for ext in extensions:
         pattern = f"*{ext}"
         for path in root.rglob(pattern):
             if path.is_file():
-                document_paths.append(str(path))
+                document_paths.append(path.relative_to(output_base).as_posix())
 
     document_paths = sorted(document_paths)
 

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -186,6 +186,36 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             },
         }
 
+        result = await session.execute(
+            select(TaskStepTemplate)
+            .where(
+                TaskStepTemplate.slug == "document-update-orchestrate",
+                TaskStepTemplate.scope_type == TaskTemplateScopeType.GLOBAL,
+                TaskStepTemplate.scope_ref.is_(None),
+            )
+            .options(selectinload(TaskStepTemplate.latest_version))
+        )
+        doc_template = result.scalar_one_or_none()
+        assert doc_template is not None
+        assert doc_template.latest_version is not None
+        doc_steps = doc_template.latest_version.steps
+        assert len(doc_steps) == 2
+        assert doc_steps[0]["type"] == "tool"
+        assert doc_steps[0]["tool"]["id"] == "document.discover"
+        assert "{{ inputs.document_directory }}" in doc_steps[0]["instructions"]
+        assert doc_steps[1]["type"] == "tool"
+        assert doc_steps[1]["tool"]["id"] == "story.create_document_update_tasks"
+        assert "documentUpdateOrchestration" in doc_steps[1]
+        assert doc_steps[1]["documentUpdateOrchestration"]["task"]["publish"] == {
+            "mode": "pr",
+            "mergeAutomation": {
+                "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+            },
+        }
+        assert doc_steps[1]["documentUpdateOrchestration"]["traceability"][
+            "sourceDirectory"
+        ] == "{{ inputs.document_directory }}"
+
 @pytest.mark.asyncio
 async def test_startup_deactivates_legacy_speckit_orchestrate_template(
     disabled_env_keys, tmp_path

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1879,6 +1879,66 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(tmp_path):
                 "dependencyMode": "linear_blocker_chain",
             }
 
+async def test_seed_catalog_includes_document_update_orchestrate_preset(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="document-update-orchestrate",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            assert template.title == "Document Update Orchestrate"
+            assert template.latest_version is not None
+            assert template.latest_version.annotations["sourceSkill"] == (
+                "document-update-orchestrate"
+            )
+            assert template.latest_version.annotations["output"] == (
+                "document-update-tasks"
+            )
+            assert [
+                step.get("tool", step.get("skill", {})).get("id")
+                for step in template.latest_version.steps
+            ] == [
+                "document.discover",
+                "story.create_document_update_tasks",
+            ]
+
+            expanded = await service.expand_template(
+                slug="document-update-orchestrate",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "document_directory": "docs",
+                    "publish_mode": "pr_with_merge_automation",
+                },
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+            )
+
+            assert len(expanded["steps"]) == 2
+            assert expanded["steps"][0]["tool"]["id"] == "document.discover"
+            assert expanded["steps"][1]["tool"]["id"] == "story.create_document_update_tasks"
+            assert expanded["steps"][1]["documentUpdateOrchestration"]["task"]["publish"] == {
+                "mode": "pr",
+                "mergeAutomation": {"enabled": True},
+            }
+            assert expanded["steps"][1]["documentUpdateOrchestration"]["traceability"][
+                "sourceDirectory"
+            ] == "docs"
+
 async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
     tmp_path,
 ):

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -7,8 +7,10 @@ import pytest
 
 from moonmind.workflows.temporal.story_output_tools import (
     check_jira_blockers,
+    create_document_update_tasks_from_paths,
     create_jira_issues_from_stories,
     create_jira_orchestrate_tasks_from_issue_mappings,
+    discover_documents,
 )
 
 class _FakeJiraService:
@@ -1437,3 +1439,181 @@ async def test_create_jira_orchestrate_tasks_reports_missing_issue_key_and_parti
     assert orchestration["dependencyCount"] == 0
     assert orchestration["failures"][0]["storyId"] == "STORY-002"
     assert orchestration["failures"][0]["errorCode"] == "task_creation_failed"
+
+
+@pytest.mark.asyncio
+async def test_discover_documents_finds_matching_files(tmp_path):
+    (tmp_path / "readme.md").write_text("# readme")
+    (tmp_path / "notes.txt").write_text("notes")
+    (tmp_path / "paper.tex").write_text("\\documentclass")
+    (tmp_path / "script.py").write_text("print()")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "deep.md").write_text("deep")
+
+    result = await discover_documents({"directory": str(tmp_path)})
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["documentCount"] == 4
+    paths = result.outputs["documentPaths"]
+    assert str(tmp_path / "readme.md") in paths
+    assert str(tmp_path / "notes.txt") in paths
+    assert str(tmp_path / "paper.tex") in paths
+    assert str(sub / "deep.md") in paths
+    assert str(tmp_path / "script.py") not in paths
+
+
+@pytest.mark.asyncio
+async def test_discover_documents_respects_custom_extensions(tmp_path):
+    (tmp_path / "a.md").write_text("a")
+    (tmp_path / "b.rst").write_text("b")
+    (tmp_path / "c.txt").write_text("c")
+
+    result = await discover_documents(
+        {"directory": str(tmp_path), "extensions": [".rst"]}
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["documentCount"] == 1
+    assert result.outputs["documentPaths"] == [str(tmp_path / "b.rst")]
+
+
+@pytest.mark.asyncio
+async def test_discover_documents_missing_directory():
+    result = await discover_documents({"directory": "/nonexistent/path"})
+
+    assert result.status == "FAILED"
+    assert result.outputs["documentPaths"] == []
+    assert "does not exist" in result.outputs["error"]
+
+
+@pytest.mark.asyncio
+async def test_discover_documents_missing_input():
+    result = await discover_documents({})
+
+    assert result.status == "FAILED"
+    assert result.outputs["documentPaths"] == []
+    assert "Missing required input" in result.outputs["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_document_update_tasks_from_inline_paths():
+    creator = _FakeExecutionCreator()
+
+    result = await create_document_update_tasks_from_paths(
+        {
+            "documentPaths": [
+                "/docs/readme.md",
+                "/docs/architecture.tex",
+            ],
+            "documentUpdateOrchestration": {
+                "task": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {
+                        "mode": "pr",
+                        "mergeAutomation": {"enabled": True},
+                    },
+                },
+                "traceability": {"sourceDirectory": "/docs"},
+            },
+        },
+        execution_creator=creator,
+    )
+
+    assert result.status == "COMPLETED"
+    orchestration = result.outputs["documentUpdateOrchestration"]
+    assert orchestration["status"] == "completed"
+    assert orchestration["documentCount"] == 2
+    assert orchestration["createdTaskCount"] == 2
+    assert orchestration["dependencyCount"] == 1
+
+    first = orchestration["tasks"][0]
+    assert first["documentPath"] == "/docs/readme.md"
+    assert first["dependsOn"] == []
+
+    second = orchestration["tasks"][1]
+    assert second["documentPath"] == "/docs/architecture.tex"
+    assert second["dependsOn"] == [first["workflowId"]]
+
+    first_task = creator.requests[0]["initial_parameters"]["task"]
+    assert first_task["taskTemplate"]["slug"] == "document-update"
+    assert first_task["publish"]["mode"] == "pr"
+    assert first_task["publish"]["mergeAutomation"]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_document_update_tasks_from_previous_outputs():
+    creator = _FakeExecutionCreator()
+
+    result = await create_document_update_tasks_from_paths(
+        {
+            "documentUpdateOrchestration": {
+                "task": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr", "mergeAutomation": {"enabled": False}},
+                },
+                "traceability": {"sourceDirectory": "/docs"},
+            }
+        },
+        {
+            "previousOutputs": {
+                "documentPaths": ["/docs/guide.md"],
+            }
+        },
+        execution_creator=creator,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["documentUpdateOrchestration"]["createdTaskCount"] == 1
+    assert creator.requests[0]["initial_parameters"]["task"]["inputs"]["document_path"] == "/docs/guide.md"
+
+
+@pytest.mark.asyncio
+async def test_create_document_update_tasks_handles_empty_paths():
+    result = await create_document_update_tasks_from_paths(
+        {"documentPaths": []},
+        execution_creator=_FakeExecutionCreator(),
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["documentUpdateOrchestration"]["status"] == "no_downstream_tasks"
+    assert result.outputs["documentUpdateOrchestration"]["createdTaskCount"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_document_update_tasks_reports_partial_failures():
+    creator = _FakeExecutionCreator(fail_at=2)
+
+    result = await create_document_update_tasks_from_paths(
+        {
+            "documentPaths": [
+                "/docs/a.md",
+                "/docs/b.md",
+                "/docs/c.md",
+            ],
+            "documentUpdateOrchestration": {
+                "task": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
+                },
+                "traceability": {"sourceDirectory": "/docs"},
+            },
+        },
+        execution_creator=creator,
+    )
+
+    orchestration = result.outputs["documentUpdateOrchestration"]
+    assert orchestration["status"] == "partial"
+    assert orchestration["createdTaskCount"] == 1
+    assert orchestration["dependencyCount"] == 0
+    assert orchestration["failures"][0]["documentPath"] == "/docs/b.md"
+    assert orchestration["failures"][0]["errorCode"] == "task_creation_failed"
+
+
+@pytest.mark.asyncio
+async def test_create_document_update_tasks_requires_execution_creator():
+    with pytest.raises(ValueError, match="execution_creator is required"):
+        await create_document_update_tasks_from_paths({"documentPaths": ["/docs/a.md"]})

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1456,11 +1456,11 @@ async def test_discover_documents_finds_matching_files(tmp_path):
     assert result.status == "COMPLETED"
     assert result.outputs["documentCount"] == 4
     paths = result.outputs["documentPaths"]
-    assert str(tmp_path / "readme.md") in paths
-    assert str(tmp_path / "notes.txt") in paths
-    assert str(tmp_path / "paper.tex") in paths
-    assert str(sub / "deep.md") in paths
-    assert str(tmp_path / "script.py") not in paths
+    assert "readme.md" in paths
+    assert "notes.txt" in paths
+    assert "paper.tex" in paths
+    assert "sub/deep.md" in paths
+    assert "script.py" not in paths
 
 
 @pytest.mark.asyncio
@@ -1475,7 +1475,24 @@ async def test_discover_documents_respects_custom_extensions(tmp_path):
 
     assert result.status == "COMPLETED"
     assert result.outputs["documentCount"] == 1
-    assert result.outputs["documentPaths"] == [str(tmp_path / "b.rst")]
+    assert result.outputs["documentPaths"] == ["b.rst"]
+
+
+@pytest.mark.asyncio
+async def test_discover_documents_returns_workspace_relative_paths(tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# guide")
+    nested = docs / "nested"
+    nested.mkdir()
+    (nested / "notes.txt").write_text("notes")
+
+    monkeypatch.chdir(tmp_path)
+
+    result = await discover_documents({"directory": str(docs)})
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["documentPaths"] == ["docs/guide.md", "docs/nested/notes.txt"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `document.discover` tool to scan directories for `.md`, `.txt`, `.tex` files.
- Add `story.create_document_update_tasks` tool to spawn child `document-update` runs for each discovered document.
- Create `document-update-orchestrate` preset YAML with configurable publish mode (`pr` or `pr_with_merge_automation`).
- Update the `document-update` agent skill to check constitution/README/architecture alignment before editing.
- Add Jira fallback when a document update contradicts the project's declared direction.
- Add unit and integration tests for new tools and preset seeding.

## Test Evidence
- 9 new unit tests in `test_story_output_tools.py` (all passing)
- 1 new unit test in `test_task_step_templates_service.py` (passing)
- Updated integration test in `test_startup_task_template_seeding.py` (passing)
- 158 targeted tests passed total.