### PR TITLE
MM-620 Remediation action contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,8 @@ Key diagnostics:
 - Existing SQLAlchemy/Alembic database with `execution_remediation_links` and existing Temporal execution source records (317-canonical-remediation-submissions)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind skill resolver/materializer services (318-refresh-managed-runtimes-after-derived-skill-activation)
 - Existing artifact-backed Skill content, resolved skillset manifests, runtime workspace/cache filesystem paths; no new persistent tables planned (318-refresh-managed-runtimes-after-derived-skill-activation)
+- Python 3.12 + Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest (320-remediation-action-contracts)
+- Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned (320-remediation-action-contracts)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -219,6 +219,8 @@ Key diagnostics:
 - Python 3.12 + Pydantic v2, Pydantic Settings, Temporal Python SDK activity boundaries, existing MoonMind agent-skill resolver/materializer services, pytest (315-disabled-skills-on-demand-controls)
 - No new persistent storage; disabled on-demand results and activation metadata are deterministic runtime outputs only (315-disabled-skills-on-demand-controls)
 - Existing SQLAlchemy/Alembic database with `execution_remediation_links` and existing Temporal execution source records (317-canonical-remediation-submissions)
+- Python 3.12 + Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest (320-remediation-action-contracts)
+- Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned (320-remediation-action-contracts)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -2025,19 +2025,40 @@ def _action_parameter_error(
     action_info: Mapping[str, Any],
     parameters: Mapping[str, Any] | None,
 ) -> str | None:
-    if not parameters:
-        return None
+    supplied_parameters = parameters or {}
     input_metadata = action_info.get("input_metadata")
     metadata = input_metadata if isinstance(input_metadata, Mapping) else {}
     allowed = {str(key) for key in metadata}
-    supplied = {str(key) for key in parameters}
+    supplied = {str(key) for key in supplied_parameters}
     if unknown := supplied - allowed:
         return "unsupported_action_parameter"
     for key, config in metadata.items():
         config_mapping = config if isinstance(config, Mapping) else {}
-        if config_mapping.get("required") is True and key not in parameters:
+        if config_mapping.get("required") is True and key not in supplied_parameters:
             return "required_action_parameter_missing"
+        if key in supplied_parameters and _parameter_type_error(
+            value=supplied_parameters[key],
+            expected_type=config_mapping.get("type"),
+        ):
+            return "invalid_action_parameter_type"
     return None
+
+
+def _parameter_type_error(*, value: Any, expected_type: Any) -> bool:
+    if expected_type == "string":
+        return not isinstance(value, str)
+    if expected_type == "boolean":
+        return not isinstance(value, bool)
+    if expected_type == "integer":
+        return not isinstance(value, int) or isinstance(value, bool)
+    if expected_type == "number":
+        return not isinstance(value, (int, float)) or isinstance(value, bool)
+    if expected_type == "object":
+        return not isinstance(value, Mapping)
+    if expected_type == "array":
+        return not isinstance(value, Sequence) or isinstance(value, (str, bytes))
+    return False
+
 
 def _scrub_paths(value: Any) -> Any:
     if isinstance(value, str):

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -47,10 +47,18 @@ _RAW_ACCESS_ACTION_KINDS = frozenset(
         "host_shell",
         "docker_daemon",
         "raw_docker",
+        "raw_volume_mount",
+        "volume_mount",
+        "raw_network_egress",
+        "network_egress_change",
         "sql_database",
         "raw_sql",
+        "secret_read",
+        "secret_reading",
+        "raw_secret_read",
         "storage_key_read",
         "raw_storage",
+        "redaction_bypass",
     }
 )
 _COMMON_REASON_INPUT = {
@@ -469,7 +477,8 @@ class RemediationActionAuthorityService:
 
     def __init__(self, *, session: AsyncSession) -> None:
         self._session = session
-        self._decisions: dict[tuple[str, str], RemediationActionAuthorityResult] = {}
+        self._decisions: dict[tuple[str, str, str], RemediationActionAuthorityResult] = {}
+        self._request_shapes: dict[tuple[str, str], str] = {}
 
     def list_allowed_actions(
         self,
@@ -525,7 +534,12 @@ class RemediationActionAuthorityService:
         workflow_id = str(remediation_workflow_id or "").strip()
         idem = str(idempotency_key or "").strip()
         normalized_action = str(action_kind or "").strip()
-        cache_key = (workflow_id, idem, normalized_action, dry_run)
+        request_shape_hash = _authority_request_shape_hash(
+            action_kind=normalized_action,
+            parameters=parameters,
+            dry_run=dry_run,
+        )
+        cache_key = (workflow_id, idem, request_shape_hash)
         if workflow_id and idem and cache_key in self._decisions:
             return self._decisions[cache_key]
 
@@ -582,6 +596,23 @@ class RemediationActionAuthorityService:
             )
             self._decisions[cache_key] = result
             return result
+        shape_key = (workflow_id, idem)
+        previous_shape = self._request_shapes.get(shape_key)
+        if previous_shape is not None and previous_shape != request_shape_hash:
+            result = self._linked_result(
+                link=link,
+                action_kind=normalized_action,
+                risk=None,
+                decision="denied",
+                reason="idempotency_key_reused_with_different_request",
+                idempotency_key=idem,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+            self._decisions[cache_key] = result
+            return result
 
         result = self._evaluate_with_link(
             link=link,
@@ -594,6 +625,7 @@ class RemediationActionAuthorityService:
             security_profile=security_profile,
             approval_ref=approval_ref,
         )
+        self._request_shapes.setdefault(shape_key, request_shape_hash)
         self._decisions[cache_key] = result
         return result
 
@@ -645,6 +677,23 @@ class RemediationActionAuthorityService:
                 risk=risk,
                 decision="denied",
                 reason="unsupported_action_kind",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        parameter_error = _action_parameter_error(
+            action_info=action_info,
+            parameters=parameters,
+        )
+        if parameter_error is not None:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason=parameter_error,
                 idempotency_key=idempotency_key,
                 requesting_principal=requesting_principal,
                 security_profile=security_profile,
@@ -1956,6 +2005,39 @@ def _redact_payload(value: Mapping[str, Any]) -> Mapping[str, Any]:
     if isinstance(redacted, Mapping):
         return _scrub_paths(redacted)
     return {}
+
+def _authority_request_shape_hash(
+    *,
+    action_kind: str,
+    parameters: Mapping[str, Any] | None,
+    dry_run: bool,
+) -> str:
+    payload = {
+        "actionKind": action_kind,
+        "dryRun": bool(dry_run),
+        "parameters": parameters or {},
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+def _action_parameter_error(
+    *,
+    action_info: Mapping[str, Any],
+    parameters: Mapping[str, Any] | None,
+) -> str | None:
+    if not parameters:
+        return None
+    input_metadata = action_info.get("input_metadata")
+    metadata = input_metadata if isinstance(input_metadata, Mapping) else {}
+    allowed = {str(key) for key in metadata}
+    supplied = {str(key) for key in parameters}
+    if unknown := supplied - allowed:
+        return "unsupported_action_parameter"
+    for key, config in metadata.items():
+        config_mapping = config if isinstance(config, Mapping) else {}
+        if config_mapping.get("required") is True and key not in parameters:
+            return "required_action_parameter_missing"
+    return None
 
 def _scrub_paths(value: Any) -> Any:
     if isinstance(value, str):

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -42,6 +42,9 @@ _PRESIGNED_URL_PATTERN = re.compile(
     r"https?://[^\s\"']*(?:X-Amz-Signature|X-Amz-Credential|AWSAccessKeyId|Signature|sig=|token=)[^\s\"']*",
     re.IGNORECASE,
 )
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(?:token|password|secret|api[_-]?key|credential)\s*[:=]\s*([^\s,;\"']+)"
+)
 
 class RemediationEvidenceToolError(RuntimeError):
     """Raised when a remediation evidence tool request is invalid."""
@@ -443,6 +446,9 @@ class RemediationEvidenceToolService:
             raise RemediationEvidenceToolError(
                 "verificationHint is required when verificationRequired is true."
             )
+        redacted_verification_hint = _redact_text(verification_hint)
+        if verification_required and redacted_verification_hint is None:
+            redacted_verification_hint = "Verification hint redacted."
         applied_at = _string_or_none(raw_result.get("appliedAt"))
         if applied_at is None and status == "applied":
             applied_at = datetime.now(timezone.utc).isoformat()
@@ -455,7 +461,7 @@ class RemediationEvidenceToolService:
             or f"Action {action_kind} completed with status {status}.",
             "appliedAt": applied_at,
             "verificationRequired": verification_required,
-            "verificationHint": verification_hint,
+            "verificationHint": redacted_verification_hint,
             "beforeStateRef": _redact_text(raw_result.get("beforeStateRef")),
             "afterStateRef": _redact_text(raw_result.get("afterStateRef")),
             "sideEffects": _redact_sequence(raw_result.get("sideEffects")),
@@ -776,16 +782,19 @@ def _redact_sequence(value: Any) -> list[Any]:
     return [_redact_payload_value(item) for item in _safe_sequence(value)]
 
 def _redact_payload_value(value: Any) -> Any:
-    redacted = redact_sensitive_payload(value)
-    if isinstance(redacted, str):
-        return _redact_text(redacted)
-    if isinstance(redacted, Mapping):
-        return {str(key): _redact_payload_value(item) for key, item in redacted.items()}
-    if isinstance(redacted, list):
-        return [_redact_payload_value(item) for item in redacted]
-    if isinstance(redacted, tuple):
-        return [_redact_payload_value(item) for item in redacted]
-    return redacted
+    def apply_custom_redaction(node: Any) -> Any:
+        if isinstance(node, str):
+            return _redact_text(node)
+        if isinstance(node, Mapping):
+            return {
+                str(key): apply_custom_redaction(item)
+                for key, item in node.items()
+            }
+        if isinstance(node, (list, tuple)):
+            return [apply_custom_redaction(item) for item in node]
+        return node
+
+    return apply_custom_redaction(redact_sensitive_payload(value))
 
 def _redact_text(value: Any) -> str | None:
     normalized = _string_or_none(value)
@@ -794,7 +803,10 @@ def _redact_text(value: Any) -> str | None:
     if normalized.startswith(("artifact://", "ref://")):
         return normalized
     redacted = redact_sensitive_text(normalized)
+    if redacted is None:
+        return None
     redacted = _PRESIGNED_URL_PATTERN.sub("[REDACTED_URL]", redacted)
+    redacted = _SECRET_ASSIGNMENT_PATTERN.sub("[REDACTED_SECRET]", redacted)
     redacted = _ABSOLUTE_PATH_PATTERN.sub("[REDACTED_PATH]", redacted)
     return redacted
 

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -8,8 +8,10 @@ that the context explicitly names.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Literal, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,8 +22,26 @@ from moonmind.workflows.temporal.remediation_context import (
     REMEDIATION_CONTEXT_LINK_TYPE,
     RemediationLifecyclePublisher,
 )
+from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 
 RemediationLogStream = Literal["stdout", "stderr", "merged", "diagnostics"]
+
+_ALLOWED_ACTION_RESULT_STATUSES = frozenset(
+    {
+        "applied",
+        "no_op",
+        "rejected",
+        "precondition_failed",
+        "approval_required",
+        "timed_out",
+        "failed",
+    }
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![\w.-])/(?:[^\s\"']+/)*[^\s\"']+")
+_PRESIGNED_URL_PATTERN = re.compile(
+    r"https?://[^\s\"']*(?:X-Amz-Signature|X-Amz-Credential|AWSAccessKeyId|Signature|sig=|token=)[^\s\"']*",
+    re.IGNORECASE,
+)
 
 class RemediationEvidenceToolError(RuntimeError):
     """Raised when a remediation evidence tool request is invalid."""
@@ -386,11 +406,13 @@ class RemediationEvidenceToolService:
             remediation_workflow_id=link.remediation_workflow_id,
             artifact_type="remediation.action_request",
             name=f"reports/remediation_action_request-{action_request['actionId']}.json",
-            payload={
-                "authority": dict(authority_result),
-                "guard": dict(guard_result),
-                "request": dict(action_request),
-            },
+            payload=_redact_payload_value(
+                {
+                    **dict(action_request),
+                    "authority": dict(authority_result),
+                    "guard": dict(guard_result),
+                }
+            ),
             target_workflow_id=link.target_workflow_id,
             target_run_id=link.target_run_id,
             principal=principal,
@@ -403,15 +425,40 @@ class RemediationEvidenceToolService:
         )
         if not isinstance(raw_result, Mapping):
             raise RemediationEvidenceToolError("action executor returned invalid result.")
-        status = _required_string(raw_result.get("status"), "status")
+        status = _normalize_action_result_status(raw_result.get("status"))
+        verification_required = _bool_or_default(
+            raw_result.get("verificationRequired"),
+            default=status == "applied",
+        )
+        verification_hint = _string_or_none(raw_result.get("verificationHint"))
+        if verification_hint is None and verification_required:
+            action_result = authority_result.get("result")
+            action_result_mapping = (
+                action_result if isinstance(action_result, Mapping) else {}
+            )
+            verification_hint = _string_or_none(
+                action_result_mapping.get("verificationHint")
+            )
+        if verification_required and verification_hint is None:
+            raise RemediationEvidenceToolError(
+                "verificationHint is required when verificationRequired is true."
+            )
+        applied_at = _string_or_none(raw_result.get("appliedAt"))
+        if applied_at is None and status == "applied":
+            applied_at = datetime.now(timezone.utc).isoformat()
         result_payload = {
             "schemaVersion": "v1",
             "actionKind": action_kind,
             "actionId": action_request["actionId"],
             "status": status,
-            "beforeStateRef": _string_or_none(raw_result.get("beforeStateRef")),
-            "afterStateRef": _string_or_none(raw_result.get("afterStateRef")),
-            "sideEffects": _safe_sequence(raw_result.get("sideEffects")),
+            "message": _redact_text(raw_result.get("message"))
+            or f"Action {action_kind} completed with status {status}.",
+            "appliedAt": applied_at,
+            "verificationRequired": verification_required,
+            "verificationHint": verification_hint,
+            "beforeStateRef": _redact_text(raw_result.get("beforeStateRef")),
+            "afterStateRef": _redact_text(raw_result.get("afterStateRef")),
+            "sideEffects": _redact_sequence(raw_result.get("sideEffects")),
         }
         result_artifact = await self._lifecycle_publisher.publish_json_artifact(
             remediation_workflow_id=link.remediation_workflow_id,
@@ -687,6 +734,14 @@ def _normalize_sequence(value: int | None, *, default_cursor: Any) -> int | None
         return max(0, parsed)
     return None
 
+def _normalize_action_result_status(value: Any) -> str:
+    status = _required_string(value, "status")
+    if status not in _ALLOWED_ACTION_RESULT_STATUSES:
+        raise RemediationEvidenceToolError(
+            f"Unsupported action result status: {status}."
+        )
+    return status
+
 def _required_string(value: Any, field_name: str) -> str:
     normalized = _string_or_none(value)
     if not normalized:
@@ -703,6 +758,45 @@ def _safe_sequence(value: Any) -> list[Any]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return list(value)
     return []
+
+def _bool_or_default(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+def _redact_sequence(value: Any) -> list[Any]:
+    return [_redact_payload_value(item) for item in _safe_sequence(value)]
+
+def _redact_payload_value(value: Any) -> Any:
+    redacted = redact_sensitive_payload(value)
+    if isinstance(redacted, str):
+        return _redact_text(redacted)
+    if isinstance(redacted, Mapping):
+        return {str(key): _redact_payload_value(item) for key, item in redacted.items()}
+    if isinstance(redacted, list):
+        return [_redact_payload_value(item) for item in redacted]
+    if isinstance(redacted, tuple):
+        return [_redact_payload_value(item) for item in redacted]
+    return redacted
+
+def _redact_text(value: Any) -> str | None:
+    normalized = _string_or_none(value)
+    if normalized is None:
+        return None
+    if normalized.startswith(("artifact://", "ref://")):
+        return normalized
+    redacted = redact_sensitive_text(normalized)
+    redacted = _PRESIGNED_URL_PATTERN.sub("[REDACTED_URL]", redacted)
+    redacted = _ABSOLUTE_PATH_PATTERN.sub("[REDACTED_PATH]", redacted)
+    return redacted
 
 def _enum_value(value: Any) -> str | None:
     if value is None:

--- a/specs/320-remediation-action-contracts/checklists/requirements.md
+++ b/specs/320-remediation-action-contracts/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Remediation Action Contracts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: `spec.md` preserves `MM-620` and the original Jira preset brief in the `**Input**` field.
+- PASS: The request is classified as a single-story runtime feature request; `moonspec-breakdown` was not needed.
+- PASS: In-scope source mappings cover `DESIGN-REQ-015`, `DESIGN-REQ-016`, `DESIGN-REQ-017`, and `DESIGN-REQ-026`.
+- PASS: No active `spec.md` existed for `MM-620`; this specify step created `specs/320-remediation-action-contracts/spec.md`.

--- a/specs/320-remediation-action-contracts/contracts/remediation-action-contracts.md
+++ b/specs/320-remediation-action-contracts/contracts/remediation-action-contracts.md
@@ -1,0 +1,141 @@
+# Contract: Remediation Action Contracts
+
+**Traceability**: Jira issue `MM-620`; feature path `specs/320-remediation-action-contracts`.
+
+## List Allowed Actions
+
+Intent: return the typed actions a remediation task may request for the current target and policy.
+
+Inputs:
+
+- `remediationWorkflowId`
+- caller permissions/principal
+- security profile or action policy context
+- pinned target workflow/run evidence
+
+Output: ordered collection of action registry entries.
+
+Each entry includes:
+
+- `actionKind`
+- `targetType`
+- `inputMetadata`
+- `riskTier`
+- `preconditions`
+- `idempotency`
+- `verificationRequired`
+- `verificationHint`
+- `auditPayloadShape`
+
+Rules:
+
+- Return only enabled, policy-compatible typed actions.
+- Do not include raw host, database, Docker, volume, network, secret-reading, or redaction-bypass actions.
+- Omit unsupported actions or return a bounded denial through the request path; never expose raw fallback instructions.
+
+## Evaluate Action Request
+
+Intent: decide whether one typed action request may proceed.
+
+Inputs:
+
+- `remediationWorkflowId`
+- `actionKind`
+- `parameters`
+- `dryRun`
+- `idempotencyKey`
+- `requestingPrincipal`
+- permissions
+- security profile
+- approval reference when available
+- current target evidence/freshness guard
+
+Output: authority/guard decision plus v1 request evidence.
+
+Required decision outcomes:
+
+- `executable`
+- `approval_required`
+- `rejected`
+- `precondition_failed`
+
+Rules:
+
+- Validate action kind, target type, authority, policy, inputs, preconditions, risk, dry-run, idempotency, and current target evidence before any side effect.
+- High-risk actions require policy-compatible approval before execution.
+- Dry-run requests cannot claim side effects were applied.
+- Unsupported raw operation classes fail before side effects.
+- Redact secrets, local paths, presigned URLs, storage keys, and raw administrative handles.
+
+## Publish Action Request Evidence
+
+Intent: durably preserve the request that led to an executable, denied, approval-required, or precondition-failed decision.
+
+Artifact type: `remediation.action_request`.
+
+Required payload fields:
+
+- `schemaVersion: v1`
+- `actionId`
+- `actionKind`
+- `requester`
+- `target`
+- `riskTier`
+- `dryRun`
+- `idempotencyKey`
+- `params`
+
+Rules:
+
+- Publish before invoking any side-effecting executor.
+- Keep payload bounded and redacted.
+- Preserve enough identity for audit without exposing unauthorized target details.
+
+## Publish Action Result Evidence
+
+Intent: durably preserve the outcome of an action request or execution attempt.
+
+Artifact type: `remediation.action_result`.
+
+Allowed statuses:
+
+- `applied`
+- `no_op`
+- `rejected`
+- `precondition_failed`
+- `approval_required`
+- `timed_out`
+- `failed`
+
+Required payload fields:
+
+- `schemaVersion: v1`
+- `actionId`
+- `actionKind`
+- `status`
+- `message`
+- `appliedAt` when applicable
+- `beforeStateRef`
+- `afterStateRef`
+- `verificationRequired`
+- `verificationHint` when verification is required
+- `sideEffects`
+
+Rules:
+
+- Unsupported statuses fail closed before publication.
+- `verificationRequired` and `verificationHint` must match action policy and result status.
+- `sideEffects` must be redacted bounded summaries, not raw output or handles.
+- A separate verification artifact may provide details, but the result artifact still declares verification requirements.
+
+## Verification Evidence
+
+Intent: prove the target state after an action when verification is required.
+
+Artifact type: `remediation.verification`.
+
+Rules:
+
+- Verification references must be linked to the action ID and action kind.
+- Failed or unavailable verification must be represented explicitly.
+- Verification evidence must remain bounded and redacted.

--- a/specs/320-remediation-action-contracts/data-model.md
+++ b/specs/320-remediation-action-contracts/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Remediation Action Contracts
+
+**Traceability**: Jira issue `MM-620`; feature path `specs/320-remediation-action-contracts`.
+
+## Remediation Action Registry Entry
+
+Represents one typed action that may be visible to a remediation task.
+
+Fields:
+
+- `actionKind`: stable typed action identifier.
+- `targetType`: target class the action may operate on.
+- `inputMetadata`: bounded action input schema/metadata.
+- `riskTier`: `low`, `medium`, or `high`.
+- `preconditions`: named checks that must pass before authorization or execution.
+- `idempotency`: rule describing duplicate request handling.
+- `verificationRequired`: whether execution requires post-action verification.
+- `verificationHint`: bounded user-safe verification guidance.
+- `auditPayloadShape`: compact metadata shape expected in audit output.
+
+Validation rules:
+
+- Raw host, database, Docker, volume, network, secret-reading, and redaction-bypass actions must not be listed.
+- Entries are returned only when enabled and compatible with caller permissions, security profile, target evidence, and action policy.
+- Returned metadata is immutable from the caller perspective; callers cannot mutate catalog state by editing a response.
+
+## Remediation Action Request Evidence
+
+Durable v1 record of an action request before any side effect is authorized.
+
+Fields:
+
+- `schemaVersion`: `v1`.
+- `actionId`: stable action/request identifier, normally tied to the idempotency key.
+- `actionKind`: typed action identifier.
+- `requester`: user, workflow, or service principal requesting the action.
+- `target`: target workflow/run/resource identity and resource kind.
+- `riskTier`: evaluated risk tier.
+- `dryRun`: whether side effects are prohibited for this request.
+- `idempotencyKey`: duplicate protection key.
+- `params`: redacted bounded action parameters.
+
+Validation rules:
+
+- Required identity fields must be non-empty.
+- `params` must not contain raw secrets, raw local paths, storage-local handles, or presigned URLs.
+- Request shape must be stable for idempotency decisions.
+- Request evidence must be published before a side effect is attempted.
+
+## Remediation Action Result Evidence
+
+Durable v1 record of an action decision or execution outcome.
+
+Fields:
+
+- `schemaVersion`: `v1`.
+- `actionId`: action/request identifier.
+- `actionKind`: typed action identifier.
+- `status`: one of `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, or `failed`.
+- `message`: bounded user-safe result message.
+- `appliedAt`: timestamp when a side effect was applied, otherwise absent/null.
+- `beforeStateRef`: optional artifact/reference to pre-action state.
+- `afterStateRef`: optional artifact/reference to post-action state.
+- `verificationRequired`: boolean flag for post-action verification.
+- `verificationHint`: bounded verification guidance when verification is required.
+- `sideEffects`: redacted bounded summary of side effects.
+
+Validation rules:
+
+- Unsupported statuses fail closed before durable publication.
+- `verificationHint` is required when `verificationRequired` is true.
+- `appliedAt` is present only when a side effect was actually applied.
+- Side effects are compact descriptions, not raw command output or administrative handles.
+
+## Action Policy
+
+Policy context used to decide action availability and execution.
+
+Fields:
+
+- `allowedActions`: typed actions that may be listed or requested.
+- `approvalRules`: risk and action-specific approval requirements.
+- `verificationRules`: actions requiring verification.
+- `retryBudget`: total and per-action attempt limits.
+- `cooldown`: time bounds between repeat attempts.
+- `locking`: mutation lock scope and mode.
+- `nesting`: nested remediation restrictions.
+
+Validation rules:
+
+- Policy cannot enable raw action kinds.
+- Missing or unsupported policy values fail with bounded denial rather than fallback execution.
+- High-risk policy must be reflected in action decisions before side effects.
+
+## State Transitions
+
+```text
+listed -> requested -> authority_decided -> guard_decided -> executed_or_denied -> result_recorded -> verification_recorded
+```
+
+Rules:
+
+- `requested` cannot proceed to side effects without executable authority and guard decisions.
+- `approval_required`, `rejected`, `precondition_failed`, `timed_out`, and `failed` are terminal for that action attempt unless a new request with valid idempotency context is submitted.
+- Duplicate idempotency keys may return prior compatible decisions but must not authorize a different action shape.

--- a/specs/320-remediation-action-contracts/implementation-notes.md
+++ b/specs/320-remediation-action-contracts/implementation-notes.md
@@ -1,0 +1,41 @@
+# Implementation Notes: Remediation Action Contracts
+
+**Traceability**: Jira issue `MM-620`; feature path `specs/320-remediation-action-contracts`.
+
+## Red-First Evidence
+
+- Focused unit command:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q`
+- Initial result: failed before production changes for the expected gaps:
+  missing top-level v1 request artifact fields, unsupported executor result status accepted, duplicate idempotency key with changed request shape not denied, raw `redaction_bypass` classified as a generic unsupported action, and unsupported action parameter accepted.
+- Integration command:
+  `pytest tests/integration/temporal/test_remediation_action_contracts.py -q`
+- Initial result: failed before production changes for the expected gaps:
+  missing top-level v1 request artifact fields and raw `redaction_bypass` not returning `raw_access_action_denied`.
+
+## Implementation Evidence
+
+- Added unit coverage for v1 request/result artifacts, status validation, idempotency request-shape reuse, raw-operation denial classes, and action parameter validation in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- Added hermetic integration coverage for the real remediation action artifact boundary in `tests/integration/temporal/test_remediation_action_contracts.py`.
+- Updated `moonmind/workflows/temporal/remediation_actions.py` to reject changed request shapes for reused idempotency keys, validate action parameters against catalog input metadata, and classify raw volume/network/secret/redaction-bypass operations as raw access denials.
+- Updated `moonmind/workflows/temporal/remediation_tools.py` to publish the v1 request payload at the artifact top level, validate result status values fail-closed, publish complete v1 result evidence, and redact sensitive request/result payload content.
+
+## Verification Evidence
+
+- Focused unit command after implementation:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q`
+- Result: PASS.
+- Targeted integration command after implementation:
+  `pytest tests/integration/temporal/test_remediation_action_contracts.py -q`
+- Result: PASS, 2 tests.
+- Integration wrapper command after implementation:
+  `./tools/test_integration.sh tests/integration/temporal/test_remediation_action_contracts.py`
+- Result: BLOCKED by managed Docker environment. Docker Compose reached image build, then the daemon returned `403 Forbidden` with "Request forbidden by administrative rules."
+- Full unit command after implementation:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Result: PASS; Python unit suite reported `4542 passed, 1 xpassed, 107 warnings, 16 subtests passed`, and frontend unit suite reported `20 passed` test files with `324 passed | 223 skipped`.
+
+## Quickstart Validation
+
+- The quickstart unit flow was validated by the focused unit and full unit wrapper results above.
+- The quickstart integration behavior was validated directly through `pytest tests/integration/temporal/test_remediation_action_contracts.py -q`; the repository Docker wrapper remains blocked in this managed runtime by daemon policy.

--- a/specs/320-remediation-action-contracts/moonspec_align_report.md
+++ b/specs/320-remediation-action-contracts/moonspec_align_report.md
@@ -1,0 +1,26 @@
+# MoonSpec Alignment Report: Remediation Action Contracts
+
+**Feature**: `specs/320-remediation-action-contracts`  
+**Date**: 2026-05-08  
+**Source**: MM-620 canonical Jira preset brief preserved in `spec.md`
+
+## Updated
+
+- `plan.md`: Aligned the integration testing strategy and source tree to require hermetic `integration_ci` coverage for the remediation action service/artifact boundary.
+- `research.md`: Updated the integration strategy decision from conditional coverage to required artifact-boundary coverage, with rationale tied to DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- `quickstart.md`: Aligned the focused unit command with `tasks.md` and made integration testing required for the remediation action artifact boundary.
+
+## Key Decisions
+
+- Integration coverage wording: chose required hermetic integration coverage because `tasks.md` includes T011 through T013 and T023 for the durable request/result/verification artifact boundary, and the plan's requirement table already marks the source design mappings as requiring integration proof.
+- Artifact regeneration: did not regenerate `spec.md` or `tasks.md` because the spec remains the higher-authority single-story contract and the task list already covered the required integration work. No downstream artifact was stale after the wording alignment.
+
+## Remaining Risks
+
+- Application implementation has not started. The known implementation risks remain the planned MM-620 gaps: result artifact completeness, result status validation, action input validation, raw-operation denial proof, and hermetic artifact-boundary evidence.
+
+## Validation
+
+- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
+- Artifact gate script: PASS; required artifacts exist, `tasks.md` has 31 sequential tasks, exactly one story phase, MM-620 traceability, unit and integration coverage, and final `/moonspec-verify` work.
+- Placeholder scan: PASS; no unresolved placeholders found in generated artifacts. The only `NEEDS CLARIFICATION` occurrence is the checklist item asserting none remain.

--- a/specs/320-remediation-action-contracts/plan.md
+++ b/specs/320-remediation-action-contracts/plan.md
@@ -44,7 +44,7 @@ MM-620 requires the remediation runtime to expose only typed, policy-compatible 
 **Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest  
 **Storage**: Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned  
 **Unit Testing**: `./tools/test_unit.sh` with focused pytest targets under `tests/unit/workflows/temporal/test_remediation_context.py` and related Temporal service tests  
-**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage when adding workflow/activity or artifact-boundary proof  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage of the remediation action service/artifact boundary planned by this story  
 **Target Platform**: MoonMind API/Temporal service runtime on Linux containers  
 **Project Type**: Python web service plus Temporal orchestration services  
 **Performance Goals**: Registry listing and action decision serialization remain bounded and deterministic for one remediation action request; action evidence payloads contain refs and compact metadata rather than raw logs, secrets, or large bodies  
@@ -99,10 +99,10 @@ tests/unit/workflows/temporal/
 └── test_temporal_service.py    # service-boundary remediation validation coverage
 
 tests/integration/
-└── ...                         # hermetic integration_ci action/tool artifact boundary coverage if added
+└── temporal/test_remediation_action_contracts.py  # hermetic integration_ci action/tool artifact boundary coverage
 ```
 
-**Structure Decision**: Use the existing remediation service layout. Runtime behavior belongs in `moonmind/workflows/temporal/remediation_actions.py` and `remediation_tools.py`; durable evidence publication uses the existing remediation lifecycle publisher and Temporal artifact service. Unit tests remain focused in the existing remediation test module, with hermetic integration coverage added only for the real service/artifact boundary.
+**Structure Decision**: Use the existing remediation service layout. Runtime behavior belongs in `moonmind/workflows/temporal/remediation_actions.py` and `remediation_tools.py`; durable evidence publication uses the existing remediation lifecycle publisher and Temporal artifact service. Unit tests remain focused in the existing remediation test module, with hermetic integration coverage added for the real service/artifact boundary.
 
 ## Complexity Tracking
 

--- a/specs/320-remediation-action-contracts/plan.md
+++ b/specs/320-remediation-action-contracts/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Remediation Action Contracts
+
+**Branch**: `320-remediation-action-contracts` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:f14332d1-2a04-407d-acdd-23b4fa3c3448/repo/specs/320-remediation-action-contracts/spec.md`
+
+## Summary
+
+MM-620 requires the remediation runtime to expose only typed, policy-compatible administrative actions and to preserve durable v1 request/result evidence for every requested action. Repo gap analysis found substantial existing implementation in `moonmind/workflows/temporal/remediation_actions.py`, `moonmind/workflows/temporal/remediation_tools.py`, and `tests/unit/workflows/temporal/test_remediation_context.py`: registry listing, authority decisions, high-risk approval gating, raw-access denial, mutation guard checks, pre-action freshness reads, and action lifecycle artifact publication already exist. Remaining work should be TDD-first and focused: tighten v1 request/result contracts, validate result statuses and required fields, verify unsupported raw operation classes more completely, and add hermetic integration evidence for the service/artifact boundary.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `RemediationActionAuthorityService.list_allowed_actions()` and `test_remediation_action_authority_lists_policy_compatible_actions` | preserve registry behavior | unit |
+| FR-002 | implemented_verified | `_ACTION_CATALOG` metadata and `test_remediation_action_authority_lists_canonical_mm483_action_registry` assert target type, inputs, risk, preconditions, idempotency, verification, audit shape | preserve metadata behavior | unit |
+| FR-003 | partial | authority evaluation, `RemediationMutationGuardService.evaluate()`, and `RemediationEvidenceToolService.prepare_action_request()` exist, but action input validation against listed metadata is not fully proven | add tests first for input/precondition/idempotency shape validation; implement missing validation if tests fail | unit + integration |
+| FR-004 | implemented_unverified | `RemediationActionAuthorityResult.to_dict()` produces a v1 `request`; `execute_action()` publishes `remediation.action_request` artifact, but artifact payload shape is not deeply asserted | add contract tests for published request evidence fields and redaction | unit + integration |
+| FR-005 | partial | `execute_action()` publishes `remediation.action_result`, but the published payload currently lacks explicit `message`, `appliedAt`, `verificationRequired`, and `verificationHint` fields required by the spec | add failing unit/integration tests, then complete the v1 result artifact payload | unit + integration |
+| FR-006 | partial | `RemediationActionAuthorityResult.to_dict()` maps decisions to some statuses; `execute_action()` accepts arbitrary executor `status` strings without enum validation | add status enum validation and tests for applied, no_op, rejected, precondition_failed, approval_required, timed_out, and failed | unit |
+| FR-007 | implemented_verified | high-risk catalog entries, approval logic, and `test_remediation_action_authority_enforces_profile_permissions_and_risk` | preserve high-risk approval behavior | unit |
+| FR-008 | implemented_unverified | raw access deny paths and no-advertise tests exist for host/Docker/SQL/storage classes; volume, network, secret-reading, and redaction-bypass variants need explicit evaluation proof | add explicit unsupported-operation tests; implement deny-list expansion if any variant is only treated as a generic unsupported action | unit |
+| FR-009 | implemented_verified | unsupported/legacy action kinds are filtered or denied in `list_allowed_actions()` and authority tests | preserve bounded omit/deny behavior | unit |
+| FR-010 | implemented_verified | `spec.md`, this plan, and design artifacts preserve `MM-620` and the original preset brief | preserve traceability through tasks, verification, commit, and PR metadata | traceability |
+| SCN-001 | implemented_verified | registry listing tests cover policy-compatible action metadata | rerun focused unit tests | unit |
+| SCN-002 | partial | authority and mutation guard decisions exist; full v1 request artifact proof needs stronger tests | add request artifact contract tests | unit + integration |
+| SCN-003 | implemented_verified | high-risk approval-required/rejected behavior covered in authority tests | rerun focused unit tests | unit |
+| SCN-004 | partial | action result artifacts are published but not complete against v1 result fields | add result artifact contract tests and implementation fix | unit + integration |
+| SCN-005 | implemented_unverified | raw host/Docker/SQL/storage denial covered; remaining raw operation classes require explicit proof | add unsupported-operation coverage | unit |
+| SCN-006 | implemented_verified | unsupported actions are filtered or denied without raw channel exposure | rerun focused unit tests | unit |
+| DESIGN-REQ-015 | partial | typed evidence/action service exists; action execution artifact boundary needs integration proof | add hermetic integration coverage for typed action request/execute/read artifact path | integration |
+| DESIGN-REQ-016 | partial | registry/request/result contracts exist in code but result contract is incomplete and status validation is loose | complete v1 result/status contract | unit + integration |
+| DESIGN-REQ-017 | partial | practical registry exists; exclusive lock and artifact behavior exist; v1 action evidence completeness needs proof | add focused unit/integration coverage | unit + integration |
+| DESIGN-REQ-026 | partial | policy inputs influence authority/guard decisions; retry/cooldown/locking evidence exists in guard service but action contract needs end-to-end proof | add policy decision and artifact contract tests | unit + integration |
+| SC-001 | implemented_verified | metadata tests assert required fields for listed actions | rerun focused unit tests | unit |
+| SC-002 | implemented_unverified | request evidence is generated but not deeply asserted at artifact boundary | add request evidence artifact tests | unit + integration |
+| SC-003 | partial | result evidence artifact exists but lacks all required v1 fields | add tests and implementation fix | unit + integration |
+| SC-004 | implemented_verified | high-risk approval logic tested | rerun focused unit tests | unit |
+| SC-005 | implemented_unverified | some raw operation classes tested; full spec list needs explicit cases | add unit tests for all unsupported operation classes | unit |
+| SC-006 | implemented_verified | artifacts preserve `MM-620` and source mappings | preserve through final verification | traceability |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest  
+**Storage**: Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned  
+**Unit Testing**: `./tools/test_unit.sh` with focused pytest targets under `tests/unit/workflows/temporal/test_remediation_context.py` and related Temporal service tests  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage when adding workflow/activity or artifact-boundary proof  
+**Target Platform**: MoonMind API/Temporal service runtime on Linux containers  
+**Project Type**: Python web service plus Temporal orchestration services  
+**Performance Goals**: Registry listing and action decision serialization remain bounded and deterministic for one remediation action request; action evidence payloads contain refs and compact metadata rather than raw logs, secrets, or large bodies  
+**Constraints**: No raw secrets or raw administrative handles in workflow payloads, artifacts, logs, summaries, or UI previews; unsupported raw operations fail closed; no compatibility aliases or fallback transforms for internal action kinds/statuses; source loading and action execution stay at service/activity boundaries  
+**Scale/Scope**: One remediation task evaluating one typed action request against one pinned target execution/run and one active action policy
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle I, Orchestrate, Don't Recreate: PASS. Action execution remains behind MoonMind-owned typed service/control-plane boundaries rather than exposing raw host or provider access to agents.
+- Principle II, One-Click Agent Deployment: PASS. No new required external service or credential is planned.
+- Principle III, Avoid Vendor Lock-In: PASS. Action contracts are provider-neutral MoonMind runtime contracts.
+- Principle IV, Own Your Data: PASS. Evidence is stored as local Temporal artifacts/refs and compact records, not external SaaS state.
+- Principle V, Skills Are First-Class: PASS. No mutation of active or checked-in skill folders is planned; remediation action tools remain ordinary runtime surfaces.
+- Principle VI, Replaceable Scaffolding: PASS. The plan tightens contracts around service boundaries and keeps cognitive/runtime behavior outside bespoke agent logic.
+- Principle VII, Runtime Configurability: PASS. Policy decisions remain driven by action policy/security profile inputs rather than hardcoded operator choices.
+- Principle VIII, Modular and Extensible Architecture: PASS. Work is scoped to remediation action, tool, guard, and artifact boundaries.
+- Principle IX, Resilient by Default: PASS. The story strengthens idempotency, precondition, status, verification, and bounded failure behavior.
+- Principle X, Continuous Improvement: PASS. Durable request/result/verification evidence improves run diagnosis and follow-up analysis.
+- Principle XI, Spec-Driven Development: PASS. `spec.md` preserves the MM-620 source brief and this plan maps every in-scope requirement before task generation.
+- Principle XII, Canonical Docs vs Migration Backlog: PASS. Planning and rollout notes live under `specs/320-remediation-action-contracts/`; canonical docs are source requirements only.
+- Principle XIII, Pre-Release Delete Don't Deprecate: PASS. Planned status/action contract tightening should remove or reject unsupported internal values rather than add aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/320-remediation-action-contracts/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-action-contracts.md
+└── tasks.md             # Phase 2 output only; not created by this plan step
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── remediation_actions.py      # action registry, authority decision, mutation guard contracts
+├── remediation_tools.py        # typed evidence/action execution artifact boundary
+├── remediation_context.py      # bounded context and lifecycle artifact publisher
+└── service.py                  # remediation link creation and target/run validation
+
+tests/unit/workflows/temporal/
+├── test_remediation_context.py # primary unit coverage for registry, authority, guard, tools, artifacts
+└── test_temporal_service.py    # service-boundary remediation validation coverage
+
+tests/integration/
+└── ...                         # hermetic integration_ci action/tool artifact boundary coverage if added
+```
+
+**Structure Decision**: Use the existing remediation service layout. Runtime behavior belongs in `moonmind/workflows/temporal/remediation_actions.py` and `remediation_tools.py`; durable evidence publication uses the existing remediation lifecycle publisher and Temporal artifact service. Unit tests remain focused in the existing remediation test module, with hermetic integration coverage added only for the real service/artifact boundary.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/320-remediation-action-contracts/quickstart.md
+++ b/specs/320-remediation-action-contracts/quickstart.md
@@ -7,14 +7,14 @@
 - Python dependencies installed for the repository.
 - Local unit test mode enabled for managed-agent containers: `MOONMIND_FORCE_LOCAL_TESTS=1`.
 - No external provider credentials are required for planned unit coverage.
-- Hermetic integration checks require the normal MoonMind compose test environment when integration tests are added.
+- Hermetic integration checks require the normal MoonMind compose test environment because this story includes required `integration_ci` artifact-boundary coverage.
 
 ## Unit Test Strategy
 
 Write or update focused tests before implementation:
 
 ```bash
-MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q
 ```
 
 Required unit coverage:
@@ -29,7 +29,7 @@ Required unit coverage:
 
 ## Integration Test Strategy
 
-If action execution artifact publication or service/activity wiring changes, add hermetic integration coverage marked `integration` and `integration_ci`, then run:
+Add hermetic integration coverage marked `integration` and `integration_ci` for the remediation action artifact boundary, then run:
 
 ```bash
 ./tools/test_integration.sh
@@ -69,7 +69,7 @@ Run the full required unit suite before closing implementation:
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
 ```
 
-Run hermetic integration tests when integration coverage was added or service/activity boundaries changed:
+Run the required hermetic integration suite for the remediation action artifact boundary:
 
 ```bash
 ./tools/test_integration.sh

--- a/specs/320-remediation-action-contracts/quickstart.md
+++ b/specs/320-remediation-action-contracts/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Remediation Action Contracts
+
+**Traceability**: Jira issue `MM-620`; feature path `specs/320-remediation-action-contracts`.
+
+## Prerequisites
+
+- Python dependencies installed for the repository.
+- Local unit test mode enabled for managed-agent containers: `MOONMIND_FORCE_LOCAL_TESTS=1`.
+- No external provider credentials are required for planned unit coverage.
+- Hermetic integration checks require the normal MoonMind compose test environment when integration tests are added.
+
+## Unit Test Strategy
+
+Write or update focused tests before implementation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py -q
+```
+
+Required unit coverage:
+
+1. Registry listing includes target type, input metadata, risk, preconditions, idempotency, verification, and audit metadata.
+2. Action request evaluation validates action kind, input shape, authority, policy, risk, dry-run, idempotency, and fresh target evidence.
+3. Published action request evidence contains the full v1 request contract and redacts sensitive values.
+4. Published action result evidence contains status, message, applied timestamp when applicable, verification requirement, verification hint, before/after refs, and side effects.
+5. Unsupported result statuses fail closed.
+6. Unsupported raw operation classes are rejected before side effects.
+7. High-risk actions return approval-required, rejected, or executable according to policy.
+
+## Integration Test Strategy
+
+If action execution artifact publication or service/activity wiring changes, add hermetic integration coverage marked `integration` and `integration_ci`, then run:
+
+```bash
+./tools/test_integration.sh
+```
+
+Required integration behavior when added:
+
+1. Create a target execution and remediation execution with a linked context artifact.
+2. List policy-compatible actions for the remediation task.
+3. Evaluate one executable action request with authority and mutation guard decisions.
+4. Execute through a fake owning action executor.
+5. Read the published `remediation.action_request`, `remediation.action_result`, and `remediation.verification` artifacts.
+6. Assert all v1 fields are present, redacted, bounded, and linked to the target workflow/run.
+7. Assert unsupported raw action attempts do not create side-effect artifacts.
+
+## End-to-End Story Validation
+
+1. Start with a remediation context whose policy allows a supportable v1 action.
+2. Confirm listed actions contain all required metadata and omit unsupported raw operations.
+3. Request the action with a stable idempotency key and valid parameters.
+4. Confirm request evidence is published before execution.
+5. Return an allowed result status from the fake owning executor.
+6. Confirm result and verification evidence are published with the v1 contract fields.
+7. Repeat with high-risk, approval-required, unsupported, stale-target, duplicate-idempotency, and failed-result cases.
+
+## Final Verification Commands
+
+Before final MoonSpec verification, run the focused unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q
+```
+
+Run the full required unit suite before closing implementation:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Run hermetic integration tests when integration coverage was added or service/activity boundaries changed:
+
+```bash
+./tools/test_integration.sh
+```
+
+Do not proceed to final verification until `plan.md`, `research.md`, `data-model.md`, this quickstart, and `contracts/remediation-action-contracts.md` remain consistent with `spec.md` and preserve `MM-620`.

--- a/specs/320-remediation-action-contracts/research.md
+++ b/specs/320-remediation-action-contracts/research.md
@@ -90,11 +90,11 @@ Test implications: unit tests first for every partial or unverified item.
 
 ## Integration Test Strategy
 
-Decision: Add hermetic integration coverage only for the real service/artifact boundary if implementation changes touch workflow/activity or artifact publication behavior.
-Evidence: Existing integration taxonomy requires `integration` + `integration_ci` for compose-backed hermetic checks; `RemediationEvidenceToolService.execute_action()` publishes real Temporal artifacts and updates remediation links.
-Rationale: Unit tests cover most logic, but durable artifact publication is an integration boundary that final evidence should exercise without external credentials.
-Alternatives considered: Provider verification was rejected because this story does not require live external providers.
-Test implications: use `./tools/test_integration.sh` for any new `integration_ci` boundary tests; otherwise document why focused unit coverage is sufficient.
+Decision: Add hermetic integration coverage for the real remediation action service/artifact boundary.
+Evidence: Existing integration taxonomy requires `integration` + `integration_ci` for compose-backed hermetic checks; `RemediationEvidenceToolService.execute_action()` publishes real Temporal artifacts and updates remediation links; `tasks.md` includes T011 through T013 and T023 for this boundary.
+Rationale: Unit tests cover most logic, but durable action request/result/verification artifact publication is an integration boundary required by DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+Alternatives considered: Provider verification was rejected because this story does not require live external providers. Unit-only coverage was rejected because final evidence must prove the durable artifact boundary.
+Test implications: add `integration` + `integration_ci` tests under `tests/integration/temporal/test_remediation_action_contracts.py` and run `./tools/test_integration.sh`.
 
 ## Storage And Migration Decision
 

--- a/specs/320-remediation-action-contracts/research.md
+++ b/specs/320-remediation-action-contracts/research.md
@@ -18,35 +18,35 @@ Test implications: rerun focused unit tests; no new implementation expected.
 
 ## FR-003 Request Evaluation Inputs And Preconditions
 
-Decision: Status `partial`; plan tests first, then implementation if gaps are confirmed.
-Evidence: `RemediationActionAuthorityService.evaluate_action_request()` validates action kind, authority mode, permissions, security profile, approval, risk, dry-run, and idempotency key. `RemediationMutationGuardService.evaluate()` covers lock, ledger, budgets, nested remediation, and target freshness. `RemediationEvidenceToolService.prepare_action_request()` rereads target health before execution. Existing tests cover many of these paths, including prepared action context and mutation guard behavior.
-Rationale: The decision chain exists, but the repo evidence does not prove action-specific parameters are validated against the registry `inputMetadata` before authorization.
+Decision: Status `implemented_verified`; preserve action input and idempotency-shape validation.
+Evidence: `RemediationActionAuthorityService.evaluate_action_request()` validates action kind, authority mode, permissions, security profile, approval, risk, dry-run, idempotency key, action-specific `inputMetadata`, and duplicate idempotency key request shape. `RemediationMutationGuardService.evaluate()` covers lock, ledger, budgets, nested remediation, and target freshness. `RemediationEvidenceToolService.prepare_action_request()` rereads target health before execution. `test_remediation_action_authority_validates_action_inputs`, `test_remediation_action_authority_cache_keys_include_request_shape`, and `test_remediation_action_authority_uses_prepared_action_context` verify these paths.
+Rationale: The decision chain now rejects unsupported action parameters and denies reused idempotency keys with different request shapes before authorization.
 Alternatives considered: Treating guard evaluation as complete input validation was rejected because guard checks do not cover every declared input shape.
-Test implications: add unit tests for required/unknown/invalid action inputs and integration proof that request evaluation consumes fresh target evidence before execution.
+Test implications: rerun focused unit tests and integration artifact-boundary tests.
 
 ## FR-004 V1 Action Request Evidence
 
-Decision: Status `implemented_unverified`; add contract tests for the published artifact payload.
-Evidence: `RemediationActionAuthorityResult.to_dict()` produces a v1 `request` object with `schemaVersion`, `actionId`, `actionKind`, requester, target, risk tier, dry-run flag, idempotency key, and params. `RemediationEvidenceToolService.execute_action()` publishes a `remediation.action_request` artifact. Existing tests assert artifact links are created but do not fully inspect the artifact payload shape.
-Rationale: Code appears aligned, but the artifact boundary is the durable contract and needs direct verification.
+Decision: Status `implemented_verified`; preserve v1 request artifact publication.
+Evidence: `RemediationActionAuthorityResult.to_dict()` produces a v1 `request` object with `schemaVersion`, `actionId`, `actionKind`, requester, target, risk tier, dry-run flag, idempotency key, and params. `RemediationEvidenceToolService.execute_action()` publishes a redacted `remediation.action_request` artifact whose top-level payload is the v1 request contract plus authority and guard evidence. `test_remediation_execute_action_publishes_v1_request_and_result_artifacts` and `test_remediation_action_contract_publishes_request_result_and_verification` read the published artifact payload directly.
+Rationale: The durable artifact boundary is now directly verified.
 Alternatives considered: Relying on `to_dict()` tests alone was rejected because final verification must prove the published evidence artifact, not just an in-memory object.
-Test implications: add unit/integration tests that read the published action request artifact and assert required fields plus redaction.
+Test implications: rerun focused unit tests and integration artifact-boundary tests.
 
 ## FR-005 V1 Action Result Evidence
 
-Decision: Status `partial`; complete the result artifact contract.
-Evidence: `RemediationEvidenceToolService.execute_action()` publishes a `remediation.action_result` artifact with `schemaVersion`, `actionKind`, `actionId`, `status`, before/after refs, and side effects. The spec requires status, user-safe message, applied timestamp when applicable, before/after refs, verification requirement, verification hint, and redacted side-effect summary. Current published result payload does not include `message`, `appliedAt`, `verificationRequired`, or `verificationHint`.
-Rationale: The durable artifact exists, but it is not complete against the v1 contract.
+Decision: Status `implemented_verified`; preserve the completed result artifact contract.
+Evidence: `RemediationEvidenceToolService.execute_action()` publishes a `remediation.action_result` artifact with `schemaVersion`, `actionKind`, `actionId`, allowed `status`, user-safe `message`, `appliedAt` when applicable, before/after refs, `verificationRequired`, `verificationHint`, and redacted `sideEffects`. `test_remediation_execute_action_publishes_v1_request_and_result_artifacts` and `test_remediation_action_contract_publishes_request_result_and_verification` read and verify the published result artifact.
+Rationale: The durable result artifact now matches the v1 contract and stays linked to verification evidence.
 Alternatives considered: Keeping verification details only in a separate `remediation.verification` artifact was rejected because the result evidence contract must still indicate whether verification is required and how to perform it.
-Test implications: write failing tests for full v1 result artifact shape before implementation.
+Test implications: rerun focused unit tests and integration artifact-boundary tests.
 
 ## FR-006 Status Enumeration
 
-Decision: Status `partial`; add fail-fast status normalization/validation.
-Evidence: `RemediationActionAuthorityResult.to_dict()` maps decisions to result statuses for authority outcomes. `RemediationEvidenceToolService.execute_action()` accepts executor `status` through `_required_string()` but does not appear to validate against the allowed status set.
-Rationale: Unsupported runtime result statuses can drift into durable artifacts unless validation is explicit.
+Decision: Status `implemented_verified`; preserve fail-fast status normalization/validation.
+Evidence: `RemediationActionAuthorityResult.to_dict()` maps decisions to result statuses for authority outcomes. `RemediationEvidenceToolService.execute_action()` validates executor `status` against `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, and `failed` before publishing result artifacts. `test_remediation_execute_action_rejects_unsupported_result_status` verifies unsupported statuses fail closed.
+Rationale: Unsupported runtime result statuses cannot drift into durable artifacts.
 Alternatives considered: Allowing arbitrary executor statuses was rejected by the compatibility policy and the spec's explicit status set.
-Test implications: add unit tests for `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, `failed`, plus an unsupported status failure case.
+Test implications: rerun focused unit tests.
 
 ## FR-007 High-Risk Actions
 
@@ -58,11 +58,11 @@ Test implications: rerun focused unit tests.
 
 ## FR-008 Unsupported Raw Operations
 
-Decision: Status `implemented_unverified`; expand explicit cases.
-Evidence: `_RAW_ACCESS_ACTION_KINDS` and raw-prefix checks deny known raw action kinds, and tests cover no-advertise behavior plus `raw_host_shell`. The spec also names arbitrary volume, network, secret-reading, and redaction-bypass operations.
-Rationale: Unknown actions are denied, but explicit proof for every spec-listed class reduces risk that a future catalog addition accidentally exposes raw access.
+Decision: Status `implemented_verified`; preserve explicit raw-operation denial coverage.
+Evidence: `_RAW_ACCESS_ACTION_KINDS` and raw-prefix checks deny host shell, database, Docker, volume mount, network egress, secret-reading, storage-key, and redaction-bypass classes before side effects. `test_remediation_action_authority_denies_raw_access_and_unknown_targets` covers the explicit unit cases, and `test_remediation_raw_action_rejection_does_not_publish_side_effect_artifacts` verifies no side-effect artifacts are published for a raw action attempt.
+Rationale: Explicit proof for every spec-listed class reduces risk that a future catalog addition accidentally exposes raw access.
 Alternatives considered: Treating generic `unsupported_action_kind` as enough was rejected because the spec requires rejection by kind before side effect for sensitive raw operation classes.
-Test implications: add explicit unit cases for host, database, Docker, volume, network, secret-reading, and redaction-bypass variants.
+Test implications: rerun focused unit tests and integration artifact-boundary tests.
 
 ## FR-009 Unsupported V1 Action Availability
 

--- a/specs/320-remediation-action-contracts/research.md
+++ b/specs/320-remediation-action-contracts/research.md
@@ -1,0 +1,105 @@
+# Research: Remediation Action Contracts
+
+## Story Scope And Classification
+
+Decision: Treat MM-620 as a single-story runtime feature and continue from `specs/320-remediation-action-contracts/spec.md`.
+Evidence: `/work/agent_jobs/mm:f14332d1-2a04-407d-acdd-23b4fa3c3448/repo/specs/320-remediation-action-contracts/spec.md` contains exactly one `## User Story - Typed Remediation Actions`, preserves `MM-620`, and maps `DESIGN-REQ-015`, `DESIGN-REQ-016`, `DESIGN-REQ-017`, and `DESIGN-REQ-026`.
+Rationale: The Jira brief selects one independently testable runtime behavior: typed remediation action listing/request/result evidence.
+Alternatives considered: Running `moonspec-breakdown` was rejected because the brief is not a broad multi-story design.
+Test implications: none beyond final MoonSpec traceability verification.
+
+## FR-001 And FR-002 Registry Listing Metadata
+
+Decision: Status `implemented_verified`; preserve existing behavior.
+Evidence: `moonmind/workflows/temporal/remediation_actions.py` defines `_ACTION_CATALOG` and `RemediationActionAuthorityService.list_allowed_actions()`. `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_action_authority_lists_canonical_mm483_action_registry` verifies canonical action kinds and required metadata: risk tier, target type, input metadata, preconditions, idempotency, verification hint, and audit payload shape.
+Rationale: Current implementation and tests directly cover registry listing and metadata requirements.
+Alternatives considered: Rebuilding a separate registry service was rejected because the existing authority service is already the runtime boundary.
+Test implications: rerun focused unit tests; no new implementation expected.
+
+## FR-003 Request Evaluation Inputs And Preconditions
+
+Decision: Status `partial`; plan tests first, then implementation if gaps are confirmed.
+Evidence: `RemediationActionAuthorityService.evaluate_action_request()` validates action kind, authority mode, permissions, security profile, approval, risk, dry-run, and idempotency key. `RemediationMutationGuardService.evaluate()` covers lock, ledger, budgets, nested remediation, and target freshness. `RemediationEvidenceToolService.prepare_action_request()` rereads target health before execution. Existing tests cover many of these paths, including prepared action context and mutation guard behavior.
+Rationale: The decision chain exists, but the repo evidence does not prove action-specific parameters are validated against the registry `inputMetadata` before authorization.
+Alternatives considered: Treating guard evaluation as complete input validation was rejected because guard checks do not cover every declared input shape.
+Test implications: add unit tests for required/unknown/invalid action inputs and integration proof that request evaluation consumes fresh target evidence before execution.
+
+## FR-004 V1 Action Request Evidence
+
+Decision: Status `implemented_unverified`; add contract tests for the published artifact payload.
+Evidence: `RemediationActionAuthorityResult.to_dict()` produces a v1 `request` object with `schemaVersion`, `actionId`, `actionKind`, requester, target, risk tier, dry-run flag, idempotency key, and params. `RemediationEvidenceToolService.execute_action()` publishes a `remediation.action_request` artifact. Existing tests assert artifact links are created but do not fully inspect the artifact payload shape.
+Rationale: Code appears aligned, but the artifact boundary is the durable contract and needs direct verification.
+Alternatives considered: Relying on `to_dict()` tests alone was rejected because final verification must prove the published evidence artifact, not just an in-memory object.
+Test implications: add unit/integration tests that read the published action request artifact and assert required fields plus redaction.
+
+## FR-005 V1 Action Result Evidence
+
+Decision: Status `partial`; complete the result artifact contract.
+Evidence: `RemediationEvidenceToolService.execute_action()` publishes a `remediation.action_result` artifact with `schemaVersion`, `actionKind`, `actionId`, `status`, before/after refs, and side effects. The spec requires status, user-safe message, applied timestamp when applicable, before/after refs, verification requirement, verification hint, and redacted side-effect summary. Current published result payload does not include `message`, `appliedAt`, `verificationRequired`, or `verificationHint`.
+Rationale: The durable artifact exists, but it is not complete against the v1 contract.
+Alternatives considered: Keeping verification details only in a separate `remediation.verification` artifact was rejected because the result evidence contract must still indicate whether verification is required and how to perform it.
+Test implications: write failing tests for full v1 result artifact shape before implementation.
+
+## FR-006 Status Enumeration
+
+Decision: Status `partial`; add fail-fast status normalization/validation.
+Evidence: `RemediationActionAuthorityResult.to_dict()` maps decisions to result statuses for authority outcomes. `RemediationEvidenceToolService.execute_action()` accepts executor `status` through `_required_string()` but does not appear to validate against the allowed status set.
+Rationale: Unsupported runtime result statuses can drift into durable artifacts unless validation is explicit.
+Alternatives considered: Allowing arbitrary executor statuses was rejected by the compatibility policy and the spec's explicit status set.
+Test implications: add unit tests for `applied`, `no_op`, `rejected`, `precondition_failed`, `approval_required`, `timed_out`, `failed`, plus an unsupported status failure case.
+
+## FR-007 High-Risk Actions
+
+Decision: Status `implemented_verified`; preserve behavior.
+Evidence: `_ACTION_CATALOG` marks high-risk actions such as `execution.force_terminate`, `session.terminate`, and `session.restart_container`; `test_remediation_action_authority_enforces_profile_permissions_and_risk` verifies high-risk approval-required behavior.
+Rationale: Existing code and tests directly cover the requirement.
+Alternatives considered: Deferring high-risk handling to external approval services was rejected because the action authority service must make bounded decisions before side effects.
+Test implications: rerun focused unit tests.
+
+## FR-008 Unsupported Raw Operations
+
+Decision: Status `implemented_unverified`; expand explicit cases.
+Evidence: `_RAW_ACCESS_ACTION_KINDS` and raw-prefix checks deny known raw action kinds, and tests cover no-advertise behavior plus `raw_host_shell`. The spec also names arbitrary volume, network, secret-reading, and redaction-bypass operations.
+Rationale: Unknown actions are denied, but explicit proof for every spec-listed class reduces risk that a future catalog addition accidentally exposes raw access.
+Alternatives considered: Treating generic `unsupported_action_kind` as enough was rejected because the spec requires rejection by kind before side effect for sensitive raw operation classes.
+Test implications: add explicit unit cases for host, database, Docker, volume, network, secret-reading, and redaction-bypass variants.
+
+## FR-009 Unsupported V1 Action Availability
+
+Decision: Status `implemented_verified`; preserve omit/deny behavior.
+Evidence: `list_allowed_actions()` filters actions by enabled catalog and security profile allowlist. `test_remediation_action_authority_rejects_legacy_action_aliases` and `test_remediation_action_authority_lists_policy_compatible_actions` verify unsupported/legacy actions are not advertised.
+Rationale: The listing surface already omits unsupported actions and the evaluator denies unsupported kinds.
+Alternatives considered: Advertising unavailable actions with raw fallback instructions was rejected by the source design.
+Test implications: rerun focused unit tests.
+
+## FR-010 Traceability
+
+Decision: Status `implemented_verified`; preserve through later artifacts.
+Evidence: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/remediation-action-contracts.md` preserve `MM-620`.
+Rationale: Final verification must compare implementation and artifacts to the original Jira preset brief.
+Alternatives considered: Relying on Jira links alone was rejected because MoonSpec verification consumes local artifacts.
+Test implications: final MoonSpec verification.
+
+## Unit Test Strategy
+
+Decision: Use focused pytest tests through `./tools/test_unit.sh`, primarily `tests/unit/workflows/temporal/test_remediation_context.py` and related Temporal service tests.
+Evidence: Existing remediation action, guard, context, and tool tests already live in that module and use local SQLite plus local artifact store fixtures.
+Rationale: Unit tests can validate registry metadata, request/result serialization, status validation, redaction, idempotency, and no-side-effect denial without external services.
+Alternatives considered: Adding a new test module was considered, but extending the existing remediation test module keeps related boundary fixtures together.
+Test implications: unit tests first for every partial or unverified item.
+
+## Integration Test Strategy
+
+Decision: Add hermetic integration coverage only for the real service/artifact boundary if implementation changes touch workflow/activity or artifact publication behavior.
+Evidence: Existing integration taxonomy requires `integration` + `integration_ci` for compose-backed hermetic checks; `RemediationEvidenceToolService.execute_action()` publishes real Temporal artifacts and updates remediation links.
+Rationale: Unit tests cover most logic, but durable artifact publication is an integration boundary that final evidence should exercise without external credentials.
+Alternatives considered: Provider verification was rejected because this story does not require live external providers.
+Test implications: use `./tools/test_integration.sh` for any new `integration_ci` boundary tests; otherwise document why focused unit coverage is sufficient.
+
+## Storage And Migration Decision
+
+Decision: Reuse existing execution remediation links and artifact storage; no new persistent table is planned.
+Evidence: `TemporalExecutionRemediationLink` stores remediation relationship/action summary state; `RemediationLifecyclePublisher` and `TemporalArtifactService` already publish context, action, result, and verification artifacts.
+Rationale: The story requires durable bounded evidence, which fits existing artifact-backed storage.
+Alternatives considered: A dedicated action ledger table was rejected for this story because current guard/ledger behavior and durable artifacts cover the v1 evidence needs; a future analytics story can revisit persistence if required.
+Test implications: tests should assert artifact contents and link updates, not a new migration.

--- a/specs/320-remediation-action-contracts/spec.md
+++ b/specs/320-remediation-action-contracts/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Remediation Action Contracts
+
+**Feature Branch**: `320-remediation-action-contracts`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-620 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-620 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-620
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Provide typed remediation action registry and v1 action evidence contracts
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-620 from MM project
+Summary: Provide typed remediation action registry and v1 action evidence contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Tasks/TaskRemediation.md
+Source Title: Task Remediation
+Source Sections:
+- 9.5 Evidence access surface for remediation tasks
+- 11. Remediation action registry
+- 17. Recommended v1
+- Appendix A. Example action policy
+Coverage IDs:
+- DESIGN-REQ-015
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+- DESIGN-REQ-026
+As a remediation task, I can list and request only typed, allowlisted administrative actions with durable v1 request/result evidence so that interventions are validated, risk-scored, idempotency-aware, and auditable.
+Acceptance Criteria
+- Allowed action listing returns only policy-compatible typed actions with target type, inputs, risk, preconditions, idempotency, verification, and audit metadata.
+- Action request/result evidence uses durable bounded v1 contracts and contains no raw secrets or raw administrative handles.
+- High-risk actions are marked high and return approval_required, rejected, or executable according to policy.
+- Unsupported raw operations are rejected by kind before any side effect.
+- The initial registry matches the practical v1 subset unless an action is unavailable, in which case it is omitted or denied with bounded reason.
+Requirements
+- All side effects are requested through typed action kinds.
+- Every action has durable evidence and verification requirements.
+- The registry is extensible without exposing raw control channels.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-620 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+Preserved source Jira preset brief: `MM-620` from the trusted `jira.get_issue` response, reproduced in the `**Input**` field above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-620` and local artifact `/work/agent_jobs/mm:f14332d1-2a04-407d-acdd-23b4fa3c3448/artifacts/moonspec/MM-620-orchestration-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserved `MM-620`, so `Specify` was the first incomplete stage.
+
+## User Story - Typed Remediation Actions
+
+**Summary**: As a remediation task, I can list and request only typed, allowlisted administrative actions with durable v1 request and result evidence so that interventions are validated, risk-scored, idempotency-aware, and auditable.
+
+**Goal**: Remediation work exposes a bounded, policy-compatible action catalog and records every action request and outcome as durable, redacted evidence before any side effect is considered successful.
+
+**Independent Test**: Create remediation contexts with different action policies and target states, then verify that allowed action listing, action request validation, risk outcomes, idempotency behavior, rejection of unsupported raw operations, and request/result evidence are all observable without requiring unrestricted administrative access.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation task has an action policy and target evidence, **When** it asks what actions are available, **Then** it receives only policy-compatible typed actions with target type, input metadata, risk tier, preconditions, idempotency expectations, verification expectations, and audit metadata.
+2. **Given** a remediation task requests an allowlisted action with valid target, inputs, preconditions, and idempotency context, **When** the request is evaluated, **Then** a bounded v1 action request record is produced and the decision is one of executable, approval-required, rejected, or precondition-failed according to policy.
+3. **Given** a high-risk remediation action is requested, **When** policy requires approval or disables the action, **Then** the result is approval-required or rejected and no side effect is executed before that decision is recorded.
+4. **Given** an action completes, is skipped as a no-op, times out, fails, or is rejected, **When** the result is recorded, **Then** a bounded v1 action result record includes status, verification requirement, verification hint, before/after evidence references when available, and a redacted side-effect summary.
+5. **Given** a remediation task attempts an unsupported raw host, database, Docker, volume, network, secret-reading, or redaction-bypass operation, **When** the action is evaluated, **Then** it is rejected by kind before any side effect and the rejection is audited.
+6. **Given** the practical v1 policy does not support a documented action in the current environment, **When** the available action registry is listed, **Then** the action is omitted or denied with a bounded reason rather than exposed as a raw control channel.
+
+### Edge Cases
+
+- Missing or stale target evidence prevents side-effecting actions until fresh preconditions can be evaluated.
+- Reusing an idempotency key with a different action, target, dry-run shape, or parameters does not inherit a previous executable decision.
+- A dry-run request produces evidence and verification guidance without claiming that a side effect was applied.
+- Evidence references that are missing, unauthorized, or no longer readable result in a bounded denial or precondition failure that does not leak hidden target details.
+- Action records redact raw secrets, storage-local handles, privileged administrative handles, and unauthorized target identifiers.
+- Registry listing remains deterministic for the same policy and target evidence even when unavailable actions are omitted.
+
+## Assumptions
+
+- Runtime intent is required because the Jira Orchestrate preset always runs as a runtime implementation workflow.
+- The referenced `docs/Tasks/TaskRemediation.md` sections are source requirements for this story, while unreferenced remediation lifecycle, user interface, and automatic self-healing behavior remain outside this specification unless needed to validate typed action evidence.
+- The practical v1 registry is allowed to expose only actions that are currently supportable through MoonMind-owned control surfaces; unsupported actions must be omitted or denied rather than simulated through raw access.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-015** (`docs/Tasks/TaskRemediation.md` section 9.5, lines 545-570): Remediation tasks must use a MoonMind-owned typed evidence and action surface for context, artifacts, logs, allowed action listing, action execution, and target verification instead of scraping pages or using raw administrative access. **Scope**: In scope. **Maps to**: FR-001, FR-002, FR-008.
+- **DESIGN-REQ-016** (`docs/Tasks/TaskRemediation.md` section 11, lines 727-900): Remediation actions must be exposed as typed action kinds with declared target type, allowed inputs, risk tier, preconditions, idempotency rules, verification requirements, audit payload shape, request contract, result contract, and explicit rejection of unsupported raw operations. **Scope**: In scope. **Maps to**: FR-001 through FR-008.
+- **DESIGN-REQ-017** (`docs/Tasks/TaskRemediation.md` section 17, lines 1309-1353): The v1 remediation registry must remain practical and bounded, with manual creation, pinned target run evidence, artifact-first context, a small supportable action registry, exclusive mutation lock expectations, and full audit artifacts. **Scope**: In scope for registry/evidence behavior; manual creation and broader lock lifecycle are covered only where they constrain action availability and evidence. **Maps to**: FR-001, FR-003, FR-004, FR-005, FR-007, FR-009.
+- **DESIGN-REQ-026** (`docs/Tasks/TaskRemediation.md` Appendix A, lines 1395-1433): Action policy must express allowed actions, approval rules, verification requirements, retry budgets, cooldowns, locking expectations, and nested-remediation restrictions in a way that bounds action decisions. **Scope**: In scope for policy-visible action decisions and evidence; detailed policy administration is out of scope. **Maps to**: FR-001, FR-003, FR-005, FR-006, FR-009.
+- **DESIGN-REQ-OUT-001** (`docs/Tasks/TaskRemediation.md` unreferenced sections): Full remediation creation flow, Mission Control presentation, automatic self-healing policy, broad audit UI, and long-term prevention pull request workflows are outside this single story except where their existing evidence or policy state affects typed action decisions. **Scope**: Out of scope to preserve a single independently testable story. **Maps to**: None.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a remediation action registry that lists only policy-compatible typed actions for the current remediation task and target evidence.
+- **FR-002**: Each listed action MUST include target type, allowed inputs, risk tier, preconditions, idempotency expectations, verification requirements, and audit metadata sufficient for a remediation task to decide whether the action can be requested.
+- **FR-003**: System MUST evaluate every action request against action kind, target type, caller/remediation authority, policy, inputs, preconditions, risk tier, dry-run flag, idempotency key, and current target evidence before any side effect is authorized.
+- **FR-004**: System MUST record every action request using a bounded v1 evidence contract that includes schema version, action identity, action kind, requester identity, target identity, risk tier, dry-run state, idempotency key, and redacted bounded parameters.
+- **FR-005**: System MUST record every action outcome using a bounded v1 evidence contract that includes schema version, action identity, status, user-safe message, applied timestamp when applicable, before/after evidence references when available, verification requirement, verification hint, and redacted side-effect summary.
+- **FR-006**: System MUST represent action decisions and results with explicit statuses for applied, no-op, rejected, precondition-failed, approval-required, timed-out, and failed outcomes.
+- **FR-007**: System MUST mark high-risk actions as high risk and return approval-required, rejected, or executable according to the active action policy before any high-risk side effect occurs.
+- **FR-008**: System MUST reject unsupported raw host, database, Docker, volume, network, secret-reading, and redaction-bypass operations by action kind before any side effect.
+- **FR-009**: System MUST omit unsupported v1 actions or deny them with a bounded reason rather than exposing raw administrative channels or fabricated availability.
+- **FR-010**: System MUST preserve Jira issue key `MM-620` and the original preset brief in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities *(include if feature involves data)*
+
+- **Remediation Action Registry Entry**: A typed, policy-compatible action available to a remediation task, including action kind, target type, input metadata, risk tier, preconditions, idempotency expectations, verification requirements, and audit metadata.
+- **Remediation Action Request Evidence**: Durable bounded record of a requested remediation action, including requester, target, risk, dry-run state, idempotency key, and redacted parameters.
+- **Remediation Action Result Evidence**: Durable bounded record of an action decision or outcome, including status, message, application timestamp when applicable, evidence references, verification requirements, and redacted side effects.
+- **Action Policy**: The policy context that determines allowed actions, risk handling, approval requirements, verification requirements, retry/cooldown limits, locking expectations, and nested remediation constraints.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every remediation action policy tested, the listed actions contain 100% of required metadata fields and contain no unsupported raw operation kinds.
+- **SC-002**: 100% of side-effecting action requests produce durable bounded request evidence before an executable or approval-required decision is returned.
+- **SC-003**: 100% of completed, denied, timed-out, failed, no-op, and approval-required action outcomes produce durable bounded result evidence with a verification requirement or explicit reason no verification applies.
+- **SC-004**: High-risk action scenarios return approval-required, rejected, or executable according to policy in 100% of validation cases, with no side effect before the decision is recorded.
+- **SC-005**: Unsupported raw operation attempts are rejected before side effects in 100% of validation cases.
+- **SC-006**: Verification evidence can trace `MM-620`, the preserved preset brief, and all in-scope source design requirements to functional requirements without unmapped in-scope coverage IDs.

--- a/specs/320-remediation-action-contracts/tasks.md
+++ b/specs/320-remediation-action-contracts/tasks.md
@@ -24,8 +24,8 @@
 
 **Purpose**: Confirm the active feature and existing tooling before writing tests.
 
-- [ ] T001 Verify `.specify/feature.json` points to `specs/320-remediation-action-contracts` and that `specs/320-remediation-action-contracts/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/remediation-action-contracts.md` exist for MM-620.
-- [ ] T002 Verify unit and integration command availability in `tools/test_unit.sh`, `tools/test_integration.sh`, and `specs/320-remediation-action-contracts/quickstart.md` before adding tests.
+- [X] T001 Verify `.specify/feature.json` points to `specs/320-remediation-action-contracts` and that `specs/320-remediation-action-contracts/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/remediation-action-contracts.md` exist for MM-620.
+- [X] T002 Verify unit and integration command availability in `tools/test_unit.sh`, `tools/test_integration.sh`, and `specs/320-remediation-action-contracts/quickstart.md` before adding tests.
 
 ---
 
@@ -35,8 +35,8 @@
 
 **Critical**: No production implementation work can begin until foundational tasks and red-first tests are complete.
 
-- [ ] T003 Add or extend reusable unit-test helpers for reading and decoding remediation lifecycle artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, FR-005, SCN-002, and SCN-004.
-- [ ] T004 Create the hermetic integration test module scaffold with `integration` and `integration_ci` markers in `tests/integration/temporal/test_remediation_action_contracts.py` for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T003 Add or extend reusable unit-test helpers for reading and decoding remediation lifecycle artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, FR-005, SCN-002, and SCN-004.
+- [X] T004 Create the hermetic integration test module scaffold with `integration` and `integration_ci` markers in `tests/integration/temporal/test_remediation_action_contracts.py` for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
 
 **Checkpoint**: Test scaffolding is ready; story tests can now be written.
 
@@ -67,36 +67,36 @@
 
 ### Unit Tests (write first)
 
-- [ ] T005 Add failing unit tests for action-specific input metadata validation, idempotency shape reuse, and fresh target evidence gating in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
-- [ ] T006 Add failing unit tests that read the published `remediation.action_request` artifact and assert the full v1 request evidence contract plus redaction in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
-- [ ] T007 Add failing unit tests that read the published `remediation.action_result` artifact and assert `message`, `appliedAt`, `verificationRequired`, `verificationHint`, status, before/after refs, and redacted side effects in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
-- [ ] T008 Add failing unit tests for allowed status validation and unsupported status rejection in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-006 and SC-003.
-- [ ] T009 Add explicit unit tests for unsupported raw host, database, Docker, volume, network, secret-reading, and redaction-bypass action classes in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
-- [ ] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and confirm T005 through T009 fail for the expected red-first reasons before production implementation.
+- [X] T005 Add failing unit tests for action-specific input metadata validation, idempotency shape reuse, and fresh target evidence gating in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T006 Add failing unit tests that read the published `remediation.action_request` artifact and assert the full v1 request evidence contract plus redaction in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
+- [X] T007 Add failing unit tests that read the published `remediation.action_result` artifact and assert `message`, `appliedAt`, `verificationRequired`, `verificationHint`, status, before/after refs, and redacted side effects in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
+- [X] T008 Add failing unit tests for allowed status validation and unsupported status rejection in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-006 and SC-003.
+- [X] T009 Add explicit unit tests for unsupported raw host, database, Docker, volume, network, secret-reading, and redaction-bypass action classes in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
+- [X] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and confirm T005 through T009 fail for the expected red-first reasons before production implementation.
 
 ### Integration Tests (write first)
 
-- [ ] T011 Add a failing hermetic integration test for one executable remediation action that verifies list, authority, guard, execute, request artifact, result artifact, verification artifact, and link update behavior in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-002, SCN-004, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
-- [ ] T012 Add a failing hermetic integration test proving unsupported raw actions are rejected and do not publish side-effect request/result artifacts in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-005, FR-008, SC-005, and DESIGN-REQ-015.
-- [ ] T013 Run `./tools/test_integration.sh` and confirm T011 through T012 fail for the expected red-first reasons before production implementation.
-- [ ] T014 Record the red-first unit and integration failure evidence in `specs/320-remediation-action-contracts/implementation-notes.md` for FR-003, FR-004, FR-005, FR-006, FR-008, SCN-002, SCN-004, SCN-005, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T011 Add a failing hermetic integration test for one executable remediation action that verifies list, authority, guard, execute, request artifact, result artifact, verification artifact, and link update behavior in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-002, SCN-004, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T012 Add a failing hermetic integration test proving unsupported raw actions are rejected and do not publish side-effect request/result artifacts in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-005, FR-008, SC-005, and DESIGN-REQ-015.
+- [X] T013 Run `./tools/test_integration.sh` and confirm T011 through T012 fail for the expected red-first reasons before production implementation. Direct pytest was used for red-first confirmation because the managed Docker wrapper is blocked by daemon policy.
+- [X] T014 Record the red-first unit and integration failure evidence in `specs/320-remediation-action-contracts/implementation-notes.md` for FR-003, FR-004, FR-005, FR-006, FR-008, SCN-002, SCN-004, SCN-005, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
 
 ### Implementation
 
-- [ ] T015 Implement action parameter/input metadata validation and idempotency shape safeguards in `moonmind/workflows/temporal/remediation_actions.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
-- [ ] T016 Conditional fallback if T006 or T011 exposes a request artifact gap: update action request artifact publication in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
-- [ ] T017 Implement allowed result status validation and fail-fast unsupported status handling in `moonmind/workflows/temporal/remediation_tools.py` for FR-006 and SC-003.
-- [ ] T018 Complete the v1 action result artifact payload in `moonmind/workflows/temporal/remediation_tools.py` with `message`, `appliedAt`, `verificationRequired`, `verificationHint`, before/after refs, and redacted side effects for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
-- [ ] T019 Conditional fallback if T009 or T012 exposes a raw-operation proof gap: expand raw operation deny-listing and explicit denial reasons in `moonmind/workflows/temporal/remediation_actions.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
-- [ ] T020 Ensure request/result/verification artifact payloads remain bounded and secret-safe in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, FR-005, DESIGN-REQ-015, DESIGN-REQ-016, and SC-002.
-- [ ] T021 Update integration fixture wiring only as needed in `tests/integration/temporal/test_remediation_action_contracts.py` so the hermetic tests exercise the real artifact service boundary for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T015 Implement action parameter/input metadata validation and idempotency shape safeguards in `moonmind/workflows/temporal/remediation_actions.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [X] T016 Conditional fallback if T006 or T011 exposes a request artifact gap: update action request artifact publication in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
+- [X] T017 Implement allowed result status validation and fail-fast unsupported status handling in `moonmind/workflows/temporal/remediation_tools.py` for FR-006 and SC-003.
+- [X] T018 Complete the v1 action result artifact payload in `moonmind/workflows/temporal/remediation_tools.py` with `message`, `appliedAt`, `verificationRequired`, `verificationHint`, before/after refs, and redacted side effects for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
+- [X] T019 Conditional fallback if T009 or T012 exposes a raw-operation proof gap: expand raw operation deny-listing and explicit denial reasons in `moonmind/workflows/temporal/remediation_actions.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
+- [X] T020 Ensure request/result/verification artifact payloads remain bounded and secret-safe in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, FR-005, DESIGN-REQ-015, DESIGN-REQ-016, and SC-002.
+- [X] T021 Update integration fixture wiring only as needed in `tests/integration/temporal/test_remediation_action_contracts.py` so the hermetic tests exercise the real artifact service boundary for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
 
 ### Story Validation
 
-- [ ] T022 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and verify all unit coverage for FR-001 through FR-010, SCN-001 through SCN-006, and SC-001 through SC-006 passes.
-- [ ] T023 Run `./tools/test_integration.sh` and verify hermetic integration coverage for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-026, SCN-002, SCN-004, and SCN-005 passes.
-- [ ] T024 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and verify the full required unit suite passes before final verification.
-- [ ] T025 Validate the independent story flow in `specs/320-remediation-action-contracts/quickstart.md` and record the result in `specs/320-remediation-action-contracts/implementation-notes.md` for MM-620 traceability.
+- [X] T022 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and verify all unit coverage for FR-001 through FR-010, SCN-001 through SCN-006, and SC-001 through SC-006 passes.
+- [ ] T023 Run `./tools/test_integration.sh` and verify hermetic integration coverage for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-026, SCN-002, SCN-004, and SCN-005 passes. BLOCKED in this managed runtime by Docker daemon `403 Forbidden`; direct `pytest tests/integration/temporal/test_remediation_action_contracts.py -q` passes.
+- [X] T024 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and verify the full required unit suite passes before final verification.
+- [X] T025 Validate the independent story flow in `specs/320-remediation-action-contracts/quickstart.md` and record the result in `specs/320-remediation-action-contracts/implementation-notes.md` for MM-620 traceability.
 
 **Checkpoint**: The single story is fully functional, covered by unit and integration tests, and independently validated.
 
@@ -106,11 +106,11 @@
 
 **Purpose**: Strengthen the completed story without adding scope.
 
-- [ ] T026 [P] Update `specs/320-remediation-action-contracts/contracts/remediation-action-contracts.md` if implementation changes the final v1 request/result contract wording for FR-004, FR-005, and FR-006.
-- [ ] T027 [P] Update `specs/320-remediation-action-contracts/data-model.md` if implementation changes action request/result fields or state transitions for FR-004, FR-005, and FR-006.
-- [ ] T028 [P] Update `specs/320-remediation-action-contracts/research.md` if implementation evidence changes any requirement status classification for FR-003, FR-004, FR-005, FR-006, or FR-008.
-- [ ] T029 Re-run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` after polish changes to guard against drift in `tests/unit/workflows/temporal/test_remediation_context.py`.
-- [ ] T030 Re-run `./tools/test_integration.sh` after polish changes when `tests/integration/temporal/test_remediation_action_contracts.py` exists or integration wiring changed.
+- [X] T026 [P] Update `specs/320-remediation-action-contracts/contracts/remediation-action-contracts.md` if implementation changes the final v1 request/result contract wording for FR-004, FR-005, and FR-006.
+- [X] T027 [P] Update `specs/320-remediation-action-contracts/data-model.md` if implementation changes action request/result fields or state transitions for FR-004, FR-005, and FR-006.
+- [X] T028 [P] Update `specs/320-remediation-action-contracts/research.md` if implementation evidence changes any requirement status classification for FR-003, FR-004, FR-005, FR-006, or FR-008.
+- [X] T029 Re-run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` after polish changes to guard against drift in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [ ] T030 Re-run `./tools/test_integration.sh` after polish changes when `tests/integration/temporal/test_remediation_action_contracts.py` exists or integration wiring changed. BLOCKED in this managed runtime by Docker daemon `403 Forbidden`; direct `pytest tests/integration/temporal/test_remediation_action_contracts.py -q` passes.
 - [ ] T031 Run `/moonspec-verify` against `specs/320-remediation-action-contracts/spec.md`, `plan.md`, `tasks.md`, source design mappings, preserved MM-620 Jira preset brief, and test evidence after implementation and tests pass.
 
 ---

--- a/specs/320-remediation-action-contracts/tasks.md
+++ b/specs/320-remediation-action-contracts/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: Remediation Action Contracts
+
+**Input**: Design documents from `/work/agent_jobs/mm:f14332d1-2a04-407d-acdd-23b4fa3c3448/repo/specs/320-remediation-action-contracts/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-action-contracts.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: `Typed Remediation Actions`.
+
+**Source Traceability**: Original Jira issue `MM-620` and the preserved Jira preset brief are in `spec.md` `**Input**`. Tasks cover FR-001 through FR-010, SCN-001 through SCN-006, SC-001 through SC-006, and DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel only when the task touches different files and has no dependency on incomplete work.
+- Every task includes a concrete path and the relevant requirement, scenario, success criterion, or source mapping when applicable.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active feature and existing tooling before writing tests.
+
+- [ ] T001 Verify `.specify/feature.json` points to `specs/320-remediation-action-contracts` and that `specs/320-remediation-action-contracts/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/remediation-action-contracts.md` exist for MM-620.
+- [ ] T002 Verify unit and integration command availability in `tools/test_unit.sh`, `tools/test_integration.sh`, and `specs/320-remediation-action-contracts/quickstart.md` before adding tests.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Prepare test-only scaffolding that blocks reliable story test authoring.
+
+**Critical**: No production implementation work can begin until foundational tasks and red-first tests are complete.
+
+- [ ] T003 Add or extend reusable unit-test helpers for reading and decoding remediation lifecycle artifacts in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, FR-005, SCN-002, and SCN-004.
+- [ ] T004 Create the hermetic integration test module scaffold with `integration` and `integration_ci` markers in `tests/integration/temporal/test_remediation_action_contracts.py` for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+
+**Checkpoint**: Test scaffolding is ready; story tests can now be written.
+
+---
+
+## Phase 3: Story - Typed Remediation Actions
+
+**Summary**: As a remediation task, I can list and request only typed, allowlisted administrative actions with durable v1 request and result evidence so that interventions are validated, risk-scored, idempotency-aware, and auditable.
+
+**Independent Test**: Create remediation contexts with different action policies and target states, then verify allowed action listing, request validation, risk outcomes, idempotency behavior, rejection of unsupported raw operations, and durable request/result evidence without unrestricted administrative access.
+
+**Traceability**: FR-001 through FR-010; SCN-001 through SCN-006; SC-001 through SC-006; DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-026.
+
+**Requirement Status Strategy**: FR-001, FR-002, FR-007, FR-009, FR-010, SCN-001, SCN-003, SCN-006, SC-001, SC-004, and SC-006 are already implemented_verified and receive validation only. FR-003, FR-005, FR-006, SCN-002, SCN-004, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-026, and SC-003 need code-and-test work. FR-004, FR-008, SCN-005, SC-002, and SC-005 are implemented_unverified and receive verification tests plus conditional fallback implementation.
+
+**Unit Test Plan**:
+
+- Verify action input validation, idempotency shape handling, and fresh target evidence consumption.
+- Verify published v1 request/result artifacts include required fields and redaction.
+- Verify action result status enumeration fails closed for unsupported values.
+- Verify unsupported raw operation classes are rejected before side effects.
+- Preserve existing high-risk, registry metadata, and unsupported action listing coverage.
+
+**Integration Test Plan**:
+
+- Verify the real remediation service/artifact boundary publishes and reads request, result, and verification artifacts for one executable action.
+- Verify unsupported raw action attempts do not publish side-effect artifacts.
+
+### Unit Tests (write first)
+
+- [ ] T005 Add failing unit tests for action-specific input metadata validation, idempotency shape reuse, and fresh target evidence gating in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [ ] T006 Add failing unit tests that read the published `remediation.action_request` artifact and assert the full v1 request evidence contract plus redaction in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
+- [ ] T007 Add failing unit tests that read the published `remediation.action_result` artifact and assert `message`, `appliedAt`, `verificationRequired`, `verificationHint`, status, before/after refs, and redacted side effects in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
+- [ ] T008 Add failing unit tests for allowed status validation and unsupported status rejection in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-006 and SC-003.
+- [ ] T009 Add explicit unit tests for unsupported raw host, database, Docker, volume, network, secret-reading, and redaction-bypass action classes in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
+- [ ] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and confirm T005 through T009 fail for the expected red-first reasons before production implementation.
+
+### Integration Tests (write first)
+
+- [ ] T011 Add a failing hermetic integration test for one executable remediation action that verifies list, authority, guard, execute, request artifact, result artifact, verification artifact, and link update behavior in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-002, SCN-004, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [ ] T012 Add a failing hermetic integration test proving unsupported raw actions are rejected and do not publish side-effect request/result artifacts in `tests/integration/temporal/test_remediation_action_contracts.py` for SCN-005, FR-008, SC-005, and DESIGN-REQ-015.
+- [ ] T013 Run `./tools/test_integration.sh` and confirm T011 through T012 fail for the expected red-first reasons before production implementation.
+- [ ] T014 Record the red-first unit and integration failure evidence in `specs/320-remediation-action-contracts/implementation-notes.md` for FR-003, FR-004, FR-005, FR-006, FR-008, SCN-002, SCN-004, SCN-005, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+
+### Implementation
+
+- [ ] T015 Implement action parameter/input metadata validation and idempotency shape safeguards in `moonmind/workflows/temporal/remediation_actions.py` for FR-003, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+- [ ] T016 Conditional fallback if T006 or T011 exposes a request artifact gap: update action request artifact publication in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, SCN-002, SC-002, and DESIGN-REQ-016.
+- [ ] T017 Implement allowed result status validation and fail-fast unsupported status handling in `moonmind/workflows/temporal/remediation_tools.py` for FR-006 and SC-003.
+- [ ] T018 Complete the v1 action result artifact payload in `moonmind/workflows/temporal/remediation_tools.py` with `message`, `appliedAt`, `verificationRequired`, `verificationHint`, before/after refs, and redacted side effects for FR-005, SCN-004, SC-003, and DESIGN-REQ-016.
+- [ ] T019 Conditional fallback if T009 or T012 exposes a raw-operation proof gap: expand raw operation deny-listing and explicit denial reasons in `moonmind/workflows/temporal/remediation_actions.py` for FR-008, SCN-005, SC-005, and DESIGN-REQ-015.
+- [ ] T020 Ensure request/result/verification artifact payloads remain bounded and secret-safe in `moonmind/workflows/temporal/remediation_tools.py` for FR-004, FR-005, DESIGN-REQ-015, DESIGN-REQ-016, and SC-002.
+- [ ] T021 Update integration fixture wiring only as needed in `tests/integration/temporal/test_remediation_action_contracts.py` so the hermetic tests exercise the real artifact service boundary for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, and DESIGN-REQ-026.
+
+### Story Validation
+
+- [ ] T022 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` and verify all unit coverage for FR-001 through FR-010, SCN-001 through SCN-006, and SC-001 through SC-006 passes.
+- [ ] T023 Run `./tools/test_integration.sh` and verify hermetic integration coverage for DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-026, SCN-002, SCN-004, and SCN-005 passes.
+- [ ] T024 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and verify the full required unit suite passes before final verification.
+- [ ] T025 Validate the independent story flow in `specs/320-remediation-action-contracts/quickstart.md` and record the result in `specs/320-remediation-action-contracts/implementation-notes.md` for MM-620 traceability.
+
+**Checkpoint**: The single story is fully functional, covered by unit and integration tests, and independently validated.
+
+---
+
+## Phase 4: Polish and Verification
+
+**Purpose**: Strengthen the completed story without adding scope.
+
+- [ ] T026 [P] Update `specs/320-remediation-action-contracts/contracts/remediation-action-contracts.md` if implementation changes the final v1 request/result contract wording for FR-004, FR-005, and FR-006.
+- [ ] T027 [P] Update `specs/320-remediation-action-contracts/data-model.md` if implementation changes action request/result fields or state transitions for FR-004, FR-005, and FR-006.
+- [ ] T028 [P] Update `specs/320-remediation-action-contracts/research.md` if implementation evidence changes any requirement status classification for FR-003, FR-004, FR-005, FR-006, or FR-008.
+- [ ] T029 Re-run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` after polish changes to guard against drift in `tests/unit/workflows/temporal/test_remediation_context.py`.
+- [ ] T030 Re-run `./tools/test_integration.sh` after polish changes when `tests/integration/temporal/test_remediation_action_contracts.py` exists or integration wiring changed.
+- [ ] T031 Run `/moonspec-verify` against `specs/320-remediation-action-contracts/spec.md`, `plan.md`, `tasks.md`, source design mappings, preserved MM-620 Jira preset brief, and test evidence after implementation and tests pass.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- Setup phase has no dependencies.
+- Foundational phase depends on Setup and blocks story test authoring.
+- Story phase depends on Foundational completion.
+- Polish and Verification depend on story validation passing.
+
+### Within The Story
+
+- T005 through T009 must be written before T010.
+- T011 through T012 must be written before T013.
+- T010 and T013 red-first confirmations must complete before T015 through T021 production implementation.
+- T016 is conditional fallback work for implemented_unverified FR-004 and is skipped only if T006 and T011 prove existing request evidence already satisfies the contract.
+- T019 is conditional fallback work for implemented_unverified FR-008 and is skipped only if T009 and T012 prove existing raw-operation denial already satisfies the contract.
+- T022 through T025 validate the completed story and must pass before Phase 4.
+- T031 is last and runs only after implementation, focused tests, integration tests, quickstart validation, and full unit tests pass.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel.
+- T003 and T004 can run in parallel because they prepare different test scopes.
+- T026 through T028 can run in parallel if implementation changes require artifact updates.
+- Test authoring in T005 through T009 touches the same unit file and should be coordinated rather than parallelized.
+- T011 and T012 touch the same integration file and should be coordinated rather than parallelized.
+
+---
+
+## Implementation Strategy
+
+1. Confirm the active feature and tooling in Phase 1.
+2. Prepare test scaffolding in Phase 2.
+3. Write all unit and integration tests first.
+4. Run focused unit and integration commands to capture red-first failures.
+5. Implement only the gaps identified by the failing tests.
+6. Skip conditional fallback implementation tasks only when verification tests pass without code changes.
+7. Re-run focused unit tests, hermetic integration tests, and the full unit suite.
+8. Validate the quickstart story flow.
+9. Run final `/moonspec-verify` with MM-620 and the preserved preset brief as source evidence.
+
+## Notes
+
+- This task list covers one story only: `Typed Remediation Actions`.
+- Existing implemented_verified rows remain traceable but do not receive unnecessary implementation tasks.
+- Partial rows receive red-first tests and implementation tasks.
+- Implemented_unverified rows receive verification tests and conditional fallback implementation tasks.
+- No production implementation should start before T010 and T013 confirm expected red-first failures.

--- a/tests/integration/temporal/test_remediation_action_contracts.py
+++ b/tests/integration/temporal/test_remediation_action_contracts.py
@@ -1,0 +1,157 @@
+"""Hermetic integration coverage for remediation action evidence contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from api_service.db.models import TemporalArtifactLink
+from moonmind.workflows.temporal import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
+from moonmind.workflows.temporal.remediation_actions import (
+    RemediationActionAuthorityService,
+    RemediationMutationGuardPolicy,
+    RemediationMutationGuardService,
+)
+from moonmind.workflows.temporal.remediation_context import RemediationContextBuilder
+from moonmind.workflows.temporal.remediation_tools import RemediationEvidenceToolService
+from tests.unit.workflows.temporal.test_remediation_context import (
+    RecordingActionExecutor,
+    _admin_permissions,
+    _admin_profile,
+    _create_target_and_remediation,
+    _read_artifact_json,
+    mock_client_adapter,
+    temporal_db,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+async def test_remediation_action_contract_publishes_request_result_and_verification(
+    tmp_path, mock_client_adapter
+) -> None:
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        action_id = "integration-action-contract"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "restart helper"},
+            dry_run=False,
+            idempotency_key=action_id,
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(allowed_action_kinds=(action_kind,)),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key=action_id,
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=RecordingActionExecutor(),
+        )
+
+        result = await tools.execute_action(
+            remediation_workflow_id=remediation.workflow_id,
+            authority_result=authority.to_dict(),
+            guard_result=guard.to_dict(),
+            principal="service:test",
+        )
+
+        request_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["actionRequest"]
+        )
+        result_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["actionResult"]
+        )
+        verification_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["verification"]
+        )
+
+        assert request_payload["schemaVersion"] == "v1"
+        assert request_payload["actionKind"] == action_kind
+        assert request_payload["target"]["workflowId"] == target.workflow_id
+        assert request_payload["idempotencyKey"] == action_id
+        assert result_payload["schemaVersion"] == "v1"
+        assert result_payload["status"] == "applied"
+        assert result_payload["message"]
+        assert result_payload["appliedAt"]
+        assert result_payload["verificationRequired"] is True
+        assert result_payload["verificationHint"]
+        assert verification_payload["actionKind"] == action_kind
+        assert verification_payload["actionId"] == action_id
+
+
+async def test_remediation_raw_action_rejection_does_not_publish_side_effect_artifacts(
+    tmp_path, mock_client_adapter
+) -> None:
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        decision = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="redaction_bypass",
+            parameters={"token": "raw-secret-token"},
+            dry_run=False,
+            idempotency_key="raw-integration",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == remediation.workflow_id,
+                    TemporalArtifactLink.link_type.in_(
+                        [
+                            "remediation.action_request",
+                            "remediation.action_result",
+                        ]
+                    ),
+                )
+            )
+        ).scalars().all()
+
+        assert decision.decision == "denied"
+        assert decision.reason == "raw_access_action_denied"
+        assert decision.executable is False
+        assert "raw-secret-token" not in json.dumps(decision.to_dict(), sort_keys=True)
+        assert links == []

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -1341,6 +1341,33 @@ class RecordingActionExecutor:
             },
         }
 
+class StatusOnlyActionExecutor:
+    def __init__(self, status: str) -> None:
+        self.status = status
+        self.calls = []
+
+    async def execute_action(self, *, action_request, guard_result, target_health):
+        self.calls.append(
+            {
+                "action_request": action_request,
+                "guard_result": guard_result,
+                "target_health": target_health,
+            }
+        )
+        return {
+            "status": self.status,
+            "message": f"returned {self.status}",
+            "sideEffects": [],
+            "verification": {"status": "not_verified"},
+        }
+
+async def _read_artifact_json(artifact_service, artifact_id: str):
+    _artifact, payload = await artifact_service.read(
+        artifact_id=artifact_id,
+        principal="service:test",
+    )
+    return json.loads(payload.decode("utf-8"))
+
 @pytest.mark.asyncio
 async def test_remediation_evidence_tools_read_only_context_declared_evidence(
     tmp_path, mock_client_adapter
@@ -1791,6 +1818,154 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
         assert link.outcome == "applied"
 
 @pytest.mark.asyncio
+async def test_remediation_execute_action_publishes_v1_request_and_result_artifacts(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        action_id = "execute-action-v1"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "Authorization: Bearer raw-secret-token"},
+            dry_run=False,
+            idempotency_key=action_id,
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(allowed_action_kinds=(action_kind,)),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key=action_id,
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=RecordingActionExecutor(),
+        )
+
+        result = await tools.execute_action(
+            remediation_workflow_id=remediation.workflow_id,
+            authority_result=authority.to_dict(),
+            guard_result=guard.to_dict(),
+            principal="service:test",
+        )
+
+        request_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["actionRequest"]
+        )
+        result_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["actionResult"]
+        )
+
+        assert request_payload["schemaVersion"] == "v1"
+        assert request_payload["actionId"] == action_id
+        assert request_payload["actionKind"] == action_kind
+        assert request_payload["requester"] == "workflow:remediator"
+        assert request_payload["target"] == {
+            "workflowId": target.workflow_id,
+            "resourceKind": "workload_container",
+        }
+        assert request_payload["riskTier"] == "medium"
+        assert request_payload["dryRun"] is False
+        assert request_payload["idempotencyKey"] == action_id
+        assert "raw-secret-token" not in json.dumps(request_payload, sort_keys=True)
+
+        assert result_payload["schemaVersion"] == "v1"
+        assert result_payload["actionId"] == action_id
+        assert result_payload["actionKind"] == action_kind
+        assert result_payload["status"] == "applied"
+        assert result_payload["message"]
+        assert result_payload["appliedAt"]
+        assert result_payload["beforeStateRef"] == "artifact://before-state"
+        assert result_payload["afterStateRef"] == "artifact://after-state"
+        assert result_payload["verificationRequired"] is True
+        assert result_payload["verificationHint"]
+        assert result_payload["sideEffects"] == [
+            {"kind": "subsystem_call", "status": "accepted"}
+        ]
+
+@pytest.mark.asyncio
+async def test_remediation_execute_action_rejects_unsupported_result_status(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "restart helper"},
+            dry_run=False,
+            idempotency_key="unsupported-status",
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(allowed_action_kinds=(action_kind,)),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key="unsupported-status",
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=StatusOnlyActionExecutor("mystery_status"),
+        )
+
+        with pytest.raises(RemediationEvidenceToolError, match="Unsupported action result status"):
+            await tools.execute_action(
+                remediation_workflow_id=remediation.workflow_id,
+                authority_result=authority.to_dict(),
+                guard_result=guard.to_dict(),
+                principal="service:test",
+            )
+
+@pytest.mark.asyncio
 async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_context(
     tmp_path, mock_client_adapter
 ):
@@ -2164,15 +2339,10 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         )
 
         assert allowed.decision == "allowed"
-        assert high_risk.decision == "approval_required"
-        assert high_risk.reason == "high_risk_requires_approval"
-        assert dry_run.decision == "allowed"
-        assert dry_run is not allowed
-        dry_run_payload = dry_run.to_dict()
-        assert dry_run_payload["request"]["dryRun"] is True
-        assert dry_run_payload["result"]["status"] == "no_op"
-        assert dry_run_payload["result"]["verificationRequired"] is False
-        assert dry_run_payload["result"]["verificationHint"] is None
+        assert high_risk.decision == "denied"
+        assert high_risk.reason == "idempotency_key_reused_with_different_request"
+        assert dry_run.decision == "denied"
+        assert dry_run.reason == "idempotency_key_reused_with_different_request"
 
 @pytest.mark.asyncio
 async def test_remediation_action_authority_redacts_audits_and_deduplicates(
@@ -2211,7 +2381,9 @@ async def test_remediation_action_authority_redacts_audits_and_deduplicates(
             security_profile=_admin_profile(),
         )
 
-        assert duplicate is result
+        assert duplicate is not result
+        assert duplicate.decision == "denied"
+        assert duplicate.reason == "idempotency_key_reused_with_different_request"
         serialized = json.dumps(result.to_dict(), sort_keys=True)
         assert "raw-secret-token" not in serialized
         assert "/work/agent_jobs" not in serialized
@@ -2243,18 +2415,29 @@ async def test_remediation_action_authority_denies_raw_access_and_unknown_target
         )
         service = RemediationActionAuthorityService(session=session)
 
-        raw_access = await service.evaluate_action_request(
-            remediation_workflow_id=remediation.workflow_id,
-            action_kind="raw_host_shell",
-            parameters={"command": "docker ps"},
-            dry_run=False,
-            idempotency_key="raw-shell",
-            requesting_principal="user:operator",
-            permissions=_admin_permissions(),
-            security_profile=_admin_profile(),
+        raw_action_kinds = (
+            "raw_host_shell",
+            "raw_sql",
+            "raw_docker",
+            "raw_volume_mount",
+            "raw_network_egress",
+            "secret_read",
+            "redaction_bypass",
         )
-        assert raw_access.decision == "denied"
-        assert raw_access.reason == "raw_access_action_denied"
+        for index, action_kind in enumerate(raw_action_kinds):
+            raw_access = await service.evaluate_action_request(
+                remediation_workflow_id=remediation.workflow_id,
+                action_kind=action_kind,
+                parameters={"command": "docker ps", "token": "raw-secret-token"},
+                dry_run=False,
+                idempotency_key=f"raw-action-{index}",
+                requesting_principal="user:operator",
+                permissions=_admin_permissions(),
+                security_profile=_admin_profile(),
+            )
+            assert raw_access.decision == "denied"
+            assert raw_access.reason == "raw_access_action_denied"
+            assert raw_access.executable is False
 
         missing = await service.evaluate_action_request(
             remediation_workflow_id="mm:missing-remediation",
@@ -2302,7 +2485,7 @@ async def test_remediation_action_authority_uses_prepared_action_context(
         decision = await service.evaluate_action_request(
             remediation_workflow_id=preparation.remediation_workflow_id,
             action_kind=preparation.action_kind,
-            parameters={"targetState": preparation.target.state},
+            parameters={"reason": f"target state was {preparation.target.state}"},
             dry_run=False,
             idempotency_key="prepared-action",
             requesting_principal="workflow:remediator",
@@ -2313,6 +2496,33 @@ async def test_remediation_action_authority_uses_prepared_action_context(
         assert preparation.target.workflow_id == target.workflow_id
         assert decision.decision == "allowed"
         assert decision.target_workflow_id == target.workflow_id
+
+@pytest.mark.asyncio
+async def test_remediation_action_authority_validates_action_inputs(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        _target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        service = RemediationActionAuthorityService(session=session)
+
+        invalid = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="workload.restart_helper_container",
+            parameters={"unknown": "value"},
+            dry_run=False,
+            idempotency_key="invalid-inputs",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert invalid.decision == "denied"
+        assert invalid.reason == "unsupported_action_parameter"
+        assert invalid.executable is False
 
 @pytest.mark.asyncio
 async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -26,6 +26,7 @@ from moonmind.workflows.temporal import (
     TemporalArtifactRepository,
     TemporalArtifactService,
     remediation_actions,
+    remediation_tools,
 )
 from moonmind.workflows.temporal.remediation_context import (
     RemediationContextBuilder,
@@ -1341,6 +1342,32 @@ class RecordingActionExecutor:
             },
         }
 
+
+class SensitiveHintActionExecutor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def execute_action(self, *, action_request, guard_result, target_health):
+        self.calls.append(
+            {
+                "action_request": action_request,
+                "guard_result": guard_result,
+                "target_health": target_health,
+            }
+        )
+        return {
+            "status": "applied",
+            "beforeStateRef": "artifact://before-state",
+            "afterStateRef": "artifact://after-state",
+            "verificationHint": (
+                "inspect /work/agent_jobs/mm:secret/repo/.env "
+                "with token=raw-secret-token"
+            ),
+            "sideEffects": [{"kind": "subsystem_call", "status": "accepted"}],
+            "verification": {"status": "verified"},
+        }
+
+
 class StatusOnlyActionExecutor:
     def __init__(self, status: str) -> None:
         self.status = status
@@ -1864,7 +1891,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
         tools = RemediationEvidenceToolService(
             session=session,
             artifact_service=artifact_service,
-            action_executor=RecordingActionExecutor(),
+            action_executor=SensitiveHintActionExecutor(),
         )
 
         result = await tools.execute_action(
@@ -1904,6 +1931,8 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
         assert result_payload["afterStateRef"] == "artifact://after-state"
         assert result_payload["verificationRequired"] is True
         assert result_payload["verificationHint"]
+        assert "raw-secret-token" not in result_payload["verificationHint"]
+        assert "/work/agent_jobs" not in result_payload["verificationHint"]
         assert result_payload["sideEffects"] == [
             {"kind": "subsystem_call", "status": "accepted"}
         ]
@@ -2403,6 +2432,33 @@ def test_remediation_action_redaction_handles_null_and_single_segment_paths(
     assert remediation_actions._redact_text(None) == ""
     assert remediation_actions._redact_text("/tmp") == "[REDACTED_PATH]"
 
+
+def test_remediation_tool_redaction_handles_null_redactor_and_single_pass_payload(
+    monkeypatch,
+):
+    calls = []
+
+    def redact_payload(value):
+        calls.append(value)
+        return {
+            "hint": "inspect /work/agent_jobs/mm:secret/repo/.env",
+            "nested": ["https://example.test/download?token=raw-secret-token"],
+        }
+
+    monkeypatch.setattr(remediation_tools, "redact_sensitive_payload", redact_payload)
+    monkeypatch.setattr(
+        remediation_tools,
+        "redact_sensitive_text",
+        lambda value: None if value == "return-none" else str(value),
+    )
+
+    assert remediation_tools._redact_text("return-none") is None
+    assert remediation_tools._redact_payload_value({"ignored": "input"}) == {
+        "hint": "inspect [REDACTED_PATH]",
+        "nested": ["[REDACTED_URL]"],
+    }
+    assert calls == [{"ignored": "input"}]
+
 @pytest.mark.asyncio
 async def test_remediation_action_authority_denies_raw_access_and_unknown_targets(
     tmp_path, mock_client_adapter
@@ -2523,6 +2579,21 @@ async def test_remediation_action_authority_validates_action_inputs(
         assert invalid.decision == "denied"
         assert invalid.reason == "unsupported_action_parameter"
         assert invalid.executable is False
+
+        wrong_type = await service.evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind="workload.restart_helper_container",
+            parameters={"reason": False},
+            dry_run=False,
+            idempotency_key="invalid-input-type",
+            requesting_principal="user:operator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(),
+        )
+
+        assert wrong_type.decision == "denied"
+        assert wrong_type.reason == "invalid_action_parameter_type"
+        assert wrong_type.executable is False
 
 @pytest.mark.asyncio
 async def test_remediation_mutation_guard_enforces_exclusive_locks_and_recovery(


### PR DESCRIPTION
## Jira Issue

MM-620

## MoonSpec Feature

`specs/320-remediation-action-contracts`

## Verification Verdict

ADDITIONAL_WORK_NEEDED for the final `moonspec-verify` gate because the managed runtime projected `.gemini/skills` as an active skill symlink, triggering `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`. Implementation-level verification passed as listed below.

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py -q` - PASS
- `pytest tests/integration/temporal/test_remediation_action_contracts.py -q` - PASS, 2 tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS
- `./tools/test_integration.sh tests/integration/temporal/test_remediation_action_contracts.py` - BLOCKED by managed Docker daemon policy, direct integration pytest passed

## Remaining Risks

- Final MoonSpec verification needs to be rerun from a clean repository view without active skill projection contamination.
- Docker-backed integration wrapper could not complete in this managed runtime because the daemon returned `403 Forbidden`; targeted hermetic integration coverage passed directly under pytest.
