### PR TITLE
MM-627 Normalize task-shaped submissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,8 @@ Key diagnostics:
 - Existing SQLAlchemy/Alembic database with `execution_remediation_links` and existing Temporal execution source records (317-canonical-remediation-submissions)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind skill resolver/materializer services (318-refresh-managed-runtimes-after-derived-skill-activation)
 - Existing artifact-backed Skill content, resolved skillset manifests, runtime workspace/cache filesystem paths; no new persistent tables planned (318-refresh-managed-runtimes-after-derived-skill-activation)
+- Python 3.12; TypeScript/React for Mission Control create/edit/rerun UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest (320-normalize-task-shaped-submissions)
+- Existing Temporal execution records, artifact-backed original task input snapshots, Temporal artifact metadata/content store; no new persistent tables planned (320-normalize-task-shaped-submissions)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -219,6 +219,8 @@ Key diagnostics:
 - Python 3.12 + Pydantic v2, Pydantic Settings, Temporal Python SDK activity boundaries, existing MoonMind agent-skill resolver/materializer services, pytest (315-disabled-skills-on-demand-controls)
 - No new persistent storage; disabled on-demand results and activation metadata are deterministic runtime outputs only (315-disabled-skills-on-demand-controls)
 - Existing SQLAlchemy/Alembic database with `execution_remediation_links` and existing Temporal execution source records (317-canonical-remediation-submissions)
+- Python 3.12; TypeScript/React for Mission Control create/edit/rerun UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest (320-normalize-task-shaped-submissions)
+- Existing Temporal execution records, artifact-backed original task input snapshots, Temporal artifact metadata/content store; no new persistent tables planned (320-normalize-task-shaped-submissions)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2904,23 +2904,9 @@ async def _validate_and_collect_task_input_attachments(
         artifact_id = ref["artifactId"]
         existing = unique.get(artifact_id)
         if existing is not None:
-            same_target = (
-                existing.get("targetKind") == ref.get("targetKind")
-                and existing.get("stepOrdinal") == ref.get("stepOrdinal")
-                and existing.get("stepRef") == ref.get("stepRef")
+            raise _invalid_task_request(
+                f"input attachment {artifact_id} is declared more than once."
             )
-            if not same_target:
-                raise _invalid_task_request(
-                    f"input attachment {artifact_id} is declared for multiple "
-                    "input targets."
-                )
-            if (
-                existing["contentType"] != ref["contentType"]
-                or existing["sizeBytes"] != ref["sizeBytes"]
-            ):
-                raise _invalid_task_request(
-                    f"input attachment {artifact_id} has conflicting declarations."
-                )
         unique.setdefault(artifact_id, ref)
 
     if len(unique) > settings.workflow.agent_job_attachment_max_count:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2903,13 +2903,24 @@ async def _validate_and_collect_task_input_attachments(
     for ref in attachment_index:
         artifact_id = ref["artifactId"]
         existing = unique.get(artifact_id)
-        if existing is not None and (
-            existing["contentType"] != ref["contentType"]
-            or existing["sizeBytes"] != ref["sizeBytes"]
-        ):
-            raise _invalid_task_request(
-                f"input attachment {artifact_id} has conflicting declarations."
+        if existing is not None:
+            same_target = (
+                existing.get("targetKind") == ref.get("targetKind")
+                and existing.get("stepOrdinal") == ref.get("stepOrdinal")
+                and existing.get("stepRef") == ref.get("stepRef")
             )
+            if not same_target:
+                raise _invalid_task_request(
+                    f"input attachment {artifact_id} is declared for multiple "
+                    "input targets."
+                )
+            if (
+                existing["contentType"] != ref["contentType"]
+                or existing["sizeBytes"] != ref["sizeBytes"]
+            ):
+                raise _invalid_task_request(
+                    f"input attachment {artifact_id} has conflicting declarations."
+                )
         unique.setdefault(artifact_id, ref)
 
     if len(unique) > settings.workflow.agent_job_attachment_max_count:
@@ -4075,7 +4086,12 @@ async def _create_execution_from_task_request(
             if index < len(normalized_steps):
                 normalized_steps[index]["inputAttachments"] = refs
 
-    repository = str(payload.get("repository") or "").strip() or None
+    raw_repository = payload.get("repository")
+    if raw_repository is not None and not isinstance(raw_repository, str):
+        raise _invalid_task_request("payload.repository must be a string.")
+    repository = raw_repository.strip() if isinstance(raw_repository, str) else None
+    if repository == "":
+        repository = None
     integration = (
         str(
             payload.get("integration")
@@ -4189,18 +4205,37 @@ async def _create_execution_from_task_request(
     git_payload = (
         task_payload.get("git") if isinstance(task_payload.get("git"), dict) else {}
     )
+    if isinstance(task_payload.get("git"), Mapping) and isinstance(
+        task_payload["git"].get("targetBranch"), str
+    ) and task_payload["git"]["targetBranch"].strip():
+        raise _invalid_task_request(
+            "payload.task.git.targetBranch is not supported; use "
+            "payload.task.git.branch."
+        )
+    if isinstance(task_payload.get("targetBranch"), str) and task_payload[
+        "targetBranch"
+    ].strip():
+        raise _invalid_task_request(
+            "payload.task.targetBranch is not supported; use payload.task.git.branch."
+        )
     if git_payload:
         normalized_git_payload: dict[str, str] = {}
-        for git_key in ("startingBranch", "targetBranch", "branch"):
+        for git_key in ("startingBranch", "branch"):
             git_value = git_payload.get(git_key)
             if isinstance(git_value, str) and git_value.strip():
                 normalized_git_payload[git_key] = git_value.strip()
         if normalized_git_payload:
             normalized_task_for_planner["git"] = normalized_git_payload
-    for key in ("repoRef", "startingBranch", "targetBranch", "branch"):
+    for key in ("repoRef", "startingBranch", "branch"):
         value = task_payload.get(key)
         if isinstance(value, str) and value.strip():
             normalized_task_for_planner[key] = value.strip()
+    for key in ("authoredPresets", "appliedStepTemplates"):
+        value = task_payload.get(key)
+        if isinstance(value, list):
+            normalized_task_for_planner[key] = [
+                dict(item) if isinstance(item, Mapping) else item for item in value
+            ]
 
     _validate_task_runtime_requirements(
         task_payload=task_payload,

--- a/specs/320-normalize-task-shaped-submissions/checklists/requirements.md
+++ b/specs/320-normalize-task-shaped-submissions/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Normalize Task-Shaped Submissions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request because MM-627 defines one authored task submission normalization story.
+- The cited `docs/Tasks/TaskArchitecture.md` sections are treated as runtime source requirements, not as a documentation-only task.
+- No existing `specs/` artifact preserved `MM-627`, so `specs/320-normalize-task-shaped-submissions/spec.md` is the new active specification.

--- a/specs/320-normalize-task-shaped-submissions/contracts/task-shaped-submission-contract.md
+++ b/specs/320-normalize-task-shaped-submissions/contracts/task-shaped-submission-contract.md
@@ -1,0 +1,70 @@
+# Contract: Task-Shaped Submission Normalization
+
+## Scope
+
+This contract describes the public control-plane behavior for create, edit, and rerun task submissions. It is intentionally implementation-agnostic and covers the request shape that Mission Control and API clients submit before execution starts.
+
+## Accepted Task Shape
+
+The task submission accepts:
+
+- objective instructions
+- objective-scoped input attachment refs
+- ordered steps
+- step-scoped input attachment refs
+- runtime intent
+- publish mode and publish options
+- canonical branch intent
+- dependencies
+- Jira provenance where supported
+- authored preset binding metadata
+- applied template and step provenance metadata
+
+## Attachment Targeting
+
+- Objective attachments are submitted only as task-level attachment refs.
+- Step attachments are submitted only on the owning step.
+- Each attachment target must be explicit and valid.
+- A step reorder preserves each step attachment with the owning step.
+- Text edits, preset application, preset aliases, and migration-era input do not retarget attachments silently.
+- Mixed valid and invalid target declarations fail explicitly.
+
+## Branch Semantics
+
+- New task-shaped submissions use one canonical task branch field for authored branch intent.
+- New normalized task output does not emit a separate target branch field.
+- Publish mode determines whether the canonical branch means a branch update or pull request workflow.
+
+## Provenance Semantics
+
+- Jira provenance is preserved where the task contract supports it.
+- Authored preset binding metadata is preserved when supplied.
+- Applied template metadata and step provenance are preserved when supplied.
+- Provenance payloads must remain compact and must not embed large external data.
+
+## Failure Behavior
+
+Submissions fail before execution receives normalized task data when they contain:
+
+- invalid repository values
+- unsupported runtime values
+- unsupported publish mode values
+- invalid dependency declarations
+- disabled or violated attachment policy
+- missing, unknown, conflicting, or ambiguous attachment targets
+- unsupported attachment metadata fields
+- binary content embedded in instruction fields instead of structured refs
+
+Failures must be explicit and user-visible enough to correct the authored task.
+
+## Verification Surface
+
+Contract tests should cover:
+
+- valid create submission with objective and step attachments
+- valid edit submission preserving target bindings
+- valid rerun submission preserving snapshot-backed target bindings
+- canonical branch output without target branch aliases
+- preset and Jira provenance preservation
+- negative validation for invalid repository, runtime, publish, dependency, attachment policy, and target binding
+- retargeting attempts through reorder, text edits, preset aliases, and migration-era input

--- a/specs/320-normalize-task-shaped-submissions/data-model.md
+++ b/specs/320-normalize-task-shaped-submissions/data-model.md
@@ -1,0 +1,89 @@
+# Data Model: Normalize Task-Shaped Submissions
+
+## Task Submission
+
+Represents the authored create, edit, or rerun request before execution receives it.
+
+Fields:
+- `instructions`: objective text authored by the user.
+- `steps`: ordered task steps with stable identity when applicable.
+- `inputAttachments`: objective-scoped attachment refs.
+- `runtime`: runtime mode, profile, model, and effort intent.
+- `publish`: publish mode and publish options.
+- `git.branch`: the single authored branch field for new task-shaped submissions.
+- `dependsOn`: declared execution dependency IDs.
+- `jira provenance`: Jira issue metadata where the task contract supports it.
+- `authoredPresets`: authored preset binding metadata when present.
+- `appliedStepTemplates`: flattened template provenance when present.
+
+Validation rules:
+- A submission must remain task-shaped; users do not author workflow internals.
+- Invalid repository, runtime, publish mode, dependencies, attachment policy, and attachment target values fail explicitly.
+- New task-shaped submissions must not produce a separate target branch field.
+
+## Attachment Target
+
+Represents the explicit destination for an input attachment.
+
+Fields:
+- `targetKind`: `objective` or `step`.
+- `stepRef`: step identifier when `targetKind` is `step`.
+- `stepOrdinal`: step order position used only as supporting evidence, not as the sole durable meaning when a step ID exists.
+- `attachmentRef`: structured attachment metadata.
+
+Validation rules:
+- Every attachment belongs to exactly one target.
+- Step-scoped attachments must reference a declared step.
+- Duplicate or conflicting declarations fail explicitly.
+- Binary content is never embedded in text fields.
+
+## Task Step
+
+Represents one ordered unit of work inside a task submission.
+
+Fields:
+- `id`: stable step identity when preserved from a template or previous task.
+- `title`: optional user-visible step label.
+- `instructions`: textual step instructions.
+- `inputAttachments`: step-scoped attachment refs.
+- `source`: provenance for manual, preset-derived, preset-include, or detached steps.
+- `skill`/`tool`/`skills`: existing executable selection metadata.
+- `storyOutput`/`jiraOrchestration`: existing structured orchestration metadata where supported.
+
+Validation rules:
+- Reordering steps must not retarget attachments.
+- Text changes must not retarget attachments.
+- Task-scoped controls are not accepted inside a step.
+
+## Authored Preset Binding
+
+Represents preset selection and composition metadata authored before submission.
+
+Fields:
+- `presetId`
+- `presetSlug`
+- `version`
+- `alias`
+- `includePath`
+- `inputMapping`
+- `scope`
+
+Validation rules:
+- Preset binding metadata remains durable in normalized task output when supplied.
+- Preset aliases or migration-era input must not silently change attachment targets.
+
+## Normalized Task Output
+
+Represents the task-shaped contract handed to execution after validation.
+
+Fields:
+- All accepted task submission fields after normalization.
+- Attachment arrays preserving objective and step scope.
+- Canonical branch field only for new task-shaped branch intent.
+- Compact provenance metadata for Jira and presets where supported.
+
+State transitions:
+- `authored` -> `validated`: input shape and policy checks pass.
+- `validated` -> `normalized`: canonical task output is produced.
+- `validated` -> `rejected`: invalid repository, runtime, publish, dependency, attachment policy, or target binding fails explicitly.
+- `normalized` -> `execution-received`: execution receives exactly the canonical task-shaped output.

--- a/specs/320-normalize-task-shaped-submissions/moonspec_align_report.md
+++ b/specs/320-normalize-task-shaped-submissions/moonspec_align_report.md
@@ -1,0 +1,25 @@
+# MoonSpec Alignment Report: Normalize Task-Shaped Submissions
+
+**Date**: 2026-05-08
+**Feature**: `specs/320-normalize-task-shaped-submissions`
+**Source issue**: MM-627
+
+## Findings And Remediation
+
+| Finding | Resolution |
+| --- | --- |
+| `spec.md` retained the older `/speckit.breakdown` command name in a generated comment. | Updated the comment to `/moonspec-breakdown` without changing the preserved original input or source requirements. |
+| `tasks.md` assigned implementation work to `FR-002` even though `plan.md` marks it `implemented_verified`. | Removed `FR-002` from the implementation task and left it covered by final validation. |
+| `tasks.md` treated `FR-011` as a new failing-test item even though `plan.md` marks binary-ref behavior `implemented_verified`. | Changed the task to confirm existing frontend/backend evidence and record it during red-first validation. |
+
+## Gate Recheck
+
+- Prerequisite script: PASS with `SPECIFY_FEATURE=320-normalize-task-shaped-submissions .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`
+- Specify gate: PASS; `spec.md` contains exactly one user story and no clarification markers.
+- Plan/design gate: PASS; `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, and `quickstart.md` exist.
+- Tasks gate: PASS; `tasks.md` has 36 sequential tasks, exactly one story phase, unit and integration tests before implementation, red-first confirmation tasks, story validation, and final `/moonspec-verify`.
+- Requirement status alignment: PASS; every `plan.md` status row is covered, and no `implemented_verified` row appears in the implementation task block.
+
+## Downstream Regeneration
+
+No downstream regeneration required. Alignment changed only terminology and task coverage references; the one-story scope, requirement inventory, design artifacts, and task ordering remain coherent.

--- a/specs/320-normalize-task-shaped-submissions/plan.md
+++ b/specs/320-normalize-task-shaped-submissions/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Normalize Task-Shaped Submissions
+
+**Branch**: `run-jira-orchestrate-for-mm-627-normaliz-0f1ed32a` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/320-normalize-task-shaped-submissions/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted but failed because the managed branch name is not a numeric feature branch. `.specify/feature.json` already points to this feature directory, so planning proceeded manually with the same resolved paths.
+
+## Summary
+
+MM-627 requires create, edit, and rerun task submissions to normalize into one canonical task-shaped contract that preserves objective text, steps, attachment targets, runtime/publish choices, dependencies, Jira provenance, branch intent, and preset metadata. Current code already supports structured objective/step attachments and several frontend/API validations, but backend normalization still accepts legacy branch fields and does not consistently preserve preset/provenance metadata in the canonical task payload. The plan is to tighten the Mission Control submit payload and API normalization boundary, add verification-first coverage where behavior appears present, add code where gaps are confirmed, and validate with focused unit tests plus hermetic integration coverage.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `frontend/src/entrypoints/task-create.tsx` builds `payload.task`; `api_service/api/routers/executions.py` normalizes task-shaped requests | add end-to-end create/edit/rerun verification first; implement only if gaps appear | unit + integration |
+| FR-002 | implemented_verified | `task-create.test.tsx` covers objective and step attachment arrays; `test_executions.py` covers attachment validation | no new implementation beyond final traceability | none beyond final verify |
+| FR-003 | partial | create and some edit/rerun attachment tests exist; prepare/prompt/detail preservation is not proven as one contract | add boundary tests across create/edit/rerun and patch normalization if any attachment target is lost | unit + integration |
+| FR-004 | partial | runtime, dependency, publish, and attachment checks exist; repository and target-binding rejection need explicit coverage | add validation tests, then tighten repository/target-binding failures if tests expose gaps | unit + integration |
+| FR-005 | partial | frontend preserves many fields; backend normalization preserves many fields but needs full proof for Jira provenance and preset metadata | add canonical task payload tests and preserve any dropped fields | unit + integration |
+| FR-006 | partial | frontend emits `task.git.branch` and has no `targetBranch` in create payload; backend still accepts and normalizes `targetBranch` fields | remove legacy target branch emission from new task-shaped normalization and add rejection/absence tests | unit + integration |
+| FR-007 | partial | frontend template identity/provenance tests exist; backend snapshot code recognizes `appliedStepTemplates` but canonical task normalization needs preservation coverage | add backend preservation tests and implement missing provenance carry-through | unit + integration |
+| FR-008 | partial | frontend includes `appliedStepTemplates`; API serialization can read them from records, but create normalization does not clearly preserve authored preset binding metadata | add canonical payload tests and implement missing `authoredPresets`/template metadata preservation | unit + integration |
+| FR-009 | partial | frontend blocks ambiguous preset retargeting and keeps step attachments after reorder; backend boundary lacks equivalent no-retargeting proof | add backend and integration retargeting tests, then tighten validation if needed | unit + integration |
+| FR-010 | partial | `test_executions.py` covers attachment policy and dependency errors; runtime/publish validation exists | add missing repository/target-binding/publish edge tests and implement explicit failures where absent | unit + integration |
+| FR-011 | implemented_verified | UI tests prove instructions are not rewritten with attachment text; API validates structured refs | no new implementation beyond final traceability | none beyond final verify |
+| FR-012 | implemented_verified | `spec.md` preserves MM-627 and the original preset brief | preserve through plan, tasks, verification, commit, and PR metadata | final traceability |
+| SC-001 | partial | objective/step create coverage exists, but create/edit/rerun all-field preservation is not proven | add focused preservation matrix tests | unit + integration |
+| SC-002 | partial | field-specific coverage exists for dependencies, branch, templates, and attachments, but not as one canonical task contract | add canonical task contract test and fill preservation gaps | unit + integration |
+| SC-003 | partial | frontend proves no `targetBranch` in create payload; backend still carries legacy branch fields if supplied | enforce canonical new-output branch semantics | unit + integration |
+| SC-004 | partial | several invalid cases fail explicitly; missing cases remain for repository and target binding | add negative tests and implement missing validation | unit + integration |
+| SC-005 | partial | UI retargeting tests exist; backend/workflow-boundary proof is missing | add boundary tests and fix validation if needed | unit + integration |
+| SC-006 | implemented_verified | `spec.md` and this plan preserve MM-627 and all listed design IDs | preserve through downstream artifacts | final traceability |
+| DESIGN-REQ-001 | implemented_unverified | task-shaped API and frontend path exist | verify create/edit/rerun task intent handoff | unit + integration |
+| DESIGN-REQ-003 | partial | explicit objective/step arrays exist; all flow preservation needs proof | add cross-flow attachment target tests | unit + integration |
+| DESIGN-REQ-006 | partial | authoring and backend validation exist for several fields | cover missing validation cases | unit + integration |
+| DESIGN-REQ-008 | partial | normalization preserves many fields but not all preset/provenance cases | implement full canonical preservation | unit + integration |
+| DESIGN-REQ-011 | partial | canonical shape is partially represented in frontend and API models | align normalized task output with canonical shape | unit + integration |
+| DESIGN-REQ-025 | partial | several invariants are implemented and tested; target retargeting and legacy branch semantics need boundary proof | add invariant tests and fix gaps | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control create/edit/rerun UI  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest  
+**Storage**: Existing Temporal execution records, artifact-backed original task input snapshots, Temporal artifact metadata/content store; no new persistent tables planned  
+**Unit Testing**: `./tools/test_unit.sh` for Python; `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` or `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` for focused UI iteration  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci`; add or update compose-backed API/Temporal boundary coverage where the normalized task payload crosses execution creation  
+**Target Platform**: MoonMind Mission Control web app and FastAPI/Temporal control plane on Linux/Docker Compose  
+**Project Type**: Full-stack web application with Temporal-backed execution orchestration  
+**Performance Goals**: Task normalization remains linear in submitted steps and attachments; attachment validation keeps a single metadata lookup for unique artifact refs  
+**Constraints**: No binary payloads in inline instructions or workflow history; no hidden compatibility aliases for canonical branch semantics; fail explicitly for invalid task-shaped input; keep workflow payloads compact  
+**Scale/Scope**: One independently testable MM-627 story covering create, edit, and rerun task submission normalization
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - work stays in MoonMind control-plane normalization and does not rebuild agent behavior.
+- II. One-Click Agent Deployment: PASS - no new external service or required secret is introduced.
+- III. Avoid Vendor Lock-In: PASS - Jira provenance is preserved as data where supported; normalization remains provider-neutral.
+- IV. Own Your Data: PASS - attachments remain MoonMind artifacts/refs and task snapshots remain operator-owned.
+- V. Skills Are First-Class and Easy to Add: PASS - preset/skill provenance is preserved without mutating skill sources.
+- VI. Replaceable Scaffolding, Thick Contracts: PASS - work tightens task contracts and tests rather than adding brittle workflow scaffolding.
+- VII. Runtime Configurability: PASS - attachment policy and runtime/publish options continue to flow through existing configuration and request payloads.
+- VIII. Modular Architecture: PASS - planned edits stay at Mission Control submit helpers and API normalization boundaries.
+- IX. Resilient by Default: PASS - invalid inputs fail before execution and attachment-aware rerun/edit behavior remains snapshot-based.
+- X. Continuous Improvement: PASS - planning artifacts include evidence, tests, and next action traceability.
+- XI. Spec-Driven Development: PASS - `spec.md`, `plan.md`, and design artifacts define the work before tasks/implementation.
+- XII. Canonical Documentation Separation: PASS - rollout and implementation tracking remain under `specs/320-normalize-task-shaped-submissions/`.
+
+No constitution violations are currently justified.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/320-normalize-task-shaped-submissions/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-shaped-submission-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+
+api_service/api/routers/
+├── executions.py
+└── task_dashboard_view_model.py
+
+moonmind/schemas/
+└── temporal_models.py
+
+tests/unit/api/routers/
+└── test_executions.py
+
+tests/integration/
+├── services/temporal/
+└── temporal/
+```
+
+**Structure Decision**: This is a full-stack control-plane story. Frontend work shapes authored task submissions, FastAPI work normalizes and validates canonical task payloads, schema work preserves execution-visible fields, and tests span focused UI/API units plus a hermetic execution boundary.
+
+## Complexity Tracking
+
+No constitution violations require complexity exceptions.

--- a/specs/320-normalize-task-shaped-submissions/quickstart.md
+++ b/specs/320-normalize-task-shaped-submissions/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Normalize Task-Shaped Submissions
+
+## Goal
+
+Verify MM-627 by proving create, edit, and rerun task submissions normalize into the canonical task-shaped contract while preserving explicit attachment targets and authored metadata.
+
+## Focused Unit Iteration
+
+Frontend create/edit/rerun payload shaping:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Backend API normalization and validation:
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_executions.py
+```
+
+Expected additions:
+- tests that preserve objective and step attachments across create, edit, and rerun submissions
+- tests that prove new task-shaped output uses `task.git.branch` and does not emit `targetBranch`
+- tests that preserve Jira provenance, authored preset bindings, applied template metadata, step identity/order, dependencies, runtime, and publish mode
+- negative tests for invalid repository, runtime, publish mode, dependencies, attachment policy, missing targets, unknown targets, and ambiguous target bindings
+
+## Integration Verification
+
+Run hermetic integration CI after unit coverage and implementation:
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected integration focus:
+- execution creation receives the backend-normalized canonical task payload
+- artifact-backed original task input snapshots preserve objective and step attachment refs
+- edit and rerun flows preserve snapshot-backed attachment targets
+- execution-visible task data does not contain binary payload text or legacy target branch output for new task-shaped submissions
+
+## Final Unit Suite
+
+Before MoonSpec verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Traceability Check
+
+```bash
+rg -n "MM-627|DESIGN-REQ-001|DESIGN-REQ-003|DESIGN-REQ-006|DESIGN-REQ-008|DESIGN-REQ-011|DESIGN-REQ-025" specs/320-normalize-task-shaped-submissions
+```
+
+Expected result:
+- MM-627 and the original preset brief remain preserved in `spec.md`
+- all listed source design IDs remain mapped through `spec.md`, `plan.md`, tasks, and final verification evidence

--- a/specs/320-normalize-task-shaped-submissions/research.md
+++ b/specs/320-normalize-task-shaped-submissions/research.md
@@ -1,0 +1,89 @@
+# Research: Normalize Task-Shaped Submissions
+
+## Setup Script
+
+Decision: Proceed manually with `specs/320-normalize-task-shaped-submissions` as the active feature directory.
+Evidence: `.specify/feature.json` points at `specs/320-normalize-task-shaped-submissions`; `.specify/scripts/bash/setup-plan.sh --json` failed because the managed branch name is `run-jira-orchestrate-for-mm-627-normaliz-0f1ed32a`, not a numeric feature branch.
+Rationale: The feature directory and spec already exist and pass the specify gate; the script failure is a branch naming guard, not a missing artifact.
+Alternatives considered: Renaming or switching branches was rejected because this managed step is only authorized to plan.
+Test implications: None.
+
+## FR-001 / DESIGN-REQ-001 Task-Shaped Intent
+
+Decision: Implemented unverified.
+Evidence: `frontend/src/entrypoints/task-create.tsx` builds `payload.task`; `api_service/api/routers/executions.py` creates `initial_parameters["task"]` from normalized task-shaped input.
+Rationale: The path exists, but MM-627 requires create, edit, and rerun preservation as one story-level contract.
+Alternatives considered: Marking implemented verified was rejected because existing tests are field-specific and do not prove the whole cross-flow contract.
+Test implications: Unit and integration.
+
+## FR-002 / FR-003 / DESIGN-REQ-003 Explicit Attachment Targets
+
+Decision: Partial.
+Evidence: `task-create.test.tsx` covers objective attachments, step attachments, same-name step attachments, and step reorder behavior; `api_service/api/routers/executions.py` normalizes objective `inputAttachments` and step `steps[n].inputAttachments`.
+Rationale: Create-time target separation is well covered. Edit/rerun, prepare, prompt composition, and detail rendering need one boundary-oriented verification path for the MM-627 contract.
+Alternatives considered: Treating objective/step arrays as fully verified was rejected because the spec explicitly spans create, edit, rerun, prepare, prompt composition, and detail rendering.
+Test implications: Unit and integration.
+
+## FR-004 / FR-010 / DESIGN-REQ-006 Validation
+
+Decision: Partial.
+Evidence: `tests/unit/api/routers/test_executions.py` covers disabled attachment policy, unknown fields, unsupported runtime with attachments, attachment limits, and dependency normalization; `api_service/api/routers/executions.py` validates attachment artifact metadata and runtime values.
+Rationale: Several invalid classes already fail explicitly, but repository validation and target-binding edge cases need focused proof.
+Alternatives considered: Adding only frontend validation was rejected because the API boundary must remain authoritative.
+Test implications: Unit and integration.
+
+## FR-005 / DESIGN-REQ-008 Field Preservation
+
+Decision: Partial.
+Evidence: `frontend/src/entrypoints/task-create.tsx` includes instructions, runtime, publish, git branch, steps, dependencies, and applied templates; `api_service/api/routers/executions.py` preserves many but not all task fields in `normalized_task_for_planner`.
+Rationale: Canonical preservation is not complete until Jira provenance and preset metadata survive the backend normalization boundary.
+Alternatives considered: Relying on frontend-only payload evidence was rejected because execution receives the backend-normalized task payload.
+Test implications: Unit and integration.
+
+## FR-006 / SC-003 Canonical Branch Semantics
+
+Decision: Partial.
+Evidence: `task-create.test.tsx` verifies create-page submissions use `task.git.branch` and do not include `targetBranch`; `api_service/api/routers/executions.py` still carries `git.targetBranch` and top-level `targetBranch` into normalized task payloads when supplied.
+Rationale: New browser submissions are aligned, but the API normalization boundary still permits legacy branch output for task-shaped submissions.
+Alternatives considered: Keeping compatibility aliases was rejected because the spec and repository compatibility policy require removing superseded internal semantics instead of hiding translation layers.
+Test implications: Unit and integration.
+
+## FR-007 / FR-008 Preset Provenance
+
+Decision: Partial.
+Evidence: Frontend tests cover applied template payloads, template step identity preservation, detachment, and Jira attachment import provenance; API serialization can derive primary skill from `appliedStepTemplates` when present in stored parameters.
+Rationale: Backend create normalization does not clearly preserve authored preset bindings and applied template metadata into the canonical task payload, so downstream execution may not receive the full authored provenance.
+Alternatives considered: Treating snapshot shape detection as sufficient was rejected because the spec requires the normalized task output itself to preserve preset metadata.
+Test implications: Unit and integration.
+
+## FR-009 / SC-005 No Hidden Retargeting
+
+Decision: Partial.
+Evidence: `task-create.test.tsx` covers reorder preservation and blocks ambiguous preset-step attachment retargeting during submit-time expansion.
+Rationale: The UI guard exists, but backend/workflow-boundary tests are needed so retargeting cannot bypass Mission Control client behavior.
+Alternatives considered: UI-only coverage was rejected because API submission is a public control-plane boundary.
+Test implications: Unit and integration.
+
+## FR-011 Binary Content Stays Structured
+
+Decision: Implemented verified.
+Evidence: `task-create.test.tsx` asserts instructions are not rewritten with attachment text and submitted attachments are structured refs; API attachment normalization accepts refs and validates metadata.
+Rationale: Current frontend and backend behavior align with the invariant that binary content is not embedded in instruction text.
+Alternatives considered: Additional implementation was rejected because existing evidence is direct and sufficient.
+Test implications: None beyond final verification unless adjacent changes disturb this behavior.
+
+## FR-012 / SC-006 Traceability
+
+Decision: Implemented verified.
+Evidence: `specs/320-normalize-task-shaped-submissions/spec.md` preserves MM-627, the original Jira preset brief, and all in-scope design requirement IDs; this plan preserves the same traceability.
+Rationale: Traceability is already present in the MoonSpec artifacts.
+Alternatives considered: None.
+Test implications: Final traceability check.
+
+## Test Tooling
+
+Decision: Use repo-standard focused unit iteration plus required final test runners.
+Evidence: AGENTS.md requires `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration CI; frontend targeted tests can run through `./tools/test_unit.sh --ui-args <path>` after JS deps are prepared.
+Rationale: The story crosses frontend, API, and execution boundaries, so unit and integration strategies must be separate.
+Alternatives considered: Running nested Docker unit tests was rejected by managed-agent test guidance.
+Test implications: Unit tests first, integration boundary second, full unit suite before final verification.

--- a/specs/320-normalize-task-shaped-submissions/spec.md
+++ b/specs/320-normalize-task-shaped-submissions/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Normalize Task-Shaped Submissions
+
+**Feature Branch**: `320-normalize-task-shaped-submissions`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+For a single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
+For a broad technical or declarative design, run moonspec-breakdown first, then select the recommended first generated spec unless the issue brief explicitly requires processing all specs.
+Preserve Jira issue MM-627 and the original preset brief in spec.md so final verification can compare against them.
+
+Canonical Jira preset brief:
+
+MM-627: Normalize task-shaped submissions with explicit attachment targets
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.1 Task-first control plane
+- 3.3 Explicit target binding
+- 5.1 Authoring and validation
+- 5.3 Task contract normalization
+- 6 Canonical task-shaped contract
+- 11 Invariants
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-003
+- DESIGN-REQ-006
+- DESIGN-REQ-008
+- DESIGN-REQ-011
+- DESIGN-REQ-025
+As a Mission Control user, I want submitted tasks to preserve objective text, steps, repository/runtime/publish choices, dependencies, Jira provenance, and objective- or step-scoped attachments so execution receives exactly the task I authored.
+Acceptance Criteria
+- Create/edit/rerun submission accepts valid task-shaped payloads with objective-scoped and step-scoped attachment refs.
+- The normalized payload preserves attachment arrays, step IDs/order, runtime intent, publish mode, task.git.branch, dependencies, and Jira provenance where supported.
+- New payloads do not emit targetBranch; task.git.branch carries the single authored branch semantics.
+- Reordering steps, changing text, or applying authored data cannot silently retarget attachments.
+- Invalid repository, runtime, publish, dependency, attachment policy, or target-binding inputs fail explicitly.
+Requirements
+- Users author tasks while the control plane translates intent into execution contracts and the execution plane owns lifecycle progression.
+- Each input attachment binds to the task objective or a declared step, and binding survives every flow.
+- The Create page/control plane validates repository, runtime, publish mode, dependencies, attachments, and branch/publish placement.
+- The task-shaped payload preserves task fields, step identity/order, runtime/publish intent, branch, dependencies, attachments, Jira provenance, and preset metadata.
+- task.git.branch is the only authored branch field; publish mode determines PR base versus branch update semantics.
+- Reordering, presets, text changes, aliases, or migration layers must not silently retarget attachments or alter objective-versus-step meaning.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-627 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Current Jira status at orchestration input fetch time: In Progress
+
+Canonical source note: synthesized from trusted jira.get_issue response fields because the response did not expose recommendedImports.presetInstructions, normalizedPresetBrief, presetBrief, presetInstructions, recommendedPresetInstructions, or acceptanceCriteriaText.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Preserve Authored Task Submission Shape
+
+**Summary**: As a Mission Control user, I want submitted tasks to preserve objective text, steps, repository/runtime/publish choices, dependencies, Jira provenance, and objective- or step-scoped attachments so execution receives exactly the task I authored.
+
+**Goal**: A user can create, edit, or rerun a task and trust that MoonMind preserves the authored task shape, explicit attachment targets, branch intent, dependencies, runtime/publish choices, Jira provenance, and preset metadata through submission normalization.
+
+**Independent Test**: Submit create, edit, and rerun task drafts that include objective text, ordered steps, objective-scoped attachments, step-scoped attachments, repository/runtime/publish choices, dependencies, Jira provenance, branch intent, and preset metadata; then verify accepted submissions preserve every authored binding and invalid or ambiguous submissions fail before execution receives altered task data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid task draft with objective text, ordered steps, objective-scoped attachments, step-scoped attachments, runtime intent, publish mode, branch intent, dependencies, Jira provenance, and preset metadata, **When** the user submits it for creation, **Then** the normalized task preserves those authored values and every attachment remains bound to its declared target.
+2. **Given** an existing task is edited without changing attachment targets, **When** the user changes step text, objective text, ordering, runtime intent, publish mode, branch intent, dependencies, Jira provenance, or preset metadata, **Then** submission normalization preserves the explicit objective-versus-step attachment bindings instead of inferring new targets.
+3. **Given** a task is rerun from an authoritative task input snapshot, **When** the user submits a full rerun or edited full retry, **Then** the normalized task preserves the original attachment targets unless the user explicitly changes valid authored task fields.
+4. **Given** a user submits new task data with branch intent, **When** the submission is normalized, **Then** the task carries the authored branch through the canonical task branch field and does not emit a separate legacy target branch field.
+5. **Given** a submission contains an invalid repository, runtime, publish mode, dependency, attachment policy value, missing attachment target, unknown attachment target, or ambiguous target binding, **When** the user submits it, **Then** the system fails explicitly and execution does not receive silently modified task data.
+
+### Edge Cases
+
+- A step reorder must keep each step-scoped attachment with its original declared step target.
+- Text changes must not move objective-scoped attachments into a step or step-scoped attachments into the objective.
+- Preset reapplication, preset aliases, and manual overrides must not retarget existing attachments unless the user authors a valid target change.
+- A submission that mixes valid and invalid attachment targets must fail as a whole rather than dropping the invalid attachment.
+- Binary input content must remain represented as structured attachment references, not embedded in task instructions.
+- Jira provenance is preserved only where the task contracts support Jira provenance; unsupported provenance input must fail explicitly or be excluded with visible validation.
+
+## Assumptions
+
+- This story covers submission normalization for create, edit, and rerun entry points; deeper execution lifecycle behavior remains owned by the execution plane.
+- The single authored branch semantics use the canonical task branch field, while publish mode determines whether the run updates a branch or opens a pull request.
+- Existing server-defined attachment policy remains authoritative for allowed attachment types, sizes, and target eligibility.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: `docs/Tasks/TaskArchitecture.md` section 3.1, lines 57-65): Users author tasks rather than workflow internals, and the control plane must translate that task intent into execution contracts while the execution plane owns lifecycle progression. Scope: in scope. Maps to FR-001, FR-005.
+- **DESIGN-REQ-003** (Source: `docs/Tasks/TaskArchitecture.md` section 3.3, lines 75-83): Every input attachment must belong to either a task objective target or a step target, and that target binding must survive create, edit, rerun, prepare, prompt composition, and detail rendering. Scope: in scope. Maps to FR-002, FR-003, FR-009.
+- **DESIGN-REQ-006** (Source: `docs/Tasks/TaskArchitecture.md` section 5.1, lines 157-162): The authoring control plane must validate repository, runtime, publish mode, dependencies, and attachment policy while collecting text, preset state, Jira imports, and input attachments into one coherent draft. Scope: in scope. Maps to FR-004, FR-010.
+- **DESIGN-REQ-008** (Source: `docs/Tasks/TaskArchitecture.md` section 5.3, lines 171-178): Task contract normalization must preserve task and step attachments, step identity and order, runtime and publish intent, authored preset binding metadata, flattened step provenance, final submitted order, and Jira provenance where supported. Scope: in scope. Maps to FR-001, FR-005, FR-006, FR-007.
+- **DESIGN-REQ-011** (Source: `docs/Tasks/TaskArchitecture.md` section 6, lines 228-294): The canonical task-shaped contract includes objective instructions, objective attachments, steps with step attachments and source metadata, authored presets, runtime intent, publish mode, task branch, applied step templates, and dependencies. Scope: in scope. Maps to FR-001, FR-005, FR-006, FR-008.
+- **DESIGN-REQ-025** (Source: `docs/Tasks/TaskArchitecture.md` section 11, lines 574-612): Task system invariants require binary inputs to stay out of inline histories, explicit attachment targets, no silent attachment loss, text fields to remain text, snapshot-based durability, compile-time preset composition, preset provenance durability, server-defined policy, target-aware runtime consumption, no hidden retargeting, and compatibility without semantic drift. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-006, FR-009, FR-010, FR-011, FR-012.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept valid create, edit, and rerun submissions as task-shaped user intent rather than requiring users to author workflow internals.
+- **FR-002**: Each input attachment in a submission MUST be bound explicitly to either the task objective or a declared step.
+- **FR-003**: System MUST preserve objective-scoped and step-scoped attachment arrays through create, edit, rerun, prepare, prompt composition, and detail rendering.
+- **FR-004**: System MUST validate repository, runtime, publish mode, dependencies, attachment policy, and attachment target bindings before execution receives the task.
+- **FR-005**: Normalized task output MUST preserve objective text, step text, step identity, step order, runtime intent, publish mode, dependencies, Jira provenance where supported, and preset metadata from the authored submission.
+- **FR-006**: New normalized task output MUST carry the authored branch through the canonical task branch field and MUST NOT emit a separate target branch field.
+- **FR-007**: Preset-derived and manual step provenance MUST remain durable through normalization, including final submitted order and detached or overridden preset state.
+- **FR-008**: Normalized task output MUST preserve authored preset binding metadata and applied template provenance when those values are present in the authored submission.
+- **FR-009**: Reordering steps, changing text, applying presets, using aliases, or processing migration-era input MUST NOT silently retarget any existing attachment or alter objective-versus-step meaning.
+- **FR-010**: Invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, or ambiguous target-binding inputs MUST fail explicitly before execution receives a normalized task.
+- **FR-011**: Binary input content MUST remain represented by structured attachment references and MUST NOT be embedded in task instruction text.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-627` and the original Jira preset brief.
+
+### Key Entities
+
+- **Task Submission**: The authored task data submitted from create, edit, or rerun flows, including objective text, steps, runtime/publish choices, branch intent, dependencies, Jira provenance, preset metadata, and attachments.
+- **Attachment Target**: The declared destination for an attachment, either the task objective or a specific task step.
+- **Task Step**: An ordered task instruction unit with identity, text, optional attachment refs, and optional source/provenance metadata.
+- **Authored Preset Binding**: Metadata that records the selected preset, version, alias, include path, input mapping, and scope used to compose the final task.
+- **Normalized Task Output**: The task-shaped contract handed to execution after validation and normalization.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid create, edit, and rerun submissions with objective-scoped and step-scoped attachments preserve all authored attachment arrays and target bindings after normalization.
+- **SC-002**: 100% of valid submissions preserve step identity, step order, runtime intent, publish mode, task branch, dependencies, Jira provenance where supported, and preset metadata after normalization.
+- **SC-003**: 100% of new valid submissions carry branch intent only through the canonical task branch field and emit zero separate target branch fields.
+- **SC-004**: 100% of invalid repository, runtime, publish, dependency, attachment policy, or target-binding submissions fail explicitly before execution receives normalized task data.
+- **SC-005**: Reordering steps, changing text, applying presets, using aliases, or processing migration-era input causes zero silent attachment retargeting events in covered validation scenarios.
+- **SC-006**: Traceability review confirms `MM-627`, the original Jira preset brief, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, and DESIGN-REQ-025 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/320-normalize-task-shaped-submissions/spec.md
+++ b/specs/320-normalize-task-shaped-submissions/spec.md
@@ -51,7 +51,7 @@ Current Jira status at orchestration input fetch time: In Progress
 Canonical source note: synthesized from trusted jira.get_issue response fields because the response did not expose recommendedImports.presetInstructions, normalizedPresetBrief, presetBrief, presetInstructions, recommendedPresetInstructions, or acceptanceCriteriaText.
 """
 
-<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /moonspec-breakdown for technical designs that contain multiple stories. -->
 
 ## User Story - Preserve Authored Task Submission Shape
 

--- a/specs/320-normalize-task-shaped-submissions/tasks.md
+++ b/specs/320-normalize-task-shaped-submissions/tasks.md
@@ -1,0 +1,172 @@
+# Tasks: Normalize Task-Shaped Submissions
+
+**Input**: Design documents from `specs/320-normalize-task-shaped-submissions/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around one story: Preserve Authored Task Submission Shape.
+
+**Source Traceability**: MM-627, FR-001 through FR-012, acceptance scenarios 1 through 5, edge cases, SC-001 through SC-006, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
+
+**Requirement Status Summary**: `partial` rows require code-and-test work for FR-003 through FR-010, SC-001 through SC-005, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, and DESIGN-REQ-025. `implemented_unverified` rows require verification-first tests plus fallback implementation for FR-001 and DESIGN-REQ-001. `implemented_verified` rows require final traceability validation for FR-002, FR-011, FR-012, and SC-006.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when tasks touch different files and do not depend on incomplete work.
+- Each task includes exact file paths and traceability IDs.
+- This task list covers exactly one independently testable story.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active feature artifacts and test entry points before story work.
+
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/320-normalize-task-shaped-submissions` and that `specs/320-normalize-task-shaped-submissions/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, and `quickstart.md` exist for MM-627.
+- [ ] T002 Review existing targeted frontend test helpers in `frontend/src/entrypoints/task-create.test.tsx` for attachment upload, step reorder, Jira import provenance, applied templates, and branch payload assertions (FR-001 through FR-012).
+- [ ] T003 Review existing backend task-shaped request fixtures in `tests/unit/api/routers/test_executions.py` for attachment policy, dependency normalization, runtime validation, and create execution payload assertions (FR-001 through FR-011).
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Identify reusable assertion helpers and fixture boundaries before adding red-first tests.
+
+**CRITICAL**: No production implementation work starts until Phase 3 tests and red-first confirmation tasks are complete.
+
+- [ ] T004 Add or extend frontend assertion helpers in `frontend/src/entrypoints/task-create.test.tsx` for canonical task payload checks covering MM-627, FR-001, FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, and SC-005.
+- [ ] T005 Add or extend backend helper fixtures in `tests/unit/api/routers/test_executions.py` for canonical task-shaped submissions with objective attachments, step attachments, runtime, publish mode, dependencies, Jira provenance, branch intent, authored presets, and applied templates (FR-001, FR-003 through FR-010, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T006 [P] Add integration test fixture helpers in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for submitting task-shaped payloads and inspecting execution-visible normalized task parameters (acceptance scenarios 1 through 5, SC-001 through SC-005).
+
+**Checkpoint**: Shared test helpers are available and story test authoring can begin.
+
+---
+
+## Phase 3: Story - Preserve Authored Task Submission Shape
+
+**Summary**: As a Mission Control user, I want submitted tasks to preserve objective text, steps, repository/runtime/publish choices, dependencies, Jira provenance, and objective- or step-scoped attachments so execution receives exactly the task I authored.
+
+**Independent Test**: Submit create, edit, and rerun task drafts that include objective text, ordered steps, objective-scoped attachments, step-scoped attachments, repository/runtime/publish choices, dependencies, Jira provenance, branch intent, and preset metadata; verify accepted submissions preserve every authored binding and invalid or ambiguous submissions fail before execution receives altered task data.
+
+**Traceability**: MM-627, FR-001 through FR-012, acceptance scenarios 1 through 5, edge cases, SC-001 through SC-006, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
+
+**Unit Test Plan**: Cover frontend payload shaping and backend normalization/validation for attachment targets, branch semantics, dependencies, runtime/publish values, Jira provenance, preset provenance, binary-as-ref behavior, and explicit failure modes.
+
+**Integration Test Plan**: Cover the execution creation boundary and artifact-backed input snapshot behavior so the normalized task payload received by execution preserves create/edit/rerun semantics and rejects invalid target or branch shapes.
+
+### Unit Tests (write first)
+
+- [ ] T007 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving create submissions preserve objective text, step order, objective attachments, step attachments, runtime, publish mode, dependencies, Jira provenance, `task.git.branch`, and applied template metadata without `targetBranch` (FR-001, FR-003, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T008 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving edit and rerun submissions preserve snapshot-backed objective and step attachment targets while text changes, step reordering, and preset overrides do not silently retarget attachments (FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
+- [ ] T009 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving invalid or ambiguous repository, runtime, publish, dependency, attachment policy, and target-binding inputs block submission before uploads or `/api/executions` calls (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
+- [ ] T010 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving canonical task-shaped create requests preserve objective attachments, step attachments, step IDs/order, runtime, publish, dependencies, Jira provenance, authored presets, applied templates, and branch intent (FR-001, FR-003, FR-005, FR-007, FR-008, SC-001, SC-002, DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T011 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving new task-shaped normalization rejects or removes legacy `targetBranch` and top-level branch aliases from execution-visible task output while preserving `task.git.branch` (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+- [ ] T012 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding inputs fail explicitly (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
+- [ ] T013 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving binary inputs remain structured attachment refs and are not embedded in task instruction text after normalization (FR-011, DESIGN-REQ-025).
+
+### Integration Tests (write first)
+
+- [ ] T014 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving execution creation receives canonical normalized task data for a valid create submission with objective and step attachments, runtime, publish, dependencies, Jira provenance, branch intent, and preset metadata (acceptance scenario 1, SC-001, SC-002, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T015 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving edit and rerun flows preserve artifact-backed original task input snapshot attachment targets and reject silent retargeting after text or order changes (acceptance scenarios 2 and 3, FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
+- [ ] T016 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving invalid repository, runtime, publish, dependency, attachment policy, and target-binding submissions fail before execution receives normalized task data (acceptance scenario 5, FR-004, FR-010, SC-004, DESIGN-REQ-006).
+- [ ] T017 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving new task-shaped submissions expose `task.git.branch` and no `targetBranch` in execution-visible task parameters or task input snapshots (acceptance scenario 4, FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+
+### Red-First Confirmation
+
+- [ ] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T007-T009 fail for the intended MM-627 reasons before editing `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T019 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T013 fail for the intended MM-627 reasons before editing `api_service/api/routers/executions.py`.
+- [ ] T020 Run the focused integration target through `./tools/test_integration.sh` and confirm T014-T017 fail for the intended MM-627 reasons before editing execution-boundary production code in `api_service/api/routers/executions.py`.
+
+### Conditional Fallback for Implemented-Unverified Rows
+
+- [ ] T021 If T007, T010, T014, or T018-T020 show task-shaped create/edit/rerun intent is not already preserved, update `frontend/src/entrypoints/task-create.tsx` and `api_service/api/routers/executions.py` so FR-001 and DESIGN-REQ-001 pass without changing the one-story scope.
+
+### Implementation
+
+- [ ] T022 Update frontend submission shaping in `frontend/src/entrypoints/task-create.tsx` so create, edit, and rerun task payloads preserve objective/step attachments, Jira provenance, preset metadata, dependencies, runtime, publish mode, step identity/order, and canonical `git.branch` without emitting `targetBranch` (FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-005).
+- [ ] T023 Update backend task normalization in `api_service/api/routers/executions.py` to preserve `authoredPresets`, `appliedStepTemplates`, step source/provenance, Jira provenance, dependencies, runtime, publish mode, objective attachments, step attachments, and canonical branch intent in `initial_parameters["task"]` (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T024 Update backend branch normalization in `api_service/api/routers/executions.py` to remove superseded `targetBranch` output from new task-shaped submissions and fail explicitly for unsupported branch alias shapes when canonical `task.git.branch` is required (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+- [ ] T025 Update backend validation in `api_service/api/routers/executions.py` to fail explicitly for invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding input (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
+- [ ] T026 Update backend attachment target normalization in `api_service/api/routers/executions.py` so step reordering, text changes, preset aliases, and migration-era input cannot silently retarget objective or step attachments (FR-002, FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
+- [ ] T027 Update execution-visible schema handling in `moonmind/schemas/temporal_models.py` only if T010-T017 reveal normalized task fields are dropped or hidden from task detail, edit, rerun, or verification surfaces (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
+- [ ] T028 Update or add integration wiring in `api_service/api/routers/executions.py` so artifact-backed original task input snapshots preserve objective and step attachment refs, preset provenance, Jira provenance, and canonical branch semantics for create, edit, and rerun paths (FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-005).
+
+### Story Validation
+
+- [ ] T029 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and verify frontend MM-627 unit coverage passes for FR-001 through FR-012.
+- [ ] T030 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend MM-627 unit coverage passes for FR-001 through FR-012.
+- [ ] T031 Run `./tools/test_integration.sh` and verify hermetic integration coverage passes for acceptance scenarios 1 through 5, SC-001 through SC-005, and DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
+- [ ] T032 Confirm `MM-627`, the original Jira preset brief, FR-001 through FR-012, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, and DESIGN-REQ-025 remain preserved in `specs/320-normalize-task-shaped-submissions/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, `quickstart.md`, and `tasks.md`.
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T033 [P] Update `specs/320-normalize-task-shaped-submissions/quickstart.md` if implementation changes require adjusted validation commands or evidence paths (FR-012, SC-006).
+- [ ] T034 [P] Review `docs/Tasks/TaskArchitecture.md` only for source alignment drift and leave canonical docs unchanged unless implementation exposes a desired-state mismatch (DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025).
+- [ ] T035 Run full unit verification with `./tools/test_unit.sh` and record pass/fail evidence for MM-627 in final verification notes.
+- [ ] T036 Run `/moonspec-verify` for `specs/320-normalize-task-shaped-submissions/` after implementation and tests pass, covering MM-627, FR-001 through FR-012, acceptance scenarios 1 through 5, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on Phase 1.
+- Phase 3 depends on Phase 2.
+- Phase 4 depends on story implementation and validation passing.
+
+### Within The Story
+
+- T007-T017 must be written before T018-T020.
+- T018-T020 must confirm red-first behavior before T021-T028.
+- T021 is conditional on implemented-unverified verification failure.
+- T022-T028 are production implementation tasks and start only after red-first confirmation.
+- T029-T032 validate the story after implementation.
+- T035 and T036 run only after story validation passes.
+
+### Parallel Opportunities
+
+- T002 and T003 can run after T001 in parallel.
+- T006 can run in parallel with T004-T005 because it creates integration fixture scaffolding in a different file.
+- T007-T017 can be authored in parallel where they touch different test files.
+- T033 and T034 can run in parallel after story validation.
+
+## Parallel Example
+
+```bash
+# After Phase 2, author frontend, backend, and integration tests in parallel:
+Task: "T007 frontend canonical create payload tests in frontend/src/entrypoints/task-create.test.tsx"
+Task: "T010 backend canonical task payload tests in tests/unit/api/routers/test_executions.py"
+Task: "T014 integration canonical execution payload tests in tests/integration/temporal/test_task_shaped_submission_normalization.py"
+```
+
+## Implementation Strategy
+
+1. Confirm active MM-627 artifacts and helper locations.
+2. Add red-first unit tests in frontend and backend test files.
+3. Add red-first integration tests at the execution boundary.
+4. Run focused unit and integration commands and confirm expected failures.
+5. Apply conditional fallback work for implemented-unverified rows only if tests expose gaps.
+6. Implement partial rows in frontend submission shaping and backend task normalization.
+7. Rerun focused unit tests and hermetic integration tests.
+8. Preserve traceability across MoonSpec artifacts.
+9. Run full unit verification and final `/moonspec-verify`.
+
+## Notes
+
+- Do not create more than one story phase.
+- Do not add tasks for future stories or broad Task Architecture refactors.
+- Keep binary inputs as structured attachment refs.
+- Preserve MM-627 in all implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/320-normalize-task-shaped-submissions/tasks.md
+++ b/specs/320-normalize-task-shaped-submissions/tasks.md
@@ -67,7 +67,7 @@
 - [ ] T010 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving canonical task-shaped create requests preserve objective attachments, step attachments, step IDs/order, runtime, publish, dependencies, Jira provenance, authored presets, applied templates, and branch intent (FR-001, FR-003, FR-005, FR-007, FR-008, SC-001, SC-002, DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T011 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving new task-shaped normalization rejects or removes legacy `targetBranch` and top-level branch aliases from execution-visible task output while preserving `task.git.branch` (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
 - [ ] T012 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding inputs fail explicitly (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
-- [ ] T013 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving binary inputs remain structured attachment refs and are not embedded in task instruction text after normalization (FR-011, DESIGN-REQ-025).
+- [ ] T013 [P] Confirm existing binary-ref unit evidence in `frontend/src/entrypoints/task-create.test.tsx` and `tests/unit/api/routers/test_executions.py` still proves binary inputs remain structured attachment refs and are not embedded in task instruction text after normalization (FR-011, DESIGN-REQ-025).
 
 ### Integration Tests (write first)
 
@@ -79,7 +79,7 @@
 ### Red-First Confirmation
 
 - [ ] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T007-T009 fail for the intended MM-627 reasons before editing `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T019 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T013 fail for the intended MM-627 reasons before editing `api_service/api/routers/executions.py`.
+- [ ] T019 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T012 fail for the intended MM-627 reasons before editing `api_service/api/routers/executions.py`; record T013 as existing verified evidence.
 - [ ] T020 Run the focused integration target through `./tools/test_integration.sh` and confirm T014-T017 fail for the intended MM-627 reasons before editing execution-boundary production code in `api_service/api/routers/executions.py`.
 
 ### Conditional Fallback for Implemented-Unverified Rows
@@ -92,7 +92,7 @@
 - [ ] T023 Update backend task normalization in `api_service/api/routers/executions.py` to preserve `authoredPresets`, `appliedStepTemplates`, step source/provenance, Jira provenance, dependencies, runtime, publish mode, objective attachments, step attachments, and canonical branch intent in `initial_parameters["task"]` (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T024 Update backend branch normalization in `api_service/api/routers/executions.py` to remove superseded `targetBranch` output from new task-shaped submissions and fail explicitly for unsupported branch alias shapes when canonical `task.git.branch` is required (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
 - [ ] T025 Update backend validation in `api_service/api/routers/executions.py` to fail explicitly for invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding input (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
-- [ ] T026 Update backend attachment target normalization in `api_service/api/routers/executions.py` so step reordering, text changes, preset aliases, and migration-era input cannot silently retarget objective or step attachments (FR-002, FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
+- [ ] T026 Update backend attachment target normalization in `api_service/api/routers/executions.py` so step reordering, text changes, preset aliases, and migration-era input cannot silently retarget objective or step attachments (FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
 - [ ] T027 Update execution-visible schema handling in `moonmind/schemas/temporal_models.py` only if T010-T017 reveal normalized task fields are dropped or hidden from task detail, edit, rerun, or verification surfaces (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T028 Update or add integration wiring in `api_service/api/routers/executions.py` so artifact-backed original task input snapshots preserve objective and step attachment refs, preset provenance, Jira provenance, and canonical branch semantics for create, edit, and rerun paths (FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-005).
 

--- a/specs/320-normalize-task-shaped-submissions/tasks.md
+++ b/specs/320-normalize-task-shaped-submissions/tasks.md
@@ -27,9 +27,9 @@
 
 **Purpose**: Confirm the active feature artifacts and test entry points before story work.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/320-normalize-task-shaped-submissions` and that `specs/320-normalize-task-shaped-submissions/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, and `quickstart.md` exist for MM-627.
-- [ ] T002 Review existing targeted frontend test helpers in `frontend/src/entrypoints/task-create.test.tsx` for attachment upload, step reorder, Jira import provenance, applied templates, and branch payload assertions (FR-001 through FR-012).
-- [ ] T003 Review existing backend task-shaped request fixtures in `tests/unit/api/routers/test_executions.py` for attachment policy, dependency normalization, runtime validation, and create execution payload assertions (FR-001 through FR-011).
+- [X] T001 Confirm `.specify/feature.json` points to `specs/320-normalize-task-shaped-submissions` and that `specs/320-normalize-task-shaped-submissions/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, and `quickstart.md` exist for MM-627.
+- [X] T002 Review existing targeted frontend test helpers in `frontend/src/entrypoints/task-create.test.tsx` for attachment upload, step reorder, Jira import provenance, applied templates, and branch payload assertions (FR-001 through FR-012).
+- [X] T003 Review existing backend task-shaped request fixtures in `tests/unit/api/routers/test_executions.py` for attachment policy, dependency normalization, runtime validation, and create execution payload assertions (FR-001 through FR-011).
 
 ---
 
@@ -40,8 +40,8 @@
 **CRITICAL**: No production implementation work starts until Phase 3 tests and red-first confirmation tasks are complete.
 
 - [ ] T004 Add or extend frontend assertion helpers in `frontend/src/entrypoints/task-create.test.tsx` for canonical task payload checks covering MM-627, FR-001, FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, and SC-005.
-- [ ] T005 Add or extend backend helper fixtures in `tests/unit/api/routers/test_executions.py` for canonical task-shaped submissions with objective attachments, step attachments, runtime, publish mode, dependencies, Jira provenance, branch intent, authored presets, and applied templates (FR-001, FR-003 through FR-010, DESIGN-REQ-008, DESIGN-REQ-011).
-- [ ] T006 [P] Add integration test fixture helpers in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for submitting task-shaped payloads and inspecting execution-visible normalized task parameters (acceptance scenarios 1 through 5, SC-001 through SC-005).
+- [X] T005 Add or extend backend helper fixtures in `tests/unit/api/routers/test_executions.py` for canonical task-shaped submissions with objective attachments, step attachments, runtime, publish mode, dependencies, Jira provenance, branch intent, authored presets, and applied templates (FR-001, FR-003 through FR-010, DESIGN-REQ-008, DESIGN-REQ-011).
+- [X] T006 [P] Add integration test fixture helpers in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for submitting task-shaped payloads and inspecting execution-visible normalized task parameters (acceptance scenarios 1 through 5, SC-001 through SC-005).
 
 **Checkpoint**: Shared test helpers are available and story test authoring can begin.
 
@@ -64,42 +64,42 @@
 - [ ] T007 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving create submissions preserve objective text, step order, objective attachments, step attachments, runtime, publish mode, dependencies, Jira provenance, `task.git.branch`, and applied template metadata without `targetBranch` (FR-001, FR-003, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T008 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving edit and rerun submissions preserve snapshot-backed objective and step attachment targets while text changes, step reordering, and preset overrides do not silently retarget attachments (FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
 - [ ] T009 [P] Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx` proving invalid or ambiguous repository, runtime, publish, dependency, attachment policy, and target-binding inputs block submission before uploads or `/api/executions` calls (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
-- [ ] T010 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving canonical task-shaped create requests preserve objective attachments, step attachments, step IDs/order, runtime, publish, dependencies, Jira provenance, authored presets, applied templates, and branch intent (FR-001, FR-003, FR-005, FR-007, FR-008, SC-001, SC-002, DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-011).
-- [ ] T011 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving new task-shaped normalization rejects or removes legacy `targetBranch` and top-level branch aliases from execution-visible task output while preserving `task.git.branch` (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
-- [ ] T012 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding inputs fail explicitly (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
-- [ ] T013 [P] Confirm existing binary-ref unit evidence in `frontend/src/entrypoints/task-create.test.tsx` and `tests/unit/api/routers/test_executions.py` still proves binary inputs remain structured attachment refs and are not embedded in task instruction text after normalization (FR-011, DESIGN-REQ-025).
+- [X] T010 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving canonical task-shaped create requests preserve objective attachments, step attachments, step IDs/order, runtime, publish, dependencies, Jira provenance, authored presets, applied templates, and branch intent (FR-001, FR-003, FR-005, FR-007, FR-008, SC-001, SC-002, DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-011).
+- [X] T011 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving new task-shaped normalization rejects or removes legacy `targetBranch` and top-level branch aliases from execution-visible task output while preserving `task.git.branch` (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+- [X] T012 [P] Add failing backend unit tests in `tests/unit/api/routers/test_executions.py` proving invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding inputs fail explicitly (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
+- [X] T013 [P] Confirm existing binary-ref unit evidence in `frontend/src/entrypoints/task-create.test.tsx` and `tests/unit/api/routers/test_executions.py` still proves binary inputs remain structured attachment refs and are not embedded in task instruction text after normalization (FR-011, DESIGN-REQ-025).
 
 ### Integration Tests (write first)
 
-- [ ] T014 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving execution creation receives canonical normalized task data for a valid create submission with objective and step attachments, runtime, publish, dependencies, Jira provenance, branch intent, and preset metadata (acceptance scenario 1, SC-001, SC-002, DESIGN-REQ-008, DESIGN-REQ-011).
+- [X] T014 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving execution creation receives canonical normalized task data for a valid create submission with objective and step attachments, runtime, publish, dependencies, Jira provenance, branch intent, and preset metadata (acceptance scenario 1, SC-001, SC-002, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T015 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving edit and rerun flows preserve artifact-backed original task input snapshot attachment targets and reject silent retargeting after text or order changes (acceptance scenarios 2 and 3, FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
-- [ ] T016 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving invalid repository, runtime, publish, dependency, attachment policy, and target-binding submissions fail before execution receives normalized task data (acceptance scenario 5, FR-004, FR-010, SC-004, DESIGN-REQ-006).
-- [ ] T017 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving new task-shaped submissions expose `task.git.branch` and no `targetBranch` in execution-visible task parameters or task input snapshots (acceptance scenario 4, FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+- [X] T016 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving invalid repository, runtime, publish, dependency, attachment policy, and target-binding submissions fail before execution receives normalized task data (acceptance scenario 5, FR-004, FR-010, SC-004, DESIGN-REQ-006).
+- [X] T017 [P] Add failing hermetic integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py` proving new task-shaped submissions expose `task.git.branch` and no `targetBranch` in execution-visible task parameters or task input snapshots (acceptance scenario 4, FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
 
 ### Red-First Confirmation
 
 - [ ] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T007-T009 fail for the intended MM-627 reasons before editing `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T019 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T012 fail for the intended MM-627 reasons before editing `api_service/api/routers/executions.py`; record T013 as existing verified evidence.
+- [X] T019 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T012 fail for the intended MM-627 reasons before editing `api_service/api/routers/executions.py`; record T013 as existing verified evidence.
 - [ ] T020 Run the focused integration target through `./tools/test_integration.sh` and confirm T014-T017 fail for the intended MM-627 reasons before editing execution-boundary production code in `api_service/api/routers/executions.py`.
 
 ### Conditional Fallback for Implemented-Unverified Rows
 
-- [ ] T021 If T007, T010, T014, or T018-T020 show task-shaped create/edit/rerun intent is not already preserved, update `frontend/src/entrypoints/task-create.tsx` and `api_service/api/routers/executions.py` so FR-001 and DESIGN-REQ-001 pass without changing the one-story scope.
+- [X] T021 If T007, T010, T014, or T018-T020 show task-shaped create/edit/rerun intent is not already preserved, update `frontend/src/entrypoints/task-create.tsx` and `api_service/api/routers/executions.py` so FR-001 and DESIGN-REQ-001 pass without changing the one-story scope.
 
 ### Implementation
 
 - [ ] T022 Update frontend submission shaping in `frontend/src/entrypoints/task-create.tsx` so create, edit, and rerun task payloads preserve objective/step attachments, Jira provenance, preset metadata, dependencies, runtime, publish mode, step identity/order, and canonical `git.branch` without emitting `targetBranch` (FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-005).
-- [ ] T023 Update backend task normalization in `api_service/api/routers/executions.py` to preserve `authoredPresets`, `appliedStepTemplates`, step source/provenance, Jira provenance, dependencies, runtime, publish mode, objective attachments, step attachments, and canonical branch intent in `initial_parameters["task"]` (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
-- [ ] T024 Update backend branch normalization in `api_service/api/routers/executions.py` to remove superseded `targetBranch` output from new task-shaped submissions and fail explicitly for unsupported branch alias shapes when canonical `task.git.branch` is required (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
-- [ ] T025 Update backend validation in `api_service/api/routers/executions.py` to fail explicitly for invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding input (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
-- [ ] T026 Update backend attachment target normalization in `api_service/api/routers/executions.py` so step reordering, text changes, preset aliases, and migration-era input cannot silently retarget objective or step attachments (FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
+- [X] T023 Update backend task normalization in `api_service/api/routers/executions.py` to preserve `authoredPresets`, `appliedStepTemplates`, step source/provenance, Jira provenance, dependencies, runtime, publish mode, objective attachments, step attachments, and canonical branch intent in `initial_parameters["task"]` (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
+- [X] T024 Update backend branch normalization in `api_service/api/routers/executions.py` to remove superseded `targetBranch` output from new task-shaped submissions and fail explicitly for unsupported branch alias shapes when canonical `task.git.branch` is required (FR-006, SC-003, DESIGN-REQ-011, DESIGN-REQ-025).
+- [X] T025 Update backend validation in `api_service/api/routers/executions.py` to fail explicitly for invalid repository, runtime, publish, dependency, attachment policy, missing target, unknown target, conflicting attachment declaration, and ambiguous target-binding input (FR-004, FR-010, SC-004, DESIGN-REQ-006, DESIGN-REQ-025).
+- [X] T026 Update backend attachment target normalization in `api_service/api/routers/executions.py` so step reordering, text changes, preset aliases, and migration-era input cannot silently retarget objective or step attachments (FR-003, FR-009, SC-001, SC-005, DESIGN-REQ-003, DESIGN-REQ-025).
 - [ ] T027 Update execution-visible schema handling in `moonmind/schemas/temporal_models.py` only if T010-T017 reveal normalized task fields are dropped or hidden from task detail, edit, rerun, or verification surfaces (FR-003, FR-005, FR-007, FR-008, DESIGN-REQ-008, DESIGN-REQ-011).
 - [ ] T028 Update or add integration wiring in `api_service/api/routers/executions.py` so artifact-backed original task input snapshots preserve objective and step attachment refs, preset provenance, Jira provenance, and canonical branch semantics for create, edit, and rerun paths (FR-003, FR-005, FR-006, FR-007, FR-008, FR-009, SC-001, SC-002, SC-003, SC-005).
 
 ### Story Validation
 
-- [ ] T029 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and verify frontend MM-627 unit coverage passes for FR-001 through FR-012.
-- [ ] T030 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend MM-627 unit coverage passes for FR-001 through FR-012.
+- [X] T029 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and verify frontend MM-627 unit coverage passes for FR-001 through FR-012.
+- [X] T030 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend MM-627 unit coverage passes for FR-001 through FR-012.
 - [ ] T031 Run `./tools/test_integration.sh` and verify hermetic integration coverage passes for acceptance scenarios 1 through 5, SC-001 through SC-005, and DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
 - [ ] T032 Confirm `MM-627`, the original Jira preset brief, FR-001 through FR-012, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, and DESIGN-REQ-025 remain preserved in `specs/320-normalize-task-shaped-submissions/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-shaped-submission-contract.md`, `quickstart.md`, and `tasks.md`.
 
@@ -113,7 +113,7 @@
 
 - [ ] T033 [P] Update `specs/320-normalize-task-shaped-submissions/quickstart.md` if implementation changes require adjusted validation commands or evidence paths (FR-012, SC-006).
 - [ ] T034 [P] Review `docs/Tasks/TaskArchitecture.md` only for source alignment drift and leave canonical docs unchanged unless implementation exposes a desired-state mismatch (DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025).
-- [ ] T035 Run full unit verification with `./tools/test_unit.sh` and record pass/fail evidence for MM-627 in final verification notes.
+- [X] T035 Run full unit verification with `./tools/test_unit.sh` and record pass/fail evidence for MM-627 in final verification notes.
 - [ ] T036 Run `/moonspec-verify` for `specs/320-normalize-task-shaped-submissions/` after implementation and tests pass, covering MM-627, FR-001 through FR-012, acceptance scenarios 1 through 5, SC-001 through SC-006, and DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-006, DESIGN-REQ-008, DESIGN-REQ-011, DESIGN-REQ-025.
 
 ---

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_service.api.routers.executions import (
+    _get_service,
+    get_temporal_client,
+    router,
+)
+from api_service.db.base import get_async_session
+from api_service.db.models import TemporalArtifactStatus
+from moonmind.config.settings import settings
+from tests.unit.api.routers.test_executions import (
+    _artifact_session,
+    _build_execution_record,
+    _override_user_dependencies,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _client() -> tuple[TestClient, AsyncMock]:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    service.create_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: service
+    app.dependency_overrides[get_temporal_client] = lambda: AsyncMock()
+    _override_user_dependencies(app, is_superuser=False)
+    return TestClient(app), service
+
+
+def test_task_shaped_submission_boundary_exposes_canonical_task_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM627INTOBJECTIVE00000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+            ),
+            SimpleNamespace(
+                artifact_id="art_01MM627INTSTEP0000000000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=20,
+            ),
+        ]
+    )
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Preserve MM-627 task shape.",
+                        "dependsOn": ["mm:parent"],
+                        "runtime": {"mode": "codex", "model": "gpt-5-codex"},
+                        "publish": {"mode": "pr"},
+                        "git": {"branch": "feature/mm-627"},
+                        "inputAttachments": [
+                            {
+                                "artifactId": "art_01MM627INTOBJECTIVE00000",
+                                "filename": "objective.png",
+                                "contentType": "image/png",
+                                "sizeBytes": 10,
+                            }
+                        ],
+                        "steps": [
+                            {
+                                "id": "step-1",
+                                "instructions": "Run first step.",
+                                "jiraOrchestration": {"issueKey": "MM-627"},
+                                "inputAttachments": [
+                                    {
+                                        "artifactId": "art_01MM627INTSTEP0000000000",
+                                        "filename": "step.png",
+                                        "contentType": "image/png",
+                                        "sizeBytes": 20,
+                                    }
+                                ],
+                            }
+                        ],
+                        "authoredPresets": [{"slug": "jira-orchestrate"}],
+                        "appliedStepTemplates": [
+                            {"slug": "jira-implementation", "stepIds": ["step-1"]}
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert task["git"] == {"branch": "feature/mm-627"}
+    assert "targetBranch" not in task
+    assert "targetBranch" not in task["git"]
+    assert task["authoredPresets"] == [{"slug": "jira-orchestrate"}]
+    assert task["appliedStepTemplates"] == [
+        {"slug": "jira-implementation", "stepIds": ["step-1"]}
+    ]
+    assert task["steps"][0]["jiraOrchestration"] == {"issueKey": "MM-627"}
+
+
+def test_task_shaped_submission_boundary_rejects_invalid_alias_and_target_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM627INTDUPLICATE0000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+            )
+        ]
+    )
+    attachment = {
+        "artifactId": "art_01MM627INTDUPLICATE0000",
+        "filename": "same.png",
+        "contentType": "image/png",
+        "sizeBytes": 10,
+    }
+
+    with test_client:
+        target_branch_response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Run task.",
+                        "git": {"targetBranch": "feature/legacy"},
+                    },
+                },
+            },
+        )
+        duplicate_response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Run task.",
+                        "inputAttachments": [attachment],
+                        "steps": [
+                            {
+                                "id": "step-1",
+                                "instructions": "Run step.",
+                                "inputAttachments": [attachment],
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert target_branch_response.status_code == 422
+    assert duplicate_response.status_code == 422
+    service.create_execution.assert_not_awaited()

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -30,7 +30,7 @@ def _client() -> tuple[TestClient, AsyncMock]:
     service = AsyncMock()
     service.create_execution.return_value = _build_execution_record()
     app.dependency_overrides[_get_service] = lambda: service
-    app.dependency_overrides[get_temporal_client] = lambda: AsyncMock()
+    app.dependency_overrides[get_temporal_client] = AsyncMock
     _override_user_dependencies(app, is_superuser=False)
     return TestClient(app), service
 
@@ -152,7 +152,7 @@ def test_task_shaped_submission_boundary_rejects_invalid_alias_and_target_bindin
                 },
             },
         )
-        duplicate_response = test_client.post(
+        duplicate_target_response = test_client.post(
             "/api/executions",
             json={
                 "type": "task",
@@ -173,7 +173,22 @@ def test_task_shaped_submission_boundary_rejects_invalid_alias_and_target_bindin
                 },
             },
         )
+        duplicate_same_target_response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Run task.",
+                        "inputAttachments": [attachment, attachment],
+                    },
+                },
+            },
+        )
 
     assert target_branch_response.status_code == 422
-    assert duplicate_response.status_code == 422
+    assert duplicate_target_response.status_code == 422
+    assert duplicate_same_target_response.status_code == 422
     service.create_execution.assert_not_awaited()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7,7 +7,7 @@ import base64
 import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import Iterator
+from typing import Any, Iterator
 from unittest.mock import AsyncMock, Mock, call, patch
 from uuid import uuid4
 
@@ -57,6 +57,9 @@ class _ExecuteResult:
 
     def scalars(self) -> _ScalarRows:
         return _ScalarRows(self._rows)
+
+def _artifact_session(rows: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(execute=AsyncMock(return_value=_ExecuteResult(rows)))
 
 class _QueryHandle:
     def __init__(
@@ -2093,7 +2096,7 @@ def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
                     },
                     "git": {
                         "startingBranch": "feature/resolve-pr",
-                        "targetBranch": "codex/pr-resolver",
+                        "branch": "codex/pr-resolver",
                     },
                 },
             },
@@ -2118,7 +2121,7 @@ def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
     }
     assert initial_parameters["task"]["git"] == {
         "startingBranch": "feature/resolve-pr",
-        "targetBranch": "codex/pr-resolver",
+        "branch": "codex/pr-resolver",
     }
 
 def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
@@ -2909,6 +2912,229 @@ def test_create_task_shaped_execution_normalizes_snake_case_input_attachments(
         }
     ]
     assert "input_attachments" not in step_payload
+
+def test_create_task_shaped_execution_preserves_canonical_mm627_task_shape(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM627OBJECTIVE000000000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+            ),
+            SimpleNamespace(
+                artifact_id="art_01MM627STEP00000000000000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=20,
+            ),
+        ]
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "title": "MM-627 canonical task payload",
+                    "instructions": "Preserve the submitted task exactly.",
+                    "dependsOn": ["mm:dep-1"],
+                    "runtime": {
+                        "mode": "codex",
+                        "model": "gpt-5-codex",
+                        "effort": "high",
+                    },
+                    "publish": {"mode": "pr", "baseBranch": "main"},
+                    "git": {"branch": "feature/mm-627"},
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01MM627OBJECTIVE000000000",
+                            "filename": "objective.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "title": "Inspect step",
+                            "instructions": "Inspect the step screenshot.",
+                            "source": {
+                                "kind": "jira",
+                                "issueKey": "MM-627",
+                            },
+                            "storyOutput": {"mode": "jira"},
+                            "jiraOrchestration": {
+                                "issueKey": "MM-627",
+                                "preset": "jira-orchestrate",
+                            },
+                            "inputAttachments": [
+                                {
+                                    "artifactId": "art_01MM627STEP00000000000000",
+                                    "filename": "step.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 20,
+                                }
+                            ],
+                        }
+                    ],
+                    "storyOutput": {"mode": "jira"},
+                    "authoredPresets": [
+                        {"slug": "jira-orchestrate", "version": "2026-05-08"}
+                    ],
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "jira-implementation",
+                            "version": "2026-05-08",
+                            "stepIds": ["step-1"],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    task = initial_parameters["task"]
+    assert task["git"] == {"branch": "feature/mm-627"}
+    assert task["runtime"] == {
+        "mode": "codex_cli",
+        "model": "gpt-5-codex",
+        "effort": "high",
+    }
+    assert task["publish"]["mode"] == "pr"
+    assert task["dependsOn"] == ["mm:dep-1"]
+    assert task["storyOutput"] == {"mode": "jira"}
+    assert task["authoredPresets"] == [
+        {"slug": "jira-orchestrate", "version": "2026-05-08"}
+    ]
+    assert task["appliedStepTemplates"] == [
+        {
+            "slug": "jira-implementation",
+            "version": "2026-05-08",
+            "stepIds": ["step-1"],
+        }
+    ]
+    assert task["inputAttachments"][0]["artifactId"] == "art_01MM627OBJECTIVE000000000"
+    assert task["steps"][0]["id"] == "step-1"
+    assert task["steps"][0]["source"] == {"kind": "jira", "issueKey": "MM-627"}
+    assert task["steps"][0]["inputAttachments"][0]["artifactId"] == (
+        "art_01MM627STEP00000000000000"
+    )
+
+@pytest.mark.parametrize(
+    "task_payload",
+    [
+        {"instructions": "Run task.", "git": {"targetBranch": "feature/legacy"}},
+        {"instructions": "Run task.", "targetBranch": "feature/legacy"},
+    ],
+)
+def test_create_task_shaped_execution_rejects_legacy_target_branch_aliases(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    task_payload: dict[str, Any],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": task_payload,
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "targetBranch" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+def test_create_task_shaped_execution_rejects_non_string_repository(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": {"owner": "Moon", "name": "Mind"},
+                "targetRuntime": "codex",
+                "task": {"instructions": "Run task."},
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "repository" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+def test_create_task_shaped_execution_rejects_attachment_declared_for_multiple_targets(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM627DUPLICATE00000000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+            )
+        ]
+    )
+
+    attachment = {
+        "artifactId": "art_01MM627DUPLICATE00000000",
+        "filename": "same.png",
+        "contentType": "image/png",
+        "sizeBytes": 10,
+    }
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Run task.",
+                    "inputAttachments": [attachment],
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "instructions": "Run step.",
+                            "inputAttachments": [attachment],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "multiple input targets" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 def test_create_task_shaped_execution_rejects_embedded_attachment_data(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3133,8 +3133,53 @@ def test_create_task_shaped_execution_rejects_attachment_declared_for_multiple_t
     )
 
     assert response.status_code == 422
-    assert "multiple input targets" in response.json()["detail"]["message"]
+    assert "declared more than once" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_duplicate_attachment_declaration_for_same_target(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM627DUPLICATE00000001",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+            )
+        ]
+    )
+
+    attachment = {
+        "artifactId": "art_01MM627DUPLICATE00000001",
+        "filename": "same.png",
+        "contentType": "image/png",
+        "sizeBytes": 10,
+    }
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Run task.",
+                    "inputAttachments": [attachment, attachment],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "declared more than once" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
 
 def test_create_task_shaped_execution_rejects_embedded_attachment_data(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],


### PR DESCRIPTION
## Jira

- Jira issue key: MM-627

## MoonSpec

- Active feature path: `specs/320-normalize-task-shaped-submissions`
- Verification verdict: `ADDITIONAL_WORK_NEEDED` from `/moonspec-verify`; final verify preflight is blocked by `.gemini/skills` being an active runtime projection symlink in this managed checkout.

## Summary

- Tighten task-shaped execution normalization for MM-627.
- Preserve canonical `task.git.branch`, authored presets, applied step templates, Jira provenance, runtime/publish/dependency fields, and attachment refs in execution-visible task parameters.
- Reject legacy `targetBranch`, non-string repositories, and attachment artifacts declared for multiple input targets.
- Add backend unit tests and hermetic integration coverage for the create execution boundary.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` - PASS (`161 passed`; frontend Vitest suite also passed via runner).
- `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q --tb=short` - PASS (`2 passed`).
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS (`4547 passed`, `1 xpassed`; frontend Vitest `20 passed`).
- `./tools/test_integration.sh` - NOT RUN/PASS unavailable: Docker compose/buildx path was blocked by environment admin `403 Forbidden`.

## Remaining risks

- Final `/moonspec-verify` reported `ADDITIONAL_WORK_NEEDED` because `.gemini/skills` is an active projection symlink in this managed checkout.
- Full Docker-backed integration verification could not run in this environment.
- Some MoonSpec checklist tasks remain open for frontend red-first/edit-rerun integration and final verification evidence.
