### PR TITLE
MM-628 Route binary inputs through authorized artifact refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,8 @@ Key diagnostics:
 - Existing Temporal execution records, artifact-backed original task input snapshots, Temporal artifact metadata/content store; no new persistent tables planned (320-normalize-task-shaped-submissions)
 - Python 3.12 + Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest (320-remediation-action-contracts)
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned (320-remediation-action-contracts)
+- Python 3.12; TypeScript/React for Mission Control attachment upload UX + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest, existing Temporal artifact service/router (321-route-binary-artifact-refs)
+- Existing Temporal artifact metadata/content store, Temporal execution records, artifact links; no new persistent tables planned (321-route-binary-artifact-refs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -223,6 +223,8 @@ Key diagnostics:
 - Existing Temporal execution records, artifact-backed original task input snapshots, Temporal artifact metadata/content store; no new persistent tables planned (320-normalize-task-shaped-submissions)
 - Python 3.12 + Pydantic v2, SQLAlchemy async ORM, FastAPI service models where exposed, Temporal Python SDK activity/service boundaries, pytest (320-remediation-action-contracts)
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned (320-remediation-action-contracts)
+- Python 3.12; TypeScript/React for Mission Control attachment upload UX + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest, existing Temporal artifact service/router (321-route-binary-artifact-refs)
+- Existing Temporal artifact metadata/content store, Temporal execution records, artifact links; no new persistent tables planned (321-route-binary-artifact-refs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2858,6 +2858,7 @@ async def _validate_and_collect_task_input_attachments(
     *,
     task_payload: Mapping[str, Any],
     session: AsyncSession | None,
+    principal: str,
 ) -> tuple[list[dict[str, Any]], dict[int, list[dict[str, Any]]], list[dict[str, Any]]]:
     objective_refs = _normalize_attachment_ref_list(
         task_payload.get("inputAttachments") or task_payload.get("input_attachments"),
@@ -2950,6 +2951,16 @@ async def _validate_and_collect_task_input_attachments(
                 raise _invalid_task_request(
                     "input attachment artifact must be complete before execution start: "
                     f"{ref['artifactId']} is {artifact.status.value}."
+                )
+            owner = str(getattr(artifact, "created_by_principal", None) or "").strip()
+            if (
+                settings.oidc.AUTH_PROVIDER != "disabled"
+                and owner
+                and owner != principal
+                and not owner.startswith("service:")
+            ):
+                raise _invalid_task_request(
+                    f"input attachment artifact is not authorized for this execution: {ref['artifactId']}."
                 )
             artifact_content_type = _normalized_attachment_content_type(
                 artifact.content_type
@@ -4064,6 +4075,7 @@ async def _create_execution_from_task_request(
     ) = await _validate_and_collect_task_input_attachments(
         task_payload=task_payload,
         session=session,
+        principal=str(user.id),
     )
     step_count = _coerce_step_count(task_payload.get("steps"))
     normalized_steps = _normalize_task_steps(task_payload)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2957,7 +2957,7 @@ async def _validate_and_collect_task_input_attachments(
                 settings.oidc.AUTH_PROVIDER != "disabled"
                 and owner
                 and owner != principal
-                and not owner.startswith("service:")
+                and not principal.startswith("service:")
             ):
                 raise _invalid_task_request(
                     f"input attachment artifact is not authorized for this execution: {ref['artifactId']}."

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -1358,6 +1358,8 @@ class QueueApiClient:
         headers: dict[str, str] = {"Accept": "application/json"}
         if worker_token:
             headers["X-MoonMind-Worker-Token"] = worker_token
+        if client is not None:
+            client.headers.update(headers)
         self._client = client or httpx.AsyncClient(
             base_url=base_url,
             timeout=timeout_seconds,

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -1358,8 +1358,7 @@ class QueueApiClient:
         headers: dict[str, str] = {"Accept": "application/json"}
         if worker_token:
             headers["X-MoonMind-Worker-Token"] = worker_token
-        if client is not None:
-            client.headers.update(headers)
+        self._request_headers = headers
         self._client = client or httpx.AsyncClient(
             base_url=base_url,
             timeout=timeout_seconds,
@@ -1661,7 +1660,7 @@ class QueueApiClient:
 
         try:
             path = f"/api/task-runs/{job_id}/live-session/worker"
-            response = await self._client.get(path)
+            response = await self._client.get(path, headers=self._request_headers)
             if response.status_code == 404:
                 return None
             response.raise_for_status()
@@ -1700,6 +1699,7 @@ class QueueApiClient:
                     f"/api/queue/jobs/{job_id}/artifacts/upload",
                     data=data,
                     files=files,
+                    headers=self._request_headers,
                 )
                 response.raise_for_status()
             except httpx.HTTPError as exc:
@@ -1710,7 +1710,7 @@ class QueueApiClient:
     async def download_artifact(self, *, artifact_id: str) -> bytes:
         path = f"/api/artifacts/{artifact_id}/download"
         try:
-            response = await self._client.get(path)
+            response = await self._client.get(path, headers=self._request_headers)
             response.raise_for_status()
             return bytes(response.content)
         except httpx.HTTPError as exc:
@@ -1720,7 +1720,9 @@ class QueueApiClient:
 
     async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
         try:
-            response = await self._client.post(path, json=json)
+            response = await self._client.post(
+                path, json=json, headers=self._request_headers
+            )
             response.raise_for_status()
             return dict(response.json()) if response.content else {}
         except httpx.HTTPError as exc:

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 import boto3
 from botocore.exceptions import ClientError
-from sqlalchemy import Select, delete, exists, select
+from sqlalchemy import Select, delete, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
@@ -836,6 +836,39 @@ class TemporalArtifactRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
+    async def principal_owns_linked_execution(
+        self, *, artifact_id: str, principal: str
+    ) -> bool:
+        canonical_match = exists().where(
+            db_models.TemporalExecutionCanonicalRecord.namespace
+            == db_models.TemporalArtifactLink.namespace,
+            db_models.TemporalExecutionCanonicalRecord.workflow_id
+            == db_models.TemporalArtifactLink.workflow_id,
+            db_models.TemporalExecutionCanonicalRecord.run_id
+            == db_models.TemporalArtifactLink.run_id,
+            db_models.TemporalExecutionCanonicalRecord.owner_id == principal,
+            db_models.TemporalExecutionCanonicalRecord.owner_type
+            == db_models.TemporalExecutionOwnerType.USER,
+        )
+        projection_match = exists().where(
+            db_models.TemporalExecutionRecord.namespace
+            == db_models.TemporalArtifactLink.namespace,
+            db_models.TemporalExecutionRecord.workflow_id
+            == db_models.TemporalArtifactLink.workflow_id,
+            db_models.TemporalExecutionRecord.run_id
+            == db_models.TemporalArtifactLink.run_id,
+            db_models.TemporalExecutionRecord.owner_id == principal,
+            db_models.TemporalExecutionRecord.owner_type
+            == db_models.TemporalExecutionOwnerType.USER,
+        )
+        stmt = select(db_models.TemporalArtifactLink.id).where(
+            db_models.TemporalArtifactLink.artifact_id == artifact_id,
+            db_models.TemporalArtifactLink.link_type == "input.attachment",
+            or_(canonical_match, projection_match),
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
     async def list_for_execution(
         self,
         *,
@@ -1092,6 +1125,26 @@ class TemporalArtifactService:
                 f"principal '{principal}' cannot read artifact {artifact.artifact_id}"
             )
 
+    async def _assert_artifact_read_access(
+        self,
+        artifact: db_models.TemporalArtifact,
+        *,
+        principal: str,
+    ) -> None:
+        try:
+            self._assert_read_access(artifact, principal=principal)
+            return
+        except TemporalArtifactAuthorizationError:
+            pass
+        if await self._repository.principal_owns_linked_execution(
+            artifact_id=artifact.artifact_id,
+            principal=principal,
+        ):
+            return
+        raise TemporalArtifactAuthorizationError(
+            f"principal '{principal}' cannot read artifact {artifact.artifact_id}"
+        )
+
     def _assert_mutation_access(
         self,
         artifact: db_models.TemporalArtifact,
@@ -1134,6 +1187,36 @@ class TemporalArtifactService:
             return
         raise TemporalArtifactAuthorizationError(
             f"principal '{principal}' cannot access restricted raw artifact {artifact.artifact_id}"
+        )
+
+    async def _assert_artifact_raw_access(
+        self,
+        artifact: db_models.TemporalArtifact,
+        *,
+        principal: str,
+    ) -> None:
+        if self._raw_access_allowed(artifact, principal=principal):
+            return
+        if await self._repository.principal_owns_linked_execution(
+            artifact_id=artifact.artifact_id,
+            principal=principal,
+        ):
+            return
+        raise TemporalArtifactAuthorizationError(
+            f"principal '{principal}' cannot access restricted raw artifact {artifact.artifact_id}"
+        )
+
+    async def _artifact_raw_access_allowed(
+        self,
+        artifact: db_models.TemporalArtifact,
+        *,
+        principal: str,
+    ) -> bool:
+        if self._raw_access_allowed(artifact, principal=principal):
+            return True
+        return await self._repository.principal_owns_linked_execution(
+            artifact_id=artifact.artifact_id,
+            principal=principal,
         )
 
     @staticmethod
@@ -1588,11 +1671,11 @@ class TemporalArtifactService:
         allow_restricted_raw: bool = False,
     ) -> tuple[db_models.TemporalArtifact, bytes]:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         if artifact.status is not db_models.TemporalArtifactStatus.COMPLETE:
             raise TemporalArtifactStateError("artifact is not readable")
         if not allow_restricted_raw:
-            self._assert_raw_access(artifact, principal=principal)
+            await self._assert_artifact_raw_access(artifact, principal=principal)
         try:
             data = await asyncio.get_running_loop().run_in_executor(
                 None, self._store.read_bytes, artifact.storage_key
@@ -1615,11 +1698,11 @@ class TemporalArtifactService:
         chunk_size: int = _STREAM_CHUNK_BYTES,
     ) -> tuple[db_models.TemporalArtifact, Iterable[bytes]]:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         if artifact.status is not db_models.TemporalArtifactStatus.COMPLETE:
             raise TemporalArtifactStateError("artifact is not readable")
         if not allow_restricted_raw:
-            self._assert_raw_access(artifact, principal=principal)
+            await self._assert_artifact_raw_access(artifact, principal=principal)
         return artifact, self._store.read_chunks(
             artifact.storage_key, chunk_size=chunk_size
         )
@@ -1632,11 +1715,11 @@ class TemporalArtifactService:
         allow_restricted_raw: bool = False,
     ) -> tuple[db_models.TemporalArtifact, Path]:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         if artifact.status is not db_models.TemporalArtifactStatus.COMPLETE:
             raise TemporalArtifactStateError("artifact is not readable")
         if not allow_restricted_raw:
-            self._assert_raw_access(artifact, principal=principal)
+            await self._assert_artifact_raw_access(artifact, principal=principal)
         try:
             path = await asyncio.get_running_loop().run_in_executor(
                 None, self._store.read_path, artifact.storage_key
@@ -1668,7 +1751,9 @@ class TemporalArtifactService:
             if preview_artifact is not None:
                 preview_ref = build_artifact_ref(preview_artifact)
 
-        raw_access_allowed = self._raw_access_allowed(artifact, principal=principal)
+        raw_access_allowed = await self._artifact_raw_access_allowed(
+            artifact, principal=principal
+        )
         default_read_ref = (
             preview_ref
             if preview_ref is not None and not raw_access_allowed
@@ -1692,7 +1777,7 @@ class TemporalArtifactService:
         ArtifactReadPolicy,
     ]:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         links = await self._repository.list_links(artifact.artifact_id)
         pinned = await self._repository.get_pin(artifact.artifact_id)
         read_policy = await self.get_read_policy(artifact=artifact, principal=principal)
@@ -1705,10 +1790,10 @@ class TemporalArtifactService:
         principal: str,
     ) -> tuple[db_models.TemporalArtifact, datetime, str]:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         if artifact.status is not db_models.TemporalArtifactStatus.COMPLETE:
             raise TemporalArtifactStateError("artifact is not readable")
-        self._assert_raw_access(artifact, principal=principal)
+        await self._assert_artifact_raw_access(artifact, principal=principal)
 
         expires_at = datetime.now(UTC) + timedelta(seconds=self._presign_ttl_seconds)
         if artifact.storage_backend is db_models.TemporalArtifactStorageBackend.S3:
@@ -1953,7 +2038,7 @@ class TemporalArtifactService:
         policy: str | None = None,
     ) -> ArtifactRef:
         artifact = await self._repository.get_artifact(artifact_id)
-        self._assert_read_access(artifact, principal=principal)
+        await self._assert_artifact_read_access(artifact, principal=principal)
         _artifact, payload = await self.read(
             artifact_id=artifact_id,
             principal=principal,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -861,13 +861,17 @@ class TemporalArtifactRepository:
             db_models.TemporalExecutionRecord.owner_type
             == db_models.TemporalExecutionOwnerType.USER,
         )
-        stmt = select(db_models.TemporalArtifactLink.id).where(
-            db_models.TemporalArtifactLink.artifact_id == artifact_id,
-            db_models.TemporalArtifactLink.link_type == "input.attachment",
-            or_(canonical_match, projection_match),
+        stmt = (
+            select(db_models.TemporalArtifactLink.id)
+            .where(
+                db_models.TemporalArtifactLink.artifact_id == artifact_id,
+                db_models.TemporalArtifactLink.link_type == "input.attachment",
+                or_(canonical_match, projection_match),
+            )
+            .limit(1)
         )
         result = await self._session.execute(stmt)
-        return result.scalar_one_or_none() is not None
+        return result.scalar() is not None
 
     async def list_for_execution(
         self,

--- a/specs/321-route-binary-artifact-refs/checklists/requirements.md
+++ b/specs/321-route-binary-artifact-refs/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Route Binary Inputs Through Authorized Artifact Refs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: `spec.md` preserves the MM-628 Jira preset brief and classifies the input as a single-story runtime feature request.
+- PASS: In-scope source design requirements DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 are mapped to functional requirements.

--- a/specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md
+++ b/specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md
@@ -1,0 +1,125 @@
+# Contract: Binary Artifact Refs For Task Submission
+
+## Create Upload Intent
+
+Endpoint: `POST /api/artifacts`
+
+Request:
+
+```json
+{
+  "content_type": "image/png",
+  "size_bytes": 12345,
+  "sha256": "optional lowercase sha256",
+  "metadata": {
+    "filename": "wireframe.png",
+    "source": "task-dashboard-objective-attachment",
+    "targetKind": "objective"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "artifact_ref": {
+    "artifact_id": "art_...",
+    "content_type": "image/png",
+    "size_bytes": 12345,
+    "sha256": "optional lowercase sha256",
+    "encryption": "none",
+    "artifact_ref_v": 1
+  },
+  "upload": {
+    "mode": "single_put",
+    "upload_url": "http://testserver/api/artifacts/art_.../content",
+    "upload_id": null,
+    "expires_at": "2026-05-08T09:00:00Z",
+    "max_size_bytes": 10485760,
+    "required_headers": {}
+  }
+}
+```
+
+Rules:
+- The browser must use this MoonMind endpoint before submitting a task with new binary input bytes.
+- The browser must not call object storage or provider file endpoints directly except through returned short-lived upload URLs.
+
+## Complete Upload
+
+Endpoints:
+- `PUT /api/artifacts/{artifactId}/content` for single-put uploads.
+- `POST /api/artifacts/{artifactId}/complete` for multipart completion.
+
+Rules:
+- Completion validates declared size, digest, content type, and image signatures where applicable.
+- Failed completion marks the artifact failed and the ref cannot be used for execution submission.
+
+## Submit Task With Structured Attachment Refs
+
+Endpoint: `POST /api/executions`
+
+Request shape:
+
+```json
+{
+  "type": "task",
+  "payload": {
+    "task": {
+      "instructions": "Review the uploaded diagram.",
+      "inputAttachments": [
+        {
+          "artifactId": "art_...",
+          "filename": "diagram.png",
+          "contentType": "image/png",
+          "sizeBytes": 12345
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-1",
+          "instructions": "Inspect the step-specific image.",
+          "inputAttachments": [
+            {
+              "artifactId": "art_...",
+              "filename": "step.png",
+              "contentType": "image/png",
+              "sizeBytes": 23456
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Acceptance rules:
+- Every referenced artifact must exist, be `complete`, match declared content type/size, and be authorized for the submitting principal and execution scope.
+- Execution submission must reject pending, failed, deleted, missing, duplicate, unsupported, oversized, or unauthorized refs before execution starts.
+- Accepted submissions link each input artifact to the execution with `linkType = "input.attachment"`.
+- Execution payloads contain structured refs only. They must not contain raw bytes, object-store credentials, presigned download URLs, or provider-specific file payloads.
+
+## Preview And Download
+
+Endpoints:
+- `GET /api/artifacts/{artifactId}`
+- `POST /api/artifacts/{artifactId}/presign-download`
+- `GET /api/artifacts/{artifactId}/download`
+
+Rules:
+- Browser preview/download must use MoonMind APIs.
+- Raw access requires owner, execution view permission, or service authorization.
+- Restricted artifacts return preview/default read refs according to artifact read policy.
+
+## Worker Materialization
+
+Runtime boundary:
+- Worker receives task structured refs.
+- Worker downloads each artifact through a MoonMind service-authorized path.
+- Worker writes files under target-aware workspace paths and writes an attachment manifest.
+
+Rules:
+- Worker materialization must fail explicitly when an artifact cannot be read or is not authorized for the execution.
+- Worker materialization must not expose storage credentials to the browser or encode raw bytes in task instructions.

--- a/specs/321-route-binary-artifact-refs/data-model.md
+++ b/specs/321-route-binary-artifact-refs/data-model.md
@@ -1,0 +1,89 @@
+# Data Model: Route Binary Inputs Through Authorized Artifact Refs
+
+## Binary Input Artifact
+
+Represents bytes uploaded through MoonMind artifact APIs before task execution submission.
+
+Fields:
+- `artifactId`: Stable MoonMind artifact identifier, required in structured attachment refs.
+- `contentType`: Normalized MIME type validated against server-defined attachment policy.
+- `sizeBytes`: Declared and verified byte size.
+- `sha256`: Optional declared digest, verified when provided during upload completion.
+- `status`: `pending_upload`, `complete`, `failed`, or `deleted`.
+- `createdByPrincipal`: Principal that created the artifact.
+- `metadata`: Observability fields such as filename, source, target kind, or step reference; not authoritative for target meaning.
+
+Validation rules:
+- Only `complete` artifacts may be submitted for execution.
+- Declared content type and size must match stored artifact metadata when present.
+- Unsupported content types, including SVG images for input attachments, are rejected.
+- Unauthorized principals cannot attach another principal's artifact to execution.
+
+State transitions:
+- `pending_upload` -> `complete` after successful write or multipart completion.
+- `pending_upload` -> `failed` after integrity, type, size, or storage completion failure.
+- `complete` -> `deleted` through artifact lifecycle deletion.
+
+## Upload Intent
+
+Represents the server-created upload session returned by `POST /api/artifacts`.
+
+Fields:
+- `mode`: `single_put` or `multipart`.
+- `uploadUrl`: Direct upload endpoint or storage presign URL.
+- `uploadId`: Multipart upload identifier when multipart is selected.
+- `expiresAt`: Time after which upload completion is no longer valid.
+- `maxSizeBytes`: Maximum direct upload size.
+- `requiredHeaders`: Headers the browser must send for storage-backed uploads.
+
+Validation rules:
+- Browser submission must wait for upload completion/finalization.
+- Expired or incomplete upload intents cannot produce accepted execution refs.
+
+## Structured Attachment Ref
+
+Execution-facing lightweight reference for a finalized binary artifact.
+
+Fields:
+- `artifactId`: Required artifact identifier.
+- `filename`: Required display/original filename.
+- `contentType`: Required normalized content type.
+- `sizeBytes`: Required non-negative integer.
+- `targetKind`: Derived from the task contract as `objective` or `step` during validation/linking.
+- `stepRef` or `stepOrdinal`: Present for step-scoped attachments when available.
+
+Validation rules:
+- Refs must contain only the supported fields in task payloads.
+- Duplicate artifact refs within one task submission are rejected.
+- The same binary ref cannot be silently retargeted by metadata or storage path.
+
+## Artifact Access Request
+
+Represents preview, download, presign-download, or worker materialization of an artifact.
+
+Fields:
+- `artifactId`: Requested artifact.
+- `principal`: User or service principal making the request.
+- `executionRef`: Namespace, workflow ID, run ID, and link type when access is execution-scoped.
+- `readMode`: Metadata, preview, raw download, or worker materialization.
+
+Validation rules:
+- Browser access goes through MoonMind APIs.
+- Raw download requires owner, view permission, or service authorization.
+- Worker materialization uses service authorization and fails explicitly when not authorized.
+
+## Execution Artifact Link
+
+Associates an artifact with an execution after task submission accepts the structured ref.
+
+Fields:
+- `artifactId`
+- `namespace`
+- `workflowId`
+- `runId`
+- `linkType`: `input.attachment` for submitted binary inputs.
+- `label`: Usually the submitted filename.
+
+Validation rules:
+- Links are execution-scoped and must not be treated as globally reusable permission grants.
+- Linking must not bypass artifact ownership or service authorization checks.

--- a/specs/321-route-binary-artifact-refs/moonspec_align_report.md
+++ b/specs/321-route-binary-artifact-refs/moonspec_align_report.md
@@ -1,0 +1,36 @@
+# MoonSpec Align Report: Route Binary Inputs Through Authorized Artifact Refs
+
+**Feature**: `321-route-binary-artifact-refs`
+**Date**: 2026-05-08
+**Source**: MM-628 canonical Jira preset brief preserved in `spec.md`
+
+## Verdict
+
+PASS. The MM-628 MoonSpec artifact set is aligned and ready for implementation.
+
+## Checks
+
+| Area | Result | Evidence | Remediation |
+| --- | --- | --- | --- |
+| Source preservation | PASS | `spec.md` preserves MM-628, the original Jira preset brief, and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022. | None |
+| Specify gate | PASS | `spec.md` contains exactly one `## User Story - ...` section and no unresolved `[NEEDS CLARIFICATION]` markers. | None |
+| Plan gate | PASS | `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/binary-artifact-ref-contract.md` exist and keep unit/integration strategies explicit. | None |
+| Task gate | PASS | `tasks.md` has 32 sequential tasks, exactly one story phase, unit and integration tests before implementation, red-first confirmation, conditional fallback implementation, story validation, and final `/moonspec-verify`. | None |
+| Coverage | PASS | All FR-001 through FR-012, SC-001 through SC-006, and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022 appear in `tasks.md`. | None |
+| Constitution | PASS | `plan.md` records PASS for all constitution principles and no unresolved complexity exception. | None |
+
+## Key Decisions
+
+- Kept `spec.md`, `plan.md`, design artifacts, and `tasks.md` unchanged because the generated artifacts already aligned with the source brief and repository conventions.
+- Treated `/moonspec-verify` as the final verification command because the active MoonSpec lifecycle uses `moonspec-*` skill names and the generated tasks already preserve that current command.
+- Preserved verification-first handling for partial and implemented-unverified rows so implementation work remains conditional on failing proof rather than speculative code changes.
+
+## Remaining Risks
+
+- Implementation may still discover authorization or execution-scoping gaps; those are already captured as test-first tasks T008 through T024.
+
+## Validation
+
+- `SPECIFY_FEATURE=321-route-binary-artifact-refs .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
+- Artifact coverage script: PASS, every `FR-*`, `SC-*`, and in-scope `DESIGN-REQ-*` from `spec.md` is present in `tasks.md`.
+- Task format check: PASS, 32 task lines, sequential T001 through T032, exactly one story phase, no invalid task lines.

--- a/specs/321-route-binary-artifact-refs/plan.md
+++ b/specs/321-route-binary-artifact-refs/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Route Binary Inputs Through Authorized Artifact Refs
+
+**Branch**: `321-route-binary-artifact-refs` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/321-route-binary-artifact-refs/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` initially failed because the managed job branch is `run-jira-orchestrate-for-mm-628-route-bi-6bcc12c5`, not a numeric feature branch. It was rerun with `SPECIFY_FEATURE=321-route-binary-artifact-refs`, resolving this feature directory and creating `plan.md`.
+
+## Summary
+
+MM-628 requires browser-selected binary inputs to be uploaded through MoonMind artifact APIs, finalized before task submission, submitted to execution only as structured refs, previewed/downloaded through authorized MoonMind APIs, and materialized by workers through service-authorized paths. Current code already has artifact create/upload/complete/download endpoints, frontend attachment upload ordering, task-shaped attachment validation, and worker materialization. Planning finds remaining delivery work around authorization at execution submission/linking, execution-scoped reuse, and explicit proof that worker materialization uses service authorization rather than browser-visible credentials. The implementation should add verification-first unit and integration coverage, then tighten the API/service boundaries where tests expose gaps.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/task-create.test.tsx` verifies `/api/artifacts` calls for objective and step attachments; `api_service/api/routers/temporal_artifacts.py` exposes `POST /api/artifacts` | no new implementation beyond preserving behavior | final traceability |
+| FR-002 | implemented_verified | `moonmind/workflows/temporal/artifacts.py` stores bytes in artifact storage; UI tests assert instructions are not rewritten with attachment text | no new implementation beyond preserving behavior | final traceability |
+| FR-003 | implemented_verified | `task-create.test.tsx` asserts presigned upload and `/complete` happen before `/api/executions` | no new implementation beyond preserving behavior | final traceability |
+| FR-004 | implemented_unverified | `api_service/api/routers/executions.py` rejects non-`COMPLETE` artifact status before execution, but MM-628 needs focused coverage for finalized binary refs | add targeted API unit/integration tests for pending/failed/deleted artifact refs; implement only if coverage exposes gaps | unit + integration |
+| FR-005 | implemented_verified | `task-create.test.tsx` and `tests/unit/api/routers/test_executions.py` verify structured attachment refs in `payload.task` and `initial_parameters` | no new implementation beyond preserving behavior | final traceability |
+| FR-006 | partial | existing validation rejects missing, invalid, duplicate, oversized, wrong content-type, and unfinalized refs; authorization of submitted refs by principal/execution scope is not proven | add authorization and execution-scope validation at submission/linking boundary if missing | unit + integration |
+| FR-007 | implemented_verified | `api_service/api/routers/temporal_artifacts.py` exposes metadata, presign-download, and download endpoints; frontend tests use artifact endpoint templates | no new implementation beyond preserving behavior | final traceability |
+| FR-008 | partial | `TemporalArtifactService` enforces owner/service raw read access; tests cover restricted previews, but execution ownership/view permission behavior needs focused proof for task input artifacts | add preview/download authorization tests for linked input attachments and patch service/router if execution viewer permissions are incomplete | unit + integration |
+| FR-009 | implemented_unverified | `moonmind/agents/codex_worker/worker.py` materializes input attachments via worker queue client; tests cover materialization and failure diagnostics but not service-principal authorization | add worker/runtime boundary test proving service-authorized artifact reads and no browser credential leakage | unit + integration |
+| FR-010 | partial | execution creation links input artifacts with `link_type="input.attachment"` and stores artifact IDs on the execution record; enforcement that refs cannot be reused outside the authorized execution context is not fully proven | add execution-scoped link/reuse tests and tighten linking/read policy if needed | unit + integration |
+| FR-011 | implemented_verified | `docs/Tasks/TaskArchitecture.md` target semantics are represented by task `inputAttachments`/step refs; worker materialization tests prove paths derive from target fields, not storage paths | no new implementation beyond preserving behavior | final traceability |
+| FR-012 | implemented_verified | `spec.md` preserves MM-628 and the original preset brief; this plan preserves MM-628 and source design IDs | preserve through tasks, verification, commit, and PR metadata | final traceability |
+| SC-001 | implemented_verified | UI tests cover upload/complete before execution submission | keep covered in final verification | final traceability |
+| SC-002 | implemented_verified | UI/API tests show structured refs and no instruction rewriting | keep covered in final verification | final traceability |
+| SC-003 | partial | invalid/unfinalized validation exists; unauthorized binary refs are not proven | add negative authorization and status tests | unit + integration |
+| SC-004 | partial | artifact APIs enforce owner/service access; execution viewer permission coverage needs focused proof | add preview/download authorization tests | unit + integration |
+| SC-005 | implemented_unverified | worker materialization tests cover download and manifest behavior, but service credential use is not proven | add service-principal materialization proof | unit + integration |
+| SC-006 | implemented_verified | `spec.md`, this plan, and design artifacts preserve MM-628 and all listed design IDs | preserve through downstream artifacts | final traceability |
+| DESIGN-REQ-002 | implemented_verified | artifact storage and structured refs exist; tests verify instructions are not rewritten with binary content | no new implementation beyond final verify | final traceability |
+| DESIGN-REQ-007 | implemented_unverified | frontend upload orchestration exists and is tested; API finalization checks need focused binary-ref coverage | add focused API tests for finalized refs before execution | unit + integration |
+| DESIGN-REQ-020 | partial | artifact service has read policies and execution links; execution ownership/view permission and execution-scoped reuse require stronger proof | add authorization/link-scope tests and implement gaps | unit + integration |
+| DESIGN-REQ-022 | partial | task invariants are mostly implemented; unauthorized refs and service-authorized worker materialization remain unproven | add boundary tests and patch service/API/runtime if needed | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control attachment upload UX  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest/Testing Library, pytest, existing Temporal artifact service/router  
+**Storage**: Existing Temporal artifact metadata/content store, Temporal execution records, artifact links; no new persistent tables planned  
+**Unit Testing**: `./tools/test_unit.sh` for final unit verification; focused Python tests in `tests/unit/api/routers/test_executions.py`, `tests/unit/api/routers/test_temporal_artifacts.py`, `tests/unit/workflows/temporal/test_artifacts.py`, and `tests/unit/agents/codex_worker/test_attachment_materialization.py`; focused UI tests via `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci`; focused additions in `tests/integration/temporal/test_task_shaped_submission_normalization.py`, `tests/integration/temporal/test_temporal_artifact_authorization.py`, and/or `tests/contract/test_temporal_execution_api.py`  
+**Target Platform**: MoonMind Mission Control web app and FastAPI/Temporal control plane on Linux/Docker Compose  
+**Project Type**: Full-stack web application with Temporal-backed execution orchestration and managed worker materialization  
+**Performance Goals**: Attachment submission validation remains linear in unique attachment refs and uses one metadata lookup for all refs; preview/download authorization adds no extra object-store round trips before permission checks  
+**Constraints**: No binary payloads in workflow history or inline instructions; browser never receives long-lived object-store credentials; unauthorized or unfinalized refs fail before execution; worker materialization uses service authorization; no new persistent storage  
+**Scale/Scope**: One independently testable MM-628 story covering binary artifact upload, finalized structured refs, authorized preview/download, and worker materialization boundaries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - work keeps binary handling in MoonMind control-plane and runtime boundaries without rebuilding agent behavior.
+- II. One-Click Agent Deployment: PASS - no new external service or required secret is introduced.
+- III. Avoid Vendor Lock-In: PASS - artifacts and refs remain provider-neutral; browser/provider file endpoints are explicitly excluded.
+- IV. Own Your Data: PASS - binary inputs stay in MoonMind-owned artifact storage and refs.
+- V. Skills Are First-Class and Easy to Add: PASS - no skill source mutation or runtime skill contract changes.
+- VI. Replaceable Scaffolding, Thick Contracts: PASS - plan tightens artifact contracts and tests at service/API/runtime boundaries.
+- VII. Runtime Configurability: PASS - attachment policy remains controlled by existing settings.
+- VIII. Modular Architecture: PASS - planned work stays in artifact service/router, task execution submission validation, frontend upload flow tests, and worker materialization boundaries.
+- IX. Resilient by Default: PASS - invalid or unauthorized input refs fail before execution and worker materialization fails explicitly.
+- X. Continuous Improvement: PASS - artifacts preserve evidence, planned tests, and next actions.
+- XI. Spec-Driven Development: PASS - `spec.md`, `plan.md`, and design artifacts define the work before tasks or implementation.
+- XII. Canonical Documentation Separation: PASS - implementation and rollout details stay under `specs/321-route-binary-artifact-refs/`.
+
+No constitution violations are currently justified.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/321-route-binary-artifact-refs/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── binary-artifact-ref-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+
+api_service/api/routers/
+├── executions.py
+└── temporal_artifacts.py
+
+moonmind/workflows/temporal/
+└── artifacts.py
+
+moonmind/agents/codex_worker/
+└── worker.py
+
+moonmind/schemas/
+└── temporal_artifact_models.py
+
+tests/unit/api/routers/
+├── test_executions.py
+└── test_temporal_artifacts.py
+
+tests/unit/agents/codex_worker/
+└── test_attachment_materialization.py
+
+tests/integration/temporal/
+├── test_task_shaped_submission_normalization.py
+├── test_temporal_artifact_authorization.py
+└── test_temporal_artifact_auth_preview.py
+
+tests/contract/
+├── test_temporal_artifact_api.py
+└── test_temporal_execution_api.py
+```
+
+**Structure Decision**: This is a full-stack artifact-boundary story. Mission Control owns browser upload orchestration, FastAPI owns artifact and execution submission validation, `TemporalArtifactService` owns authorization/read policies, the execution record owns links to input artifacts, and managed workers own service-authorized materialization.
+
+## Complexity Tracking
+
+No constitution violations require complexity exceptions.

--- a/specs/321-route-binary-artifact-refs/quickstart.md
+++ b/specs/321-route-binary-artifact-refs/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: Route Binary Inputs Through Authorized Artifact Refs
+
+## Focused Unit Strategy
+
+1. Add or update frontend tests:
+   - `frontend/src/entrypoints/task-create.test.tsx`
+   - Verify upload intent creation, upload completion, execution submission ordering, structured refs, and no instruction rewriting remain intact.
+
+2. Add or update API/router tests:
+   - `tests/unit/api/routers/test_executions.py`
+   - `tests/unit/api/routers/test_temporal_artifacts.py`
+   - Cover pending, failed, deleted, missing, duplicate, unsupported, oversized, and unauthorized input artifact refs before execution starts.
+
+3. Add or update artifact service and worker tests:
+   - `tests/unit/workflows/temporal/test_artifacts.py`
+   - `tests/unit/agents/codex_worker/test_attachment_materialization.py`
+   - Prove read policy, execution-scoped links, and service-authorized materialization for task input artifacts.
+
+Focused commands:
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_temporal_artifacts.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Final unit command:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Integration Strategy
+
+Add or update hermetic `integration_ci` coverage for:
+- completed binary refs accepted into task-shaped execution submission,
+- pending/failed/unauthorized refs rejected before execution creation,
+- artifact preview/download authorization for linked input attachments,
+- worker materialization through service-authorized artifact reads.
+
+Likely files:
+- `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+- `tests/integration/temporal/test_temporal_artifact_authorization.py`
+- `tests/contract/test_temporal_execution_api.py`
+
+Focused integration command where practical:
+
+```bash
+pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py -m 'integration_ci' -q --tb=short
+```
+
+Final integration command:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-To-End Validation Scenario
+
+1. Create a binary artifact upload intent through `POST /api/artifacts`.
+2. Upload bytes and complete/finalize the artifact.
+3. Submit a task with objective and step `inputAttachments` referencing the completed artifact refs.
+4. Confirm execution creation succeeds and links refs as `input.attachment`.
+5. Confirm task instructions and workflow parameters contain structured refs, not raw bytes or storage credentials.
+6. Confirm browser preview/download succeeds only for authorized principals.
+7. Confirm a worker can materialize the same refs with service authorization and writes a target-aware manifest.
+8. Repeat with pending, failed, deleted, missing, wrong-owner, and cross-execution refs; each must fail before execution starts or before unauthorized content is returned.
+
+## Traceability Checks
+
+Before task generation and final verification, confirm:
+- `MM-628` remains in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/binary-artifact-ref-contract.md`, `quickstart.md`, `tasks.md`, and verification output.
+- DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 remain mapped to tests and implementation evidence.

--- a/specs/321-route-binary-artifact-refs/research.md
+++ b/specs/321-route-binary-artifact-refs/research.md
@@ -1,0 +1,89 @@
+# Research: Route Binary Inputs Through Authorized Artifact Refs
+
+## Setup Script
+
+Decision: Use `SPECIFY_FEATURE=321-route-binary-artifact-refs .specify/scripts/bash/setup-plan.sh --json` for setup.
+Evidence: Running `.specify/scripts/bash/setup-plan.sh --json` directly failed because the managed branch name is `run-jira-orchestrate-for-mm-628-route-bi-6bcc12c5`; with `SPECIFY_FEATURE` set, the script resolved `specs/321-route-binary-artifact-refs` and created `plan.md`.
+Rationale: The feature directory and active spec are already valid; the direct failure is a branch naming guard, not a missing feature artifact.
+Alternatives considered: Renaming or switching branches was rejected because this managed step is only authorized to plan.
+Test implications: None.
+
+## FR-001 Artifact Upload Intents
+
+Decision: Implemented verified.
+Evidence: `api_service/api/routers/temporal_artifacts.py` exposes `POST /api/artifacts`; `frontend/src/entrypoints/task-create.test.tsx` asserts objective and step attachment selections call `/api/artifacts` with attachment metadata.
+Rationale: The browser path and API endpoint for creating upload intents already exist and have focused UI/API coverage.
+Alternatives considered: Planning new upload-intent APIs was rejected because the existing artifact API already provides the required surface.
+Test implications: None beyond final verification unless adjacent changes alter upload orchestration.
+
+## FR-002 / FR-005 Binary Bytes Stay Out Of Instructions And Execution Payloads
+
+Decision: Implemented verified.
+Evidence: `moonmind/workflows/temporal/artifacts.py` stores bytes through `TemporalArtifactStore`; `task-create.test.tsx` asserts task and step instructions are not rewritten with attachment text and that submissions contain `inputAttachments` refs; `tests/unit/api/routers/test_executions.py` verifies attachment refs reach initial parameters.
+Rationale: Existing behavior directly matches the requirement that execution receives structured refs rather than binary bytes or credentials.
+Alternatives considered: Adding a new binary payload sanitizer was rejected because structured attachment refs are already the boundary.
+Test implications: None beyond final traceability unless implementation touches payload composition.
+
+## FR-003 / DESIGN-REQ-007 Upload Completion Before Submission
+
+Decision: Implemented verified for browser ordering, implemented unverified for binary-ref API finalization coverage.
+Evidence: `task-create.test.tsx` asserts presigned upload and `/api/artifacts/{id}/complete` occur before `/api/executions`; `api_service/api/routers/executions.py` rejects artifacts whose status is not `COMPLETE`.
+Rationale: Browser ordering is covered, but MM-628 should add focused API tests for pending/failed/deleted binary refs before relying on this as a full boundary guarantee.
+Alternatives considered: UI-only verification was rejected because API submission must remain authoritative.
+Test implications: Unit and integration tests for pending/failed/deleted refs.
+
+## FR-004 / FR-006 Invalid, Unfinalized, And Unauthorized Uploads
+
+Decision: Partial.
+Evidence: `api_service/api/routers/executions.py` validates artifact status, content type, size, duplicate refs, max count, max bytes, and policy enablement; existing tests cover several invalid cases. Authorization of a submitted artifact ref by the current principal and execution scope is not proven in the submission/linking path.
+Rationale: MM-628 explicitly requires unauthorized refs to be rejected before execution. Existing status/content validation is strong, but ownership or view-permission checks are not clearly enforced before linking input artifacts to an execution.
+Alternatives considered: Deferring authorization to preview/download was rejected because the spec requires rejection before execution submission for unauthorized refs.
+Test implications: Unit and integration tests must cover another user's completed artifact, a service principal path, and execution creation/link rejection.
+
+## FR-007 / FR-008 Browser Preview And Download Authorization
+
+Decision: Partial.
+Evidence: `api_service/api/routers/temporal_artifacts.py` exposes metadata, presign-download, and download endpoints; `TemporalArtifactService` has owner/service read checks and restricted raw access policy; `tests/integration/temporal/test_temporal_artifact_auth_preview.py` covers preview metadata for restricted artifacts.
+Rationale: Browser access is routed through MoonMind APIs, but execution ownership/view permission behavior for linked input artifacts needs focused proof.
+Alternatives considered: Marking fully verified was rejected because owner-only checks do not necessarily prove execution viewer permission semantics.
+Test implications: Unit and integration tests for owner, non-owner, service, and execution-linked artifact reads.
+
+## FR-009 Worker Materialization Authorization
+
+Decision: Implemented unverified.
+Evidence: `moonmind/agents/codex_worker/worker.py` collects and materializes input attachments through the queue client; `tests/unit/agents/codex_worker/test_attachment_materialization.py` verifies target-aware downloads, manifests, and failure diagnostics.
+Rationale: Materialization behavior exists, but the tests use a fake queue client and do not prove service-principal authorization or absence of browser-visible credentials in the worker read path.
+Alternatives considered: Treating fake queue download coverage as sufficient was rejected because MM-628 names service credentials and execution authorization.
+Test implications: Add worker/API boundary proof that materialization uses service-authorized artifact reads.
+
+## FR-010 Execution-Scoped Artifact Links
+
+Decision: Partial.
+Evidence: `api_service/api/routers/executions.py` links submitted input artifacts to execution records with `link_type="input.attachment"` and appends IDs to `record.artifact_refs`.
+Rationale: Links exist, but the requirement that refs cannot be reused outside their authorized execution context needs explicit enforcement and tests.
+Alternatives considered: Relying on artifact IDs alone was rejected because the source design says artifact links are execution-scoped.
+Test implications: Integration tests for linked execution reads and unauthorized cross-execution reuse.
+
+## FR-011 Metadata Is Observability Only
+
+Decision: Implemented verified.
+Evidence: `docs/Tasks/TaskArchitecture.md` states target binding comes from task contract and snapshot semantics; `tests/unit/agents/codex_worker/test_attachment_materialization.py` verifies materialization paths derive from objective/step refs and are stable across unrelated target order.
+Rationale: Existing task contract and worker tests preserve target meaning independently of storage paths.
+Alternatives considered: Adding metadata-only target inference was rejected because it would contradict the source design.
+Test implications: None beyond final traceability.
+
+## FR-012 / SC-006 Traceability
+
+Decision: Implemented verified.
+Evidence: `specs/321-route-binary-artifact-refs/spec.md` preserves MM-628, the original Jira preset brief, and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022; this plan and design artifacts preserve the same IDs.
+Rationale: Traceability is present and must be carried forward by tasks, implementation notes, verification output, commit text, and PR metadata.
+Alternatives considered: None.
+Test implications: Final traceability check.
+
+## Test Tooling
+
+Decision: Use repository-standard unit and hermetic integration runners, with focused UI iteration routed through the unit wrapper.
+Evidence: AGENTS.md requires `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration CI. It also allows `./tools/test_unit.sh --ui-args <path>` for targeted Vitest files.
+Rationale: The story crosses frontend upload orchestration, FastAPI artifact/execution APIs, artifact service authorization, and worker materialization; unit and integration strategies must be separate.
+Alternatives considered: Nested Docker unit testing was rejected by managed-agent guidance.
+Test implications: Write failing focused tests first, then run targeted tests, final `./tools/test_unit.sh`, and relevant `./tools/test_integration.sh`.

--- a/specs/321-route-binary-artifact-refs/spec.md
+++ b/specs/321-route-binary-artifact-refs/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Route Binary Inputs Through Authorized Artifact Refs
+
+**Feature Branch**: `321-route-binary-artifact-refs`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-628 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-628 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-628
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Route binary inputs through authorized artifact refs
+- Priority: Medium
+- Labels:
+  - `moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-628 from MM project
+Summary: Route binary inputs through authorized artifact refs
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-628 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-628: Route binary inputs through authorized artifact refs
+
+Source Reference
+- Source document: `docs/Tasks/TaskArchitecture.md`
+- Source title: Task Architecture (Control Plane)
+- Source sections:
+  - 3.2 Artifact-first binary handling
+  - 5.2 Artifact upload orchestration
+  - 9 Artifact and authorization boundary
+  - 11 Invariants
+- Coverage IDs:
+  - DESIGN-REQ-002
+  - DESIGN-REQ-007
+  - DESIGN-REQ-020
+  - DESIGN-REQ-022
+
+User Story
+As an operator, I want browser-selected binary inputs uploaded, authorized, finalized, and submitted as lightweight artifact refs so workflow histories and instructions never contain image bytes or storage credentials.
+
+Acceptance Criteria
+- Binary input bytes are stored as artifacts and never embedded in workflow history or inline instruction text.
+- Incomplete or invalid uploads are rejected before execution submission.
+- Execution submission includes only structured attachment refs.
+- Browser preview/download use MoonMind APIs authorized by execution ownership and view permissions.
+- Worker materialization uses service credentials and execution authorization.
+
+Requirements
+- Binary inputs are artifacts represented by lightweight refs, never workflow-history or instruction-text bytes.
+- The browser creates upload intents, completes uploads before submission, rejects incomplete uploads, and submits structured refs only.
+- Browsers use MoonMind APIs, preview/download is authorized by ownership, and workers use service credentials.
+- Attachment policy is server-defined and enforced by browser/API; browsers do not call Jira, storage, or provider file endpoints directly.
+
+Relevant Jira Links At Fetch Time
+- MM-627: Normalize task-shaped submissions with explicit attachment targets (Done)
+- MM-629: Persist authoritative task snapshots for reconstruction (Backlog)
+
+## Orchestration Notes
+
+- Input classification: single-story runtime feature request.
+- Runtime mode: Jira Orchestrate should proceed from this artifact when later workflow steps are authorized.
+- Source design path: `docs/Tasks/TaskArchitecture.md`.
+- Preserve `MM-628`, the source design coverage IDs, and this canonical brief in downstream MoonSpec artifacts and final verification evidence.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /moonspec-breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Submit Binary Inputs As Authorized Artifact References
+
+**Summary**: As an operator, I want browser-selected binary inputs uploaded, authorized, finalized, and submitted as lightweight artifact refs so workflow histories and instructions never contain image bytes or storage credentials.
+
+**Goal**: Operators can submit tasks with binary inputs while MoonMind stores the bytes as artifacts, submits only structured refs to execution, enforces upload completeness, and keeps browser and worker access inside authorized MoonMind artifact boundaries.
+
+**Independent Test**: Submit a task draft with browser-selected binary inputs, verify upload intents are created and finalized before execution submission, confirm the execution payload contains only structured artifact refs, and validate preview/download plus worker materialization use authorized MoonMind service paths without exposing raw bytes or storage credentials in workflow history or inline instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator selects a binary input for a task, **When** the browser prepares the task for submission, **Then** MoonMind creates an artifact upload intent and stores the binary bytes as an artifact rather than embedding bytes in task instructions or workflow history.
+2. **Given** a binary upload intent has not been completed or finalized, **When** the operator submits the task, **Then** the system rejects the submission before execution receives the task.
+3. **Given** all selected binary inputs have completed valid uploads, **When** the task is submitted, **Then** the execution submission contains only structured attachment refs and no inline binary bytes or storage credentials.
+4. **Given** an authorized user previews or downloads an attached binary input, **When** they access it from Mission Control, **Then** the browser uses MoonMind APIs that enforce execution ownership and view permissions.
+5. **Given** a worker needs an attached binary input during execution, **When** the runtime materializes the input, **Then** materialization uses service credentials and execution authorization without exposing object-store credentials to the browser.
+6. **Given** attachment metadata includes target kind, step reference, filename, or source import path, **When** the system stores or displays that metadata, **Then** target meaning remains defined by task contracts and snapshots rather than inferred from metadata or storage paths alone.
+
+### Edge Cases
+
+- An upload that starts but never finalizes must block submission rather than create a dangling execution reference.
+- A finalized artifact ref that the submitting user is not authorized to use must be rejected before execution starts.
+- Browser preview or download requests from a user without execution ownership or view permission must fail explicitly.
+- Worker materialization must fail explicitly when execution authorization does not cover the requested artifact.
+- Attachment metadata may be missing or partial, but missing metadata must not cause the system to infer a different target or authorization scope.
+- Text instructions that mention an image or file must remain text and must not become a hidden binary payload.
+
+## Assumptions
+
+- The existing server-defined attachment policy remains authoritative for allowed binary input types, sizes, and target eligibility.
+- This story covers artifact-backed binary submission, preview/download authorization, and worker materialization boundaries; broader attachment target preservation across edit, rerun, and resume flows is covered by adjacent Jira issues.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-002** (Source: `docs/Tasks/TaskArchitecture.md` section 3.2, lines 67-75): Binary inputs must be stored as artifacts, referenced in execution contracts by lightweight refs, and never embedded in workflow histories or text instructions. Scope: in scope. Maps to FR-001, FR-002, FR-004, FR-005.
+- **DESIGN-REQ-007** (Source: `docs/Tasks/TaskArchitecture.md` section 5.2, lines 164-169): The browser must create upload intents through MoonMind artifact APIs, upload files before execution submission, finalize artifact creation, reject incomplete uploads, and submit only structured attachment refs. Scope: in scope. Maps to FR-001, FR-003, FR-004, FR-006.
+- **DESIGN-REQ-020** (Source: `docs/Tasks/TaskArchitecture.md` section 9, lines 535-559): Browser access must avoid long-lived object-store credentials, previews and downloads must be authorized by execution ownership and view permissions, worker downloads must use service credentials and execution authorization, artifact links must be execution-scoped, and target binding must not be inferred from storage paths alone. Scope: in scope. Maps to FR-007, FR-008, FR-009, FR-010, FR-011.
+- **DESIGN-REQ-022** (Source: `docs/Tasks/TaskArchitecture.md` section 11, lines 574-612): Task system invariants require no binary payloads in Temporal history, explicit attachment targets, no silent attachment loss, text remaining text, server-defined attachment policy, MoonMind-owned browser APIs, and target-aware runtime consumption. Scope: in scope. Maps to FR-002, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST create artifact upload intents for browser-selected binary inputs through MoonMind artifact APIs before task execution submission.
+- **FR-002**: System MUST store binary input bytes as artifacts and MUST NOT embed binary bytes in workflow histories, execution payload text, or inline task instructions.
+- **FR-003**: Browser upload flow MUST complete binary file uploads before execution submission is accepted.
+- **FR-004**: System MUST finalize artifact creation before accepting an execution submission that references the uploaded binary input.
+- **FR-005**: Execution submissions MUST include only structured attachment refs for binary inputs, not object-store credentials, raw bytes, or provider-specific file payloads.
+- **FR-006**: Incomplete, invalid, unauthorized, or unfinalized binary uploads MUST be rejected before execution receives the task.
+- **FR-007**: Browser preview and download of binary inputs MUST go through MoonMind APIs rather than direct Jira, storage, or provider file endpoints.
+- **FR-008**: Browser preview and download MUST enforce execution ownership and view permissions before returning artifact content.
+- **FR-009**: Worker-side binary input download and materialization MUST use service credentials and execution authorization.
+- **FR-010**: Artifact links for submitted binary inputs MUST be execution-scoped so refs cannot be reused outside their authorized execution context.
+- **FR-011**: Attachment metadata MAY support observability, but target meaning and authorization scope MUST be defined by task contracts and snapshots rather than inferred from metadata or storage paths alone.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-628` and the original Jira preset brief.
+
+### Key Entities
+
+- **Binary Input Artifact**: Stored binary content selected by the browser and represented by a lightweight ref after upload and finalization.
+- **Upload Intent**: The authorization and metadata envelope that permits a browser-selected binary file to be uploaded through MoonMind artifact APIs before submission.
+- **Structured Attachment Ref**: The lightweight execution-facing reference to a finalized artifact, scoped to the authorized execution context.
+- **Artifact Access Request**: A preview, download, or materialization request that must be authorized by user permissions or service execution authorization.
+- **Attachment Metadata**: Optional descriptive information such as target kind, step reference, filename, or source import path that aids observability but does not define target meaning by itself.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid task submissions with browser-selected binary inputs complete and finalize artifact uploads before execution submission is accepted.
+- **SC-002**: 100% of accepted execution submissions with binary inputs contain structured attachment refs and contain zero inline binary bytes, object-store credentials, or provider-specific file payloads.
+- **SC-003**: 100% of incomplete, invalid, unauthorized, or unfinalized binary uploads are rejected before execution receives the task.
+- **SC-004**: 100% of covered browser preview and download requests are served through MoonMind APIs and enforce execution ownership or view permissions.
+- **SC-005**: 100% of covered worker materialization requests use service credentials and execution authorization rather than browser-visible storage credentials.
+- **SC-006**: Traceability review confirms `MM-628`, the original Jira preset brief, and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/321-route-binary-artifact-refs/tasks.md
+++ b/specs/321-route-binary-artifact-refs/tasks.md
@@ -33,9 +33,9 @@
 
 **Purpose**: Confirm task inputs and preserve the existing artifact/task test surfaces before story work.
 
-- [ ] T001 Confirm active feature artifacts and traceability for MM-628 in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, and specs/321-route-binary-artifact-refs/quickstart.md (FR-012, SC-006)
-- [ ] T002 [P] Confirm existing frontend attachment upload tests still identify artifact create, complete, and submit ordering in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002)
-- [ ] T003 [P] Confirm existing API and worker attachment test fixtures are reusable in tests/unit/api/routers/test_executions.py, tests/unit/api/routers/test_temporal_artifacts.py, tests/unit/workflows/temporal/test_artifacts.py, and tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-004, FR-006, FR-008, FR-009, FR-010)
+- [X] T001 Confirm active feature artifacts and traceability for MM-628 in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, and specs/321-route-binary-artifact-refs/quickstart.md (FR-012, SC-006)
+- [X] T002 [P] Confirm existing frontend attachment upload tests still identify artifact create, complete, and submit ordering in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002)
+- [X] T003 [P] Confirm existing API and worker attachment test fixtures are reusable in tests/unit/api/routers/test_executions.py, tests/unit/api/routers/test_temporal_artifacts.py, tests/unit/workflows/temporal/test_artifacts.py, and tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-004, FR-006, FR-008, FR-009, FR-010)
 
 ---
 
@@ -45,10 +45,10 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T004 Add shared unit-test helpers for completed, pending, failed, deleted, and wrong-owner Temporal artifacts in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
-- [ ] T005 [P] Add shared artifact authorization fixtures for owner, non-owner, service principal, and execution-linked reads in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
-- [ ] T006 [P] Add worker materialization service-authorization test doubles in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T007 [P] Add contract fixture data for structured binary attachment refs in tests/contract/test_temporal_execution_api.py (FR-005, FR-006, FR-010, DESIGN-REQ-007, DESIGN-REQ-020)
+- [X] T004 Add shared unit-test helpers for completed, pending, failed, deleted, and wrong-owner Temporal artifacts in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
+- [X] T005 [P] Add shared artifact authorization fixtures for owner, non-owner, service principal, and execution-linked reads in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [X] T006 [P] Add worker materialization service-authorization test doubles in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T007 [P] Add contract fixture data for structured binary attachment refs in tests/contract/test_temporal_execution_api.py (FR-005, FR-006, FR-010, DESIGN-REQ-007, DESIGN-REQ-020)
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -79,38 +79,38 @@
 
 > Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass. For implemented-unverified rows, run verification tests first; skip conditional implementation tasks if the tests pass unchanged.
 
-- [ ] T008 [P] Add failing unit tests for pending, failed, deleted, missing, and mismatched binary input artifact refs in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
-- [ ] T009 Add failing unit test proving another user's completed input artifact ref is rejected before execution creation in tests/unit/api/routers/test_executions.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T010 [P] Add failing unit tests for owner, non-owner, service principal, and execution-linked input artifact read policy in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
-- [ ] T011 [P] Add failing unit test proving worker input attachment materialization uses service-authorized artifact reads and does not expose browser storage credentials in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T012 [P] Add frontend regression test preserving upload-intent, upload-complete, and execution-submit ordering for objective and step binary refs in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-007)
+- [X] T008 [P] Add failing unit tests for pending, failed, deleted, missing, and mismatched binary input artifact refs in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
+- [X] T009 Add failing unit test proving another user's completed input artifact ref is rejected before execution creation in tests/unit/api/routers/test_executions.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T010 [P] Add failing unit tests for owner, non-owner, service principal, and execution-linked input artifact read policy in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [X] T011 [P] Add failing unit test proving worker input attachment materialization uses service-authorized artifact reads and does not expose browser storage credentials in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T012 [P] Add frontend regression test preserving upload-intent, upload-complete, and execution-submit ordering for objective and step binary refs in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-007)
 
 ### Integration Tests (write first)
 
-- [ ] T013 [P] Add failing integration test for completed binary refs accepted into task-shaped execution submission in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-003, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-007)
-- [ ] T014 Add failing integration test for pending, failed, and unauthorized binary refs rejected before execution creation in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T015 [P] Add failing integration test for browser preview/download authorization on execution-linked input attachments in tests/integration/temporal/test_temporal_artifact_authorization.py (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
-- [ ] T016 [P] Add failing contract test proving accepted task-shaped execution payloads contain structured refs only and no raw bytes, presigned URLs, or storage credentials in tests/contract/test_temporal_execution_api.py (FR-002, FR-005, SC-002, DESIGN-REQ-002)
+- [X] T013 [P] Add failing integration test for completed binary refs accepted into task-shaped execution submission in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-003, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-007)
+- [X] T014 Add failing integration test for pending, failed, and unauthorized binary refs rejected before execution creation in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T015 [P] Add failing integration test for browser preview/download authorization on execution-linked input attachments in tests/integration/temporal/test_temporal_artifact_authorization.py (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [X] T016 [P] Add failing contract test proving accepted task-shaped execution payloads contain structured refs only and no raw bytes, presigned URLs, or storage credentials in tests/contract/test_temporal_execution_api.py (FR-002, FR-005, SC-002, DESIGN-REQ-002)
 
 ### Red-First Confirmation
 
-- [ ] T017 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm T008-T011 fail for the expected missing authorization/finalization/materialization behavior before implementation (FR-004, FR-006, FR-008, FR-009, FR-010)
-- [ ] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T012 either passes as existing verified behavior or fails for the exact ordering regression to fix (FR-001, FR-002, FR-003, FR-005)
-- [ ] T019 Run `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short` and confirm T013-T016 fail for expected missing authorization/link-scope proof before implementation (SC-001, SC-002, SC-003, SC-004)
+- [X] T017 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm T008-T011 fail for the expected missing authorization/finalization/materialization behavior before implementation (FR-004, FR-006, FR-008, FR-009, FR-010)
+- [X] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T012 either passes as existing verified behavior or fails for the exact ordering regression to fix (FR-001, FR-002, FR-003, FR-005)
+- [X] T019 Run `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short` and confirm T013-T016 fail for expected missing authorization/link-scope proof before implementation (SC-001, SC-002, SC-003, SC-004)
 
 ### Conditional Fallback Implementation
 
-- [ ] T020 If T008 or T013 exposes missing finalized-ref handling, update input attachment status validation in api_service/api/routers/executions.py so only complete binary artifacts can be submitted and pending, failed, deleted, missing, content-type mismatched, and size-mismatched refs fail explicitly (FR-004, FR-006, SC-003, DESIGN-REQ-007)
-- [ ] T021 If T009 or T014 exposes missing ownership checks, update input attachment submission authorization in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so unauthorized artifact refs are rejected before execution creation or linking (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T022 If T010 or T015 exposes incomplete preview/download permission semantics, update read policy and router behavior in moonmind/workflows/temporal/artifacts.py and api_service/api/routers/temporal_artifacts.py so browser reads require owner, execution view permission, or service authorization (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
-- [ ] T023 If T011 exposes missing service authorization in worker materialization, update moonmind/agents/codex_worker/worker.py and the worker queue artifact read path so input attachment downloads use service-authorized MoonMind reads and fail explicitly without browser credentials (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T024 If T014 or T015 exposes cross-execution reuse, update execution artifact linking in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so `input.attachment` links are execution-scoped and cannot be reused outside the authorized execution context (FR-010, SC-003, SC-004, DESIGN-REQ-020)
+- [X] T020 If T008 or T013 exposes missing finalized-ref handling, update input attachment status validation in api_service/api/routers/executions.py so only complete binary artifacts can be submitted and pending, failed, deleted, missing, content-type mismatched, and size-mismatched refs fail explicitly (FR-004, FR-006, SC-003, DESIGN-REQ-007)
+- [X] T021 If T009 or T014 exposes missing ownership checks, update input attachment submission authorization in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so unauthorized artifact refs are rejected before execution creation or linking (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T022 If T010 or T015 exposes incomplete preview/download permission semantics, update read policy and router behavior in moonmind/workflows/temporal/artifacts.py and api_service/api/routers/temporal_artifacts.py so browser reads require owner, execution view permission, or service authorization (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [X] T023 If T011 exposes missing service authorization in worker materialization, update moonmind/agents/codex_worker/worker.py and the worker queue artifact read path so input attachment downloads use service-authorized MoonMind reads and fail explicitly without browser credentials (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T024 If T014 or T015 exposes cross-execution reuse, update execution artifact linking in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so `input.attachment` links are execution-scoped and cannot be reused outside the authorized execution context (FR-010, SC-003, SC-004, DESIGN-REQ-020)
 
 ### Story Validation
 
-- [ ] T025 Run focused unit commands `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_temporal_artifacts.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`, then fix failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, moonmind/agents/codex_worker/worker.py, or frontend/src/entrypoints/task-create.tsx (FR-001 through FR-011)
-- [ ] T026 Run focused integration command `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short`, then fix boundary failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, or moonmind/agents/codex_worker/worker.py (SC-001 through SC-005, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022)
-- [ ] T027 Confirm MM-628 and the original Jira preset brief remain preserved in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, specs/321-route-binary-artifact-refs/quickstart.md, and specs/321-route-binary-artifact-refs/tasks.md (FR-012, SC-006)
+- [X] T025 Run focused unit commands `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_temporal_artifacts.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`, then fix failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, moonmind/agents/codex_worker/worker.py, or frontend/src/entrypoints/task-create.tsx (FR-001 through FR-011)
+- [X] T026 Run focused integration command `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short`, then fix boundary failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, or moonmind/agents/codex_worker/worker.py (SC-001 through SC-005, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022)
+- [X] T027 Confirm MM-628 and the original Jira preset brief remain preserved in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, specs/321-route-binary-artifact-refs/quickstart.md, and specs/321-route-binary-artifact-refs/tasks.md (FR-012, SC-006)
 
 **Checkpoint**: The story is fully testable independently when focused unit tests, focused integration tests, and traceability checks pass.
 
@@ -120,9 +120,9 @@
 
 **Purpose**: Strengthen the completed story without expanding scope.
 
-- [ ] T028 [P] Review security-sensitive error messages and logs in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, and moonmind/workflows/temporal/artifacts.py so authorization failures do not expose credentials or storage paths (FR-006, FR-008, DESIGN-REQ-020)
-- [ ] T029 [P] Update implementation notes in specs/321-route-binary-artifact-refs/research.md only if implementation discovers different evidence or status classifications during T020-T024 (FR-012, SC-006)
-- [ ] T030 Run full unit verification with `./tools/test_unit.sh` from repository root (FR-001 through FR-012)
+- [X] T028 [P] Review security-sensitive error messages and logs in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, and moonmind/workflows/temporal/artifacts.py so authorization failures do not expose credentials or storage paths (FR-006, FR-008, DESIGN-REQ-020)
+- [X] T029 [P] Update implementation notes in specs/321-route-binary-artifact-refs/research.md only if implementation discovers different evidence or status classifications during T020-T024 (FR-012, SC-006)
+- [X] T030 Run full unit verification with `./tools/test_unit.sh` from repository root (FR-001 through FR-012)
 - [ ] T031 Run full hermetic integration verification with `./tools/test_integration.sh` from repository root (SC-001 through SC-005)
 - [ ] T032 Run `/moonspec-verify` for specs/321-route-binary-artifact-refs/spec.md after implementation and tests pass, preserving MM-628 and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 in verification output (FR-012, SC-006)
 

--- a/specs/321-route-binary-artifact-refs/tasks.md
+++ b/specs/321-route-binary-artifact-refs/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: Route Binary Inputs Through Authorized Artifact Refs
+
+**Input**: Design documents from `/work/agent_jobs/mm:59d3265d-03a5-445d-8ce4-876c3355a9de/repo/specs/321-route-binary-artifact-refs/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/binary-artifact-ref-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: submit binary inputs as authorized artifact references for MM-628.
+
+**Source Traceability**: MM-628 and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 are preserved from `spec.md`.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_temporal_artifacts.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py`
+- Frontend unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short`
+- Full unit verification: `./tools/test_unit.sh`
+- Full integration verification: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because it touches different files and does not depend on incomplete work.
+- Every task includes an exact file path and relevant requirement, scenario, success criterion, or source ID.
+
+## Requirement Status Coverage
+
+- Already verified, final traceability only: FR-001, FR-002, FR-003, FR-005, FR-007, FR-011, FR-012, SC-001, SC-002, SC-006, DESIGN-REQ-002.
+- Verification tests plus conditional fallback: FR-004, FR-009, SC-005, DESIGN-REQ-007.
+- Code-and-test completion required if tests expose gaps: FR-006, FR-008, FR-010, SC-003, SC-004, DESIGN-REQ-020, DESIGN-REQ-022.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm task inputs and preserve the existing artifact/task test surfaces before story work.
+
+- [ ] T001 Confirm active feature artifacts and traceability for MM-628 in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, and specs/321-route-binary-artifact-refs/quickstart.md (FR-012, SC-006)
+- [ ] T002 [P] Confirm existing frontend attachment upload tests still identify artifact create, complete, and submit ordering in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002)
+- [ ] T003 [P] Confirm existing API and worker attachment test fixtures are reusable in tests/unit/api/routers/test_executions.py, tests/unit/api/routers/test_temporal_artifacts.py, tests/unit/workflows/temporal/test_artifacts.py, and tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-004, FR-006, FR-008, FR-009, FR-010)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prepare shared test helpers and contract coverage before story behavior tests.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T004 Add shared unit-test helpers for completed, pending, failed, deleted, and wrong-owner Temporal artifacts in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
+- [ ] T005 [P] Add shared artifact authorization fixtures for owner, non-owner, service principal, and execution-linked reads in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [ ] T006 [P] Add worker materialization service-authorization test doubles in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T007 [P] Add contract fixture data for structured binary attachment refs in tests/contract/test_temporal_execution_api.py (FR-005, FR-006, FR-010, DESIGN-REQ-007, DESIGN-REQ-020)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Submit Binary Inputs As Authorized Artifact References
+
+**Summary**: As an operator, I want browser-selected binary inputs uploaded, authorized, finalized, and submitted as lightweight artifact refs so workflow histories and instructions never contain image bytes or storage credentials.
+
+**Independent Test**: Submit a task draft with browser-selected binary inputs, verify upload intents are created and finalized before execution submission, confirm the execution payload contains only structured artifact refs, and validate preview/download plus worker materialization use authorized MoonMind service paths without exposing raw bytes or storage credentials in workflow history or inline instructions.
+
+**Traceability**: FR-001 through FR-012, SC-001 through SC-006, DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022.
+
+**Unit Test Plan**:
+
+- API submission validation for pending/failed/deleted/missing/unauthorized binary refs.
+- Artifact read policy and execution-scoped link behavior for preview/download and raw reads.
+- Worker materialization with service-authorized downloads and failure diagnostics.
+- Frontend regression coverage for upload intent, completion ordering, and structured refs.
+
+**Integration Test Plan**:
+
+- Task-shaped execution accepts completed refs and rejects invalid/unauthorized refs before execution creation.
+- Artifact preview/download authorization is enforced for linked input attachments.
+- Contract boundary proves accepted execution payloads contain structured refs and no raw bytes or credentials.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass. For implemented-unverified rows, run verification tests first; skip conditional implementation tasks if the tests pass unchanged.
+
+- [ ] T008 [P] Add failing unit tests for pending, failed, deleted, missing, and mismatched binary input artifact refs in tests/unit/api/routers/test_executions.py (FR-004, FR-006, SC-003, DESIGN-REQ-007, DESIGN-REQ-022)
+- [ ] T009 Add failing unit test proving another user's completed input artifact ref is rejected before execution creation in tests/unit/api/routers/test_executions.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T010 [P] Add failing unit tests for owner, non-owner, service principal, and execution-linked input artifact read policy in tests/unit/workflows/temporal/test_artifacts.py (FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [ ] T011 [P] Add failing unit test proving worker input attachment materialization uses service-authorized artifact reads and does not expose browser storage credentials in tests/unit/agents/codex_worker/test_attachment_materialization.py (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T012 [P] Add frontend regression test preserving upload-intent, upload-complete, and execution-submit ordering for objective and step binary refs in frontend/src/entrypoints/task-create.test.tsx (FR-001, FR-002, FR-003, FR-005, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-007)
+
+### Integration Tests (write first)
+
+- [ ] T013 [P] Add failing integration test for completed binary refs accepted into task-shaped execution submission in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-003, FR-004, FR-005, SC-001, SC-002, DESIGN-REQ-007)
+- [ ] T014 Add failing integration test for pending, failed, and unauthorized binary refs rejected before execution creation in tests/integration/temporal/test_task_shaped_submission_normalization.py (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T015 [P] Add failing integration test for browser preview/download authorization on execution-linked input attachments in tests/integration/temporal/test_temporal_artifact_authorization.py (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [ ] T016 [P] Add failing contract test proving accepted task-shaped execution payloads contain structured refs only and no raw bytes, presigned URLs, or storage credentials in tests/contract/test_temporal_execution_api.py (FR-002, FR-005, SC-002, DESIGN-REQ-002)
+
+### Red-First Confirmation
+
+- [ ] T017 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm T008-T011 fail for the expected missing authorization/finalization/materialization behavior before implementation (FR-004, FR-006, FR-008, FR-009, FR-010)
+- [ ] T018 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm T012 either passes as existing verified behavior or fails for the exact ordering regression to fix (FR-001, FR-002, FR-003, FR-005)
+- [ ] T019 Run `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short` and confirm T013-T016 fail for expected missing authorization/link-scope proof before implementation (SC-001, SC-002, SC-003, SC-004)
+
+### Conditional Fallback Implementation
+
+- [ ] T020 If T008 or T013 exposes missing finalized-ref handling, update input attachment status validation in api_service/api/routers/executions.py so only complete binary artifacts can be submitted and pending, failed, deleted, missing, content-type mismatched, and size-mismatched refs fail explicitly (FR-004, FR-006, SC-003, DESIGN-REQ-007)
+- [ ] T021 If T009 or T014 exposes missing ownership checks, update input attachment submission authorization in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so unauthorized artifact refs are rejected before execution creation or linking (FR-006, SC-003, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T022 If T010 or T015 exposes incomplete preview/download permission semantics, update read policy and router behavior in moonmind/workflows/temporal/artifacts.py and api_service/api/routers/temporal_artifacts.py so browser reads require owner, execution view permission, or service authorization (FR-007, FR-008, FR-010, SC-004, DESIGN-REQ-020)
+- [ ] T023 If T011 exposes missing service authorization in worker materialization, update moonmind/agents/codex_worker/worker.py and the worker queue artifact read path so input attachment downloads use service-authorized MoonMind reads and fail explicitly without browser credentials (FR-009, SC-005, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T024 If T014 or T015 exposes cross-execution reuse, update execution artifact linking in api_service/api/routers/executions.py and moonmind/workflows/temporal/artifacts.py so `input.attachment` links are execution-scoped and cannot be reused outside the authorized execution context (FR-010, SC-003, SC-004, DESIGN-REQ-020)
+
+### Story Validation
+
+- [ ] T025 Run focused unit commands `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_temporal_artifacts.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`, then fix failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, moonmind/agents/codex_worker/worker.py, or frontend/src/entrypoints/task-create.tsx (FR-001 through FR-011)
+- [ ] T026 Run focused integration command `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short`, then fix boundary failures in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, moonmind/workflows/temporal/artifacts.py, or moonmind/agents/codex_worker/worker.py (SC-001 through SC-005, DESIGN-REQ-007, DESIGN-REQ-020, DESIGN-REQ-022)
+- [ ] T027 Confirm MM-628 and the original Jira preset brief remain preserved in specs/321-route-binary-artifact-refs/spec.md, specs/321-route-binary-artifact-refs/plan.md, specs/321-route-binary-artifact-refs/research.md, specs/321-route-binary-artifact-refs/data-model.md, specs/321-route-binary-artifact-refs/contracts/binary-artifact-ref-contract.md, specs/321-route-binary-artifact-refs/quickstart.md, and specs/321-route-binary-artifact-refs/tasks.md (FR-012, SC-006)
+
+**Checkpoint**: The story is fully testable independently when focused unit tests, focused integration tests, and traceability checks pass.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [ ] T028 [P] Review security-sensitive error messages and logs in api_service/api/routers/executions.py, api_service/api/routers/temporal_artifacts.py, and moonmind/workflows/temporal/artifacts.py so authorization failures do not expose credentials or storage paths (FR-006, FR-008, DESIGN-REQ-020)
+- [ ] T029 [P] Update implementation notes in specs/321-route-binary-artifact-refs/research.md only if implementation discovers different evidence or status classifications during T020-T024 (FR-012, SC-006)
+- [ ] T030 Run full unit verification with `./tools/test_unit.sh` from repository root (FR-001 through FR-012)
+- [ ] T031 Run full hermetic integration verification with `./tools/test_integration.sh` from repository root (SC-001 through SC-005)
+- [ ] T032 Run `/moonspec-verify` for specs/321-route-binary-artifact-refs/spec.md after implementation and tests pass, preserving MM-628 and DESIGN-REQ-002, DESIGN-REQ-007, DESIGN-REQ-020, and DESIGN-REQ-022 in verification output (FR-012, SC-006)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story test/implementation work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish & Verification (Phase 4)**: Depends on focused story validation passing.
+
+### Within The Story
+
+- T008-T016 must be written before implementation tasks.
+- T017-T019 must run before T020-T024.
+- T020-T024 are conditional fallback implementation tasks and are skipped only when their verification tests pass without code changes.
+- T025-T027 validate the complete one-story slice before polish.
+- T030-T032 run only after focused unit and integration validation passes.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T005, T006, and T007 can run in parallel after T004 starts if helpers do not overlap.
+- T008, T010, T011, T012, T015, and T016 touch different files and can be authored in parallel.
+- T013 and T014 share `tests/integration/temporal/test_task_shaped_submission_normalization.py` and should not be authored in parallel with each other.
+- T020-T024 touch overlapping authorization boundaries and should be sequenced after red-first results identify the exact gaps.
+- T028 and T029 can run in parallel after T025-T027.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Safe parallel test authoring after Phase 2:
+Task: "T008 Add failing API input-ref validation tests in tests/unit/api/routers/test_executions.py"
+Task: "T010 Add failing artifact read-policy tests in tests/unit/workflows/temporal/test_artifacts.py"
+Task: "T011 Add failing worker materialization authorization test in tests/unit/agents/codex_worker/test_attachment_materialization.py"
+Task: "T016 Add failing structured-ref-only contract test in tests/contract/test_temporal_execution_api.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and shared fixture tasks.
+2. Write unit and integration tests for partial and implemented-unverified rows first.
+3. Run red-first commands and record whether tests fail for the expected missing behavior or pass as existing verified behavior.
+4. Execute conditional fallback implementation tasks only for failed verification areas.
+5. Re-run focused unit and integration commands.
+6. Run full unit and integration suites.
+7. Run `/moonspec-verify` and preserve MM-628 traceability.
+
+### Requirement Status Handling
+
+- `implemented_verified` rows receive regression and final validation coverage only.
+- `implemented_unverified` rows receive verification tests plus conditional fallback implementation tasks.
+- `partial` rows receive failing tests, red-first confirmation, and implementation tasks to close the gap.
+- No task broadens scope beyond MM-628's binary artifact-ref submission, authorization, preview/download, and worker materialization boundaries.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -1164,6 +1164,13 @@ async def test_task_shaped_create_preserves_image_input_attachments(tmp_path, mo
                 task = canonical.parameters["task"]
                 assert task["inputAttachments"][0]["artifactId"] == objective_artifact
                 assert task["steps"][0]["inputAttachments"][0]["artifactId"] == step_artifact
+                task_payload_json = json.dumps(task, sort_keys=True)
+                assert "data:" not in task_payload_json
+                assert "base64" not in task_payload_json.lower()
+                assert "uploadUrl" not in task_payload_json
+                assert "downloadUrl" not in task_payload_json
+                assert "presign" not in task_payload_json.lower()
+                assert "storageKey" not in task_payload_json
                 assert objective_artifact in canonical.artifact_refs
                 assert step_artifact in canonical.artifact_refs
 

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -192,3 +192,108 @@ def test_task_shaped_submission_boundary_rejects_invalid_alias_and_target_bindin
     assert duplicate_target_response.status_code == 422
     assert duplicate_same_target_response.status_code == 422
     service.create_execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("artifact_status", "message_fragment"),
+    [
+        (TemporalArtifactStatus.PENDING_UPLOAD, "pending_upload"),
+        (TemporalArtifactStatus.FAILED, "failed"),
+    ],
+)
+def test_task_shaped_submission_boundary_rejects_unfinalized_binary_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_status: TemporalArtifactStatus,
+    message_fragment: str,
+) -> None:
+    """MM-628: unfinalized binary refs fail before execution creation."""
+
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    artifact_id = f"art_01MM628INT{artifact_status.value.upper():0<14}"[:30]
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id=artifact_id,
+                status=artifact_status,
+                content_type="image/png",
+                size_bytes=10,
+            )
+        ]
+    )
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Reject unfinalized binary input.",
+                        "inputAttachments": [
+                            {
+                                "artifactId": artifact_id,
+                                "filename": "unfinalized.png",
+                                "contentType": "image/png",
+                                "sizeBytes": 10,
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert message_fragment in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_task_shaped_submission_boundary_rejects_wrong_owner_binary_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MM-628: unauthorized binary refs fail before execution creation."""
+
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak")
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    artifact_id = "art_01MM628INTWRONGOWNER0000"
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id=artifact_id,
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=10,
+                created_by_principal="another-user",
+            )
+        ]
+    )
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Reject unauthorized binary input.",
+                        "inputAttachments": [
+                            {
+                                "artifactId": artifact_id,
+                                "filename": "wrong-owner.png",
+                                "contentType": "image/png",
+                                "sizeBytes": 10,
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert "not authorized" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()

--- a/tests/integration/temporal/test_temporal_artifact_authorization.py
+++ b/tests/integration/temporal/test_temporal_artifact_authorization.py
@@ -13,9 +13,17 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-from api_service.db.models import Base, TemporalArtifactRedactionLevel
+from api_service.db.models import (
+    Base,
+    MoonMindWorkflowState,
+    TemporalArtifactRedactionLevel,
+    TemporalExecutionCanonicalRecord,
+    TemporalExecutionOwnerType,
+    TemporalWorkflowType,
+)
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.artifacts import (
+    ExecutionRef,
     LocalTemporalArtifactStore,
     TemporalArtifactAuthorizationError,
     TemporalArtifactRepository,
@@ -199,3 +207,74 @@ class TestArtifactAuthorizationBoundaries:
                     principal="anyone",
                 )
                 assert payload2 == b"updated"
+
+    async def test_execution_owner_can_preview_and_download_linked_input_attachment(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MM-628: linked input attachment reads are authorized by execution owner."""
+
+        monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak")
+        async with _db(tmp_path) as maker:
+            async with maker() as session:
+                service = TemporalArtifactService(
+                    TemporalArtifactRepository(session),
+                    store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+                )
+                execution_owner = "user-execution-owner"
+                artifact, _upload = await service.create(
+                    principal="uploader@example.com",
+                    content_type="application/octet-stream",
+                    redaction_level=TemporalArtifactRedactionLevel.RESTRICTED,
+                )
+                await service.write_complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="uploader@example.com",
+                    payload=b"content",
+                    content_type="application/octet-stream",
+                )
+                session.add(
+                    TemporalExecutionCanonicalRecord(
+                        namespace="moonmind",
+                        workflow_id="wf-mm-628-auth",
+                        run_id="run-mm-628-auth",
+                        workflow_type=TemporalWorkflowType.RUN,
+                        owner_id=execution_owner,
+                        owner_type=TemporalExecutionOwnerType.USER,
+                        state=MoonMindWorkflowState.EXECUTING,
+                        entry="run",
+                        search_attributes={},
+                        memo={},
+                        artifact_refs=[artifact.artifact_id],
+                        parameters={},
+                    )
+                )
+                await session.flush()
+                await service.link_artifact(
+                    artifact_id=artifact.artifact_id,
+                    principal="service:execution-linker",
+                    execution_ref=ExecutionRef(
+                        namespace="moonmind",
+                        workflow_id="wf-mm-628-auth",
+                        run_id="run-mm-628-auth",
+                        link_type="input.attachment",
+                    ),
+                )
+
+                _metadata_artifact, _links, _pinned, policy = await service.get_metadata(
+                    artifact_id=artifact.artifact_id,
+                    principal=execution_owner,
+                )
+                _read_artifact, payload = await service.read(
+                    artifact_id=artifact.artifact_id,
+                    principal=execution_owner,
+                )
+
+                assert policy.raw_access_allowed is True
+                assert payload == b"content"
+                with pytest.raises(TemporalArtifactAuthorizationError):
+                    await service.read(
+                        artifact_id=artifact.artifact_id,
+                        principal="user-without-view",
+                    )

--- a/tests/unit/agents/codex_worker/test_attachment_materialization.py
+++ b/tests/unit/agents/codex_worker/test_attachment_materialization.py
@@ -6,12 +6,14 @@ import json
 from pathlib import Path
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from moonmind.agents.codex_worker.handlers import WorkerExecutionResult
 from moonmind.agents.codex_worker.worker import (
     CodexWorker,
     CodexWorkerConfig,
+    QueueApiClient,
 )
 
 class _FakeQueueClient:
@@ -237,6 +239,33 @@ async def test_materialize_input_attachments_records_prepare_download_diagnostic
     assert [event["payload"]["event"] for event in queue.events] == [
         event["event"] for event in diagnostic_events
     ]
+
+@pytest.mark.asyncio
+async def test_queue_artifact_download_uses_worker_service_authorization() -> None:
+    """MM-628: worker materialization reads through MoonMind with worker credentials."""
+
+    captured: list[httpx.Request] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"artifact-bytes", request=request)
+
+    client = httpx.AsyncClient(
+        base_url="http://moonmind.test",
+        transport=httpx.MockTransport(_handler),
+    )
+    queue = QueueApiClient(
+        base_url="http://moonmind.test",
+        worker_token="worker-secret",
+        client=client,
+    )
+
+    payload = await queue.download_artifact(artifact_id="art_objective")
+
+    assert payload == b"artifact-bytes"
+    assert len(captured) == 1
+    assert captured[0].url.path == "/api/artifacts/art_objective/download"
+    assert captured[0].headers["X-MoonMind-Worker-Token"] == "worker-secret"
 
 @pytest.mark.asyncio
 async def test_materialize_input_attachments_records_failed_step_diagnostics(

--- a/tests/unit/agents/codex_worker/test_attachment_materialization.py
+++ b/tests/unit/agents/codex_worker/test_attachment_materialization.py
@@ -266,6 +266,7 @@ async def test_queue_artifact_download_uses_worker_service_authorization() -> No
     assert len(captured) == 1
     assert captured[0].url.path == "/api/artifacts/art_objective/download"
     assert captured[0].headers["X-MoonMind-Worker-Token"] == "worker-secret"
+    assert "X-MoonMind-Worker-Token" not in client.headers
 
 @pytest.mark.asyncio
 async def test_materialize_input_attachments_records_failed_step_diagnostics(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -61,6 +61,21 @@ class _ExecuteResult:
 def _artifact_session(rows: list[SimpleNamespace]) -> SimpleNamespace:
     return SimpleNamespace(execute=AsyncMock(return_value=_ExecuteResult(rows)))
 
+def _completed_attachment_artifact(
+    artifact_id: str,
+    *,
+    content_type: str = "image/png",
+    size_bytes: int = 10,
+    created_by_principal: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        artifact_id=artifact_id,
+        status=TemporalArtifactStatus.COMPLETE,
+        content_type=content_type,
+        size_bytes=size_bytes,
+        created_by_principal=created_by_principal,
+    )
+
 class _QueryHandle:
     def __init__(
         self,
@@ -3178,6 +3193,146 @@ def test_create_task_shaped_execution_rejects_duplicate_attachment_declaration_f
 
     assert response.status_code == 422
     assert "declared more than once" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("artifact_status", "message_fragment"),
+    [
+        (TemporalArtifactStatus.PENDING_UPLOAD, "pending_upload"),
+        (TemporalArtifactStatus.FAILED, "failed"),
+        (TemporalArtifactStatus.DELETED, "deleted"),
+    ],
+)
+def test_create_task_shaped_execution_rejects_unfinalized_input_attachment_refs(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_status: TemporalArtifactStatus,
+    message_fragment: str,
+) -> None:
+    """MM-628: binary input refs must be finalized before execution creation."""
+
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    artifact_id = f"art_01MM628{artifact_status.value.upper():0<18}"[:30]
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id=artifact_id,
+                status=artifact_status,
+                content_type="image/png",
+                size_bytes=10,
+                created_by_principal=str(_user.id),
+            )
+        ]
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Review binary input.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": artifact_id,
+                            "filename": "input.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert message_fragment in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_missing_input_attachment_artifact(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session([])
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Review binary input.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01MM628MISSING000000000",
+                            "filename": "input.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "was not found" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_other_users_completed_input_attachment_ref(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MM-628: another user's completed artifact cannot be attached to a new execution."""
+
+    test_client, service, user = client
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak")
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    artifact_id = "art_01MM628WRONGOWNER0000000"
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            _completed_attachment_artifact(
+                artifact_id,
+                created_by_principal=f"other-{user.id}",
+            )
+        ]
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Review binary input.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": artifact_id,
+                            "filename": "input.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "not authorized" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3336,6 +3336,52 @@ def test_create_task_shaped_execution_rejects_other_users_completed_input_attach
     service.create_execution.assert_not_awaited()
 
 
+def test_create_task_shaped_execution_rejects_service_owned_attachment_for_user(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MM-628: service ownership does not make an artifact attachable by any user."""
+
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak")
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    artifact_id = "art_01MM628SERVICEOWNER0000"
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            _completed_attachment_artifact(
+                artifact_id,
+                created_by_principal="service:artifact-generator",
+            )
+        ]
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Review binary input.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": artifact_id,
+                            "filename": "input.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "not authorized" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_rejects_embedded_attachment_data(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -1499,6 +1499,22 @@ async def test_execution_owner_can_read_linked_input_attachment_from_other_princ
                     parameters={},
                 )
             )
+            session.add(
+                TemporalExecutionCanonicalRecord(
+                    namespace="moonmind",
+                    workflow_id="wf-mm-628-second",
+                    run_id="run-mm-628-second",
+                    workflow_type=TemporalWorkflowType.RUN,
+                    owner_id=execution_owner,
+                    owner_type=TemporalExecutionOwnerType.USER,
+                    state=MoonMindWorkflowState.EXECUTING,
+                    entry="run",
+                    search_attributes={},
+                    memo={},
+                    artifact_refs=[artifact.artifact_id],
+                    parameters={},
+                )
+            )
             await session.flush()
             await service.link_artifact(
                 artifact_id=artifact.artifact_id,
@@ -1507,6 +1523,16 @@ async def test_execution_owner_can_read_linked_input_attachment_from_other_princ
                     namespace="moonmind",
                     workflow_id="wf-mm-628",
                     run_id="run-mm-628",
+                    link_type="input.attachment",
+                ),
+            )
+            await service.link_artifact(
+                artifact_id=artifact.artifact_id,
+                principal="service:execution-linker",
+                execution_ref=ExecutionRef(
+                    namespace="moonmind",
+                    workflow_id="wf-mm-628-second",
+                    run_id="run-mm-628-second",
                     link_type="input.attachment",
                 ),
             )

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -13,6 +13,10 @@ from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import (
     Base,
+    MoonMindWorkflowState,
+    TemporalExecutionCanonicalRecord,
+    TemporalExecutionOwnerType,
+    TemporalWorkflowType,
     TemporalArtifactRedactionLevel,
     TemporalArtifactRetentionClass,
     TemporalArtifactStatus,
@@ -22,6 +26,7 @@ from moonmind.workflows.temporal.artifacts import (
     ExecutionRef,
     LocalTemporalArtifactStore,
     S3TemporalArtifactStore,
+    TemporalArtifactAuthorizationError,
     TemporalArtifactRepository,
     TemporalArtifactService,
     TemporalArtifactStateError,
@@ -1450,6 +1455,80 @@ async def test_write_integration_event_artifact_creates_restricted_preview(
             assert artifact.metadata_json["artifact_kind"] == "integration_event"
             assert artifact.retention_class.value == "ephemeral"
             assert policy.preview_artifact_ref is not None
+
+async def test_execution_owner_can_read_linked_input_attachment_from_other_principal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MM-628: browser reads may use execution ownership, not storage ownership alone."""
+
+    monkeypatch.setattr(artifact_module.settings.oidc, "AUTH_PROVIDER", "keycloak")
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            execution_owner = "user-execution-owner"
+            artifact, _upload = await service.create(
+                principal="user-uploader",
+                content_type="application/octet-stream",
+                size_bytes=4,
+                redaction_level=TemporalArtifactRedactionLevel.RESTRICTED,
+            )
+            await service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal="user-uploader",
+                payload=b"data",
+                content_type="application/octet-stream",
+            )
+            session.add(
+                TemporalExecutionCanonicalRecord(
+                    namespace="moonmind",
+                    workflow_id="wf-mm-628",
+                    run_id="run-mm-628",
+                    workflow_type=TemporalWorkflowType.RUN,
+                    owner_id=execution_owner,
+                    owner_type=TemporalExecutionOwnerType.USER,
+                    state=MoonMindWorkflowState.EXECUTING,
+                    entry="run",
+                    search_attributes={},
+                    memo={},
+                    artifact_refs=[artifact.artifact_id],
+                    parameters={},
+                )
+            )
+            await session.flush()
+            await service.link_artifact(
+                artifact_id=artifact.artifact_id,
+                principal="service:execution-linker",
+                execution_ref=ExecutionRef(
+                    namespace="moonmind",
+                    workflow_id="wf-mm-628",
+                    run_id="run-mm-628",
+                    link_type="input.attachment",
+                ),
+            )
+
+            linked_artifact, _links, _pinned, policy = await service.get_metadata(
+                artifact_id=artifact.artifact_id,
+                principal=execution_owner,
+            )
+            _raw_artifact, payload = await service.read(
+                artifact_id=artifact.artifact_id,
+                principal=execution_owner,
+            )
+
+            assert linked_artifact.artifact_id == artifact.artifact_id
+            assert policy.raw_access_allowed is True
+            assert payload == b"data"
+
+            with pytest.raises(TemporalArtifactAuthorizationError, match="cannot read"):
+                await service.get_metadata(
+                    artifact_id=artifact.artifact_id,
+                    principal="user-no-execution-access",
+                )
 
 async def test_write_integration_result_and_failure_artifacts_assign_link_retention(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Route task binary input submission through finalized, authorized artifact refs for MM-628.
- Add execution-owner read authorization for linked `input.attachment` artifacts.
- Preserve worker materialization through service-authorized MoonMind artifact downloads.

## Jira
- MM-628

## MoonSpec
- Active feature path: `specs/321-route-binary-artifact-refs`

## Verification verdict
- ADDITIONAL_WORK_NEEDED from `/moonspec-verify` because the verify preflight detected `.gemini/skills` as an active skill projection symlink and full hermetic integration could not run in this managed environment.

## Tests run
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/agents/codex_worker/test_attachment_materialization.py` - PASS, 222 tests.
- `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py tests/integration/temporal/test_temporal_artifact_authorization.py tests/contract/test_temporal_execution_api.py -m 'integration_ci' -q --tb=short` - PASS, 10 tests.
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` - PASS, full Python unit pass plus targeted UI pass.
- `./tools/test_unit.sh` - PASS, 4559 Python tests and 20 UI test files.
- `./tools/test_integration.sh` - BLOCKED, Docker/buildx path returned administrative 403 before tests started.

## Remaining risks
- Full hermetic integration needs to be rerun in an environment with permitted Docker/buildx access.
- Final MoonSpec verification should be rerun from a checkout without active skill projection contamination.
