### PR TITLE
MM-623 publish remediation audit evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,8 @@ Key diagnostics:
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and in-memory guard/ledger state in the current service; no new persistent database tables planned (320-remediation-action-contracts)
 - Python 3.12 + Pydantic v2 where models are exposed, SQLAlchemy async ORM, Temporal Python SDK service/activity boundaries, existing Temporal artifact service, pytest (322-remediation-lifecycle-repair-prevention)
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and existing remediation lock/ledger state; no new persistent database tables planned (322-remediation-lifecycle-repair-prevention)
+- Python 3.12 + Pydantic v2 where exposed, SQLAlchemy async ORM, FastAPI service/router patterns where query surfaces are exposed, Temporal Python SDK activity/service boundaries, existing Temporal artifact service (323-publish-remediation-audit)
+- Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and an existing or reusable control-event/audit persistence mechanism; no new persistent table planned unless queryable audit events cannot safely reuse current control-event/audit infrastructure (323-publish-remediation-audit)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -31,6 +31,8 @@ REMEDIATION_ARTIFACT_TYPES = frozenset(
         "remediation.decision_log",
         "remediation.action_request",
         "remediation.action_result",
+        "remediation.audit_event",
+        "remediation.target_annotation",
         "remediation.verification",
         "remediation.summary",
     }
@@ -702,6 +704,54 @@ class RemediationLifecyclePublisher:
         await self._session.refresh(artifact)
         return artifact
 
+    async def publish_target_annotation(
+        self,
+        *,
+        remediation_workflow_id: str,
+        target_workflow_id: str,
+        target_run_id: str,
+        name: str,
+        payload: Mapping[str, Any],
+        principal: str = "service:remediation-lifecycle",
+    ) -> db_models.TemporalArtifact:
+        """Publish a supplemental remediation annotation linked to the target."""
+
+        artifact = await self.publish_json_artifact(
+            remediation_workflow_id=remediation_workflow_id,
+            artifact_type="remediation.target_annotation",
+            name=name,
+            payload=payload,
+            target_workflow_id=target_workflow_id,
+            target_run_id=target_run_id,
+            principal=principal,
+        )
+        target_record = await self._session.get(
+            db_models.TemporalExecutionCanonicalRecord,
+            _required_string(target_workflow_id, "target_workflow_id"),
+        )
+        if target_record is None:
+            raise RemediationContextError(
+                f"Target execution not found: {target_workflow_id}"
+            )
+        self._session.add(
+            db_models.TemporalArtifactLink(
+                artifact_id=artifact.artifact_id,
+                namespace=target_record.namespace,
+                workflow_id=target_record.workflow_id,
+                run_id=_required_string(target_run_id, "target_run_id"),
+                link_type="remediation.target_annotation",
+                label=name,
+                created_by_activity_type="remediation.target.annotation.publish",
+            )
+        )
+        refs = list(target_record.artifact_refs or [])
+        if artifact.artifact_id not in refs:
+            refs.append(artifact.artifact_id)
+            target_record.artifact_refs = refs
+        await self._session.commit()
+        await self._session.refresh(artifact)
+        return artifact
+
 def normalize_remediation_phase(value: Any) -> str:
     """Return a bounded remediation phase value."""
 
@@ -815,6 +865,109 @@ def build_remediation_continue_as_new_state(
         "retryBudgetState": _safe_policy_mapping(retry_budget_state) or {},
         "liveFollowCursor": _safe_policy_mapping(live_follow_cursor) or {},
     }
+
+def build_non_applicable_remediation_artifact_reason(
+    *,
+    artifact_type: str,
+    reason: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Describe why an expected remediation artifact is not applicable."""
+
+    normalized_artifact_type = _required_string(artifact_type, "artifact_type")
+    if normalized_artifact_type not in REMEDIATION_ARTIFACT_TYPES:
+        raise ValueError(
+            f"artifact_type must be one of {sorted(REMEDIATION_ARTIFACT_TYPES)}"
+        )
+    payload: dict[str, Any] = {
+        "artifactType": normalized_artifact_type,
+        "reason": _required_redacted_text(reason, "reason"),
+    }
+    if safe_metadata := _safe_policy_mapping(metadata):
+        payload["metadata"] = safe_metadata
+    return payload
+
+def build_remediation_evidence_set(
+    *,
+    remediation_workflow_id: str,
+    remediation_run_id: str,
+    target_workflow_id: str,
+    target_run_id: str,
+    artifacts: Mapping[str, Any],
+    non_applicable_artifacts: Sequence[Mapping[str, Any]] = (),
+    evidence_degraded: bool = False,
+    degraded_reasons: Sequence[Any] = (),
+) -> dict[str, Any]:
+    """Build the queryable remediation evidence set for verification."""
+
+    non_applicable: list[dict[str, Any]] = []
+    for item in non_applicable_artifacts[:50]:
+        if not isinstance(item, Mapping):
+            continue
+        reason = build_non_applicable_remediation_artifact_reason(
+            artifact_type=item.get("artifactType") or item.get("artifact_type"),
+            reason=item.get("reason"),
+            metadata=item.get("metadata")
+            if isinstance(item.get("metadata"), Mapping)
+            else None,
+        )
+        non_applicable.append(reason)
+
+    return {
+        "schemaVersion": "v1",
+        "remediationWorkflowId": _required_lifecycle_string(
+            remediation_workflow_id, "remediation_workflow_id"
+        ),
+        "remediationRunId": _required_lifecycle_string(
+            remediation_run_id, "remediation_run_id"
+        ),
+        "targetWorkflowId": _required_lifecycle_string(
+            target_workflow_id, "target_workflow_id"
+        ),
+        "targetRunId": _required_lifecycle_string(target_run_id, "target_run_id"),
+        "artifacts": _artifact_refs_mapping(artifacts),
+        "nonApplicableArtifacts": non_applicable,
+        "evidenceDegraded": bool(evidence_degraded),
+        "degradedReasons": _safe_string_list(degraded_reasons),
+    }
+
+def build_remediation_target_annotation(
+    *,
+    target_workflow_id: str,
+    target_run_id: str,
+    remediation_workflow_id: str,
+    remediation_run_id: str,
+    action_kind: str,
+    decision: str,
+    artifact_refs: Mapping[str, Any],
+    timestamp: datetime | str,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a bounded, supplemental annotation for the target execution."""
+
+    payload: dict[str, Any] = {
+        "schemaVersion": "v1",
+        "kind": "remediation.target_annotation",
+        "targetWorkflowId": _required_lifecycle_string(
+            target_workflow_id, "target_workflow_id"
+        ),
+        "targetRunId": _required_lifecycle_string(target_run_id, "target_run_id"),
+        "remediationWorkflowId": _required_lifecycle_string(
+            remediation_workflow_id, "remediation_workflow_id"
+        ),
+        "remediationRunId": _required_lifecycle_string(
+            remediation_run_id, "remediation_run_id"
+        ),
+        "actionKind": _required_redacted_text(action_kind, "action_kind"),
+        "decision": _validated_choice(
+            decision, REMEDIATION_REPAIR_DECISIONS, "decision"
+        ),
+        "artifactRefs": _artifact_refs_mapping(artifact_refs),
+        "timestamp": _timestamp_string(timestamp),
+    }
+    if safe_metadata := _safe_policy_mapping(metadata):
+        payload["metadata"] = safe_metadata
+    return payload
 
 def build_remediation_repair_decision(
     *,

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Sequence
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
@@ -649,14 +650,21 @@ class RemediationLifecyclePublisher:
         if not isinstance(payload, Mapping):
             raise RemediationContextError("payload must be a mapping")
 
-        remediation_record = await self._session.get(
-            db_models.TemporalExecutionCanonicalRecord,
-            workflow_id,
-        )
+        remediation_record = await self._execution_record_for_update(workflow_id)
         if remediation_record is None:
             raise RemediationContextError(
                 f"Remediation execution not found: {workflow_id}"
             )
+        existing_artifact = await self._published_artifact(
+            namespace=remediation_record.namespace,
+            workflow_id=remediation_record.workflow_id,
+            run_id=remediation_record.run_id,
+            link_type=artifact_type,
+            label=name,
+        )
+        if existing_artifact is not None:
+            await self._append_artifact_ref(remediation_record, existing_artifact)
+            return existing_artifact
 
         safe_payload = _safe_lifecycle_payload(payload)
         payload_bytes = json.dumps(
@@ -725,32 +733,103 @@ class RemediationLifecyclePublisher:
             target_run_id=target_run_id,
             principal=principal,
         )
-        target_record = await self._session.get(
-            db_models.TemporalExecutionCanonicalRecord,
-            _required_string(target_workflow_id, "target_workflow_id"),
+        target_record = await self._execution_record_for_update(
+            _required_string(target_workflow_id, "target_workflow_id")
         )
         if target_record is None:
             raise RemediationContextError(
                 f"Target execution not found: {target_workflow_id}"
             )
-        self._session.add(
-            db_models.TemporalArtifactLink(
-                artifact_id=artifact.artifact_id,
-                namespace=target_record.namespace,
-                workflow_id=target_record.workflow_id,
-                run_id=_required_string(target_run_id, "target_run_id"),
-                link_type="remediation.target_annotation",
-                label=name,
-                created_by_activity_type="remediation.target.annotation.publish",
-            )
+        target_run_id = _required_string(target_run_id, "target_run_id")
+        existing_target_link = await self._published_artifact(
+            namespace=target_record.namespace,
+            workflow_id=target_record.workflow_id,
+            run_id=target_run_id,
+            link_type="remediation.target_annotation",
+            label=name,
+            artifact_id=artifact.artifact_id,
         )
-        refs = list(target_record.artifact_refs or [])
-        if artifact.artifact_id not in refs:
-            refs.append(artifact.artifact_id)
-            target_record.artifact_refs = refs
+        if existing_target_link is None:
+            self._session.add(
+                db_models.TemporalArtifactLink(
+                    artifact_id=artifact.artifact_id,
+                    namespace=target_record.namespace,
+                    workflow_id=target_record.workflow_id,
+                    run_id=target_run_id,
+                    link_type="remediation.target_annotation",
+                    label=name,
+                    created_by_activity_type="remediation.target.annotation.publish",
+                )
+            )
+        self._append_artifact_ref_sync(target_record, artifact)
         await self._session.commit()
         await self._session.refresh(artifact)
         return artifact
+
+    async def _execution_record_for_update(
+        self,
+        workflow_id: str,
+    ) -> db_models.TemporalExecutionCanonicalRecord | None:
+        return (
+            await self._session.execute(
+                select(db_models.TemporalExecutionCanonicalRecord)
+                .where(
+                    db_models.TemporalExecutionCanonicalRecord.workflow_id
+                    == workflow_id
+                )
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+
+    async def _published_artifact(
+        self,
+        *,
+        namespace: str,
+        workflow_id: str,
+        run_id: str,
+        link_type: str,
+        label: str,
+        artifact_id: str | None = None,
+    ) -> db_models.TemporalArtifact | None:
+        statement = (
+            select(db_models.TemporalArtifact)
+            .join(db_models.TemporalArtifactLink)
+            .where(
+                db_models.TemporalArtifactLink.namespace == namespace,
+                db_models.TemporalArtifactLink.workflow_id == workflow_id,
+                db_models.TemporalArtifactLink.run_id == run_id,
+                db_models.TemporalArtifactLink.link_type == link_type,
+                db_models.TemporalArtifactLink.label == label,
+                db_models.TemporalArtifact.status
+                == db_models.TemporalArtifactStatus.COMPLETE,
+            )
+            .order_by(db_models.TemporalArtifact.created_at.asc())
+            .limit(1)
+        )
+        if artifact_id is not None:
+            statement = statement.where(
+                db_models.TemporalArtifactLink.artifact_id == artifact_id
+            )
+        return (await self._session.execute(statement)).scalar_one_or_none()
+
+    async def _append_artifact_ref(
+        self,
+        record: db_models.TemporalExecutionCanonicalRecord,
+        artifact: db_models.TemporalArtifact,
+    ) -> None:
+        self._append_artifact_ref_sync(record, artifact)
+        await self._session.commit()
+        await self._session.refresh(artifact)
+
+    @staticmethod
+    def _append_artifact_ref_sync(
+        record: db_models.TemporalExecutionCanonicalRecord,
+        artifact: db_models.TemporalArtifact,
+    ) -> None:
+        refs = list(record.artifact_refs or [])
+        if artifact.artifact_id not in refs:
+            refs.append(artifact.artifact_id)
+            record.artifact_refs = refs
 
 def normalize_remediation_phase(value: Any) -> str:
     """Return a bounded remediation phase value."""
@@ -901,7 +980,7 @@ def build_remediation_evidence_set(
     """Build the queryable remediation evidence set for verification."""
 
     non_applicable: list[dict[str, Any]] = []
-    for item in non_applicable_artifacts[:50]:
+    for item in (non_applicable_artifacts or [])[:50]:
         if not isinstance(item, Mapping):
             continue
         reason = build_non_applicable_remediation_artifact_reason(

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -21,8 +21,10 @@ from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 from moonmind.workflows.temporal.remediation_context import (
     REMEDIATION_CONTEXT_LINK_TYPE,
     RemediationLifecyclePublisher,
+    build_remediation_audit_event,
     build_remediation_decision_log,
     build_remediation_final_summary,
+    build_remediation_target_annotation,
 )
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 
@@ -496,6 +498,70 @@ class RemediationEvidenceToolService:
             principal=principal,
         )
 
+        audit_timestamp = datetime.now(timezone.utc)
+        audit_payload = build_remediation_audit_event(
+            event_id=f"{link.remediation_workflow_id}:{action_request['actionId']}:action",
+            event_type="remediation.action",
+            actor_user=_string_or_none(action_request.get("requester")),
+            execution_principal=principal,
+            remediation_workflow_id=link.remediation_workflow_id,
+            remediation_run_id=link.remediation_run_id,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            action_kind=action_kind,
+            risk_tier=_string_or_none(
+                action_request.get("riskTier") or authority_result.get("risk")
+            ),
+            approval_decision=_string_or_none(authority_result.get("decision")),
+            timestamp=audit_timestamp,
+            metadata={
+                "status": status,
+                "idempotencyKey": action_request["actionId"],
+                "verificationRequired": verification_required,
+            },
+        )
+        audit_artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.audit_event",
+            name=f"events/remediation_action-{action_request['actionId']}.json",
+            payload=audit_payload,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+        annotation_payload = build_remediation_target_annotation(
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            remediation_workflow_id=link.remediation_workflow_id,
+            remediation_run_id=link.remediation_run_id,
+            action_kind=action_kind,
+            decision=_annotation_decision_for_status(status),
+            artifact_refs={
+                "actionRequest": request_artifact.artifact_id,
+                "actionResult": result_artifact.artifact_id,
+                "verification": verification_artifact.artifact_id,
+                "auditEvent": audit_artifact.artifact_id,
+            },
+            timestamp=audit_timestamp,
+            metadata={
+                "status": status,
+                "nativeArtifactPolicy": "preserve",
+            },
+        )
+        annotation_artifact = (
+            await self._lifecycle_publisher.publish_target_annotation(
+                remediation_workflow_id=link.remediation_workflow_id,
+                target_workflow_id=link.target_workflow_id,
+                target_run_id=link.target_run_id,
+                name=(
+                    "annotations/remediation_target-"
+                    f"{action_request['actionId']}.json"
+                ),
+                payload=annotation_payload,
+                principal=principal,
+            )
+        )
+
         link.latest_action_summary = action_kind
         link.outcome = status
         await self._session.commit()
@@ -507,6 +573,8 @@ class RemediationEvidenceToolService:
                 "actionRequest": request_artifact.artifact_id,
                 "actionResult": result_artifact.artifact_id,
                 "verification": verification_artifact.artifact_id,
+                "auditEvent": audit_artifact.artifact_id,
+                "targetAnnotation": annotation_artifact.artifact_id,
             },
         }
 
@@ -809,6 +877,17 @@ def _normalize_action_result_status(value: Any) -> str:
             f"Unsupported action result status: {status}."
         )
     return status
+
+def _annotation_decision_for_status(status: str) -> str:
+    if status in {"applied", "failed", "timed_out"}:
+        return "attempted"
+    if status == "no_op":
+        return "skipped"
+    if status == "approval_required":
+        return "approval_required"
+    if status in {"rejected", "precondition_failed"}:
+        return "denied"
+    return "escalated"
 
 def _required_string(value: Any, field_name: str) -> str:
     normalized = _string_or_none(value)

--- a/specs/323-publish-remediation-audit/checklists/requirements.md
+++ b/specs/323-publish-remediation-audit/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Publish Remediation Audit Evidence
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves `MM-623`, the original Jira preset brief, and the cited source design coverage IDs.
+- PASS: The request is classified as a single-story runtime feature request, so `/speckit.breakdown` is not required before planning.

--- a/specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md
+++ b/specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md
@@ -4,13 +4,15 @@
 
 This contract describes the public and integration-visible behavior required by MM-623. It covers artifact metadata, lifecycle summary shape, queryable audit events, and target-side remediation annotations. It does not redefine artifact storage internals or grant raw artifact access.
 
+Source coverage: DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-028.
+
 ## Artifact Family Contract
 
 Every remediation evidence artifact published for this story must expose:
 
 ```json
 {
-  "artifact_type": "remediation.context | remediation.plan | remediation.decision_log | remediation.action_request | remediation.action_result | remediation.verification | remediation.summary",
+  "artifact_type": "remediation.context | remediation.plan | remediation.decision_log | remediation.action_request | remediation.action_result | remediation.audit_event | remediation.target_annotation | remediation.verification | remediation.summary",
   "name": "bounded display name",
   "schemaVersion": "v1",
   "targetWorkflowId": "target workflow identity when applicable",
@@ -149,11 +151,12 @@ When remediation mutates a target-managed session or workload, the target side m
   "remediationWorkflowId": "remediation workflow identity",
   "remediationRunId": "remediation run identity",
   "actionKind": "action kind",
-  "decision": "attempted | skipped | denied | escalated",
+  "decision": "attempted | skipped | denied | approval_required | escalated",
   "artifactRefs": {
     "actionRequest": "artifact id",
     "actionResult": "artifact id",
-    "verification": "artifact id"
+    "verification": "artifact id",
+    "auditEvent": "artifact id"
   },
   "timestamp": "RFC3339 timestamp",
   "metadata": {

--- a/specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md
+++ b/specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md
@@ -1,0 +1,175 @@
+# Contract: Remediation Audit Evidence
+
+## Scope
+
+This contract describes the public and integration-visible behavior required by MM-623. It covers artifact metadata, lifecycle summary shape, queryable audit events, and target-side remediation annotations. It does not redefine artifact storage internals or grant raw artifact access.
+
+## Artifact Family Contract
+
+Every remediation evidence artifact published for this story must expose:
+
+```json
+{
+  "artifact_type": "remediation.context | remediation.plan | remediation.decision_log | remediation.action_request | remediation.action_result | remediation.verification | remediation.summary",
+  "name": "bounded display name",
+  "schemaVersion": "v1",
+  "targetWorkflowId": "target workflow identity when applicable",
+  "targetRunId": "target run identity when applicable"
+}
+```
+
+Rules:
+- `artifact_type` must be remediation-specific.
+- Artifact metadata must be safe for control-plane display.
+- Artifact refs are identifiers only; clients must not treat them as access grants or URLs.
+- Non-applicable artifacts must be explained by bounded summary or decision-log reasons.
+
+## Decision Log Contract
+
+Decision log artifacts use this shape:
+
+```json
+{
+  "schemaVersion": "v1",
+  "entries": [
+    {
+      "timestamp": "2026-05-08T00:00:00Z",
+      "phase": "diagnosing | acting | verifying | resolved | escalated | failed",
+      "decisionType": "repair_candidate | prevention | approval | cancellation | verification",
+      "decision": "attempted | skipped | denied | escalated | findings_reported | policy_blocked",
+      "reason": "bounded rationale",
+      "actor": "service or operator principal",
+      "actionKind": "optional action kind",
+      "targetWorkflowId": "target workflow identity",
+      "targetRunId": "target run identity",
+      "artifactRefs": {
+        "actionRequest": "artifact id",
+        "actionResult": "artifact id",
+        "verification": "artifact id",
+        "prevention": "artifact id"
+      },
+      "metadata": {
+        "safeKey": "safe value"
+      }
+    }
+  ]
+}
+```
+
+Rules:
+- A decision log must include at least one entry.
+- Attempted repair decisions must reference action and verification evidence.
+- Skipped, denied, escalated, prevention, and no-PR decisions must include bounded reasons.
+- Metadata must be redacted and bounded.
+
+## Remediation Summary Contract
+
+Final remediation summary artifacts use this shape:
+
+```json
+{
+  "targetWorkflowId": "target workflow identity",
+  "targetRunId": "pinned target run identity",
+  "resultingTargetRunId": "optional resulting target run identity",
+  "phase": "resolved | escalated | failed",
+  "mode": "remediation mode",
+  "authorityMode": "observe_only | approval_gated | admin_auto",
+  "actionsAttempted": [
+    {
+      "kind": "action kind",
+      "status": "applied | skipped | denied | escalated"
+    }
+  ],
+  "resolution": "not_applicable | diagnosis_only | no_action_needed | resolved_after_action | escalated | unsafe_to_act | lock_conflict | evidence_unavailable | failed",
+  "lockConflicts": 0,
+  "approvalCount": 0,
+  "evidenceDegraded": false,
+  "escalated": false,
+  "unavailableEvidenceClasses": [],
+  "fallbacksUsed": [],
+  "repair": {
+    "schemaVersion": "v1",
+    "decision": "attempted | skipped | denied | unsafe | approval_required | escalated",
+    "repairOutcome": "repaired | still_failed | not_attempted | unsafe | approval_required | escalated"
+  },
+  "prevention": {
+    "schemaVersion": "v1",
+    "status": "reviewable_change_created | findings_reported | no_reviewable_fix | policy_blocked"
+  },
+  "decisionLogRef": "artifact id",
+  "finalAuditRef": "optional queryable audit ref",
+  "lockRelease": "attempted | released | not_held | failed"
+}
+```
+
+Rules:
+- Required fields must remain present for every completed remediation run.
+- Unknown or unsupported phase/resolution values must fail or normalize to bounded failure values rather than silently disappearing.
+- Repair and prevention sections must include bounded status and safe artifact refs.
+
+## Queryable Audit Event Contract
+
+Side-effecting remediation decisions must publish compact queryable events:
+
+```json
+{
+  "eventId": "durable event id",
+  "eventType": "remediation.action",
+  "actorUser": "optional user principal",
+  "executionPrincipal": "service principal",
+  "remediationWorkflowId": "remediation workflow identity",
+  "remediationRunId": "remediation run identity",
+  "targetWorkflowId": "target workflow identity",
+  "targetRunId": "target run identity",
+  "actionKind": "action kind",
+  "riskTier": "low | medium | high",
+  "approvalDecision": "approved | denied | not_required | approval_required",
+  "timestamp": "RFC3339 timestamp",
+  "metadata": {
+    "safeKey": "safe value"
+  }
+}
+```
+
+Rules:
+- Events must be queryable by remediation workflow/run and target workflow/run.
+- Event metadata must not include artifact bodies, raw logs, secrets, presigned URLs, raw storage keys, or absolute local paths.
+- Retried publication of the same side-effecting decision must be idempotent.
+
+## Target-Side Annotation Contract
+
+When remediation mutates a target-managed session or workload, the target side must receive supplemental evidence:
+
+```json
+{
+  "schemaVersion": "v1",
+  "kind": "remediation.target_annotation",
+  "targetWorkflowId": "target workflow identity",
+  "targetRunId": "target run identity",
+  "remediationWorkflowId": "remediation workflow identity",
+  "remediationRunId": "remediation run identity",
+  "actionKind": "action kind",
+  "decision": "attempted | skipped | denied | escalated",
+  "artifactRefs": {
+    "actionRequest": "artifact id",
+    "actionResult": "artifact id",
+    "verification": "artifact id"
+  },
+  "timestamp": "RFC3339 timestamp",
+  "metadata": {
+    "safeKey": "safe value"
+  }
+}
+```
+
+Rules:
+- Target annotations must supplement target-native artifacts and must not overwrite them.
+- Annotation metadata must be safe for target detail views.
+- Annotation publication must be retry-safe.
+
+## Compatibility and Failure Rules
+
+- Workflow/activity payloads must remain compact and should carry refs rather than artifact bodies.
+- If a new persisted audit shape is introduced and existing in-flight workflows may invoke older activity signatures, preserve worker-bound invocation compatibility or document a versioned cutover before implementation.
+- Missing evidence must be represented with bounded degraded or escalated outcomes.
+- Secret-like values must be redacted before persistence, publication, or display.

--- a/specs/323-publish-remediation-audit/data-model.md
+++ b/specs/323-publish-remediation-audit/data-model.md
@@ -1,0 +1,172 @@
+# Data Model: Publish Remediation Audit Evidence
+
+## Remediation Evidence Set
+
+Represents the complete operator-facing evidence trail for one remediation run.
+
+Fields:
+- `remediationWorkflowId`: logical remediation execution identity.
+- `remediationRunId`: concrete remediation run identity.
+- `targetWorkflowId`: logical target execution identity.
+- `targetRunId`: pinned target run used for the evidence snapshot.
+- `artifacts`: typed references to applicable remediation evidence artifacts.
+- `nonApplicableArtifacts`: bounded reasons for artifacts that do not apply to the selected path.
+- `evidenceDegraded`: boolean indicating incomplete evidence.
+- `degradedReasons`: bounded reason codes or messages when evidence is incomplete.
+
+Relationships:
+- Belongs to one remediation run.
+- References one target execution and pinned target run.
+- Contains many artifact references.
+- Links to one remediation summary and zero or more audit events.
+
+Validation rules:
+- Artifact references must be identifiers, not URLs or local paths.
+- Metadata must not contain secrets, auth headers, cookies, raw storage keys, presigned URLs, or absolute local paths.
+- Missing non-applicable artifacts must have bounded reasons.
+
+## Remediation Artifact Record
+
+Represents one durable artifact in the remediation evidence trail.
+
+Fields:
+- `artifactId`: durable artifact reference.
+- `artifactType`: one of `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, or `remediation.summary`.
+- `name`: presentation label or path-like artifact name.
+- `contentType`: artifact content type.
+- `redactionLevel`: presentation safety classification.
+- `metadata`: bounded safe metadata.
+- `targetWorkflowId`: target identity when applicable.
+- `targetRunId`: target run identity when applicable.
+
+Relationships:
+- Belongs to one remediation evidence set.
+- May be referenced by decision log entries, repair decisions, prevention outcomes, or the final summary.
+
+Validation rules:
+- `artifactType` must be remediation-specific for this feature.
+- Metadata must be safe for control-plane display.
+- Raw artifact access must not be implied by artifact references.
+
+## Decision Log Entry
+
+Represents one bounded remediation decision.
+
+Fields:
+- `timestamp`: event time.
+- `phase`: bounded remediation phase.
+- `decisionType`: category such as repair candidate, prevention, approval, cancellation, or verification.
+- `decision`: attempted, skipped, denied, escalated, or equivalent bounded outcome.
+- `reason`: bounded human-readable rationale.
+- `actor`: service, operator, or remediation principal.
+- `actionKind`: action kind when applicable.
+- `targetWorkflowId`: target execution identity.
+- `targetRunId`: target run identity.
+- `artifactRefs`: references to related action, verification, prevention, or no-PR evidence.
+- `metadata`: bounded safe metadata.
+
+Relationships:
+- Belongs to a remediation decision log artifact.
+- May reference action request, action result, verification, prevention findings, or summary artifacts.
+
+Validation rules:
+- At least one entry is required when publishing a decision log.
+- Unsafe metadata keys and values must be removed or redacted.
+- Attempted repair decisions require action and verification references.
+
+## Remediation Summary
+
+Represents the stable run-level summary used for operator review and final reporting.
+
+Fields:
+- `targetWorkflowId`
+- `targetRunId`
+- `resultingTargetRunId`
+- `phase`
+- `mode`
+- `authorityMode`
+- `actionsAttempted`
+- `resolution`
+- `lockConflicts`
+- `approvalCount`
+- `evidenceDegraded`
+- `escalated`
+- `unavailableEvidenceClasses`
+- `fallbacksUsed`
+- `repair`
+- `prevention`
+- `decisionLogRef`
+- `finalAuditRef`
+- `lockRelease`
+
+Relationships:
+- Belongs to one remediation evidence set.
+- References the decision log artifact.
+- References repair and prevention evidence when applicable.
+
+Validation rules:
+- Target workflow and pinned run identity are required.
+- Resolution and phase must be bounded values.
+- Repair/prevention sections must use bounded status values and safe references.
+
+## Queryable Remediation Audit Event
+
+Represents compact control-plane evidence for a side-effecting remediation action decision.
+
+Fields:
+- `eventId`: deterministic or durable event identifier.
+- `eventType`: remediation action or related bounded event type.
+- `actorUser`: operator actor when applicable.
+- `executionPrincipal`: remediation execution principal.
+- `remediationWorkflowId`
+- `remediationRunId`
+- `targetWorkflowId`
+- `targetRunId`
+- `actionKind`
+- `riskTier`
+- `approvalDecision`
+- `timestamp`
+- `metadata`: bounded query/display metadata.
+
+Relationships:
+- Belongs to one remediation run.
+- References one target execution and target run.
+- May correspond to one decision log entry and action artifact set.
+
+Validation rules:
+- Must be queryable by remediation identity and target identity.
+- Must not contain artifact bodies, logs, secrets, raw storage keys, presigned URLs, or absolute local paths.
+- Must be idempotent for retried publication of the same side-effecting decision.
+
+## Target-Side Remediation Annotation
+
+Represents supplemental evidence on the mutated target side.
+
+Fields:
+- `targetWorkflowId`
+- `targetRunId`
+- `remediationWorkflowId`
+- `remediationRunId`
+- `actionKind`
+- `decision`
+- `artifactRefs`
+- `timestamp`
+- `metadata`
+
+Relationships:
+- Belongs to the target execution evidence surface.
+- References the remediation evidence set.
+- Does not replace subsystem-native control, continuity, diagnostic, or summary artifacts.
+
+Validation rules:
+- Must be supplemental and non-destructive.
+- Must preserve target-native evidence.
+- Must use safe refs and bounded metadata only.
+
+## State Transitions
+
+1. `collecting_evidence`: context artifacts are created or evidence degradation is recorded.
+2. `diagnosing`: remediation plan and candidate decisions are recorded.
+3. `acting`: action request/result and audit events are published for side-effecting actions.
+4. `verifying`: verification artifacts and target-side annotations are linked when applicable.
+5. `resolved`, `escalated`, or `failed`: summary and decision log artifacts are finalized with bounded outcome state.

--- a/specs/323-publish-remediation-audit/data-model.md
+++ b/specs/323-publish-remediation-audit/data-model.md
@@ -1,5 +1,7 @@
 # Data Model: Publish Remediation Audit Evidence
 
+Traceability: MM-623, DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-028.
+
 ## Remediation Evidence Set
 
 Represents the complete operator-facing evidence trail for one remediation run.
@@ -31,7 +33,7 @@ Represents one durable artifact in the remediation evidence trail.
 
 Fields:
 - `artifactId`: durable artifact reference.
-- `artifactType`: one of `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, or `remediation.summary`.
+- `artifactType`: one of `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.audit_event`, `remediation.target_annotation`, `remediation.verification`, or `remediation.summary`.
 - `name`: presentation label or path-like artifact name.
 - `contentType`: artifact content type.
 - `redactionLevel`: presentation safety classification.

--- a/specs/323-publish-remediation-audit/plan.md
+++ b/specs/323-publish-remediation-audit/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Publish Remediation Audit Evidence
+
+**Branch**: `run-jira-orchestrate-for-mm-623-publish-bce76a9b` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:ee5f7fbd-9025-4fd3-b856-ce19a43c453d/repo/specs/323-publish-remediation-audit/spec.md`
+
+## Summary
+
+MM-623 requires remediation runs to leave a durable, operator-reviewable evidence trail: applicable remediation artifacts, bounded decision logs, stable lifecycle summaries, compact queryable audit events, and target-side annotations that supplement target-native evidence. Current repo inspection shows the core artifact publisher, summary builders, action request/result/verification artifacts, and several bounded serialization tests already exist, but queryable remediation audit event persistence, target-side mutation annotation publication, and end-to-end representative path coverage are incomplete. The implementation approach is to extend the existing remediation context/tools boundary and artifact service patterns, reuse existing artifact presentation policy, add compact audit persistence/query behavior through an existing control-event style surface where feasible, and verify with focused unit tests plus hermetic integration tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `moonmind/workflows/temporal/remediation_context.py` defines remediation artifact types; `RemediationLifecyclePublisher` can publish required artifacts; tests cover publisher behavior but not every run path | Add or complete lifecycle publication for all applicable path artifacts and document non-applicable artifact handling | unit + integration |
+| FR-002 | implemented_verified | `REMEDIATION_ARTIFACT_TYPES` and `RemediationLifecyclePublisher.publish_json_artifact()` preserve `artifact_type`; `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_lifecycle_publisher_creates_required_artifacts` verifies link types and metadata | Preserve existing behavior while extending coverage for MM-623 paths | unit + integration |
+| FR-003 | partial | `build_remediation_decision_log()` and `publish_lifecycle_summary()` publish decision log artifacts; tests cover attempted and cancellation entries | Add coverage for skipped, denied, escalated, prevention/no-PR, and verification refs across representative remediation outcomes | unit + integration |
+| FR-004 | implemented_unverified | `build_remediation_summary_block()` and `build_remediation_final_summary()` expose stable fields; unit and integration tests cover repaired and escalated examples, but not every required field combination from MM-623 | Add verification-first coverage for full MM-623 summary field set; patch builders or lifecycle publisher if gaps appear | unit + integration |
+| FR-005 | partial | `build_remediation_audit_event()` builds bounded audit payloads, but repo search found no durable remediation-specific audit event persistence/query path | Persist compact queryable audit events for side-effecting action decisions using bounded metadata; expose or reuse a queryable control-event surface | unit + integration |
+| FR-006 | missing | Managed-session control events exist, but no remediation target-side mutation annotation contract or publication path was found for action execution | Add target-side annotation publication for remediation mutations without replacing subsystem-native artifacts | unit + integration |
+| FR-007 | partial | Summary builders normalize failed/degraded states; unit tests cover bounded degraded and cancellation examples | Add explicit representative tests for missing, degraded, skipped, unsafe, and escalated evidence states | unit + integration |
+| FR-008 | implemented_unverified | Artifact presentation contract requires safe metadata, refs, preview/redaction; remediation context artifacts use restricted redaction and artifact refs | Add remediation-specific artifact presentation tests proving no raw URLs, paths, or secrets appear in metadata/default previews | unit + integration |
+| FR-009 | implemented_verified | `spec.md` preserves `MM-623`, original preset brief, and source coverage IDs | Preserve traceability across plan, research, data model, contracts, quickstart, tasks, implementation, verification, commit text, and PR metadata | final verify |
+| SCN-001 | partial | Diagnosis-only summary behavior can be represented by existing summary helpers, but no MM-623 representative diagnosis-only path test was found | Add diagnosis-only evidence publication test | integration |
+| SCN-002 | partial | Decision log builder supports bounded entries; representative skipped/denied/escalated repair candidate coverage is incomplete | Add decision log scenario tests for candidate outcomes and refs | unit + integration |
+| SCN-003 | partial | Audit event builder exists; durable query behavior missing | Add side-effecting action audit persistence and query test | unit + integration |
+| SCN-004 | missing | No remediation target-side annotation publication path found | Add mutation annotation scenario test against target-side evidence | integration |
+| SCN-005 | implemented_unverified | Summary helpers expose degraded/escalated fields; representative integration coverage is limited | Add degraded and escalated summary verification | unit + integration |
+| SCN-006 | implemented_unverified | Artifact presentation rules exist; remediation-specific presentation checks are incomplete | Add preview/redaction verification for remediation artifacts | unit + integration |
+| SC-001 | partial | Publisher can emit artifact types, but every representative path is not covered | Add full representative-path artifact matrix tests | integration |
+| SC-002 | partial | Audit builder exists; no queryable persistence evidence | Add audit persistence/query tests | unit + integration |
+| SC-003 | implemented_unverified | Summary helper tests cover core fields, but full representative completion coverage is missing | Add full completion summary tests | unit + integration |
+| SC-004 | partial | Decision log builder redacts and refs artifacts; candidate outcome coverage incomplete | Add candidate outcome matrix tests | unit + integration |
+| SC-005 | implemented_unverified | Existing redaction helpers and artifact metadata policy are present; remediation-specific presentation tests are incomplete | Add no-secret/no-raw-reference artifact metadata and preview tests | unit + integration |
+| SC-006 | implemented_verified | `spec.md`, this plan, and generated design artifacts preserve `MM-623` and source IDs | Keep traceability checks in tasks and final verification | final verify |
+| DESIGN-REQ-022 | partial | Required artifact type constants and publisher exist, but path-complete evidence publication is incomplete | Complete and verify applicable artifact set plus safe presentation | unit + integration |
+| DESIGN-REQ-023 | partial | Decision log builder exists; target-side annotation and queryable audit event persistence are missing or incomplete | Add compact audit persistence and target-side annotation publication | unit + integration |
+| DESIGN-REQ-028 | implemented_unverified | Summary helper and lifecycle summary publisher exist with tests, but MM-623 requires broader representative field validation | Verify all required lifecycle summary fields and repair/prevention outcomes | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2 where exposed, SQLAlchemy async ORM, FastAPI service/router patterns where query surfaces are exposed, Temporal Python SDK activity/service boundaries, existing Temporal artifact service  
+**Storage**: Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and an existing or reusable control-event/audit persistence mechanism; no new persistent table planned unless queryable audit events cannot safely reuse current control-event/audit infrastructure  
+**Unit Testing**: `pytest` via `./tools/test_unit.sh`  
+**Integration Testing**: Hermetic `pytest` integration suite via `./tools/test_integration.sh`, with `integration` + `integration_ci` markers  
+**Target Platform**: MoonMind API/worker services on Linux containers with local-first Docker Compose support  
+**Project Type**: Backend orchestration services and Temporal workflow/activity boundary  
+**Performance Goals**: Representative remediation evidence publication completes without adding unbounded artifact bodies to workflow history; compact audit events remain bounded metadata suitable for query/display  
+**Constraints**: Preserve artifact-first evidence, avoid secrets/raw URLs/raw paths in metadata or previews, keep workflow payloads compact, maintain retry-safe side effects, and preserve in-flight workflow/activity compatibility where boundary shapes are changed  
+**Scale/Scope**: One single-story remediation evidence feature for MM-623, covering representative remediation run paths rather than the entire remediation system backlog
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - Plan extends existing remediation orchestration/tool boundaries rather than introducing a separate agent model.
+- II. One-Click Agent Deployment: PASS - No new required external service is planned; tests remain local/hermetic.
+- III. Avoid Vendor Lock-In: PASS - Evidence and audit records remain portable JSON/artifact metadata and do not bind to one provider.
+- IV. Own Your Data: PASS - Durable evidence stays in MoonMind-owned artifacts/control-plane records.
+- V. Skills Are First-Class and Easy to Add: PASS - No skill runtime mutation is planned; generated artifacts preserve the selected skill workflow traceability.
+- VI. Scientific Method Scaffold: PASS - Plan uses explicit hypothesis, test-first verification, and publishable evidence.
+- VII. Runtime Configurability: PASS - No hardcoded deployment configuration is introduced; any new behavior should follow existing settings/policy patterns if configuration is needed.
+- VIII. Modular Architecture: PASS - Planned work stays within remediation context/tools, artifact, and API/control-event boundaries.
+- IX. Resilient by Default: PASS - Side effects must be retry-safe/idempotent, bounded, and covered at workflow/activity or service boundaries.
+- X. Continuous Improvement: PASS - Evidence summary and traceability support operator review.
+- XI. Spec-Driven Development: PASS - `spec.md` is the source of truth and this plan preserves all requirement IDs.
+- XII. Canonical Docs vs Migration: PASS - Implementation sequencing remains in this feature artifact, not canonical docs.
+- XIII. Pre-Release Velocity: PASS - No compatibility aliases or deprecated parallel contracts are planned.
+- Security/Observability clauses: PASS - Planned artifacts and audit records must be secret-safe and operator-diagnosable.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/323-publish-remediation-audit/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-audit-evidence.md
+├── checklists/
+│   └── requirements.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── remediation_context.py
+├── remediation_tools.py
+├── remediation_actions.py
+└── service.py
+
+api_service/
+├── api/routers/
+├── db/models.py
+└── services/
+
+tests/unit/workflows/temporal/
+└── test_remediation_context.py
+
+tests/integration/temporal/
+└── test_remediation_action_contracts.py
+
+docs/
+├── Tasks/TaskRemediation.md
+└── Artifacts/ArtifactPresentationContract.md
+```
+
+**Structure Decision**: Use the existing backend orchestration and artifact-service layout. The primary implementation surface is the remediation service/activity boundary in `moonmind/workflows/temporal/`, with API/control-event exposure only if queryable audit requirements cannot be satisfied through an existing service surface. Unit tests stay near remediation helpers; hermetic integration tests validate artifact and persistence behavior through the existing Temporal artifact service and database fixtures.
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/323-publish-remediation-audit/quickstart.md
+++ b/specs/323-publish-remediation-audit/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: Publish Remediation Audit Evidence
+
+## Prerequisites
+
+- Work from the repository root.
+- Use the active feature directory: `specs/323-publish-remediation-audit`.
+- Keep `MM-623` and the original Jira preset brief traceable in every downstream artifact.
+- Managed-agent local test mode should use `MOONMIND_FORCE_LOCAL_TESTS=1`.
+
+## Unit Test Strategy
+
+Run focused unit tests while developing:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py
+```
+
+Expected unit coverage:
+- Remediation artifact type validation and metadata safety.
+- Decision log outcome matrix for attempted, skipped, denied, escalated, prevention, and no-PR decisions.
+- Remediation summary full field set for repaired, no-action, degraded, unsafe, and escalated outcomes.
+- Queryable audit event validation, redaction, timestamp handling, and idempotency keys.
+- Target-side annotation payload validation and safe refs.
+
+Before final verification, run the full unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Integration Test Strategy
+
+Run the required hermetic integration suite:
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected integration coverage:
+- Representative remediation run paths publish every applicable remediation artifact and bounded non-applicable reasons.
+- Side-effecting action execution publishes action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence.
+- Diagnosis-only and no-action runs publish context, plan or bounded no-plan reason, decision log, and summary without action artifacts.
+- Degraded and escalated runs expose degraded/evidence-unavailable state in artifacts, summary, and audit trail.
+- Artifact metadata and previews do not expose raw URLs, local paths, storage keys, auth headers, tokens, or secrets.
+
+## End-to-End Validation Scenario
+
+1. Create or load a target execution and a remediation execution with a pinned target run.
+2. Build the remediation context artifact.
+3. Evaluate an allowed remediation action and mutation guard.
+4. Execute the action through the remediation evidence tool service.
+5. Publish repair/prevention lifecycle summary evidence and decision logs.
+6. Persist a compact queryable audit event for the side-effecting action decision.
+7. Publish a target-side remediation annotation without removing target-native artifacts.
+8. Query artifacts and audit records by remediation identity and target identity.
+9. Confirm summary fields, decision refs, audit metadata, and target annotations agree.
+10. Confirm no artifact metadata, previews, logs, or audit records expose secret-like values or raw storage/local references.
+
+## Traceability Check
+
+```bash
+rg -n "MM-623|DESIGN-REQ-022|DESIGN-REQ-023|DESIGN-REQ-028" specs/323-publish-remediation-audit
+```
+
+Expected result: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, `quickstart.md`, and final verification evidence preserve the Jira issue key and source coverage IDs.

--- a/specs/323-publish-remediation-audit/research.md
+++ b/specs/323-publish-remediation-audit/research.md
@@ -1,0 +1,91 @@
+# Research: Publish Remediation Audit Evidence
+
+This research artifact supports Jira issue `MM-623` and the single-story feature "Publish remediation audit artifacts, summaries, and queryable events." Source coverage IDs are preserved for DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-028.
+
+## Planning Setup
+
+Decision: Continue from the active feature directory recorded in `.specify/feature.json`.
+Evidence: `.specify/feature.json` points to `specs/323-publish-remediation-audit`; `.specify/scripts/bash/setup-plan.sh --json` failed because the managed branch is `run-jira-orchestrate-for-mm-623-publish-bce76a9b` rather than a `###-feature-name` branch.
+Rationale: The feature directory and spec already exist and are the authoritative artifacts for this managed run.
+Alternatives considered: Renaming or switching branches was rejected because this step is scoped to planning artifacts and should not mutate branch state.
+Test implications: None beyond preserving the active feature pointer.
+
+## FR-001 / DESIGN-REQ-022 - Applicable Remediation Artifact Set
+
+Decision: Status is partial; complete path-aware publication and verification of all applicable remediation artifact types.
+Evidence: `moonmind/workflows/temporal/remediation_context.py` defines `REMEDIATION_ARTIFACT_TYPES`; `RemediationLifecyclePublisher` publishes JSON artifacts; `tests/unit/workflows/temporal/test_remediation_context.py::test_remediation_lifecycle_publisher_creates_required_artifacts` verifies several required types and metadata. Representative run-path coverage remains incomplete.
+Rationale: The repository has reusable publishing primitives but the MM-623 requirement is stronger than primitive availability; every representative remediation run path needs evidence that applicable artifacts are present and non-applicable artifacts are explained.
+Alternatives considered: Treating the publisher helper as complete was rejected because it does not prove all remediation lifecycle paths invoke it consistently.
+Test implications: Unit tests for artifact classification helpers; integration tests for representative diagnosis-only, action-attempted, degraded, and escalated paths.
+
+## FR-002 - Remediation Artifact Classification
+
+Decision: Status is implemented_verified; preserve existing artifact classification behavior while extending scenario coverage.
+Evidence: `REMEDIATION_ARTIFACT_TYPES` includes `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, and `remediation.summary`; existing unit coverage verifies artifact metadata and links.
+Rationale: Current code and tests directly prove artifact classification for the required type family.
+Alternatives considered: Reworking artifact taxonomy was rejected because the source design already names the target taxonomy and existing code implements it.
+Test implications: No new standalone unit test is required for the constant set, but integration tests should ensure all representative publications preserve the metadata.
+
+## FR-003 / SCN-002 - Decision Log Completeness
+
+Decision: Status is partial; add outcome-matrix coverage for repair candidates and prevention/no-PR reasons.
+Evidence: `build_remediation_decision_log()` redacts metadata and requires bounded decision entries; `publish_lifecycle_summary()` publishes the decision log artifact; tests cover attempted and cancellation examples.
+Rationale: The existing builder is suitable, but the story requires attempted, skipped, denied, escalated, prevention, verification refs, and no-PR reasons to be reviewable.
+Alternatives considered: Only using action authority audit payloads was rejected because operators need an artifact-backed decision log that is readable after run completion.
+Test implications: Unit tests for every decision outcome shape; integration tests proving the log artifact is linked and referenced by the summary.
+
+## FR-004 / DESIGN-REQ-028 - Stable Remediation Summary
+
+Decision: Status is implemented_unverified; verify the full MM-623 field set and patch if gaps appear.
+Evidence: `build_remediation_summary_block()` emits target IDs, phase, mode, authority, actions, resolution, lock conflicts, approvals, degraded state, escalation, unavailable evidence, fallback data, and resulting run ID. `build_remediation_final_summary()` attaches repair/prevention and decision refs. Existing tests cover repaired and escalated samples.
+Rationale: The core behavior appears present, but MM-623 needs a complete representative field check across repair, prevention, degraded, and escalation outcomes.
+Alternatives considered: Marking implemented_verified was rejected because current tests do not explicitly cover the entire story matrix.
+Test implications: Verification-first unit and integration tests; implementation contingency if required fields or validation are missing.
+
+## FR-005 / SCN-003 - Queryable Audit Events
+
+Decision: Status is partial; add durable queryable audit event persistence for side-effecting remediation decisions.
+Evidence: `build_remediation_audit_event()` produces bounded metadata and redacts unsafe fields, but repo search did not find a remediation-specific persistence/query path for those events. Existing control/audit surfaces exist for other domains, such as settings audit and managed-session control events.
+Rationale: A builder alone does not satisfy "queryable audit events"; operators and control-plane queries need persisted compact records or a reused queryable event mechanism.
+Alternatives considered: Storing audit events only inside summary artifacts was rejected because artifacts are the deep evidence trail, while the spec requires compact queryable control-plane records.
+Test implications: Unit tests for audit event validation/redaction and integration tests proving events are persisted and queryable by remediation workflow/run or target identity.
+
+## FR-006 / SCN-004 - Target-Side Mutation Annotations
+
+Decision: Status is missing; add a publication path for supplemental target-side annotations when remediation mutates a target-managed session or workload.
+Evidence: Managed-session control event artifacts exist in runtime supervisor/controller code, but no remediation-specific target-side annotation publication path was found in remediation action execution.
+Rationale: Source design requires remediation audit trail to supplement subsystem-native artifacts. A side-effecting remediation action needs visible linkage on the target side without overwriting target-native continuity or control artifacts.
+Alternatives considered: Treating remediation-side action artifacts as sufficient was rejected because the requirement explicitly mentions target-side annotations.
+Test implications: Integration test for a side-effecting action that preserves native target records and adds a supplemental remediation annotation/ref.
+
+## FR-007 / SCN-005 - Bounded Degraded, Skipped, Unsafe, and Escalated States
+
+Decision: Status is partial; expand representative coverage and patch lifecycle serialization if any state is ambiguous.
+Evidence: `normalize_remediation_phase()`, `normalize_remediation_resolution()`, `build_remediation_summary_block()`, and lifecycle tests cover degraded and escalated examples.
+Rationale: The primitives normalize states, but the operator-facing story requires every missing/degraded/skipped/unsafe/escalated state to carry a bounded reason.
+Alternatives considered: Relying on generic failure status was rejected because remediation evidence must explain the decision path.
+Test implications: Unit tests for serialization and integration tests for representative no-action, unsafe, evidence-unavailable, and escalated runs.
+
+## FR-008 / SC-005 - Artifact Presentation Safety
+
+Decision: Status is implemented_unverified; add remediation-specific presentation checks against the existing artifact presentation contract.
+Evidence: `docs/Artifacts/ArtifactPresentationContract.md` requires safe metadata, artifact refs instead of URLs, and redaction behavior. Remediation context artifacts use restricted redaction and artifact refs. Existing remediation tests check several redaction helpers.
+Rationale: Existing platform rules should satisfy the requirement, but MM-623 needs direct proof for remediation artifact metadata and previews.
+Alternatives considered: Duplicating artifact presentation logic in remediation services was rejected because the generic artifact contract owns presentation behavior.
+Test implications: Unit and integration tests asserting remediation artifact metadata and preview/default-read data contain no secrets, raw local paths, raw storage keys, or presigned URLs.
+
+## FR-009 / SC-006 - Jira Traceability
+
+Decision: Status is implemented_verified for planning artifacts; preserve through downstream work.
+Evidence: `specs/323-publish-remediation-audit/spec.md` preserves the original MM-623 preset brief; this plan, research, data model, contract, and quickstart preserve MM-623 and source IDs.
+Rationale: Traceability is currently satisfied at the specification and planning stage.
+Alternatives considered: Storing only the issue key was rejected because final verification must compare against the original preset brief.
+Test implications: Final verification should run a traceability search across feature artifacts and delivery metadata.
+
+## Test Strategy
+
+Decision: Use focused unit tests for serialization, validation, and redaction; use hermetic integration tests for artifact persistence, audit queryability, and target-side annotation behavior.
+Evidence: Existing repo instructions require `./tools/test_unit.sh` for unit tests and `./tools/test_integration.sh` for required hermetic integration tests. Existing remediation coverage already uses `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py`.
+Rationale: The feature crosses service/activity and artifact boundaries, so isolated helper tests are not enough.
+Alternatives considered: Provider verification tests were rejected because MM-623 does not require external provider credentials.
+Test implications: Add or update unit tests first, then integration tests, then run the full unit suite and required hermetic integration suite before final verification.

--- a/specs/323-publish-remediation-audit/spec.md
+++ b/specs/323-publish-remediation-audit/spec.md
@@ -104,7 +104,7 @@ Requirements
 ## Source Design Requirements
 
 - **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` lines 1084-1115): Remediation runs must publish the applicable durable evidence artifacts with remediation artifact types, bounded safe metadata, artifact references instead of URLs, preview/redaction handling, and no secrets in metadata or bodies. Scope: in scope. Mapped to FR-001, FR-002, FR-007, and FR-008.
-- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` lines 1117-1127 and 1476-1487): When remediation mutates a target-managed session or workload, target-side annotations or continuity artifacts must supplement, not replace, subsystem-native artifacts, and corrected or side-effecting decisions must remain auditable rather than silently mutating the original input. Scope: in scope. Mapped to FR-003, FR-005, FR-006, and FR-007.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` lines 1117-1127, 1179-1192, and 1476-1487): When remediation mutates a target-managed session or workload, target-side annotations or continuity artifacts must supplement, not replace, subsystem-native artifacts; side-effecting remediation decisions must produce compact queryable audit events; and corrected or side-effecting decisions must remain auditable rather than silently mutating the original input. Scope: in scope. Mapped to FR-003, FR-005, FR-006, and FR-007.
 - **DESIGN-REQ-028** (`docs/Tasks/TaskRemediation.md` lines 1129-1165 and 1434-1469): Remediation summaries must expose stable remediation fields, immediate repair and prevention outcomes when applicable, bounded resolution states, degraded-evidence state, and escalation state. Scope: in scope. Mapped to FR-004, FR-007, and FR-008.
 
 ## Requirements *(mandatory)*

--- a/specs/323-publish-remediation-audit/spec.md
+++ b/specs/323-publish-remediation-audit/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Publish Remediation Audit Evidence
+
+**Feature Branch**: `323-publish-remediation-audit`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-623 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-623 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-623
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Publish remediation audit artifacts, summaries, and queryable events
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose a normalized preset brief or recommended preset instructions.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-623 from MM project
+Summary: Publish remediation audit artifacts, summaries, and queryable events
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-623 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-623: Publish remediation audit artifacts, summaries, and queryable events
+
+Source Reference
+Source Document: docs/Tasks/TaskRemediation.md
+Source Title: Task Remediation
+Source Sections:
+- 14. Artifacts, summaries, and audit
+- Appendix B. Example remediation summary
+
+Coverage IDs:
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+- DESIGN-REQ-028
+
+As an operator, I can inspect durable remediation evidence, decisions, actions, verification, summary blocks, target-side annotations, and compact audit events so that every diagnosis and intervention remains reviewable after the run completes.
+
+Acceptance Criteria
+- Every remediation run publishes the minimum required artifact set that applies to its path and uses remediation.* artifact types.
+- Decision logs record attempted/skipped/denied/escalated repair candidates, action refs, verification refs, prevention refs or no-PR reasons.
+- Run summary includes stable remediation fields such as target ids, mode, authority, actions, immediateRepair, prevention, resolution, evidenceDegraded, and escalated.
+- Queryable audit events exist for side-effecting action decisions and contain bounded metadata only.
+- Artifact presentation obeys normal preview/redaction rules.
+
+Requirements
+- Durable artifacts are the operator-facing evidence trail.
+- Audit events are compact queryable control-plane records.
+- Target-side mutation annotations do not replace subsystem-native artifacts.
+"""
+
+## User Story - Review Remediation Evidence
+
+**Summary**: As an operator, I want each remediation run to publish durable evidence, summaries, target annotations, and compact audit records so that every diagnosis and intervention remains reviewable after the run completes.
+
+**Goal**: Operators can reconstruct what a remediation run observed, decided, attempted, verified, summarized, and escalated without relying on transient logs or mutable target-side state.
+
+**Independent Test**: Can be fully tested by completing representative remediation runs across diagnosis-only, repair-attempted, prevention-attempted, degraded-evidence, and escalated paths, then validating that the operator-visible evidence trail, summary fields, and queryable audit records describe the same bounded run history.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remediation run completes with diagnosis-only output, **When** an operator inspects its evidence, **Then** the applicable remediation artifacts and run summary are present and identify why no repair action was needed.
+2. **Given** a remediation run attempts or skips repair candidates, **When** an operator reviews the decision evidence, **Then** each attempted, skipped, denied, or escalated candidate includes bounded rationale and references to any action, verification, prevention, or no-PR evidence.
+3. **Given** a remediation run performs a side-effecting action, **When** audit records are queried for that run, **Then** a compact event records the action decision with bounded metadata and no sensitive or raw storage data.
+4. **Given** a remediation run mutates a target-managed session or workload, **When** the target and remediation evidence are inspected, **Then** target-side annotations supplement the subsystem-native artifacts without replacing them.
+5. **Given** a remediation run has degraded evidence or escalates, **When** the run summary is inspected, **Then** the summary exposes the degraded or escalated state and stable remediation fields needed for review.
+6. **Given** an operator previews remediation artifacts, **When** artifact presentation rules apply, **Then** only safe metadata, artifact references, and redacted preview content are visible.
+
+### Edge Cases
+
+- A remediation run may complete without any side-effecting action; the evidence trail must still explain the no-action outcome.
+- Some artifact types apply only to paths that request or perform actions; missing non-applicable artifacts must not be reported as evidence loss.
+- Evidence can be partially unavailable or degraded; the summary and audit trail must expose a bounded degraded reason instead of implying complete evidence.
+- Target-managed systems can already publish their own control artifacts; remediation annotations must remain supplementary and must not overwrite or replace subsystem-native evidence.
+- A prevention effort may not produce a pull request; the decision log must record the bounded reason.
+
+## Assumptions
+
+- Runtime intent is required because Jira Orchestrate selected a runtime implementation workflow and the brief describes product behavior, not documentation-only work.
+- The cited Task Remediation sections are source requirements for the selected story, while unrelated remediation design sections are out of scope for this specification.
+- Existing artifact preview, redaction, and authorization policies define the normal presentation rules that remediation artifacts must obey.
+- Queryable audit events are expected to contain compact control-plane metadata rather than full artifact bodies or logs.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` lines 1084-1115): Remediation runs must publish the applicable durable evidence artifacts with remediation artifact types, bounded safe metadata, artifact references instead of URLs, preview/redaction handling, and no secrets in metadata or bodies. Scope: in scope. Mapped to FR-001, FR-002, FR-007, and FR-008.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` lines 1117-1127 and 1476-1487): When remediation mutates a target-managed session or workload, target-side annotations or continuity artifacts must supplement, not replace, subsystem-native artifacts, and corrected or side-effecting decisions must remain auditable rather than silently mutating the original input. Scope: in scope. Mapped to FR-003, FR-005, FR-006, and FR-007.
+- **DESIGN-REQ-028** (`docs/Tasks/TaskRemediation.md` lines 1129-1165 and 1434-1469): Remediation summaries must expose stable remediation fields, immediate repair and prevention outcomes when applicable, bounded resolution states, degraded-evidence state, and escalation state. Scope: in scope. Mapped to FR-004, FR-007, and FR-008.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST publish the minimum remediation evidence artifact set that applies to each completed remediation run path.
+- **FR-002**: Remediation evidence artifacts MUST use remediation-specific artifact classifications so operators can identify context, plan, decision log, action request, action result, verification, and summary evidence.
+- **FR-003**: Decision evidence MUST record attempted, skipped, denied, and escalated repair candidates with bounded rationale and references to any action, verification, prevention, or no-PR evidence.
+- **FR-004**: Run summaries MUST expose stable remediation fields covering target identifiers, remediation mode, authority, attempted actions, immediate repair, prevention, resolution, degraded evidence, and escalation state when applicable.
+- **FR-005**: The system MUST produce queryable audit records for side-effecting remediation action decisions using bounded metadata only.
+- **FR-006**: Target-side mutation annotations MUST supplement subsystem-native target artifacts and MUST NOT replace or overwrite those artifacts.
+- **FR-007**: Missing, degraded, skipped, unsafe, or escalated evidence states MUST be represented with bounded operator-visible reasons.
+- **FR-008**: Artifact presentation for remediation evidence MUST obey normal preview, redaction, authorization, and safe-reference rules.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-623` and the original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Remediation Evidence Set**: The complete operator-facing evidence trail for one remediation run, including only artifacts applicable to that run path.
+- **Decision Log Entry**: A bounded record of one repair candidate decision, including outcome, rationale, and references to related action, verification, prevention, or no-PR evidence.
+- **Remediation Summary**: The stable run-level summary block that exposes target identity, remediation mode, authority, actions, repair/prevention outcomes, resolution, degraded evidence, and escalation state.
+- **Audit Event**: A compact queryable control-plane record for a side-effecting remediation decision.
+- **Target Annotation**: Supplemental target-side evidence that links a target-managed session or workload mutation back to the remediation decision without replacing target-native records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of representative remediation run paths expose every applicable remediation evidence artifact and clearly identify non-applicable artifacts as such.
+- **SC-002**: 100% of side-effecting remediation action decisions in representative runs produce a queryable bounded audit record.
+- **SC-003**: 100% of completed representative remediation runs include stable summary fields for target identity, mode, authority, resolution, degraded evidence, and escalation state.
+- **SC-004**: 100% of attempted, skipped, denied, or escalated repair candidates in representative runs include bounded rationale and evidence references where applicable.
+- **SC-005**: Artifact preview and metadata checks reveal zero raw storage URLs, raw local paths, secrets, or unredacted sensitive values across representative remediation evidence.
+- **SC-006**: Traceability review confirms `MM-623`, the original Jira preset brief, and source coverage IDs DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-028 are preserved in MoonSpec artifacts and final evidence.

--- a/specs/323-publish-remediation-audit/tasks.md
+++ b/specs/323-publish-remediation-audit/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Publish Remediation Audit Evidence
+
+**Input**: Design documents from `/work/agent_jobs/mm:ee5f7fbd-9025-4fd3-b856-ce19a43c453d/repo/specs/323-publish-remediation-audit/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/remediation-audit-evidence.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one independently testable story: Review Remediation Evidence.
+
+**Source Traceability**: MM-623 and the original Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-009, acceptance scenarios 1 through 6, edge cases, SC-001 through SC-006, and DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-028.
+
+**Requirement Status Summary**: 12 partial rows require code-and-test completion, 2 missing rows require new tests and implementation, 7 implemented-unverified rows require verification-first tests with conditional fallback implementation, and 3 implemented-verified rows require traceability-preserving final validation only.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and does not depend on incomplete work.
+- Every implementation or validation task names exact file paths and requirement, scenario, success, or source IDs.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm feature artifacts and existing remediation test surfaces before story work begins.
+
+- [ ] T001 Review `specs/323-publish-remediation-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, and `quickstart.md` for MM-623 traceability and one-story scope. (FR-009, SC-006)
+- [ ] T002 Inspect existing remediation helper and publisher surfaces in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_tools.py`, and `moonmind/workflows/temporal/remediation_actions.py` before editing. (FR-001 through FR-008)
+- [ ] T003 Inspect existing remediation unit and integration coverage in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` to avoid duplicate fixtures. (FR-001 through FR-008)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prepare shared test fixtures and contract baselines that all story tests depend on.
+
+**CRITICAL**: No production implementation work can begin until this phase is complete.
+
+- [ ] T004 Add or update shared remediation evidence fixture helpers in `tests/unit/workflows/temporal/test_remediation_context.py` for diagnosis-only, action-attempted, skipped, denied, escalated, degraded, and no-PR cases. (FR-001, FR-003, FR-007, DESIGN-REQ-022, DESIGN-REQ-023)
+- [ ] T005 Add or update integration fixture helpers in `tests/integration/temporal/test_remediation_action_contracts.py` for querying remediation artifacts, audit records, target-side annotations, and target-native artifacts by workflow/run identity. (FR-005, FR-006, SCN-003, SCN-004)
+- [ ] T006 Confirm the remediation audit evidence contract in `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` matches the current test fixture shapes before adding red tests. (FR-005, FR-006, DESIGN-REQ-023)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Review Remediation Evidence
+
+**Summary**: As an operator, I want each remediation run to publish durable evidence, summaries, target annotations, and compact audit records so that every diagnosis and intervention remains reviewable after the run completes.
+
+**Independent Test**: Complete representative remediation runs across diagnosis-only, repair-attempted, prevention-attempted, degraded-evidence, and escalated paths, then validate that operator-visible evidence, summary fields, queryable audit records, and target annotations describe the same bounded run history.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009; SCN-001 through SCN-006; SC-001 through SC-006; DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-028.
+
+**Test Plan**:
+
+- Unit: serialization, validation, bounded state normalization, redaction, decision-log outcome matrix, summary field matrix, audit event payloads, target annotation payloads.
+- Integration: artifact persistence and metadata, queryable audit persistence, target-side annotation behavior, representative remediation paths, artifact preview/redaction safety.
+
+### Unit Tests (write first) ⚠️
+
+> Write these tests FIRST. Run them and confirm missing/partial behavior fails for the expected reason before production implementation.
+
+- [ ] T007 [P] Add failing unit tests for applicable artifact set and non-applicable artifact reasons in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-022)
+- [ ] T008 [P] Add failing unit tests for decision log attempted, skipped, denied, escalated, prevention, verification-ref, and no-PR reason entries in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
+- [ ] T009 [P] Add verification-first unit tests for the full remediation summary field set across repaired, no-action, degraded, unsafe, and escalated outcomes in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-004, FR-007, SC-003, DESIGN-REQ-028)
+- [ ] T010 [P] Add failing unit tests for queryable remediation audit event persistence payload validation, redaction, timestamp normalization, and idempotency key behavior in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-005, SC-002, DESIGN-REQ-023)
+- [ ] T011 [P] Add failing unit tests for target-side remediation annotation payload validation, safe artifact refs, supplemental semantics, and retry-safe identity in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
+- [ ] T012 [P] Add verification-first unit tests proving remediation artifact metadata and default presentation payloads reject raw URLs, local paths, storage keys, tokens, and secret-like values in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-008, SC-005, DESIGN-REQ-022)
+- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and confirm T007, T008, T010, and T011 fail for missing/partial behavior while T009 and T012 establish verification evidence or expose gaps. (FR-001, FR-003, FR-004, FR-005, FR-006, FR-008)
+
+### Integration Tests (write first) ⚠️
+
+- [ ] T014 [P] Add failing integration test for a diagnosis-only remediation run publishing applicable artifacts, bounded non-applicable action evidence, decision log, and summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-001, FR-001, FR-003, FR-007, SC-001)
+- [ ] T015 [P] Add failing integration test for side-effecting action execution publishing action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-003, SCN-004, FR-005, FR-006, DESIGN-REQ-023)
+- [ ] T016 [P] Add failing integration test for skipped, denied, escalated, prevention, and no-PR decision evidence remaining bounded and linked from the final summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-002, FR-003, FR-007, SC-004)
+- [ ] T017 [P] Add verification-first integration test for degraded and escalated remediation summaries exposing stable fields and bounded degraded reasons in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-005, FR-004, FR-007, DESIGN-REQ-028)
+- [ ] T018 [P] Add verification-first integration test for remediation artifact metadata and preview/default-read safety in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-006, FR-008, SC-005, DESIGN-REQ-022)
+- [ ] T019 Run `./tools/test_integration.sh` and confirm T014, T015, and T016 fail for missing/partial behavior while T017 and T018 establish verification evidence or expose gaps. (SCN-001 through SCN-006)
+
+### Red-First Confirmation
+
+- [ ] T020 Record the expected red-first failures from T013 and T019 in `specs/323-publish-remediation-audit/tasks.md` implementation notes before modifying production code. (FR-001, FR-003, FR-005, FR-006, FR-007)
+- [ ] T021 Confirm no implementation tasks are started before missing/partial unit and integration tests fail for the intended reason in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py`. (FR-001, FR-003, FR-005, FR-006, DESIGN-REQ-022, DESIGN-REQ-023)
+
+### Conditional Fallback Implementation for Implemented-Unverified Rows
+
+- [ ] T022 If T009 exposes missing summary fields or invalid lifecycle state handling, update `moonmind/workflows/temporal/remediation_context.py` to complete the remediation summary field set and bounded validation. (FR-004, SC-003, DESIGN-REQ-028)
+- [ ] T023 If T012 or T018 exposes artifact presentation safety gaps, update remediation artifact metadata generation in `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py` without duplicating generic artifact presentation logic. (FR-008, SC-005, DESIGN-REQ-022)
+- [ ] T024 If T017 exposes degraded or escalated summary gaps, update lifecycle summary publication in `moonmind/workflows/temporal/remediation_tools.py` and bounded state helpers in `moonmind/workflows/temporal/remediation_context.py`. (FR-004, FR-007, SCN-005, DESIGN-REQ-028)
+
+### Implementation
+
+- [ ] T025 Implement path-aware remediation evidence-set helpers and non-applicable artifact reason serialization in `moonmind/workflows/temporal/remediation_context.py`. (FR-001, FR-007, SC-001, DESIGN-REQ-022)
+- [ ] T026 Update lifecycle publication in `moonmind/workflows/temporal/remediation_tools.py` so diagnosis-only, action-attempted, degraded, and escalated paths publish all applicable remediation evidence artifacts. (FR-001, FR-003, FR-007, SCN-001, SCN-002)
+- [ ] T027 Complete bounded decision-log outcome support in `moonmind/workflows/temporal/remediation_context.py` for attempted, skipped, denied, escalated, prevention, verification, and no-PR reasons. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
+- [ ] T028 Implement compact queryable remediation audit event persistence and lookup support in `moonmind/workflows/temporal/remediation_context.py`, reusing existing control-event or artifact-backed persistence patterns where feasible. (FR-005, SC-002, DESIGN-REQ-023)
+- [ ] T029 Wire side-effecting action audit event publication from `RemediationEvidenceToolService.execute_action()` in `moonmind/workflows/temporal/remediation_tools.py`. (FR-005, SCN-003, DESIGN-REQ-023)
+- [ ] T030 Implement target-side remediation annotation payload construction in `moonmind/workflows/temporal/remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
+- [ ] T031 Wire target-side remediation annotation publication from side-effecting action execution in `moonmind/workflows/temporal/remediation_tools.py` without replacing target-native artifacts. (FR-006, SCN-004, DESIGN-REQ-023)
+- [ ] T032 Add any required API or service query support for compact remediation audit records in `api_service/api/routers/task_runs.py` or an existing remediation-related service file, only if artifact/control-event querying is not already sufficient. (FR-005, SC-002)
+- [ ] T033 Preserve existing remediation artifact classification behavior in `moonmind/workflows/temporal/remediation_context.py` while adding new audit or annotation evidence. (FR-002, FR-009, DESIGN-REQ-022)
+
+### Story Validation
+
+- [ ] T034 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and fix failures in `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py`. (FR-001 through FR-008)
+- [ ] T035 Run `./tools/test_integration.sh` and fix failures in remediation evidence, audit, and annotation paths. (SCN-001 through SCN-006)
+- [ ] T036 Run `rg -n "MM-623|DESIGN-REQ-022|DESIGN-REQ-023|DESIGN-REQ-028" specs/323-publish-remediation-audit` and confirm traceability remains present in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, `quickstart.md`, and `tasks.md`. (FR-009, SC-006)
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without expanding beyond MM-623.
+
+- [ ] T037 Review `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` against implemented behavior and update it only if implementation reveals a contract clarification need. (FR-005, FR-006, DESIGN-REQ-023)
+- [ ] T038 Review `specs/323-publish-remediation-audit/data-model.md` against implemented persistence and artifact behavior and update it only if implementation reveals a model clarification need. (FR-001 through FR-008)
+- [ ] T039 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for the full unit suite and fix any regressions. (FR-001 through FR-009)
+- [ ] T040 Run `./tools/test_integration.sh` for the required hermetic integration suite and fix any regressions. (SCN-001 through SCN-006)
+- [ ] T041 Run the quickstart validation steps in `specs/323-publish-remediation-audit/quickstart.md` and record any deviations in final verification evidence. (SC-001 through SC-006)
+- [ ] T042 Run `/speckit.verify` to validate the final implementation against MM-623, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, and required tests. (FR-009, SC-006)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; start immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks story test and implementation work.
+- **Story (Phase 3)**: Depends on Phase 2; tests must be written and red-first confirmed before production implementation.
+- **Polish (Phase 4)**: Depends on the story being functionally complete with focused unit and integration tests passing.
+
+### Within The Story
+
+- T007 through T012 must be authored before T013.
+- T014 through T018 must be authored before T019.
+- T020 and T021 must complete before T022 through T033.
+- T022 through T024 are conditional fallback tasks for implemented-unverified rows and should be skipped only when verification tests pass without production changes.
+- T025 through T033 are production implementation tasks for missing and partial rows.
+- T034 through T036 validate the complete story before polish work.
+- T042 runs only after implementation and required tests pass.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001.
+- T004 and T005 can run in parallel after T003 because they update different test files.
+- T007 through T012 are logically parallel test-authoring tasks, but they all edit `tests/unit/workflows/temporal/test_remediation_context.py`; coordinate carefully if multiple agents work on them.
+- T014 through T018 are logically parallel scenario tasks, but they all edit `tests/integration/temporal/test_remediation_action_contracts.py`; coordinate carefully if multiple agents work on them.
+- T028 and T030 can run in parallel after red-first confirmation because they build different domain helpers in the same module only with careful coordination; otherwise run sequentially.
+- T037 and T038 can run in parallel after story validation.
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and foundational fixture tasks.
+2. Add unit tests and integration tests for missing and partial rows first.
+3. Run focused unit and integration tests to confirm red-first failures.
+4. Run verification-first tests for implemented-unverified summary and presentation rows; skip fallback implementation only if those tests pass.
+5. Implement evidence-set completion, decision logs, queryable audit persistence, and target-side annotations.
+6. Re-run focused tests, then full unit and hermetic integration suites.
+7. Preserve `MM-623` and source IDs across all final artifacts.
+8. Run `/speckit.verify` after implementation and tests pass.
+
+### Coverage Mapping
+
+- Code-and-test completion: FR-001, FR-003, FR-005, FR-006, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, SC-001, SC-002, SC-004, DESIGN-REQ-022, DESIGN-REQ-023.
+- Verification-first with conditional fallback: FR-004, FR-008, SCN-005, SCN-006, SC-003, SC-005, DESIGN-REQ-028.
+- Already verified, preserve in final validation: FR-002, FR-009, SC-006.
+
+## Notes
+
+- The task list covers one story only: Review Remediation Evidence.
+- Do not generate broad remediation backlog tasks outside MM-623.
+- Do not create compatibility aliases for internal remediation contracts; update live callers and tests together if contracts change.
+- Keep large artifact bodies out of workflow history; pass refs and compact metadata through workflow/activity boundaries.
+- Secret-like values, raw local paths, raw storage keys, presigned URLs, cookies, and auth headers must not appear in artifacts, metadata, logs, audit records, PR text, or final verification evidence.

--- a/specs/323-publish-remediation-audit/tasks.md
+++ b/specs/323-publish-remediation-audit/tasks.md
@@ -38,8 +38,8 @@
 
 **CRITICAL**: No production implementation work can begin until this phase is complete.
 
-- [ ] T004 Add or update shared remediation evidence fixture helpers in `tests/unit/workflows/temporal/test_remediation_context.py` for diagnosis-only, action-attempted, skipped, denied, escalated, degraded, and no-PR cases. (FR-001, FR-003, FR-007, DESIGN-REQ-022, DESIGN-REQ-023)
-- [ ] T005 Add or update integration fixture helpers in `tests/integration/temporal/test_remediation_action_contracts.py` for querying remediation artifacts, audit records, target-side annotations, and target-native artifacts by workflow/run identity. (FR-005, FR-006, SCN-003, SCN-004)
+- [ ] T004 [P] Add or update shared remediation evidence fixture helpers in `tests/unit/workflows/temporal/test_remediation_context.py` for diagnosis-only, action-attempted, skipped, denied, escalated, degraded, and no-PR cases. (FR-001, FR-003, FR-007, DESIGN-REQ-022, DESIGN-REQ-023)
+- [ ] T005 [P] Add or update integration fixture helpers in `tests/integration/temporal/test_remediation_action_contracts.py` for querying remediation artifacts, audit records, target-side annotations, and target-native artifacts by workflow/run identity. (FR-005, FR-006, SCN-003, SCN-004)
 - [ ] T006 Confirm the remediation audit evidence contract in `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` matches the current test fixture shapes before adding red tests. (FR-005, FR-006, DESIGN-REQ-023)
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
@@ -63,26 +63,26 @@
 
 > Write these tests FIRST. Run them and confirm missing/partial behavior fails for the expected reason before production implementation.
 
-- [ ] T007 [P] Add failing unit tests for applicable artifact set and non-applicable artifact reasons in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-022)
-- [ ] T008 [P] Add failing unit tests for decision log attempted, skipped, denied, escalated, prevention, verification-ref, and no-PR reason entries in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
-- [ ] T009 [P] Add verification-first unit tests for the full remediation summary field set across repaired, no-action, degraded, unsafe, and escalated outcomes in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-004, FR-007, SC-003, DESIGN-REQ-028)
-- [ ] T010 [P] Add failing unit tests for queryable remediation audit event persistence payload validation, redaction, timestamp normalization, and idempotency key behavior in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-005, SC-002, DESIGN-REQ-023)
-- [ ] T011 [P] Add failing unit tests for target-side remediation annotation payload validation, safe artifact refs, supplemental semantics, and retry-safe identity in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
-- [ ] T012 [P] Add verification-first unit tests proving remediation artifact metadata and default presentation payloads reject raw URLs, local paths, storage keys, tokens, and secret-like values in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-008, SC-005, DESIGN-REQ-022)
+- [ ] T007 Add failing unit tests for applicable artifact set and non-applicable artifact reasons in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-022)
+- [ ] T008 Add failing unit tests for decision log attempted, skipped, denied, escalated, prevention, verification-ref, and no-PR reason entries in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
+- [ ] T009 Add verification-first unit tests for the full remediation summary field set across repaired, no-action, degraded, unsafe, and escalated outcomes in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-004, FR-007, SC-003, DESIGN-REQ-028)
+- [ ] T010 Add failing unit tests for queryable remediation audit event persistence payload validation, redaction, timestamp normalization, and idempotency key behavior in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-005, SC-002, DESIGN-REQ-023)
+- [ ] T011 Add failing unit tests for target-side remediation annotation payload validation, safe artifact refs, supplemental semantics, and retry-safe identity in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
+- [ ] T012 Add verification-first unit tests proving remediation artifact metadata and default presentation payloads reject raw URLs, local paths, storage keys, tokens, and secret-like values in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-008, SC-005, DESIGN-REQ-022)
 - [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and confirm T007, T008, T010, and T011 fail for missing/partial behavior while T009 and T012 establish verification evidence or expose gaps. (FR-001, FR-003, FR-004, FR-005, FR-006, FR-008)
 
 ### Integration Tests (write first) ⚠️
 
-- [ ] T014 [P] Add failing integration test for a diagnosis-only remediation run publishing applicable artifacts, bounded non-applicable action evidence, decision log, and summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-001, FR-001, FR-003, FR-007, SC-001)
-- [ ] T015 [P] Add failing integration test for side-effecting action execution publishing action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-003, SCN-004, FR-005, FR-006, DESIGN-REQ-023)
-- [ ] T016 [P] Add failing integration test for skipped, denied, escalated, prevention, and no-PR decision evidence remaining bounded and linked from the final summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-002, FR-003, FR-007, SC-004)
-- [ ] T017 [P] Add verification-first integration test for degraded and escalated remediation summaries exposing stable fields and bounded degraded reasons in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-005, FR-004, FR-007, DESIGN-REQ-028)
-- [ ] T018 [P] Add verification-first integration test for remediation artifact metadata and preview/default-read safety in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-006, FR-008, SC-005, DESIGN-REQ-022)
+- [ ] T014 Add failing integration test for a diagnosis-only remediation run publishing applicable artifacts, bounded non-applicable action evidence, decision log, and summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-001, FR-001, FR-003, FR-007, SC-001)
+- [ ] T015 Add failing integration test for side-effecting action execution publishing action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-003, SCN-004, FR-005, FR-006, DESIGN-REQ-023)
+- [ ] T016 Add failing integration test for skipped, denied, escalated, prevention, and no-PR decision evidence remaining bounded and linked from the final summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-002, FR-003, FR-007, SC-004)
+- [ ] T017 Add verification-first integration test for degraded and escalated remediation summaries exposing stable fields and bounded degraded reasons in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-005, FR-004, FR-007, DESIGN-REQ-028)
+- [ ] T018 Add verification-first integration test for remediation artifact metadata and preview/default-read safety in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-006, FR-008, SC-005, DESIGN-REQ-022)
 - [ ] T019 Run `./tools/test_integration.sh` and confirm T014, T015, and T016 fail for missing/partial behavior while T017 and T018 establish verification evidence or expose gaps. (SCN-001 through SCN-006)
 
 ### Red-First Confirmation
 
-- [ ] T020 Record the expected red-first failures from T013 and T019 in `specs/323-publish-remediation-audit/tasks.md` implementation notes before modifying production code. (FR-001, FR-003, FR-005, FR-006, FR-007)
+- [ ] T020 Confirm and summarize the expected red-first failures from T013 and T019 for `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` before modifying production code. (FR-001, FR-003, FR-005, FR-006, FR-007)
 - [ ] T021 Confirm no implementation tasks are started before missing/partial unit and integration tests fail for the intended reason in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py`. (FR-001, FR-003, FR-005, FR-006, DESIGN-REQ-022, DESIGN-REQ-023)
 
 ### Conditional Fallback Implementation for Implemented-Unverified Rows
@@ -117,8 +117,8 @@
 
 **Purpose**: Strengthen the completed story without expanding beyond MM-623.
 
-- [ ] T037 Review `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` against implemented behavior and update it only if implementation reveals a contract clarification need. (FR-005, FR-006, DESIGN-REQ-023)
-- [ ] T038 Review `specs/323-publish-remediation-audit/data-model.md` against implemented persistence and artifact behavior and update it only if implementation reveals a model clarification need. (FR-001 through FR-008)
+- [ ] T037 [P] Review `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` against implemented behavior and update it only if implementation reveals a contract clarification need. (FR-005, FR-006, DESIGN-REQ-023)
+- [ ] T038 [P] Review `specs/323-publish-remediation-audit/data-model.md` against implemented persistence and artifact behavior and update it only if implementation reveals a model clarification need. (FR-001 through FR-008)
 - [ ] T039 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for the full unit suite and fix any regressions. (FR-001 through FR-009)
 - [ ] T040 Run `./tools/test_integration.sh` for the required hermetic integration suite and fix any regressions. (SCN-001 through SCN-006)
 - [ ] T041 Run the quickstart validation steps in `specs/323-publish-remediation-audit/quickstart.md` and record any deviations in final verification evidence. (SC-001 through SC-006)
@@ -149,8 +149,8 @@
 
 - T002 and T003 can run in parallel after T001.
 - T004 and T005 can run in parallel after T003 because they update different test files.
-- T007 through T012 are logically parallel test-authoring tasks, but they all edit `tests/unit/workflows/temporal/test_remediation_context.py`; coordinate carefully if multiple agents work on them.
-- T014 through T018 are logically parallel scenario tasks, but they all edit `tests/integration/temporal/test_remediation_action_contracts.py`; coordinate carefully if multiple agents work on them.
+- T007 through T012 are ordered unit-test authoring tasks because they all edit `tests/unit/workflows/temporal/test_remediation_context.py`.
+- T014 through T018 are ordered integration-test authoring tasks because they all edit `tests/integration/temporal/test_remediation_action_contracts.py`.
 - T028 and T030 can run in parallel after red-first confirmation because they build different domain helpers in the same module only with careful coordination; otherwise run sequentially.
 - T037 and T038 can run in parallel after story validation.
 

--- a/specs/323-publish-remediation-audit/tasks.md
+++ b/specs/323-publish-remediation-audit/tasks.md
@@ -26,9 +26,9 @@
 
 **Purpose**: Confirm feature artifacts and existing remediation test surfaces before story work begins.
 
-- [ ] T001 Review `specs/323-publish-remediation-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, and `quickstart.md` for MM-623 traceability and one-story scope. (FR-009, SC-006)
-- [ ] T002 Inspect existing remediation helper and publisher surfaces in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_tools.py`, and `moonmind/workflows/temporal/remediation_actions.py` before editing. (FR-001 through FR-008)
-- [ ] T003 Inspect existing remediation unit and integration coverage in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` to avoid duplicate fixtures. (FR-001 through FR-008)
+- [X] T001 Review `specs/323-publish-remediation-audit/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, and `quickstart.md` for MM-623 traceability and one-story scope. (FR-009, SC-006)
+- [X] T002 Inspect existing remediation helper and publisher surfaces in `moonmind/workflows/temporal/remediation_context.py`, `moonmind/workflows/temporal/remediation_tools.py`, and `moonmind/workflows/temporal/remediation_actions.py` before editing. (FR-001 through FR-008)
+- [X] T003 Inspect existing remediation unit and integration coverage in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` to avoid duplicate fixtures. (FR-001 through FR-008)
 
 ---
 
@@ -38,9 +38,9 @@
 
 **CRITICAL**: No production implementation work can begin until this phase is complete.
 
-- [ ] T004 [P] Add or update shared remediation evidence fixture helpers in `tests/unit/workflows/temporal/test_remediation_context.py` for diagnosis-only, action-attempted, skipped, denied, escalated, degraded, and no-PR cases. (FR-001, FR-003, FR-007, DESIGN-REQ-022, DESIGN-REQ-023)
-- [ ] T005 [P] Add or update integration fixture helpers in `tests/integration/temporal/test_remediation_action_contracts.py` for querying remediation artifacts, audit records, target-side annotations, and target-native artifacts by workflow/run identity. (FR-005, FR-006, SCN-003, SCN-004)
-- [ ] T006 Confirm the remediation audit evidence contract in `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` matches the current test fixture shapes before adding red tests. (FR-005, FR-006, DESIGN-REQ-023)
+- [X] T004 [P] Add or update shared remediation evidence fixture helpers in `tests/unit/workflows/temporal/test_remediation_context.py` for diagnosis-only, action-attempted, skipped, denied, escalated, degraded, and no-PR cases. (FR-001, FR-003, FR-007, DESIGN-REQ-022, DESIGN-REQ-023)
+- [X] T005 [P] Add or update integration fixture helpers in `tests/integration/temporal/test_remediation_action_contracts.py` for querying remediation artifacts, audit records, target-side annotations, and target-native artifacts by workflow/run identity. (FR-005, FR-006, SCN-003, SCN-004)
+- [X] T006 Confirm the remediation audit evidence contract in `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` matches the current test fixture shapes before adding red tests. (FR-005, FR-006, DESIGN-REQ-023)
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -63,18 +63,18 @@
 
 > Write these tests FIRST. Run them and confirm missing/partial behavior fails for the expected reason before production implementation.
 
-- [ ] T007 Add failing unit tests for applicable artifact set and non-applicable artifact reasons in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-022)
-- [ ] T008 Add failing unit tests for decision log attempted, skipped, denied, escalated, prevention, verification-ref, and no-PR reason entries in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
-- [ ] T009 Add verification-first unit tests for the full remediation summary field set across repaired, no-action, degraded, unsafe, and escalated outcomes in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-004, FR-007, SC-003, DESIGN-REQ-028)
-- [ ] T010 Add failing unit tests for queryable remediation audit event persistence payload validation, redaction, timestamp normalization, and idempotency key behavior in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-005, SC-002, DESIGN-REQ-023)
-- [ ] T011 Add failing unit tests for target-side remediation annotation payload validation, safe artifact refs, supplemental semantics, and retry-safe identity in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
-- [ ] T012 Add verification-first unit tests proving remediation artifact metadata and default presentation payloads reject raw URLs, local paths, storage keys, tokens, and secret-like values in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-008, SC-005, DESIGN-REQ-022)
-- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and confirm T007, T008, T010, and T011 fail for missing/partial behavior while T009 and T012 establish verification evidence or expose gaps. (FR-001, FR-003, FR-004, FR-005, FR-006, FR-008)
+- [X] T007 Add failing unit tests for applicable artifact set and non-applicable artifact reasons in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-001, FR-002, FR-007, SC-001, DESIGN-REQ-022)
+- [X] T008 Add failing unit tests for decision log attempted, skipped, denied, escalated, prevention, verification-ref, and no-PR reason entries in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
+- [X] T009 Add verification-first unit tests for the full remediation summary field set across repaired, no-action, degraded, unsafe, and escalated outcomes in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-004, FR-007, SC-003, DESIGN-REQ-028)
+- [X] T010 Add failing unit tests for queryable remediation audit event persistence payload validation, redaction, timestamp normalization, and idempotency key behavior in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-005, SC-002, DESIGN-REQ-023)
+- [X] T011 Add failing unit tests for target-side remediation annotation payload validation, safe artifact refs, supplemental semantics, and retry-safe identity in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
+- [X] T012 Add verification-first unit tests proving remediation artifact metadata and default presentation payloads reject raw URLs, local paths, storage keys, tokens, and secret-like values in `tests/unit/workflows/temporal/test_remediation_context.py`. (FR-008, SC-005, DESIGN-REQ-022)
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and confirm T007, T008, T010, and T011 fail for missing/partial behavior while T009 and T012 establish verification evidence or expose gaps. (FR-001, FR-003, FR-004, FR-005, FR-006, FR-008)
 
 ### Integration Tests (write first) ⚠️
 
 - [ ] T014 Add failing integration test for a diagnosis-only remediation run publishing applicable artifacts, bounded non-applicable action evidence, decision log, and summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-001, FR-001, FR-003, FR-007, SC-001)
-- [ ] T015 Add failing integration test for side-effecting action execution publishing action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-003, SCN-004, FR-005, FR-006, DESIGN-REQ-023)
+- [X] T015 Add failing integration test for side-effecting action execution publishing action request, action result, verification, decision log, summary, queryable audit event, and target-side annotation evidence in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-003, SCN-004, FR-005, FR-006, DESIGN-REQ-023)
 - [ ] T016 Add failing integration test for skipped, denied, escalated, prevention, and no-PR decision evidence remaining bounded and linked from the final summary in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-002, FR-003, FR-007, SC-004)
 - [ ] T017 Add verification-first integration test for degraded and escalated remediation summaries exposing stable fields and bounded degraded reasons in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-005, FR-004, FR-007, DESIGN-REQ-028)
 - [ ] T018 Add verification-first integration test for remediation artifact metadata and preview/default-read safety in `tests/integration/temporal/test_remediation_action_contracts.py`. (SCN-006, FR-008, SC-005, DESIGN-REQ-022)
@@ -82,7 +82,7 @@
 
 ### Red-First Confirmation
 
-- [ ] T020 Confirm and summarize the expected red-first failures from T013 and T019 for `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` before modifying production code. (FR-001, FR-003, FR-005, FR-006, FR-007)
+- [X] T020 Confirm and summarize the expected red-first failures from T013 and T019 for `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py` before modifying production code. (FR-001, FR-003, FR-005, FR-006, FR-007)
 - [ ] T021 Confirm no implementation tasks are started before missing/partial unit and integration tests fail for the intended reason in `tests/unit/workflows/temporal/test_remediation_context.py` and `tests/integration/temporal/test_remediation_action_contracts.py`. (FR-001, FR-003, FR-005, FR-006, DESIGN-REQ-022, DESIGN-REQ-023)
 
 ### Conditional Fallback Implementation for Implemented-Unverified Rows
@@ -93,21 +93,21 @@
 
 ### Implementation
 
-- [ ] T025 Implement path-aware remediation evidence-set helpers and non-applicable artifact reason serialization in `moonmind/workflows/temporal/remediation_context.py`. (FR-001, FR-007, SC-001, DESIGN-REQ-022)
+- [X] T025 Implement path-aware remediation evidence-set helpers and non-applicable artifact reason serialization in `moonmind/workflows/temporal/remediation_context.py`. (FR-001, FR-007, SC-001, DESIGN-REQ-022)
 - [ ] T026 Update lifecycle publication in `moonmind/workflows/temporal/remediation_tools.py` so diagnosis-only, action-attempted, degraded, and escalated paths publish all applicable remediation evidence artifacts. (FR-001, FR-003, FR-007, SCN-001, SCN-002)
-- [ ] T027 Complete bounded decision-log outcome support in `moonmind/workflows/temporal/remediation_context.py` for attempted, skipped, denied, escalated, prevention, verification, and no-PR reasons. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
-- [ ] T028 Implement compact queryable remediation audit event persistence and lookup support in `moonmind/workflows/temporal/remediation_context.py`, reusing existing control-event or artifact-backed persistence patterns where feasible. (FR-005, SC-002, DESIGN-REQ-023)
-- [ ] T029 Wire side-effecting action audit event publication from `RemediationEvidenceToolService.execute_action()` in `moonmind/workflows/temporal/remediation_tools.py`. (FR-005, SCN-003, DESIGN-REQ-023)
-- [ ] T030 Implement target-side remediation annotation payload construction in `moonmind/workflows/temporal/remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
-- [ ] T031 Wire target-side remediation annotation publication from side-effecting action execution in `moonmind/workflows/temporal/remediation_tools.py` without replacing target-native artifacts. (FR-006, SCN-004, DESIGN-REQ-023)
-- [ ] T032 Add any required API or service query support for compact remediation audit records in `api_service/api/routers/task_runs.py` or an existing remediation-related service file, only if artifact/control-event querying is not already sufficient. (FR-005, SC-002)
-- [ ] T033 Preserve existing remediation artifact classification behavior in `moonmind/workflows/temporal/remediation_context.py` while adding new audit or annotation evidence. (FR-002, FR-009, DESIGN-REQ-022)
+- [X] T027 Complete bounded decision-log outcome support in `moonmind/workflows/temporal/remediation_context.py` for attempted, skipped, denied, escalated, prevention, verification, and no-PR reasons. (FR-003, FR-007, SC-004, DESIGN-REQ-023)
+- [X] T028 Implement compact queryable remediation audit event persistence and lookup support in `moonmind/workflows/temporal/remediation_context.py`, reusing existing control-event or artifact-backed persistence patterns where feasible. (FR-005, SC-002, DESIGN-REQ-023)
+- [X] T029 Wire side-effecting action audit event publication from `RemediationEvidenceToolService.execute_action()` in `moonmind/workflows/temporal/remediation_tools.py`. (FR-005, SCN-003, DESIGN-REQ-023)
+- [X] T030 Implement target-side remediation annotation payload construction in `moonmind/workflows/temporal/remediation_context.py`. (FR-006, SCN-004, DESIGN-REQ-023)
+- [X] T031 Wire target-side remediation annotation publication from side-effecting action execution in `moonmind/workflows/temporal/remediation_tools.py` without replacing target-native artifacts. (FR-006, SCN-004, DESIGN-REQ-023)
+- [X] T032 Add any required API or service query support for compact remediation audit records in `api_service/api/routers/task_runs.py` or an existing remediation-related service file, only if artifact/control-event querying is not already sufficient. (FR-005, SC-002)
+- [X] T033 Preserve existing remediation artifact classification behavior in `moonmind/workflows/temporal/remediation_context.py` while adding new audit or annotation evidence. (FR-002, FR-009, DESIGN-REQ-022)
 
 ### Story Validation
 
-- [ ] T034 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and fix failures in `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py`. (FR-001 through FR-008)
+- [X] T034 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` and fix failures in `moonmind/workflows/temporal/remediation_context.py` and `moonmind/workflows/temporal/remediation_tools.py`. (FR-001 through FR-008)
 - [ ] T035 Run `./tools/test_integration.sh` and fix failures in remediation evidence, audit, and annotation paths. (SCN-001 through SCN-006)
-- [ ] T036 Run `rg -n "MM-623|DESIGN-REQ-022|DESIGN-REQ-023|DESIGN-REQ-028" specs/323-publish-remediation-audit` and confirm traceability remains present in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, `quickstart.md`, and `tasks.md`. (FR-009, SC-006)
+- [X] T036 Run `rg -n "MM-623|DESIGN-REQ-022|DESIGN-REQ-023|DESIGN-REQ-028" specs/323-publish-remediation-audit` and confirm traceability remains present in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-audit-evidence.md`, `quickstart.md`, and `tasks.md`. (FR-009, SC-006)
 
 **Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable.
 
@@ -117,9 +117,9 @@
 
 **Purpose**: Strengthen the completed story without expanding beyond MM-623.
 
-- [ ] T037 [P] Review `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` against implemented behavior and update it only if implementation reveals a contract clarification need. (FR-005, FR-006, DESIGN-REQ-023)
-- [ ] T038 [P] Review `specs/323-publish-remediation-audit/data-model.md` against implemented persistence and artifact behavior and update it only if implementation reveals a model clarification need. (FR-001 through FR-008)
-- [ ] T039 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for the full unit suite and fix any regressions. (FR-001 through FR-009)
+- [X] T037 [P] Review `specs/323-publish-remediation-audit/contracts/remediation-audit-evidence.md` against implemented behavior and update it only if implementation reveals a contract clarification need. (FR-005, FR-006, DESIGN-REQ-023)
+- [X] T038 [P] Review `specs/323-publish-remediation-audit/data-model.md` against implemented persistence and artifact behavior and update it only if implementation reveals a model clarification need. (FR-001 through FR-008)
+- [X] T039 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for the full unit suite and fix any regressions. (FR-001 through FR-009)
 - [ ] T040 Run `./tools/test_integration.sh` for the required hermetic integration suite and fix any regressions. (SCN-001 through SCN-006)
 - [ ] T041 Run the quickstart validation steps in `specs/323-publish-remediation-audit/quickstart.md` and record any deviations in final verification evidence. (SC-001 through SC-006)
 - [ ] T042 Run `/speckit.verify` to validate the final implementation against MM-623, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, and required tests. (FR-009, SC-006)
@@ -182,3 +182,5 @@
 - Do not create compatibility aliases for internal remediation contracts; update live callers and tests together if contracts change.
 - Keep large artifact bodies out of workflow history; pass refs and compact metadata through workflow/activity boundaries.
 - Secret-like values, raw local paths, raw storage keys, presigned URLs, cookies, and auth headers must not appear in artifacts, metadata, logs, audit records, PR text, or final verification evidence.
+- Implementation evidence: unit red-first failed with missing `build_remediation_evidence_set`; integration red-first in a temporary HEAD worktree failed with missing `auditEvent`; focused unit, targeted integration, and full unit reruns passed after implementation.
+- Environment limitation: `./tools/test_integration.sh` could not complete in this managed container because Docker build access returned 403 Forbidden.

--- a/tests/integration/temporal/test_remediation_action_contracts.py
+++ b/tests/integration/temporal/test_remediation_action_contracts.py
@@ -104,6 +104,12 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
         verification_payload = await _read_artifact_json(
             artifact_service, result["artifactRefs"]["verification"]
         )
+        audit_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["auditEvent"]
+        )
+        annotation_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["targetAnnotation"]
+        )
 
         assert request_payload["schemaVersion"] == "v1"
         assert request_payload["actionKind"] == action_kind
@@ -117,6 +123,36 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
         assert result_payload["verificationHint"]
         assert verification_payload["actionKind"] == action_kind
         assert verification_payload["actionId"] == action_id
+        assert audit_payload["eventType"] == "remediation.action"
+        assert audit_payload["remediationWorkflowId"] == remediation.workflow_id
+        assert audit_payload["targetWorkflowId"] == target.workflow_id
+        assert audit_payload["actionKind"] == action_kind
+        assert annotation_payload["kind"] == "remediation.target_annotation"
+        assert annotation_payload["targetWorkflowId"] == target.workflow_id
+        assert annotation_payload["remediationWorkflowId"] == remediation.workflow_id
+        assert (
+            annotation_payload["artifactRefs"]["actionRequest"]
+            == result["artifactRefs"]["actionRequest"]
+        )
+
+        audit_links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == remediation.workflow_id,
+                    TemporalArtifactLink.link_type == "remediation.audit_event",
+                )
+            )
+        ).scalars().all()
+        target_annotation_links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == target.workflow_id,
+                    TemporalArtifactLink.link_type == "remediation.target_annotation",
+                )
+            )
+        ).scalars().all()
+        assert len(audit_links) == 1
+        assert len(target_annotation_links) == 1
 
 
 async def test_remediation_raw_action_rejection_does_not_publish_side_effect_artifacts(

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -1251,6 +1251,19 @@ def test_remediation_evidence_set_records_non_applicable_artifacts_safely():
     assert "/tmp/raw/path" not in json.dumps(evidence, sort_keys=True)
 
 
+def test_remediation_evidence_set_accepts_none_non_applicable_artifacts():
+    evidence = build_remediation_evidence_set(
+        remediation_workflow_id="remediation-workflow",
+        remediation_run_id="remediation-run",
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        artifacts={},
+        non_applicable_artifacts=None,
+    )
+
+    assert evidence["nonApplicableArtifacts"] == []
+
+
 def test_remediation_target_annotation_is_bounded_and_supplemental():
     annotation = build_remediation_target_annotation(
         target_workflow_id="target-workflow",
@@ -2199,6 +2212,100 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
         assert link is not None
         assert link.latest_action_summary == action_kind
         assert link.outcome == "applied"
+
+
+@pytest.mark.asyncio
+async def test_remediation_execute_action_reuses_retry_artifacts(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+        )
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+
+        action_kind = "workload.restart_helper_container"
+        action_id = "execute-action-retry"
+        authority = await RemediationActionAuthorityService(
+            session=session
+        ).evaluate_action_request(
+            remediation_workflow_id=remediation.workflow_id,
+            action_kind=action_kind,
+            parameters={"reason": "restart helper"},
+            dry_run=False,
+            idempotency_key=action_id,
+            requesting_principal="workflow:remediator",
+            permissions=_admin_permissions(),
+            security_profile=_admin_profile(allowed_action_kinds=(action_kind,)),
+        )
+        guard = await RemediationMutationGuardService(session=session).evaluate(
+            remediation_workflow_id=remediation.workflow_id,
+            remediation_run_id=remediation.run_id,
+            target_workflow_id=target.workflow_id,
+            target_run_id=target.run_id,
+            action_kind=action_kind,
+            idempotency_key=action_id,
+            parameters={"reason": "restart helper"},
+            policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
+            now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+        )
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+            action_executor=RecordingActionExecutor(),
+        )
+
+        first = await tools.execute_action(
+            remediation_workflow_id=remediation.workflow_id,
+            authority_result=authority.to_dict(),
+            guard_result=guard.to_dict(),
+            principal="service:test",
+        )
+        second = await tools.execute_action(
+            remediation_workflow_id=remediation.workflow_id,
+            authority_result=authority.to_dict(),
+            guard_result=guard.to_dict(),
+            principal="service:test",
+        )
+
+        assert second["artifactRefs"] == first["artifactRefs"]
+        remediation_links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == remediation.workflow_id,
+                    TemporalArtifactLink.link_type.in_(
+                        [
+                            "remediation.action_request",
+                            "remediation.action_result",
+                            "remediation.verification",
+                            "remediation.audit_event",
+                            "remediation.target_annotation",
+                        ]
+                    ),
+                )
+            )
+        ).scalars().all()
+        target_links = (
+            await session.execute(
+                select(TemporalArtifactLink).where(
+                    TemporalArtifactLink.workflow_id == target.workflow_id,
+                    TemporalArtifactLink.link_type == "remediation.target_annotation",
+                )
+            )
+        ).scalars().all()
+
+        assert len(remediation_links) == 5
+        assert len(target_links) == 1
+
 
 @pytest.mark.asyncio
 async def test_remediation_execute_action_publishes_v1_request_and_result_artifacts(

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -34,12 +34,15 @@ from moonmind.workflows.temporal.remediation_context import (
     RemediationLifecyclePublisher,
     build_corrected_instruction_retry_provenance,
     build_remediation_decision_log,
+    build_remediation_evidence_set,
     build_remediation_audit_event,
     build_remediation_continue_as_new_state,
     build_remediation_final_summary,
+    build_non_applicable_remediation_artifact_reason,
     build_remediation_prevention_outcome,
     build_remediation_repair_decision,
     build_remediation_summary_block,
+    build_remediation_target_annotation,
     build_target_remediation_linkage_summary,
     normalize_remediation_phase,
     normalize_remediation_resolution,
@@ -1196,6 +1199,98 @@ def test_remediation_lifecycle_repair_prevention_and_decision_log_are_bounded():
     serialized = json.dumps(final_summary, sort_keys=True)
     assert "raw-secret" not in serialized
     assert "/tmp/raw/path" not in serialized
+
+
+def test_remediation_evidence_set_records_non_applicable_artifacts_safely():
+    reason = build_non_applicable_remediation_artifact_reason(
+        artifact_type="remediation.action_request",
+        reason="diagnosis_only",
+        metadata={
+            "safe": "value",
+            "token": "raw-secret",
+            "path": "/tmp/raw/path",
+        },
+    )
+    evidence = build_remediation_evidence_set(
+        remediation_workflow_id="remediation-workflow",
+        remediation_run_id="remediation-run",
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        artifacts={
+            "context": "art_context",
+            "decisionLog": "art_decision",
+            "summary": "art_summary",
+        },
+        non_applicable_artifacts=(reason,),
+        evidence_degraded=True,
+        degraded_reasons=("live_follow_unavailable", "token=raw-secret"),
+    )
+
+    assert evidence == {
+        "schemaVersion": "v1",
+        "remediationWorkflowId": "remediation-workflow",
+        "remediationRunId": "remediation-run",
+        "targetWorkflowId": "target-workflow",
+        "targetRunId": "target-run",
+        "artifacts": {
+            "context": "art_context",
+            "decisionLog": "art_decision",
+            "summary": "art_summary",
+        },
+        "nonApplicableArtifacts": [
+            {
+                "artifactType": "remediation.action_request",
+                "reason": "diagnosis_only",
+                "metadata": {"safe": "value"},
+            }
+        ],
+        "evidenceDegraded": True,
+        "degradedReasons": ["live_follow_unavailable"],
+    }
+    assert "raw-secret" not in json.dumps(evidence, sort_keys=True)
+    assert "/tmp/raw/path" not in json.dumps(evidence, sort_keys=True)
+
+
+def test_remediation_target_annotation_is_bounded_and_supplemental():
+    annotation = build_remediation_target_annotation(
+        target_workflow_id="target-workflow",
+        target_run_id="target-run",
+        remediation_workflow_id="remediation-workflow",
+        remediation_run_id="remediation-run",
+        action_kind="workload.restart_helper_container",
+        decision="attempted",
+        artifact_refs={
+            "actionRequest": "art_request",
+            "actionResult": "art_result",
+            "verification": "art_verification",
+        },
+        timestamp="2026-05-08T00:00:00Z",
+        metadata={
+            "nativeArtifactPolicy": "preserve",
+            "token": "raw-secret",
+            "path": "/tmp/raw/path",
+        },
+    )
+
+    assert annotation == {
+        "schemaVersion": "v1",
+        "kind": "remediation.target_annotation",
+        "targetWorkflowId": "target-workflow",
+        "targetRunId": "target-run",
+        "remediationWorkflowId": "remediation-workflow",
+        "remediationRunId": "remediation-run",
+        "actionKind": "workload.restart_helper_container",
+        "decision": "attempted",
+        "artifactRefs": {
+            "actionRequest": "art_request",
+            "actionResult": "art_result",
+            "verification": "art_verification",
+        },
+        "timestamp": "2026-05-08T00:00:00Z",
+        "metadata": {"nativeArtifactPolicy": "preserve"},
+    }
+    assert "raw-secret" not in json.dumps(annotation, sort_keys=True)
+    assert "/tmp/raw/path" not in json.dumps(annotation, sort_keys=True)
 
 def test_reviewable_prevention_pr_url_survives_final_summary_sanitization():
     repair = build_remediation_repair_decision(


### PR DESCRIPTION
## Summary

Publishes MM-623 remediation audit evidence support for side-effecting remediation actions, including compact audit events, target-side annotations, bounded evidence-set helpers, and MoonSpec artifact updates.

## Required Handoff Fields

- Jira issue key: MM-623
- Active MoonSpec feature path: `specs/323-publish-remediation-audit`
- Verification verdict: `ADDITIONAL_WORK_NEEDED` from `moonspec-verify` because the verify preflight found `.gemini/skills` as a skill projection symlink and the hermetic integration suite could not run in this environment.

## Tests Run

- Red-first unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` failed before implementation on missing `build_remediation_evidence_set`.
- Red-first integration: temporary HEAD worktree with integration test patch failed on missing `auditEvent`.
- Focused unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py` passed.
- Targeted integration via local runner: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/integration/temporal/test_remediation_action_contracts.py` passed.
- Full unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed: 4558 passed, 1 xpassed; frontend 20 files passed.
- Hygiene: `git diff --check` passed.

## Remaining Risks

- `./tools/test_integration.sh` did not complete in the managed container because Docker build access returned 403 Forbidden.
- `moonspec-verify` did not issue `FULLY_IMPLEMENTED`; it reported `ADDITIONAL_WORK_NEEDED` due checkout skill-projection contamination and missing full hermetic integration evidence.
- `tasks.md` keeps remaining integration/verify work open for diagnosis-only, degraded/preview-safety coverage, full integration, and final verify.
