### PR TITLE
MM-629 Persist authoritative task snapshots

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2493,27 +2493,6 @@ async def _load_execution_step_ledger(
         ) from exc
 
 
-def _has_reconstructable_task_parameters(record) -> bool:
-    parameters = dict(getattr(record, "parameters", None) or {})
-    task_payload = parameters.get("task")
-    if not isinstance(task_payload, Mapping):
-        return False
-    instructions = str(task_payload.get("instructions") or "").strip()
-    if instructions:
-        return True
-    steps = task_payload.get("steps")
-    if isinstance(steps, list) and any(
-        isinstance(item, Mapping)
-        and str(item.get("instructions") or "").strip()
-        for item in steps
-    ):
-        return True
-    return any(
-        task_payload.get(key)
-        for key in ("tool", "skill", "skills", "inputArtifactRef")
-    )
-
-
 def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
     raw_state = str(record.state.value).strip().lower()
     workflow_type_value = _enum_value(getattr(record, "workflow_type", None))
@@ -2583,13 +2562,10 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         _task_input_snapshot_ref_from_memo(dict(getattr(record, "memo", None) or {}))
     )
     has_resume_checkpoint = bool(_resume_checkpoint_ref_from_record(record))
-    has_task_parameter_fallback = _has_reconstructable_task_parameters(record)
     if workflow_type_value != "MoonMind.Run" or not temporal_task_editing_enabled:
         enabled = enabled - {"can_update_inputs", "can_edit_for_rerun", "can_rerun"}
     elif not has_task_input_snapshot:
-        enabled = enabled - {"can_update_inputs"}
-        if not has_task_parameter_fallback:
-            enabled = enabled - {"can_edit_for_rerun", "can_rerun"}
+        enabled = enabled - {"can_update_inputs", "can_edit_for_rerun", "can_rerun"}
     if (
         workflow_type_value == "MoonMind.Run"
         and temporal_task_editing_enabled
@@ -2642,7 +2618,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                 disabled_reasons[alias] = "original_task_input_snapshot_missing"
                 continue
             if field_name in {"can_edit_for_rerun", "can_rerun"}:
-                if not has_task_input_snapshot and not has_task_parameter_fallback:
+                if not has_task_input_snapshot:
                     disabled_reasons[alias] = "original_task_input_snapshot_missing"
                     continue
         disabled_reasons[alias] = "state_not_eligible"

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2562,9 +2562,11 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         _task_input_snapshot_ref_from_memo(dict(getattr(record, "memo", None) or {}))
     )
     has_resume_checkpoint = bool(_resume_checkpoint_ref_from_record(record))
-    if workflow_type_value != "MoonMind.Run" or not temporal_task_editing_enabled:
-        enabled = enabled - {"can_update_inputs", "can_edit_for_rerun", "can_rerun"}
-    elif not has_task_input_snapshot:
+    if (
+        workflow_type_value != "MoonMind.Run"
+        or not temporal_task_editing_enabled
+        or not has_task_input_snapshot
+    ):
         enabled = enabled - {"can_update_inputs", "can_edit_for_rerun", "can_rerun"}
     if (
         workflow_type_value == "MoonMind.Run"

--- a/specs/323-persist-task-snapshots/checklists/requirements.md
+++ b/specs/323-persist-task-snapshots/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Persist Authoritative Task Snapshots
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is classified as a single-story runtime feature request from the preserved MM-629 Jira preset brief.
+- PASS: No existing feature directory for MM-629 was found, so this specify artifact starts the MoonSpec lifecycle at the first incomplete stage.
+- PASS: Source design requirements from `docs/Tasks/TaskArchitecture.md` sections 3.4, 5.5, 7, and 11 are mapped to functional requirements.

--- a/specs/323-persist-task-snapshots/contracts/execution-reconstruction.md
+++ b/specs/323-persist-task-snapshots/contracts/execution-reconstruction.md
@@ -1,0 +1,58 @@
+# Contract: Execution Reconstruction And Task Snapshot Actions
+
+## Execution Detail Response
+
+Execution detail responses expose task reconstruction state through `taskInputSnapshot`:
+
+```json
+{
+  "taskInputSnapshot": {
+    "available": true,
+    "artifactRef": "art_snapshot_1",
+    "snapshotVersion": 1,
+    "sourceKind": "create",
+    "reconstructionMode": "authoritative",
+    "disabledReasons": {},
+    "fallbackEvidenceRefs": []
+  },
+  "actions": {
+    "canEditForRerun": true,
+    "canRerun": true,
+    "canResumeFromFailedStep": false,
+    "disabledReasons": {}
+  }
+}
+```
+
+When the original task input snapshot is missing, edit and rerun actions are disabled even if execution parameters contain reconstructable-looking task text:
+
+```json
+{
+  "taskInputSnapshot": {
+    "available": false,
+    "artifactRef": null,
+    "snapshotVersion": null,
+    "sourceKind": "unknown",
+    "reconstructionMode": "degraded_read_only",
+    "disabledReasons": {
+      "draft": "original_task_input_snapshot_missing"
+    },
+    "fallbackEvidenceRefs": ["artifact://input/source"]
+  },
+  "actions": {
+    "canEditForRerun": false,
+    "canRerun": false,
+    "disabledReasons": {
+      "canEditForRerun": "original_task_input_snapshot_missing",
+      "canRerun": "original_task_input_snapshot_missing"
+    }
+  }
+}
+```
+
+## Policy Rules
+
+- `taskInputSnapshot.reconstructionMode=authoritative` requires `taskInputSnapshot.artifactRef`.
+- `canEditForRerun` and `canRerun` require an authoritative task input snapshot.
+- `canResumeFromFailedStep` requires an authoritative task input snapshot and a resume checkpoint.
+- Parameter payloads, input artifacts, plan artifacts, logs, and projections are diagnostic evidence only when the original snapshot is missing.

--- a/specs/323-persist-task-snapshots/data-model.md
+++ b/specs/323-persist-task-snapshots/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: Persist Authoritative Task Snapshots
+
+## Task Input Snapshot
+
+- `snapshotVersion`: Required integer version for the snapshot payload.
+- `source.kind`: Required source classification such as `create`, `edit`, or `rerun`.
+- `source.sourceWorkflowId` / `source.sourceRunId`: Optional source identity for rerun-derived snapshots.
+- `draft.taskShape`: Required classification of the authored task shape.
+- `draft.repository`: Optional authored repository selection.
+- `draft.targetRuntime`: Optional authored runtime selection.
+- `draft.requiredCapabilities`: Authored capability selection.
+- `draft.task`: Required task-shaped authored payload, including objective text, steps, ordering, preset metadata, dependencies, and structured inputs.
+- `attachmentRefs`: Bounded attachment ref metadata associated with the snapshot.
+- `lineage`: Reserved compact provenance metadata.
+- `excluded`: Explicit non-editable creation-time controls.
+
+Validation rules:
+- An authoritative reconstruction descriptor requires an artifact ref.
+- Missing authoritative snapshot refs disable edit/rerun actions.
+- Snapshot payloads remain artifact-backed and are not embedded in workflow history.
+
+## Task Input Snapshot Descriptor
+
+- `available`: Whether an authoritative snapshot artifact ref exists.
+- `artifactRef`: Snapshot artifact ref when available.
+- `snapshotVersion`: Snapshot version when available.
+- `sourceKind`: Snapshot source kind when available.
+- `reconstructionMode`: `authoritative`, `degraded_read_only`, or `unavailable`.
+- `disabledReasons`: Operator-facing reason map when reconstruction is degraded or unavailable.
+- `fallbackEvidenceRefs`: Non-authoritative refs useful for diagnostics only.
+
+State transitions:
+- Missing snapshot plus fallback evidence -> `degraded_read_only`.
+- Missing snapshot without fallback evidence -> `unavailable`.
+- Present snapshot artifact ref -> `authoritative`.
+
+## Execution Action Capabilities
+
+- `canEditForRerun`: Enabled only for eligible terminal `MoonMind.Run` executions with an authoritative task input snapshot and task editing enabled.
+- `canRerun`: Enabled only for eligible terminal `MoonMind.Run` executions with an authoritative task input snapshot and task editing enabled.
+- `canResumeFromFailedStep`: Enabled only for failed `MoonMind.Run` executions with an authoritative task input snapshot and a resume checkpoint.
+- `disabledReasons`: Uses `original_task_input_snapshot_missing` when snapshot absence blocks edit, rerun, update inputs, or failed-step resume.

--- a/specs/323-persist-task-snapshots/moonspec_align_report.md
+++ b/specs/323-persist-task-snapshots/moonspec_align_report.md
@@ -5,7 +5,7 @@
 
 ## Result
 
-PASS. The MoonSpec artifacts are aligned after implementation.
+PASS. The MoonSpec artifacts are aligned after task generation, implementation, and verification.
 
 ## Checks
 
@@ -14,11 +14,15 @@ PASS. The MoonSpec artifacts are aligned after implementation.
 | Original input preservation | PASS | `spec.md` preserves MM-629 and the canonical Jira preset brief. |
 | Single-story scope | PASS | `spec.md` defines one user story: Authoritative Task Snapshot Reconstruction. |
 | Plan coverage | PASS | `plan.md` identifies the bounded action-capability fallback gap and existing snapshot/resume evidence. |
-| Task coverage | PASS | `tasks.md` maps FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-011 to setup, tests, implementation, and verification. |
+| Design artifact coverage | PASS | `data-model.md`, `contracts/execution-reconstruction.md`, `research.md`, and `quickstart.md` cover snapshot state, action capability policy, test strategy, and validation commands. |
+| Task coverage | PASS | `tasks.md` maps FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-011 to setup, red-first tests, implementation, validation, and `/moonspec-verify` evidence. |
 | Contract alignment | PASS | `contracts/execution-reconstruction.md` states edit/rerun require authoritative task snapshots and parameters are diagnostic only. |
 | Implementation alignment | PASS | `api_service/api/routers/executions.py` disables edit/rerun when `task_input_snapshot_ref` is missing. |
 | Test alignment | PASS | `tests/unit/api/routers/test_executions.py` covers parameter fallback rejection and existing snapshot-required behavior. |
+| Verification alignment | PASS | `verification.md` records `FULLY_IMPLEMENTED` with targeted and full unit-suite evidence. |
 
 ## Remediation
 
-No artifact drift requiring further remediation was found.
+- Updated `tasks.md` source traceability wording so the parameter fallback gap is described as the pre-implementation plan finding, with T005-T013 recording the completed remediation and verification.
+
+No downstream artifact regeneration is required.

--- a/specs/323-persist-task-snapshots/moonspec_align_report.md
+++ b/specs/323-persist-task-snapshots/moonspec_align_report.md
@@ -1,0 +1,24 @@
+# MoonSpec Align Report: Persist Authoritative Task Snapshots
+
+**Source**: MM-629 canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-08
+
+## Result
+
+PASS. The MoonSpec artifacts are aligned after implementation.
+
+## Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Original input preservation | PASS | `spec.md` preserves MM-629 and the canonical Jira preset brief. |
+| Single-story scope | PASS | `spec.md` defines one user story: Authoritative Task Snapshot Reconstruction. |
+| Plan coverage | PASS | `plan.md` identifies the bounded action-capability fallback gap and existing snapshot/resume evidence. |
+| Task coverage | PASS | `tasks.md` maps FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-011 to setup, tests, implementation, and verification. |
+| Contract alignment | PASS | `contracts/execution-reconstruction.md` states edit/rerun require authoritative task snapshots and parameters are diagnostic only. |
+| Implementation alignment | PASS | `api_service/api/routers/executions.py` disables edit/rerun when `task_input_snapshot_ref` is missing. |
+| Test alignment | PASS | `tests/unit/api/routers/test_executions.py` covers parameter fallback rejection and existing snapshot-required behavior. |
+
+## Remediation
+
+No artifact drift requiring further remediation was found.

--- a/specs/323-persist-task-snapshots/plan.md
+++ b/specs/323-persist-task-snapshots/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Persist Authoritative Task Snapshots
+
+**Branch**: `323-persist-task-snapshots` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime spec from MM-629 Jira preset brief.
+
+## Summary
+
+MoonMind already persists original task input snapshot artifacts for direct task submissions, rerun-created executions, and Jira Orchestrate child runs, and it exposes `taskInputSnapshot` status in execution detail responses. The remaining MM-629 delivery gap is that terminal edit/rerun actions still allow a parameter-derived fallback when `task_input_snapshot_ref` is missing. This plan removes that fallback for edit/rerun capability decisions so attachment-aware or preset-derived executions without an authoritative snapshot are explicitly degraded, while preserving existing snapshot creation, descriptor, rerun, and resume behavior.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `api_service/api/routers/executions.py` persists snapshot artifacts; `moonmind/workflows/temporal/worker_runtime.py` persists Jira Orchestrate child snapshots | add/confirm focused coverage for submitted task snapshot contents | unit |
+| FR-002 | partial | `_task_input_snapshot_descriptor_from_record()` exposes authoritative/degraded state, but `_build_action_capabilities()` permits parameter fallback for edit/full retry | remove parameter fallback from edit/rerun eligibility | unit |
+| FR-003 | implemented_unverified | `_create_fresh_rerun_execution()` carries source identity and parameters | retain existing behavior, verify no fallback enables rerun without snapshot | unit |
+| FR-004 | implemented_unverified | snapshot payload carries `attachmentRefs`; related attachment policy tests exist | confirm no silent action enablement when snapshot missing | unit |
+| FR-005 | implemented_unverified | snapshot stores full task payload and child task payloads with template metadata when present | preserve payload shape; no live catalog dependency introduced | unit |
+| FR-006 | partial | descriptor reports `degraded_read_only`, but actions may still allow edit/rerun from parameter fallback | make missing snapshot disable edit/rerun consistently | unit |
+| FR-007 | implemented_unverified | `create_failed_step_resume_execution()` requires source snapshot and checkpoint match | keep resume snapshot requirement intact | unit |
+| FR-008 | partial | `taskInputSnapshot` descriptor reports degraded/unavailable; actions reasons are inconsistent when fallback exists | align action disabled reasons with descriptor | unit |
+| FR-009 | missing | new spec exists and preserves MM-629 | preserve traceability through plan, tasks, implementation, and verification | review |
+| DESIGN-REQ-001..011 | partial | source behavior is mostly present; fallback gap conflicts with authoritative snapshot requirement | close fallback gap and verify boundary | unit + final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React present but not expected for this narrow boundary change.
+**Primary Dependencies**: FastAPI route models, Pydantic v2 schemas, SQLAlchemy async execution records, Temporal execution service models.
+**Storage**: Existing Temporal artifact metadata/content store and execution memo/artifact refs; no new persistent tables.
+**Unit Testing**: `./tools/test_unit.sh` with targeted pytest paths during iteration.
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration if broader behavior changes; not expected for this route/model boundary.
+**Target Platform**: MoonMind API service and Mission Control execution detail consumers.
+**Project Type**: Python backend with existing React frontend consumers.
+**Performance Goals**: No additional database or artifact reads in action capability serialization.
+**Constraints**: Do not mutate checked-in skills. Preserve Temporal payload compatibility. Keep large task bodies out of workflow history. Do not introduce compatibility aliases for internal contracts.
+**Scale/Scope**: One execution detail/action capability boundary and its tests.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The change preserves MoonMind orchestration boundaries and does not alter agent cognition.
+- II. One-Click Agent Deployment: PASS. No new deployment dependency.
+- III. Avoid Vendor Lock-In: PASS. No vendor-specific coupling.
+- IV. Own Your Data: PASS. Snapshot artifacts remain MoonMind-owned data.
+- V. Skills Are First-Class: PASS. No skill runtime mutation.
+- VI. Replaceable Scaffolding: PASS. The change tightens contract behavior behind existing route/model boundaries.
+- VII. Runtime Configurability: PASS. Existing task editing feature flag behavior remains.
+- VIII. Modular Architecture: PASS. Work stays in API serialization/action capability logic and tests.
+- IX. Resilient by Default: PASS. Missing authoritative data fails explicitly instead of synthesizing unsafe recovery state.
+- X. Continuous Improvement: PASS. Verification evidence will be captured in MoonSpec artifacts.
+- XI. Spec-Driven Development: PASS. Spec, plan, tasks, implementation, and verification are traceable to MM-629.
+- XII. Canonical Docs vs Tmp: PASS. Runtime implementation notes live under `specs/323-persist-task-snapshots/`; canonical docs are read-only sources.
+- XIII. Pre-release Compatibility: PASS. Removes fallback behavior rather than adding compatibility aliases.
+
+## Project Structure
+
+```text
+api_service/api/routers/executions.py        # execution detail serialization and action capability policy
+tests/unit/api/routers/test_executions.py    # API route/action capability unit coverage
+moonmind/schemas/temporal_models.py          # taskInputSnapshot descriptor model
+moonmind/workflows/temporal/service.py       # rerun/resume execution creation boundaries
+moonmind/workflows/temporal/worker_runtime.py# Jira Orchestrate child snapshot persistence
+specs/323-persist-task-snapshots/            # MoonSpec artifacts for MM-629
+```
+
+## Complexity Tracking
+
+No constitution violations or extra complexity accepted.

--- a/specs/323-persist-task-snapshots/quickstart.md
+++ b/specs/323-persist-task-snapshots/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Persist Authoritative Task Snapshots
+
+## Test-First Validation
+
+1. Run the focused API action capability tests:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/api/routers/test_executions.py
+   ```
+
+2. Confirm terminal `MoonMind.Run` executions without `task_input_snapshot_ref` disable edit/rerun actions even when task parameters include instructions or steps.
+
+3. Confirm terminal executions with `task_input_snapshot_ref` still expose edit/rerun actions when the task editing feature flag is enabled.
+
+4. Confirm failed-step resume remains gated on both `task_input_snapshot_ref` and `resume_checkpoint_ref`.
+
+## Final Verification
+
+Run the required unit suite before closing the story:
+
+```bash
+./tools/test_unit.sh
+```
+
+Run hermetic integration only if implementation expands beyond API serialization/action capability logic:
+
+```bash
+./tools/test_integration.sh
+```

--- a/specs/323-persist-task-snapshots/research.md
+++ b/specs/323-persist-task-snapshots/research.md
@@ -1,0 +1,33 @@
+# Research: Persist Authoritative Task Snapshots
+
+## Snapshot Persistence Boundary
+
+Decision: Treat existing original task input snapshot artifact persistence as the authoritative storage path and keep this story focused on enforcing its use.
+Evidence: `api_service/api/routers/executions.py` builds and persists `OriginalTaskInputSnapshot`; `moonmind/workflows/temporal/worker_runtime.py` persists child `MoonMind.Run` snapshots for Jira Orchestrate.
+Rationale: The current code already writes compact artifact refs and records them in execution memo/artifact refs, matching the source design's artifact-backed durability model.
+Alternatives considered: Adding a new database table was rejected because the spec and current implementation already use artifact-backed snapshots.
+Test implications: Unit tests should verify snapshot-dependent action behavior; existing snapshot creation tests remain relevant.
+
+## Edit And Rerun Reconstruction Policy
+
+Decision: Remove parameter-derived fallback as an eligibility path for terminal edit/rerun actions when the authoritative task input snapshot is missing.
+Evidence: `_build_action_capabilities()` currently computes `has_task_parameter_fallback` and allows `canEditForRerun`/`canRerun` without `task_input_snapshot_ref` when task parameters contain instructions or tool data.
+Rationale: MM-629 explicitly requires edit, rerun, full retry, and resume reconstruction to use durable snapshots rather than lossy projections, and attachment-aware executions without reconstructible snapshots must be degraded explicitly.
+Alternatives considered: Keeping fallback for text-only tasks was rejected because the spec requires the authored task snapshot as the authority for preset provenance, ordering, and dependencies, not just attachment refs.
+Test implications: Update unit coverage so terminal executions without snapshots disable edit/rerun even if parameters look reconstructable.
+
+## Resume Snapshot Requirement
+
+Decision: Preserve the existing failed-step resume requirement that source executions have a task input snapshot ref and matching resume checkpoint payload.
+Evidence: `TemporalExecutionService.create_failed_step_resume_execution()` raises when `task_input_snapshot_ref` is missing and validates checkpoint `taskInputSnapshotRef` against the source memo.
+Rationale: This already satisfies MM-629's requirement that Resume uses original inputs unchanged and cannot become an edit flow.
+Alternatives considered: No change needed.
+Test implications: Existing unit tests cover required snapshot and checkpoint mismatches; final verification should cite them.
+
+## Operator Evidence Surface
+
+Decision: Keep `taskInputSnapshot` descriptor as the operator-visible source for authoritative, degraded, and unavailable reconstruction state, and align action disabled reasons with it.
+Evidence: `_task_input_snapshot_descriptor_from_record()` returns `authoritative` when an artifact ref exists and `degraded_read_only` with fallback evidence refs when only input/plan refs exist.
+Rationale: This gives operators bounded evidence without loading large artifact bodies while preventing unsafe edit/rerun entrypoints.
+Alternatives considered: Hydrating artifacts during action serialization was rejected for performance and authorization complexity.
+Test implications: Existing descriptor tests plus updated action tests are sufficient for this boundary.

--- a/specs/323-persist-task-snapshots/spec.md
+++ b/specs/323-persist-task-snapshots/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Persist Authoritative Task Snapshots
+
+**Feature Branch**: `323-persist-task-snapshots`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-629 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): docs/Tasks/TaskArchitecture.md.
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-629 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-629
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Persist authoritative task snapshots for reconstruction
+- Priority: Medium
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-629 from MM project
+Summary: Persist authoritative task snapshots for reconstruction
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-629 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-629: Persist authoritative task snapshots for reconstruction
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.4 Durable reconstruction
+- 5.5 Snapshot durability
+- 7 Snapshot, full retry, and Resume architecture
+- 11 Invariants
+
+Coverage IDs:
+- DESIGN-REQ-004
+- DESIGN-REQ-010
+
+As a user retrying or reviewing a task, I want MoonMind to reconstruct the original authored task from a durable snapshot so edit, rerun, and resume flows cannot lose task intent.
+
+Acceptance Criteria:
+- Submission persists an authoritative task input snapshot with all section 7 fields.
+- Edit and full retry initial browser state comes from the snapshot, not derived projections.
+- Snapshot reconstruction preserves attachment target binding exactly.
+- Snapshot reconstruction preserves pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- Attachment-aware executions without reconstructible snapshots are explicitly degraded.
+
+Requirements:
+- Edit, rerun, full retry, and resume reconstruct authored input from durable snapshots rather than lossy projections.
+- Snapshots and payloads preserve authored preset bindings, include-tree summaries, source provenance, detachment state, and final order.
+
+Relevant Jira links from trusted issue response:
+- MM-629 blocks MM-628: Route binary inputs through authorized artifact refs (status: Done)
+- MM-629 is blocked by MM-630: Compile recursive task presets before execution (status: Backlog)
+"""
+
+## Classification
+
+Input classification: single-story runtime feature request. The Jira brief selects one independently testable task reconstruction and retry story from `docs/Tasks/TaskArchitecture.md`; it does not require `moonspec-breakdown`.
+
+Resume decision: no existing Moon Spec feature directory or checked-in spec artifact matched `MM-629` under `specs/`, so `Specify` is the first incomplete stage.
+
+## User Story - Authoritative Task Snapshot Reconstruction
+
+**Summary**: As a user retrying or reviewing a task, I want MoonMind to reconstruct the original authored task from a durable snapshot so edit, rerun, and resume flows cannot lose task intent.
+
+**Goal**: Preserve the complete authored task input as the authoritative source for reconstruction so all recovery and review flows retain the user's original intent, attachment targets, preset provenance, and submitted ordering.
+
+**Independent Test**: Submit a task with objective text, ordered steps, target-bound attachments, runtime and publish selections, pinned preset metadata, provenance, dependencies, and detached state; then open edit, full retry, exact rerun, and resume views and verify each reconstructs from the authoritative snapshot with no field loss or retargeting.
+
+**Acceptance Scenarios**:
+1. **Given** a submitted task with objective-scoped and step-scoped attachments, **When** the task is persisted, **Then** the authoritative snapshot contains the task objective, ordered steps, attachment refs and targets, runtime selections, publish selections, branch selection, preset metadata, provenance, detachment state, dependencies, and final submitted order.
+2. **Given** an existing execution with an authoritative snapshot, **When** a user opens edit or full retry, **Then** the initial browser state is reconstructed from that snapshot rather than from derived execution projections.
+3. **Given** an existing execution with pinned preset bindings and flattened steps, **When** reconstruction occurs, **Then** the preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order remain visible and intact without live preset catalog lookup.
+4. **Given** an attachment-aware execution without a reconstructible authoritative snapshot, **When** edit, rerun, full retry, or resume reconstruction is requested, **Then** the system explicitly reports the execution as degraded instead of silently dropping attachments or retargeting inputs.
+5. **Given** a failed execution with completed prior steps and an authoritative snapshot, **When** resume is evaluated, **Then** resume uses the original task input snapshot unchanged and does not present it as an editable authoring surface.
+
+**Edge Cases**:
+- A task contains only text fields and no attachments but still requires preset provenance and ordering to reconstruct accurately.
+- A task references attachments whose artifact metadata exists but whose task target binding is missing from the snapshot.
+- A preset used by the original task has changed or been removed after submission.
+- A user reorders or edits steps during full retry while existing attachments remain bound to their original targets unless explicitly changed through normal authoring controls.
+- Resume is requested for a run whose checkpoint exists but whose original task input snapshot is missing, corrupted, or unauthorized.
+
+## Assumptions
+
+- Existing artifact authorization and attachment upload behavior remain the source of binary access control; this story concerns the durable task input snapshot and reconstruction semantics.
+- Existing edit, rerun, full retry, and resume entrypoints remain the operator-facing recovery surfaces.
+- Jira-linked MM-630 may add recursive preset compilation details later, but this story preserves the compiled bindings and provenance that are present at submission time.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Tasks/TaskArchitecture.md` section 3.4): Task input reconstruction must use an authoritative snapshot; text-only reconstruction is insufficient for attachment-aware tasks. Scope: in scope, mapped to FR-001, FR-002, FR-006.
+- **DESIGN-REQ-002** (`docs/Tasks/TaskArchitecture.md` section 3.4): Silent loss of attachment bindings is a contract violation. Scope: in scope, mapped to FR-004, FR-006, FR-008.
+- **DESIGN-REQ-003** (`docs/Tasks/TaskArchitecture.md` section 5.5): Edit and rerun must reconstruct from the authoritative snapshot rather than lossy derived projections. Scope: in scope, mapped to FR-002, FR-003.
+- **DESIGN-REQ-004** (`docs/Tasks/TaskArchitecture.md` section 5.5): The snapshot must preserve attachment target binding. Scope: in scope, mapped to FR-001, FR-004, FR-008.
+- **DESIGN-REQ-005** (`docs/Tasks/TaskArchitecture.md` section 5.5): The snapshot must preserve pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order. Scope: in scope, mapped to FR-001, FR-005.
+- **DESIGN-REQ-006** (`docs/Tasks/TaskArchitecture.md` section 7): Original task input snapshot must preserve objective text, objective attachments, step text, step attachments, step order and identity, runtime and publish selections, repository and branch selection, preset application metadata, dependency declarations, and other authored fields. Scope: in scope, mapped to FR-001, FR-005.
+- **DESIGN-REQ-007** (`docs/Tasks/TaskArchitecture.md` section 7): Edit, exact full rerun, edited full retry, and resume depend on the snapshot for the original authored task input. Scope: in scope, mapped to FR-002, FR-003, FR-007.
+- **DESIGN-REQ-008** (`docs/Tasks/TaskArchitecture.md` section 7): Edit and full retry derive their initial browser state from the snapshot, while resume reuses the snapshot without making it editable. Scope: in scope, mapped to FR-002, FR-007.
+- **DESIGN-REQ-009** (`docs/Tasks/TaskArchitecture.md` section 7): Reconstruction must not depend on current live preset catalog correctness for already submitted work. Scope: in scope, mapped to FR-005.
+- **DESIGN-REQ-010** (`docs/Tasks/TaskArchitecture.md` section 7): Attachment-aware executions without reconstructible snapshots are degraded and must be treated explicitly. Scope: in scope, mapped to FR-006, FR-008.
+- **DESIGN-REQ-011** (`docs/Tasks/TaskArchitecture.md` section 11): Resume uses original task inputs unchanged and edits require edited full retry. Scope: in scope, mapped to FR-007.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST persist an authoritative task input snapshot at submission time containing the full authored task objective, steps, step identity and order, runtime selections, publish selections, repository and branch selection, dependency declarations, attachment refs, attachment targets, preset application metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- **FR-002**: Edit and full retry flows MUST initialize their browser state from the authoritative task input snapshot rather than execution projections, rendered logs, current preset definitions, or partial task summaries.
+- **FR-003**: Exact full rerun MUST reuse the authoritative task input snapshot as the execution input without importing completed execution progress from the source run.
+- **FR-004**: Reconstruction MUST preserve objective-scoped and step-scoped attachment target bindings exactly across create, detail, edit, full retry, exact rerun, prepare, and prompt composition surfaces.
+- **FR-005**: Reconstruction MUST preserve pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order without requiring live preset catalog lookup for already submitted work.
+- **FR-006**: If an attachment-aware execution lacks a reconstructible authoritative task input snapshot, the system MUST classify the reconstruction as explicitly degraded and MUST NOT silently drop attachments, retarget attachments, or synthesize replacement authoring state.
+- **FR-007**: Resume from failed step MUST reuse the original task input snapshot unchanged and MUST NOT expose task input edits; any user change to instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies MUST require edited full retry.
+- **FR-008**: User-facing task detail, edit, rerun, full retry, and resume readiness surfaces MUST expose enough snapshot and degradation evidence for operators to understand whether reconstruction is authoritative or degraded.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-629` and this canonical Jira preset brief for traceability.
+
+### Key Entities
+
+- **Task Input Snapshot**: The durable authoritative representation of the authored task input, including text, steps, selected runtime behavior, publish behavior, source branch, dependencies, attachments, target bindings, preset metadata, and final submitted order.
+- **Attachment Target Binding**: The association between an input attachment and either the task objective target or a specific step target that must survive reconstruction and execution preparation.
+- **Preset Provenance**: The durable metadata describing pinned preset bindings, include-tree summary, per-step provenance, detachment state, and compiled order for preset-derived task content.
+- **Reconstruction State**: The result of loading authoring state from a snapshot for detail, edit, full retry, exact rerun, or resume readiness, including whether the result is authoritative or degraded.
+
+## Success Criteria
+
+- **SC-001**: A task containing objective text, multiple steps, objective-scoped attachments, step-scoped attachments, runtime settings, publish settings, branch selection, dependencies, and preset provenance can be submitted and later reconstructed with every authored field preserved.
+- **SC-002**: Edit and full retry entrypoints display initial state from the authoritative snapshot for representative tasks and do not depend on lossy projections or current preset catalog data.
+- **SC-003**: Exact full rerun starts from the original snapshot while resume preserves prior completed work only through resume checkpoint semantics and does not modify the original task input.
+- **SC-004**: Attachment-aware executions with missing or invalid snapshots are reported as degraded with no silent attachment loss, target retargeting, or synthetic authoring state.
+- **SC-005**: Tests cover submission snapshot persistence, snapshot-based edit/full retry reconstruction, preset provenance preservation, attachment target preservation, degraded reconstruction, and resume snapshot immutability.
+- **SC-006**: Traceability review confirms `MM-629`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-011 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/323-persist-task-snapshots/tasks.md
+++ b/specs/323-persist-task-snapshots/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: Persist Authoritative Task Snapshots
+
+**Input**: `specs/323-persist-task-snapshots/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/execution-reconstruction.md`, `quickstart.md`
+**Prerequisites**: Existing execution route tests and Temporal service tests are available.
+**Unit test command**: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py`
+**Integration test command**: `./tools/test_integration.sh` only if implementation expands beyond API action capability serialization.
+
+## Source Traceability
+
+The original MM-629 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-009, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-011. Plan status summary: FR-002, FR-006, and FR-008 are partial because parameter-derived fallback currently enables edit/rerun when the authoritative snapshot is missing; the rest are implemented-unverified or traceability work for this bounded story.
+
+## Story
+
+As a user retrying or reviewing a task, I want MoonMind to reconstruct the original authored task from a durable snapshot so edit, rerun, and resume flows cannot lose task intent.
+
+**Independent Test**: Submit or serialize representative terminal task executions with and without `task_input_snapshot_ref`; verify edit/rerun/resume actions are enabled only when the authoritative snapshot and required resume checkpoint exist, and missing snapshots are reported as degraded or unavailable rather than reconstructed from parameters.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm MM-629 is a single-story runtime feature and no existing `specs/*` directory already owns MM-629 in `specs/323-persist-task-snapshots/spec.md` (FR-009, SC-006)
+- [X] T002 Create MoonSpec specify, plan, research, data model, contract, and quickstart artifacts under `specs/323-persist-task-snapshots/` (FR-009, SC-006)
+
+## Phase 2: Foundational
+
+- [X] T003 Identify execution action capability and task snapshot descriptor boundaries in `api_service/api/routers/executions.py` and `moonmind/schemas/temporal_models.py` (FR-002, FR-006, FR-008)
+- [X] T004 Identify existing snapshot persistence and resume validation evidence in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `moonmind/workflows/temporal/service.py` (FR-001, FR-003, FR-004, FR-005, FR-007)
+
+## Phase 3: Authoritative Task Snapshot Reconstruction
+
+### Unit Test Plan
+
+Update `tests/unit/api/routers/test_executions.py` so terminal `MoonMind.Run` executions without `task_input_snapshot_ref` disable `canEditForRerun` and `canRerun` even when task parameters contain instructions, steps, tool data, or skill data. Preserve tests proving snapshots enable edit/rerun and resume remains checkpoint-gated.
+
+### Integration Test Plan
+
+No new hermetic integration test is required for the scoped code change because the behavior is a deterministic API serialization policy already covered by unit route/model tests. Run full unit verification before finalizing.
+
+- [X] T005 Add/update failing unit coverage in `tests/unit/api/routers/test_executions.py` for terminal task parameters without authoritative snapshots disabling edit/rerun (FR-002, FR-006, FR-008, DESIGN-REQ-001, DESIGN-REQ-010)
+- [X] T006 Add/update unit coverage in `tests/unit/api/routers/test_executions.py` confirming missing snapshots report `original_task_input_snapshot_missing` for edit/rerun despite reconstructable parameters (FR-006, FR-008)
+- [X] T007 Run targeted red-first test command `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm the updated test fails before production edits (FR-002, FR-006, FR-008)
+- [X] T008 Remove parameter-derived edit/rerun fallback from `_build_action_capabilities()` in `api_service/api/routers/executions.py` (FR-002, FR-006, FR-008)
+- [X] T009 Remove now-unused reconstructable-parameter helper code in `api_service/api/routers/executions.py` if no callers remain (FR-006, DESIGN-REQ-001)
+- [X] T010 Run targeted unit verification `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and require PASS (FR-001 through FR-008)
+- [X] T011 Review `taskInputSnapshot` descriptor output against `contracts/execution-reconstruction.md` for authoritative/degraded/unavailable states (FR-008)
+
+## Final Phase: Polish And Verification
+
+- [X] T012 Run full unit suite `./tools/test_unit.sh` before final verification (SC-005)
+- [X] T013 Run `/speckit.verify` equivalent and write `specs/323-persist-task-snapshots/verification.md` with verdict, evidence, and MM-629 traceability (FR-009, SC-006)
+
+## Dependencies And Execution Order
+
+1. T001-T004 establish artifacts and code boundaries.
+2. T005-T007 must complete before production code edits.
+3. T008-T009 implement the scoped policy change.
+4. T010-T013 validate and verify the story.
+
+## Implementation Strategy
+
+Close only the unsafe fallback gap identified in the plan. Do not change snapshot payload schemas, artifact storage, resume checkpoint models, frontend UI, or Temporal workflow payload shapes unless targeted tests expose a direct requirement gap.

--- a/specs/323-persist-task-snapshots/tasks.md
+++ b/specs/323-persist-task-snapshots/tasks.md
@@ -46,7 +46,7 @@ No new hermetic integration test is required for the scoped code change because 
 ## Final Phase: Polish And Verification
 
 - [X] T012 Run full unit suite `./tools/test_unit.sh` before final verification (SC-005)
-- [X] T013 Run `/speckit.verify` equivalent and write `specs/323-persist-task-snapshots/verification.md` with verdict, evidence, and MM-629 traceability (FR-009, SC-006)
+- [X] T013 Run `/moonspec-verify` equivalent and write `specs/323-persist-task-snapshots/verification.md` with verdict, evidence, and MM-629 traceability (FR-009, SC-006)
 
 ## Dependencies And Execution Order
 

--- a/specs/323-persist-task-snapshots/tasks.md
+++ b/specs/323-persist-task-snapshots/tasks.md
@@ -7,7 +7,7 @@
 
 ## Source Traceability
 
-The original MM-629 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-009, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-011. Plan status summary: FR-002, FR-006, and FR-008 are partial because parameter-derived fallback currently enables edit/rerun when the authoritative snapshot is missing; the rest are implemented-unverified or traceability work for this bounded story.
+The original MM-629 Jira preset brief is preserved in `spec.md`. Tasks cover FR-001 through FR-009, acceptance scenarios 1-5, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-011. Plan status summary: FR-002, FR-006, and FR-008 were partial before implementation because parameter-derived fallback enabled edit/rerun when the authoritative snapshot was missing; T005-T013 now record the test-first remediation and verification work for that bounded story.
 
 ## Story
 

--- a/specs/323-persist-task-snapshots/verification.md
+++ b/specs/323-persist-task-snapshots/verification.md
@@ -1,0 +1,34 @@
+# Verification: Persist Authoritative Task Snapshots
+
+**Jira Issue**: MM-629
+**Original Request Source**: `spec.md` Input preserving the canonical Jira preset brief for MM-629
+**Verdict**: FULLY_IMPLEMENTED
+
+## Summary
+
+MM-629 required MoonMind to reconstruct edit, rerun, full retry, and resume flows from the authoritative task input snapshot instead of lossy projections or derived payloads. Existing code already persisted task input snapshot artifacts and required snapshots for failed-step resume. This implementation closes the remaining gap by removing parameter-derived edit/rerun fallback when `task_input_snapshot_ref` is missing.
+
+## Requirement Coverage
+
+| Requirement | Status | Evidence |
+| --- | --- | --- |
+| FR-001 | VERIFIED | Existing snapshot persistence in `api_service/api/routers/executions.py`; existing direct submission and Jira Orchestrate child snapshot tests. |
+| FR-002 | VERIFIED | `_build_action_capabilities()` now disables edit/rerun without authoritative snapshot; `test_terminal_task_editing_actions_reject_parameter_fallback_without_snapshot`. |
+| FR-003 | VERIFIED | Existing rerun creation keeps source identity; edit/rerun no longer enabled without snapshot. |
+| FR-004 | VERIFIED | Snapshot-based gating prevents attachment-aware reconstruction from falling back to task parameters. |
+| FR-005 | VERIFIED | Existing snapshot payload remains the durable task payload and no live preset lookup fallback was introduced. |
+| FR-006 | VERIFIED | Missing snapshots disable edit/rerun with `original_task_input_snapshot_missing` even when parameters contain instructions and steps. |
+| FR-007 | VERIFIED | Existing failed-step resume service still requires source task input snapshot and matching checkpoint payload. |
+| FR-008 | VERIFIED | `taskInputSnapshot` descriptor remains the evidence surface; action disabled reasons now align with missing snapshot state. |
+| FR-009 | VERIFIED | MM-629 and the canonical Jira preset brief are preserved in `spec.md`, `plan.md`, `tasks.md`, and this verification report. |
+
+## Test Evidence
+
+- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'terminal_task_editing_actions_reject_parameter_fallback_without_snapshot or terminal_task_editing_actions_reject_title_only_parameter_fallback or temporal_task_editing_actions_require_original_snapshot or describe_execution_exposes_edit_for_rerun_for_failed_task'`: PASS, 4 passed.
+- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py`: PASS, 168 passed.
+- `./tools/test_unit.sh`: PASS, Python unit suite 4564 passed, 1 xpassed, 16 subtests passed; frontend Vitest 20 files passed, 324 passed, 223 skipped.
+
+## Notes
+
+- `scripts/bash/update-agent-context.sh codex` was requested by the plan skill workflow but is not present in this checkout, so no agent context update was possible.
+- Hermetic integration was not run because the implementation is limited to deterministic API action capability serialization and unit coverage exercises the changed boundary.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6266,7 +6266,7 @@ def test_temporal_task_editing_actions_require_original_snapshot(
     )
 
 
-def test_terminal_task_editing_actions_allow_parameter_fallback_without_snapshot(
+def test_terminal_task_editing_actions_reject_parameter_fallback_without_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
@@ -6298,10 +6298,16 @@ def test_terminal_task_editing_actions_allow_parameter_fallback_without_snapshot
         actions.disabled_reasons["canUpdateInputs"]
         == "original_task_input_snapshot_missing"
     )
-    assert actions.can_edit_for_rerun is True
-    assert actions.can_rerun is True
-    assert "canEditForRerun" not in actions.disabled_reasons
-    assert "canRerun" not in actions.disabled_reasons
+    assert actions.can_edit_for_rerun is False
+    assert actions.can_rerun is False
+    assert (
+        actions.disabled_reasons["canEditForRerun"]
+        == "original_task_input_snapshot_missing"
+    )
+    assert (
+        actions.disabled_reasons["canRerun"]
+        == "original_task_input_snapshot_missing"
+    )
 
 
 def test_terminal_task_editing_actions_reject_title_only_parameter_fallback(


### PR DESCRIPTION
Jira issue key: MM-629

Active MoonSpec feature path: specs/323-persist-task-snapshots

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- ./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'terminal_task_editing_actions_reject_parameter_fallback_without_snapshot or terminal_task_editing_actions_reject_title_only_parameter_fallback or temporal_task_editing_actions_require_original_snapshot or describe_execution_exposes_edit_for_rerun_for_failed_task': PASS, 4 passed\n- ./tools/test_unit.sh tests/unit/api/routers/test_executions.py: PASS, 168 passed\n- ./tools/test_unit.sh: PASS, Python unit suite 4564 passed, 1 xpassed, 16 subtests passed; frontend Vitest 20 files passed, 324 passed, 223 skipped\n\nRemaining risks:\n- None known.\n\nNotes:\n- Hermetic integration was not run because the implementation is scoped to deterministic API action capability serialization and unit coverage exercises the changed boundary.