### PR TITLE
MM-630 compile recursive task presets

### DIFF
--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -428,6 +428,34 @@ def _composition_capabilities(node: dict[str, Any]) -> list[str]:
             capabilities.extend(_composition_capabilities(child))
     return _normalize_capabilities(capabilities)
 
+def _authored_presets_from_composition(node: dict[str, Any]) -> list[dict[str, Any]]:
+    presets: list[dict[str, Any]] = []
+
+    def visit(candidate: dict[str, Any]) -> None:
+        entry: dict[str, Any] = {
+            "presetSlug": str(candidate.get("slug") or "").strip(),
+            "presetVersion": str(candidate.get("version") or "").strip(),
+            "scope": str(candidate.get("scope") or "").strip(),
+            "includePath": [
+                str(item).strip()
+                for item in candidate.get("path") or []
+                if str(item).strip()
+            ],
+        }
+        alias = str(candidate.get("alias") or "").strip()
+        if alias:
+            entry["alias"] = alias
+        input_mapping = candidate.get("inputMapping")
+        if isinstance(input_mapping, Mapping) and input_mapping:
+            entry["inputMapping"] = dict(input_mapping)
+        presets.append({key: value for key, value in entry.items() if value})
+        for child in candidate.get("includes") or []:
+            if isinstance(child, dict):
+                visit(child)
+
+    visit(node)
+    return presets
+
 def _render_value(
     env: SandboxedEnvironment,
     value: Any,
@@ -1363,6 +1391,7 @@ class TaskTemplateCatalogService:
         visited: set[tuple[str, str, str]],
         resolved_steps: list[dict[str, Any]],
         alias: str | None = None,
+        input_mapping: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         node: dict[str, Any] = {
             "slug": template.slug,
@@ -1378,6 +1407,8 @@ class TaskTemplateCatalogService:
         }
         if alias:
             node["alias"] = alias
+        if input_mapping:
+            node["inputMapping"] = dict(input_mapping)
 
         for source_index, source_step in enumerate(version_model.steps or [], start=1):
             rendered = _render_value(
@@ -1487,6 +1518,7 @@ class TaskTemplateCatalogService:
                     visited={*visited, target_key},
                     resolved_steps=resolved_steps,
                     alias=include_alias,
+                    input_mapping=child_inputs,
                 )
                 node["includes"].append(child_node)
                 node["stepIds"].extend(child_node["stepIds"])
@@ -1540,6 +1572,12 @@ class TaskTemplateCatalogService:
                         "stepIndex": source_index,
                     },
                     "path": list(path),
+                },
+                "source": {
+                    "kind": "preset-derived",
+                    "presetSlug": template.slug,
+                    "presetVersion": version_model.version,
+                    "includePath": list(path),
                 },
             }
             if alias:
@@ -1688,6 +1726,7 @@ class TaskTemplateCatalogService:
             visited={(normalized_scope.value, template.slug, selected_version.version)},
             resolved_steps=resolved_steps,
         )
+        authored_presets = _authored_presets_from_composition(composition)
 
         template_caps = _normalize_capabilities(
             list(template.required_capabilities or [])
@@ -1722,12 +1761,15 @@ class TaskTemplateCatalogService:
         return {
             "steps": resolved_steps,
             "composition": composition,
+            "authoredPresets": authored_presets,
             "appliedTemplate": {
                 "slug": template.slug,
                 "version": selected_version.version,
                 "inputs": validated_inputs,
                 "stepIds": [step["id"] for step in resolved_steps],
                 "appliedAt": applied_at,
+                "composition": composition,
+                "authoredPresets": authored_presets,
             },
             "capabilities": template_caps,
             "warnings": warnings,

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -86,6 +86,7 @@ _STEP_RESERVED_KEYS = frozenset(
     {
         "id",
         "kind",
+        "source",
         "type",
         "title",
         "slug",
@@ -431,6 +432,15 @@ def _composition_capabilities(node: dict[str, Any]) -> list[str]:
 def _authored_presets_from_composition(node: dict[str, Any]) -> list[dict[str, Any]]:
     presets: list[dict[str, Any]] = []
 
+    def has_authored_preset_value(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value)
+        if isinstance(value, (list, dict, tuple, set)):
+            return bool(value)
+        return True
+
     def visit(candidate: dict[str, Any]) -> None:
         entry: dict[str, Any] = {
             "presetSlug": str(candidate.get("slug") or "").strip(),
@@ -448,7 +458,13 @@ def _authored_presets_from_composition(node: dict[str, Any]) -> list[dict[str, A
         input_mapping = candidate.get("inputMapping")
         if isinstance(input_mapping, Mapping) and input_mapping:
             entry["inputMapping"] = dict(input_mapping)
-        presets.append({key: value for key, value in entry.items() if value})
+        presets.append(
+            {
+                key: value
+                for key, value in entry.items()
+                if has_authored_preset_value(value)
+            }
+        )
         for child in candidate.get("includes") or []:
             if isinstance(child, dict):
                 visit(child)

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12848,6 +12848,27 @@ describe("Task Create MM-578 Preset expansion", () => {
           appliedTemplate: {
             slug: "mm-578-preset",
             version: "1.0.0",
+            stepIds: [
+              "tpl:mm-578-preset:1.0.0:01",
+              "tpl:mm-578-preset:1.0.0:02",
+            ],
+            composition: {
+              slug: "mm-578-preset",
+              version: "1.0.0",
+              path: ["mm-578-preset@1.0.0"],
+              stepIds: [
+                "tpl:mm-578-preset:1.0.0:01",
+                "tpl:mm-578-preset:1.0.0:02",
+              ],
+              includes: [],
+            },
+            authoredPresets: [
+              {
+                presetSlug: "mm-578-preset",
+                presetVersion: "1.0.0",
+                includePath: ["mm-578-preset@1.0.0"],
+              },
+            ],
           },
           capabilities: ["jira"],
           warnings: ["Generated steps should be reviewed before apply."],
@@ -13460,7 +13481,13 @@ describe("Task Create MM-578 Preset expansion", () => {
       );
     });
     const request = latestCreateRequest() as {
-      payload: { task: { steps: Array<Record<string, unknown>> } };
+      payload: {
+        task: {
+          steps: Array<Record<string, unknown>>;
+          authoredPresets?: Array<Record<string, unknown>>;
+          appliedStepTemplates?: Array<Record<string, unknown>>;
+        };
+      };
     };
     expect(request.payload.task.steps[0]).toEqual({
       id: "tpl:mm-578-preset:1.0.0:01",
@@ -13499,6 +13526,29 @@ describe("Task Create MM-578 Preset expansion", () => {
       },
     });
     expect(request.payload.task.steps[1]?.["tool"]).toBeUndefined();
+    expect(request.payload.task.authoredPresets).toEqual([
+      {
+        presetSlug: "mm-578-preset",
+        presetVersion: "1.0.0",
+        includePath: ["mm-578-preset@1.0.0"],
+      },
+    ]);
+    expect(request.payload.task.appliedStepTemplates?.[0]).toMatchObject({
+      slug: "mm-578-preset",
+      composition: {
+        slug: "mm-578-preset",
+        stepIds: [
+          "tpl:mm-578-preset:1.0.0:01",
+          "tpl:mm-578-preset:1.0.0:02",
+        ],
+      },
+      authoredPresets: [
+        {
+          presetSlug: "mm-578-preset",
+          presetVersion: "1.0.0",
+        },
+      ],
+    });
   });
 
   it("auto-expands an unresolved Preset during Create submit without mutating the visible draft", async () => {
@@ -13531,6 +13581,19 @@ describe("Task Create MM-578 Preset expansion", () => {
       includePath: ["root", "fetch"],
       originalStepId: "fetch-jira-issue",
     });
+    expect(
+      (
+        latestCreateRequest() as {
+          payload?: { task?: { authoredPresets?: Array<Record<string, unknown>> } };
+        }
+      ).payload?.task?.authoredPresets,
+    ).toEqual([
+      {
+        presetSlug: "mm-578-preset",
+        presetVersion: "1.0.0",
+        includePath: ["mm-578-preset@1.0.0"],
+      },
+    ]);
     expect(
       screen.getByDisplayValue("Keep unresolved MM-578 preset placeholder."),
     ).toBeTruthy();

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -503,6 +503,7 @@ interface ExpandedStepPayload {
   tool?: TaskTemplateStepSkill;
   type?: string;
   source?: Record<string, unknown>;
+  presetProvenance?: Record<string, unknown>;
   inputAttachments?: StepAttachmentRef[];
   attachments?: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
@@ -519,7 +520,10 @@ interface TaskTemplateExpandResponse {
     inputs?: Record<string, unknown>;
     stepIds?: string[];
     appliedAt?: string;
+    composition?: Record<string, unknown>;
+    authoredPresets?: Array<Record<string, unknown>>;
   };
+  authoredPresets?: Array<Record<string, unknown>>;
   capabilities?: string[];
   warnings?: string[];
 }
@@ -654,6 +658,8 @@ interface AppliedTemplateState {
   stepIds: string[];
   appliedAt: string;
   capabilities: string[];
+  composition?: Record<string, unknown>;
+  authoredPresets?: Array<Record<string, unknown>>;
 }
 
 function readDashboardConfig(payload: BootPayload): DashboardConfig {
@@ -756,6 +762,25 @@ function recordValue(value: unknown): Record<string, unknown> {
 function nonEmptyRecordValue(value: unknown): Record<string, unknown> | undefined {
   const record = recordValue(value);
   return Object.keys(record).length > 0 ? record : undefined;
+}
+
+function compactSourceFromPresetProvenance(
+  provenance: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!provenance) {
+    return undefined;
+  }
+  const source = recordValue(provenance.source);
+  const path = Array.isArray(provenance.path)
+    ? provenance.path.map((entry) => String(entry).trim()).filter(Boolean)
+    : [];
+  const presetSlug = String(source.slug || "").trim();
+  const presetVersion = String(source.version || "").trim();
+  const compact: Record<string, unknown> = { kind: "preset-derived" };
+  if (presetSlug) compact.presetSlug = presetSlug;
+  if (presetVersion) compact.presetVersion = presetVersion;
+  if (path.length > 0) compact.includePath = path;
+  return Object.keys(compact).length > 1 ? compact : undefined;
 }
 
 function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
@@ -1412,6 +1437,14 @@ function activeAppliedTemplatesForSteps(
       stepIds.some((stepId) => activeStepIds.has(stepId))
     );
   });
+}
+
+function authoredPresetsFromAppliedTemplates(
+  appliedTemplates: AppliedTemplateState[],
+): Array<Record<string, unknown>> {
+  return appliedTemplates.flatMap((template) =>
+    Array.isArray(template.authoredPresets) ? template.authoredPresets : [],
+  );
 }
 
 function parseCapabilitiesCsv(value: string): string[] {
@@ -2083,7 +2116,9 @@ function mapExpandedStepToState(
   const jiraOrchestration =
     nonEmptyRecordValue(step.jiraOrchestration) ||
     nonEmptyRecordValue(step.jira_orchestration);
-  const source = nonEmptyRecordValue(step.source);
+  const source =
+    nonEmptyRecordValue(step.source) ||
+    compactSourceFromPresetProvenance(nonEmptyRecordValue(step.presetProvenance));
   const normalizedSource = source
     ? {
         ...source,
@@ -5922,6 +5957,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         String(appliedTemplate.appliedAt || "").trim() ||
         new Date().toISOString(),
       capabilities: expansion.capabilities,
+      ...(appliedTemplate.composition &&
+      typeof appliedTemplate.composition === "object"
+        ? { composition: appliedTemplate.composition }
+        : {}),
+      ...(Array.isArray(appliedTemplate.authoredPresets)
+        ? { authoredPresets: appliedTemplate.authoredPresets }
+        : {}),
     };
   }
 
@@ -7306,6 +7348,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       submissionAppliedTemplates.length > 0
         ? { include: [{ name: effectiveSubmissionSkillId }] }
         : undefined;
+    const submissionAuthoredPresets =
+      authoredPresetsFromAppliedTemplates(submissionAppliedTemplates);
 
     // Address: Gemini r3034477068 — keep tool/skill objects in sync with effectiveSkillId
     const resolvedTool = effectiveSubmissionSkillId !== primarySkillId
@@ -7365,6 +7409,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       ...(normalizedSteps.length > 0 ? { steps: normalizedSteps } : {}),
       ...(submissionAppliedTemplates.length > 0
         ? { appliedStepTemplates: submissionAppliedTemplates }
+        : {}),
+      ...(submissionAuthoredPresets.length > 0
+        ? { authoredPresets: submissionAuthoredPresets }
         : {}),
       ...(selectedDependencies.length > 0
         ? { dependsOn: selectedDependencies }

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -1084,6 +1084,11 @@ class TaskStepSpec(BaseModel):
         if not isinstance(value, Mapping):
             return value
         payload = dict(value)
+        raw_kind = _clean_optional_str(payload.get("kind"))
+        if raw_kind is not None and raw_kind.lower() == "include":
+            raise TaskContractError(
+                "task.steps entries must not contain unresolved preset include work"
+            )
         raw_type = _clean_optional_str(payload.get("type"))
         if raw_type is not None:
             step_type = raw_type.lower()

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -269,10 +269,6 @@ async def _expand_task_template_for_child_run(
         "authoredPresets"
     )
     if isinstance(authored_presets, list):
-        applied_template_payload["authoredPresets"] = [
-            dict(item) if isinstance(item, Mapping) else item
-            for item in authored_presets
-        ]
         task_payload["authoredPresets"] = [
             dict(item) if isinstance(item, Mapping) else item
             for item in authored_presets

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -253,18 +253,32 @@ async def _expand_task_template_for_child_run(
         )
 
     applied_template = _coerce_mapping(expanded.get("appliedTemplate"))
+    applied_template_payload: dict[str, Any] = {
+        "slug": str(applied_template.get("slug") or template_slug),
+        "version": str(applied_template.get("version") or template_version),
+        "inputs": _coerce_mapping(applied_template.get("inputs"))
+        or template_inputs,
+        "stepIds": list(applied_template.get("stepIds") or []),
+        "appliedAt": str(applied_template.get("appliedAt") or ""),
+        "capabilities": list(expanded.get("capabilities") or []),
+    }
+    composition = applied_template.get("composition") or expanded.get("composition")
+    if isinstance(composition, Mapping):
+        applied_template_payload["composition"] = dict(composition)
+    authored_presets = applied_template.get("authoredPresets") or expanded.get(
+        "authoredPresets"
+    )
+    if isinstance(authored_presets, list):
+        applied_template_payload["authoredPresets"] = [
+            dict(item) if isinstance(item, Mapping) else item
+            for item in authored_presets
+        ]
+        task_payload["authoredPresets"] = [
+            dict(item) if isinstance(item, Mapping) else item
+            for item in authored_presets
+        ]
     task_payload["steps"] = list(expanded_steps)
-    task_payload["appliedStepTemplates"] = [
-        {
-            "slug": str(applied_template.get("slug") or template_slug),
-            "version": str(applied_template.get("version") or template_version),
-            "inputs": _coerce_mapping(applied_template.get("inputs"))
-            or template_inputs,
-            "stepIds": list(applied_template.get("stepIds") or []),
-            "appliedAt": str(applied_template.get("appliedAt") or ""),
-            "capabilities": list(expanded.get("capabilities") or []),
-        }
-    ]
+    task_payload["appliedStepTemplates"] = [applied_template_payload]
     task_payload["taskTemplate"] = {
         **template_payload,
         "slug": str(applied_template.get("slug") or template_slug),

--- a/specs/324-compile-recursive-presets/checklists/requirements.md
+++ b/specs/324-compile-recursive-presets/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Compile Recursive Task Presets
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves Jira issue `MM-630`, the original Jira preset brief, one runtime user story, and source mappings for the selected Task Architecture requirements.

--- a/specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md
+++ b/specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md
@@ -1,0 +1,46 @@
+# Task Preset Compilation Contract
+
+## Boundary
+
+Preset compilation is a control-plane boundary that runs before task execution finalization. The output is the authoritative submitted task contract.
+
+## Input
+
+A task draft may contain:
+- manual steps,
+- unresolved preset authoring steps,
+- applied template metadata,
+- task-level runtime, publish, repository, Jira, dependency, and attachment fields.
+
+Each preset include must identify:
+- preset slug or ID,
+- pinned version,
+- scope,
+- optional alias,
+- optional input mapping.
+
+## Output
+
+The submitted task contract contains:
+- final ordered executable steps,
+- no unresolved preset include work for workers,
+- per-step source provenance for preset-derived, included, manual, or detached steps when reliable,
+- authored preset bindings for root and included presets when reliable,
+- recursive composition/include-tree summary suitable for audit and reconstruction,
+- existing task-level runtime, publish, Jira, dependency, and attachment fields unchanged except for normalized canonical shape.
+
+## Required Behavior
+
+1. The control plane validates the full recursive include tree before execution finalization.
+2. Invalid include trees fail explicitly and do not create worker-facing unresolved preset work.
+3. Manual and preset-derived steps are flattened into deterministic final submitted order.
+4. Submitted snapshots preserve enough compact metadata to reconstruct the authored preset composition after live catalog definitions change.
+5. Workers consume only resolved executable steps and do not consult the live preset catalog to recover task structure.
+6. Manual-only tasks remain valid and do not gain fabricated preset provenance.
+
+## Compatibility And Failure Rules
+
+- Do not add compatibility aliases for new internal preset metadata.
+- Unsupported internal payload shapes fail explicitly.
+- Existing attachment target, runtime, publish, Jira provenance, edit, rerun, and resume semantics remain unchanged unless they need compiled preset provenance for reconstruction.
+- Large template or skill content must not be embedded in workflow history.

--- a/specs/324-compile-recursive-presets/data-model.md
+++ b/specs/324-compile-recursive-presets/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Compile Recursive Task Presets
+
+## Task Draft
+
+Represents the authoring state before submission.
+
+Fields:
+- `instructions`: objective text.
+- `steps`: manual, skill, tool, or unresolved preset authoring steps.
+- `appliedStepTemplates`: client-side record of templates expanded into the draft when present.
+- `authoredPresets`: authored preset selections and bindings when present or derivable from expansion.
+- `runtime`, `publish`, `git`, `dependsOn`, `inputAttachments`: existing task-level submission fields.
+
+Validation rules:
+- Unresolved preset authoring steps must be compiled before execution finalization.
+- Manual-only drafts remain valid without preset metadata.
+- Invalid preset references, cycles, disabled templates, unsupported include shapes, and incompatible mappings fail explicitly.
+
+## Preset Include Tree
+
+Represents the recursive template composition selected by the author.
+
+Fields:
+- `slug` or `presetSlug`: preset identifier.
+- `version` or `presetVersion`: pinned version.
+- `scope`: global or personal scope.
+- `alias`: include alias when provided.
+- `path` or `includePath`: ordered path from root preset to included preset or step.
+- `inputMapping`: mapping used to supply child preset inputs.
+- `includes`: child include nodes.
+- `stepIds`: flattened executable step identifiers produced by this node.
+- `requiredCapabilities`: compact capabilities contributed by the node.
+
+Validation rules:
+- Every include must resolve to an allowed active preset version before execution.
+- Include paths must be deterministic and cycle-free.
+- Include aliases must not create ambiguous bindings within the same include scope.
+
+## Compiled Task Snapshot
+
+Represents the authoritative submitted task after preset compilation.
+
+Fields:
+- `steps`: final ordered executable steps.
+- `authoredPresets`: compact authored preset binding metadata for root and included presets.
+- `appliedStepTemplates`: applied root template metadata plus recursive composition summary when available.
+- `source`: per-step provenance for manual, preset-derived, preset-include, or detached steps.
+- Existing task fields: runtime, publish, git, Jira provenance, dependencies, and attachments.
+
+Validation rules:
+- Snapshot reconstruction must not require live preset catalog lookup.
+- Snapshot metadata must be compact and suitable for execution records/artifacts.
+- Existing attachment target and runtime/publish semantics must not change.
+
+## Worker-Facing Payload
+
+Represents the task contract consumed by execution workers.
+
+Fields:
+- `steps`: executable skill/tool/manual steps only.
+- `source`: optional compact provenance.
+- `authoredPresets` and `appliedStepTemplates`: optional audit/reconstruction metadata.
+
+Validation rules:
+- No unresolved preset include objects are accepted as worker work.
+- Workers consume the resolved steps they receive and do not expand presets.
+
+## State Transitions
+
+- `draft-authored` -> `preset-compiled`: recursive include tree resolves and flattened executable steps are produced.
+- `draft-authored` -> `rejected`: include tree is invalid, disabled, unauthorized, cyclic, or incompatible.
+- `preset-compiled` -> `submitted-snapshot`: flattened steps and provenance are persisted as authoritative submitted task state.
+- `submitted-snapshot` -> `worker-received`: worker receives resolved executable steps without live catalog lookup.
+- `submitted-snapshot` -> `reconstructed`: edit/rerun/audit reconstructs from snapshot even if live preset definitions changed.

--- a/specs/324-compile-recursive-presets/moonspec_align_report.md
+++ b/specs/324-compile-recursive-presets/moonspec_align_report.md
@@ -1,0 +1,23 @@
+# MoonSpec Align Report: Compile Recursive Task Presets
+
+**Source**: MM-630 canonical Jira preset brief preserved in `spec.md`
+**Feature**: `specs/324-compile-recursive-presets`
+**Result**: PASS after conservative task-list remediation
+
+## Findings And Remediation
+
+| Finding | Resolution | Artifact |
+| --- | --- | --- |
+| One spec edge case, conflicting include aliases or mappings, lacked explicit task coverage. | Added a red-first catalog unit test task for conflicting aliases or incompatible mappings. | `tasks.md` |
+| Some implementation tasks used non-specific path language such as "or a focused helper module" or "related snapshot helpers." | Replaced those references with concrete file paths so tasks remain directly executable. | `tasks.md` |
+| Adding the edge-case task required sequential task IDs and dependency references to be updated. | Renumbered T010 through T047 and updated dependency and parallelization sections. | `tasks.md` |
+
+## Gate Re-Check
+
+- Specify gate: PASS. `spec.md` still has exactly one user story and preserves MM-630 plus the original preset brief.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and the contract remain aligned with one runtime story and explicit unit/integration strategies.
+- Tasks gate: PASS. `tasks.md` now has red-first unit tests, integration tests, red-first confirmation, conditional fallback implementation, production implementation, story validation, and final `/moonspec-verify`.
+
+## Remaining Risks
+
+- No artifact-level risk found. Implementation may still reveal whether existing catalog validation already covers all invalid include target variants; `tasks.md` handles that through verification-first and conditional fallback tasks.

--- a/specs/324-compile-recursive-presets/plan.md
+++ b/specs/324-compile-recursive-presets/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Compile Recursive Task Presets
+
+**Branch**: `run-jira-orchestrate-for-mm-630-compile-428a2508` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime spec from the MM-630 Jira preset brief.
+
+## Summary
+
+MM-630 requires task preset composition to be finalized before execution: recursive includes are validated, flattened into deterministic executable steps, and preserved with enough authored-preset and step-source provenance to audit or reconstruct submitted work after live preset catalog changes. The repo already has recursive catalog expansion with cycle/inactive/input validation and several task-contract provenance fields. The remaining planning gap is to make the submission/snapshot boundary authoritative for compiled recursive presets, including authored preset bindings and include-tree summaries, with unit coverage for catalog and normalization behavior plus a hermetic integration check proving workers receive resolved steps without live catalog dependency.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `api_service/services/task_templates/catalog.py` recursively expands includes before returning steps; Create auto-expands unresolved presets before submit | ensure create/API submitted task snapshot records compiled include-tree metadata as authoritative before execution | unit + integration |
+| FR-002 | implemented_unverified | catalog tests cover cycles, inactive includes, incompatible input mappings, personal/global scope violations, and flattened step limits | add or extend focused tests for missing/unauthorized include targets if not already covered by current errors | unit |
+| FR-003 | implemented_unverified | catalog expansion appends resolved steps in deterministic order and frontend submits expanded steps | add boundary test from recursive preset draft through submitted task payload order | unit + integration |
+| FR-004 | partial | `TaskExecutionSpec` accepts `authoredPresets` and `steps[].source`; frontend preserves `source`; API preserves `authoredPresets` only when supplied | derive and persist reliable authored preset binding/include-tree summary from expansion output for recursive presets | unit + integration |
+| FR-005 | implemented_unverified | worker runtime expands top-level task templates before child execution and docs say workers consume flattened steps; current tests cover executable expanded steps | add integration coverage that execution receives resolved steps and no unresolved preset step remains | integration_ci |
+| FR-006 | partial | task snapshots and `appliedStepTemplates` exist, but applied template metadata currently omits recursive `composition`/include-tree summary | preserve compiled include-tree summary and provenance in task snapshot so reconstruction does not depend on live catalog | unit + integration |
+| FR-007 | implemented_unverified | normalization preserves runtime, publish, Jira provenance, attachments, and template metadata in existing API/integration tests | keep existing behavior and add regression assertions around preset compilation path | unit + integration |
+| FR-008 | missing | `spec.md` preserves MM-630 and the original Jira preset brief | preserve MM-630 through plan, tasks, implementation, verification, commit text, and PR metadata | final verify |
+| SCN-001 | partial | catalog expansion validates include tree; submission boundary proof is incomplete | test invalid include tree blocks submission/execution finalization | unit + integration |
+| SCN-002 | implemented_unverified | expansion appends resolved steps deterministically | test repeated equivalent submissions produce the same step order and IDs where expected | unit |
+| SCN-003 | partial | frontend/source and task contract preserve step source; authored bindings are not consistently synthesized from expansion | add provenance derivation/preservation tests | unit + integration |
+| SCN-004 | implemented_unverified | worker receives expanded steps from task template expansion | add catalog-unavailable-after-submit scenario at boundary | integration_ci |
+| SCN-005 | partial | snapshots exist, but recursive composition summary is not preserved in applied template metadata | add snapshot reconstruction assertions after simulated catalog change | unit + integration |
+| SCN-006 | implemented_unverified | manual-only task paths already have broad create/normalization coverage | add regression that manual-only tasks do not gain preset metadata | unit |
+| SC-001 | partial | include validation exists at expansion time | prove validation occurs before execution finalization for task submissions | unit + integration |
+| SC-002 | implemented_unverified | deterministic order appears present in catalog expansion | add deterministic-order regression | unit |
+| SC-003 | partial | reliable step source is preserved; authored preset include-tree details need stronger persistence | implement and test provenance completeness | unit + integration |
+| SC-004 | implemented_unverified | worker-facing paths use expanded steps | add live-catalog-unavailable verification | integration_ci |
+| SC-005 | partial | task snapshots preserve task payloads but not full recursive composition summary | preserve and verify reconstruction metadata | unit + integration |
+| SC-006 | implemented_unverified | manual-only submissions are established | retain and assert unchanged manual-only behavior | unit |
+| DESIGN-REQ-001 | partial | task normalization preserves supplied metadata but does not synthesize missing compiled include-tree bindings | extend normalization/submission metadata preservation | unit + integration |
+| DESIGN-REQ-002 | partial | recursive compile and validation exists in catalog; final execution contract lacks full composition metadata | persist compiled composition at task boundary | unit + integration |
+| DESIGN-REQ-003 | implemented_unverified | task contract models support source and authored preset fields | add targeted validation around recursive authored bindings | unit |
+| DESIGN-REQ-004 | partial | source/authored metadata are supported for reconstruction; recursive composition summary is incomplete | preserve include-tree summary for audit/reconstruction | unit + integration |
+| DESIGN-REQ-005 | implemented_unverified | execution plane consumes resolved steps and tests cover expanded template execution shape | add boundary proof that workers do not require live catalog after submission | integration_ci |
+| DESIGN-REQ-006 | partial | compile-time composition exists; provenance durability is incomplete | close provenance durability gap | unit + integration |
+| DESIGN-REQ-007 | implemented_unverified | attachment and snapshot invariants are existing behavior; out of scope for new behavior | no implementation unless regression appears | final verify |
+| DESIGN-REQ-008 | implemented_unverified | prepare/step attachment context is out of scope | no implementation unless preset changes disturb existing behavior | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Create page submission behavior if frontend provenance payloads change.  
+**Primary Dependencies**: FastAPI route/service layer, SQLAlchemy async task template catalog, Pydantic v2 task contract models, Temporal Python SDK worker/runtime boundaries, React Create page.  
+**Storage**: Existing task template tables, Temporal execution records, artifact-backed original task input snapshots, and existing task payload metadata only; no new persistent tables planned.  
+**Unit Testing**: `./tools/test_unit.sh`; focused iteration with pytest paths and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` when frontend payload behavior changes.  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage of task-shaped submission/execution boundary; no provider credentials required.  
+**Target Platform**: MoonMind API service, Mission Control Create page, and Temporal managed task execution on Linux.  
+**Project Type**: Python backend workflow/control plane with existing React frontend entrypoint.  
+**Performance Goals**: Recursive compilation remains bounded by existing maximum flattened step count; no live preset catalog lookup is needed after submission.  
+**Constraints**: Preserve Temporal payload compatibility; keep large content out of workflow history; do not mutate checked-in skill folders; do not add internal compatibility aliases; fail explicitly for invalid include trees.  
+**Scale/Scope**: One task preset compilation slice spanning catalog expansion, create/API normalization, task snapshots, and worker-facing task payloads.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The plan strengthens MoonMind control-plane orchestration and does not recreate agent cognition.
+- II. One-Click Agent Deployment: PASS. No new service, external dependency, or deployment prerequisite.
+- III. Avoid Vendor Lock-In: PASS. Uses MoonMind task contracts and template metadata, not provider-specific behavior.
+- IV. Own Your Data: PASS. Submitted snapshots and provenance remain MoonMind-owned data.
+- V. Skills Are First-Class: PASS. Presets/skills stay composable authoring inputs that compile to runtime-neutral task steps.
+- VI. Replaceable Scaffolding / Thick Contracts: PASS. Work centers on explicit task and preset compilation contracts.
+- VII. Runtime Configurability: PASS. Existing template catalog/runtime settings remain the control points; no hardcoded deployment changes.
+- VIII. Modular Architecture: PASS. Work stays inside catalog, create/API normalization, snapshot, and worker boundary modules.
+- IX. Resilient by Default: PASS. Invalid or unresolved preset trees fail before execution, and submitted work is reconstructable without live catalog drift.
+- X. Continuous Improvement: PASS. Planning, tests, and verification artifacts preserve evidence for MM-630.
+- XI. Spec-Driven Development: PASS. `spec.md`, this plan, design artifacts, tasks, implementation, and verification remain traceable to MM-630.
+- XII. Canonical Docs vs Tmp: PASS. Runtime rollout notes live under `specs/324-compile-recursive-presets/`; canonical docs are source references only.
+- XIII. Pre-release Compatibility: PASS. The plan avoids new compatibility aliases and favors a single canonical compiled task contract.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/324-compile-recursive-presets/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-preset-compilation-contract.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/executions.py
+└── services/task_templates/catalog.py
+
+moonmind/
+└── workflows/
+    ├── tasks/task_contract.py
+    └── temporal/worker_runtime.py
+
+frontend/
+└── src/entrypoints/task-create.tsx
+
+tests/
+├── unit/api/test_task_step_templates_service.py
+├── unit/api/routers/test_executions.py
+├── unit/workflows/tasks/test_task_contract.py
+├── integration/temporal/test_task_shaped_submission_normalization.py
+└── frontend task-create Vitest coverage when Create payload behavior changes
+```
+
+## Complexity Tracking
+
+No constitution violations or extra complexity accepted.

--- a/specs/324-compile-recursive-presets/quickstart.md
+++ b/specs/324-compile-recursive-presets/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Compile Recursive Task Presets
+
+## Focused Unit Validation
+
+Run focused backend tests while implementing catalog, task contract, and API boundary changes:
+
+```bash
+python -m pytest tests/unit/api/test_task_step_templates_service.py -q
+python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q
+python -m pytest tests/unit/api/routers/test_executions.py -q
+```
+
+If Create page submission payload behavior changes, run focused frontend tests through the repo test runner:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+## Required Unit Suite
+
+```bash
+./tools/test_unit.sh
+```
+
+## Hermetic Integration Validation
+
+Run the required integration suite after adding the task submission/execution boundary coverage:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-to-End Story Check
+
+1. Create a task draft with a root preset that includes a child preset and at least one manual step.
+2. Submit the task and confirm recursive includes are validated before execution finalization.
+3. Confirm the submitted task has one deterministic flattened step order.
+4. Confirm `authoredPresets`, `appliedStepTemplates` composition metadata, and `steps[].source` preserve reliable preset provenance.
+5. Simulate live preset catalog change or unavailability after submission.
+6. Confirm the worker-facing task still contains resolved executable steps and reconstruction uses submitted snapshot metadata, not live catalog lookup.
+7. Confirm a manual-only task still submits without fabricated preset metadata.
+8. Confirm `MM-630` remains preserved in MoonSpec artifacts and final verification output.

--- a/specs/324-compile-recursive-presets/research.md
+++ b/specs/324-compile-recursive-presets/research.md
@@ -1,0 +1,73 @@
+# Research: Compile Recursive Task Presets
+
+## FR-001 / Preset Compilation Before Finalization
+
+Decision: partial; implement missing authoritative submission/snapshot metadata after existing recursive expansion.
+Evidence: `api_service/services/task_templates/catalog.py` recursively expands include steps in `_expand_version_steps()` and returns flattened `steps`; `frontend/src/entrypoints/task-create.tsx` auto-expands unresolved preset steps before create submission.
+Rationale: Expansion exists, but the submitted task contract needs to clearly carry compiled include-tree metadata as the final execution contract, not just live expansion output.
+Alternatives considered: Rely only on `appliedStepTemplates` was rejected because it currently records root template metadata and step IDs, not the recursive include tree needed for reconstruction.
+Test implications: unit plus hermetic integration.
+
+## FR-002 / Invalid Include Trees
+
+Decision: implemented_unverified; current catalog behavior appears strong, but final planning keeps verification coverage explicit.
+Evidence: `tests/unit/api/test_task_step_templates_service.py` covers global-to-personal rejection, include cycles, inactive includes, incompatible inputs, and flattened step limits.
+Rationale: Existing validation likely satisfies most invalid-tree cases, but MM-630 should add or confirm missing/unauthorized target coverage if gaps remain.
+Alternatives considered: Reimplement include validation at execution time was rejected because the spec requires control-plane compile-time validation.
+Test implications: focused unit tests.
+
+## FR-003 / Deterministic Flattened Order
+
+Decision: implemented_unverified; verify deterministic order through submission boundary.
+Evidence: `TaskTemplateCatalogService._expand_version_steps()` appends executable steps to one `resolved_steps` list; `test_expand_template_flattens_pinned_include_with_provenance` asserts child step order.
+Rationale: Catalog order appears deterministic, but the story needs proof that submitted task payload order matches compiled order and remains stable across repeated equivalent submissions.
+Alternatives considered: Trust catalog unit coverage only; rejected because Create/API payload serialization can still reorder or drop steps.
+Test implications: unit and integration.
+
+## FR-004 / Authored Preset And Step Source Provenance
+
+Decision: partial; implement provenance derivation/preservation for recursive authored bindings and include-tree summary.
+Evidence: `moonmind/workflows/tasks/task_contract.py` models `TaskStepSource` and `AuthoredPresetBinding`; `frontend/src/entrypoints/task-create.tsx` preserves `source` when present; `api_service/api/routers/executions.py` preserves supplied `authoredPresets` and `appliedStepTemplates`.
+Rationale: Step source is already supported, but recursive include-tree and authored preset binding details are not consistently synthesized from catalog expansion output.
+Alternatives considered: Store only per-step source; rejected because the spec requires authored preset bindings, include-tree summaries, mappings, alias, detachment state, and reconstruction support.
+Test implications: unit and integration.
+
+## FR-005 / Worker-Facing Resolved Steps
+
+Decision: implemented_unverified; add a boundary test proving no live catalog dependency after submission.
+Evidence: `moonmind/workflows/temporal/worker_runtime.py` expands top-level task templates before child execution and sets `task_payload["steps"]`; docs and existing tests expect workers to consume flattened steps.
+Rationale: The execution-facing behavior appears present, but MM-630 requires proof that workers do not expand presets or read the live catalog after the task has been compiled.
+Alternatives considered: Add worker-side catalog fallback; rejected because it would violate the source design and live-catalog independence.
+Test implications: hermetic integration_ci.
+
+## FR-006 / Reconstruction After Catalog Changes
+
+Decision: partial; preserve recursive composition summary in submitted snapshots.
+Evidence: Existing snapshots and `appliedStepTemplates` are preserved in API and integration tests, but `TaskTemplateCatalogService.expand_template()` returns `composition` separately and `appliedTemplate` omits it.
+Rationale: A submitted task can only be safely reconstructed after catalog changes when the snapshot includes both flattened steps and enough composition/provenance metadata.
+Alternatives considered: Re-expand from live catalog during edit/rerun; rejected because live catalog definitions may drift.
+Test implications: unit and integration.
+
+## FR-007 / Existing Behavior Preservation
+
+Decision: implemented_unverified; protect with regression assertions while changing preset metadata.
+Evidence: Existing API tests preserve runtime, publish, dependencies, attachments, Jira provenance, `authoredPresets`, and `appliedStepTemplates`; integration test `test_task_shaped_submission_normalization.py` covers normalized task submission.
+Rationale: MM-630 should not alter attachment, runtime, publish, Jira, edit, rerun, or resume semantics except where compiled preset provenance is needed.
+Alternatives considered: Broaden the story into attachment/recovery changes; rejected as out of scope.
+Test implications: unit and integration regression coverage.
+
+## FR-008 / MM-630 Traceability
+
+Decision: missing until final verification; preserve throughout artifacts and downstream metadata.
+Evidence: `specs/324-compile-recursive-presets/spec.md` preserves MM-630 and the original Jira preset brief.
+Rationale: Final verification and PR metadata need the issue key and original brief available for comparison.
+Alternatives considered: Store only the Jira key; rejected because final verification compares against the original brief.
+Test implications: final verify.
+
+## Test Strategy
+
+Decision: use both unit and hermetic integration testing.
+Evidence: Unit tests already exist for catalog expansion, task contract models, API normalization, and Create page payload behavior; integration tests cover task-shaped submission normalization.
+Rationale: Catalog behavior can be tested hermetically in unit tests, while the no-live-catalog worker/submission boundary requires integration-level evidence.
+Alternatives considered: Provider verification tests; rejected because MM-630 uses local task/preset contracts and does not require external credentials.
+Test implications: `./tools/test_unit.sh` and `./tools/test_integration.sh`.

--- a/specs/324-compile-recursive-presets/spec.md
+++ b/specs/324-compile-recursive-presets/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Compile Recursive Task Presets
+
+**Feature Branch**: `324-compile-recursive-presets`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-630 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-630 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-630
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Compile recursive task presets before execution
+- Labels: `moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-630 from MM project
+Summary: Compile recursive task presets before execution
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-630 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-630: Compile recursive task presets before execution
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 5.4 Preset compilation
+- 5.3 Task contract normalization
+- 6 Canonical task-shaped contract
+- 8 Execution-plane responsibilities
+- 11 Invariants
+
+Coverage IDs:
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+
+As a task author using presets, I want recursive preset includes resolved into final ordered steps before execution while MoonMind keeps provenance for audit and safe reconstruction.
+
+Acceptance Criteria:
+- Recursive preset include trees are validated before execution contract finalization.
+- Manual and preset-derived steps are flattened into deterministic final submitted order.
+- `authoredPresets` and `steps[].source` preserve IDs/slugs, versions, aliases, include paths, mappings, original step IDs, and detachment state.
+- Workers receive resolved steps and do not expand presets or read the live preset catalog.
+- Already submitted work can be reconstructed after live preset catalog changes.
+
+Requirements:
+- Recursive presets are authoring objects resolved before execution; workers consume flattened steps without live preset catalog lookup.
+- Snapshots and payloads preserve authored preset bindings, include-tree summaries, source provenance, detachment state, and final order.
+"""
+
+**Implementation Intent**: Runtime. The Jira preset brief selects product behavior for task submission and execution boundaries; the referenced architecture document is treated as runtime source requirements.
+
+## User Story - Recursive Preset Compilation
+
+**Summary**: Task authors can submit tasks that include nested presets and receive one final, ordered, executable step list with durable provenance.
+
+**Goal**: Enable authors to compose work from presets without making execution depend on live preset definitions after submission.
+
+**Independent Test**: Submit a task draft containing manual steps plus a recursive preset include tree, then verify before execution begins that the task has a deterministic flattened step order, complete preset provenance, and a worker-facing payload that remains executable after the live preset catalog changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task draft with a preset that includes another preset, **When** the task is submitted, **Then** the system validates the full include tree before finalizing the execution contract.
+2. **Given** manual steps interleaved with preset-derived steps, **When** compilation succeeds, **Then** the submitted task contains a deterministic final step order that preserves the author's intended ordering.
+3. **Given** preset-derived or detached steps, **When** the submitted task snapshot is recorded, **Then** the snapshot preserves preset identifiers or slugs, versions, aliases, include paths, input mappings, original step identifiers, detachment state, and per-step source provenance where those values exist.
+4. **Given** a compiled task, **When** a worker starts execution, **Then** the worker receives resolved executable steps and does not need to expand presets or consult the live preset catalog.
+5. **Given** a task was already submitted and then preset catalog definitions changed, **When** the task is viewed, rerun, audited, or reconstructed, **Then** the system uses the submitted snapshot and provenance rather than changed live preset definitions.
+
+**Edge Cases**:
+
+- A recursive include tree contains a cycle or unsupported include shape.
+- A nested preset references a missing, disabled, or unauthorized preset.
+- A preset-derived step has been detached or edited before submission.
+- Two included presets provide conflicting aliases or mappings.
+- A task contains no presets and should continue to submit as a manual flat task.
+- A live preset is modified or deleted after a task has already been submitted.
+
+## Assumptions
+
+- A task draft may already contain manual steps, preset selections, and nested preset include metadata before submission.
+- Existing task edit, rerun, and audit surfaces can read from an authoritative submitted task snapshot when the snapshot preserves enough provenance.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tasks/TaskArchitecture.md` lines 171-178. Task contract normalization must preserve authored preset binding metadata, flattened provenance, manual and preset-derived order, fully resolved execution payloads, and allowed Jira provenance. Scope: in scope. Mapped to FR-001, FR-003, FR-004, FR-006.
+- **DESIGN-REQ-002**: Source `docs/Tasks/TaskArchitecture.md` lines 180-191. Preset compilation must be a control-plane phase before execution finalization, resolve recursive composition, validate include trees, flatten steps, preserve provenance, and produce payloads that do not require live preset lookup. Scope: in scope. Mapped to FR-001 through FR-005.
+- **DESIGN-REQ-003**: Source `docs/Tasks/TaskArchitecture.md` lines 240-257 and 275-293. The canonical task contract defines source and authored preset fields capable of carrying preset identifiers, slugs, versions, aliases, include paths, mappings, and original step identifiers. Scope: in scope. Mapped to FR-003, FR-004.
+- **DESIGN-REQ-004**: Source `docs/Tasks/TaskArchitecture.md` lines 324-337. Authored presets and step source are task contract fields for reconstruction, audit, diagnostics, and safe rerun semantics, and worker-facing payloads must already be resolved. Scope: in scope. Mapped to FR-004, FR-006.
+- **DESIGN-REQ-005**: Source `docs/Tasks/TaskArchitecture.md` lines 452-461. The execution plane consumes normalized resolved steps and must not expand presets or depend on live preset catalog correctness for already submitted work. Scope: in scope. Mapped to FR-005, FR-006.
+- **DESIGN-REQ-006**: Source `docs/Tasks/TaskArchitecture.md` lines 593-597. Compile-time preset composition and preset provenance durability are task system invariants. Scope: in scope. Mapped to FR-001 through FR-006.
+- **DESIGN-REQ-007**: Source `docs/Tasks/TaskArchitecture.md` lines 578-592 and 599-600. Attachment payload, attachment target, text, snapshot, and server policy invariants are preserved by this story but not expanded. Scope: out of scope; MM-630 focuses on preset compilation and provenance rather than attachment policy behavior. Mapped to FR-007.
+- **DESIGN-REQ-008**: Source `docs/Tasks/TaskArchitecture.md` lines 463-490. Workflow, prepare, and step execution responsibilities around attachments and target-aware context remain outside the preset compilation slice. Scope: out of scope; workers still consume resolved task context, but attachment preparation behavior is not changed by this story. Mapped to FR-007.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST compile recursive preset include trees before execution contract finalization.
+- **FR-002**: The system MUST reject or block finalization of preset include trees that are cyclic, missing required preset references, unauthorized, disabled, or otherwise invalid.
+- **FR-003**: The system MUST flatten manual and preset-derived steps into one deterministic submitted order before workers can execute the task.
+- **FR-004**: The submitted task snapshot and payload MUST preserve reliable authored preset binding and step source provenance, including identifiers or slugs, versions, aliases, include paths, input mappings, original step identifiers, and detachment state when those values exist.
+- **FR-005**: Worker-facing execution payloads MUST contain resolved executable steps and MUST NOT require workers to expand presets or read the live preset catalog.
+- **FR-006**: Already submitted work MUST be reconstructable from its submitted snapshot and provenance after live preset catalog definitions change.
+- **FR-007**: The feature MUST preserve existing task behavior for attachment handling, runtime selection, publish intent, Jira provenance, edit, rerun, and resume semantics except where those behaviors need the compiled preset provenance selected by MM-630.
+- **FR-008**: The system MUST preserve Jira issue key `MM-630` and the canonical Jira preset brief in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Task Draft**: The authoring-state task before submission, containing manual steps, preset selections, optional nested includes, runtime selections, publish intent, and Jira provenance.
+- **Preset Include Tree**: The nested structure of selected presets and included presets that must be validated and resolved before execution.
+- **Compiled Task Snapshot**: The authoritative submitted representation containing final ordered steps plus enough provenance to audit, reconstruct, edit, rerun, or resume safely.
+- **Step Source Provenance**: Per-step metadata describing whether a step is manual, preset-derived, included, or detached, including reliable origin identifiers and include path data when available.
+- **Worker-Facing Payload**: The resolved task contract consumed by execution workers after preset compilation.
+
+## Success Criteria
+
+- **SC-001**: 100% of submitted tasks with recursive preset includes are validated before execution contract finalization.
+- **SC-002**: Re-submitting the same valid draft inputs produces the same final step order in 100% of repeated submissions.
+- **SC-003**: 100% of compiled preset-derived or detached steps with reliable origin data preserve source provenance in the submitted snapshot.
+- **SC-004**: Workers can execute a compiled preset-derived task when live preset lookup is unavailable after submission.
+- **SC-005**: A submitted task can be reconstructed after live preset catalog changes without changing its original final step order or provenance.
+- **SC-006**: Manual-only task submission behavior remains unchanged for tasks with zero presets.

--- a/specs/324-compile-recursive-presets/tasks.md
+++ b/specs/324-compile-recursive-presets/tasks.md
@@ -13,15 +13,15 @@ Requirement status from `plan.md`: partial rows require red-first tests and impl
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm active feature locator points to `specs/324-compile-recursive-presets` in `.specify/feature.json`
-- [ ] T002 Confirm `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, and `quickstart.md` exist before implementation
-- [ ] T003 Review current task preset catalog, task contract, Create page, execution router, worker runtime, and integration test fixtures in `api_service/services/task_templates/catalog.py`, `moonmind/workflows/tasks/task_contract.py`, `frontend/src/entrypoints/task-create.tsx`, `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+- [X] T001 Confirm active feature locator points to `specs/324-compile-recursive-presets` in `.specify/feature.json`
+- [X] T002 Confirm `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, and `quickstart.md` exist before implementation
+- [X] T003 Review current task preset catalog, task contract, Create page, execution router, worker runtime, and integration test fixtures in `api_service/services/task_templates/catalog.py`, `moonmind/workflows/tasks/task_contract.py`, `frontend/src/entrypoints/task-create.tsx`, `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`
 
 ## Phase 2: Foundational
 
-- [ ] T004 Identify or add reusable recursive preset fixture helpers for unit tests in `tests/unit/api/test_task_step_templates_service.py` and `tests/unit/api/routers/test_executions.py` without changing production behavior
-- [ ] T005 Identify or add reusable recursive task submission fixture helpers for integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py`
-- [ ] T006 Confirm no database migration or new persistent table is required by reviewing existing task template and execution snapshot storage in `api_service/db/models.py` and `api_service/api/routers/executions.py`
+- [X] T004 Identify or add reusable recursive preset fixture helpers for unit tests in `tests/unit/api/test_task_step_templates_service.py` and `tests/unit/api/routers/test_executions.py` without changing production behavior
+- [X] T005 Identify or add reusable recursive task submission fixture helpers for integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+- [X] T006 Confirm no database migration or new persistent table is required by reviewing existing task template and execution snapshot storage in `api_service/db/models.py` and `api_service/api/routers/executions.py`
 
 ## Phase 3: Story - Recursive Preset Compilation
 
@@ -37,64 +37,64 @@ Requirement status from `plan.md`: partial rows require red-first tests and impl
 
 ### Unit Tests First
 
-- [ ] T007 [P] Add failing unit test for missing or unavailable recursive include targets in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: missing/unauthorized preset)
-- [ ] T008 [P] Add failing unit test for deterministic repeated recursive expansion order and stable step IDs in `tests/unit/api/test_task_step_templates_service.py` (FR-003, SCN-002, SC-002, DESIGN-REQ-002)
-- [ ] T009 [P] Add failing unit test that recursive expansion returns compact composition metadata suitable for authored preset bindings in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T010 [P] Add failing unit test for conflicting include aliases or incompatible mappings in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: conflicting aliases or mappings)
-- [ ] T011 [P] Add failing task contract unit test for recursive `authoredPresets` bindings with slug/version/alias/includePath/inputMapping/scope in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-003)
-- [ ] T012 [P] Add failing task contract unit test rejecting invalid unresolved preset worker-step shape when represented as executable task work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-005, DESIGN-REQ-005)
-- [ ] T013 [P] Add failing API route unit test that task-shaped submission preserves recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, and attachments in `tests/unit/api/routers/test_executions.py` (FR-001, FR-004, FR-006, FR-007, SCN-003, DESIGN-REQ-001)
-- [ ] T014 [P] Add failing API route unit test that manual-only submission does not fabricate `authoredPresets`, composition, or preset source metadata in `tests/unit/api/routers/test_executions.py` (FR-007, SCN-006, SC-006)
-- [ ] T015 [P] Add failing Create page unit test that recursive preset expansion submits `steps[].source`, `authoredPresets`, and composition metadata in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-003)
-- [ ] T016 [P] Add failing Create page unit test that auto-expanding an unresolved recursive preset before submit does not mutate the visible draft and still submits resolved executable steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-003, SCN-001, SCN-002)
+- [X] T007 [P] Add failing unit test for missing or unavailable recursive include targets in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: missing/unauthorized preset)
+- [X] T008 [P] Add failing unit test for deterministic repeated recursive expansion order and stable step IDs in `tests/unit/api/test_task_step_templates_service.py` (FR-003, SCN-002, SC-002, DESIGN-REQ-002)
+- [X] T009 [P] Add failing unit test that recursive expansion returns compact composition metadata suitable for authored preset bindings in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-001, DESIGN-REQ-004)
+- [X] T010 [P] Add failing unit test for conflicting include aliases or incompatible mappings in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: conflicting aliases or mappings)
+- [X] T011 [P] Add failing task contract unit test for recursive `authoredPresets` bindings with slug/version/alias/includePath/inputMapping/scope in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-003)
+- [X] T012 [P] Add failing task contract unit test rejecting invalid unresolved preset worker-step shape when represented as executable task work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-005, DESIGN-REQ-005)
+- [X] T013 [P] Add failing API route unit test that task-shaped submission preserves recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, and attachments in `tests/unit/api/routers/test_executions.py` (FR-001, FR-004, FR-006, FR-007, SCN-003, DESIGN-REQ-001)
+- [X] T014 [P] Add failing API route unit test that manual-only submission does not fabricate `authoredPresets`, composition, or preset source metadata in `tests/unit/api/routers/test_executions.py` (FR-007, SCN-006, SC-006)
+- [X] T015 [P] Add failing Create page unit test that recursive preset expansion submits `steps[].source`, `authoredPresets`, and composition metadata in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-003)
+- [X] T016 [P] Add failing Create page unit test that auto-expanding an unresolved recursive preset before submit does not mutate the visible draft and still submits resolved executable steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-003, SCN-001, SCN-002)
 
 ### Integration Tests First
 
-- [ ] T017 [P] Add failing hermetic integration test for recursive task-shaped submission preserving final flattened order and compiled provenance in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001, FR-003, FR-004, SCN-001, SCN-002, SCN-003)
-- [ ] T018 [P] Add failing hermetic integration test proving worker-facing task payload contains resolved executable steps and no unresolved preset include work after submission in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-005, SCN-004, SC-004, DESIGN-REQ-005)
-- [ ] T019 [P] Add failing hermetic integration test simulating live preset catalog change or unavailability after submission while reconstruction uses submitted snapshot metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-006, SCN-005, SC-005)
-- [ ] T020 [P] Add integration regression for manual-only task submission staying unchanged in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-007, SCN-006, SC-006, DESIGN-REQ-007, DESIGN-REQ-008)
+- [X] T017 [P] Add failing hermetic integration test for recursive task-shaped submission preserving final flattened order and compiled provenance in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001, FR-003, FR-004, SCN-001, SCN-002, SCN-003)
+- [X] T018 [P] Add failing hermetic integration test proving worker-facing task payload contains resolved executable steps and no unresolved preset include work after submission in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-005, SCN-004, SC-004, DESIGN-REQ-005)
+- [X] T019 [P] Add failing hermetic integration test simulating live preset catalog change or unavailability after submission while reconstruction uses submitted snapshot metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-006, SCN-005, SC-005)
+- [X] T020 [P] Add integration regression for manual-only task submission staying unchanged in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-007, SCN-006, SC-006, DESIGN-REQ-007, DESIGN-REQ-008)
 
 ### Red-First Confirmation
 
-- [ ] T021 Run focused catalog and task contract unit tests and confirm new tests fail for the expected missing behavior using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py -q` (FR-001 through FR-006)
+- [X] T021 Run focused catalog and task contract unit tests and confirm new tests fail for the expected missing behavior using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py -q` (FR-001 through FR-006)
 - [ ] T022 Run focused API route unit tests and confirm new tests fail for the expected metadata/snapshot gaps using `python -m pytest tests/unit/api/routers/test_executions.py -q` (FR-001, FR-004, FR-006, FR-007)
 - [ ] T023 Run focused Create page tests and confirm new tests fail for the expected recursive provenance submission gaps using `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
 - [ ] T024 Run focused integration tests and confirm new tests fail for unresolved worker payload or missing reconstruction metadata using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007)
 
 ### Conditional Fallback Implementation For Implemented-Unverified Rows
 
-- [ ] T025 If T007 shows missing or unauthorized include target handling is not already adequate, implement explicit include target failure behavior in `api_service/services/task_templates/catalog.py` (FR-002, SCN-001)
-- [ ] T026 If T008 shows deterministic expansion is not stable, implement deterministic recursive ordering and stable step ID generation in `api_service/services/task_templates/catalog.py` (FR-003, SCN-002, SC-002)
-- [ ] T027 If T012 shows unresolved preset work can enter worker-facing payloads, tighten task step validation in `moonmind/workflows/tasks/task_contract.py` (FR-005, DESIGN-REQ-005)
-- [ ] T028 If T018 shows workers still depend on live catalog after submission, adjust worker task preparation in `moonmind/workflows/temporal/worker_runtime.py` to consume only submitted resolved steps (FR-005, SCN-004, SC-004)
-- [ ] T029 If T014 or T020 shows manual-only submissions gain preset metadata, remove fabricated preset provenance from `api_service/api/routers/executions.py` or `frontend/src/entrypoints/task-create.tsx` (FR-007, SCN-006, SC-006)
+- [X] T025 If T007 shows missing or unauthorized include target handling is not already adequate, implement explicit include target failure behavior in `api_service/services/task_templates/catalog.py` (FR-002, SCN-001)
+- [X] T026 If T008 shows deterministic expansion is not stable, implement deterministic recursive ordering and stable step ID generation in `api_service/services/task_templates/catalog.py` (FR-003, SCN-002, SC-002)
+- [X] T027 If T012 shows unresolved preset work can enter worker-facing payloads, tighten task step validation in `moonmind/workflows/tasks/task_contract.py` (FR-005, DESIGN-REQ-005)
+- [X] T028 If T018 shows workers still depend on live catalog after submission, adjust worker task preparation in `moonmind/workflows/temporal/worker_runtime.py` to consume only submitted resolved steps (FR-005, SCN-004, SC-004)
+- [X] T029 If T014 or T020 shows manual-only submissions gain preset metadata, remove fabricated preset provenance from `api_service/api/routers/executions.py` or `frontend/src/entrypoints/task-create.tsx` (FR-007, SCN-006, SC-006)
 
 ### Production Implementation
 
-- [ ] T030 Implement compact recursive composition output on template expansion in `api_service/services/task_templates/catalog.py` (FR-001, FR-004, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
-- [ ] T031 Implement derived authored preset binding metadata from recursive composition in `api_service/services/task_templates/catalog.py` (FR-004, SC-003, DESIGN-REQ-003)
-- [ ] T032 Preserve recursive composition metadata in `appliedTemplate` or submitted `appliedStepTemplates` without embedding large template content in `api_service/services/task_templates/catalog.py` (FR-006, SC-005, DESIGN-REQ-006)
-- [ ] T033 Update Create page expansion/submission mapping to carry recursive `authoredPresets`, `appliedStepTemplates` composition, and `steps[].source` in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-004, SCN-003)
-- [ ] T034 Update API task-shaped normalization to preserve recursive `authoredPresets`, `appliedStepTemplates` composition, final step order, and existing runtime/publish/Jira/attachment fields in `api_service/api/routers/executions.py` (FR-001, FR-004, FR-006, FR-007)
-- [ ] T035 Update task contract models only as needed for compact recursive composition or authored preset metadata in `moonmind/workflows/tasks/task_contract.py` (FR-004, DESIGN-REQ-003)
-- [ ] T036 Update worker runtime preparation only as needed to persist and consume submitted resolved steps and compact preset provenance in `moonmind/workflows/temporal/worker_runtime.py` (FR-005, FR-006, DESIGN-REQ-005)
-- [ ] T037 Ensure task snapshots preserve compiled recursive preset metadata without live catalog lookup in `api_service/api/routers/executions.py` (FR-006, SCN-005, SC-005)
-- [ ] T038 Ensure invalid recursive preset submissions produce explicit recoverable errors without creating execution work in `api_service/services/task_templates/catalog.py` and `api_service/api/routers/executions.py` (FR-002, SCN-001, SC-001)
+- [X] T030 Implement compact recursive composition output on template expansion in `api_service/services/task_templates/catalog.py` (FR-001, FR-004, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
+- [X] T031 Implement derived authored preset binding metadata from recursive composition in `api_service/services/task_templates/catalog.py` (FR-004, SC-003, DESIGN-REQ-003)
+- [X] T032 Preserve recursive composition metadata in `appliedTemplate` or submitted `appliedStepTemplates` without embedding large template content in `api_service/services/task_templates/catalog.py` (FR-006, SC-005, DESIGN-REQ-006)
+- [X] T033 Update Create page expansion/submission mapping to carry recursive `authoredPresets`, `appliedStepTemplates` composition, and `steps[].source` in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-004, SCN-003)
+- [X] T034 Update API task-shaped normalization to preserve recursive `authoredPresets`, `appliedStepTemplates` composition, final step order, and existing runtime/publish/Jira/attachment fields in `api_service/api/routers/executions.py` (FR-001, FR-004, FR-006, FR-007)
+- [X] T035 Update task contract models only as needed for compact recursive composition or authored preset metadata in `moonmind/workflows/tasks/task_contract.py` (FR-004, DESIGN-REQ-003)
+- [X] T036 Update worker runtime preparation only as needed to persist and consume submitted resolved steps and compact preset provenance in `moonmind/workflows/temporal/worker_runtime.py` (FR-005, FR-006, DESIGN-REQ-005)
+- [X] T037 Ensure task snapshots preserve compiled recursive preset metadata without live catalog lookup in `api_service/api/routers/executions.py` (FR-006, SCN-005, SC-005)
+- [X] T038 Ensure invalid recursive preset submissions produce explicit recoverable errors without creating execution work in `api_service/services/task_templates/catalog.py` and `api_service/api/routers/executions.py` (FR-002, SCN-001, SC-001)
 
 ### Story Validation
 
-- [ ] T039 Re-run focused unit tests for catalog, task contract, API router, and Create page using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py -q` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-001 through FR-007)
-- [ ] T040 Re-run focused hermetic integration coverage using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (SCN-001 through SCN-006)
-- [ ] T041 Verify the task preset compilation contract remains satisfied by comparing implementation behavior against `specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md` (FR-001 through FR-007)
-- [ ] T042 Verify `MM-630` and the original Jira preset brief remain preserved in `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`, and `tasks.md` (FR-008)
+- [X] T039 Re-run focused unit tests for catalog, task contract, API router, and Create page using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py -q` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-001 through FR-007)
+- [X] T040 Re-run focused hermetic integration coverage using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (SCN-001 through SCN-006)
+- [X] T041 Verify the task preset compilation contract remains satisfied by comparing implementation behavior against `specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md` (FR-001 through FR-007)
+- [X] T042 Verify `MM-630` and the original Jira preset brief remain preserved in `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`, and `tasks.md` (FR-008)
 
 ## Final Phase: Polish And Verification
 
-- [ ] T043 Refactor duplicated recursive preset provenance helpers after tests pass while keeping behavior unchanged in `api_service/services/task_templates/catalog.py`, `api_service/api/routers/executions.py`, and `frontend/src/entrypoints/task-create.tsx`
-- [ ] T044 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
+- [X] T043 Refactor duplicated recursive preset provenance helpers after tests pass while keeping behavior unchanged in `api_service/services/task_templates/catalog.py`, `api_service/api/routers/executions.py`, and `frontend/src/entrypoints/task-create.tsx`
+- [X] T044 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
 - [ ] T045 Run the required hermetic integration suite with `./tools/test_integration.sh` (SCN-001 through SCN-006)
-- [ ] T046 Confirm no provider verification or credentialed tests are required for MM-630 and document any intentionally skipped provider checks in final verification notes in `specs/324-compile-recursive-presets/verification.md`
+- [X] T046 Confirm no provider verification or credentialed tests are required for MM-630 and document any intentionally skipped provider checks in final verification notes in `specs/324-compile-recursive-presets/verification.md`
 - [ ] T047 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-630, the original Jira preset brief, FR-001 through FR-008, SCN-001 through SCN-006, SC-001 through SC-006, DESIGN-REQ-001 through DESIGN-REQ-008, commands run, and remaining risks
 
 ## Dependencies And Execution Order

--- a/specs/324-compile-recursive-presets/tasks.md
+++ b/specs/324-compile-recursive-presets/tasks.md
@@ -40,79 +40,80 @@ Requirement status from `plan.md`: partial rows require red-first tests and impl
 - [ ] T007 [P] Add failing unit test for missing or unavailable recursive include targets in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: missing/unauthorized preset)
 - [ ] T008 [P] Add failing unit test for deterministic repeated recursive expansion order and stable step IDs in `tests/unit/api/test_task_step_templates_service.py` (FR-003, SCN-002, SC-002, DESIGN-REQ-002)
 - [ ] T009 [P] Add failing unit test that recursive expansion returns compact composition metadata suitable for authored preset bindings in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T010 [P] Add failing task contract unit test for recursive `authoredPresets` bindings with slug/version/alias/includePath/inputMapping/scope in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-003)
-- [ ] T011 [P] Add failing task contract unit test rejecting invalid unresolved preset worker-step shape when represented as executable task work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-005, DESIGN-REQ-005)
-- [ ] T012 [P] Add failing API route unit test that task-shaped submission preserves recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, and attachments in `tests/unit/api/routers/test_executions.py` (FR-001, FR-004, FR-006, FR-007, SCN-003, DESIGN-REQ-001)
-- [ ] T013 [P] Add failing API route unit test that manual-only submission does not fabricate `authoredPresets`, composition, or preset source metadata in `tests/unit/api/routers/test_executions.py` (FR-007, SCN-006, SC-006)
-- [ ] T014 [P] Add failing Create page unit test that recursive preset expansion submits `steps[].source`, `authoredPresets`, and composition metadata in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-003)
-- [ ] T015 [P] Add failing Create page unit test that auto-expanding an unresolved recursive preset before submit does not mutate the visible draft and still submits resolved executable steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-003, SCN-001, SCN-002)
+- [ ] T010 [P] Add failing unit test for conflicting include aliases or incompatible mappings in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: conflicting aliases or mappings)
+- [ ] T011 [P] Add failing task contract unit test for recursive `authoredPresets` bindings with slug/version/alias/includePath/inputMapping/scope in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-003)
+- [ ] T012 [P] Add failing task contract unit test rejecting invalid unresolved preset worker-step shape when represented as executable task work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-005, DESIGN-REQ-005)
+- [ ] T013 [P] Add failing API route unit test that task-shaped submission preserves recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, and attachments in `tests/unit/api/routers/test_executions.py` (FR-001, FR-004, FR-006, FR-007, SCN-003, DESIGN-REQ-001)
+- [ ] T014 [P] Add failing API route unit test that manual-only submission does not fabricate `authoredPresets`, composition, or preset source metadata in `tests/unit/api/routers/test_executions.py` (FR-007, SCN-006, SC-006)
+- [ ] T015 [P] Add failing Create page unit test that recursive preset expansion submits `steps[].source`, `authoredPresets`, and composition metadata in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-003)
+- [ ] T016 [P] Add failing Create page unit test that auto-expanding an unresolved recursive preset before submit does not mutate the visible draft and still submits resolved executable steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-003, SCN-001, SCN-002)
 
 ### Integration Tests First
 
-- [ ] T016 [P] Add failing hermetic integration test for recursive task-shaped submission preserving final flattened order and compiled provenance in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001, FR-003, FR-004, SCN-001, SCN-002, SCN-003)
-- [ ] T017 [P] Add failing hermetic integration test proving worker-facing task payload contains resolved executable steps and no unresolved preset include work after submission in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-005, SCN-004, SC-004, DESIGN-REQ-005)
-- [ ] T018 [P] Add failing hermetic integration test simulating live preset catalog change or unavailability after submission while reconstruction uses submitted snapshot metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-006, SCN-005, SC-005)
-- [ ] T019 [P] Add integration regression for manual-only task submission staying unchanged in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-007, SCN-006, SC-006, DESIGN-REQ-007, DESIGN-REQ-008)
+- [ ] T017 [P] Add failing hermetic integration test for recursive task-shaped submission preserving final flattened order and compiled provenance in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001, FR-003, FR-004, SCN-001, SCN-002, SCN-003)
+- [ ] T018 [P] Add failing hermetic integration test proving worker-facing task payload contains resolved executable steps and no unresolved preset include work after submission in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-005, SCN-004, SC-004, DESIGN-REQ-005)
+- [ ] T019 [P] Add failing hermetic integration test simulating live preset catalog change or unavailability after submission while reconstruction uses submitted snapshot metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-006, SCN-005, SC-005)
+- [ ] T020 [P] Add integration regression for manual-only task submission staying unchanged in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-007, SCN-006, SC-006, DESIGN-REQ-007, DESIGN-REQ-008)
 
 ### Red-First Confirmation
 
-- [ ] T020 Run focused catalog and task contract unit tests and confirm new tests fail for the expected missing behavior using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py -q` (FR-001 through FR-006)
-- [ ] T021 Run focused API route unit tests and confirm new tests fail for the expected metadata/snapshot gaps using `python -m pytest tests/unit/api/routers/test_executions.py -q` (FR-001, FR-004, FR-006, FR-007)
-- [ ] T022 Run focused Create page tests and confirm new tests fail for the expected recursive provenance submission gaps using `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
-- [ ] T023 Run focused integration tests and confirm new tests fail for unresolved worker payload or missing reconstruction metadata using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007)
+- [ ] T021 Run focused catalog and task contract unit tests and confirm new tests fail for the expected missing behavior using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py -q` (FR-001 through FR-006)
+- [ ] T022 Run focused API route unit tests and confirm new tests fail for the expected metadata/snapshot gaps using `python -m pytest tests/unit/api/routers/test_executions.py -q` (FR-001, FR-004, FR-006, FR-007)
+- [ ] T023 Run focused Create page tests and confirm new tests fail for the expected recursive provenance submission gaps using `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
+- [ ] T024 Run focused integration tests and confirm new tests fail for unresolved worker payload or missing reconstruction metadata using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007)
 
 ### Conditional Fallback Implementation For Implemented-Unverified Rows
 
-- [ ] T024 If T007 shows missing or unauthorized include target handling is not already adequate, implement explicit include target failure behavior in `api_service/services/task_templates/catalog.py` (FR-002, SCN-001)
-- [ ] T025 If T008 shows deterministic expansion is not stable, implement deterministic recursive ordering and stable step ID generation in `api_service/services/task_templates/catalog.py` (FR-003, SCN-002, SC-002)
-- [ ] T026 If T011 shows unresolved preset work can enter worker-facing payloads, tighten task step validation in `moonmind/workflows/tasks/task_contract.py` (FR-005, DESIGN-REQ-005)
-- [ ] T027 If T017 shows workers still depend on live catalog after submission, adjust worker task preparation in `moonmind/workflows/temporal/worker_runtime.py` to consume only submitted resolved steps (FR-005, SCN-004, SC-004)
-- [ ] T028 If T013 or T019 shows manual-only submissions gain preset metadata, remove fabricated preset provenance from `api_service/api/routers/executions.py` or `frontend/src/entrypoints/task-create.tsx` (FR-007, SCN-006, SC-006)
+- [ ] T025 If T007 shows missing or unauthorized include target handling is not already adequate, implement explicit include target failure behavior in `api_service/services/task_templates/catalog.py` (FR-002, SCN-001)
+- [ ] T026 If T008 shows deterministic expansion is not stable, implement deterministic recursive ordering and stable step ID generation in `api_service/services/task_templates/catalog.py` (FR-003, SCN-002, SC-002)
+- [ ] T027 If T012 shows unresolved preset work can enter worker-facing payloads, tighten task step validation in `moonmind/workflows/tasks/task_contract.py` (FR-005, DESIGN-REQ-005)
+- [ ] T028 If T018 shows workers still depend on live catalog after submission, adjust worker task preparation in `moonmind/workflows/temporal/worker_runtime.py` to consume only submitted resolved steps (FR-005, SCN-004, SC-004)
+- [ ] T029 If T014 or T020 shows manual-only submissions gain preset metadata, remove fabricated preset provenance from `api_service/api/routers/executions.py` or `frontend/src/entrypoints/task-create.tsx` (FR-007, SCN-006, SC-006)
 
 ### Production Implementation
 
-- [ ] T029 Implement compact recursive composition output on template expansion in `api_service/services/task_templates/catalog.py` (FR-001, FR-004, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
-- [ ] T030 Implement derived authored preset binding metadata from recursive composition in `api_service/services/task_templates/catalog.py` or a focused helper module under `api_service/services/task_templates/` (FR-004, SC-003, DESIGN-REQ-003)
-- [ ] T031 Preserve recursive composition metadata in `appliedTemplate` or submitted `appliedStepTemplates` without embedding large template content in `api_service/services/task_templates/catalog.py` (FR-006, SC-005, DESIGN-REQ-006)
-- [ ] T032 Update Create page expansion/submission mapping to carry recursive `authoredPresets`, `appliedStepTemplates` composition, and `steps[].source` in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-004, SCN-003)
-- [ ] T033 Update API task-shaped normalization to preserve recursive `authoredPresets`, `appliedStepTemplates` composition, final step order, and existing runtime/publish/Jira/attachment fields in `api_service/api/routers/executions.py` (FR-001, FR-004, FR-006, FR-007)
-- [ ] T034 Update task contract models only as needed for compact recursive composition or authored preset metadata in `moonmind/workflows/tasks/task_contract.py` (FR-004, DESIGN-REQ-003)
-- [ ] T035 Update worker runtime preparation only as needed to persist and consume submitted resolved steps and compact preset provenance in `moonmind/workflows/temporal/worker_runtime.py` (FR-005, FR-006, DESIGN-REQ-005)
-- [ ] T036 Ensure task snapshots preserve compiled recursive preset metadata without live catalog lookup in `api_service/api/routers/executions.py` and related snapshot helpers (FR-006, SCN-005, SC-005)
-- [ ] T037 Ensure invalid recursive preset submissions produce explicit recoverable errors without creating execution work in `api_service/services/task_templates/catalog.py` and `api_service/api/routers/executions.py` (FR-002, SCN-001, SC-001)
+- [ ] T030 Implement compact recursive composition output on template expansion in `api_service/services/task_templates/catalog.py` (FR-001, FR-004, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
+- [ ] T031 Implement derived authored preset binding metadata from recursive composition in `api_service/services/task_templates/catalog.py` (FR-004, SC-003, DESIGN-REQ-003)
+- [ ] T032 Preserve recursive composition metadata in `appliedTemplate` or submitted `appliedStepTemplates` without embedding large template content in `api_service/services/task_templates/catalog.py` (FR-006, SC-005, DESIGN-REQ-006)
+- [ ] T033 Update Create page expansion/submission mapping to carry recursive `authoredPresets`, `appliedStepTemplates` composition, and `steps[].source` in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-004, SCN-003)
+- [ ] T034 Update API task-shaped normalization to preserve recursive `authoredPresets`, `appliedStepTemplates` composition, final step order, and existing runtime/publish/Jira/attachment fields in `api_service/api/routers/executions.py` (FR-001, FR-004, FR-006, FR-007)
+- [ ] T035 Update task contract models only as needed for compact recursive composition or authored preset metadata in `moonmind/workflows/tasks/task_contract.py` (FR-004, DESIGN-REQ-003)
+- [ ] T036 Update worker runtime preparation only as needed to persist and consume submitted resolved steps and compact preset provenance in `moonmind/workflows/temporal/worker_runtime.py` (FR-005, FR-006, DESIGN-REQ-005)
+- [ ] T037 Ensure task snapshots preserve compiled recursive preset metadata without live catalog lookup in `api_service/api/routers/executions.py` (FR-006, SCN-005, SC-005)
+- [ ] T038 Ensure invalid recursive preset submissions produce explicit recoverable errors without creating execution work in `api_service/services/task_templates/catalog.py` and `api_service/api/routers/executions.py` (FR-002, SCN-001, SC-001)
 
 ### Story Validation
 
-- [ ] T038 Re-run focused unit tests for catalog, task contract, API router, and Create page using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py -q` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-001 through FR-007)
-- [ ] T039 Re-run focused hermetic integration coverage using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (SCN-001 through SCN-006)
-- [ ] T040 Verify the task preset compilation contract remains satisfied by comparing implementation behavior against `specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md` (FR-001 through FR-007)
-- [ ] T041 Verify `MM-630` and the original Jira preset brief remain preserved in `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`, and `tasks.md` (FR-008)
+- [ ] T039 Re-run focused unit tests for catalog, task contract, API router, and Create page using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py -q` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-001 through FR-007)
+- [ ] T040 Re-run focused hermetic integration coverage using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (SCN-001 through SCN-006)
+- [ ] T041 Verify the task preset compilation contract remains satisfied by comparing implementation behavior against `specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md` (FR-001 through FR-007)
+- [ ] T042 Verify `MM-630` and the original Jira preset brief remain preserved in `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`, and `tasks.md` (FR-008)
 
 ## Final Phase: Polish And Verification
 
-- [ ] T042 Refactor duplicated recursive preset provenance helpers after tests pass while keeping behavior unchanged in `api_service/services/task_templates/catalog.py`, `api_service/api/routers/executions.py`, and `frontend/src/entrypoints/task-create.tsx`
-- [ ] T043 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
-- [ ] T044 Run the required hermetic integration suite with `./tools/test_integration.sh` (SCN-001 through SCN-006)
-- [ ] T045 Confirm no provider verification or credentialed tests are required for MM-630 and document any intentionally skipped provider checks in final verification notes in `specs/324-compile-recursive-presets/verification.md`
-- [ ] T046 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-630, the original Jira preset brief, FR-001 through FR-008, SCN-001 through SCN-006, SC-001 through SC-006, DESIGN-REQ-001 through DESIGN-REQ-008, commands run, and remaining risks
+- [ ] T043 Refactor duplicated recursive preset provenance helpers after tests pass while keeping behavior unchanged in `api_service/services/task_templates/catalog.py`, `api_service/api/routers/executions.py`, and `frontend/src/entrypoints/task-create.tsx`
+- [ ] T044 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
+- [ ] T045 Run the required hermetic integration suite with `./tools/test_integration.sh` (SCN-001 through SCN-006)
+- [ ] T046 Confirm no provider verification or credentialed tests are required for MM-630 and document any intentionally skipped provider checks in final verification notes in `specs/324-compile-recursive-presets/verification.md`
+- [ ] T047 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-630, the original Jira preset brief, FR-001 through FR-008, SCN-001 through SCN-006, SC-001 through SC-006, DESIGN-REQ-001 through DESIGN-REQ-008, commands run, and remaining risks
 
 ## Dependencies And Execution Order
 
 1. Phase 1 setup tasks T001-T003 must complete first.
 2. Phase 2 foundational tasks T004-T006 prepare reusable fixtures and confirm storage boundaries.
-3. Unit tests T007-T015 and integration tests T016-T019 are written before production implementation.
-4. Red-first confirmation T020-T023 must run before implementation tasks T024-T037.
-5. Conditional fallback tasks T024-T028 are executed only if verification tests expose gaps in implemented_unverified rows.
-6. Production implementation tasks T029-T037 complete partial and missing behavior.
-7. Story validation T038-T041 proves the single story before final polish.
-8. Final verification T042-T046 closes the feature.
+3. Unit tests T007-T016 and integration tests T017-T020 are written before production implementation.
+4. Red-first confirmation T021-T024 must run before implementation tasks T025-T038.
+5. Conditional fallback tasks T025-T029 are executed only if verification tests expose gaps in implemented_unverified rows.
+6. Production implementation tasks T030-T038 complete partial and missing behavior.
+7. Story validation T039-T042 proves the single story before final polish.
+8. Final verification T043-T047 closes the feature.
 
 ## Parallel Examples
 
-- T007, T010, T012, T014, and T016 can be drafted in parallel because they target different test files.
-- T024, T025, and T030 all touch `api_service/services/task_templates/catalog.py`; do not run them in parallel.
-- T032 and T033 can run in parallel after red-first confirmation because they touch frontend and backend route files separately, but both must be reconciled before T038.
-- T043 and T044 should run after focused validation, not in parallel with implementation edits.
+- T007, T011, T013, T015, and T017 can be drafted in parallel because they target different test files.
+- T025, T026, and T031 all touch `api_service/services/task_templates/catalog.py`; do not run them in parallel.
+- T033 and T034 can run in parallel after red-first confirmation because they touch frontend and backend route files separately, but both must be reconciled before T039.
+- T044 and T045 should run after focused validation, not in parallel with implementation edits.
 
 ## Implementation Strategy
 

--- a/specs/324-compile-recursive-presets/tasks.md
+++ b/specs/324-compile-recursive-presets/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Compile Recursive Task Presets
+
+**Input**: `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, and `quickstart.md` exist for one story.
+**Unit Test Command**: `./tools/test_unit.sh`
+**Integration Test Command**: `./tools/test_integration.sh`
+
+## Source Traceability
+
+MM-630 and the original Jira preset brief are preserved in `spec.md`. This task list covers exactly one story: Recursive Preset Compilation. Traceability spans FR-001 through FR-008, acceptance scenarios SCN-001 through SCN-006, edge cases, SC-001 through SC-006, DESIGN-REQ-001 through DESIGN-REQ-008, and the task preset compilation contract.
+
+Requirement status from `plan.md`: partial rows require red-first tests and implementation; implemented_unverified rows require verification tests first plus conditional fallback implementation if verification fails; missing traceability requires final verification evidence. There are no implemented_verified rows.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm active feature locator points to `specs/324-compile-recursive-presets` in `.specify/feature.json`
+- [ ] T002 Confirm `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, and `quickstart.md` exist before implementation
+- [ ] T003 Review current task preset catalog, task contract, Create page, execution router, worker runtime, and integration test fixtures in `api_service/services/task_templates/catalog.py`, `moonmind/workflows/tasks/task_contract.py`, `frontend/src/entrypoints/task-create.tsx`, `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+
+## Phase 2: Foundational
+
+- [ ] T004 Identify or add reusable recursive preset fixture helpers for unit tests in `tests/unit/api/test_task_step_templates_service.py` and `tests/unit/api/routers/test_executions.py` without changing production behavior
+- [ ] T005 Identify or add reusable recursive task submission fixture helpers for integration tests in `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+- [ ] T006 Confirm no database migration or new persistent table is required by reviewing existing task template and execution snapshot storage in `api_service/db/models.py` and `api_service/api/routers/executions.py`
+
+## Phase 3: Story - Recursive Preset Compilation
+
+**Story Summary**: Task authors can submit tasks with nested presets and receive one final ordered executable step list with durable provenance.
+
+**Independent Test**: Submit a task draft containing manual steps plus a recursive preset include tree, then verify before execution begins that the task has deterministic flattened order, complete preset provenance, and a worker-facing payload that remains executable after live preset catalog changes.
+
+**Traceability IDs**: FR-001 through FR-008; SCN-001 through SCN-006; SC-001 through SC-006; DESIGN-REQ-001 through DESIGN-REQ-008.
+
+**Unit Test Plan**: Cover catalog validation/order/composition, task contract validation, API task normalization/snapshot metadata, and Create page submission payload preservation.
+
+**Integration Test Plan**: Cover task-shaped submission with recursive preset metadata, no unresolved preset worker payload, live catalog unavailability after submission, and manual-only regression.
+
+### Unit Tests First
+
+- [ ] T007 [P] Add failing unit test for missing or unavailable recursive include targets in `tests/unit/api/test_task_step_templates_service.py` (FR-002, SCN-001, Edge: missing/unauthorized preset)
+- [ ] T008 [P] Add failing unit test for deterministic repeated recursive expansion order and stable step IDs in `tests/unit/api/test_task_step_templates_service.py` (FR-003, SCN-002, SC-002, DESIGN-REQ-002)
+- [ ] T009 [P] Add failing unit test that recursive expansion returns compact composition metadata suitable for authored preset bindings in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-006, SC-003, SC-005, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T010 [P] Add failing task contract unit test for recursive `authoredPresets` bindings with slug/version/alias/includePath/inputMapping/scope in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, DESIGN-REQ-003)
+- [ ] T011 [P] Add failing task contract unit test rejecting invalid unresolved preset worker-step shape when represented as executable task work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-005, DESIGN-REQ-005)
+- [ ] T012 [P] Add failing API route unit test that task-shaped submission preserves recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, and attachments in `tests/unit/api/routers/test_executions.py` (FR-001, FR-004, FR-006, FR-007, SCN-003, DESIGN-REQ-001)
+- [ ] T013 [P] Add failing API route unit test that manual-only submission does not fabricate `authoredPresets`, composition, or preset source metadata in `tests/unit/api/routers/test_executions.py` (FR-007, SCN-006, SC-006)
+- [ ] T014 [P] Add failing Create page unit test that recursive preset expansion submits `steps[].source`, `authoredPresets`, and composition metadata in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004, SCN-003)
+- [ ] T015 [P] Add failing Create page unit test that auto-expanding an unresolved recursive preset before submit does not mutate the visible draft and still submits resolved executable steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-003, SCN-001, SCN-002)
+
+### Integration Tests First
+
+- [ ] T016 [P] Add failing hermetic integration test for recursive task-shaped submission preserving final flattened order and compiled provenance in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001, FR-003, FR-004, SCN-001, SCN-002, SCN-003)
+- [ ] T017 [P] Add failing hermetic integration test proving worker-facing task payload contains resolved executable steps and no unresolved preset include work after submission in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-005, SCN-004, SC-004, DESIGN-REQ-005)
+- [ ] T018 [P] Add failing hermetic integration test simulating live preset catalog change or unavailability after submission while reconstruction uses submitted snapshot metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-006, SCN-005, SC-005)
+- [ ] T019 [P] Add integration regression for manual-only task submission staying unchanged in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-007, SCN-006, SC-006, DESIGN-REQ-007, DESIGN-REQ-008)
+
+### Red-First Confirmation
+
+- [ ] T020 Run focused catalog and task contract unit tests and confirm new tests fail for the expected missing behavior using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py -q` (FR-001 through FR-006)
+- [ ] T021 Run focused API route unit tests and confirm new tests fail for the expected metadata/snapshot gaps using `python -m pytest tests/unit/api/routers/test_executions.py -q` (FR-001, FR-004, FR-006, FR-007)
+- [ ] T022 Run focused Create page tests and confirm new tests fail for the expected recursive provenance submission gaps using `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
+- [ ] T023 Run focused integration tests and confirm new tests fail for unresolved worker payload or missing reconstruction metadata using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007)
+
+### Conditional Fallback Implementation For Implemented-Unverified Rows
+
+- [ ] T024 If T007 shows missing or unauthorized include target handling is not already adequate, implement explicit include target failure behavior in `api_service/services/task_templates/catalog.py` (FR-002, SCN-001)
+- [ ] T025 If T008 shows deterministic expansion is not stable, implement deterministic recursive ordering and stable step ID generation in `api_service/services/task_templates/catalog.py` (FR-003, SCN-002, SC-002)
+- [ ] T026 If T011 shows unresolved preset work can enter worker-facing payloads, tighten task step validation in `moonmind/workflows/tasks/task_contract.py` (FR-005, DESIGN-REQ-005)
+- [ ] T027 If T017 shows workers still depend on live catalog after submission, adjust worker task preparation in `moonmind/workflows/temporal/worker_runtime.py` to consume only submitted resolved steps (FR-005, SCN-004, SC-004)
+- [ ] T028 If T013 or T019 shows manual-only submissions gain preset metadata, remove fabricated preset provenance from `api_service/api/routers/executions.py` or `frontend/src/entrypoints/task-create.tsx` (FR-007, SCN-006, SC-006)
+
+### Production Implementation
+
+- [ ] T029 Implement compact recursive composition output on template expansion in `api_service/services/task_templates/catalog.py` (FR-001, FR-004, FR-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
+- [ ] T030 Implement derived authored preset binding metadata from recursive composition in `api_service/services/task_templates/catalog.py` or a focused helper module under `api_service/services/task_templates/` (FR-004, SC-003, DESIGN-REQ-003)
+- [ ] T031 Preserve recursive composition metadata in `appliedTemplate` or submitted `appliedStepTemplates` without embedding large template content in `api_service/services/task_templates/catalog.py` (FR-006, SC-005, DESIGN-REQ-006)
+- [ ] T032 Update Create page expansion/submission mapping to carry recursive `authoredPresets`, `appliedStepTemplates` composition, and `steps[].source` in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-004, SCN-003)
+- [ ] T033 Update API task-shaped normalization to preserve recursive `authoredPresets`, `appliedStepTemplates` composition, final step order, and existing runtime/publish/Jira/attachment fields in `api_service/api/routers/executions.py` (FR-001, FR-004, FR-006, FR-007)
+- [ ] T034 Update task contract models only as needed for compact recursive composition or authored preset metadata in `moonmind/workflows/tasks/task_contract.py` (FR-004, DESIGN-REQ-003)
+- [ ] T035 Update worker runtime preparation only as needed to persist and consume submitted resolved steps and compact preset provenance in `moonmind/workflows/temporal/worker_runtime.py` (FR-005, FR-006, DESIGN-REQ-005)
+- [ ] T036 Ensure task snapshots preserve compiled recursive preset metadata without live catalog lookup in `api_service/api/routers/executions.py` and related snapshot helpers (FR-006, SCN-005, SC-005)
+- [ ] T037 Ensure invalid recursive preset submissions produce explicit recoverable errors without creating execution work in `api_service/services/task_templates/catalog.py` and `api_service/api/routers/executions.py` (FR-002, SCN-001, SC-001)
+
+### Story Validation
+
+- [ ] T038 Re-run focused unit tests for catalog, task contract, API router, and Create page using `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py -q` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-001 through FR-007)
+- [ ] T039 Re-run focused hermetic integration coverage using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (SCN-001 through SCN-006)
+- [ ] T040 Verify the task preset compilation contract remains satisfied by comparing implementation behavior against `specs/324-compile-recursive-presets/contracts/task-preset-compilation-contract.md` (FR-001 through FR-007)
+- [ ] T041 Verify `MM-630` and the original Jira preset brief remain preserved in `specs/324-compile-recursive-presets/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-compilation-contract.md`, `quickstart.md`, and `tasks.md` (FR-008)
+
+## Final Phase: Polish And Verification
+
+- [ ] T042 Refactor duplicated recursive preset provenance helpers after tests pass while keeping behavior unchanged in `api_service/services/task_templates/catalog.py`, `api_service/api/routers/executions.py`, and `frontend/src/entrypoints/task-create.tsx`
+- [ ] T043 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
+- [ ] T044 Run the required hermetic integration suite with `./tools/test_integration.sh` (SCN-001 through SCN-006)
+- [ ] T045 Confirm no provider verification or credentialed tests are required for MM-630 and document any intentionally skipped provider checks in final verification notes in `specs/324-compile-recursive-presets/verification.md`
+- [ ] T046 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-630, the original Jira preset brief, FR-001 through FR-008, SCN-001 through SCN-006, SC-001 through SC-006, DESIGN-REQ-001 through DESIGN-REQ-008, commands run, and remaining risks
+
+## Dependencies And Execution Order
+
+1. Phase 1 setup tasks T001-T003 must complete first.
+2. Phase 2 foundational tasks T004-T006 prepare reusable fixtures and confirm storage boundaries.
+3. Unit tests T007-T015 and integration tests T016-T019 are written before production implementation.
+4. Red-first confirmation T020-T023 must run before implementation tasks T024-T037.
+5. Conditional fallback tasks T024-T028 are executed only if verification tests expose gaps in implemented_unverified rows.
+6. Production implementation tasks T029-T037 complete partial and missing behavior.
+7. Story validation T038-T041 proves the single story before final polish.
+8. Final verification T042-T046 closes the feature.
+
+## Parallel Examples
+
+- T007, T010, T012, T014, and T016 can be drafted in parallel because they target different test files.
+- T024, T025, and T030 all touch `api_service/services/task_templates/catalog.py`; do not run them in parallel.
+- T032 and T033 can run in parallel after red-first confirmation because they touch frontend and backend route files separately, but both must be reconciled before T038.
+- T043 and T044 should run after focused validation, not in parallel with implementation edits.
+
+## Implementation Strategy
+
+Start with red-first tests that expose the remaining partial behavior: recursive composition metadata, authored preset bindings, snapshot reconstruction, and no-live-catalog execution boundary. Preserve implemented_unverified rows through verification tests first, then execute the conditional fallback implementation tasks only when tests show gaps. Keep metadata compact and contract-shaped, avoid embedding large template content in workflow history, and preserve manual-only behavior without fabricated preset provenance.

--- a/specs/324-compile-recursive-presets/verification.md
+++ b/specs/324-compile-recursive-presets/verification.md
@@ -1,0 +1,41 @@
+# Verification: Compile Recursive Task Presets
+
+## Scope
+
+Implementation scope remains the single MM-630 story from `spec.md`: compile recursive task presets before execution, preserve compact provenance, and keep manual-only task behavior unchanged.
+
+## TDD Evidence
+
+- Red-first backend unit check was reconstructed in `/tmp/mm630-redfirst` by applying only the test diff to `HEAD`.
+- Command: `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`
+- Expected failures observed before production changes:
+  - `KeyError: 'authoredPresets'` for recursive catalog expansion metadata.
+  - `DID NOT RAISE ValidationError` for unresolved preset include work in task steps.
+  - `KeyError: 'authoredPresets'` for worker runtime expanded seeded template metadata.
+- The hermetic integration test diff passed against `HEAD` before production changes, so that coverage is regression evidence rather than red-first evidence.
+
+## Passing Checks
+
+- `python -m pytest tests/unit/api/routers/test_executions.py -q` -> 170 passed.
+- `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` -> 314 passed.
+- `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` -> 7 passed.
+- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` -> Python suite 4573 passed, 1 xpassed, 16 subtests passed; Create page target 30 passed, 223 skipped.
+- `./tools/test_unit.sh` -> Python suite 4575 passed, 1 xpassed, 16 subtests passed; frontend suite 20 files passed, 324 tests passed, 223 skipped.
+
+## Blocked Checks
+
+- `./tools/test_integration.sh` did not run to completion in this environment. Docker returned `403 Forbidden` after reporting the buildx plugin warning while building the `repo-pytest` image.
+- Provider verification is not required for MM-630. The story covers local task preset compilation, task contract normalization, frontend submission shape, and Temporal task-shaped submission boundaries without credentialed external providers.
+
+## Requirement Coverage
+
+- FR-001, FR-003, FR-004, FR-006: catalog expansion now emits deterministic flattened steps, compact composition metadata, authored preset bindings, and per-step source provenance.
+- FR-002: existing catalog validation continues to reject invalid include trees, including missing targets and duplicate aliases, with explicit errors.
+- FR-005: task contract and worker runtime coverage prevent unresolved preset include work from reaching worker-facing task steps.
+- FR-007: route, integration, and frontend coverage preserve manual-only behavior without fabricated preset metadata.
+- FR-008: MM-630 and the original Jira preset brief remain preserved in the MoonSpec artifacts.
+
+## Remaining Verification
+
+- Final `/moonspec-verify` was not run in this implementation step.
+- Full required integration remains blocked by the local Docker administrative policy described above.

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -114,6 +114,149 @@ def test_task_shaped_submission_boundary_exposes_canonical_task_parameters(
     ]
     assert task["steps"][0]["jiraOrchestration"] == {"issueKey": "MM-627"}
 
+def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        []
+    )
+    authored_presets = [
+        {
+            "presetSlug": "parent-flow",
+            "presetVersion": "1.0.0",
+            "scope": "global",
+            "includePath": ["parent-flow@1.0.0"],
+        },
+        {
+            "presetSlug": "child-checks",
+            "presetVersion": "1.0.0",
+            "alias": "quality",
+            "scope": "global",
+            "includePath": [
+                "parent-flow@1.0.0",
+                "quality:child-checks@1.0.0",
+            ],
+            "inputMapping": {"target": "preset composition"},
+        },
+    ]
+    composition = {
+        "slug": "parent-flow",
+        "version": "1.0.0",
+        "scope": "global",
+        "path": ["parent-flow@1.0.0"],
+        "stepIds": ["tpl:parent-flow:1.0.0:01"],
+        "includes": [
+            {
+                "slug": "child-checks",
+                "version": "1.0.0",
+                "scope": "global",
+                "alias": "quality",
+                "path": [
+                    "parent-flow@1.0.0",
+                    "quality:child-checks@1.0.0",
+                ],
+                "inputMapping": {"target": "preset composition"},
+                "stepIds": ["tpl:parent-flow:1.0.0:01"],
+                "includes": [],
+            }
+        ],
+    }
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Compile recursive presets.",
+                        "runtime": {"mode": "codex"},
+                        "publish": {"mode": "none"},
+                        "steps": [
+                            {
+                                "id": "tpl:parent-flow:1.0.0:01",
+                                "type": "skill",
+                                "instructions": "Run child check.",
+                                "skill": {"id": "auto"},
+                                "source": {
+                                    "kind": "preset-derived",
+                                    "presetSlug": "child-checks",
+                                    "presetVersion": "1.0.0",
+                                    "includePath": [
+                                        "parent-flow@1.0.0",
+                                        "quality:child-checks@1.0.0",
+                                    ],
+                                },
+                            }
+                        ],
+                        "authoredPresets": authored_presets,
+                        "appliedStepTemplates": [
+                            {
+                                "slug": "parent-flow",
+                                "version": "1.0.0",
+                                "stepIds": ["tpl:parent-flow:1.0.0:01"],
+                                "composition": composition,
+                                "authoredPresets": authored_presets,
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert task["authoredPresets"] == authored_presets
+    assert task["appliedStepTemplates"][0]["composition"] == composition
+    assert task["appliedStepTemplates"][0]["authoredPresets"] == authored_presets
+    assert task["steps"][0]["source"]["includePath"] == [
+        "parent-flow@1.0.0",
+        "quality:child-checks@1.0.0",
+    ]
+    assert all(step.get("type") != "preset" for step in task["steps"])
+
+def test_task_shaped_submission_boundary_does_not_fabricate_preset_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        []
+    )
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Manual only.",
+                        "steps": [
+                            {
+                                "id": "manual-1",
+                                "type": "skill",
+                                "instructions": "Run manual step.",
+                                "skill": {"id": "auto"},
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert "authoredPresets" not in task
+    assert "appliedStepTemplates" not in task
+    assert "source" not in task["steps"][0]
+
 
 def test_task_shaped_submission_boundary_rejects_invalid_alias_and_target_binding(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2687,6 +2687,156 @@ def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaul
         },
     ]
 
+def test_create_task_shaped_execution_preserves_recursive_preset_metadata(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "task": {
+                    "title": "Compile recursive presets",
+                    "instructions": "Run the compiled task.",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
+                    "jira": {"issueKey": "MM-630"},
+                    "authoredPresets": [
+                        {
+                            "presetSlug": "root-preset",
+                            "presetVersion": "1.0.0",
+                            "includePath": ["root-preset@1.0.0"],
+                        },
+                        {
+                            "presetSlug": "child-preset",
+                            "presetVersion": "1.0.0",
+                            "alias": "checks",
+                            "inputMapping": {"target": "recursive presets"},
+                            "includePath": [
+                                "root-preset@1.0.0",
+                                "checks:child-preset@1.0.0",
+                            ],
+                        },
+                    ],
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "root-preset",
+                            "version": "1.0.0",
+                            "stepIds": [
+                                "tpl:root-preset:1.0.0:01",
+                                "tpl:child-preset:1.0.0:01",
+                            ],
+                            "composition": {
+                                "slug": "root-preset",
+                                "version": "1.0.0",
+                                "path": ["root-preset@1.0.0"],
+                                "stepIds": [
+                                    "tpl:root-preset:1.0.0:01",
+                                    "tpl:child-preset:1.0.0:01",
+                                ],
+                                "includes": [
+                                    {
+                                        "slug": "child-preset",
+                                        "version": "1.0.0",
+                                        "alias": "checks",
+                                        "path": [
+                                            "root-preset@1.0.0",
+                                            "checks:child-preset@1.0.0",
+                                        ],
+                                        "stepIds": ["tpl:child-preset:1.0.0:01"],
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "id": "tpl:root-preset:1.0.0:01",
+                            "title": "Prepare task",
+                            "instructions": "Prepare the task context.",
+                            "source": {
+                                "kind": "preset-derived",
+                                "presetSlug": "root-preset",
+                                "presetVersion": "1.0.0",
+                                "includePath": ["root-preset@1.0.0"],
+                            },
+                        },
+                        {
+                            "id": "tpl:child-preset:1.0.0:01",
+                            "title": "Run checks",
+                            "instructions": "Run recursive preset checks.",
+                            "source": {
+                                "kind": "preset-derived",
+                                "presetSlug": "child-preset",
+                                "presetVersion": "1.0.0",
+                                "includePath": [
+                                    "root-preset@1.0.0",
+                                    "checks:child-preset@1.0.0",
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert task["steps"][0]["source"]["presetSlug"] == "root-preset"
+    assert task["steps"][1]["source"]["includePath"] == [
+        "root-preset@1.0.0",
+        "checks:child-preset@1.0.0",
+    ]
+    assert [preset["presetSlug"] for preset in task["authoredPresets"]] == [
+        "root-preset",
+        "child-preset",
+    ]
+    assert task["authoredPresets"][1]["inputMapping"] == {
+        "target": "recursive presets"
+    }
+    assert task["appliedStepTemplates"][0]["composition"]["includes"][0]["alias"] == (
+        "checks"
+    )
+    assert task["runtime"] == {"mode": "codex_cli"}
+    assert task["publish"] == {"mode": "pr"}
+
+def test_create_task_shaped_execution_does_not_fabricate_manual_preset_metadata(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "title": "Manual task",
+                    "instructions": "Run one manual step.",
+                    "steps": [
+                        {
+                            "id": "manual-1",
+                            "title": "Manual step",
+                            "instructions": "Do the manual work.",
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert "authoredPresets" not in task
+    assert "appliedStepTemplates" not in task
+    assert "source" not in task["steps"][0]
+
 def test_create_task_shaped_execution_rejects_pr_resolver_without_selector_or_instructions(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -456,6 +456,199 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["composition"]["includes"][0]["stepIds"] == [
         step["id"] for step in expanded["steps"]
     ]
+    assert expanded["authoredPresets"] == [
+        {
+            "presetSlug": "parent-flow",
+            "presetVersion": "1.0.0",
+            "scope": "global",
+            "includePath": ["parent-flow@1.0.0"],
+        },
+        {
+            "presetSlug": "child-checks",
+            "presetVersion": "1.0.0",
+            "alias": "quality",
+            "scope": "global",
+            "includePath": [
+                "parent-flow@1.0.0",
+                "quality:child-checks@1.0.0",
+            ],
+            "inputMapping": {"target": "preset composition"},
+        },
+    ]
+    assert expanded["appliedTemplate"]["composition"] == expanded["composition"]
+    assert expanded["appliedTemplate"]["authoredPresets"] == expanded[
+        "authoredPresets"
+    ]
+    assert expanded["steps"][0]["source"] == {
+        "kind": "preset-derived",
+        "presetSlug": "child-checks",
+        "presetVersion": "1.0.0",
+        "includePath": [
+            "parent-flow@1.0.0",
+            "quality:child-checks@1.0.0",
+        ],
+    }
+
+async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="stable-child",
+                title="Stable Child",
+                description="Reusable child",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {"title": "First child", "instructions": "First child"},
+                    {"title": "Second child", "instructions": "Second child"},
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="stable-parent",
+                title="Stable Parent",
+                description="Composed parent",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {"title": "Manual before", "instructions": "Manual before"},
+                    {
+                        "kind": "include",
+                        "slug": "stable-child",
+                        "version": "1.0.0",
+                        "alias": "child",
+                        "scope": "global",
+                    },
+                    {"title": "Manual after", "instructions": "Manual after"},
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            first = await service.expand_template(
+                slug="stable-parent",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={},
+                context={},
+            )
+            second = await service.expand_template(
+                slug="stable-parent",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={},
+                context={},
+            )
+
+    assert [step["title"] for step in first["steps"]] == [
+        "Manual before",
+        "First child",
+        "Second child",
+        "Manual after",
+    ]
+    assert [step["id"] for step in first["steps"]] == [
+        step["id"] for step in second["steps"]
+    ]
+    assert first["composition"]["stepIds"] == [
+        step["id"] for step in first["steps"]
+    ]
+
+async def test_expand_template_rejects_duplicate_include_aliases(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="duplicate-child",
+                title="Duplicate Child",
+                description="Reusable child",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[{"instructions": "child"}],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="include alias 'same' is duplicated",
+            ):
+                await service.create_template(
+                    slug="duplicate-parent",
+                    title="Duplicate Parent",
+                    description="Invalid includes",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "kind": "include",
+                            "slug": "duplicate-child",
+                            "version": "1.0.0",
+                            "alias": "same",
+                        },
+                        {
+                            "kind": "include",
+                            "slug": "duplicate-child",
+                            "version": "1.0.0",
+                            "alias": "same",
+                        },
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+async def test_expand_template_rejects_missing_include_target(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="missing-target-parent",
+                title="Missing Target Parent",
+                description="Invalid include target",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "missing-child",
+                        "version": "1.0.0",
+                        "alias": "missing",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="missing:missing-child@1.0.0",
+            ):
+                await service.expand_template(
+                    slug="missing-target-parent",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                )
 
 async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
     tmp_path,

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -379,6 +379,7 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
                     {
                         "title": "Lint target",
                         "instructions": "Lint {{ inputs.target }}",
+                        "source": {"kind": "manual"},
                         "skill": {
                             "id": "auto",
                             "args": {},
@@ -488,6 +489,7 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
             "quality:child-checks@1.0.0",
         ],
     }
+    assert expanded["steps"][0]["source"]["kind"] != "manual"
 
 async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
     async with template_db(tmp_path) as session_maker:

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -219,6 +219,80 @@ def test_task_steps_validate_without_resolving_source_provenance(
     else:
         assert dumped["source"] == source
 
+def test_task_authored_presets_accept_recursive_bindings() -> None:
+    payload = CanonicalTaskPayload.model_validate(
+        {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "Run recursive preset.",
+                "authoredPresets": [
+                    {
+                        "presetSlug": "parent-flow",
+                        "presetVersion": "1.0.0",
+                        "scope": "global",
+                        "includePath": ["parent-flow@1.0.0"],
+                    },
+                    {
+                        "presetSlug": "child-checks",
+                        "presetVersion": "1.0.0",
+                        "alias": "quality",
+                        "scope": "global",
+                        "includePath": [
+                            "parent-flow@1.0.0",
+                            "quality:child-checks@1.0.0",
+                        ],
+                        "inputMapping": {"target": "preset composition"},
+                    },
+                ],
+                "steps": [
+                    {
+                        "type": "skill",
+                        "instructions": "Run child check.",
+                        "skill": {"id": "auto"},
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetSlug": "child-checks",
+                            "presetVersion": "1.0.0",
+                            "includePath": [
+                                "parent-flow@1.0.0",
+                                "quality:child-checks@1.0.0",
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+    )
+
+    task = payload.model_dump(by_alias=True, exclude_none=True)["task"]
+    assert task["authoredPresets"][1] == {
+        "presetSlug": "child-checks",
+        "presetVersion": "1.0.0",
+        "alias": "quality",
+        "includePath": [
+            "parent-flow@1.0.0",
+            "quality:child-checks@1.0.0",
+        ],
+        "inputMapping": {"target": "preset composition"},
+        "scope": "global",
+    }
+
+def test_task_steps_reject_unresolved_preset_include_work() -> None:
+    with pytest.raises(ValidationError, match="unresolved preset include"):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Invalid worker payload.",
+                "steps": [
+                    {
+                        "kind": "include",
+                        "slug": "child-checks",
+                        "version": "1.0.0",
+                        "alias": "quality",
+                    }
+                ],
+            }
+        )
+
 @pytest.mark.parametrize("step_type", ["preset", "activity", "Activity"])
 def test_task_steps_reject_non_executable_step_types(step_type: str) -> None:
     with pytest.raises(ValidationError, match="task\\.steps\\[\\]\\.type"):

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1149,6 +1149,13 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert task["steps"][12]["title"] == "Move Jira issue to Code Review"
     assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
     assert len(task["appliedStepTemplates"][0]["stepIds"]) == 13
+    assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
+    assert task["authoredPresets"][0]["presetVersion"] == "1.0.0"
+    assert task["appliedStepTemplates"][0]["authoredPresets"] == task[
+        "authoredPresets"
+    ]
+    assert task["appliedStepTemplates"][0]["composition"]["slug"] == "jira-orchestrate"
+    assert all(step["type"] != "preset" for step in task["steps"])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1151,9 +1151,7 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert len(task["appliedStepTemplates"][0]["stepIds"]) == 13
     assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
     assert task["authoredPresets"][0]["presetVersion"] == "1.0.0"
-    assert task["appliedStepTemplates"][0]["authoredPresets"] == task[
-        "authoredPresets"
-    ]
+    assert "authoredPresets" not in task["appliedStepTemplates"][0]
     assert task["appliedStepTemplates"][0]["composition"]["slug"] == "jira-orchestrate"
     assert all(step["type"] != "preset" for step in task["steps"])
 


### PR DESCRIPTION
## Summary

- Jira issue key: MM-630
- Active MoonSpec feature path: `specs/324-compile-recursive-presets`
- Compiles recursive task presets into deterministic executable steps before worker execution.
- Preserves compact recursive preset composition, authored preset bindings, and step source provenance through catalog expansion, task submission, worker preparation, and Create page submission.
- Adds unit, frontend, and hermetic integration coverage for recursive preset metadata and manual-only regressions.

## Verification verdict

ADDITIONAL_WORK_NEEDED from `/moonspec-verify` because the final verify preflight found a managed `.gemini/skills` projection symlink and the required Docker-backed integration runner was blocked by local Docker policy. Implementation requirements FR-001 through FR-008 were otherwise verified by code inspection and focused tests.

## Tests run

- `python -m pytest tests/unit/api/routers/test_executions.py -q` -> 170 passed.
- `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` -> 314 passed.
- `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` -> 7 passed.
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` -> Python 4573 passed, Create page target 30 passed.
- `./tools/test_unit.sh` -> Python 4575 passed, frontend 20 files / 324 tests passed.
- `git diff --check` -> passed.

## Remaining risks

- `./tools/test_integration.sh` could not complete because Docker returned `403 Forbidden` while building `repo-pytest`.
- `/moonspec-verify` reported `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION` because `.gemini/skills` is a tracked symlink into the managed runtime skill projection.
- API/frontend/integration red-first failure evidence could not be truthfully confirmed for all task-list items; backend unit red-first evidence was reconstructed and recorded in `specs/324-compile-recursive-presets/verification.md`.
