### PR TITLE
MM-631 Prepare target-aware inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,8 @@ Key diagnostics:
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and existing remediation lock/ledger state; no new persistent database tables planned (322-remediation-lifecycle-repair-prevention)
 - Python 3.12 + Pydantic v2 where exposed, SQLAlchemy async ORM, FastAPI service/router patterns where query surfaces are exposed, Temporal Python SDK activity/service boundaries, existing Temporal artifact service (323-publish-remediation-audit)
 - Existing Temporal execution records, `execution_remediation_links`, Temporal artifact metadata/content store, and an existing or reusable control-event/audit persistence mechanism; no new persistent table planned unless queryable audit events cannot safely reuse current control-event/audit infrastructure (323-publish-remediation-audit)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind artifact and vision services (325-prepare-target-aware-inputs)
+- Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned (325-prepare-target-aware-inputs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -227,6 +227,8 @@ Key diagnostics:
 - Existing Temporal artifact metadata/content store, Temporal execution records, artifact links; no new persistent tables planned (321-route-binary-artifact-refs)
 - Python 3.12 + Pydantic v2 where models are exposed, SQLAlchemy async ORM, Temporal Python SDK service/activity boundaries, existing Temporal artifact service, pytest (322-remediation-lifecycle-repair-prevention)
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and existing remediation lock/ledger state; no new persistent database tables planned (322-remediation-lifecycle-repair-prevention)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind artifact and vision services (325-prepare-target-aware-inputs)
+- Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned (325-prepare-target-aware-inputs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/tasks/__init__.py
+++ b/moonmind/workflows/tasks/__init__.py
@@ -1,7 +1,25 @@
 """Task payload compilation helpers."""
 
 from .payload import compile_task_payload_templates
+from .prepared_context import (
+    PreparedContextFailure,
+    PreparedInputEntry,
+    PreparedInputManifest,
+    StepPreparedContext,
+    build_prepared_input_manifest,
+    merge_prepared_input_refs,
+    select_step_prepared_context,
+    task_payload_has_input_attachments,
+)
 
 __all__ = [
+    "PreparedContextFailure",
+    "PreparedInputEntry",
+    "PreparedInputManifest",
+    "StepPreparedContext",
+    "build_prepared_input_manifest",
     "compile_task_payload_templates",
+    "merge_prepared_input_refs",
+    "select_step_prepared_context",
+    "task_payload_has_input_attachments",
 ]

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -1,0 +1,362 @@
+"""Compact target-aware prepared context contracts for runtime steps."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+TargetKind = Literal["objective", "step"]
+
+_INLINE_ATTACHMENT_KEYS = {
+    "base64",
+    "bytes",
+    "content",
+    "data",
+    "dataUrl",
+    "generatedMarkdown",
+    "markdown",
+}
+_DATA_URL_RE = re.compile(r"data:[^\\s'\")]+", re.IGNORECASE)
+_SECRETISH_RE = re.compile(
+    r"(ghp_|github_pat_|AIza|ATATT|AKIA|token=|password=|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----)",
+    re.IGNORECASE,
+)
+_SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._:-]+")
+
+
+class PreparedInputEntry(BaseModel):
+    """One compact prepared input ref bound to objective or one logical step."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    artifact_id: str = Field(alias="artifactId")
+    filename: str | None = None
+    content_type: str | None = Field(default=None, alias="contentType")
+    size_bytes: int | None = Field(default=None, alias="sizeBytes")
+    target_kind: TargetKind = Field(alias="targetKind")
+    raw_input_ref: str = Field(alias="rawInputRef")
+    derived_context_ref: str | None = Field(default=None, alias="derivedContextRef")
+    step_ref: str | None = Field(default=None, alias="stepRef")
+    step_ordinal: int | None = Field(default=None, alias="stepOrdinal")
+
+    @model_validator(mode="after")
+    def _validate_target_binding(self) -> "PreparedInputEntry":
+        if self.target_kind == "step" and not self.step_ref:
+            raise ValueError("stepRef is required for step prepared inputs")
+        if self.target_kind == "objective" and self.step_ref:
+            raise ValueError("objective prepared inputs must not include stepRef")
+        return self
+
+
+class PreparedInputManifest(BaseModel):
+    """Bounded manifest for all prepared inputs on a task."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    manifest_ref: str = Field(alias="manifestRef")
+    entries: list[PreparedInputEntry]
+
+    @property
+    def has_entries(self) -> bool:
+        return bool(self.entries)
+
+
+class StepPreparedContext(BaseModel):
+    """Prepared context selected for exactly one logical runtime step."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    logical_step_id: str = Field(alias="logicalStepId")
+    manifest_ref: str = Field(alias="manifestRef")
+    objective_context_refs: list[str] = Field(
+        default_factory=list,
+        alias="objectiveContextRefs",
+    )
+    step_context_refs: list[str] = Field(default_factory=list, alias="stepContextRefs")
+    raw_input_refs: list[str] = Field(default_factory=list, alias="rawInputRefs")
+
+    @property
+    def input_refs(self) -> list[str]:
+        return _dedupe_refs(
+            [
+                *self.objective_context_refs,
+                *self.step_context_refs,
+                *self.raw_input_refs,
+            ]
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "manifestRef": self.manifest_ref,
+            "logicalStepId": self.logical_step_id,
+            "objectiveContextRefs": list(self.objective_context_refs),
+            "stepContextRefs": list(self.step_context_refs),
+            "rawInputRefs": list(self.raw_input_refs),
+            "inputRefs": self.input_refs,
+            "targetCounts": {
+                "objective": len(self.objective_context_refs),
+                "step": len(self.step_context_refs),
+            },
+        }
+
+
+class PreparedContextFailure(BaseModel):
+    """Bounded failure diagnostic for prepared context generation."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    logical_step_id: str | None = Field(default=None, alias="logicalStepId")
+    manifest_ref: str | None = Field(default=None, alias="manifestRef")
+    reason: str
+    message: str
+
+    @classmethod
+    def from_exception(
+        cls,
+        exc: BaseException,
+        *,
+        logical_step_id: str | None = None,
+        manifest_ref: str | None = None,
+    ) -> "PreparedContextFailure":
+        return cls(
+            logicalStepId=logical_step_id,
+            manifestRef=manifest_ref,
+            reason=type(exc).__name__,
+            message=_bounded_message(str(exc)),
+        )
+
+
+def build_prepared_input_manifest(
+    payload: Mapping[str, Any],
+    *,
+    manifest_ref: str = "prepared-context-manifest://task-inputs",
+) -> PreparedInputManifest:
+    """Build a compact manifest from objective and step input attachments."""
+
+    task_payload = _task_payload(payload)
+    entries: list[PreparedInputEntry] = []
+
+    for attachment in _attachment_sequence(task_payload.get("inputAttachments")):
+        entries.append(
+            _entry_from_attachment(
+                attachment,
+                target_kind="objective",
+            )
+        )
+
+    for index, step in enumerate(_step_sequence(task_payload.get("steps")), start=1):
+        step_ref = _step_ref(step, index)
+        for attachment in _attachment_sequence(step.get("inputAttachments")):
+            entries.append(
+                _entry_from_attachment(
+                    attachment,
+                    target_kind="step",
+                    step_ref=step_ref,
+                    step_ordinal=index,
+                )
+            )
+
+    return PreparedInputManifest(manifestRef=manifest_ref, entries=entries)
+
+
+def select_step_prepared_context(
+    manifest: PreparedInputManifest,
+    *,
+    logical_step_id: str,
+) -> StepPreparedContext:
+    """Select objective entries plus entries bound to one logical step."""
+
+    objective_refs: list[str] = []
+    step_refs: list[str] = []
+    raw_refs: list[str] = []
+
+    for entry in manifest.entries:
+        if entry.target_kind == "objective":
+            objective_refs.append(entry.derived_context_ref or entry.raw_input_ref)
+            raw_refs.append(entry.raw_input_ref)
+        elif entry.step_ref == logical_step_id:
+            step_refs.append(entry.derived_context_ref or entry.raw_input_ref)
+            raw_refs.append(entry.raw_input_ref)
+
+    return StepPreparedContext(
+        logicalStepId=logical_step_id,
+        manifestRef=manifest.manifest_ref,
+        objectiveContextRefs=_dedupe_refs(objective_refs),
+        stepContextRefs=_dedupe_refs(step_refs),
+        rawInputRefs=_dedupe_refs(raw_refs),
+    )
+
+
+def merge_prepared_input_refs(
+    existing_refs: Sequence[Any] | None,
+    prepared_context: StepPreparedContext,
+) -> list[str]:
+    """Merge node input refs with selected prepared context refs."""
+
+    refs: list[str] = []
+    if isinstance(existing_refs, str):
+        existing_values: Sequence[Any] = [existing_refs]
+    elif existing_refs is None:
+        existing_values = []
+    else:
+        existing_values = existing_refs
+    for ref in existing_values:
+        if isinstance(ref, str) and ref.strip():
+            refs.append(ref.strip())
+    refs.extend(prepared_context.input_refs)
+    return _dedupe_refs(refs)
+
+
+def task_payload_has_input_attachments(payload: Mapping[str, Any] | None) -> bool:
+    if not isinstance(payload, Mapping):
+        return False
+    task_payload = _task_payload(payload)
+    if _attachment_sequence(task_payload.get("inputAttachments")):
+        return True
+    return any(
+        _attachment_sequence(step.get("inputAttachments"))
+        for step in _step_sequence(task_payload.get("steps"))
+    )
+
+
+def _entry_from_attachment(
+    attachment: Mapping[str, Any],
+    *,
+    target_kind: TargetKind,
+    step_ref: str | None = None,
+    step_ordinal: int | None = None,
+) -> PreparedInputEntry:
+    _reject_inline_attachment_content(attachment)
+    artifact_id = _artifact_id(attachment)
+    safe_artifact_id = _safe_segment(artifact_id)
+    raw_input_ref = _artifact_ref(artifact_id)
+    if target_kind == "objective":
+        derived_context_ref = f"prepared-context://objective/{safe_artifact_id}"
+    else:
+        safe_step_ref = _safe_segment(step_ref or "")
+        derived_context_ref = (
+            f"prepared-context://steps/{safe_step_ref}/{safe_artifact_id}"
+        )
+    return PreparedInputEntry(
+        artifactId=artifact_id,
+        filename=_optional_text(attachment.get("filename") or attachment.get("name")),
+        contentType=_optional_text(
+            attachment.get("contentType") or attachment.get("mimeType")
+        ),
+        sizeBytes=_optional_int(attachment.get("sizeBytes") or attachment.get("size")),
+        targetKind=target_kind,
+        rawInputRef=raw_input_ref,
+        derivedContextRef=derived_context_ref,
+        stepRef=step_ref,
+        stepOrdinal=step_ordinal,
+    )
+
+
+def _task_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = payload.get("task")
+    if isinstance(nested, Mapping):
+        return nested
+    return payload
+
+
+def _attachment_sequence(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _step_sequence(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _step_ref(step: Mapping[str, Any], index: int) -> str:
+    candidate = _optional_text(
+        step.get("id")
+        or step.get("stepRef")
+        or step.get("ref")
+        or step.get("name")
+    )
+    return candidate or f"step-{index}"
+
+
+def _artifact_id(attachment: Mapping[str, Any]) -> str:
+    for key in (
+        "artifactId",
+        "artifact_id",
+        "artifactRef",
+        "artifact_ref",
+        "id",
+        "ref",
+    ):
+        candidate = _optional_text(attachment.get(key))
+        if candidate:
+            if candidate.startswith("artifact://"):
+                return candidate.removeprefix("artifact://")
+            return candidate
+    raise ValueError("input attachment is missing artifactId")
+
+
+def _artifact_ref(artifact_id: str) -> str:
+    if artifact_id.startswith("artifact://"):
+        return artifact_id
+    return f"artifact://{artifact_id}"
+
+
+def _reject_inline_attachment_content(attachment: Mapping[str, Any]) -> None:
+    for key, value in attachment.items():
+        if key in _INLINE_ATTACHMENT_KEYS and value not in (None, ""):
+            if key in {"generatedMarkdown", "markdown"}:
+                raise ValueError("generated markdown is not allowed in prepared inputs")
+            raise ValueError(
+                "inline attachment content is not allowed in prepared inputs"
+            )
+        if isinstance(value, str) and _DATA_URL_RE.search(value):
+            raise ValueError(
+                "inline attachment content is not allowed in prepared inputs"
+            )
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    return candidate or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_segment(value: str) -> str:
+    cleaned = _SAFE_SEGMENT_RE.sub("-", value.strip()).strip("-")
+    return cleaned or "input"
+
+
+def _dedupe_refs(refs: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for ref in refs:
+        if ref and ref not in seen:
+            seen.add(ref)
+            result.append(ref)
+    return result
+
+
+def _bounded_message(message: str, *, max_chars: int = 180) -> str:
+    scrubbed = _DATA_URL_RE.sub("[redacted-data-url]", message)
+    scrubbed = _SECRETISH_RE.sub("[redacted-secret]", scrubbed)
+    scrubbed = " ".join(scrubbed.split())
+    if len(scrubbed) <= max_chars:
+        return scrubbed
+    return scrubbed[: max_chars - 3].rstrip() + "..."

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -19,7 +19,7 @@ _INLINE_ATTACHMENT_KEYS = {
     "generatedMarkdown",
     "markdown",
 }
-_DATA_URL_RE = re.compile(r"data:[^\\s'\")]+", re.IGNORECASE)
+_DATA_URL_RE = re.compile(r"data:[^\s'\")]+", re.IGNORECASE)
 _SECRETISH_RE = re.compile(
     r"(ghp_|github_pat_|AIza|ATATT|AKIA|token=|password=|"
     r"-----BEGIN [A-Z ]*PRIVATE KEY-----)",
@@ -247,7 +247,11 @@ def _entry_from_attachment(
         contentType=_optional_text(
             attachment.get("contentType") or attachment.get("mimeType")
         ),
-        sizeBytes=_optional_int(attachment.get("sizeBytes") or attachment.get("size")),
+        sizeBytes=_optional_int(
+            attachment.get("sizeBytes")
+            if attachment.get("sizeBytes") is not None
+            else attachment.get("size")
+        ),
         targetKind=target_kind,
         rawInputRef=raw_input_ref,
         derivedContextRef=derived_context_ref,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -49,6 +49,11 @@ from moonmind.schemas.temporal_activity_models import (
 )
 from moonmind.workflows.report_output import report_output_display_name
 from moonmind.workflows.tasks.routing import _coerce_bool
+from moonmind.workflows.tasks.prepared_context import (
+    PreparedContextFailure,
+    build_prepared_input_manifest,
+    select_step_prepared_context,
+)
 from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
 )
@@ -206,6 +211,33 @@ _GITHUB_PULL_REQUEST_URL_PATTERN = re.compile(
 )
 _GEMINI_ERROR_REPORT_DIR = Path("/tmp")
 _GEMINI_ERROR_REPORT_GLOB = "gemini-client-error-*.json"
+
+
+def build_target_aware_prepared_context_payload(
+    task_payload: Mapping[str, Any],
+    *,
+    logical_step_id: str,
+) -> dict[str, Any]:
+    """Return compact prepared context payload or bounded prepare failure."""
+
+    try:
+        manifest = build_prepared_input_manifest(task_payload)
+        context = select_step_prepared_context(
+            manifest,
+            logical_step_id=logical_step_id,
+        )
+        return {
+            "ok": True,
+            "manifestRef": manifest.manifest_ref,
+            "context": context.to_metadata(),
+        }
+    except Exception as exc:
+        failure = PreparedContextFailure.from_exception(
+            exc,
+            logical_step_id=logical_step_id,
+        )
+        return {"ok": False, "failure": failure.model_dump(by_alias=True)}
+
 
 def _managed_session_telemetry_context(
     payload: Mapping[str, Any] | BaseModel | None,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -38,6 +38,12 @@ with workflow.unsafe.imports_passed_through():
         is_jules_agent_runtime_node,
     )
     from moonmind.workflows.tasks.routing import _coerce_bool
+    from moonmind.workflows.tasks.prepared_context import (
+        build_prepared_input_manifest,
+        merge_prepared_input_refs,
+        select_step_prepared_context,
+        task_payload_has_input_attachments,
+    )
     from moonmind.workflows.agent_skills.selection import selected_agent_skill
     from moonmind.config.settings import settings
     from moonmind.utils.logging import scrub_github_tokens
@@ -4869,6 +4875,31 @@ class MoonMindRunWorkflow:
             metadata_payload["moonmind"] = moonmind_payload
             parameters["metadata"] = metadata_payload
 
+        input_refs = node_inputs.get("inputRefs") or []
+        if isinstance(workflow_parameters, Mapping):
+            task_payload = workflow_parameters.get("task")
+            if isinstance(task_payload, Mapping) and task_payload_has_input_attachments(task_payload):
+                prepared_manifest = build_prepared_input_manifest(task_payload)
+                prepared_context = select_step_prepared_context(
+                    prepared_manifest,
+                    logical_step_id=node_id,
+                )
+                if prepared_context.input_refs:
+                    input_refs = merge_prepared_input_refs(input_refs, prepared_context)
+                    metadata_payload = (
+                        parameters.get("metadata")
+                        if isinstance(parameters.get("metadata"), dict)
+                        else {}
+                    )
+                    moonmind_payload = (
+                        metadata_payload.get("moonmind")
+                        if isinstance(metadata_payload.get("moonmind"), dict)
+                        else {}
+                    )
+                    moonmind_payload["preparedContext"] = prepared_context.to_metadata()
+                    metadata_payload["moonmind"] = moonmind_payload
+                    parameters["metadata"] = metadata_payload
+
         return AgentExecutionRequest(
             agent_kind=agent_kind,
             agent_id=agent_id,
@@ -4878,7 +4909,7 @@ class MoonMindRunWorkflow:
             instruction_ref=node_inputs.get("instructions")
             or node_inputs.get("instructionRef"),
             resolved_skillset_ref=resolved_skillset_ref,
-            input_refs=node_inputs.get("inputRefs") or [],
+            input_refs=input_refs,
             workspace_spec=workspace_spec,
             parameters=parameters,
             timeout_policy=node_inputs.get("timeoutPolicy") or {},

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -42,7 +42,6 @@ with workflow.unsafe.imports_passed_through():
         build_prepared_input_manifest,
         merge_prepared_input_refs,
         select_step_prepared_context,
-        task_payload_has_input_attachments,
     )
     from moonmind.workflows.agent_skills.selection import selected_agent_skill
     from moonmind.config.settings import settings
@@ -4878,27 +4877,34 @@ class MoonMindRunWorkflow:
         input_refs = node_inputs.get("inputRefs") or []
         if isinstance(workflow_parameters, Mapping):
             task_payload = workflow_parameters.get("task")
-            if isinstance(task_payload, Mapping) and task_payload_has_input_attachments(task_payload):
+            if isinstance(task_payload, Mapping):
                 prepared_manifest = build_prepared_input_manifest(task_payload)
-                prepared_context = select_step_prepared_context(
-                    prepared_manifest,
-                    logical_step_id=node_id,
-                )
-                if prepared_context.input_refs:
-                    input_refs = merge_prepared_input_refs(input_refs, prepared_context)
-                    metadata_payload = (
-                        parameters.get("metadata")
-                        if isinstance(parameters.get("metadata"), dict)
-                        else {}
+                if prepared_manifest.has_entries:
+                    prepared_context = select_step_prepared_context(
+                        prepared_manifest,
+                        logical_step_id=node_id,
                     )
-                    moonmind_payload = (
-                        metadata_payload.get("moonmind")
-                        if isinstance(metadata_payload.get("moonmind"), dict)
-                        else {}
-                    )
-                    moonmind_payload["preparedContext"] = prepared_context.to_metadata()
-                    metadata_payload["moonmind"] = moonmind_payload
-                    parameters["metadata"] = metadata_payload
+                    if prepared_context.input_refs:
+                        if agent_kind != "managed":
+                            input_refs = merge_prepared_input_refs(
+                                input_refs,
+                                prepared_context,
+                            )
+                        metadata_payload = (
+                            parameters.get("metadata")
+                            if isinstance(parameters.get("metadata"), dict)
+                            else {}
+                        )
+                        moonmind_payload = (
+                            metadata_payload.get("moonmind")
+                            if isinstance(metadata_payload.get("moonmind"), dict)
+                            else {}
+                        )
+                        moonmind_payload["preparedContext"] = (
+                            prepared_context.to_metadata()
+                        )
+                        metadata_payload["moonmind"] = moonmind_payload
+                        parameters["metadata"] = metadata_payload
 
         return AgentExecutionRequest(
             agent_kind=agent_kind,

--- a/specs/325-prepare-target-aware-inputs/checklists/requirements.md
+++ b/specs/325-prepare-target-aware-inputs/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Prepare Target-Aware Inputs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification defines one runtime story, preserves `MM-631` and the original Jira preset brief, and maps all in-scope source design requirements to functional requirements.

--- a/specs/325-prepare-target-aware-inputs/contracts/target-aware-prepared-context.md
+++ b/specs/325-prepare-target-aware-inputs/contracts/target-aware-prepared-context.md
@@ -1,0 +1,134 @@
+# Contract: Target-Aware Prepared Context
+
+## Purpose
+
+Define the compact runtime boundary between task-shaped attachment refs, prepare output, `MoonMind.Run` step execution, delegated `MoonMind.AgentRun` children, and runtime adapters.
+
+## Prepare Input
+
+```json
+{
+  "task": {
+    "instructions": "Review the supplied diagrams.",
+    "inputAttachments": [
+      {
+        "artifactId": "art_objective",
+        "filename": "overview.png",
+        "contentType": "image/png",
+        "sizeBytes": 1234
+      }
+    ],
+    "steps": [
+      {
+        "id": "review-step",
+        "instructions": "Review the current screen.",
+        "inputAttachments": [
+          {
+            "artifactId": "art_step_review",
+            "filename": "review.png",
+            "contentType": "image/png",
+            "sizeBytes": 5678
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Rules:
+- `task.inputAttachments` are objective-scoped.
+- `task.steps[n].inputAttachments` are scoped only to the owning step.
+- Instruction fields remain text.
+- Embedded binary, base64, data URLs, and generated markdown are invalid in attachment refs.
+
+## Prepare Result
+
+```json
+{
+  "manifestRef": "artifact://prepared-input-manifest/MM-631-run-1",
+  "attachments": [
+    {
+      "artifactId": "art_objective",
+      "targetKind": "objective",
+      "contentType": "image/png",
+      "sizeBytes": 1234,
+      "workspacePath": ".moonmind/inputs/objective/art_objective-overview.png",
+      "derivedContextRef": "artifact://image-context/task"
+    },
+    {
+      "artifactId": "art_step_review",
+      "targetKind": "step",
+      "stepRef": "review-step",
+      "stepOrdinal": 0,
+      "contentType": "image/png",
+      "sizeBytes": 5678,
+      "workspacePath": ".moonmind/inputs/steps/review-step/art_step_review-review.png",
+      "derivedContextRef": "artifact://image-context/steps/review-step"
+    }
+  ],
+  "diagnostics": [
+    {
+      "event": "prepare_download_completed",
+      "status": "completed",
+      "artifactId": "art_objective",
+      "targetKind": "objective"
+    }
+  ]
+}
+```
+
+Rules:
+- Workflow history carries compact refs and bounded metadata only.
+- Raw file bytes and long derived context bodies stay behind refs.
+- Failure to prepare a required item returns a failed prepare result or raises a deterministic prepare error before the affected step dispatches.
+
+## Step Prepared Context
+
+```json
+{
+  "logicalStepId": "review-step",
+  "manifestRef": "artifact://prepared-input-manifest/MM-631-run-1",
+  "objectiveContextRefs": ["artifact://image-context/task"],
+  "stepContextRefs": ["artifact://image-context/steps/review-step"],
+  "rawInputRefs": [
+    ".moonmind/inputs/objective/art_objective-overview.png",
+    ".moonmind/inputs/steps/review-step/art_step_review-review.png"
+  ]
+}
+```
+
+Rules:
+- `objectiveContextRefs` may be shared with each step by default.
+- `stepContextRefs` and step raw refs include only entries for `logicalStepId`.
+- No unrelated step's prepared context may be present.
+
+## Child AgentRun Request Boundary
+
+When `MoonMind.Run` delegates a step to `MoonMind.AgentRun`, the child request must carry only the represented step's prepared context through compact refs or metadata.
+
+Expected properties:
+- `inputRefs` contains only relevant objective refs plus represented-step refs.
+- `parameters.metadata.moonmind.preparedContext` or equivalent bounded metadata identifies the manifest ref and target filtering decision.
+- Child requests do not receive unrelated step refs.
+- Runtime adapters may realize refs as text-first or multimodal payloads but must not change target binding.
+
+## Failure Contract
+
+A prepare failure result includes:
+
+```json
+{
+  "status": "failed",
+  "targetKind": "step",
+  "stepRef": "review-step",
+  "artifactId": "art_step_review",
+  "reason": "artifact unavailable",
+  "retryable": false
+}
+```
+
+Rules:
+- The affected step is not dispatched after failed required preparation.
+- Operator-visible diagnostics identify target kind, step ref when applicable, artifact id, and bounded reason.
+- Secrets, raw credentials, and binary payloads are never included in failure metadata.

--- a/specs/325-prepare-target-aware-inputs/data-model.md
+++ b/specs/325-prepare-target-aware-inputs/data-model.md
@@ -1,0 +1,81 @@
+# Data Model: Prepare Target-Aware Inputs
+
+## Input Attachment Ref
+
+Represents one authored structured input from the canonical task payload.
+
+Fields:
+- `artifactId`: Stable artifact identifier for source bytes.
+- `filename`: Original display filename.
+- `contentType`: MIME type.
+- `sizeBytes`: Non-negative source size.
+- `targetKind`: Derived from containing field, either `objective` for `task.inputAttachments` or `step` for `task.steps[].inputAttachments`.
+- `stepRef`: Required for step-scoped refs after normalization; absent for objective-scoped refs.
+- `stepOrdinal`: Step position used only as bounded metadata and fallback traceability.
+
+Validation rules:
+- Entries must not contain embedded binary, base64, data URLs, or generated markdown.
+- Objective refs must come only from `task.inputAttachments`.
+- Step refs must come only from the owning step's `inputAttachments`.
+
+## Prepared Input Manifest
+
+Canonical preparation output for an attachment-aware runtime execution.
+
+Fields:
+- `version`: Manifest schema version.
+- `attachments`: Ordered prepared input entries.
+- `manifestRef` or `manifestPath`: Bounded reference to the manifest artifact or workspace-local manifest.
+- `diagnostics`: Bounded preparation events suitable for operator troubleshooting.
+
+Validation rules:
+- Every valid authored attachment needed for execution has exactly one manifest entry.
+- Entries preserve target kind and step reference from the authored task contract.
+- Manifest body may be artifact-backed or workspace-local, but workflow history carries only compact refs/metadata.
+
+## Prepared Input Entry
+
+Represents one materialized source input.
+
+Fields:
+- `artifactId`
+- `filename`
+- `contentType`
+- `sizeBytes`
+- `targetKind`
+- `stepRef` when target kind is `step`
+- `stepOrdinal` when target kind is `step`
+- `workspacePath` or equivalent raw input ref
+- `derivedContextRef` or `derivedContextPath` when image context exists
+- `status`: `prepared`, `skipped`, or `failed`
+
+Validation rules:
+- Raw file content is never embedded inline in workflow state.
+- Derived image context is secondary context and never mutates instruction text.
+- Failed entries include bounded reason metadata and prevent affected step dispatch.
+
+## Step Prepared Context
+
+Adapter-visible filtered context for one logical step.
+
+Fields:
+- `logicalStepId`
+- `objectiveContextRefs`: Prepared objective entries relevant to the step.
+- `stepContextRefs`: Prepared entries whose `stepRef` matches the represented step.
+- `manifestRef`: Reference to the canonical manifest.
+- `diagnosticRefs`: Optional bounded diagnostic refs.
+
+Validation rules:
+- Step context must not contain entries for unrelated step refs.
+- Objective context may be included for each step by default.
+- Child `AgentRun` requests receive only the `Step Prepared Context` for the represented step.
+
+## State Transitions
+
+1. Authored task submitted with structured attachment refs.
+2. Runtime prepare starts before affected step execution.
+3. Prepare materializes raw files and generates secondary image context.
+4. Prepare writes manifest and records bounded refs/diagnostics.
+5. For each step, the workflow filters prepared context to objective plus represented step.
+6. Step or child `AgentRun` executes with only filtered prepared context.
+7. Prepare failure stops affected execution before dispatch and exposes an operator-readable reason.

--- a/specs/325-prepare-target-aware-inputs/data-model.md
+++ b/specs/325-prepare-target-aware-inputs/data-model.md
@@ -1,5 +1,7 @@
 # Data Model: Prepare Target-Aware Inputs
 
+Traceability: Jira issue `MM-631`; this artifact supports the original Jira preset brief preserved in `spec.md`.
+
 ## Input Attachment Ref
 
 Represents one authored structured input from the canonical task payload.

--- a/specs/325-prepare-target-aware-inputs/moonspec_align_report.md
+++ b/specs/325-prepare-target-aware-inputs/moonspec_align_report.md
@@ -1,0 +1,30 @@
+# MoonSpec Alignment Report: Prepare Target-Aware Inputs
+
+**Source**: MM-631 canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-08
+
+## Findings And Remediation
+
+| Finding | Decision | Artifact updates |
+| --- | --- | --- |
+| `plan.md` documentation tree did not list `tasks.md` after task generation. | Add `tasks.md` to the feature artifact tree because task generation is complete and downstream readers expect it. | `plan.md` |
+| `research.md` still named the older `/speckit.verify` command only. | Use `/moonspec-verify` while preserving `/speckit.verify` as the equivalent command name used by existing MoonSpec tooling. | `research.md` |
+| `tasks.md` had duplicate `SC-002` references in two task traceability lists. | Remove duplicate references without changing coverage. | `tasks.md` |
+| `tasks.md` foundational task T009 sounded like creating production code before red tests. | Reword T009 as reserving/confirming the implementation path without adding behavior before red tests. | `tasks.md` |
+
+## Gate Re-Checks
+
+- Specify gate: PASS. `spec.md` still has exactly one user story and preserves MM-631 plus the original Jira preset brief.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/target-aware-prepared-context.md` exist and remain aligned with the runtime boundary plan.
+- Task gate: PASS. `tasks.md` has one story phase, red-first unit and integration tasks before implementation, sequential task IDs T001-T043, and final `/moonspec-verify` work.
+- Constitution gate: PASS. No new constitution conflict was introduced.
+
+## Validation Evidence
+
+- `SPECIFY_FEATURE=325-prepare-target-aware-inputs .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
+- Placeholder scan for generated artifacts: PASS except the checklist line documenting no clarification markers, which is intentional checklist text.
+- Task ID sequence check: PASS, T001-T043.
+
+## Remaining Risks
+
+None found in MoonSpec artifacts. Implementation still needs to execute the generated tasks and prove the runtime workflow/AgentRun prepared-context boundary with tests.

--- a/specs/325-prepare-target-aware-inputs/plan.md
+++ b/specs/325-prepare-target-aware-inputs/plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan: Prepare Target-Aware Inputs
+
+**Branch**: `run-jira-orchestrate-for-mm-631-prepare-10a604d1` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:33deef30-3a30-4229-8cae-32c434b9aad5/repo/specs/325-prepare-target-aware-inputs/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted, but the managed Jira branch name does not match the script's numeric feature-branch guard. Planning continued from `.specify/feature.json`, which points to `specs/325-prepare-target-aware-inputs`.
+
+## Summary
+
+MM-631 requires target-aware prepared input delivery for the canonical runtime workflow: objective-scoped attachments and current-step-scoped attachments must be materialized, represented by a manifest, converted into derived image context as secondary artifacts, and delivered across `MoonMind.Run` and `MoonMind.AgentRun` boundaries without leaking unrelated step inputs. Current repo evidence shows the task contract, API submission normalization, Codex worker materialization, vision target context generation, and Codex text-first instruction filtering already cover parts of the behavior. The main gap is the Temporal `MoonMind.Run`/child `AgentRun` contract: prepared context refs are not yet carried or filtered at that boundary. The implementation should add tests first at the unit and workflow boundary levels, then add the smallest runtime contract and activity/workflow behavior needed to prepare, retain, and pass target-aware context refs.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workflows/tasks/task_contract.py`, `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/agents/codex_worker/test_worker.py` | Preserve existing behavior; ensure new Temporal paths do not inline binary or derived content into instructions | unit regression |
+| FR-002 | implemented_verified | `TaskInputAttachmentRef` in `moonmind/workflows/tasks/task_contract.py`; API and integration normalization tests reference `inputAttachments` | Reuse structured refs as source input for new runtime prepare contract | unit + integration |
+| FR-003 | implemented_verified | `moonmind/vision/service.py`; `tests/unit/moonmind/vision/test_service.py` target-context tests | Reuse generated image context as secondary prepared context and reference it from the runtime contract | unit + integration |
+| FR-004 | partial | Codex worker prepare exists in `moonmind/agents/codex_worker/worker.py`; `MoonMind.Run` has no `inputAttachments` handling beyond generic `inputRefs` | Add/extend Temporal prepare activity/service contract and invoke it before affected step execution | unit + integration |
+| FR-005 | partial | Codex worker preserves target distinction in local manifest; `moonmind/workflows/temporal/workflows/run.py` does not carry prepared target context | Add compact prepared-context refs to `MoonMind.Run` state/step inputs while preserving objective vs step target distinction | workflow boundary integration |
+| FR-006 | partial | Codex worker downloads attachments; no Temporal prepare evidence | Ensure runtime prepare downloads or resolves every objective/step attachment needed before step execution, failing before affected step runs | unit + integration |
+| FR-007 | partial | `.moonmind/attachments_manifest.json` shape exists in Codex worker tests | Define canonical prepared manifest payload for runtime workflow and expose manifest ref/path through prepared context | unit + integration |
+| FR-008 | partial | Codex step instruction filtering omits non-current step context; no Temporal child request evidence | Filter prepared context per logical step before step execution and planner/agent dispatch | unit + workflow boundary integration |
+| FR-009 | missing | `MoonMind.Run` builds `AgentExecutionRequest` without prepared attachment/context refs for the represented step | Add child `AgentRun` request metadata/input refs containing only objective plus represented-step prepared context | workflow boundary integration |
+| FR-010 | partial | `AgentExecutionRequest.inputRefs` exists; step ledger exists, but no prepared context refs are recorded | Retain bounded manifest/context refs in workflow state and step evidence without embedding large bodies | unit + workflow boundary integration |
+| FR-011 | partial | Codex worker text-first adapter consumes manifest/vision index; generic runtime adapter boundary lacks target-aware contract | Define adapter-visible prepared context contract and verify adapters cannot invent target rules | unit + integration |
+| FR-012 | partial | Codex worker fails on materialization download errors; no Temporal prepare failure path | Add explicit runtime prepare failure result/error handling before affected step execution | unit + integration |
+| FR-013 | implemented_unverified | `spec.md` preserves `MM-631` and original Jira brief; plan preserves it here | Preserve `MM-631` through plan, design artifacts, tasks, verification, commit, and PR metadata | final verification |
+| SCN-001 | partial | Codex manifest tests cover objective and step targets | Add Temporal prepare manifest scenario covering objective and multiple step targets | integration |
+| SCN-002 | partial | Codex materialization and vision tests exist | Verify raw refs and derived context refs remain separate in runtime prepare result | unit + integration |
+| SCN-003 | partial | Codex instruction composition proves current-step filtering | Add workflow-level test that step execution sees only relevant objective/current-step context | integration |
+| SCN-004 | missing | Child `AgentRun` request lacks target-aware prepared context | Add child workflow dispatch test proving represented-step filtering | integration |
+| SCN-005 | partial | Codex adapter behavior exists | Add adapter contract tests for prepared refs and target-rule preservation | unit |
+| SCN-006 | partial | Codex worker fails on download errors | Add runtime prepare failure test before step dispatch | integration |
+| SC-001 | partial | Codex worker instruction tests cover current step only | Add end-to-end workflow boundary validation for one objective and two step attachments | integration |
+| SC-002 | partial | Codex worker writes manifest; workflow prepare does not | Add prepare result assertion that every attachment-aware runtime execution has a manifest ref | integration |
+| SC-003 | missing | No child-run prepared-context assertion | Add child-run test proving no unrelated step context | integration |
+| SC-004 | partial | Codex worker error path exists | Add Temporal prepare failure path before affected step runs | integration |
+| SC-005 | implemented_unverified | `spec.md` and this plan preserve traceability | Preserve in generated tasks and final verify artifacts | final verification |
+| DESIGN-REQ-001 | implemented_verified | Task contract and vision service preserve text vs structured/derived inputs | Preserve behavior while adding runtime refs | unit regression |
+| DESIGN-REQ-002 | partial | `MoonMind.Run` owns step ledger but not target-aware prepare refs | Extend runtime workflow prepare/context delivery state | workflow boundary integration |
+| DESIGN-REQ-003 | partial | Codex worker performs target-aware materialization | Move/extend behavior to canonical runtime boundary | unit + integration |
+| DESIGN-REQ-004 | partial | Codex worker filters context per step | Add workflow-level filtering | integration |
+| DESIGN-REQ-005 | missing | Child `AgentRun` request lacks prepared context boundary | Add represented-step prepared context contract | integration |
+| DESIGN-REQ-006 | partial | Codex adapter consumes generated context; generic contract missing | Define adapter-visible target-aware prepared context contract | unit + integration |
+| DESIGN-REQ-007 | partial | `MoonMind.Run` and `AgentRun` exist, but prepared input refs are not in their boundary | Add parent-owned prepared context refs for child dispatch and recovery evidence | workflow boundary integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, pytest, existing MoonMind artifact and vision services  
+**Storage**: Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned  
+**Unit Testing**: `./tools/test_unit.sh` and focused `pytest` targets through that runner  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage; focused Temporal workflow boundary tests where possible  
+**Target Platform**: Linux service and managed worker containers  
+**Project Type**: Backend workflow/control-plane feature with runtime adapter boundary impact  
+**Performance Goals**: Prepared context selection must remain bounded by attachment count and must avoid embedding large/binary content in workflow history  
+**Constraints**: Preserve secret hygiene; keep large bodies behind refs; fail explicitly on invalid preparation; avoid compatibility aliases for internal pre-release contracts unless Temporal in-flight safety requires an explicit versioned cutover  
+**Scale/Scope**: One runtime story for objective-scoped and step-scoped input delivery across `MoonMind.Run`, step execution, and `MoonMind.AgentRun`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The plan adds orchestration/context delivery around existing agents, not a new cognitive engine.
+- II. One-Click Agent Deployment: PASS. No mandatory external service or deployment prerequisite is introduced.
+- III. Avoid Vendor Lock-In: PASS. Prepared context is a runtime contract with adapter-specific realization, not Codex-only behavior.
+- IV. Own Your Data: PASS. Prepared files and context remain in MoonMind-controlled artifacts/workspaces.
+- V. Skills Are First-Class and Easy to Add: PASS. The feature preserves selected-skill/runtime boundaries and does not mutate skill sources.
+- VI. Replaceable Scaffolding, Thick Contracts: PASS. The plan defines explicit contracts and tests around volatile runtime adapter behavior.
+- VII. Runtime Configurability: PASS. Existing artifact/vision settings remain the configuration surface; no hardcoded provider behavior is planned.
+- VIII. Modular and Extensible Architecture: PASS. Work is planned at task contract, prepare activity/service, workflow, and adapter boundaries.
+- IX. Resilient by Default: PASS. Explicit prepare failures and workflow-boundary tests are required.
+- X. Facilitate Continuous Improvement: PASS. Diagnostics and artifact refs remain operator-visible evidence.
+- XI. Spec-Driven Development: PASS. `spec.md`, this `plan.md`, and design artifacts preserve the MM-631 story.
+- XII. Documentation Separation: PASS. Implementation tracking stays under `specs/325-prepare-target-aware-inputs/`.
+- XIII. Pre-Release Velocity: PASS. The plan avoids compatibility aliases and requires updating callers/tests in one cohesive change.
+
+Post-design re-check: PASS. The Phase 1 artifacts keep contracts explicit, store large bodies behind refs, and preserve runtime adapter boundaries without introducing new constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/325-prepare-target-aware-inputs/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── target-aware-prepared-context.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── workflows/
+│   ├── tasks/task_contract.py
+│   ├── temporal/workflows/run.py
+│   ├── temporal/workflows/agent_run.py
+│   ├── temporal/activity_runtime.py
+│   └── adapters/
+│       ├── codex_session_adapter.py
+│       └── managed_agent_adapter.py
+├── vision/service.py
+└── agents/codex_worker/worker.py
+
+api_service/
+└── api/routers/executions.py
+
+tests/
+├── unit/
+│   ├── workflows/tasks/test_task_contract.py
+│   ├── moonmind/vision/test_service.py
+│   ├── agents/codex_worker/test_attachment_materialization.py
+│   ├── agents/codex_worker/test_worker.py
+│   └── workflows/temporal/workflows/
+└── integration/
+    ├── temporal/test_task_shaped_submission_normalization.py
+    └── workflows/temporal/workflows/
+```
+
+**Structure Decision**: Use the existing backend workflow, task contract, vision service, runtime adapter, and Temporal workflow test layout. No frontend, database migration, or new persistent storage tree is planned unless implementation discovers that existing artifact refs cannot express the required prepared context.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/325-prepare-target-aware-inputs/plan.md
+++ b/specs/325-prepare-target-aware-inputs/plan.md
@@ -91,6 +91,7 @@ specs/325-prepare-target-aware-inputs/
 ├── quickstart.md
 ├── contracts/
 │   └── target-aware-prepared-context.md
+├── tasks.md
 └── checklists/
     └── requirements.md
 ```

--- a/specs/325-prepare-target-aware-inputs/quickstart.md
+++ b/specs/325-prepare-target-aware-inputs/quickstart.md
@@ -19,6 +19,7 @@ Focused unit iteration should cover:
 ./tools/test_unit.sh tests/unit/moonmind/vision/test_service.py
 ./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py
 ./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py
+./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
 ```
 
@@ -39,6 +40,11 @@ Run hermetic integration CI before finalizing when Docker is available:
 ```
 
 Focused integration scenarios should cover:
+
+```bash
+pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short
+```
+
 - A task with one objective attachment and two step-scoped attachments.
 - Runtime prepare writes a manifest or manifest artifact ref before first affected step execution.
 - Step 1 receives objective context plus Step 1 context and no Step 2 context.

--- a/specs/325-prepare-target-aware-inputs/quickstart.md
+++ b/specs/325-prepare-target-aware-inputs/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Prepare Target-Aware Inputs
+
+## Scope
+
+Validate MM-631 after implementation by proving that objective-scoped and current-step-scoped prepared context reaches each runtime step and delegated `AgentRun` child without unrelated step leakage.
+
+## Unit Test Strategy
+
+Run the full unit suite before finalizing:
+
+```bash
+./tools/test_unit.sh
+```
+
+Focused unit iteration should cover:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
+./tools/test_unit.sh tests/unit/moonmind/vision/test_service.py
+./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py
+./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py
+./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+```
+
+Expected unit coverage:
+- Structured `inputAttachments` remain text/binary separated.
+- Prepared manifest/result models preserve objective and step targets.
+- Derived image context remains secondary context behind refs.
+- Step prepared context filtering includes objective plus current step only.
+- Adapter-visible payloads preserve prepared target bindings.
+- Prepare failures are explicit and bounded.
+
+## Integration Test Strategy
+
+Run hermetic integration CI before finalizing when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+Focused integration scenarios should cover:
+- A task with one objective attachment and two step-scoped attachments.
+- Runtime prepare writes a manifest or manifest artifact ref before first affected step execution.
+- Step 1 receives objective context plus Step 1 context and no Step 2 context.
+- A delegated child `AgentRun` receives only the represented step context.
+- A missing or unauthorized attachment causes prepare failure before step dispatch.
+
+If a Temporal time-skipping workflow test is too slow for `integration_ci`, keep it as local workflow boundary coverage and document the reason in final verification.
+
+## End-to-End Validation Shape
+
+1. Construct a task-shaped payload with:
+   - `task.inputAttachments`: one objective image ref.
+   - `task.steps[0].inputAttachments`: one step image ref.
+   - `task.steps[1].inputAttachments`: a different step image ref.
+2. Execute the runtime prepare path.
+3. Confirm the prepared manifest includes all three refs with correct target kind and step refs.
+4. Confirm generated image context is referenced separately from instruction text.
+5. Dispatch Step 1 and inspect the step or child request boundary.
+6. Confirm Step 1 contains objective context plus Step 1 context only.
+7. Dispatch Step 2 and confirm the inverse filtering.
+8. Repeat with a missing attachment and confirm no affected step dispatch occurs.
+
+## Traceability Checks
+
+Final verification must confirm:
+- `MM-631` is preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md`, verification output, commit text, and PR metadata.
+- The original Jira preset brief remains available in `spec.md`.
+- Source design mappings from `docs/Tasks/TaskArchitecture.md` remain mapped to tests and implementation evidence.

--- a/specs/325-prepare-target-aware-inputs/research.md
+++ b/specs/325-prepare-target-aware-inputs/research.md
@@ -1,0 +1,73 @@
+# Research: Prepare Target-Aware Inputs
+
+## Existing Task Input Contract
+
+Decision: Treat `task.inputAttachments` as objective-scoped input refs and `task.steps[].inputAttachments` as step-scoped input refs; status is implemented_verified for source contract validation.
+Evidence: `moonmind/workflows/tasks/task_contract.py` defines `TaskInputAttachmentRef`, task-level `inputAttachments`, and step-level `inputAttachments`; API and integration tests assert task and step refs are preserved.
+Rationale: The source of target binding is already explicit in the canonical task payload, so the new work should consume this shape rather than inventing a parallel target field.
+Alternatives considered: Inferring target binding from filenames, artifact metadata, or storage paths was rejected because the spec requires authored target binding to remain authoritative.
+Test implications: Unit regression for contract validation; integration tests for workflow delivery.
+
+## Prepared Manifest and Materialization
+
+Decision: Reuse the existing manifest entry shape as the planned canonical prepared-input manifest, but move/extend the behavior to the canonical runtime workflow boundary; status is partial.
+Evidence: `moonmind/agents/codex_worker/worker.py` collects targets, materializes files, and writes `.moonmind/attachments_manifest.json`; `tests/unit/agents/codex_worker/test_attachment_materialization.py` verifies objective and step entries, stable paths, diagnostics, and failure on download errors.
+Rationale: The current behavior satisfies many file/manifest details but lives in the Codex worker prepare path. MM-631 requires `MoonMind.Run` and delegated `MoonMind.AgentRun` children to observe target-aware prepared context.
+Alternatives considered: Keeping this as Codex-worker-only behavior was rejected because runtime adapters and child runs must not redefine target binding.
+Test implications: Unit tests for manifest/result models and integration-style workflow tests proving prepare occurs before affected step dispatch.
+
+## Derived Image Context
+
+Decision: Reuse `VisionService.render_target_contexts` for target-aware derived context and store only refs/paths in runtime state; status is implemented_verified for the service and partial for workflow integration.
+Evidence: `moonmind/vision/service.py` renders objective and step target contexts with diagnostics; `tests/unit/moonmind/vision/test_service.py` verifies target preservation, disabled/provider-failed diagnostics, safe step-ref paths, and collision handling.
+Rationale: Derived context already has the correct target-aware concept; the missing work is linking those outputs into the runtime prepare result and adapter-visible context.
+Alternatives considered: Embedding generated markdown directly in step instructions was rejected because the spec requires derived context to remain secondary and large content to stay out of workflow history.
+Test implications: Unit tests for prepare-result indexing; integration tests for manifest/context refs delivered to step execution.
+
+## Step Runtime Delivery
+
+Decision: Add workflow-level prepared context filtering so each step receives relevant objective context plus only its own step-scoped context; status is partial.
+Evidence: `tests/unit/agents/codex_worker/test_worker.py` proves Codex instruction composition includes objective and current-step context while omitting non-current steps. `moonmind/workflows/temporal/workflows/run.py` currently builds `AgentExecutionRequest` with generic `inputRefs` but no prepared target-aware context.
+Rationale: Existing Codex text-first filtering is valuable evidence, but MM-631 requires the canonical workflow boundary to enforce filtering before adapter realization.
+Alternatives considered: Letting adapters filter from the full manifest was rejected because adapters must not invent or broaden target rules.
+Test implications: Workflow boundary tests for `MoonMind.Run` step dispatch and adapter unit tests for preserving prepared target bindings.
+
+## Child AgentRun Boundary
+
+Decision: Extend child `AgentRun` request metadata/input refs to carry only the prepared context relevant to the represented step; status is missing.
+Evidence: `moonmind/workflows/temporal/workflows/run.py` creates `AgentExecutionRequest` with `input_refs=node_inputs.get("inputRefs") or []`; searches found no `inputAttachments`, manifest, or image context handling in `run.py` or `agent_run.py`.
+Rationale: The child boundary is where unrelated step attachments can leak unless the parent supplies a pre-filtered, bounded context set.
+Alternatives considered: Passing the whole prepared manifest to every child was rejected because it would make every adapter responsible for target filtering.
+Test implications: Workflow boundary integration test with one objective attachment and at least two step attachments, asserting child request refs/metadata omit unrelated step context.
+
+## Failure Behavior
+
+Decision: Add an explicit Temporal prepare failure path before affected step execution; status is partial.
+Evidence: Codex worker materialization raises on download failures and records diagnostics. No equivalent `MoonMind.Run` prepare failure path exists for attachment preparation.
+Rationale: The spec requires explicit failure before running with incomplete context.
+Alternatives considered: Continuing with missing refs and warning diagnostics was rejected because silent context loss is a contract violation.
+Test implications: Unit test for prepare activity error result and integration test that a failed prepare does not dispatch the affected step.
+
+## Unit Test Strategy
+
+Decision: Use focused pytest unit coverage through `./tools/test_unit.sh` for contract/model filtering, prepared manifest/result construction, adapter-visible context selection, and failure classification.
+Evidence: Existing unit suites cover task contracts, vision service, Codex worker materialization, Codex prompt filtering, and workflow helper behavior.
+Rationale: Unit tests should pin deterministic model and filtering behavior before workflow integration is updated.
+Alternatives considered: Relying only on workflow tests was rejected because target filtering and manifest construction need faster, more local regression coverage.
+Test implications: Add or update tests under `tests/unit/workflows/tasks/`, `tests/unit/moonmind/vision/`, `tests/unit/workflows/temporal/workflows/`, and adapter/worker tests as implementation touches those seams.
+
+## Integration Test Strategy
+
+Decision: Use hermetic Temporal/workflow boundary coverage and run it through `./tools/test_integration.sh` when marked `integration_ci`; use focused local workflow tests when Temporal time-skipping coverage is too slow for CI.
+Evidence: Existing integration suites include `tests/integration/temporal/test_task_shaped_submission_normalization.py` and `tests/integration/workflows/temporal/workflows/`.
+Rationale: MM-631 changes workflow/activity and child request boundaries, so integration evidence must prove real invocation shapes and no unrelated context leakage.
+Alternatives considered: API-only submission tests were rejected because they do not prove runtime prepare or child dispatch behavior.
+Test implications: Add an integration scenario with objective plus two step attachments, one delegated child step, and one prepare failure path.
+
+## Traceability
+
+Decision: Preserve `MM-631`, the original preset brief, and source design mappings in every generated artifact; status is implemented_unverified until final verification.
+Evidence: `spec.md` preserves MM-631 and the original preset brief; this research and plan preserve MM-631.
+Rationale: Final verification compares the implementation and artifacts against the original Jira brief.
+Alternatives considered: Keeping only the issue key was rejected because the final verifier needs the full source brief.
+Test implications: Final `/speckit.verify` must include traceability review.

--- a/specs/325-prepare-target-aware-inputs/research.md
+++ b/specs/325-prepare-target-aware-inputs/research.md
@@ -70,4 +70,4 @@ Decision: Preserve `MM-631`, the original preset brief, and source design mappin
 Evidence: `spec.md` preserves MM-631 and the original preset brief; this research and plan preserve MM-631.
 Rationale: Final verification compares the implementation and artifacts against the original Jira brief.
 Alternatives considered: Keeping only the issue key was rejected because the final verifier needs the full source brief.
-Test implications: Final `/speckit.verify` must include traceability review.
+Test implications: Final `/moonspec-verify` (`/speckit.verify` equivalent) must include traceability review.

--- a/specs/325-prepare-target-aware-inputs/spec.md
+++ b/specs/325-prepare-target-aware-inputs/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Prepare Target-Aware Inputs
+
+**Feature Branch**: `325-prepare-target-aware-inputs`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+For a single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
+For a broad technical or declarative design, run moonspec-breakdown first, then select the recommended first generated spec unless the issue brief explicitly requires processing all specs.
+Preserve Jira issue MM-631 and the original preset brief in spec.md so final verification can compare against them.
+
+Canonical Jira preset brief:
+
+# MM-631 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-631
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Prepare target-aware inputs for step execution
+- Priority: Medium
+- Labels: `moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; potentially related custom fields `Implementation plan`, `Backout plan`, and `Test plan` were present but empty.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-631 from MM project
+Summary: Prepare target-aware inputs for step execution
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-631 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-631: Prepare target-aware inputs for step execution
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.5 Separation of text from structured inputs
+- 8.1 Workflow responsibilities
+- 8.2 Prepare responsibilities
+- 8.3 Step execution responsibilities
+- 8.4 Child workflow responsibilities
+- 10 Runtime and prompt boundary
+- 12 Workload-specific behavior
+
+Coverage IDs:
+- DESIGN-REQ-005
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-019
+- DESIGN-REQ-021
+
+As a runtime step, I want prepared context to include relevant objective inputs and only my step-scoped inputs so attachments are materialized, contextualized, and passed across workflow boundaries without leakage.
+
+Acceptance Criteria
+- Prepare downloads objective-scoped and step-scoped attachments and writes a canonical manifest.
+- Raw files are materialized into stable workspace locations and image context artifacts are produced as secondary artifacts.
+- Instruction fields remain textual.
+- Each step receives relevant objective context plus only its own step-scoped context by default.
+- AgentRun children receive only the prepared context relevant to the represented step.
+- Runtime adapters may consume generated context or raw refs but must not invent new targeting rules.
+
+Requirements
+- Instruction text remains text, images remain structured inputs, and derived image context is a secondary artifact.
+- MoonMind.Run owns progression, prepare orchestration, context generation, target-aware context delivery, ledgers, checkpoints, and full/resumed starts.
+- Prepare downloads attachments, writes manifests, materializes stable workspace files, emits target-aware context artifacts, and fails on invalid preparation.
+- Step runtimes and AgentRun children receive only relevant objective/current-step context and cannot redefine target binding.
+- Adapters may realize normalized intent and artifact refs as text-first or multimodal payloads without inventing new target rules.
+
+Relevant Jira links from trusted issue response:
+- MM-630: Compile recursive task presets before execution; relationship: Blocks outward issue; status: Done; issue type: Story.
+- MM-632: Expose distinct full retry recovery actions; relationship: Blocks inward issue; status: Backlog; issue type: Story.
+"""
+
+## User Story - Prepare Step-Scoped Inputs
+
+**Summary**: As a runtime step, I want prepared context to include relevant objective inputs and only my own step-scoped inputs so that attachments are materialized, contextualized, and passed across workflow boundaries without leaking unrelated inputs.
+
+**Goal**: Each task step receives a complete, target-aware prepared context that includes applicable objective-scoped attachments and only the current step's scoped attachments, while preserving text instructions as text and structured inputs as structured inputs.
+
+**Independent Test**: Can be fully tested by submitting a task with objective-scoped attachments and multiple step-scoped attachments, then verifying that preparation produces a canonical manifest and that each step, including a delegated child step, receives only the prepared context targeted to it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a submitted task has objective-scoped attachments and step-scoped attachments for multiple steps, **When** preparation runs, **Then** the prepared manifest records the objective target and each step target separately.
+2. **Given** preparation processes files for objective and step targets, **When** raw files and derived image context are prepared, **Then** raw files have stable materialized locations and derived context is recorded as secondary context rather than merged into instruction text.
+3. **Given** a step starts after preparation succeeds, **When** its runtime context is assembled, **Then** it includes relevant objective context plus only that step's scoped prepared context by default.
+4. **Given** a step delegates execution to a child agent run, **When** the child receives its prepared inputs, **Then** the child receives only the prepared context relevant to the represented step and cannot broaden the target binding.
+5. **Given** an adapter consumes prepared context, **When** it realizes text-first or multimodal payloads, **Then** it follows the prepared target bindings and does not create new targeting rules.
+6. **Given** preparation cannot fully download, materialize, or contextualize a targeted attachment, **When** the failure is detected, **Then** the task fails explicitly with an operator-readable reason instead of running with incomplete or leaked context.
+
+### Edge Cases
+
+- A task has objective-scoped attachments but no step-scoped attachments; each step still receives the relevant objective context without synthetic step targets.
+- A step has no scoped attachments; it receives objective context when relevant and no unrelated step context.
+- Multiple steps reference attachments with similar filenames or source metadata; target identity remains based on authored binding, not names or storage paths.
+- A child run is started for one step while other steps have attachments; the child receives only the represented step's prepared context plus relevant objective context.
+- A runtime adapter supports raw structured inputs while another supports text-first context; both observe the same target binding semantics.
+
+## Assumptions
+
+- The feature applies to the canonical attachment-aware task workflow used for runtime implementation work.
+- Objective-scoped context is relevant to each step unless future task policy narrows objective visibility.
+- Existing artifact authorization and preview rules continue to govern access to prepared raw files and derived context.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tasks/TaskArchitecture.md`, section 3.5. Instruction text remains text, images remain structured inputs, and derived image context is a secondary artifact. Scope: in scope. Maps to FR-001, FR-002, and FR-003. Original Jira coverage ID: DESIGN-REQ-005.
+- **DESIGN-REQ-002**: Source `docs/Tasks/TaskArchitecture.md`, section 8.1. The runtime workflow owns preparation orchestration, image context generation, target-aware context delivery, and preservation of bounded step evidence needed for resume eligibility. Scope: in scope. Maps to FR-004, FR-005, and FR-010. Original Jira coverage ID: DESIGN-REQ-017.
+- **DESIGN-REQ-003**: Source `docs/Tasks/TaskArchitecture.md`, section 8.2. Preparation downloads objective-scoped and step-scoped attachments, writes a canonical manifest, materializes stable raw files, produces target-aware image context artifacts, and fails explicitly when preparation is incomplete or invalid. Scope: in scope. Maps to FR-002, FR-003, FR-006, and FR-007. Original Jira coverage ID: DESIGN-REQ-018.
+- **DESIGN-REQ-004**: Source `docs/Tasks/TaskArchitecture.md`, section 8.3. Step execution consumes task-level objective context when relevant and only the current step's step-scoped context by default. Scope: in scope. Maps to FR-008. Original Jira coverage ID: DESIGN-REQ-019.
+- **DESIGN-REQ-005**: Source `docs/Tasks/TaskArchitecture.md`, section 8.4. Child agent runs receive only the prepared context relevant to the represented step and do not redefine target binding semantics. Scope: in scope. Maps to FR-009. Original Jira coverage ID: DESIGN-REQ-021.
+- **DESIGN-REQ-006**: Source `docs/Tasks/TaskArchitecture.md`, section 10. Runtime adapters may consume generated context or raw refs according to capability but must not change control-plane targeting rules. Scope: in scope. Maps to FR-011.
+- **DESIGN-REQ-007**: Source `docs/Tasks/TaskArchitecture.md`, section 12. The canonical task workflow is responsible for attachment-aware task authoring, step ledger state, and prepared context passed to delegated child runs. Scope: in scope. Maps to FR-004, FR-009, and FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST preserve authored instruction fields as textual content and MUST NOT inline binary or derived attachment content into those instruction fields.
+- **FR-002**: System MUST treat uploaded images and other binary task inputs as structured input references throughout preparation and runtime delivery.
+- **FR-003**: System MUST represent derived image context as secondary prepared context that remains linked to the original target binding.
+- **FR-004**: System MUST orchestrate preparation before step execution for tasks with objective-scoped or step-scoped attachments.
+- **FR-005**: System MUST carry target-aware prepared context through runtime progression without losing the distinction between objective targets and step targets.
+- **FR-006**: System MUST download or otherwise make available every valid objective-scoped and step-scoped attachment needed for execution before the affected step runs.
+- **FR-007**: System MUST produce a canonical prepared-input manifest that records each prepared item, its target kind, and its step target when applicable.
+- **FR-008**: System MUST provide each step with relevant objective context plus only that step's own step-scoped prepared context by default.
+- **FR-009**: System MUST provide delegated child agent runs only the prepared context relevant to the represented step and MUST NOT allow child runs to broaden attachment targeting.
+- **FR-010**: System MUST retain bounded prepared-context references and step evidence needed to support later recovery decisions without embedding large or binary content in run history.
+- **FR-011**: Runtime adapters MUST consume prepared context according to their capabilities while preserving the control-plane target bindings exactly.
+- **FR-012**: System MUST fail explicitly with an operator-readable reason when required preparation is incomplete, invalid, unauthorized, or otherwise unavailable.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-631` and the original Jira preset brief for traceability.
+
+### Key Entities *(include if feature involves data)*
+
+- **Input Attachment**: A structured reference to a user-provided file or imported input, including its authored target binding.
+- **Prepared Input Manifest**: The canonical preparation record that lists prepared items, target bindings, materialized raw-file references, derived context references, and preparation status.
+- **Prepared Context Item**: A raw input reference or derived context artifact made available to a runtime according to target binding.
+- **Step Runtime Context**: The bounded set of objective and current-step prepared context delivered to a step or delegated child run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a task with one objective attachment and at least two differently targeted step attachments, 100% of steps receive only the objective context plus their own step-scoped context during verification.
+- **SC-002**: Preparation produces one canonical manifest for every attachment-aware task execution before the first affected step begins.
+- **SC-003**: Verification of delegated child runs confirms 100% of child runs receive no prepared context for unrelated steps.
+- **SC-004**: Invalid, unavailable, or unauthorized attachment preparation paths produce an explicit terminal or retryable preparation failure before any affected step executes.
+- **SC-005**: Traceability review confirms `MM-631`, the original Jira preset brief, and source design mappings remain present in the specification and final verification evidence.

--- a/specs/325-prepare-target-aware-inputs/tasks.md
+++ b/specs/325-prepare-target-aware-inputs/tasks.md
@@ -48,7 +48,7 @@
 - [ ] T006 Create placeholder workflow unit test module `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` for `MoonMind.Run` prepared-context state and child request coverage. (FR-004, FR-005, FR-008, FR-009, FR-010, SCN-003, SCN-004, SC-001, SC-003, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
 - [ ] T007 Create placeholder integration test module `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for hermetic workflow boundary scenarios. (SCN-001, SCN-003, SCN-004, SCN-006, SC-001, SC-002, SC-003, SC-004)
 - [ ] T008 [P] Create placeholder adapter unit test module `tests/unit/workflows/adapters/test_target_aware_prepared_context.py` for adapter-visible prepared context contract checks. (FR-011, SCN-005, DESIGN-REQ-006)
-- [ ] T009 [P] Create placeholder implementation module `moonmind/workflows/tasks/prepared_context.py` for compact prepared input contracts and pure filtering helpers. (FR-004, FR-005, FR-007, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [ ] T009 [P] Confirm planned implementation path `moonmind/workflows/tasks/prepared_context.py` is reserved for compact prepared input contracts and pure filtering helpers without adding behavior before red tests. (FR-004, FR-005, FR-007, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
 
 **Checkpoint**: Test and contract locations exist; story test authoring can begin.
 
@@ -85,7 +85,7 @@
 
 ### Integration Tests (write first)
 
-- [ ] T016 [P] Add failing workflow unit test proving `MoonMind.Run` records a prepared manifest ref before the first affected step dispatch in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SC-002, SC-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-007)
+- [ ] T016 [P] Add failing workflow unit test proving `MoonMind.Run` records a prepared manifest ref before the first affected step dispatch in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-007)
 - [ ] T017 [P] Add failing workflow unit test proving step dispatch receives objective plus current-step prepared context and omits later-step context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
 - [ ] T018 [P] Add failing workflow unit test proving delegated child `AgentRun` request `inputRefs` or metadata contains only represented-step prepared context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
 - [ ] T019 [P] Add failing workflow unit test proving prepare failure prevents affected step dispatch and records bounded diagnostics in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
@@ -106,7 +106,7 @@
 - [ ] T025 Implement compact prepared input models, validation, target derivation, step filtering, and failure payload helpers in `moonmind/workflows/tasks/prepared_context.py`. (FR-004, FR-005, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, SCN-003, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
 - [ ] T026 Export prepared context helpers from `moonmind/workflows/tasks/__init__.py` for workflow and adapter use. (FR-004, FR-005, FR-008, FR-010)
 - [ ] T027 Implement or extend runtime prepare activity/service behavior in `moonmind/workflows/temporal/activity_runtime.py` to produce compact manifest/context refs and explicit prepare failures. (FR-004, FR-006, FR-007, FR-012, SCN-001, SCN-002, SCN-006, SC-002, SC-004, DESIGN-REQ-003)
-- [ ] T028 Wire `MoonMind.Run` prepare orchestration and bounded prepared-context state in `moonmind/workflows/temporal/workflows/run.py`. (FR-004, FR-005, FR-010, SCN-001, SCN-002, SC-002, DESIGN-REQ-002, DESIGN-REQ-007)
+- [ ] T028 Wire `MoonMind.Run` prepare orchestration and bounded prepared-context state in `moonmind/workflows/temporal/workflows/run.py`. (FR-004, FR-005, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-007)
 - [ ] T029 Wire per-step prepared context filtering in `moonmind/workflows/temporal/workflows/run.py` before planner, step runtime, or child dispatch. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
 - [ ] T030 Wire child `AgentRun` request `inputRefs` or bounded metadata in `moonmind/workflows/temporal/workflows/run.py` so represented child steps receive only relevant objective and current-step context. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
 - [ ] T031 Update `moonmind/workflows/temporal/workflows/agent_run.py` only if child request validation or metadata propagation requires accepting the prepared-context contract. (FR-009, FR-011, DESIGN-REQ-005, DESIGN-REQ-006)

--- a/specs/325-prepare-target-aware-inputs/tasks.md
+++ b/specs/325-prepare-target-aware-inputs/tasks.md
@@ -31,10 +31,10 @@
 
 **Purpose**: Confirm planning artifacts, test paths, and feature scope before writing red tests.
 
-- [ ] T001 Confirm `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/target-aware-prepared-context.md`, and `quickstart.md` exist and preserve `MM-631`. (FR-013, SC-005)
-- [ ] T002 Confirm `.specify/feature.json` points to `specs/325-prepare-target-aware-inputs` and that this task list covers exactly one `## User Story -` section in `specs/325-prepare-target-aware-inputs/spec.md`. (FR-013, SC-005)
-- [ ] T003 [P] Inspect existing unit fixtures in `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/moonmind/vision/test_service.py`, and `tests/unit/agents/codex_worker/test_worker.py` for reusable target-aware attachment payload builders. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
-- [ ] T004 [P] Inspect existing Temporal workflow test fixtures in `tests/unit/workflows/temporal/workflows/conftest.py` and `tests/integration/workflows/temporal/workflows/test_run.py` for child `AgentRun` dispatch interception patterns. (FR-004, FR-009, DESIGN-REQ-005)
+- [X] T001 Confirm `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/target-aware-prepared-context.md`, and `quickstart.md` exist and preserve `MM-631`. (FR-013, SC-005)
+- [X] T002 Confirm `.specify/feature.json` points to `specs/325-prepare-target-aware-inputs` and that this task list covers exactly one `## User Story -` section in `specs/325-prepare-target-aware-inputs/spec.md`. (FR-013, SC-005)
+- [X] T003 [P] Inspect existing unit fixtures in `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/moonmind/vision/test_service.py`, and `tests/unit/agents/codex_worker/test_worker.py` for reusable target-aware attachment payload builders. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+- [X] T004 [P] Inspect existing Temporal workflow test fixtures in `tests/unit/workflows/temporal/workflows/conftest.py` and `tests/integration/workflows/temporal/workflows/test_run.py` for child `AgentRun` dispatch interception patterns. (FR-004, FR-009, DESIGN-REQ-005)
 
 ---
 
@@ -44,11 +44,11 @@
 
 **CRITICAL**: No production implementation work can begin until Phase 2 and the red-first test authoring tasks in Phase 3 are complete.
 
-- [ ] T005 Create placeholder test module `tests/unit/workflows/tasks/test_prepared_context.py` for prepared input manifest, step filtering, and failure-model unit coverage. (FR-004, FR-005, FR-006, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
-- [ ] T006 Create placeholder workflow unit test module `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` for `MoonMind.Run` prepared-context state and child request coverage. (FR-004, FR-005, FR-008, FR-009, FR-010, SCN-003, SCN-004, SC-001, SC-003, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
-- [ ] T007 Create placeholder integration test module `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for hermetic workflow boundary scenarios. (SCN-001, SCN-003, SCN-004, SCN-006, SC-001, SC-002, SC-003, SC-004)
-- [ ] T008 [P] Create placeholder adapter unit test module `tests/unit/workflows/adapters/test_target_aware_prepared_context.py` for adapter-visible prepared context contract checks. (FR-011, SCN-005, DESIGN-REQ-006)
-- [ ] T009 [P] Confirm planned implementation path `moonmind/workflows/tasks/prepared_context.py` is reserved for compact prepared input contracts and pure filtering helpers without adding behavior before red tests. (FR-004, FR-005, FR-007, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [X] T005 Create placeholder test module `tests/unit/workflows/tasks/test_prepared_context.py` for prepared input manifest, step filtering, and failure-model unit coverage. (FR-004, FR-005, FR-006, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [X] T006 Create placeholder workflow unit test module `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` for `MoonMind.Run` prepared-context state and child request coverage. (FR-004, FR-005, FR-008, FR-009, FR-010, SCN-003, SCN-004, SC-001, SC-003, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
+- [X] T007 Create placeholder integration test module `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for hermetic workflow boundary scenarios. (SCN-001, SCN-003, SCN-004, SCN-006, SC-001, SC-002, SC-003, SC-004)
+- [X] T008 [P] Create placeholder adapter unit test module `tests/unit/workflows/adapters/test_target_aware_prepared_context.py` for adapter-visible prepared context contract checks. (FR-011, SCN-005, DESIGN-REQ-006)
+- [X] T009 [P] Confirm planned implementation path `moonmind/workflows/tasks/prepared_context.py` is reserved for compact prepared input contracts and pure filtering helpers without adding behavior before red tests. (FR-004, FR-005, FR-007, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
 
 **Checkpoint**: Test and contract locations exist; story test authoring can begin.
 
@@ -76,49 +76,49 @@
 
 ### Unit Tests (write first)
 
-- [ ] T010 [P] Add failing unit tests for `PreparedInputManifest`, `PreparedInputEntry`, and `StepPreparedContext` validation in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003)
-- [ ] T011 [P] Add failing unit tests proving objective context plus only current-step entries are selected in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
-- [ ] T012 [P] Add failing unit tests proving unrelated step refs, embedded binary, data URLs, and generated markdown are rejected or omitted in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-001, FR-002, FR-003, FR-008, FR-010, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T013 [P] Add failing unit tests for bounded prepare failure payloads in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
-- [ ] T014 [P] Add failing adapter contract tests proving prepared context refs are consumed without inventing target rules in `tests/unit/workflows/adapters/test_target_aware_prepared_context.py`. (FR-011, SCN-005, DESIGN-REQ-006)
-- [ ] T015 [P] Add regression unit tests proving existing `TaskInputAttachmentRef` and `VisionService.render_target_contexts` behavior remains compatible in `tests/unit/workflows/tasks/test_task_contract.py` and `tests/unit/moonmind/vision/test_service.py`. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+- [X] T010 [P] Add failing unit tests for `PreparedInputManifest`, `PreparedInputEntry`, and `StepPreparedContext` validation in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003)
+- [X] T011 [P] Add failing unit tests proving objective context plus only current-step entries are selected in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [X] T012 [P] Add failing unit tests proving unrelated step refs, embedded binary, data URLs, and generated markdown are rejected or omitted in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-001, FR-002, FR-003, FR-008, FR-010, DESIGN-REQ-001, DESIGN-REQ-004)
+- [X] T013 [P] Add failing unit tests for bounded prepare failure payloads in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
+- [X] T014 [P] Add failing adapter contract tests proving prepared context refs are consumed without inventing target rules in `tests/unit/workflows/adapters/test_target_aware_prepared_context.py`. (FR-011, SCN-005, DESIGN-REQ-006)
+- [X] T015 [P] Add regression unit tests proving existing `TaskInputAttachmentRef` and `VisionService.render_target_contexts` behavior remains compatible in `tests/unit/workflows/tasks/test_task_contract.py` and `tests/unit/moonmind/vision/test_service.py`. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
 
 ### Integration Tests (write first)
 
-- [ ] T016 [P] Add failing workflow unit test proving `MoonMind.Run` records a prepared manifest ref before the first affected step dispatch in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-007)
-- [ ] T017 [P] Add failing workflow unit test proving step dispatch receives objective plus current-step prepared context and omits later-step context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
-- [ ] T018 [P] Add failing workflow unit test proving delegated child `AgentRun` request `inputRefs` or metadata contains only represented-step prepared context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
-- [ ] T019 [P] Add failing workflow unit test proving prepare failure prevents affected step dispatch and records bounded diagnostics in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
-- [ ] T020 [P] Add failing hermetic integration scenario with one objective attachment and two step attachments in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (SCN-001, SCN-003, SCN-004, SC-001, SC-002, SC-003)
+- [X] T016 [P] Add failing workflow unit test proving `MoonMind.Run` records a prepared manifest ref before the first affected step dispatch in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-007)
+- [X] T017 [P] Add failing workflow unit test proving step dispatch receives objective plus current-step prepared context and omits later-step context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [X] T018 [P] Add failing workflow unit test proving delegated child `AgentRun` request `inputRefs` or metadata contains only represented-step prepared context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
+- [X] T019 [P] Add failing workflow unit test proving prepare failure prevents affected step dispatch and records bounded diagnostics in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
+- [X] T020 [P] Add failing hermetic integration scenario with one objective attachment and two step attachments in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (SCN-001, SCN-003, SCN-004, SC-001, SC-002, SC-003)
 
 ### Red-First Confirmation
 
-- [ ] T021 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and confirm T010-T014 fail for missing prepared-context contracts/helpers. (FR-004 through FR-012, SCN-001 through SCN-006)
-- [ ] T022 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T016-T019 fail for missing `MoonMind.Run` prepared-context wiring. (FR-004, FR-005, FR-008, FR-009, FR-010, FR-012, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
-- [ ] T023 Run `./tools/test_integration.sh` or a focused equivalent for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T020 fails for missing workflow boundary behavior. (SC-001, SC-002, SC-003, SC-004)
+- [X] T021 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and confirm T010-T014 fail for missing prepared-context contracts/helpers. (FR-004 through FR-012, SCN-001 through SCN-006)
+- [X] T022 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T016-T019 fail for missing `MoonMind.Run` prepared-context wiring. (FR-004, FR-005, FR-008, FR-009, FR-010, FR-012, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
+- [X] T023 Run `./tools/test_integration.sh` or a focused equivalent for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T020 fails for missing workflow boundary behavior. (SC-001, SC-002, SC-003, SC-004)
 
 ### Conditional Fallback for Verification-Only Rows
 
-- [ ] T024 If T001-T002 or final verification show `MM-631` traceability is missing, update `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/target-aware-prepared-context.md`, and `tasks.md` to restore the issue key and original preset brief references. (FR-013, SC-005)
+- [X] T024 If T001-T002 or final verification show `MM-631` traceability is missing, update `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/target-aware-prepared-context.md`, and `tasks.md` to restore the issue key and original preset brief references. (FR-013, SC-005)
 
 ### Implementation
 
-- [ ] T025 Implement compact prepared input models, validation, target derivation, step filtering, and failure payload helpers in `moonmind/workflows/tasks/prepared_context.py`. (FR-004, FR-005, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, SCN-003, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
-- [ ] T026 Export prepared context helpers from `moonmind/workflows/tasks/__init__.py` for workflow and adapter use. (FR-004, FR-005, FR-008, FR-010)
-- [ ] T027 Implement or extend runtime prepare activity/service behavior in `moonmind/workflows/temporal/activity_runtime.py` to produce compact manifest/context refs and explicit prepare failures. (FR-004, FR-006, FR-007, FR-012, SCN-001, SCN-002, SCN-006, SC-002, SC-004, DESIGN-REQ-003)
-- [ ] T028 Wire `MoonMind.Run` prepare orchestration and bounded prepared-context state in `moonmind/workflows/temporal/workflows/run.py`. (FR-004, FR-005, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-007)
-- [ ] T029 Wire per-step prepared context filtering in `moonmind/workflows/temporal/workflows/run.py` before planner, step runtime, or child dispatch. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
-- [ ] T030 Wire child `AgentRun` request `inputRefs` or bounded metadata in `moonmind/workflows/temporal/workflows/run.py` so represented child steps receive only relevant objective and current-step context. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
-- [ ] T031 Update `moonmind/workflows/temporal/workflows/agent_run.py` only if child request validation or metadata propagation requires accepting the prepared-context contract. (FR-009, FR-011, DESIGN-REQ-005, DESIGN-REQ-006)
-- [ ] T032 Update runtime adapter realization in `moonmind/workflows/adapters/codex_session_adapter.py` and `moonmind/workflows/adapters/managed_agent_adapter.py` only as needed to consume prepared context refs without broadening target rules. (FR-011, SCN-005, DESIGN-REQ-006)
-- [ ] T033 Preserve existing Codex worker materialization behavior in `moonmind/agents/codex_worker/worker.py`, changing it only if the shared prepared-context helpers replace duplicate target filtering safely. (FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003)
+- [X] T025 Implement compact prepared input models, validation, target derivation, step filtering, and failure payload helpers in `moonmind/workflows/tasks/prepared_context.py`. (FR-004, FR-005, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, SCN-003, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [X] T026 Export prepared context helpers from `moonmind/workflows/tasks/__init__.py` for workflow and adapter use. (FR-004, FR-005, FR-008, FR-010)
+- [X] T027 Implement or extend runtime prepare activity/service behavior in `moonmind/workflows/temporal/activity_runtime.py` to produce compact manifest/context refs and explicit prepare failures. (FR-004, FR-006, FR-007, FR-012, SCN-001, SCN-002, SCN-006, SC-002, SC-004, DESIGN-REQ-003)
+- [X] T028 Wire `MoonMind.Run` prepare orchestration and bounded prepared-context state in `moonmind/workflows/temporal/workflows/run.py`. (FR-004, FR-005, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-007)
+- [X] T029 Wire per-step prepared context filtering in `moonmind/workflows/temporal/workflows/run.py` before planner, step runtime, or child dispatch. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [X] T030 Wire child `AgentRun` request `inputRefs` or bounded metadata in `moonmind/workflows/temporal/workflows/run.py` so represented child steps receive only relevant objective and current-step context. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
+- [X] T031 Update `moonmind/workflows/temporal/workflows/agent_run.py` only if child request validation or metadata propagation requires accepting the prepared-context contract. (FR-009, FR-011, DESIGN-REQ-005, DESIGN-REQ-006)
+- [X] T032 Update runtime adapter realization in `moonmind/workflows/adapters/codex_session_adapter.py` and `moonmind/workflows/adapters/managed_agent_adapter.py` only as needed to consume prepared context refs without broadening target rules. (FR-011, SCN-005, DESIGN-REQ-006)
+- [X] T033 Preserve existing Codex worker materialization behavior in `moonmind/agents/codex_worker/worker.py`, changing it only if the shared prepared-context helpers replace duplicate target filtering safely. (FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003)
 
 ### Story Validation
 
-- [ ] T034 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and fix failures until unit coverage passes. (FR-001 through FR-012, DESIGN-REQ-001 through DESIGN-REQ-007)
-- [ ] T035 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/moonmind/vision/test_service.py tests/unit/agents/codex_worker/test_attachment_materialization.py tests/unit/agents/codex_worker/test_worker.py` and fix regressions in existing verified attachment behavior. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
-- [ ] T036 Run `./tools/test_integration.sh` or the focused workflow integration target for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and fix failures until the independent story passes. (SCN-001 through SCN-006, SC-001 through SC-004)
-- [ ] T037 Update `specs/325-prepare-target-aware-inputs/quickstart.md` only if validated commands or workflow-boundary constraints changed during implementation. (FR-013, SC-005)
+- [X] T034 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and fix failures until unit coverage passes. (FR-001 through FR-012, DESIGN-REQ-001 through DESIGN-REQ-007)
+- [X] T035 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/moonmind/vision/test_service.py tests/unit/agents/codex_worker/test_attachment_materialization.py tests/unit/agents/codex_worker/test_worker.py` and fix regressions in existing verified attachment behavior. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+- [X] T036 Run `./tools/test_integration.sh` or the focused workflow integration target for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and fix failures until the independent story passes. (SCN-001 through SCN-006, SC-001 through SC-004)
+- [X] T037 Update `specs/325-prepare-target-aware-inputs/quickstart.md` only if validated commands or workflow-boundary constraints changed during implementation. (FR-013, SC-005)
 
 **Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable against the MM-631 brief.
 
@@ -128,11 +128,11 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T038 [P] Refactor duplicated target filtering or manifest mapping introduced during implementation in `moonmind/workflows/tasks/prepared_context.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `moonmind/workflows/temporal/workflows/run.py`. (FR-004 through FR-012)
-- [ ] T039 [P] Review bounded diagnostics and secret hygiene in `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/workflows/run.py`. (FR-010, FR-012, SC-004)
-- [ ] T040 [P] Review `specs/325-prepare-target-aware-inputs/contracts/target-aware-prepared-context.md` and `data-model.md` against implemented payload shapes, updating artifacts if behavior changed. (FR-013, SC-005)
-- [ ] T041 Run full unit verification with `./tools/test_unit.sh`. (FR-001 through FR-013, DESIGN-REQ-001 through DESIGN-REQ-007)
-- [ ] T042 Run hermetic integration verification with `./tools/test_integration.sh`, or document why any required Temporal workflow boundary test remains local-only. (SCN-001 through SCN-006, SC-001 through SC-004)
+- [X] T038 [P] Refactor duplicated target filtering or manifest mapping introduced during implementation in `moonmind/workflows/tasks/prepared_context.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `moonmind/workflows/temporal/workflows/run.py`. (FR-004 through FR-012)
+- [X] T039 [P] Review bounded diagnostics and secret hygiene in `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/workflows/run.py`. (FR-010, FR-012, SC-004)
+- [X] T040 [P] Review `specs/325-prepare-target-aware-inputs/contracts/target-aware-prepared-context.md` and `data-model.md` against implemented payload shapes, updating artifacts if behavior changed. (FR-013, SC-005)
+- [X] T041 Run full unit verification with `./tools/test_unit.sh`. (FR-001 through FR-013, DESIGN-REQ-001 through DESIGN-REQ-007)
+- [X] T042 Run hermetic integration verification with `./tools/test_integration.sh`, or document why any required Temporal workflow boundary test remains local-only. (SCN-001 through SCN-006, SC-001 through SC-004)
 - [ ] T043 Run `/moonspec-verify` (`/speckit.verify` equivalent) to validate the final implementation against `MM-631`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-013, SC-005)
 
 ---

--- a/specs/325-prepare-target-aware-inputs/tasks.md
+++ b/specs/325-prepare-target-aware-inputs/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Prepare Target-Aware Inputs
+
+**Input**: Design documents from `/work/agent_jobs/mm:33deef30-3a30-4229-8cae-32c434b9aad5/repo/specs/325-prepare-target-aware-inputs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/target-aware-prepared-context.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: `Prepare Step-Scoped Inputs`.
+
+**Source Traceability**: Preserves Jira issue `MM-631`, the original Jira preset brief in `spec.md`, FR-001 through FR-013, SCN-001 through SCN-006, SC-001 through SC-005, edge cases, and DESIGN-REQ-001 through DESIGN-REQ-007.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when files do not overlap and no dependency is incomplete
+- Every task includes an exact file path and traceability IDs where applicable
+
+## Requirement Status Summary
+
+- Already verified rows preserved by regression/final validation: FR-001, FR-002, FR-003, DESIGN-REQ-001
+- Verification-only rows with conditional fallback: FR-013, SC-005
+- Code-and-test rows: FR-004 through FR-012, SCN-001 through SCN-006, SC-001 through SC-004, DESIGN-REQ-002 through DESIGN-REQ-007
+- Missing highest-risk boundary rows: FR-009, SCN-004, SC-003, DESIGN-REQ-005
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm planning artifacts, test paths, and feature scope before writing red tests.
+
+- [ ] T001 Confirm `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/target-aware-prepared-context.md`, and `quickstart.md` exist and preserve `MM-631`. (FR-013, SC-005)
+- [ ] T002 Confirm `.specify/feature.json` points to `specs/325-prepare-target-aware-inputs` and that this task list covers exactly one `## User Story -` section in `specs/325-prepare-target-aware-inputs/spec.md`. (FR-013, SC-005)
+- [ ] T003 [P] Inspect existing unit fixtures in `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/moonmind/vision/test_service.py`, and `tests/unit/agents/codex_worker/test_worker.py` for reusable target-aware attachment payload builders. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+- [ ] T004 [P] Inspect existing Temporal workflow test fixtures in `tests/unit/workflows/temporal/workflows/conftest.py` and `tests/integration/workflows/temporal/workflows/test_run.py` for child `AgentRun` dispatch interception patterns. (FR-004, FR-009, DESIGN-REQ-005)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the red-test surfaces and shared contract locations before story implementation begins.
+
+**CRITICAL**: No production implementation work can begin until Phase 2 and the red-first test authoring tasks in Phase 3 are complete.
+
+- [ ] T005 Create placeholder test module `tests/unit/workflows/tasks/test_prepared_context.py` for prepared input manifest, step filtering, and failure-model unit coverage. (FR-004, FR-005, FR-006, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [ ] T006 Create placeholder workflow unit test module `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` for `MoonMind.Run` prepared-context state and child request coverage. (FR-004, FR-005, FR-008, FR-009, FR-010, SCN-003, SCN-004, SC-001, SC-003, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
+- [ ] T007 Create placeholder integration test module `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for hermetic workflow boundary scenarios. (SCN-001, SCN-003, SCN-004, SCN-006, SC-001, SC-002, SC-003, SC-004)
+- [ ] T008 [P] Create placeholder adapter unit test module `tests/unit/workflows/adapters/test_target_aware_prepared_context.py` for adapter-visible prepared context contract checks. (FR-011, SCN-005, DESIGN-REQ-006)
+- [ ] T009 [P] Create placeholder implementation module `moonmind/workflows/tasks/prepared_context.py` for compact prepared input contracts and pure filtering helpers. (FR-004, FR-005, FR-007, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+
+**Checkpoint**: Test and contract locations exist; story test authoring can begin.
+
+---
+
+## Phase 3: Story - Prepare Step-Scoped Inputs
+
+**Summary**: As a runtime step, I want prepared context to include relevant objective inputs and only my own step-scoped inputs so that attachments are materialized, contextualized, and passed across workflow boundaries without leaking unrelated inputs.
+
+**Independent Test**: Submit or construct a task with objective-scoped attachments and multiple step-scoped attachments, then verify preparation produces a canonical manifest and each step, including a delegated child step, receives only the prepared context targeted to it.
+
+**Traceability**: FR-001 through FR-013; SCN-001 through SCN-006; SC-001 through SC-005; DESIGN-REQ-001 through DESIGN-REQ-007; MM-631.
+
+**Unit Test Plan**:
+
+- Validate prepared manifest/result contracts, objective vs step target derivation, step filtering, large-content guardrails, and failure payloads.
+- Preserve existing verified behavior for text/binary separation and derived image context as secondary data.
+- Verify adapter-visible context cannot broaden target binding.
+
+**Integration Test Plan**:
+
+- Verify `MoonMind.Run` prepares objective and step attachments before affected step dispatch.
+- Verify child `MoonMind.AgentRun` requests receive only objective plus represented-step context.
+- Verify missing or unauthorized preparation fails before affected step execution.
+
+### Unit Tests (write first)
+
+- [ ] T010 [P] Add failing unit tests for `PreparedInputManifest`, `PreparedInputEntry`, and `StepPreparedContext` validation in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SCN-002, DESIGN-REQ-002, DESIGN-REQ-003)
+- [ ] T011 [P] Add failing unit tests proving objective context plus only current-step entries are selected in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [ ] T012 [P] Add failing unit tests proving unrelated step refs, embedded binary, data URLs, and generated markdown are rejected or omitted in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-001, FR-002, FR-003, FR-008, FR-010, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T013 [P] Add failing unit tests for bounded prepare failure payloads in `tests/unit/workflows/tasks/test_prepared_context.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
+- [ ] T014 [P] Add failing adapter contract tests proving prepared context refs are consumed without inventing target rules in `tests/unit/workflows/adapters/test_target_aware_prepared_context.py`. (FR-011, SCN-005, DESIGN-REQ-006)
+- [ ] T015 [P] Add regression unit tests proving existing `TaskInputAttachmentRef` and `VisionService.render_target_contexts` behavior remains compatible in `tests/unit/workflows/tasks/test_task_contract.py` and `tests/unit/moonmind/vision/test_service.py`. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+
+### Integration Tests (write first)
+
+- [ ] T016 [P] Add failing workflow unit test proving `MoonMind.Run` records a prepared manifest ref before the first affected step dispatch in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-004, FR-005, FR-007, FR-010, SCN-001, SC-002, SC-002, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-007)
+- [ ] T017 [P] Add failing workflow unit test proving step dispatch receives objective plus current-step prepared context and omits later-step context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [ ] T018 [P] Add failing workflow unit test proving delegated child `AgentRun` request `inputRefs` or metadata contains only represented-step prepared context in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
+- [ ] T019 [P] Add failing workflow unit test proving prepare failure prevents affected step dispatch and records bounded diagnostics in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (FR-006, FR-012, SCN-006, SC-004, DESIGN-REQ-003)
+- [ ] T020 [P] Add failing hermetic integration scenario with one objective attachment and two step attachments in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py`. (SCN-001, SCN-003, SCN-004, SC-001, SC-002, SC-003)
+
+### Red-First Confirmation
+
+- [ ] T021 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and confirm T010-T014 fail for missing prepared-context contracts/helpers. (FR-004 through FR-012, SCN-001 through SCN-006)
+- [ ] T022 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T016-T019 fail for missing `MoonMind.Run` prepared-context wiring. (FR-004, FR-005, FR-008, FR-009, FR-010, FR-012, DESIGN-REQ-002, DESIGN-REQ-005, DESIGN-REQ-007)
+- [ ] T023 Run `./tools/test_integration.sh` or a focused equivalent for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and confirm T020 fails for missing workflow boundary behavior. (SC-001, SC-002, SC-003, SC-004)
+
+### Conditional Fallback for Verification-Only Rows
+
+- [ ] T024 If T001-T002 or final verification show `MM-631` traceability is missing, update `specs/325-prepare-target-aware-inputs/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/target-aware-prepared-context.md`, and `tasks.md` to restore the issue key and original preset brief references. (FR-013, SC-005)
+
+### Implementation
+
+- [ ] T025 Implement compact prepared input models, validation, target derivation, step filtering, and failure payload helpers in `moonmind/workflows/tasks/prepared_context.py`. (FR-004, FR-005, FR-007, FR-008, FR-010, FR-012, SCN-001, SCN-002, SCN-003, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004)
+- [ ] T026 Export prepared context helpers from `moonmind/workflows/tasks/__init__.py` for workflow and adapter use. (FR-004, FR-005, FR-008, FR-010)
+- [ ] T027 Implement or extend runtime prepare activity/service behavior in `moonmind/workflows/temporal/activity_runtime.py` to produce compact manifest/context refs and explicit prepare failures. (FR-004, FR-006, FR-007, FR-012, SCN-001, SCN-002, SCN-006, SC-002, SC-004, DESIGN-REQ-003)
+- [ ] T028 Wire `MoonMind.Run` prepare orchestration and bounded prepared-context state in `moonmind/workflows/temporal/workflows/run.py`. (FR-004, FR-005, FR-010, SCN-001, SCN-002, SC-002, DESIGN-REQ-002, DESIGN-REQ-007)
+- [ ] T029 Wire per-step prepared context filtering in `moonmind/workflows/temporal/workflows/run.py` before planner, step runtime, or child dispatch. (FR-008, SCN-003, SC-001, DESIGN-REQ-004)
+- [ ] T030 Wire child `AgentRun` request `inputRefs` or bounded metadata in `moonmind/workflows/temporal/workflows/run.py` so represented child steps receive only relevant objective and current-step context. (FR-009, SCN-004, SC-003, DESIGN-REQ-005, DESIGN-REQ-007)
+- [ ] T031 Update `moonmind/workflows/temporal/workflows/agent_run.py` only if child request validation or metadata propagation requires accepting the prepared-context contract. (FR-009, FR-011, DESIGN-REQ-005, DESIGN-REQ-006)
+- [ ] T032 Update runtime adapter realization in `moonmind/workflows/adapters/codex_session_adapter.py` and `moonmind/workflows/adapters/managed_agent_adapter.py` only as needed to consume prepared context refs without broadening target rules. (FR-011, SCN-005, DESIGN-REQ-006)
+- [ ] T033 Preserve existing Codex worker materialization behavior in `moonmind/agents/codex_worker/worker.py`, changing it only if the shared prepared-context helpers replace duplicate target filtering safely. (FR-001, FR-002, FR-003, DESIGN-REQ-001, DESIGN-REQ-003)
+
+### Story Validation
+
+- [ ] T034 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py` and fix failures until unit coverage passes. (FR-001 through FR-012, DESIGN-REQ-001 through DESIGN-REQ-007)
+- [ ] T035 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/moonmind/vision/test_service.py tests/unit/agents/codex_worker/test_attachment_materialization.py tests/unit/agents/codex_worker/test_worker.py` and fix regressions in existing verified attachment behavior. (FR-001, FR-002, FR-003, DESIGN-REQ-001)
+- [ ] T036 Run `./tools/test_integration.sh` or the focused workflow integration target for `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` and fix failures until the independent story passes. (SCN-001 through SCN-006, SC-001 through SC-004)
+- [ ] T037 Update `specs/325-prepare-target-aware-inputs/quickstart.md` only if validated commands or workflow-boundary constraints changed during implementation. (FR-013, SC-005)
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable against the MM-631 brief.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T038 [P] Refactor duplicated target filtering or manifest mapping introduced during implementation in `moonmind/workflows/tasks/prepared_context.py`, `moonmind/workflows/temporal/activity_runtime.py`, and `moonmind/workflows/temporal/workflows/run.py`. (FR-004 through FR-012)
+- [ ] T039 [P] Review bounded diagnostics and secret hygiene in `moonmind/workflows/temporal/activity_runtime.py` and `moonmind/workflows/temporal/workflows/run.py`. (FR-010, FR-012, SC-004)
+- [ ] T040 [P] Review `specs/325-prepare-target-aware-inputs/contracts/target-aware-prepared-context.md` and `data-model.md` against implemented payload shapes, updating artifacts if behavior changed. (FR-013, SC-005)
+- [ ] T041 Run full unit verification with `./tools/test_unit.sh`. (FR-001 through FR-013, DESIGN-REQ-001 through DESIGN-REQ-007)
+- [ ] T042 Run hermetic integration verification with `./tools/test_integration.sh`, or document why any required Temporal workflow boundary test remains local-only. (SCN-001 through SCN-006, SC-001 through SC-004)
+- [ ] T043 Run `/moonspec-verify` (`/speckit.verify` equivalent) to validate the final implementation against `MM-631`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-013, SC-005)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Phase 1 completion and blocks story work.
+- **Story (Phase 3)**: Depends on Phase 2 completion.
+- **Polish And Verification (Phase 4)**: Depends on story implementation and validation tasks passing.
+
+### Within The Story
+
+- Unit tests T010-T015 must be written before implementation T025-T033.
+- Integration tests T016-T020 must be written before implementation T025-T033.
+- Red-first confirmations T021-T023 must complete before implementation T025-T033.
+- Contract/model helpers T025-T026 should land before activity and workflow wiring T027-T030.
+- Child request and adapter work T030-T032 depends on the step prepared context shape from T025.
+- Story validation T034-T037 runs after implementation tasks.
+- Final `/moonspec-verify` (`/speckit.verify` equivalent) T043 runs only after unit and integration verification.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel.
+- T007 and T008 can run in parallel with T005-T006 once paths are agreed.
+- T010-T015 can be authored in parallel because they cover separate unit-test concerns.
+- T016-T020 can be authored in parallel because they cover separate workflow scenarios.
+- T038-T040 can run in parallel after story validation.
+
+## Parallel Example: Story Test Authoring
+
+```bash
+# Unit tests in separate files or non-overlapping sections:
+Task: "T010 Add prepared manifest validation tests in tests/unit/workflows/tasks/test_prepared_context.py"
+Task: "T014 Add adapter contract tests in tests/unit/workflows/adapters/test_target_aware_prepared_context.py"
+
+# Workflow boundary tests by scenario:
+Task: "T017 Add step dispatch filtering workflow unit test in tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py"
+Task: "T020 Add hermetic integration scenario in tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py"
+```
+
+## Implementation Strategy
+
+1. Preserve verified behavior first: keep task input refs, text/binary separation, and vision target context tests green.
+2. Add red unit tests for compact prepared context models and pure filtering helpers.
+3. Add red workflow and integration tests for `MoonMind.Run` prepare, child `AgentRun` dispatch, and prepare failures.
+4. Implement the shared prepared context contract with compact refs and bounded diagnostics.
+5. Wire runtime prepare into `MoonMind.Run` before affected step dispatch.
+6. Filter prepared context per step before planner, runtime, and child dispatch.
+7. Update adapters only where needed to consume the prepared context contract without changing target rules.
+8. Run focused unit and integration validation, then full unit and integration suites.
+9. Run `/moonspec-verify` (`/speckit.verify` equivalent) and preserve `MM-631` traceability in final evidence.
+
+## Coverage Inventory
+
+- FR-001, FR-002, FR-003, DESIGN-REQ-001: preserved by existing evidence plus regression tests T015, T033, T035, T041.
+- FR-004, FR-005, FR-006, FR-007, FR-008, FR-010, FR-012, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-007: covered by T010-T013, T016-T019, T025-T029, T034, T036.
+- FR-009, SCN-004, SC-003, DESIGN-REQ-005: covered by T018, T020, T030, T031, T036.
+- FR-011, SCN-005, DESIGN-REQ-006: covered by T014, T032, T034.
+- SCN-001, SCN-002, SCN-003, SCN-006, SC-001, SC-002, SC-004: covered by T016-T020, T027-T030, T036, T042.
+- FR-013, SC-005, MM-631 traceability: covered by T001, T002, T024, T037, T040, T043.
+
+## Notes
+
+- This task list intentionally does not create future stories or broad refactors.
+- `MoonMind.Run` remains the parent source of truth for target binding; adapters consume prepared refs but must not invent target rules.
+- Large or binary content must remain behind artifact or workspace refs and out of workflow history.

--- a/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("temporalio")
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def test_run_boundary_prepares_objective_and_current_step_context_only() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=SimpleNamespace(
+            workflow_id="run-target-aware-integration",
+            run_id="run-id-1",
+            namespace="default",
+        ),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="first-step",
+            tool_name="codex_cli",
+            workflow_parameters={
+                "task": {
+                    "inputAttachments": [
+                        {"artifactId": "objective-artifact", "contentType": "image/png"}
+                    ],
+                    "steps": [
+                        {
+                            "id": "first-step",
+                            "inputAttachments": [{"artifactId": "first-step-artifact"}],
+                        },
+                        {
+                            "id": "second-step",
+                            "inputAttachments": [
+                                {"artifactId": "second-step-artifact"}
+                            ],
+                        },
+                    ],
+                }
+            },
+        )
+
+    dumped = request.model_dump(by_alias=True)
+
+    assert "objective-artifact" in str(dumped)
+    assert "first-step-artifact" in str(dumped)
+    assert "second-step-artifact" not in str(dumped)
+    assert dumped["parameters"]["metadata"]["moonmind"]["preparedContext"][
+        "targetCounts"
+    ] == {"objective": 1, "step": 1}

--- a/tests/unit/workflows/adapters/test_target_aware_prepared_context.py
+++ b/tests/unit/workflows/adapters/test_target_aware_prepared_context.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from moonmind.workflows.tasks.prepared_context import (
+    build_prepared_input_manifest,
+    select_step_prepared_context,
+)
+
+
+def test_adapter_contract_consumes_selected_refs_without_broadening_targets() -> None:
+    manifest = build_prepared_input_manifest(
+        {
+            "inputAttachments": [
+                {"artifactId": "objective-doc", "contentType": "text/plain"}
+            ],
+            "steps": [
+                {
+                    "id": "first-step",
+                    "inputAttachments": [{"artifactId": "first-step-image"}],
+                },
+                {
+                    "id": "second-step",
+                    "inputAttachments": [{"artifactId": "second-step-image"}],
+                },
+            ],
+        }
+    )
+
+    context = select_step_prepared_context(manifest, logical_step_id="first-step")
+
+    assert context.input_refs == [
+        "prepared-context://objective/objective-doc",
+        "prepared-context://steps/first-step/first-step-image",
+        "artifact://objective-doc",
+        "artifact://first-step-image",
+    ]
+    assert "second-step-image" not in str(context.to_metadata())

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -67,6 +67,22 @@ def test_prepared_manifest_preserves_objective_and_step_targets() -> None:
     assert manifest.entries[2].step_ref == "write-report"
 
 
+def test_prepared_manifest_preserves_zero_byte_size() -> None:
+    manifest = build_prepared_input_manifest(
+        {
+            "inputAttachments": [
+                {
+                    "artifactId": "empty-file",
+                    "sizeBytes": 0,
+                    "size": 42,
+                }
+            ]
+        }
+    )
+
+    assert manifest.entries[0].size_bytes == 0
+
+
 def test_prepared_models_reject_missing_step_binding_and_embedded_content() -> None:
     with pytest.raises(ValidationError, match="stepRef"):
         PreparedInputEntry.model_validate(
@@ -86,6 +102,19 @@ def test_prepared_models_reject_missing_step_binding_and_embedded_content() -> N
                         "filename": "objective.png",
                         "contentType": "image/png",
                         "dataUrl": "data:image/png;base64,AAAA",
+                    }
+                ]
+            }
+        )
+
+    with pytest.raises(ValueError, match="inline attachment content"):
+        build_prepared_input_manifest(
+            {
+                "inputAttachments": [
+                    {
+                        "artifactId": "artifact-objective",
+                        "filename": "has-space-in-data-url.txt",
+                        "url": "data:image/png;base64,AAAA remaining-safe-text",
                     }
                 ]
             }

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.workflows.tasks.prepared_context import (
+    PreparedContextFailure,
+    PreparedInputEntry,
+    PreparedInputManifest,
+    build_prepared_input_manifest,
+    select_step_prepared_context,
+)
+
+
+def _task_payload() -> dict[str, object]:
+    return {
+        "inputAttachments": [
+            {
+                "artifactId": "artifact-objective",
+                "filename": "objective.png",
+                "contentType": "image/png",
+                "sizeBytes": 42,
+            }
+        ],
+        "steps": [
+            {
+                "id": "collect-evidence",
+                "inputAttachments": [
+                    {
+                        "artifactId": "artifact-step-1",
+                        "filename": "evidence.txt",
+                        "contentType": "text/plain",
+                        "sizeBytes": 17,
+                    }
+                ],
+            },
+            {
+                "id": "write-report",
+                "inputAttachments": [
+                    {
+                        "artifactId": "artifact-step-2",
+                        "filename": "report-notes.txt",
+                        "contentType": "text/plain",
+                        "sizeBytes": 19,
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def test_prepared_manifest_preserves_objective_and_step_targets() -> None:
+    manifest = build_prepared_input_manifest(_task_payload())
+
+    assert isinstance(manifest, PreparedInputManifest)
+    assert manifest.manifest_ref.startswith("prepared-context-manifest://")
+    assert [entry.target_kind for entry in manifest.entries] == [
+        "objective",
+        "step",
+        "step",
+    ]
+    assert manifest.entries[0].raw_input_ref == "artifact://artifact-objective"
+    assert manifest.entries[0].derived_context_ref == (
+        "prepared-context://objective/artifact-objective"
+    )
+    assert manifest.entries[1].step_ref == "collect-evidence"
+    assert manifest.entries[2].step_ref == "write-report"
+
+
+def test_prepared_models_reject_missing_step_binding_and_embedded_content() -> None:
+    with pytest.raises(ValidationError, match="stepRef"):
+        PreparedInputEntry.model_validate(
+            {
+                "artifactId": "artifact-step",
+                "targetKind": "step",
+                "rawInputRef": "artifact://artifact-step",
+            }
+        )
+
+    with pytest.raises(ValueError, match="inline attachment content"):
+        build_prepared_input_manifest(
+            {
+                "inputAttachments": [
+                    {
+                        "artifactId": "artifact-objective",
+                        "filename": "objective.png",
+                        "contentType": "image/png",
+                        "dataUrl": "data:image/png;base64,AAAA",
+                    }
+                ]
+            }
+        )
+
+    with pytest.raises(ValueError, match="generated markdown"):
+        build_prepared_input_manifest(
+            {
+                "steps": [
+                    {
+                        "id": "collect-evidence",
+                        "inputAttachments": [
+                            {
+                                "artifactId": "artifact-step-1",
+                                "markdown": "![image](data:image/png;base64,AAAA)",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+
+def test_select_step_context_includes_objective_and_current_step_only() -> None:
+    manifest = build_prepared_input_manifest(_task_payload())
+
+    context = select_step_prepared_context(
+        manifest,
+        logical_step_id="collect-evidence",
+    )
+
+    assert context.logical_step_id == "collect-evidence"
+    assert context.objective_context_refs == [
+        "prepared-context://objective/artifact-objective"
+    ]
+    assert context.step_context_refs == [
+        "prepared-context://steps/collect-evidence/artifact-step-1"
+    ]
+    assert context.raw_input_refs == [
+        "artifact://artifact-objective",
+        "artifact://artifact-step-1",
+    ]
+    assert "artifact-step-2" not in str(context.model_dump(by_alias=True))
+
+
+def test_step_context_metadata_is_bounded_and_target_aware() -> None:
+    manifest = build_prepared_input_manifest(_task_payload())
+    context = select_step_prepared_context(manifest, logical_step_id="collect-evidence")
+
+    metadata = context.to_metadata()
+
+    assert metadata["manifestRef"] == manifest.manifest_ref
+    assert metadata["logicalStepId"] == "collect-evidence"
+    assert metadata["targetCounts"] == {"objective": 1, "step": 1}
+    assert metadata["inputRefs"] == [
+        "prepared-context://objective/artifact-objective",
+        "prepared-context://steps/collect-evidence/artifact-step-1",
+        "artifact://artifact-objective",
+        "artifact://artifact-step-1",
+    ]
+    assert "data:image" not in str(metadata)
+
+
+def test_prepare_failure_payload_is_bounded() -> None:
+    failure = PreparedContextFailure.from_exception(
+        RuntimeError("data:image/png;base64,AAAA " + "x" * 400),
+        logical_step_id="collect-evidence",
+        manifest_ref="prepared-context-manifest://task-inputs",
+    )
+
+    dumped = failure.model_dump(by_alias=True)
+
+    assert dumped["logicalStepId"] == "collect-evidence"
+    assert dumped["manifestRef"] == "prepared-context-manifest://task-inputs"
+    assert dumped["reason"] == "RuntimeError"
+    assert "data:image" not in dumped["message"]
+    assert len(dumped["message"]) <= 180

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("temporalio")
+
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _workflow_info() -> SimpleNamespace:
+    return SimpleNamespace(
+        workflow_id="run-target-aware",
+        run_id="run-id-1",
+        namespace="default",
+    )
+
+
+def _task_payload() -> dict[str, object]:
+    return {
+        "inputAttachments": [
+            {"artifactId": "objective-image", "contentType": "image/png"}
+        ],
+        "steps": [
+            {
+                "id": "collect-evidence",
+                "inputAttachments": [{"artifactId": "collect-notes"}],
+            },
+            {
+                "id": "write-report",
+                "inputAttachments": [{"artifactId": "report-notes"}],
+            },
+        ],
+    }
+
+
+def _build_request_for_step(step_id: str):
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        return wf._build_agent_execution_request(
+            node_inputs={
+                "runtime": {"mode": "codex_cli"},
+                "inputRefs": ["artifact://explicit-node-input"],
+            },
+            node_id=step_id,
+            tool_name="codex_cli",
+            workflow_parameters={"task": _task_payload()},
+        )
+
+
+def test_run_request_records_prepared_manifest_before_step_dispatch() -> None:
+    request = _build_request_for_step("collect-evidence")
+
+    prepared_context = request.parameters["metadata"]["moonmind"]["preparedContext"]
+
+    assert prepared_context["manifestRef"].startswith("prepared-context-manifest://")
+    assert prepared_context["logicalStepId"] == "collect-evidence"
+    assert prepared_context["targetCounts"] == {"objective": 1, "step": 1}
+
+
+def test_run_request_filters_prepared_context_to_current_step() -> None:
+    request = _build_request_for_step("collect-evidence")
+
+    assert request.input_refs == [
+        "artifact://explicit-node-input",
+        "prepared-context://objective/objective-image",
+        "prepared-context://steps/collect-evidence/collect-notes",
+        "artifact://objective-image",
+        "artifact://collect-notes",
+    ]
+    assert "report-notes" not in str(request.model_dump(by_alias=True))
+
+
+def test_child_agent_run_request_receives_only_represented_step_context() -> None:
+    request = _build_request_for_step("write-report")
+
+    assert "report-notes" in str(request.model_dump(by_alias=True))
+    assert "collect-notes" not in str(request.model_dump(by_alias=True))
+
+
+def test_prepare_failure_prevents_unbounded_context_dispatch() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        with pytest.raises(ValueError, match="inline attachment content"):
+            wf._build_agent_execution_request(
+                node_inputs={"runtime": {"mode": "codex_cli"}},
+                node_id="collect-evidence",
+                tool_name="codex_cli",
+                workflow_parameters={
+                    "task": {
+                        "steps": [
+                            {
+                                "id": "collect-evidence",
+                                "inputAttachments": [
+                                    {
+                                        "artifactId": "inline-image",
+                                        "dataUrl": "data:image/png;base64,AAAA",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                },
+            )

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -36,7 +36,7 @@ def _task_payload() -> dict[str, object]:
     }
 
 
-def _build_request_for_step(step_id: str):
+def _build_request_for_step(step_id: str, *, runtime_mode: str = "jules"):
     wf = MoonMindRunWorkflow()
     with patch(
         "moonmind.workflows.temporal.workflows.run.workflow.info",
@@ -44,11 +44,11 @@ def _build_request_for_step(step_id: str):
     ):
         return wf._build_agent_execution_request(
             node_inputs={
-                "runtime": {"mode": "codex_cli"},
+                "runtime": {"mode": runtime_mode},
                 "inputRefs": ["artifact://explicit-node-input"],
             },
             node_id=step_id,
-            tool_name="codex_cli",
+            tool_name=runtime_mode,
             workflow_parameters={"task": _task_payload()},
         )
 
@@ -81,6 +81,30 @@ def test_child_agent_run_request_receives_only_represented_step_context() -> Non
 
     assert "report-notes" in str(request.model_dump(by_alias=True))
     assert "collect-notes" not in str(request.model_dump(by_alias=True))
+
+
+def test_managed_codex_request_keeps_prepared_context_out_of_input_refs() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="collect-evidence",
+            tool_name="codex_cli",
+            workflow_parameters={"task": _task_payload()},
+        )
+
+    assert request.agent_kind == "managed"
+    assert request.input_refs == []
+    prepared_context = request.parameters["metadata"]["moonmind"]["preparedContext"]
+    assert prepared_context["inputRefs"] == [
+        "prepared-context://objective/objective-image",
+        "prepared-context://steps/collect-evidence/collect-notes",
+        "artifact://objective-image",
+        "artifact://collect-notes",
+    ]
 
 
 def test_prepare_failure_prevents_unbounded_context_dispatch() -> None:


### PR DESCRIPTION
## Summary

- Jira issue: MM-631
- Active MoonSpec feature path: `specs/325-prepare-target-aware-inputs`
- Adds compact prepared input contracts for objective-scoped and step-scoped attachments.
- Wires `MoonMind.Run` request building so child agent requests receive objective context plus only the represented step context.
- Adds bounded prepare failure metadata and workflow/adapter tests for target-aware prepared context.

## Verification Verdict

- MoonSpec verify verdict: `ADDITIONAL_WORK_NEEDED`
- Reason: the verify step was blocked by workspace projection contamination (`.gemini/skills` active projection and `CLAUDE.md` type change). Those local projection changes were restored before PR publication, but the verify gate was not rerun in this PR-publication step.

## Tests Run

- Red-first unit confirmation: `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` initially failed for missing prepared-context contracts/helpers.
- Red-first integration confirmation: `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short` initially failed because `MoonMind.Run` omitted target-aware prepared refs.
- Focused unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/adapters/test_target_aware_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` passed.
- Focused integration: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short` passed.
- Regression unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/moonmind/vision/test_service.py tests/unit/agents/codex_worker/test_attachment_materialization.py tests/unit/agents/codex_worker/test_worker.py` passed.
- Full unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed during implementation.

## Remaining Risks

- Full `./tools/test_integration.sh` could not run in the managed container because Docker/Compose returned `403 Forbidden` from administrative rules.
- Final MoonSpec verify should be rerun now that local projection contamination has been cleaned.
- Branch push via raw `git push` was blocked by a missing MoonMind GitHub auth socket, so the GitHub connector was used to update the branch ref and create this PR.