### PR TITLE
MM-633 Gate Resume on durable checkpoint evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,8 @@ Key diagnostics:
 - Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned (325-prepare-target-aware-inputs)
 - Python 3.12; TypeScript/React for Mission Control UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Vitest, pytest (326-expose-distinct-full-retry-recovery-actions)
 - Existing Temporal execution records, canonical execution parameters/memo/search attributes, Temporal artifact metadata/content store, and existing original task input snapshot artifacts; no new persistent tables planned (326-expose-distinct-full-retry-recovery-actions)
+- Python 3.12; TypeScript/React for Mission Control UI where availability display is affected + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest (327-gate-resume-checkpoint-evidence)
+- Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned (327-gate-resume-checkpoint-evidence)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -229,6 +229,8 @@ Key diagnostics:
 - Existing `execution_remediation_links`, Temporal execution source records, Temporal artifact metadata/content store, and existing remediation lock/ledger state; no new persistent database tables planned (322-remediation-lifecycle-repair-prevention)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind artifact and vision services (325-prepare-target-aware-inputs)
 - Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned (325-prepare-target-aware-inputs)
+- Python 3.12; TypeScript/React for Mission Control UI where availability display is affected + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest (327-gate-resume-checkpoint-evidence)
+- Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned (327-gate-resume-checkpoint-evidence)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1957,6 +1957,119 @@ def _resume_failed_step_id_from_record(record) -> str | None:
             return candidate
     return None
 
+def _resume_source_block_from_record(record) -> Mapping[str, Any]:
+    params = dict(getattr(record, "parameters", None) or {})
+    resume_block = params.get("resumeSource")
+    if not isinstance(resume_block, Mapping):
+        resume_block = params.get("resume_source")
+    if not isinstance(resume_block, Mapping):
+        return {}
+    return resume_block
+
+def _first_nonempty_text(*values: Any) -> str | None:
+    for value in values:
+        candidate = str(value or "").strip()
+        if candidate:
+            return candidate
+    return None
+
+def _resume_completed_step_refs_from_record(record) -> list[str]:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    resume_block = _resume_source_block_from_record(record)
+    candidates = (
+        memo.get("resume_completed_step_refs"),
+        memo.get("resumeCompletedStepRefs"),
+        memo.get("resume_preserved_step_refs"),
+        memo.get("resumePreservedStepRefs"),
+        search_attributes.get("mm_resume_completed_step_refs"),
+        resume_block.get("completedStepRefs"),
+        resume_block.get("completed_step_refs"),
+    )
+    refs: list[str] = []
+    for value in candidates:
+        if isinstance(value, str):
+            parts = [item.strip() for item in value.split(",")]
+        elif isinstance(value, list):
+            parts = [str(item or "").strip() for item in value]
+        else:
+            parts = []
+        refs.extend(part for part in parts if part)
+    if refs:
+        return refs
+    preserved_steps = resume_block.get("preservedSteps") or resume_block.get(
+        "preserved_steps"
+    )
+    if not isinstance(preserved_steps, list):
+        return []
+    for step in preserved_steps:
+        if not isinstance(step, Mapping):
+            continue
+        artifacts = step.get("artifacts")
+        if isinstance(artifacts, Mapping):
+            refs.extend(
+                str(value or "").strip()
+                for value in artifacts.values()
+                if str(value or "").strip()
+            )
+    return refs
+
+def _resume_workspace_checkpoint_ref_from_record(record) -> str | None:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    resume_block = _resume_source_block_from_record(record)
+    workspace = resume_block.get("resumeWorkspace") or resume_block.get(
+        "resume_workspace"
+    )
+    if not isinstance(workspace, Mapping):
+        workspace = {}
+    return _first_nonempty_text(
+        memo.get("resume_workspace_checkpoint_ref"),
+        memo.get("resumeWorkspaceCheckpointRef"),
+        memo.get("resume_workspace_ref"),
+        memo.get("resumeWorkspaceRef"),
+        search_attributes.get("mm_resume_workspace_checkpoint_ref"),
+        search_attributes.get("mm_resume_workspace_ref"),
+        resume_block.get("resumeWorkspaceCheckpointRef"),
+        resume_block.get("resume_workspace_checkpoint_ref"),
+        workspace.get("checkpointRef"),
+        workspace.get("checkpoint_ref"),
+        workspace.get("ref"),
+    )
+
+def _resume_plan_identity_from_record(record) -> str | None:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    resume_block = _resume_source_block_from_record(record)
+    return _first_nonempty_text(
+        getattr(record, "plan_ref", None),
+        memo.get("resume_plan_ref"),
+        memo.get("resumePlanRef"),
+        memo.get("resume_plan_digest"),
+        memo.get("resumePlanDigest"),
+        memo.get("plan_ref"),
+        memo.get("plan_digest"),
+        search_attributes.get("mm_resume_plan_ref"),
+        search_attributes.get("mm_resume_plan_digest"),
+        resume_block.get("sourcePlanRef"),
+        resume_block.get("source_plan_ref"),
+        resume_block.get("sourcePlanDigest"),
+        resume_block.get("source_plan_digest"),
+    )
+
+def _resume_evidence_disabled_reason(record) -> str | None:
+    if not _resume_checkpoint_ref_from_record(record):
+        return "resume_checkpoint_missing"
+    if not _resume_failed_step_id_from_record(record):
+        return "failed_step_identity_missing"
+    if not _resume_completed_step_refs_from_record(record):
+        return "completed_step_refs_missing"
+    if not _resume_workspace_checkpoint_ref_from_record(record):
+        return "workspace_checkpoint_missing"
+    if not _resume_plan_identity_from_record(record):
+        return "plan_identity_missing"
+    return None
+
 def _build_resume_summary(
     record,
     *,
@@ -2561,7 +2674,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
     has_task_input_snapshot = bool(
         _task_input_snapshot_ref_from_memo(dict(getattr(record, "memo", None) or {}))
     )
-    has_resume_checkpoint = bool(_resume_checkpoint_ref_from_record(record))
+    resume_evidence_disabled_reason = _resume_evidence_disabled_reason(record)
     if (
         workflow_type_value != "MoonMind.Run"
         or not temporal_task_editing_enabled
@@ -2573,7 +2686,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         and temporal_task_editing_enabled
         and raw_state == "failed"
         and has_task_input_snapshot
-        and has_resume_checkpoint
+        and resume_evidence_disabled_reason is None
     ):
         enabled = enabled | {"can_resume_from_failed_step"}
     capability_values = {
@@ -2613,8 +2726,8 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                 if not has_task_input_snapshot:
                     disabled_reasons[alias] = "original_task_input_snapshot_missing"
                     continue
-                if not has_resume_checkpoint:
-                    disabled_reasons[alias] = "resume_checkpoint_missing"
+                if resume_evidence_disabled_reason is not None:
+                    disabled_reasons[alias] = resume_evidence_disabled_reason
                     continue
             if field_name == "can_update_inputs" and not has_task_input_snapshot:
                 disabled_reasons[alias] = "original_task_input_snapshot_missing"
@@ -3671,6 +3784,34 @@ async def _hydrate_resume_checkpoint_payload(
             allow_restricted_raw=True,
         )
         decoded = json.loads(body.decode("utf-8"))
+    except PermissionError as exc:
+        logger.warning(
+            "Failed to hydrate Resume checkpoint artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step Resume is not available for this execution.",
+                "reason": "checkpoint_unauthorized",
+            },
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Failed to hydrate Resume checkpoint artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step Resume is not available for this execution.",
+                "reason": "checkpoint_corrupted",
+            },
+        ) from exc
     except Exception as exc:
         logger.warning(
             "Failed to hydrate Resume checkpoint artifact %s: %s",
@@ -3695,6 +3836,25 @@ async def _hydrate_resume_checkpoint_payload(
             },
         )
     return decoded
+
+
+def _resume_not_available_reason(exc: Exception) -> str:
+    message = str(exc).lower()
+    if "plan" in message:
+        return "plan_identity_missing"
+    if "workspace" in message:
+        return "workspace_checkpoint_missing"
+    if "preserved step" in message or "completed" in message:
+        return "completed_step_refs_missing"
+    if "failed step" in message:
+        return "failed_step_identity_missing"
+    if "snapshot" in message:
+        return "original_task_input_snapshot_missing"
+    if "payload" in message or "invalid" in message:
+        return "checkpoint_corrupted"
+    if "does not match" in message:
+        return "checkpoint_inconsistent"
+    return "resume_checkpoint_missing"
 
 
 def _snapshot_task_from_artifact_payload(
@@ -6157,7 +6317,7 @@ async def resume_execution_from_failed_step(
             detail={
                 "code": "resume_not_available",
                 "message": "Failed-step Resume is not available for this execution.",
-                "reason": "resume_checkpoint_missing",
+                "reason": _resume_not_available_reason(exc),
             },
         ) from exc
     except TemporalExecutionValidationError as exc:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -95,7 +95,10 @@ from moonmind.workflows.temporal import (
     TemporalExecutionValidationError,
     build_manifest_status_snapshot,
 )
-from moonmind.workflows.temporal.artifacts import build_artifact_ref
+from moonmind.workflows.temporal.artifacts import (
+    TemporalArtifactAuthorizationError,
+    build_artifact_ref,
+)
 from moonmind.workflows.temporal.report_artifacts import build_report_projection_summary
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.client import TemporalClientAdapter, query_workflow
@@ -3784,7 +3787,7 @@ async def _hydrate_resume_checkpoint_payload(
             allow_restricted_raw=True,
         )
         decoded = json.loads(body.decode("utf-8"))
-    except PermissionError as exc:
+    except (PermissionError, TemporalArtifactAuthorizationError) as exc:
         logger.warning(
             "Failed to hydrate Resume checkpoint artifact %s: %s",
             artifact_id,
@@ -3840,6 +3843,8 @@ async def _hydrate_resume_checkpoint_payload(
 
 def _resume_not_available_reason(exc: Exception) -> str:
     message = str(exc).lower()
+    if "does not match" in message:
+        return "checkpoint_inconsistent"
     if "plan" in message:
         return "plan_identity_missing"
     if "workspace" in message:
@@ -3852,8 +3857,6 @@ def _resume_not_available_reason(exc: Exception) -> str:
         return "original_task_input_snapshot_missing"
     if "payload" in message or "invalid" in message:
         return "checkpoint_corrupted"
-    if "does not match" in message:
-        return "checkpoint_inconsistent"
     return "resume_checkpoint_missing"
 
 

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -534,11 +534,29 @@ class ResumeCheckpointPreservedStepModel(BaseModel):
     status: Literal["succeeded", "skipped"] = Field(..., alias="status")
     source_attempt: int = Field(..., alias="sourceAttempt", ge=1)
     artifacts: dict[str, Any] = Field(default_factory=dict, alias="artifacts")
+    state_checkpoint_ref: Optional[str] = Field(None, alias="stateCheckpointRef")
+
+    @field_validator("artifacts", mode="before")
+    @classmethod
+    def _validate_compact_artifacts(cls, value: Any) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value, field_name="preservedStep.artifacts"
+        )
+
+    @field_validator("state_checkpoint_ref", mode="before")
+    @classmethod
+    def _normalize_state_checkpoint_ref(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
 
     @model_validator(mode="after")
-    def _require_output_refs(self) -> "ResumeCheckpointPreservedStepModel":
+    def _require_resume_evidence(self) -> "ResumeCheckpointPreservedStepModel":
         if not any(value for value in self.artifacts.values()):
             raise ValueError("preserved step requires at least one artifact ref")
+        if self.state_checkpoint_ref is None:
+            raise ValueError("preserved step requires a state checkpoint ref")
         return self
 
 class ResumeCheckpointModel(BaseModel):
@@ -560,10 +578,33 @@ class ResumeCheckpointModel(BaseModel):
     )
     resume_workspace: dict[str, Any] = Field(default_factory=dict, alias="resumeWorkspace")
 
+    @field_validator("plan_ref", "plan_digest", mode="before")
+    @classmethod
+    def _normalize_optional_ref(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator("resume_workspace", mode="before")
+    @classmethod
+    def _validate_compact_resume_workspace(cls, value: Any) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value, field_name="resumeWorkspace"
+        )
+
     @field_validator("prepared_artifact_refs")
     @classmethod
     def _normalize_prepared_refs(cls, value: list[str]) -> list[str]:
         return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+    @model_validator(mode="after")
+    def _require_resume_evidence(self) -> "ResumeCheckpointModel":
+        if self.plan_ref is None and self.plan_digest is None:
+            raise ValueError("resume checkpoint requires plan identity or digest")
+        if not any(value for value in self.resume_workspace.values()):
+            raise ValueError("resume checkpoint requires workspace checkpoint evidence")
+        return self
 
 class ResumeSourceModel(BaseModel):
     """Compact source provenance carried by a resumed execution."""

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -88,6 +88,45 @@ FULL_RERUN_RECOVERY_CARRYOVER_PARAM_KEYS = frozenset(
 ALLOWED_REMEDIATION_AUTHORITY_MODES = frozenset(
     {"observe_only", "approval_gated", "admin_auto"}
 )
+
+
+def _first_nonempty_text(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)):
+            nested = _first_nonempty_text(*value)
+            if nested:
+                return nested
+            continue
+        candidate = str(value).strip()
+        if candidate:
+            return candidate
+    return None
+
+
+def _resume_source_block_from_record(record: TemporalExecutionRecord) -> Mapping[str, Any]:
+    parameters = getattr(record, "parameters", None)
+    if not isinstance(parameters, Mapping):
+        return {}
+    resume_source = parameters.get("resumeSource") or parameters.get("resume_source")
+    if isinstance(resume_source, Mapping):
+        return resume_source
+    return {}
+
+
+def _resume_plan_digest_from_record(record: TemporalExecutionRecord) -> str | None:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    resume_block = _resume_source_block_from_record(record)
+    return _first_nonempty_text(
+        memo.get("resume_plan_digest"),
+        memo.get("resumePlanDigest"),
+        memo.get("plan_digest"),
+        search_attributes.get("mm_resume_plan_digest"),
+        resume_block.get("sourcePlanDigest"),
+        resume_block.get("source_plan_digest"),
+    )
 ALLOWED_REMEDIATION_ACTION_POLICY_REFS = frozenset({"admin_healer_default"})
 PENDING_REMEDIATION_APPROVAL_STATUSES = frozenset(
     {"awaiting_approval", "approval_required"}
@@ -2629,6 +2668,12 @@ class TemporalExecutionService:
         source_plan_ref = str(record.plan_ref or "").strip() or None
         if checkpoint.plan_ref is not None and source_plan_ref is not None:
             if checkpoint.plan_ref != source_plan_ref:
+                raise TemporalExecutionResumeCheckpointError(
+                    "Resume checkpoint plan identity does not match source execution."
+                )
+        source_plan_digest = _resume_plan_digest_from_record(record)
+        if checkpoint.plan_digest is not None and source_plan_digest is not None:
+            if checkpoint.plan_digest != source_plan_digest:
                 raise TemporalExecutionResumeCheckpointError(
                     "Resume checkpoint plan identity does not match source execution."
                 )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2626,6 +2626,12 @@ class TemporalExecutionService:
             raise TemporalExecutionResumeCheckpointError(
                 "Resume checkpoint task input snapshot does not match source execution."
             )
+        source_plan_ref = str(record.plan_ref or "").strip() or None
+        if checkpoint.plan_ref is not None and source_plan_ref is not None:
+            if checkpoint.plan_ref != source_plan_ref:
+                raise TemporalExecutionResumeCheckpointError(
+                    "Resume checkpoint plan identity does not match source execution."
+                )
         failed_step_id = checkpoint.failed_step.logical_step_id
         failed_step_attempt = checkpoint.failed_step.attempt
         if not failed_step_id:
@@ -2640,8 +2646,8 @@ class TemporalExecutionService:
             sourceWorkflowId=record.workflow_id,
             sourceRunId=source_run_id,
             sourceTaskInputSnapshotRef=source_snapshot_ref,
-            sourcePlanRef=record.plan_ref,
-            sourcePlanDigest=(checkpoint.plan_digest if checkpoint else None),
+            sourcePlanRef=checkpoint.plan_ref or source_plan_ref,
+            sourcePlanDigest=checkpoint.plan_digest,
             failedStepId=failed_step_id,
             failedStepAttempt=failed_step_attempt,
             resumeCheckpointRef=checkpoint_ref,

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -122,6 +122,15 @@ def materialize_preserved_steps(
             for key, value in raw_artifacts.items():
                 if key in artifacts:
                     artifacts[key] = value
+        state_checkpoint_ref = str(
+            preserved.get("stateCheckpointRef")
+            or preserved.get("state_checkpoint_ref")
+            or ""
+        ).strip()
+        if not state_checkpoint_ref:
+            raise ValueError(
+                f"preserved step {logical_step_id} requires a state checkpoint ref"
+            )
         try:
             source_attempt = int(
                 preserved.get("sourceAttempt") or preserved.get("source_attempt") or 1
@@ -134,6 +143,7 @@ def materialize_preserved_steps(
         row["waitingReason"] = None
         row["attentionRequired"] = False
         row["artifacts"] = artifacts
+        row["stateCheckpointRef"] = state_checkpoint_ref
         row["preservedFrom"] = {
             "workflowId": source_workflow_id,
             "runId": source_run_id,

--- a/specs/327-gate-resume-checkpoint-evidence/checklists/requirements.md
+++ b/specs/327-gate-resume-checkpoint-evidence/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Gate Resume on Durable Checkpoint Evidence
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification defines one runtime story for `MM-633`, preserves the canonical Jira preset brief verbatim in `spec.md` `**Input**`, maps all in-scope source design requirements to functional requirements, and contains no clarification markers.

--- a/specs/327-gate-resume-checkpoint-evidence/contracts/resume-evidence.md
+++ b/specs/327-gate-resume-checkpoint-evidence/contracts/resume-evidence.md
@@ -1,0 +1,120 @@
+# Contract: Failed-Step Resume Evidence Gate
+
+Traceability: MM-633, `spec.md` FR-001 through FR-013.
+
+## Execution Detail Contract
+
+`GET /api/executions/{workflow_id}` must expose failed-step Resume availability from backend evidence.
+
+Response fields:
+
+```json
+{
+  "actions": {
+    "canResumeFromFailedStep": true,
+    "disabledReasons": {}
+  },
+  "resume": {
+    "available": true,
+    "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+    "failedStepId": "implement",
+    "sourceRunId": "run-source",
+    "disabledReason": null
+  }
+}
+```
+
+Rules:
+- `canResumeFromFailedStep=true` only when the evidence bundle is complete and valid.
+- When unavailable, `disabledReasons.canResumeFromFailedStep` and `resume.disabledReason` should expose a bounded reason.
+- The UI must render availability from these backend fields and must not infer Resume eligibility from local text or status alone.
+
+## Resume Submission Contract
+
+`POST /api/executions/{workflow_id}/resume-from-failed-step`
+
+Request body:
+
+```json
+{
+  "idempotencyKey": "resume-operator-action-1",
+  "resumeCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1"
+}
+```
+
+Rules:
+- `idempotencyKey` is required.
+- `resumeCheckpointRef` may be omitted only when the source execution has one canonical validated checkpoint ref.
+- Task mutation fields remain forbidden.
+- The route must hydrate checkpoint evidence, validate it against the source execution, and fail before creating a resumed execution when evidence is missing, stale, unauthorized, corrupted, or inconsistent.
+
+Success response:
+
+```json
+{
+  "accepted": true,
+  "applied": "created_resumed_execution",
+  "source": {"workflowId": "mm:source", "runId": "run-source"},
+  "execution": {"workflowId": "mm:resumed", "runId": "run-resumed", "detailHref": "/tasks/mm:resumed"},
+  "relationship": "Resumed from failed step",
+  "resumeCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1"
+}
+```
+
+Failure response shape:
+
+```json
+{
+  "detail": {
+    "code": "resume_not_available",
+    "message": "Failed-step Resume is not available for this execution.",
+    "reason": "workspace_checkpoint_missing"
+  }
+}
+```
+
+Required bounded reasons include:
+- `original_task_input_snapshot_missing`
+- `resume_checkpoint_missing`
+- `failed_step_identity_missing`
+- `completed_step_refs_missing`
+- `workspace_checkpoint_missing`
+- `plan_identity_missing`
+- `checkpoint_unauthorized`
+- `checkpoint_corrupted`
+- `checkpoint_inconsistent`
+- `state_not_eligible`
+
+## Checkpoint Evidence Contract
+
+Compact checkpoint payload shape:
+
+```json
+{
+  "schemaVersion": "v1",
+  "source": {"workflowId": "mm:source", "runId": "run-source"},
+  "taskInputSnapshotRef": "artifact://snapshot/source",
+  "planRef": "artifact://plan/source",
+  "planDigest": "sha256:plan",
+  "failedStep": {"logicalStepId": "implement", "order": 2, "attempt": 1, "title": "Implement"},
+  "preservedSteps": [
+    {
+      "logicalStepId": "prepare",
+      "order": 1,
+      "status": "succeeded",
+      "sourceAttempt": 1,
+      "artifacts": {"outputSummary": "artifact://prepare-summary"},
+      "stateCheckpointRef": "artifact://workspace/before-implement"
+    }
+  ],
+  "preparedArtifactRefs": ["artifact://prepared/input"],
+  "resumeWorkspace": {"kind": "workspace_checkpoint", "ref": "artifact://workspace/before-implement"}
+}
+```
+
+Rules:
+- Plan identity must be present as `planRef`, `planDigest`, or both according to the final implementation contract.
+- `resumeWorkspace` must point to recoverable state and must not be empty for eligible Resume.
+- Large or binary payload bodies must be behind refs.
+- Completed prior steps without recoverable refs or state checkpoint evidence must block Resume eligibility.
+- Repeated checkpoint writes for the same source failed-step evidence must be idempotent.

--- a/specs/327-gate-resume-checkpoint-evidence/data-model.md
+++ b/specs/327-gate-resume-checkpoint-evidence/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: Gate Resume on Durable Checkpoint Evidence
+
+Traceability: MM-633, `spec.md` FR-001 through FR-013.
+
+## Resume Eligibility Result
+
+Represents backend-computed availability for failed-step Resume.
+
+Fields:
+- `available`: boolean. True only when every required evidence category is present and valid.
+- `checkpointRef`: durable checkpoint artifact ref when evidence exists.
+- `failedStepId`: logical failed step identity from the source ledger or validated checkpoint.
+- `sourceRunId`: pinned source run id.
+- `disabledReason`: bounded reason when unavailable, such as `original_task_input_snapshot_missing`, `resume_checkpoint_missing`, `failed_step_identity_missing`, `completed_step_refs_missing`, `workspace_checkpoint_missing`, `plan_identity_missing`, `checkpoint_unauthorized`, `checkpoint_corrupted`, or `checkpoint_inconsistent`.
+
+Validation rules:
+- Must be computed by backend code, not UI inference.
+- `available=true` requires all Resume Evidence Bundle rules below to pass.
+- Disabled reasons must not expose secrets or raw checkpoint payloads.
+
+## Resume Evidence Bundle
+
+Logical evidence set required before Resume can be offered or accepted.
+
+Fields:
+- `sourceWorkflowId`: source execution workflow id.
+- `sourceRunId`: source execution run id.
+- `taskInputSnapshotRef`: authoritative original task input snapshot ref.
+- `failedStep`: failed-step ledger identity.
+- `preservedSteps`: completed prior step refs and provenance.
+- `preparedArtifactRefs`: prepared input refs safe to reuse.
+- `workspaceCheckpoint`: workspace, branch, commit, or equivalent state checkpoint ref.
+- `planRef` or `planDigest`: plan identity proving step graph compatibility.
+- `resumeCheckpointRef`: durable artifact ref for the compact evidence bundle.
+
+Validation rules:
+- `sourceWorkflowId` and `sourceRunId` must match the failed source execution.
+- `taskInputSnapshotRef` must match source execution memo/canonical snapshot state.
+- `failedStep` must identify the last failed step in the source step ledger.
+- Every completed step before the failed step that will be preserved must have recoverable output refs and state checkpoint evidence.
+- `workspaceCheckpoint` cannot be empty for a valid Resume offer.
+- At least one plan identity value must be present and must match the source execution plan identity.
+- Large or binary state must be represented by refs, never inline bodies.
+
+## Resume Checkpoint Artifact
+
+Artifact-backed compact payload that can be hydrated before Resume execution.
+
+State transitions:
+- `candidate`: checkpoint write is being assembled from source execution evidence.
+- `valid`: all evidence categories are present, compact, authorized, and internally consistent.
+- `invalid`: evidence is missing, stale, unauthorized, corrupted, or inconsistent and cannot be used for Resume.
+- `consumed`: a valid Resume request used this checkpoint to create a linked follow-up execution.
+
+Validation rules:
+- Checkpoint writes must be idempotent for the same source workflow/run and failed-step identity.
+- Repeated writes for unchanged evidence must resolve to the same checkpoint ref or an equivalent deterministic replacement.
+- Hydration failures must produce unavailable Resume status before step execution.
+
+## Preserved Step Evidence
+
+Represents one completed prior step that may be materialized as preserved progress.
+
+Fields:
+- `logicalStepId`
+- `order`
+- `status`
+- `sourceAttempt`
+- `artifacts`
+- `stateCheckpointRef` or equivalent state evidence
+- `preservedFrom` provenance when materialized in the resumed run
+
+Validation rules:
+- Must include at least one semantic output ref.
+- Must not embed large output content inline.
+- Must point back to the pinned source workflow/run and source attempt.
+- Must not be materialized if the source ledger row is not completed or does not precede the failed step.
+
+## Relationships
+
+- Failed Source Execution has one Original Task Input Snapshot.
+- Failed Source Execution may have one valid Resume Eligibility Result at a time.
+- Resume Eligibility Result references one Resume Checkpoint Artifact.
+- Resume Checkpoint Artifact contains one failed step and zero or more Preserved Step Evidence entries.
+- Resumed Execution references the pinned Failed Source Execution and Resume Checkpoint Artifact.

--- a/specs/327-gate-resume-checkpoint-evidence/moonspec_align_report.md
+++ b/specs/327-gate-resume-checkpoint-evidence/moonspec_align_report.md
@@ -1,0 +1,41 @@
+# MoonSpec Alignment Report: Gate Resume on Durable Checkpoint Evidence
+
+**Feature**: `327-gate-resume-checkpoint-evidence`
+**Date**: 2026-05-08
+**Verdict**: PASS
+
+## Scope Reviewed
+
+- `spec.md`
+- `plan.md`
+- `research.md`
+- `data-model.md`
+- `contracts/resume-evidence.md`
+- `quickstart.md`
+- `tasks.md`
+- `.specify/memory/constitution.md`
+
+## Findings
+
+| ID | Area | Severity | Result |
+| --- | --- | --- | --- |
+| ALIGN-001 | Source preservation | PASS | `spec.md` preserves MM-633 and the canonical Jira preset brief for final verification. |
+| ALIGN-002 | Single-story scope | PASS | `spec.md` and `tasks.md` cover one story: Evidence-Gated Resume Eligibility. |
+| ALIGN-003 | Requirement coverage | PASS | `tasks.md` maps FR-001 through FR-013, SC-001 through SC-007, acceptance scenarios, and DESIGN-REQ-001 through DESIGN-REQ-004. |
+| ALIGN-004 | Test-first ordering | PASS | Unit and integration test tasks T008-T017 precede implementation tasks T022-T032, with red-first confirmation tasks T018-T019. |
+| ALIGN-005 | Design artifact consistency | PASS | `data-model.md`, `contracts/resume-evidence.md`, `quickstart.md`, and `plan.md` all require backend evidence gating, compact refs, idempotent checkpoint writes, and no full-rerun fallback. |
+| ALIGN-006 | Constitution alignment | PASS | Planning and tasks keep work in feature artifacts, require unit and integration tests, preserve MoonMind-owned evidence, and avoid docs-only completion. |
+
+## Remediation
+
+No remediation edits were required for `spec.md`, `plan.md`, design artifacts, or `tasks.md`.
+
+## Gate Recheck
+
+- Specify gate: PASS. `spec.md` exists, contains one user story, preserves original input, and has no unresolved clarification markers.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist with explicit unit and integration strategies.
+- Tasks gate: PASS. `tasks.md` contains one story phase, red-first unit tests, integration tests, implementation tasks, story validation, and final `/moonspec-verify` work.
+
+## Remaining Risks
+
+- Implementation may require an explicit cutover decision if tightening `ResumeCheckpointModel` affects already-running workflow payloads. This is already covered by tasks T040 and the plan constraints.

--- a/specs/327-gate-resume-checkpoint-evidence/plan.md
+++ b/specs/327-gate-resume-checkpoint-evidence/plan.md
@@ -1,0 +1,140 @@
+# Implementation Plan: Gate Resume on Durable Checkpoint Evidence
+
+**Branch**: `run-jira-orchestrate-for-mm-633-gate-res-1e30fa1a` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/327-gate-resume-checkpoint-evidence/spec.md`
+
+**Setup Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted, but the managed job branch name is not in the script's expected `NNN-feature-name` form. Planning proceeds from the active feature directory `specs/327-gate-resume-checkpoint-evidence`.
+
+## Summary
+
+MM-633 requires failed-step Resume to be offered and accepted only when backend-owned durable evidence proves the original task input snapshot, pinned source workflow/run, failed-step identity, completed-step refs, workspace or branch checkpoint, and plan identity are recoverable and consistent. The repository already contains Resume request/response models, a `/resume-from-failed-step` route, Task Detail UI controls, checkpoint hydration, and service validation for several source/checkpoint mismatches. The main gap is that availability is currently gated mostly by snapshot and checkpoint-ref presence, while checkpoint contents allow optional plan and workspace evidence and do not yet prove ledger-derived completed-step recoverability before Resume is exposed. Implementation should add verification-first API/service/model tests, tighten checkpoint and eligibility validation, then add hermetic integration coverage proving invalid evidence blocks before execution and valid evidence remains ref-backed.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `_build_action_capabilities()` in `api_service/api/routers/executions.py` computes `canResumeFromFailedStep`, but currently uses failed state, snapshot ref, and checkpoint ref presence rather than full checkpoint evidence validation | Move or add backend eligibility validation that evaluates hydrated/checkpoint metadata and returns disabled reasons for missing evidence | unit + integration |
+| FR-002 | implemented_unverified | `_build_action_capabilities()` requires task input snapshot; `TemporalExecutionService.create_failed_step_resume_execution()` rejects missing source snapshot | Add focused tests proving missing snapshot blocks both availability and submission | unit |
+| FR-003 | implemented_unverified | `ResumeCheckpointSourceModel` requires `workflowId` and `runId`; service validates both against the source record before creating a resumed execution | Add tests for missing and mismatched source identity with operator-readable reasons | unit + integration |
+| FR-004 | partial | `ResumeCheckpointFailedStepModel` requires logical step ID/order/attempt, but availability can be true before validating checkpoint contents and no step-ledger cross-check is present | Validate checkpoint failed-step identity against source ledger or canonical recovery metadata before exposing/starting Resume | unit + integration |
+| FR-005 | partial | `ResumeCheckpointPreservedStepModel` requires artifact refs when preserved steps are present; no evidence proves every completed prior step has refs before eligibility | Compare source completed-step ledger state to preserved step refs and block when a completed prior step lacks recoverable refs | unit + integration |
+| FR-006 | missing | `ResumeCheckpointModel.resume_workspace` currently defaults to `{}` and tests allow empty optional resume sections | Require workspace/branch/commit/equivalent checkpoint evidence for eligibility and request acceptance | unit + integration |
+| FR-007 | missing | `planRef` and `planDigest` are optional in `ResumeCheckpointModel`; service passes `record.plan_ref` and checkpoint digest when present | Require plan identity or digest and validate it against source execution plan metadata | unit + integration |
+| FR-008 | missing | Resume execution creation uses an idempotency key, but checkpoint creation/write idempotency for step-boundary evidence is not implemented or verified | Define checkpoint write idempotency key/semantics and add tests for repeated checkpoint writes resolving to the same evidence | unit + integration |
+| FR-009 | partial | Temporal payload policy discourages large inline bodies; checkpoint model still allows arbitrary `resumeWorkspace` dict and artifact dict values | Enforce compact refs for large/binary checkpoint content and reject inline checkpoint payload bodies where applicable | unit |
+| FR-010 | partial | Preserved-step model rejects preserved steps without artifacts, but empty preserved steps and lack of ledger comparison can still pass | Validate that every completed step intended for preservation has recoverable output refs and state checkpoint evidence | unit + integration |
+| FR-011 | partial | Route hydrates checkpoint artifacts and service rejects invalid payload, checkpoint ref mismatch, run mismatch, workflow mismatch, and snapshot mismatch | Expand missing/stale/unauthorized/corrupted/inconsistent evidence coverage and preserve distinct disabled/failure reasons before execution | unit + integration |
+| FR-012 | implemented_unverified | Service raises validation errors before creating a resumed execution; tests cover selected mismatch cases and no full-rerun fallback is present | Add explicit assertions that invalid Resume creates no new execution and never triggers full rerun behavior | unit + integration |
+| FR-013 | implemented_unverified | `spec.md` preserves MM-633 and the canonical Jira preset brief | Preserve traceability through plan, research, data model, contract, quickstart, tasks, implementation notes, verification, commit, and PR metadata | final verify |
+| SCN-001 | partial | Availability can be true with only snapshot and checkpoint-ref presence | Add valid-evidence availability test matrix with full required evidence | unit + integration |
+| SCN-002 | partial | Missing checkpoint and missing snapshot reasons exist; other missing evidence reasons do not | Add one disabled reason per required evidence category | unit |
+| SCN-003 | partial | Route/service fail before creating execution for malformed or mismatched checkpoint payloads | Add stale, unauthorized, corrupted, inconsistent plan, and missing workspace cases | unit + integration |
+| SCN-004 | partial | Preserved steps can carry artifact refs, but no source-ledger completeness check exists | Add source ledger comparison and preserved-step ref tests | unit + integration |
+| SCN-005 | partial | Payload policy tests cover general large-body refs; checkpoint-specific inline payload guard is absent | Add checkpoint-specific compact-ref validation | unit |
+| SCN-006 | missing | Checkpoint write idempotency is not represented for Resume checkpoint evidence | Add checkpoint write/create idempotency design and tests | unit + integration |
+| SCN-007 | missing | Plan identity/digest is optional | Require and test plan identity/digest mismatch blocking | unit + integration |
+| SC-001 | partial | Backend computes a boolean but from insufficient evidence | Expand backend evidence matrix | unit + integration |
+| SC-002 | partial | Valid resume path includes snapshot, workflow/run, failed step, and checkpoint ref; workspace and plan are optional | Tighten model/service requirements and test complete valid evidence | unit + integration |
+| SC-003 | partial | Some invalid evidence cases block; many required cases are generic or untested | Add complete invalid evidence matrix with operator-readable reasons | unit + integration |
+| SC-004 | implemented_unverified | Resume service creates linked execution only on success and errors otherwise | Add explicit no-created-execution/no-full-rerun assertions | unit + integration |
+| SC-005 | missing | No checkpoint-write retry semantics are implemented for this evidence | Add idempotent write behavior and tests | unit + integration |
+| SC-006 | partial | General payload policy exists; checkpoint-specific large/binary inline prevention is incomplete | Add checkpoint ref-only validation and tests | unit |
+| SC-007 | implemented_unverified | `spec.md` and this plan preserve MM-633 and source IDs | Preserve traceability through all artifacts and final verification | final verify |
+| DESIGN-REQ-001 | partial | Snapshot/checkpoint-ref gating exists; full evidence gating is incomplete | Implement complete backend eligibility evidence evaluation | unit + integration |
+| DESIGN-REQ-002 | partial | Resume source pinning and checkpoint mismatch validation exist; completed refs/workspace/plan evidence are incomplete | Tighten checkpoint model and service validation; add ledger comparison | unit + integration |
+| DESIGN-REQ-003 | partial | Prepared refs and preserved refs models exist; workspace and idempotent checkpoint writes are incomplete | Add checkpoint write semantics and compact evidence validation | unit + integration |
+| DESIGN-REQ-004 | partial | Resume intent and source pinning exist; checkpointed progress and no silent preserved-step behavior need proof | Add pre-execution failure and no-fallback integration coverage | unit + integration |
+
+Status summary: 4 missing, 20 partial, 6 implemented_unverified, 0 implemented_verified.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI where availability display is affected  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest  
+**Storage**: Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned  
+**Unit Testing**: `./tools/test_unit.sh` for full unit verification; focused Python tests under `tests/unit/api/routers/test_executions.py` and `tests/unit/workflows/temporal/test_temporal_service.py`; focused UI tests through `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` if display copy changes
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage; targeted workflow/step-ledger tests under `tests/integration/workflows/temporal/**` where no external credentials are required
+**Target Platform**: MoonMind API service, Temporal execution service, and Mission Control task detail surface in the existing containerized deployment  
+**Project Type**: Web service plus frontend dashboard with Temporal-backed orchestration  
+**Performance Goals**: Eligibility computation remains bounded enough for task detail polling and recovery submission; checkpoint payloads stay compact by keeping large/binary data behind refs  
+**Constraints**: Preserve in-flight Temporal payload compatibility or explicitly version any breaking change; fail before execution on invalid evidence; do not add hidden full-rerun fallback; do not embed large checkpoint content in workflow history; preserve source execution immutability  
+**Scale/Scope**: One runtime story for `MoonMind.Run` failed-step Resume evidence gating; excludes implementing the full resumed step execution path beyond eligibility, checkpoint validation, and pre-execution failure guarantees
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The work strengthens MoonMind orchestration around existing agents rather than adding a new agent engine.
+- **II. One-Click Agent Deployment**: PASS. No new external service, secret, or deployment prerequisite is planned.
+- **III. Avoid Vendor Lock-In**: PASS. Resume evidence is MoonMind task orchestration state, not provider-specific behavior.
+- **IV. Own Your Data**: PASS. Evidence remains in MoonMind-owned execution records and artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime contract changes are planned.
+- **VI. Scaffolds Are Replaceable, Tests Are the Anchor**: PASS. The plan requires tests first around evidence and failure contracts.
+- **VII. Powerful Runtime Configurability**: PASS. Existing action capability and feature flag surfaces remain observable.
+- **VIII. Modular and Extensible Architecture**: PASS. Planned changes stay inside existing schema, API route, Temporal service, step ledger/checkpoint, and UI boundaries.
+- **IX. Resilient by Default**: PASS. The story directly improves deterministic recovery failure behavior and requires boundary coverage.
+- **X. Facilitate Continuous Improvement**: PASS. Artifacts preserve outcome and traceability for later verification.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Planning derives from the single-story spec and keeps all requirements visible.
+- **XII. Documentation Separation**: PASS. Planning artifacts stay under `specs/327-gate-resume-checkpoint-evidence/`; canonical docs remain desired-state references.
+- **XIII. Pre-Release Compatibility Policy**: PASS. The plan tightens internal evidence contracts and requires explicit handling for compatibility-sensitive payload changes instead of hidden aliases.
+
+Re-check after Phase 1 design: PASS. `research.md`, `data-model.md`, `contracts/resume-evidence.md`, and `quickstart.md` introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/327-gate-resume-checkpoint-evidence/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── resume-evidence.md
+├── checklists/
+│   └── requirements.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── executions.py
+
+moonmind/
+├── schemas/
+│   ├── temporal_models.py
+│   └── temporal_payload_policy.py
+└── workflows/
+    └── temporal/
+        ├── service.py
+        ├── step_ledger.py
+        └── workflows/
+            └── run.py
+
+frontend/
+└── src/
+    ├── entrypoints/
+    │   ├── task-detail.tsx
+    │   └── task-detail.test.tsx
+    └── generated/
+        └── openapi.ts
+
+tests/
+├── unit/
+│   ├── api/routers/test_executions.py
+│   ├── workflows/temporal/test_temporal_service.py
+│   └── schemas/test_temporal_payload_policy.py
+└── integration/
+    └── workflows/temporal/workflows/test_run_resume_from_failed_step.py
+```
+
+**Structure Decision**: Use the existing API route, schema, Temporal service, step ledger, and Task Detail UI surfaces. Add verification-first unit tests around evidence validation and add hermetic integration coverage for the Resume boundary before implementation changes.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/327-gate-resume-checkpoint-evidence/plan.md
+++ b/specs/327-gate-resume-checkpoint-evidence/plan.md
@@ -49,15 +49,15 @@ Status summary: 4 missing, 20 partial, 6 implemented_unverified, 0 implemented_v
 
 ## Technical Context
 
-**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI where availability display is affected  
-**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest  
-**Storage**: Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned  
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI where availability display is affected
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest
+**Storage**: Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned
 **Unit Testing**: `./tools/test_unit.sh` for full unit verification; focused Python tests under `tests/unit/api/routers/test_executions.py` and `tests/unit/workflows/temporal/test_temporal_service.py`; focused UI tests through `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` if display copy changes
 **Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage; targeted workflow/step-ledger tests under `tests/integration/workflows/temporal/**` where no external credentials are required
-**Target Platform**: MoonMind API service, Temporal execution service, and Mission Control task detail surface in the existing containerized deployment  
-**Project Type**: Web service plus frontend dashboard with Temporal-backed orchestration  
-**Performance Goals**: Eligibility computation remains bounded enough for task detail polling and recovery submission; checkpoint payloads stay compact by keeping large/binary data behind refs  
-**Constraints**: Preserve in-flight Temporal payload compatibility or explicitly version any breaking change; fail before execution on invalid evidence; do not add hidden full-rerun fallback; do not embed large checkpoint content in workflow history; preserve source execution immutability  
+**Target Platform**: MoonMind API service, Temporal execution service, and Mission Control task detail surface in the existing containerized deployment
+**Project Type**: Web service plus frontend dashboard with Temporal-backed orchestration
+**Performance Goals**: Eligibility computation remains bounded enough for task detail polling and recovery submission; checkpoint payloads stay compact by keeping large/binary data behind refs
+**Constraints**: Preserve in-flight Temporal payload compatibility or explicitly version any breaking change; fail before execution on invalid evidence; do not add hidden full-rerun fallback; do not embed large checkpoint content in workflow history; preserve source execution immutability
 **Scale/Scope**: One runtime story for `MoonMind.Run` failed-step Resume evidence gating; excludes implementing the full resumed step execution path beyond eligibility, checkpoint validation, and pre-execution failure guarantees
 
 ## Constitution Check

--- a/specs/327-gate-resume-checkpoint-evidence/quickstart.md
+++ b/specs/327-gate-resume-checkpoint-evidence/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Gate Resume on Durable Checkpoint Evidence
+
+Traceability: MM-633, `spec.md` FR-001 through FR-013.
+
+## Prerequisites
+
+- Run from the repository root.
+- Use managed-agent local test mode for unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1`.
+- Do not require external provider credentials for the required tests.
+
+## Test-First Validation Flow
+
+1. Add failing unit tests for backend availability gating in `tests/unit/api/routers/test_executions.py`:
+   - complete evidence enables `canResumeFromFailedStep`
+   - missing snapshot disables Resume
+   - missing checkpoint disables Resume
+   - missing failed-step identity disables Resume
+   - missing completed-step refs disables Resume
+   - missing workspace checkpoint disables Resume
+   - missing or mismatched plan identity disables Resume
+
+2. Add failing service/model tests in `tests/unit/workflows/temporal/test_temporal_service.py`:
+   - checkpoint source workflow/run mismatch fails before `create_execution`
+   - task snapshot mismatch fails before `create_execution`
+   - missing workspace checkpoint fails
+   - missing plan identity fails
+   - corrupted or inconsistent checkpoint payload fails with a bounded reason
+   - repeated checkpoint writes are idempotent once checkpoint writing is implemented
+
+3. Add checkpoint payload policy tests in `tests/schemas/test_temporal_payload_policy.py` or an adjacent schema test:
+   - compact artifact refs pass
+   - inline large or binary checkpoint payload content fails or is rejected by the chosen boundary
+
+4. Add or update UI tests only if display behavior changes in `frontend/src/entrypoints/task-detail.test.tsx`:
+   - Resume button visibility follows backend `actions.canResumeFromFailedStep`
+   - unavailable reasons are displayed from backend disabled reasons
+
+5. Add hermetic integration coverage in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` or an adjacent `integration_ci` file:
+   - valid checkpoint evidence materializes preserved prior steps and unblocks the failed step
+   - invalid evidence blocks before a resumed execution is created
+   - no invalid Resume path silently becomes a full rerun
+
+## Commands
+
+Focused Python unit iteration:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py
+```
+
+Focused UI iteration if Task Detail display changes:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+```
+
+Full unit verification before handoff:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Hermetic integration verification:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-to-End Story Check
+
+A failed `MoonMind.Run` execution should expose Resume only after backend evidence proves:
+- original task input snapshot
+- pinned source workflow/run IDs
+- failed-step ledger identity
+- completed-step refs and state evidence
+- workspace/branch/commit checkpoint
+- plan identity or digest
+
+Invalid, stale, unauthorized, corrupted, or inconsistent evidence must block Resume before execution and must not create a full rerun fallback.

--- a/specs/327-gate-resume-checkpoint-evidence/research.md
+++ b/specs/327-gate-resume-checkpoint-evidence/research.md
@@ -1,0 +1,91 @@
+# Research: Gate Resume on Durable Checkpoint Evidence
+
+Traceability: MM-633, source coverage IDs DESIGN-REQ-013 and DESIGN-REQ-016, spec FR-001 through FR-013.
+
+## FR-001 / SCN-001 / SC-001 / DESIGN-REQ-001 - Backend Evidence-Based Eligibility
+
+Decision: `partial`; backend eligibility exists but is not yet complete evidence validation.
+Evidence: `_build_action_capabilities()` in `api_service/api/routers/executions.py` sets `canResumeFromFailedStep` for failed `MoonMind.Run` executions with a task input snapshot and resume checkpoint ref. `ExecutionResumeSummaryModel` exposes availability, checkpoint ref, failed step id, source run id, and disabled reason.
+Rationale: The UI does not infer Resume by itself, but the backend gate currently treats checkpoint-ref presence as sufficient. MM-633 requires backend evaluation of all required evidence before offering Resume.
+Alternatives considered: Deferring full validation to submission was rejected because the acceptance criteria require Resume to be offered only when the backend can prove recoverability.
+Test implications: Unit matrix for availability and disabled reasons; integration coverage for valid and invalid evidence paths.
+
+## FR-002 / FR-003 - Original Snapshot And Pinned Source Identity
+
+Decision: `implemented_unverified`; service and model checks exist, but targeted coverage should prove both availability and submission behavior.
+Evidence: `_build_action_capabilities()` requires `_task_input_snapshot_ref_from_memo()` for Resume availability. `ResumeCheckpointSourceModel` requires `workflowId` and `runId`; `TemporalExecutionService.create_failed_step_resume_execution()` rejects missing source run id, workflow mismatch, run mismatch, and task snapshot mismatch.
+Rationale: The core validation is present. The plan still requires focused tests to prove missing snapshot/source identity blocks with operator-readable reasons at both surfaces.
+Alternatives considered: Marking implemented_verified was rejected because current tests focus on selected service mismatch cases and not the full availability-to-submission contract.
+Test implications: Unit route/service tests; one integration test for source identity mismatch at the boundary.
+
+## FR-004 / FR-005 / FR-010 - Failed-Step Ledger And Completed-Step Refs
+
+Decision: `partial`; checkpoint models validate preserved steps when present, but no source-ledger completeness check exists.
+Evidence: `ResumeCheckpointFailedStepModel` requires `logicalStepId`, order, and attempt. `ResumeCheckpointPreservedStepModel` rejects preserved steps without artifact refs. `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` verifies materializing a preserved step unblocks a failed step.
+Rationale: The data shape supports failed and preserved step evidence, but MM-633 requires proving the last failed step and all completed prior work from source ledger evidence. Current code does not compare checkpoint preserved steps against completed source ledger rows.
+Alternatives considered: Trusting checkpoint artifact contents was rejected because corrupted or incomplete checkpoints must block before execution.
+Test implications: Unit tests for ledger/checkpoint comparison and integration tests proving incomplete preserved refs block Resume.
+
+## FR-006 / SCN-005 / SC-006 - Workspace Or Branch Checkpoint And Compact Refs
+
+Decision: `missing` for required workspace evidence and `partial` for large/binary ref handling.
+Evidence: `ResumeCheckpointModel.resume_workspace` defaults to `{}` and `test_resume_checkpoint_model_allows_empty_optional_resume_sections` explicitly allows empty optional resume sections. General payload policy tests cover large bodies, but checkpoint-specific inline content enforcement is not present.
+Rationale: The spec requires recoverable workspace, branch, commit, or equivalent checkpoint evidence. Optional empty workspace evidence does not satisfy that contract.
+Alternatives considered: Treating prepared artifact refs as enough was rejected because the source design calls out workspace/branch/commit checkpoint separately.
+Test implications: Unit model/service tests requiring checkpoint evidence and rejecting inline large/binary checkpoint payloads.
+
+## FR-007 / SCN-007 - Plan Identity Or Digest
+
+Decision: `missing`; plan identity is currently optional.
+Evidence: `ResumeCheckpointModel` has optional `planRef` and `planDigest`. `ResumeSourceModel` carries optional `sourcePlanRef` and `sourcePlanDigest`. The service passes `record.plan_ref` and checkpoint digest when present but does not require or compare a plan identity.
+Rationale: MM-633 requires proof that restored progress belongs to the same planned step graph, so plan identity/digest must be required and validated.
+Alternatives considered: Relying on task input snapshot identity alone was rejected because the same task input can be planned differently.
+Test implications: Unit tests for missing and mismatched plan identity; integration test for stale plan digest blocking before execution.
+
+## FR-008 / SCN-006 / SC-005 - Idempotent Checkpoint Writes
+
+Decision: `missing`; resumed execution creation is idempotent, but checkpoint creation/write idempotency is not yet defined for Resume evidence.
+Evidence: `TemporalExecutionService._resume_create_idempotency_key()` derives idempotency for the follow-up execution. No equivalent checkpoint write service or test was found for step-boundary Resume checkpoint evidence.
+Rationale: The spec explicitly requires checkpoint creation and writes to be idempotent, independent of follow-up execution idempotency.
+Alternatives considered: Counting execution idempotency was rejected because retries may occur while recording source checkpoint evidence before any Resume request is submitted.
+Test implications: Unit tests for repeat checkpoint writes resolving to the same evidence ref; integration test around retry-safe checkpoint recording if a workflow activity boundary exists.
+
+## FR-009 - Large Or Binary Checkpoint Content Behind Refs
+
+Decision: `partial`; general payload policy exists, but Resume checkpoint-specific validation is incomplete.
+Evidence: `moonmind/schemas/temporal_payload_policy.py` and `tests/schemas/test_temporal_payload_policy.py` address large bodies and checkpoint refs generally. `ResumeCheckpointModel` allows arbitrary dict values in `resume_workspace` and preserved-step artifact values.
+Rationale: The story requires checkpoint-specific assurance that large or binary content stays behind refs.
+Alternatives considered: Relying only on broad payload policy was rejected because checkpoint artifacts are their own contract and can be hydrated before submission.
+Test implications: Unit schema/service tests rejecting inline checkpoint bodies and accepting compact refs.
+
+## FR-011 / SCN-003 / SC-003 - Explicit Pre-Execution Failure
+
+Decision: `partial`; selected failure paths exist, but the invalid-evidence matrix is incomplete.
+Evidence: `_hydrate_resume_checkpoint_payload()` fails checkpoint hydration with `resume_not_available`; service tests reject invalid/missing payloads, noncanonical checkpoint refs, and run mismatches. Route errors currently collapse many checkpoint failures to `resume_checkpoint_missing`.
+Rationale: MM-633 requires missing, stale, unauthorized, corrupted, inconsistent, and stale plan evidence to block before execution with useful operator-readable reasons.
+Alternatives considered: Generic failure was rejected because operators need to understand why Resume is unavailable.
+Test implications: Unit route/service tests for each reason and integration coverage for no follow-up execution on invalid evidence.
+
+## FR-012 / SC-004 - No Full-Rerun Fallback
+
+Decision: `implemented_unverified`; behavior appears aligned, but explicit proof is needed.
+Evidence: `create_failed_step_resume_execution()` raises before `create_execution()` on validation errors. Existing tests assert exceptions for some invalid evidence; no test explicitly asserts that no full rerun or substitute execution is created.
+Rationale: The code structure suggests no fallback, but MM-633 needs direct boundary evidence.
+Alternatives considered: Inferring from exceptions was rejected because a future catch-and-fallback path would violate the story.
+Test implications: Unit and integration assertions that invalid Resume leaves execution creation uncalled and no new run appears.
+
+## FR-013 / SC-007 - Jira Traceability
+
+Decision: `implemented_unverified`; preserve through downstream artifacts and final verification.
+Evidence: `specs/327-gate-resume-checkpoint-evidence/spec.md` preserves the MM-633 Jira preset brief verbatim; this plan, research, data model, contract, and quickstart reference MM-633.
+Rationale: Final verification must compare implementation against the original Jira brief.
+Alternatives considered: Storing only the issue key was rejected because final verification requires the original brief.
+Test implications: Final verification and artifact traceability check.
+
+## Test Tooling Strategy
+
+Decision: Use distinct unit and hermetic integration strategies.
+Evidence: Repo instructions define `./tools/test_unit.sh`, `./tools/test_unit.sh --ui-args <path>`, and `./tools/test_integration.sh`. Existing relevant tests live in `tests/unit/api/routers/test_executions.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/schemas/test_temporal_payload_policy.py`, `frontend/src/entrypoints/task-detail.test.tsx`, and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`.
+Rationale: Model and service validation are fast unit concerns, while source-ledger preservation and no-execution-on-invalid-evidence need boundary-level integration coverage.
+Alternatives considered: API-only tests were rejected because evidence gating spans schemas, artifact hydration, service creation, step ledger, and UI availability.
+Test implications: Write failing unit tests first for each missing/partial evidence rule, then add hermetic integration coverage for the complete valid path and at least one invalid-evidence path.

--- a/specs/327-gate-resume-checkpoint-evidence/spec.md
+++ b/specs/327-gate-resume-checkpoint-evidence/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Gate Resume on Durable Checkpoint Evidence
+
+**Feature Branch**: `327-gate-resume-checkpoint-evidence`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-633 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-633 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-633
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Gate Resume on durable checkpoint evidence
+- Labels: moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; related custom fields `Implementation plan`, `Backout plan`, and `Test plan` were present but empty.
+- Trusted response artifact: `/work/agent_jobs/mm:be31223e-5ff3-4a5b-a8ef-b41922d005eb/artifacts/moonspec-inputs/MM-633-trusted-jira-get-issue-expanded.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-633 from MM project
+Summary: Gate Resume on durable checkpoint evidence
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-633 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-633: Gate Resume on durable checkpoint evidence
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 5.7 Failed-task recovery orchestration
+- 7.3 Resume from failed step
+- 8.5 Resume checkpoint responsibilities
+- 11 Invariants
+Coverage IDs:
+- DESIGN-REQ-013
+- DESIGN-REQ-016
+
+As an operator, I want Resume offered only when MoonMind can prove the failed step and completed work are recoverable from pinned run evidence.
+
+Acceptance Criteria
+- Resume eligibility is computed by the backend, not inferred by UI.
+- Eligibility requires original snapshot, pinned source workflowId/runId, failed-step ledger identity, completed-step refs, workspace/branch/commit checkpoint, and plan identity/digest.
+- Checkpoint creation and writes are idempotent.
+- Large or binary checkpoint content remains behind refs.
+- Resume requests fail explicitly before execution when evidence is missing, stale, unauthorized, corrupted, or inconsistent.
+
+Requirements
+- Resume requires backend evidence: snapshot, pinned workflow/run IDs, failed-step ledger state, completed outputs, checkpoint, and plan identity.
+- Missing, stale, unauthorized, corrupted, or inconsistent resume evidence must block Resume or fail before execution, never full-rerun silently.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Runtime decision: Jira Orchestrate always runs as a runtime implementation workflow, and `docs/Tasks/TaskArchitecture.md` is treated as runtime source requirements.
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-633 Jira preset brief defines one operator story with one recovery eligibility goal, bounded evidence requirements, and explicit failure behavior.
+- Resume decision: No existing Moon Spec artifact set for `MM-633` was found under `specs/`; specification was the first incomplete stage.
+
+## User Story - Evidence-Gated Resume Eligibility
+
+**Summary**: As an operator recovering from a failed task, I want Resume to be offered only when MoonMind can prove the failed step and completed prior work are recoverable from durable, pinned evidence so that a resume attempt never silently falls back to an unsafe full rerun or partial reconstruction.
+
+**Goal**: Failed-step Resume is gated by backend-verified evidence for the original task snapshot, pinned source workflow and run, failed-step identity, completed-step refs, workspace or branch checkpoint, and plan identity before the action is exposed or executed.
+
+**Independent Test**: Create failed task recovery cases with complete, missing, stale, unauthorized, corrupted, and inconsistent resume evidence; verify that only complete evidence enables Resume, that valid Resume requests carry pinned source and checkpoint identity, and that invalid requests fail before execution with an operator-readable reason while preserving large or binary content behind refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a failed task has a complete original snapshot, pinned source workflow and run, failed-step ledger identity, completed-step refs, checkpoint, and plan identity, **When** backend recovery eligibility is evaluated, **Then** Resume is eligible and the eligibility result identifies the durable evidence used.
+2. **Given** a failed task lacks any required resume evidence, **When** backend recovery eligibility is evaluated, **Then** Resume is not eligible and the result explains the missing evidence without relying on UI inference.
+3. **Given** a Resume request is submitted with missing, stale, unauthorized, corrupted, or inconsistent evidence, **When** execution would otherwise start, **Then** the request fails explicitly before executing the failed step.
+4. **Given** completed prior steps have recoverable output refs and workspace or branch checkpoint evidence, **When** Resume eligibility is computed, **Then** those steps may be preserved by ref rather than re-executed.
+5. **Given** completed prior steps have large or binary checkpoint content, **When** checkpoint evidence is recorded or evaluated, **Then** large or binary content remains behind durable refs and is not embedded in workflow history or inline eligibility payloads.
+6. **Given** checkpoint creation or checkpoint writes are retried, **When** the same recovery boundary is processed again, **Then** checkpoint records remain idempotent and continue to identify the same recoverable state.
+7. **Given** plan identity or digest does not match the failed source run, **When** Resume eligibility is evaluated or a Resume request is submitted, **Then** Resume is blocked before execution as inconsistent evidence.
+
+### Edge Cases
+
+- The original task input snapshot exists, but the source `workflowId` or `runId` is missing or no longer matches the failed run.
+- The failed-step ledger contains no single last failed step or contains a step identity that does not belong to the plan graph.
+- A completed step succeeded but has no durable output refs or no recoverable workspace or branch checkpoint.
+- A checkpoint ref points to content that is unavailable, unauthorized for the requester, corrupted, or inconsistent with the source run.
+- The plan identity or digest changed between the source run and the resume attempt.
+- A checkpoint write is retried after an activity or workflow task retry.
+- The recovery surface receives a stale eligibility result after source run evidence has changed.
+
+## Assumptions
+
+- This story covers backend Resume eligibility, durable evidence gating, and pre-execution rejection behavior; detailed Resume execution after a valid checkpoint is loaded remains bounded to the adjacent failed-step Resume execution story.
+- Existing authorization rules for task details, artifacts, and execution recovery apply to all resume evidence reads.
+- Evidence refs are operator-visible enough to support diagnostics, but the spec does not require exposing large checkpoint contents inline.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: `docs/Tasks/TaskArchitecture.md` section 5.7, lines 206-224): Resume eligibility must be computed by the backend and require an authoritative original snapshot, pinned source workflow/run identity, failed-step ledger identity, completed-step refs, checkpoint state, plan identity, and explicit rejection when required evidence is missing, stale, unauthorized, or inconsistent. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-011.
+- **DESIGN-REQ-002** (Source: `docs/Tasks/TaskArchitecture.md` section 7.3, lines 397-450): Resume must pin the source execution, identify the last failed step, create or resolve a checkpoint containing completed-step refs and workspace or branch state, preserve prior progress instead of re-executing it, and fail before executing when restoration evidence is incomplete, corrupted, unauthorized, or inconsistent. Scope: in scope for eligibility and pre-execution gating; detailed resumed execution of later steps is out of scope. Maps to FR-001, FR-003, FR-004, FR-005, FR-006, FR-007, FR-011, FR-012.
+- **DESIGN-REQ-003** (Source: `docs/Tasks/TaskArchitecture.md` section 8.5, lines 502-512): The execution plane must record prepared input refs, bounded step state, semantic output refs, workspace or branch checkpoints, idempotent checkpoint writes, and external refs for large or binary checkpoint content; steps without recoverable refs or checkpoints are not eligible for preservation. Scope: in scope. Maps to FR-004, FR-007, FR-008, FR-009, FR-010.
+- **DESIGN-REQ-004** (Source: `docs/Tasks/TaskArchitecture.md` section 11, lines 574-624): System invariants require snapshot-based durability, explicit recovery intent, unchanged original inputs for Resume, checkpointed progress before Resume is offered, no silent re-execution of preserved steps, and pinned source workflow/run identity. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-006, FR-011, FR-012, FR-013.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Resume eligibility MUST be computed by backend recovery logic rather than inferred by the UI.
+- **FR-002**: Resume eligibility MUST require an authoritative original task input snapshot for the failed source execution.
+- **FR-003**: Resume eligibility MUST require pinned source `workflowId` and `runId` values for the failed source execution.
+- **FR-004**: Resume eligibility MUST require a failed-step ledger identity that uniquely identifies the last failed step in the source run's planned step graph.
+- **FR-005**: Resume eligibility MUST require durable refs for every completed step that would be preserved before the failed step.
+- **FR-006**: Resume eligibility MUST require a workspace, branch, commit, or equivalent checkpoint representing recoverable state immediately before the failed step.
+- **FR-007**: Resume eligibility MUST require a plan identity or digest proving that preserved progress belongs to the same planned step graph.
+- **FR-008**: Checkpoint creation and checkpoint writes MUST be idempotent across activity and workflow retries.
+- **FR-009**: Large or binary checkpoint content MUST remain behind durable refs and MUST NOT be embedded inline in workflow history, eligibility payloads, or task input text.
+- **FR-010**: A completed step without recoverable output refs or state checkpoint evidence MUST NOT be eligible for Resume preservation.
+- **FR-011**: Resume requests MUST fail explicitly before executing the failed step when required evidence is missing, stale, unauthorized, corrupted, or inconsistent.
+- **FR-012**: Resume recovery MUST NOT silently fall back to full rerun behavior when evidence validation fails.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-633` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Failed Source Execution**: The original failed task run whose workflow and run identity must be pinned for Resume.
+- **Original Task Input Snapshot**: The authoritative immutable task input captured for the source execution.
+- **Failed-Step Ledger Identity**: The durable identity of the last failed step within the planned step graph.
+- **Completed-Step Refs**: Durable refs for outputs and bounded state produced by steps before the failed step.
+- **Resume Checkpoint**: The recoverable state record that binds source execution, plan identity, completed-step refs, prepared inputs, and workspace or branch state.
+- **Plan Identity**: A stable plan identifier or digest used to prove preserved progress belongs to the same planned step graph.
+- **Resume Eligibility Result**: Backend-computed availability and diagnostic state explaining whether Resume can be offered or must be blocked.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of eligibility evaluations in the test matrix are computed from backend evidence fields rather than UI-only state.
+- **SC-002**: 100% of valid Resume-eligible cases include original snapshot, pinned workflow/run IDs, failed-step identity, completed-step refs, checkpoint state, and plan identity.
+- **SC-003**: 100% of missing, stale, unauthorized, corrupted, or inconsistent evidence cases block Resume or fail before execution with an operator-readable reason.
+- **SC-004**: 0 invalid Resume requests silently become full reruns or re-execute preserved prior steps.
+- **SC-005**: 100% of checkpoint retry scenarios preserve idempotent checkpoint identity and do not duplicate or corrupt evidence.
+- **SC-006**: 0 large or binary checkpoint payloads are embedded inline in workflow history, eligibility payloads, or task input text during validation.
+- **SC-007**: Traceability review confirms `MM-633`, the canonical Jira preset brief, and source coverage IDs DESIGN-REQ-013 and DESIGN-REQ-016 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/327-gate-resume-checkpoint-evidence/tasks.md
+++ b/specs/327-gate-resume-checkpoint-evidence/tasks.md
@@ -26,9 +26,9 @@
 
 **Purpose**: Confirm the active artifact set and test targets before writing red-first tests.
 
-- [ ] T001 Confirm `specs/327-gate-resume-checkpoint-evidence/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-evidence.md`, and `quickstart.md` are present and all preserve MM-633 traceability. (FR-013, SC-007)
-- [ ] T002 Confirm the one-story scope by checking `specs/327-gate-resume-checkpoint-evidence/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-007)
-- [ ] T003 Identify current focused test targets and fixtures in `tests/unit/api/routers/test_executions.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/schemas/test_temporal_payload_policy.py`, `frontend/src/entrypoints/task-detail.test.tsx`, and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`. (FR-001 through FR-012)
+- [X] T001 Confirm `specs/327-gate-resume-checkpoint-evidence/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-evidence.md`, and `quickstart.md` are present and all preserve MM-633 traceability. (FR-013, SC-007)
+- [X] T002 Confirm the one-story scope by checking `specs/327-gate-resume-checkpoint-evidence/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-007)
+- [X] T003 Identify current focused test targets and fixtures in `tests/unit/api/routers/test_executions.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/schemas/test_temporal_payload_policy.py`, `frontend/src/entrypoints/task-detail.test.tsx`, and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`. (FR-001 through FR-012)
 
 ---
 
@@ -38,9 +38,9 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T004 [P] Add or extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for complete evidence, missing workspace checkpoint, missing plan identity, missing preserved refs, source mismatch, stale plan, corrupted payload, and inline large content cases. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-009, FR-011)
-- [ ] T005 [P] Add or extend API execution record/checkpoint artifact fixtures in `tests/unit/api/routers/test_executions.py` for complete evidence and every bounded disabled reason from `specs/327-gate-resume-checkpoint-evidence/contracts/resume-evidence.md`. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011)
-- [ ] T006 [P] Add or extend integration step-ledger fixture helpers in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for completed prior steps with and without recoverable output refs and workspace checkpoint refs. (FR-004, FR-005, FR-010, DESIGN-REQ-002, DESIGN-REQ-003)
+- [X] T004 [P] Add or extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for complete evidence, missing workspace checkpoint, missing plan identity, missing preserved refs, source mismatch, stale plan, corrupted payload, and inline large content cases. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-009, FR-011)
+- [X] T005 [P] Add or extend API execution record/checkpoint artifact fixtures in `tests/unit/api/routers/test_executions.py` for complete evidence and every bounded disabled reason from `specs/327-gate-resume-checkpoint-evidence/contracts/resume-evidence.md`. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011)
+- [X] T006 [P] Add or extend integration step-ledger fixture helpers in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for completed prior steps with and without recoverable output refs and workspace checkpoint refs. (FR-004, FR-005, FR-010, DESIGN-REQ-002, DESIGN-REQ-003)
 - [ ] T007 [P] Add or extend Task Detail UI mock payload helpers in `frontend/src/entrypoints/task-detail.test.tsx` for backend-provided `actions.canResumeFromFailedStep`, `disabledReasons.canResumeFromFailedStep`, and `resume.disabledReason`. (FR-001, SCN-002)
 
 **Checkpoint**: Test fixtures are ready; story tests and implementation work can now begin.
@@ -72,49 +72,49 @@
 
 > Write these tests FIRST. Run them and confirm they fail for the expected reason before production implementation.
 
-- [ ] T008 [P] Add failing API unit tests for backend-only Resume eligibility and disabled-reason matrix in `tests/unit/api/routers/test_executions.py`. Cover complete evidence, missing snapshot, missing checkpoint, missing failed-step identity, missing completed refs, missing workspace checkpoint, missing plan identity, and stale/inconsistent evidence. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002, SC-001, SC-002, SC-003, DESIGN-REQ-001)
-- [ ] T009 [P] Add failing service/model unit tests for `ResumeCheckpointModel` and `TemporalExecutionService.create_failed_step_resume_execution()` in `tests/unit/workflows/temporal/test_temporal_service.py`. Cover required workspace checkpoint, required plan identity, source workflow/run mismatch, snapshot mismatch, failed-step identity validation, preserved-step refs, and no `create_execution()` call on invalid evidence. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-002, DESIGN-REQ-004)
-- [ ] T010 [P] Add failing checkpoint payload policy tests in `tests/schemas/test_temporal_payload_policy.py` or an adjacent schema test to accept compact checkpoint refs and reject inline large or binary checkpoint payload bodies. (FR-009, SCN-005, SC-006, DESIGN-REQ-003)
+- [X] T008 [P] Add failing API unit tests for backend-only Resume eligibility and disabled-reason matrix in `tests/unit/api/routers/test_executions.py`. Cover complete evidence, missing snapshot, missing checkpoint, missing failed-step identity, missing completed refs, missing workspace checkpoint, missing plan identity, and stale/inconsistent evidence. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002, SC-001, SC-002, SC-003, DESIGN-REQ-001)
+- [X] T009 [P] Add failing service/model unit tests for `ResumeCheckpointModel` and `TemporalExecutionService.create_failed_step_resume_execution()` in `tests/unit/workflows/temporal/test_temporal_service.py`. Cover required workspace checkpoint, required plan identity, source workflow/run mismatch, snapshot mismatch, failed-step identity validation, preserved-step refs, and no `create_execution()` call on invalid evidence. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-002, DESIGN-REQ-004)
+- [X] T010 [P] Add failing checkpoint payload policy tests in `tests/schemas/test_temporal_payload_policy.py` or an adjacent schema test to accept compact checkpoint refs and reject inline large or binary checkpoint payload bodies. (FR-009, SCN-005, SC-006, DESIGN-REQ-003)
 - [ ] T011 [P] Add failing Task Detail UI tests in `frontend/src/entrypoints/task-detail.test.tsx` verifying Resume button visibility and unavailable reason text come only from backend `actions.canResumeFromFailedStep`, `disabledReasons`, and `resume.disabledReason`. (FR-001, SCN-002, SC-001)
-- [ ] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and confirm T008-T010 fail for the expected evidence-gating reasons before production changes. (FR-001 through FR-012)
+- [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and confirm T008-T010 fail for the expected evidence-gating reasons before production changes. (FR-001 through FR-012)
 - [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T011 fails for the expected backend-eligibility display reason before production changes. (FR-001, SCN-002)
 
 ### Integration Tests (write first) ⚠️
 
-- [ ] T014 [P] Add failing hermetic integration test for complete Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving complete snapshot, pinned source IDs, failed-step identity, completed-step refs, workspace checkpoint, and plan identity allow preservation and unblock the failed step. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SCN-001, SCN-004, SC-002, DESIGN-REQ-001, DESIGN-REQ-002)
-- [ ] T015 [P] Add failing hermetic integration test for invalid Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving missing or inconsistent evidence blocks before creating a resumed execution and never silently falls back to full rerun. (FR-011, FR-012, SCN-003, SC-003, SC-004, DESIGN-REQ-004)
+- [X] T014 [P] Add failing hermetic integration test for complete Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving complete snapshot, pinned source IDs, failed-step identity, completed-step refs, workspace checkpoint, and plan identity allow preservation and unblock the failed step. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SCN-001, SCN-004, SC-002, DESIGN-REQ-001, DESIGN-REQ-002)
+- [X] T015 [P] Add failing hermetic integration test for invalid Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving missing or inconsistent evidence blocks before creating a resumed execution and never silently falls back to full rerun. (FR-011, FR-012, SCN-003, SC-003, SC-004, DESIGN-REQ-004)
 - [ ] T016 [P] Add failing hermetic integration test for idempotent checkpoint writes in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` or a new adjacent `integration_ci` test file if the checkpoint write boundary belongs outside the step-ledger helper. (FR-008, SCN-006, SC-005, DESIGN-REQ-003)
 - [ ] T017 Run `./tools/test_integration.sh` and confirm T014-T016 fail for the expected missing evidence-gating and checkpoint-idempotency reasons before production changes. (FR-001 through FR-012)
 
 ### Red-First Confirmation
 
-- [ ] T018 Record the expected failing unit test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
-- [ ] T019 Record the expected failing integration test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
+- [X] T018 Record the expected failing unit test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
+- [X] T019 Record the expected failing integration test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
 
 ### Fallback Verification Tasks for Implemented-Unverified Rows
 
-- [ ] T020 If T008/T009 show current snapshot or source identity checks already satisfy FR-002 or FR-003, mark only the relevant validation subtask complete and skip redundant implementation for those checks; otherwise keep T022-T026 in scope. (FR-002, FR-003)
-- [ ] T021 If T009/T015 prove invalid Resume already creates no execution and no full rerun fallback, preserve that evidence and skip redundant fallback work for FR-012; otherwise keep T030 in scope. (FR-012)
+- [X] T020 If T008/T009 show current snapshot or source identity checks already satisfy FR-002 or FR-003, mark only the relevant validation subtask complete and skip redundant implementation for those checks; otherwise keep T022-T026 in scope. (FR-002, FR-003)
+- [X] T021 If T009/T015 prove invalid Resume already creates no execution and no full rerun fallback, preserve that evidence and skip redundant fallback work for FR-012; otherwise keep T030 in scope. (FR-012)
 
 ### Implementation
 
-- [ ] T022 Update Resume checkpoint schema validation in `moonmind/schemas/temporal_models.py` to require plan identity and workspace/branch/commit checkpoint evidence, preserve compact refs, and keep task mutation fields forbidden. (FR-006, FR-007, FR-009, DESIGN-REQ-002, DESIGN-REQ-003)
-- [ ] T023 Update preserved-step evidence modeling in `moonmind/schemas/temporal_models.py` to represent required state checkpoint evidence for preserved completed steps without embedding large or binary content. (FR-005, FR-009, FR-010, DESIGN-REQ-003)
-- [ ] T024 Add or update compact checkpoint payload validation in `moonmind/schemas/temporal_payload_policy.py` or the chosen checkpoint validation boundary so inline large/binary Resume checkpoint content is rejected while artifact refs pass. (FR-009, SC-006)
-- [ ] T025 Implement backend Resume eligibility evaluation in `api_service/api/routers/executions.py` or a shared service helper so `canResumeFromFailedStep` and `resume.disabledReason` require the full evidence bundle before the action is exposed. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002)
-- [ ] T026 Update checkpoint hydration and submission failure mapping in `api_service/api/routers/executions.py` so missing, stale, unauthorized, corrupted, inconsistent, workspace-missing, plan-missing, and completed-ref-missing evidence return bounded operator-readable reasons. (FR-011, SCN-003, SC-003)
-- [ ] T027 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to validate the complete evidence bundle against the source execution before calling `create_execution()`. (FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
-- [ ] T028 Add source ledger and preserved-step completeness checks in `moonmind/workflows/temporal/step_ledger.py` or the service boundary selected by T027 so completed prior steps without recoverable refs or state evidence are not eligible for preservation. (FR-004, FR-005, FR-010, SCN-004)
+- [X] T022 Update Resume checkpoint schema validation in `moonmind/schemas/temporal_models.py` to require plan identity and workspace/branch/commit checkpoint evidence, preserve compact refs, and keep task mutation fields forbidden. (FR-006, FR-007, FR-009, DESIGN-REQ-002, DESIGN-REQ-003)
+- [X] T023 Update preserved-step evidence modeling in `moonmind/schemas/temporal_models.py` to represent required state checkpoint evidence for preserved completed steps without embedding large or binary content. (FR-005, FR-009, FR-010, DESIGN-REQ-003)
+- [X] T024 Add or update compact checkpoint payload validation in `moonmind/schemas/temporal_payload_policy.py` or the chosen checkpoint validation boundary so inline large/binary Resume checkpoint content is rejected while artifact refs pass. (FR-009, SC-006)
+- [X] T025 Implement backend Resume eligibility evaluation in `api_service/api/routers/executions.py` or a shared service helper so `canResumeFromFailedStep` and `resume.disabledReason` require the full evidence bundle before the action is exposed. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002)
+- [X] T026 Update checkpoint hydration and submission failure mapping in `api_service/api/routers/executions.py` so missing, stale, unauthorized, corrupted, inconsistent, workspace-missing, plan-missing, and completed-ref-missing evidence return bounded operator-readable reasons. (FR-011, SCN-003, SC-003)
+- [X] T027 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to validate the complete evidence bundle against the source execution before calling `create_execution()`. (FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
+- [X] T028 Add source ledger and preserved-step completeness checks in `moonmind/workflows/temporal/step_ledger.py` or the service boundary selected by T027 so completed prior steps without recoverable refs or state evidence are not eligible for preservation. (FR-004, FR-005, FR-010, SCN-004)
 - [ ] T029 Implement idempotent Resume checkpoint write/create behavior at the workflow or service boundary in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/service.py`, or a new focused helper under `moonmind/workflows/temporal/`, using deterministic source workflow/run and failed-step identity. (FR-008, SCN-006, SC-005, DESIGN-REQ-003)
-- [ ] T030 Add explicit guardrails in `moonmind/workflows/temporal/service.py` ensuring invalid Resume evidence never creates a resumed execution and never calls any full-rerun path. (FR-012, SC-004, DESIGN-REQ-004)
+- [X] T030 Add explicit guardrails in `moonmind/workflows/temporal/service.py` ensuring invalid Resume evidence never creates a resumed execution and never calls any full-rerun path. (FR-012, SC-004, DESIGN-REQ-004)
 - [ ] T031 Update generated or handwritten frontend/API types only if response schemas or bounded disabled reasons change, including `frontend/src/generated/openapi.ts` when the repository's OpenAPI generation flow requires it. (FR-001, FR-011)
 - [ ] T032 Update Task Detail display behavior in `frontend/src/entrypoints/task-detail.tsx` only if T011 proves the UI is inferring eligibility or not showing backend disabled reasons correctly. (FR-001, SCN-002)
 
 ### Story Validation
 
-- [ ] T033 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and make T008-T010 pass. (FR-001 through FR-012)
+- [X] T033 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and make T008-T010 pass. (FR-001 through FR-012)
 - [ ] T034 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and make T011 pass if UI work was needed. (FR-001, SCN-002)
-- [ ] T035 Run `./tools/test_integration.sh` and make T014-T016 pass or record the exact blocker if the managed environment cannot run Docker-backed integration tests. (FR-001 through FR-012)
+- [X] T035 Run `./tools/test_integration.sh` and make T014-T016 pass or record the exact blocker if the managed environment cannot run Docker-backed integration tests. (FR-001 through FR-012)
 - [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after focused tests pass. (FR-001 through FR-013)
 - [ ] T037 Validate the story against `specs/327-gate-resume-checkpoint-evidence/quickstart.md`, confirming complete evidence enables Resume and invalid evidence blocks before execution without full-rerun fallback. (FR-001 through FR-013, SC-001 through SC-007)
 
@@ -201,3 +201,20 @@ Task: "Add failing integration invalid-evidence test in tests/integration/workfl
 - Tasks marked `[P]` are safe to run in parallel because they touch separate files and do not depend on incomplete task output.
 - This task list intentionally includes conditional fallback implementation tasks for implemented-unverified rows; skip only when the new verification tests prove existing behavior already satisfies the requirement.
 - Do not create commits, pull requests, Jira transitions, or implementation changes during task generation.
+
+## Implementation Notes
+
+- Red-first unit confirmation before production changes:
+  - `test_describe_execution_requires_complete_resume_evidence[...]` failed because `actions.canResumeFromFailedStep` was still true with incomplete evidence.
+  - `test_resume_checkpoint_model_requires_plan_identity`, `test_resume_checkpoint_model_requires_workspace_checkpoint`, and `test_resume_checkpoint_model_requires_preserved_step_state_checkpoint` failed because checkpoint evidence fields were optional.
+  - `test_resume_checkpoint_rejects_large_inline_workspace_content` failed because checkpoint workspace metadata accepted large inline content.
+- Red-first integration confirmation before production changes:
+  - `test_failed_step_resume_preserves_prior_steps_and_unblocks_failed_step` failed because preserved ledger rows did not carry `stateCheckpointRef`.
+  - `test_failed_step_resume_rejects_preserved_step_without_state_checkpoint` failed because missing state checkpoint evidence did not block preservation.
+- Post-implementation verification:
+  - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` passed before the final additional focused guardrail tests.
+  - `pytest tests/unit/api/routers/test_executions.py -q --tb=short -k "resume"` passed: 8 passed.
+  - `pytest tests/unit/workflows/temporal/test_temporal_service.py -q --tb=short -k "resume_checkpoint or failed_step_resume"` passed: 10 passed.
+  - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/schemas/test_temporal_payload_policy.py` passed: 7 Python tests passed; the runner also executed the frontend unit suite, 20 files passed with 324 passed and 225 skipped.
+  - `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` passed: 2 passed.
+  - `./tools/test_integration.sh` was blocked in this managed environment by Docker/daemon access: `403 Forbidden` from administrative rules after compose attempted to build `repo-pytest`.

--- a/specs/327-gate-resume-checkpoint-evidence/tasks.md
+++ b/specs/327-gate-resume-checkpoint-evidence/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: Gate Resume on Durable Checkpoint Evidence
+
+**Input**: Design documents from `specs/327-gate-resume-checkpoint-evidence/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/resume-evidence.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped around one independently testable story: Evidence-Gated Resume Eligibility.
+
+**Source Traceability**: MM-633 and the original Jira preset brief are preserved in `spec.md`. Tasks cover FR-001 through FR-013, acceptance scenarios 1-7, edge cases, SC-001 through SC-007, and DESIGN-REQ-001 through DESIGN-REQ-004.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Focused UI tests when Task Detail display changes: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and has no dependency on incomplete work
+- Each task includes exact file paths and requirement, scenario, or source IDs when applicable
+- This task list covers exactly one story and must not add hidden scope beyond MM-633
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active artifact set and test targets before writing red-first tests.
+
+- [ ] T001 Confirm `specs/327-gate-resume-checkpoint-evidence/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-evidence.md`, and `quickstart.md` are present and all preserve MM-633 traceability. (FR-013, SC-007)
+- [ ] T002 Confirm the one-story scope by checking `specs/327-gate-resume-checkpoint-evidence/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-007)
+- [ ] T003 Identify current focused test targets and fixtures in `tests/unit/api/routers/test_executions.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/schemas/test_temporal_payload_policy.py`, `frontend/src/entrypoints/task-detail.test.tsx`, and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`. (FR-001 through FR-012)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prepare reusable test fixtures and evidence helpers before story tests and implementation.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T004 [P] Add or extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for complete evidence, missing workspace checkpoint, missing plan identity, missing preserved refs, source mismatch, stale plan, corrupted payload, and inline large content cases. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-009, FR-011)
+- [ ] T005 [P] Add or extend API execution record/checkpoint artifact fixtures in `tests/unit/api/routers/test_executions.py` for complete evidence and every bounded disabled reason from `specs/327-gate-resume-checkpoint-evidence/contracts/resume-evidence.md`. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011)
+- [ ] T006 [P] Add or extend integration step-ledger fixture helpers in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for completed prior steps with and without recoverable output refs and workspace checkpoint refs. (FR-004, FR-005, FR-010, DESIGN-REQ-002, DESIGN-REQ-003)
+- [ ] T007 [P] Add or extend Task Detail UI mock payload helpers in `frontend/src/entrypoints/task-detail.test.tsx` for backend-provided `actions.canResumeFromFailedStep`, `disabledReasons.canResumeFromFailedStep`, and `resume.disabledReason`. (FR-001, SCN-002)
+
+**Checkpoint**: Test fixtures are ready; story tests and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Evidence-Gated Resume Eligibility
+
+**Summary**: As an operator recovering from a failed task, I want Resume offered only when MoonMind can prove the failed step and completed prior work are recoverable from durable, pinned evidence.
+
+**Independent Test**: Create failed task recovery cases with complete, missing, stale, unauthorized, corrupted, and inconsistent resume evidence; verify that only complete evidence enables Resume, invalid evidence fails before execution, and large or binary checkpoint content remains behind refs.
+
+**Traceability**: FR-001 through FR-013; acceptance scenarios 1-7; SC-001 through SC-007; DESIGN-REQ-001 through DESIGN-REQ-004.
+
+**Unit Test Plan**:
+
+- API route/action capability tests for complete evidence, missing evidence, bounded disabled reasons, and no UI inference.
+- Temporal service/model tests for source identity, failed-step identity, preserved refs, workspace checkpoint, plan identity, compact refs, and no fallback execution.
+- Payload policy/schema tests for checkpoint-specific compact refs and inline large/binary rejection.
+- UI tests verifying Task Detail follows backend action and disabled-reason fields.
+
+**Integration Test Plan**:
+
+- Hermetic workflow/step-ledger test for valid evidence materializing preserved steps.
+- Hermetic invalid-evidence test proving Resume blocks before creating a follow-up execution or full rerun fallback.
+- Hermetic idempotent checkpoint write test when checkpoint recording is implemented at a workflow/service boundary.
+
+### Unit Tests (write first) ⚠️
+
+> Write these tests FIRST. Run them and confirm they fail for the expected reason before production implementation.
+
+- [ ] T008 [P] Add failing API unit tests for backend-only Resume eligibility and disabled-reason matrix in `tests/unit/api/routers/test_executions.py`. Cover complete evidence, missing snapshot, missing checkpoint, missing failed-step identity, missing completed refs, missing workspace checkpoint, missing plan identity, and stale/inconsistent evidence. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002, SC-001, SC-002, SC-003, DESIGN-REQ-001)
+- [ ] T009 [P] Add failing service/model unit tests for `ResumeCheckpointModel` and `TemporalExecutionService.create_failed_step_resume_execution()` in `tests/unit/workflows/temporal/test_temporal_service.py`. Cover required workspace checkpoint, required plan identity, source workflow/run mismatch, snapshot mismatch, failed-step identity validation, preserved-step refs, and no `create_execution()` call on invalid evidence. (FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-002, DESIGN-REQ-004)
+- [ ] T010 [P] Add failing checkpoint payload policy tests in `tests/schemas/test_temporal_payload_policy.py` or an adjacent schema test to accept compact checkpoint refs and reject inline large or binary checkpoint payload bodies. (FR-009, SCN-005, SC-006, DESIGN-REQ-003)
+- [ ] T011 [P] Add failing Task Detail UI tests in `frontend/src/entrypoints/task-detail.test.tsx` verifying Resume button visibility and unavailable reason text come only from backend `actions.canResumeFromFailedStep`, `disabledReasons`, and `resume.disabledReason`. (FR-001, SCN-002, SC-001)
+- [ ] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and confirm T008-T010 fail for the expected evidence-gating reasons before production changes. (FR-001 through FR-012)
+- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T011 fails for the expected backend-eligibility display reason before production changes. (FR-001, SCN-002)
+
+### Integration Tests (write first) ⚠️
+
+- [ ] T014 [P] Add failing hermetic integration test for complete Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving complete snapshot, pinned source IDs, failed-step identity, completed-step refs, workspace checkpoint, and plan identity allow preservation and unblock the failed step. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SCN-001, SCN-004, SC-002, DESIGN-REQ-001, DESIGN-REQ-002)
+- [ ] T015 [P] Add failing hermetic integration test for invalid Resume evidence in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, proving missing or inconsistent evidence blocks before creating a resumed execution and never silently falls back to full rerun. (FR-011, FR-012, SCN-003, SC-003, SC-004, DESIGN-REQ-004)
+- [ ] T016 [P] Add failing hermetic integration test for idempotent checkpoint writes in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` or a new adjacent `integration_ci` test file if the checkpoint write boundary belongs outside the step-ledger helper. (FR-008, SCN-006, SC-005, DESIGN-REQ-003)
+- [ ] T017 Run `./tools/test_integration.sh` and confirm T014-T016 fail for the expected missing evidence-gating and checkpoint-idempotency reasons before production changes. (FR-001 through FR-012)
+
+### Red-First Confirmation
+
+- [ ] T018 Record the expected failing unit test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
+- [ ] T019 Record the expected failing integration test names and failure reasons in `specs/327-gate-resume-checkpoint-evidence/tasks.md` notes or implementation handoff comments before changing production code. (FR-001 through FR-012)
+
+### Fallback Verification Tasks for Implemented-Unverified Rows
+
+- [ ] T020 If T008/T009 show current snapshot or source identity checks already satisfy FR-002 or FR-003, mark only the relevant validation subtask complete and skip redundant implementation for those checks; otherwise keep T022-T026 in scope. (FR-002, FR-003)
+- [ ] T021 If T009/T015 prove invalid Resume already creates no execution and no full rerun fallback, preserve that evidence and skip redundant fallback work for FR-012; otherwise keep T030 in scope. (FR-012)
+
+### Implementation
+
+- [ ] T022 Update Resume checkpoint schema validation in `moonmind/schemas/temporal_models.py` to require plan identity and workspace/branch/commit checkpoint evidence, preserve compact refs, and keep task mutation fields forbidden. (FR-006, FR-007, FR-009, DESIGN-REQ-002, DESIGN-REQ-003)
+- [ ] T023 Update preserved-step evidence modeling in `moonmind/schemas/temporal_models.py` to represent required state checkpoint evidence for preserved completed steps without embedding large or binary content. (FR-005, FR-009, FR-010, DESIGN-REQ-003)
+- [ ] T024 Add or update compact checkpoint payload validation in `moonmind/schemas/temporal_payload_policy.py` or the chosen checkpoint validation boundary so inline large/binary Resume checkpoint content is rejected while artifact refs pass. (FR-009, SC-006)
+- [ ] T025 Implement backend Resume eligibility evaluation in `api_service/api/routers/executions.py` or a shared service helper so `canResumeFromFailedStep` and `resume.disabledReason` require the full evidence bundle before the action is exposed. (FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-011, SCN-001, SCN-002)
+- [ ] T026 Update checkpoint hydration and submission failure mapping in `api_service/api/routers/executions.py` so missing, stale, unauthorized, corrupted, inconsistent, workspace-missing, plan-missing, and completed-ref-missing evidence return bounded operator-readable reasons. (FR-011, SCN-003, SC-003)
+- [ ] T027 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to validate the complete evidence bundle against the source execution before calling `create_execution()`. (FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004)
+- [ ] T028 Add source ledger and preserved-step completeness checks in `moonmind/workflows/temporal/step_ledger.py` or the service boundary selected by T027 so completed prior steps without recoverable refs or state evidence are not eligible for preservation. (FR-004, FR-005, FR-010, SCN-004)
+- [ ] T029 Implement idempotent Resume checkpoint write/create behavior at the workflow or service boundary in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/service.py`, or a new focused helper under `moonmind/workflows/temporal/`, using deterministic source workflow/run and failed-step identity. (FR-008, SCN-006, SC-005, DESIGN-REQ-003)
+- [ ] T030 Add explicit guardrails in `moonmind/workflows/temporal/service.py` ensuring invalid Resume evidence never creates a resumed execution and never calls any full-rerun path. (FR-012, SC-004, DESIGN-REQ-004)
+- [ ] T031 Update generated or handwritten frontend/API types only if response schemas or bounded disabled reasons change, including `frontend/src/generated/openapi.ts` when the repository's OpenAPI generation flow requires it. (FR-001, FR-011)
+- [ ] T032 Update Task Detail display behavior in `frontend/src/entrypoints/task-detail.tsx` only if T011 proves the UI is inferring eligibility or not showing backend disabled reasons correctly. (FR-001, SCN-002)
+
+### Story Validation
+
+- [ ] T033 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/schemas/test_temporal_payload_policy.py` and make T008-T010 pass. (FR-001 through FR-012)
+- [ ] T034 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and make T011 pass if UI work was needed. (FR-001, SCN-002)
+- [ ] T035 Run `./tools/test_integration.sh` and make T014-T016 pass or record the exact blocker if the managed environment cannot run Docker-backed integration tests. (FR-001 through FR-012)
+- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after focused tests pass. (FR-001 through FR-013)
+- [ ] T037 Validate the story against `specs/327-gate-resume-checkpoint-evidence/quickstart.md`, confirming complete evidence enables Resume and invalid evidence blocks before execution without full-rerun fallback. (FR-001 through FR-013, SC-001 through SC-007)
+
+**Checkpoint**: The story is functionally complete, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding scope beyond MM-633.
+
+- [ ] T038 [P] Review `specs/327-gate-resume-checkpoint-evidence/data-model.md` and `contracts/resume-evidence.md` against the final implementation; update only if behavior changed during implementation. (FR-013, SC-007)
+- [ ] T039 [P] Review operator-facing error text and logs in `api_service/api/routers/executions.py` and `moonmind/workflows/temporal/service.py` to ensure no raw checkpoint payloads, credentials, or large/binary content are emitted. (FR-009, FR-011, DESIGN-REQ-003)
+- [ ] T040 [P] Review compatibility-sensitive payload changes in `moonmind/schemas/temporal_models.py` and `moonmind/workflows/temporal/service.py`; document any required explicit cutover notes in `specs/327-gate-resume-checkpoint-evidence/research.md` or `plan.md` if in-flight compatibility cannot be preserved. (DESIGN-REQ-001 through DESIGN-REQ-004)
+- [ ] T041 Preserve MM-633 and the original Jira preset brief in implementation notes, verification output, commit text, and pull request metadata. (FR-013, SC-007)
+- [ ] T042 Run `/moonspec-verify` after implementation and tests pass, validating against `specs/327-gate-resume-checkpoint-evidence/spec.md`, `plan.md`, `tasks.md`, and the preserved MM-633 Jira preset brief. (FR-001 through FR-013, SC-001 through SC-007, DESIGN-REQ-001 through DESIGN-REQ-004)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; start immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks story tests and implementation.
+- **Story (Phase 3)**: Depends on Phase 2; tests must be written and confirmed red before production changes.
+- **Polish & Verification (Phase 4)**: Depends on story implementation and tests passing.
+
+### Within The Story
+
+- Unit tests T008-T011 must be written before implementation.
+- Red-first confirmations T012-T019 must complete before production changes T022-T032.
+- Integration tests T014-T016 must be written before implementation and confirmed red by T017.
+- Schema/model changes T022-T024 should happen before service/API changes T025-T030.
+- Backend service/API changes T025-T030 should happen before frontend type/display changes T031-T032.
+- Story validation T033-T037 must pass before polish and `/moonspec-verify`.
+
+### Parallel Opportunities
+
+- T004-T007 can run in parallel because they touch different test fixture files.
+- T008-T011 can run in parallel after foundational fixtures are ready because they touch different test files.
+- T014-T016 can run in parallel because they cover distinct integration scenarios.
+- T038-T040 can run in parallel after story validation because they review different files.
+
+## Parallel Example: Story Test Authoring
+
+```bash
+Task: "Add failing API eligibility matrix tests in tests/unit/api/routers/test_executions.py"
+Task: "Add failing service/model evidence tests in tests/unit/workflows/temporal/test_temporal_service.py"
+Task: "Add failing checkpoint payload policy tests in tests/schemas/test_temporal_payload_policy.py"
+Task: "Add failing integration invalid-evidence test in tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py"
+```
+
+## Implementation Strategy
+
+1. Complete setup and fixture tasks T001-T007.
+2. Write unit tests T008-T011 and integration tests T014-T016 before production changes.
+3. Run T012, T013, T017 and confirm expected red-first failures.
+4. Apply fallback decisions T020-T021 for implemented-unverified rows based on verification evidence.
+5. Implement schema, payload, eligibility, service, ledger, idempotency, API, and UI changes T022-T032.
+6. Run focused unit, UI, and integration validation T033-T035.
+7. Run full unit validation and quickstart story validation T036-T037.
+8. Complete polish and final `/moonspec-verify` tasks T038-T042.
+
+## Coverage Matrix
+
+| Requirement / Scenario | Test Tasks | Implementation / Validation Tasks |
+| --- | --- | --- |
+| FR-001, SCN-001, SC-001, DESIGN-REQ-001 | T008, T011, T014 | T025, T032, T033-T037 |
+| FR-002 | T008, T009, T014 | T020, T025, T027, T033-T037 |
+| FR-003 | T009, T014 | T020, T027, T033-T037 |
+| FR-004, SCN-004 | T008, T009, T014 | T025, T027, T028, T033-T037 |
+| FR-005, FR-010 | T008, T009, T014 | T023, T027, T028, T033-T037 |
+| FR-006 | T008, T009, T014 | T022, T025, T027, T033-T037 |
+| FR-007, SCN-007 | T008, T009, T014 | T022, T025, T027, T033-T037 |
+| FR-008, SCN-006, SC-005 | T016, T017 | T029, T035, T037 |
+| FR-009, SCN-005, SC-006, DESIGN-REQ-003 | T010 | T022-T024, T039 |
+| FR-011, SCN-002, SCN-003, SC-003 | T008, T009, T011, T015 | T025-T027, T032, T033-T037 |
+| FR-012, SC-004, DESIGN-REQ-004 | T009, T015 | T021, T030, T035, T037 |
+| FR-013, SC-007 | T001, T002 | T038, T041, T042 |
+
+## Notes
+
+- Tasks marked `[P]` are safe to run in parallel because they touch separate files and do not depend on incomplete task output.
+- This task list intentionally includes conditional fallback implementation tasks for implemented-unverified rows; skip only when the new verification tests prove existing behavior already satisfies the requirement.
+- Do not create commits, pull requests, Jira transitions, or implementation changes during task generation.

--- a/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -34,6 +34,7 @@ def test_failed_step_resume_preserves_prior_steps_and_unblocks_failed_step() -> 
                 "status": "succeeded",
                 "sourceAttempt": 1,
                 "artifacts": {"outputSummary": "artifact://prepare-summary"},
+                "stateCheckpointRef": "artifact://workspace/prepare",
             }
         ],
         updated_at=now,
@@ -42,4 +43,35 @@ def test_failed_step_resume_preserves_prior_steps_and_unblocks_failed_step() -> 
 
     assert rows[0]["preservedFrom"]["workflowId"] == "mm:source"
     assert rows[0]["artifacts"]["outputSummary"] == "artifact://prepare-summary"
+    assert rows[0]["stateCheckpointRef"] == "artifact://workspace/prepare"
     assert rows[1]["status"] == "ready"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_failed_step_resume_rejects_preserved_step_without_state_checkpoint() -> None:
+    now = datetime.now(UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {"id": "prepare", "title": "Prepare"},
+            {"id": "implement", "title": "Implement"},
+        ],
+        dependency_map={"implement": ["prepare"]},
+        updated_at=now,
+    )
+
+    with pytest.raises(ValueError, match="state checkpoint"):
+        materialize_preserved_steps(
+            rows,
+            source_workflow_id="mm:source",
+            source_run_id="run-source",
+            preserved_steps=[
+                {
+                    "logicalStepId": "prepare",
+                    "status": "succeeded",
+                    "sourceAttempt": 1,
+                    "artifacts": {"outputSummary": "artifact://prepare-summary"},
+                }
+            ],
+            updated_at=now,
+        )

--- a/tests/schemas/test_temporal_payload_policy.py
+++ b/tests/schemas/test_temporal_payload_policy.py
@@ -8,7 +8,10 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionState,
     CodexManagedSessionTurnResponse,
 )
-from moonmind.schemas.temporal_models import IntegrationCallbackRequest
+from moonmind.schemas.temporal_models import (
+    IntegrationCallbackRequest,
+    ResumeCheckpointModel,
+)
 from moonmind.schemas.temporal_payload_policy import (
     MAX_TEMPORAL_METADATA_STRING_CHARS,
     compact_temporal_ref_metadata,
@@ -79,3 +82,25 @@ def test_external_event_provider_summary_accepts_compact_refs() -> None:
     )
 
     assert signal.provider_summary == {"resultRef": "art-result", "status": "done"}
+
+
+def test_resume_checkpoint_rejects_large_inline_workspace_content() -> None:
+    with pytest.raises(ValidationError, match="store large payloads in artifacts"):
+        ResumeCheckpointModel.model_validate(
+            {
+                "schemaVersion": "v1",
+                "source": {"workflowId": "mm:source", "runId": "run-source"},
+                "taskInputSnapshotRef": "artifact://snapshot",
+                "planDigest": "sha256:plan",
+                "failedStep": {
+                    "logicalStepId": "implement",
+                    "order": 2,
+                    "attempt": 1,
+                },
+                "resumeWorkspace": {
+                    "branch": "feature",
+                    "commit": "abc123",
+                    "inlineDiff": "x" * (MAX_TEMPORAL_METADATA_STRING_CHARS + 1),
+                },
+            }
+        )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -20,6 +20,7 @@ from api_service.api.routers.executions import (
     _get_service,
     _artifact_id_from_ref,
     _merge_task_preserving_artifact_instructions,
+    _resume_not_available_reason,
     get_temporal_client,
     _serialize_execution,
     router,
@@ -38,6 +39,7 @@ from moonmind.workflows.temporal import (
     TemporalExecutionNotFoundError,
     TemporalExecutionValidationError,
 )
+from moonmind.workflows.temporal.artifacts import TemporalArtifactAuthorizationError
 from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProgressModel,
@@ -6454,6 +6456,57 @@ def test_failed_step_resume_hydrates_checkpoint_artifact(
     call_kwargs = mock_service.create_failed_step_resume_execution.await_args.kwargs
     assert call_kwargs["checkpoint_payload"] == checkpoint_payload
     assert call_kwargs["resume_checkpoint_ref"] is None
+
+
+def test_failed_step_resume_reports_checkpoint_authorization_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.memo = {
+        **canonical.memo,
+        "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+    }
+    mock_service.describe_execution.return_value = canonical
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(side_effect=TemporalArtifactAuthorizationError("denied"))
+    )
+
+    class Session:
+        async def get(self, model, key):
+            return canonical
+
+        async def commit(self):
+            return None
+
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: Session()
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/resume-from-failed-step",
+            json={"idempotencyKey": "resume-1"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["reason"] == "checkpoint_unauthorized"
+    mock_service.create_failed_step_resume_execution.assert_not_awaited()
+
+
+def test_resume_not_available_reason_prioritizes_mismatch_over_missing_plan() -> None:
+    reason = _resume_not_available_reason(
+        ValueError("Resume checkpoint plan identity does not match source execution.")
+    )
+
+    assert reason == "checkpoint_inconsistent"
 
 def test_temporal_task_editing_actions_require_run_workflow_and_feature_flag(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6239,6 +6239,9 @@ def test_describe_execution_exposes_failed_step_resume_distinct_from_lifecycle_r
         **record.memo,
         "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
         "resume_failed_step_id": "implement",
+        "resume_completed_step_refs": ["artifact://completed/plan"],
+        "resume_workspace_checkpoint_ref": "artifact://workspace/before-implement",
+        "resume_plan_digest": "sha256:resume-plan",
     }
     mock_service.describe_execution.return_value = record
     app.dependency_overrides[_get_service] = lambda: mock_service
@@ -6261,6 +6264,83 @@ def test_describe_execution_exposes_failed_step_resume_distinct_from_lifecycle_r
     )
     assert body["resume"]["failedStepId"] == "implement"
     assert body["resume"]["sourceRunId"] == "run-2"
+
+
+@pytest.mark.parametrize(
+    ("memo_updates", "expected_reason"),
+    [
+        (
+            {
+                "resume_failed_step_id": "implement",
+                "resume_completed_step_refs": ["artifact://completed/plan"],
+                "resume_workspace_checkpoint_ref": "artifact://workspace/before-implement",
+                "resume_plan_digest": "sha256:resume-plan",
+            },
+            "resume_checkpoint_missing",
+        ),
+        (
+            {
+                "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+                "resume_completed_step_refs": ["artifact://completed/plan"],
+                "resume_workspace_checkpoint_ref": "artifact://workspace/before-implement",
+                "resume_plan_digest": "sha256:resume-plan",
+            },
+            "failed_step_identity_missing",
+        ),
+        (
+            {
+                "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+                "resume_failed_step_id": "implement",
+                "resume_workspace_checkpoint_ref": "artifact://workspace/before-implement",
+                "resume_plan_digest": "sha256:resume-plan",
+            },
+            "completed_step_refs_missing",
+        ),
+        (
+            {
+                "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+                "resume_failed_step_id": "implement",
+                "resume_completed_step_refs": ["artifact://completed/plan"],
+                "resume_plan_digest": "sha256:resume-plan",
+            },
+            "workspace_checkpoint_missing",
+        ),
+        (
+            {
+                "resume_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+                "resume_failed_step_id": "implement",
+                "resume_completed_step_refs": ["artifact://completed/plan"],
+                "resume_workspace_checkpoint_ref": "artifact://workspace/before-implement",
+            },
+            "plan_identity_missing",
+        ),
+    ],
+)
+def test_describe_execution_requires_complete_resume_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    memo_updates: dict[str, object],
+    expected_reason: str,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.memo = {**record.memo, **memo_updates}
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(settings.temporal_dashboard, "temporal_task_editing_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["actions"]["canResumeFromFailedStep"] is False
+    assert body["resume"]["available"] is False
+    assert body["resume"]["disabledReason"] == expected_reason
 
 def test_failed_step_resume_request_rejects_edited_task_payload_fields() -> None:
     app = FastAPI()
@@ -6319,10 +6399,27 @@ def test_failed_step_resume_hydrates_checkpoint_artifact(
         "schemaVersion": "v1",
         "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
         "taskInputSnapshotRef": "artifact://snapshot/source",
+        "planRef": "artifact://plan/source",
+        "planDigest": "sha256:resume-plan",
         "failedStep": {
             "logicalStepId": "implement",
             "order": 2,
             "attempt": 1,
+        },
+        "preservedSteps": [
+            {
+                "logicalStepId": "plan",
+                "order": 1,
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {"summary": "artifact://completed/plan"},
+                "stateCheckpointRef": "artifact://workspace/before-implement",
+            }
+        ],
+        "resumeWorkspace": {
+            "branch": "feature/resume",
+            "commit": "abc123",
+            "checkpointRef": "artifact://workspace/before-implement",
         },
     }
     artifact_service = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2398,6 +2398,50 @@ async def test_failed_step_resume_rejects_checkpoint_plan_mismatch(
                 checkpoint_payload=payload,
             )
 
+
+@pytest.mark.asyncio
+async def test_failed_step_resume_rejects_checkpoint_plan_digest_mismatch(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="resume source",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "resume_checkpoint_ref": "artifact://checkpoint/source",
+            "resume_plan_digest": "sha256:source-plan",
+        }
+        await session.commit()
+
+        with pytest.raises(
+            TemporalExecutionResumeCheckpointError,
+            match="plan identity does not match",
+        ):
+            await service.create_failed_step_resume_execution(
+                created,
+                resume_checkpoint_ref=None,
+                idempotency_key="resume-1",
+                checkpoint_payload=_valid_resume_checkpoint_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                    snapshot_ref="artifact://snapshot/source",
+                ),
+            )
+
 @pytest.mark.asyncio
 async def test_request_rerun_bounds_fresh_execution_idempotency_key(
     tmp_path, mock_client_adapter

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -2041,29 +2042,93 @@ def _valid_resume_checkpoint_payload(
                 "status": "succeeded",
                 "sourceAttempt": 1,
                 "artifacts": {"outputSummary": "artifact://summary"},
+                "stateCheckpointRef": "artifact://workspace/before-plan",
             }
         ],
         "preparedArtifactRefs": ["artifact://prepared"],
         "resumeWorkspace": {"branch": "feature", "commit": "abc123"},
     }
 
-def test_resume_checkpoint_model_allows_empty_optional_resume_sections() -> None:
+def test_resume_checkpoint_model_requires_plan_identity() -> None:
+    with pytest.raises(ValidationError, match="plan identity"):
+        ResumeCheckpointModel.model_validate(
+            {
+                "schemaVersion": "v1",
+                "source": {"workflowId": "mm:source", "runId": "run-source"},
+                "taskInputSnapshotRef": "artifact://snapshot",
+                "failedStep": {
+                    "logicalStepId": "implement",
+                    "order": 2,
+                    "attempt": 1,
+                },
+                "resumeWorkspace": {"branch": "feature", "commit": "abc123"},
+            }
+        )
+
+
+def test_resume_checkpoint_model_requires_workspace_checkpoint() -> None:
+    with pytest.raises(ValidationError, match="workspace"):
+        ResumeCheckpointModel.model_validate(
+            {
+                "schemaVersion": "v1",
+                "source": {"workflowId": "mm:source", "runId": "run-source"},
+                "taskInputSnapshotRef": "artifact://snapshot",
+                "planDigest": "sha256:plan",
+                "failedStep": {
+                    "logicalStepId": "implement",
+                    "order": 2,
+                    "attempt": 1,
+                },
+            }
+        )
+
+
+def test_resume_checkpoint_model_requires_preserved_step_state_checkpoint() -> None:
+    with pytest.raises(ValidationError, match="state checkpoint"):
+        ResumeCheckpointModel.model_validate(
+            {
+                "schemaVersion": "v1",
+                "source": {"workflowId": "mm:source", "runId": "run-source"},
+                "taskInputSnapshotRef": "artifact://snapshot",
+                "planDigest": "sha256:plan",
+                "failedStep": {
+                    "logicalStepId": "implement",
+                    "order": 2,
+                    "attempt": 1,
+                },
+                "preservedSteps": [
+                    {
+                        "logicalStepId": "plan",
+                        "order": 1,
+                        "status": "succeeded",
+                        "sourceAttempt": 1,
+                        "artifacts": {"outputSummary": "artifact://summary"},
+                    }
+                ],
+                "resumeWorkspace": {"branch": "feature", "commit": "abc123"},
+            }
+        )
+
+
+def test_resume_checkpoint_model_accepts_complete_evidence() -> None:
     checkpoint = ResumeCheckpointModel.model_validate(
         {
             "schemaVersion": "v1",
             "source": {"workflowId": "mm:source", "runId": "run-source"},
             "taskInputSnapshotRef": "artifact://snapshot",
+            "planDigest": "sha256:plan",
             "failedStep": {
                 "logicalStepId": "implement",
                 "order": 2,
                 "attempt": 1,
             },
+            "resumeWorkspace": {"branch": "feature", "commit": "abc123"},
         }
     )
 
     assert checkpoint.preserved_steps == []
     assert checkpoint.prepared_artifact_refs == []
-    assert checkpoint.resume_workspace == {}
+    assert checkpoint.resume_workspace == {"branch": "feature", "commit": "abc123"}
 
 
 @pytest.mark.asyncio
@@ -2158,6 +2223,56 @@ async def test_failed_step_resume_requires_hydrated_checkpoint_payload(
 
 
 @pytest.mark.asyncio
+async def test_failed_step_resume_invalid_evidence_does_not_create_execution(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="resume source",
+            input_artifact_ref="artifact://input/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "resume_checkpoint_ref": "artifact://checkpoint/source",
+        }
+        await session.commit()
+
+        invalid_payload = _valid_resume_checkpoint_payload(
+            workflow_id=created.workflow_id,
+            run_id=created.run_id,
+            snapshot_ref="artifact://snapshot/source",
+        )
+        invalid_payload.pop("planDigest")
+        create_execution = AsyncMock(
+            side_effect=AssertionError("create_execution must not be called")
+        )
+        monkeypatch.setattr(service, "create_execution", create_execution)
+
+        with pytest.raises(TemporalExecutionResumeCheckpointError, match="invalid"):
+            await service.create_failed_step_resume_execution(
+                created,
+                resume_checkpoint_ref=None,
+                idempotency_key="resume-1",
+                checkpoint_payload=invalid_payload,
+            )
+
+        create_execution.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_failed_step_resume_rejects_noncanonical_checkpoint_ref(
     tmp_path, mock_client_adapter
 ):
@@ -2238,6 +2353,49 @@ async def test_failed_step_resume_rejects_checkpoint_run_mismatch(
                     run_id="stale-run-id",
                     snapshot_ref="artifact://snapshot/source",
                 ),
+            )
+
+
+@pytest.mark.asyncio
+async def test_failed_step_resume_rejects_checkpoint_plan_mismatch(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="resume source",
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "resume_checkpoint_ref": "artifact://checkpoint/source",
+        }
+        await session.commit()
+
+        payload = _valid_resume_checkpoint_payload(
+            workflow_id=created.workflow_id,
+            run_id=created.run_id,
+            snapshot_ref="artifact://snapshot/source",
+        )
+        payload["planRef"] = "artifact://plan/stale"
+
+        with pytest.raises(TemporalExecutionResumeCheckpointError, match="plan"):
+            await service.create_failed_step_resume_execution(
+                created,
+                resume_checkpoint_ref=None,
+                idempotency_key="resume-1",
+                checkpoint_payload=payload,
             )
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -31,6 +31,7 @@ def test_materialize_preserved_steps_marks_source_provenance_without_new_attempt
                 "status": "succeeded",
                 "sourceAttempt": 2,
                 "artifacts": {"outputSummary": "artifact://summary"},
+                "stateCheckpointRef": "artifact://workspace/before-plan",
             }
         ],
         updated_at=now,
@@ -46,4 +47,5 @@ def test_materialize_preserved_steps_marks_source_provenance_without_new_attempt
         "attempt": 2,
     }
     assert rows[0]["artifacts"]["outputSummary"] == "artifact://summary"
+    assert rows[0]["stateCheckpointRef"] == "artifact://workspace/before-plan"
     assert rows[1]["status"] == "ready"


### PR DESCRIPTION
## Summary

Implements MM-633 failed-step Resume evidence gating for backend availability, checkpoint validation, preserved-step state evidence, and bounded failure reasons.

## Jira

- Jira issue key: MM-633

## MoonSpec

- Active MoonSpec feature path: `specs/327-gate-resume-checkpoint-evidence`

## Verification Verdict

- MoonSpec verification verdict: ADDITIONAL_WORK_NEEDED
- Reason: the final verify pass found the implemented evidence-gating slice covered, but FR-008 checkpoint-write idempotency remains open and full-suite verification was blocked by environment constraints.

## Tests Run

- `pytest tests/unit/api/routers/test_executions.py -q --tb=short -k "resume"` - 8 passed
- `pytest tests/unit/workflows/temporal/test_temporal_service.py -q --tb=short -k "resume_checkpoint or failed_step_resume"` - 10 passed
- `pytest tests/schemas/test_temporal_payload_policy.py -q --tb=short` - 7 passed
- `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` - 2 passed

## Remaining Risks

- FR-008 checkpoint-write idempotency still needs implementation and integration coverage.
- Full `./tools/test_integration.sh` could not be completed in the managed environment because Docker returned a 403 administrative-rule error.
- Full-suite verification was blocked locally by active skill projection contamination on `.gemini/skills`.
