### PR TITLE
Fix deployment.update_compose_stack skill routing

### DIFF
--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -122,7 +122,7 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
             "selector": {"mode": "by_capability"},
         },
         "requirements": {
-            "capabilities": ["deployment_control", "docker_admin"],
+            "capabilities": ["docker_workload", "deployment_control", "docker_admin"],
         },
         "policies": {
             "timeouts": {

--- a/tests/unit/workflows/skills/test_deployment_tool_contracts.py
+++ b/tests/unit/workflows/skills/test_deployment_tool_contracts.py
@@ -75,7 +75,11 @@ def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
     assert definition.version == DEPLOYMENT_UPDATE_TOOL_VERSION
     assert definition.executor.activity_type == "mm.tool.execute"
     assert definition.executor.selector_mode == "by_capability"
-    assert definition.required_capabilities == ("deployment_control", "docker_admin")
+    assert definition.required_capabilities == (
+        "docker_workload",
+        "deployment_control",
+        "docker_admin",
+    )
     assert definition.allowed_roles == ("admin",)
     assert definition.policies.retries.max_attempts == 1
     assert definition.policies.retries.non_retryable_error_codes == (

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -752,6 +752,7 @@ async def test_default_skill_registry_payload_uses_curated_deployment_tool_defin
         "selector": {"mode": "by_capability"},
     }
     assert definition["requirements"]["capabilities"] == [
+        "docker_workload",
         "deployment_control",
         "docker_admin",
     ]
@@ -767,6 +768,7 @@ async def test_default_skill_registry_payload_uses_curated_deployment_tool_defin
         (DEPLOYMENT_UPDATE_TOOL_NAME, DEPLOYMENT_UPDATE_TOOL_VERSION)
     ]
     assert parsed[0].required_capabilities == (
+        "docker_workload",
         "deployment_control",
         "docker_admin",
     )


### PR DESCRIPTION
## Summary
- The `deployment.update_compose_stack` skill declared only policy capabilities (`deployment_control`, `docker_admin`), neither recognized as a routing capability by `_skill_route_family` (`moonmind/workflows/temporal/activity_catalog.py:124-160`). Every run failed pre-dispatch with `Skill definition must declare one routing capability` — observed on `mm:a7a61076-b6a0-4023-a7d9-b65a6cc127a8`, the "Update deployment stack moonmind" task.
- Added `docker_workload` as the first capability so the skill routes to `AGENT_RUNTIME_FLEET`, which is the fleet where `register_deployment_update_tool_handler()` actually lives. Policy capabilities are preserved unchanged — the router ignores unrecognized entries.
- Updated the two unit tests that assert the exact capability tuple/list.

## Test plan
- [x] `poetry run pytest tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/workflows/temporal/test_activity_runtime.py` (62 passed)
- [x] `poetry run pytest tests/unit/workflows/temporal/test_activity_catalog.py` (8 passed)
- [ ] Re-trigger the failing deployment update task and confirm it dispatches to the agent_runtime worker (no longer fails during skill resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)