### PR TITLE
MM-634 Execute resume from failed step only

### DIFF
--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -745,7 +745,7 @@ const StepLedgerRowSchema = z
       .object({
         workflowId: z.string(),
         runId: z.string(),
-        logicalStepId: z.string().optional(),
+        logicalStepId: z.string(),
         attempt: z.number(),
       })
       .passthrough()

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -745,6 +745,7 @@ const StepLedgerRowSchema = z
       .object({
         workflowId: z.string(),
         runId: z.string(),
+        logicalStepId: z.string().optional(),
         attempt: z.number(),
       })
       .passthrough()

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5370,6 +5370,8 @@ export interface components {
             workflowId: string;
             /** Runid */
             runId: string;
+            /** Logicalstepid */
+            logicalStepId: string;
             /** Attempt */
             attempt: number;
         };

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -576,7 +576,9 @@ class ResumeCheckpointModel(BaseModel):
     prepared_artifact_refs: list[str] = Field(
         default_factory=list, alias="preparedArtifactRefs"
     )
-    resume_workspace: dict[str, Any] = Field(default_factory=dict, alias="resumeWorkspace")
+    resume_workspace: dict[str, Any] = Field(
+        default_factory=dict, alias="resumeWorkspace"
+    )
 
     @field_validator("plan_ref", "plan_digest", mode="before")
     @classmethod
@@ -624,6 +626,9 @@ class ResumeSourceModel(BaseModel):
     failed_step_id: str = Field(..., alias="failedStepId", min_length=1)
     failed_step_attempt: int = Field(..., alias="failedStepAttempt", ge=1)
     resume_checkpoint_ref: str = Field(..., alias="resumeCheckpointRef", min_length=1)
+    resume_workspace: dict[str, Any] = Field(
+        default_factory=dict, alias="resumeWorkspace"
+    )
     preserved_steps: list[ResumeCheckpointPreservedStepModel] = Field(
         default_factory=list, alias="preservedSteps"
     )
@@ -1127,6 +1132,7 @@ class PreservedStepProvenanceModel(BaseModel):
 
     workflow_id: str = Field(..., alias="workflowId", min_length=1)
     run_id: str = Field(..., alias="runId", min_length=1)
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
     attempt: int = Field(..., alias="attempt", ge=1)
 
 class StepLedgerRowModel(BaseModel):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2697,7 +2697,7 @@ class TemporalExecutionService:
             failedStepAttempt=failed_step_attempt,
             resumeCheckpointRef=checkpoint_ref,
             resumeWorkspace=checkpoint.resume_workspace,
-            preservedSteps=(checkpoint.preserved_steps if checkpoint else []),
+            preservedSteps=checkpoint.preserved_steps,
         ).model_dump(by_alias=True, mode="json")
 
         task_params = params.get("task") if isinstance(params.get("task"), dict) else {}

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2696,6 +2696,7 @@ class TemporalExecutionService:
             failedStepId=failed_step_id,
             failedStepAttempt=failed_step_attempt,
             resumeCheckpointRef=checkpoint_ref,
+            resumeWorkspace=checkpoint.resume_workspace,
             preservedSteps=(checkpoint.preserved_steps if checkpoint else []),
         ).model_dump(by_alias=True, mode="json")
 

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -147,6 +147,7 @@ def materialize_preserved_steps(
         row["preservedFrom"] = {
             "workflowId": source_workflow_id,
             "runId": source_run_id,
+            "logicalStepId": logical_step_id,
             "attempt": source_attempt,
         }
         row["updatedAt"] = updated_at.isoformat()

--- a/specs/328-execute-resume-failed-step/checklists/requirements.md
+++ b/specs/328-execute-resume-failed-step/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Execute Resume From the Failed Step Only
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification defines one runtime story for `MM-634`, preserves the canonical Jira preset brief verbatim in `spec.md` `**Input**`, maps all in-scope source design requirements to functional requirements, and contains no clarification markers.

--- a/specs/328-execute-resume-failed-step/contracts/resume-execution.md
+++ b/specs/328-execute-resume-failed-step/contracts/resume-execution.md
@@ -1,0 +1,109 @@
+# Contract: Failed-Step Resume Execution
+
+## POST `/api/executions/{workflow_id}/resume-from-failed-step`
+
+Failed-step Resume creates a linked execution from a failed `MoonMind.Run` source.
+
+Request body:
+
+```json
+{
+  "idempotencyKey": "resume-1",
+  "resumeCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1"
+}
+```
+
+Rules:
+
+- The request must not include edited task instructions, steps, attachments, runtime, publish mode, branch, dependencies, or preset metadata.
+- The source execution must be failed and must identify an original task input snapshot.
+- The checkpoint ref must match the source execution's canonical checkpoint ref.
+- Checkpoint payload validation and restoration preconditions must pass before the new execution is created or before any step executes.
+
+Success response:
+
+```json
+{
+  "accepted": true,
+  "applied": "created_resumed_execution",
+  "source": {
+    "workflowId": "mm:source",
+    "runId": "source-run-id"
+  },
+  "execution": {
+    "workflowId": "mm:resumed",
+    "runId": "resumed-run-id",
+    "detailHref": "/tasks/mm:resumed"
+  },
+  "relationship": "Resumed from failed step",
+  "resumeCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1"
+}
+```
+
+Failure behavior:
+
+- Invalid source identity, snapshot identity, plan identity, checkpoint payload, workspace evidence, or preserved output evidence must return an operator-readable failure.
+- Invalid restoration must not create a full rerun.
+- Invalid restoration must not re-execute preserved prior steps.
+
+## Resumed Execution `resumeSource`
+
+The resumed execution parameters include compact Resume source metadata:
+
+```json
+{
+  "kind": "resume_from_failed_step",
+  "sourceWorkflowId": "mm:source",
+  "sourceRunId": "source-run-id",
+  "sourceTaskInputSnapshotRef": "artifact://snapshot/source",
+  "sourcePlanRef": "artifact://plan/source",
+  "sourcePlanDigest": "sha256:source-plan",
+  "failedStepId": "implement",
+  "failedStepAttempt": 1,
+  "resumeCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+  "preservedSteps": [
+    {
+      "logicalStepId": "prepare",
+      "order": 1,
+      "status": "succeeded",
+      "sourceAttempt": 1,
+      "artifacts": {
+        "outputSummary": "artifact://steps/prepare-summary"
+      },
+      "stateCheckpointRef": "artifact://workspace/before-prepare"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `preservedSteps` are imported as preserved progress only.
+- Preserved output refs must be available to the failed and downstream steps as continuous-run context.
+- The failed step named by `failedStepId` is the first newly executed step.
+
+## Step Row Preserved Provenance
+
+Step rows for resumed executions expose preserved provenance:
+
+```json
+{
+  "logicalStepId": "prepare",
+  "status": "succeeded",
+  "attempt": 0,
+  "summary": "Preserved from source run.",
+  "stateCheckpointRef": "artifact://workspace/before-prepare",
+  "preservedFrom": {
+    "workflowId": "mm:source",
+    "runId": "source-run-id",
+    "logicalStepId": "prepare",
+    "attempt": 1
+  }
+}
+```
+
+Rules:
+
+- Preserved rows must not be rendered as newly executed by the resumed run.
+- Preserved rows must carry source workflow ID, run ID, logical step ID, and attempt.
+- Newly executed failed and downstream steps must not carry `preservedFrom`.

--- a/specs/328-execute-resume-failed-step/data-model.md
+++ b/specs/328-execute-resume-failed-step/data-model.md
@@ -1,0 +1,106 @@
+# Data Model: Execute Resume From the Failed Step Only
+
+## Resumed Execution
+
+Represents the new execution created when a user chooses failed-step Resume.
+
+Fields:
+
+- `workflowId`: new resumed execution workflow identity.
+- `runId`: new resumed execution run identity when available.
+- `resumeSource`: compact source provenance and checkpoint metadata.
+- `parameters`: original source task parameters minus stale task-run identity fields.
+
+Validation rules:
+
+- Must be created only after checkpoint validation succeeds.
+- Must reuse the original task input snapshot.
+- Must not include edited task authoring fields supplied by the Resume request.
+- Must not be created when checkpoint validation or restoration fails.
+
+## Resume Source
+
+Compact provenance carried by the resumed execution.
+
+Fields:
+
+- `kind`: constant `resume_from_failed_step`.
+- `sourceWorkflowId`: failed source workflow ID.
+- `sourceRunId`: failed source run ID.
+- `sourceTaskInputSnapshotRef`: original source task input snapshot ref.
+- `sourcePlanRef`: source plan ref when available.
+- `sourcePlanDigest`: source plan digest when available.
+- `failedStepId`: logical ID of the failed step to retry.
+- `failedStepAttempt`: source failed-step attempt number.
+- `resumeCheckpointRef`: durable checkpoint evidence ref.
+- `preservedSteps[]`: completed prior steps to materialize as preserved progress.
+
+Validation rules:
+
+- Source workflow and run ID must match the checkpoint source.
+- Snapshot identity must match the source execution memo.
+- Plan identity or digest must match when source metadata exists.
+
+## Resume Checkpoint
+
+Durable evidence used to restore the resumed execution before new work begins.
+
+Fields:
+
+- `source`: source workflow ID and run ID.
+- `taskInputSnapshotRef`: original task input snapshot ref.
+- `planRef` or `planDigest`: plan identity evidence.
+- `failedStep`: logical ID, order, attempt, and optional title of the failed step.
+- `preservedSteps[]`: completed prior source steps that can be reused.
+- `preparedArtifactRefs[]`: prepared input refs available for reuse.
+- `resumeWorkspace`: compact workspace, branch, commit, or equivalent restoration evidence.
+
+Validation rules:
+
+- Must include plan identity or digest.
+- Must include workspace restoration evidence.
+- Must keep large or binary content behind refs.
+- Must fail validation when source, snapshot, plan, or failed-step identity is inconsistent.
+
+## Preserved Step
+
+A source-run completed step represented as reused progress in the resumed run.
+
+Fields:
+
+- `logicalStepId`: source logical step ID.
+- `order`: source step order.
+- `status`: terminal source status eligible for preservation.
+- `sourceAttempt`: source attempt number.
+- `artifacts`: compact output refs needed by downstream contracts.
+- `stateCheckpointRef`: state checkpoint ref for the preserved step boundary.
+- `preservedFrom`: operator-visible provenance on the resumed step row.
+
+Validation rules:
+
+- Must include at least one semantic artifact ref.
+- Must include state checkpoint evidence.
+- Must carry source workflow ID, source run ID, logical step ID, and attempt provenance.
+- Must not be newly executed by the resumed run.
+
+## Retried Failed Step
+
+The failed source step executed as the first new step in the resumed run.
+
+Validation rules:
+
+- Must not execute until checkpoint validation and workspace restoration have succeeded.
+- Must receive preserved outputs needed to match continuous-run contracts.
+- Must produce fresh resumed-run ledger rows, artifacts, and checkpoints.
+
+## State Transitions
+
+1. Failed source execution has valid checkpoint evidence.
+2. User submits failed-step Resume without editable task input.
+3. Service validates checkpoint source, snapshot, plan, failed-step identity, preserved refs, and workspace evidence.
+4. Resumed execution is created with `resumeSource`.
+5. `MoonMind.Run` restores workspace or equivalent runtime state before the failed step.
+6. Completed prior steps are materialized as preserved rows with provenance.
+7. Failed step is the first newly executed step.
+8. Later steps execute normally and produce fresh resumed-run evidence.
+9. Invalid validation or restoration fails explicitly before new step execution.

--- a/specs/328-execute-resume-failed-step/moonspec_align_report.md
+++ b/specs/328-execute-resume-failed-step/moonspec_align_report.md
@@ -5,7 +5,7 @@
 
 ## Result
 
-PASS. The generated Moon Spec artifacts describe exactly one runtime story, preserve the original Jira preset brief, and provide TDD-first task coverage for every functional requirement, success criterion, acceptance scenario, and in-scope source design requirement.
+ADDITIONAL_WORK_NEEDED. The generated Moon Spec artifacts describe exactly one runtime story, preserve the original Jira preset brief, and provide TDD-first task coverage for every functional requirement, success criterion, acceptance scenario, and in-scope source design requirement. Final MoonSpec verification for the PR still requires follow-up evidence and implementation for the remaining runtime resume gaps listed below.
 
 ## Checks
 
@@ -19,6 +19,8 @@ PASS. The generated Moon Spec artifacts describe exactly one runtime story, pres
 - Corrected the `plan.md` requirement status summary counts to match the Requirement Status table.
 - Corrected the `tasks.md` parallel task range typo from `T015-T18` to `T015-T018`.
 
-## Remaining Risks
+## Remaining Work
 
-- Implementation has not started. Workspace restoration, preserved logical-step provenance, preserved-output injection, failed-step-first ordering, and no preserved-step re-execution remain planned implementation/test work.
+- Runtime restoration from `resumeWorkspace` before the failed step still needs implementation/evidence.
+- Preserved output injection into retried and downstream step input context is only partially proven.
+- Full workflow evidence for failed-step-first execution, downstream fresh evidence, and no fallback/no preserved-step reexecution remains incomplete.

--- a/specs/328-execute-resume-failed-step/moonspec_align_report.md
+++ b/specs/328-execute-resume-failed-step/moonspec_align_report.md
@@ -1,0 +1,24 @@
+# MoonSpec Alignment Report: Execute Resume From the Failed Step Only
+
+**Source**: MM-634 canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-08
+
+## Result
+
+PASS. The generated Moon Spec artifacts describe exactly one runtime story, preserve the original Jira preset brief, and provide TDD-first task coverage for every functional requirement, success criterion, acceptance scenario, and in-scope source design requirement.
+
+## Checks
+
+- Specify gate: PASS. `spec.md` has exactly one `## User Story` section, no `[NEEDS CLARIFICATION]` markers, and preserves MM-634 in the `**Input**` block.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` exist and define unit plus integration strategy.
+- Tasks gate: PASS. `tasks.md` is one-story, TDD-first, includes unit and integration tests before implementation, includes red-first confirmation tasks, and ends with `/moonspec-verify`.
+- Traceability: PASS. FR-001 through FR-013, SC-001 through SC-008, DESIGN-REQ-001 through DESIGN-REQ-005, and original Jira source coverage IDs DESIGN-REQ-014 through DESIGN-REQ-017 remain represented.
+
+## Remediation Applied
+
+- Corrected the `plan.md` requirement status summary counts to match the Requirement Status table.
+- Corrected the `tasks.md` parallel task range typo from `T015-T18` to `T015-T018`.
+
+## Remaining Risks
+
+- Implementation has not started. Workspace restoration, preserved logical-step provenance, preserved-output injection, failed-step-first ordering, and no preserved-step re-execution remain planned implementation/test work.

--- a/specs/328-execute-resume-failed-step/plan.md
+++ b/specs/328-execute-resume-failed-step/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Execute Resume From the Failed Step Only
+
+**Branch**: `run-jira-orchestrate-for-mm-634-execute-r-7bdf3ad6` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/328-execute-resume-failed-step/spec.md`
+
+**Setup Note**: `.specify/scripts/bash/setup-plan.sh --json` was not used because this managed job branch name is not in the script's expected `NNN-feature-name` form. Planning proceeds from the active feature directory `specs/328-execute-resume-failed-step`.
+
+## Summary
+
+MM-634 requires failed-step Resume execution to reuse the original task input snapshot, validate checkpoint identity before execution, restore runtime state before the failed step, materialize completed prior steps as preserved source progress, retry the failed step first, and continue later steps normally without falling back to full rerun. Current code already has Resume request/response models, checkpoint payload validation, linked resumed execution creation, preserved-step materialization, and Task Detail display for preserved rows. The main gaps are boundary proof that workspace restoration is actually performed before the failed step, preserved provenance includes logical step identity, preserved outputs are used as continuous-run inputs, and invalid restoration cannot re-execute preserved steps or degrade to full rerun.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `TemporalExecutionService.create_failed_step_resume_execution()` carries source snapshot refs in `resumeSource`; Task Detail renders Resume action without opening Create authoring UI | Add tests proving Resume submission accepts only checkpoint refs and never opens or submits an editable authoring payload | unit + UI |
+| FR-002 | implemented_unverified | Service validates checkpoint workflow ID, run ID, task snapshot, and plan ref/digest before creating the resumed execution | Add explicit pre-execution boundary tests for all identity mismatches | unit + integration |
+| FR-003 | implemented_unverified | Service raises `TemporalExecutionResumeCheckpointError` before `create_execution()` for invalid checkpoint payloads; unit tests cover selected invalid evidence | Add complete restoration-failure matrix and assert no new execution is created | unit + integration |
+| FR-004 | missing | `ResumeCheckpointModel.resume_workspace` requires evidence, but no current execution-boundary proof shows workspace/branch/commit restoration before the failed step | Implement or expose runtime restoration from `resumeWorkspace` before first new step and test ordering | unit + integration |
+| FR-005 | implemented_unverified | `materialize_preserved_steps()` marks matching initial ledger rows as preserved and refreshes dependencies | Add end-to-end resumed-run test proving prior completed steps are not executed again | integration |
+| FR-006 | partial | Preserved rows carry source workflow ID, run ID, and attempt, but not the preserved logical step ID in `preservedFrom` | Add logical step ID to preserved provenance and update schema/tests/UI expectations if needed | unit + integration |
+| FR-007 | partial | Preserved artifact refs are copied onto ledger rows, but continuous-run output injection into failed/downstream step context is not proven | Add workflow/context tests proving failed and downstream steps receive preserved outputs | unit + integration |
+| FR-008 | partial | `refresh_ready_steps()` can unblock the failed step after preserved rows are materialized; integration tests cover a two-step ledger helper | Add workflow-level assertion that the failed step is the first newly executed step | integration |
+| FR-009 | implemented_unverified | Normal workflow progression should execute later ready steps after the failed step succeeds | Add resumed-run scenario proving later steps produce fresh resumed-run ledgers/artifacts/checkpoints | integration |
+| FR-010 | implemented_unverified | Invalid checkpoint validation errors before resumed execution creation; no full-rerun call path is present in the service method | Add explicit no-full-rerun/no-created-execution assertions for restoration failure cases | unit + integration |
+| FR-011 | partial | Preserved rows are materialized with attempt `0`, but no workflow boundary test proves preserved source rows are skipped by execution | Add a resumed-run test that preserved steps never enter running/executed states | integration |
+| FR-012 | implemented_unverified | Task Detail parses and renders `preservedFrom` for step rows | Add UI/API tests ensuring preserved rows are distinguished from newly executed resumed-run rows | unit + UI |
+| FR-013 | implemented_unverified | `spec.md` preserves MM-634 and this plan preserves source coverage | Preserve MM-634 through research, data model, contract, quickstart, tasks, implementation notes, verification, commit, and PR metadata | final verify |
+| SC-001 | implemented_unverified | Resume source carries original snapshot ref | Add authoring-form exclusion tests | unit + UI |
+| SC-002 | implemented_unverified | Service validates source and plan identity | Expand mismatch matrix | unit + integration |
+| SC-003 | missing | Resume workspace evidence is validated but not restored under tested execution ordering | Add runtime state restoration test before failed step | unit + integration |
+| SC-004 | partial | Preserved provenance lacks logical step ID | Add logical step provenance and tests | unit + integration |
+| SC-005 | partial | Preserved artifact refs are copied but not proven as execution inputs | Add context/output injection tests | unit + integration |
+| SC-006 | partial | Failed step becomes ready in helper tests | Add first-newly-executed-step workflow test | integration |
+| SC-007 | implemented_unverified | Invalid checkpoint validation errors before resumed execution creation | Add no-fallback/no-reexecution assertions | unit + integration |
+| SC-008 | implemented_unverified | `spec.md` and this plan preserve MM-634 and source IDs | Preserve traceability through all artifacts and final verification | final verify |
+| DESIGN-REQ-001 | partial | Distinct Resume workflow exists; no editable UI is present; restoration failure behavior needs broader proof | Strengthen boundary tests and restoration failure handling | unit + integration |
+| DESIGN-REQ-002 | partial | Source pinning, checkpoint model, and preserved progress exist; restored state and output injection are incomplete or unverified | Implement/test restoration and continuous-output injection | unit + integration |
+| DESIGN-REQ-003 | partial | `MoonMind.Run` initializes preserved ledger rows from `resumeSource`; restoration and fresh downstream checkpointing need proof | Add workflow-boundary tests and code as needed | integration |
+| DESIGN-REQ-004 | partial | Explicit recovery intent and no-fallback service behavior exist; no-reexecution proof is incomplete | Add preserved-step no-execution assertions | integration |
+| DESIGN-REQ-005 | partial | `MoonMind.Run` consumes resume source and materializes preserved steps; checkpoint durability/restoration ownership needs proof | Add `MoonMind.Run` boundary coverage | integration |
+
+Status summary: 2 missing, 12 partial, 12 implemented_unverified, 0 implemented_verified.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI where preserved-step display changes
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest
+**Storage**: Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned
+**Unit Testing**: `./tools/test_unit.sh`; focused Python tests under `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, and `tests/unit/api/routers/test_executions.py`; focused UI tests through `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` if display shape changes
+**Integration Testing**: `./tools/test_integration.sh`; targeted hermetic coverage under `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`
+**Target Platform**: MoonMind API service, `MoonMind.Run` workflow, Temporal execution service, and Mission Control task detail surface in the existing containerized deployment
+**Project Type**: Web service plus frontend dashboard with Temporal-backed orchestration
+**Performance Goals**: Resume startup remains bounded by checkpoint validation and state restoration; preserved refs stay compact and avoid large inline workflow payloads
+**Constraints**: Preserve in-flight Temporal payload compatibility or document explicit cutover; fail before executing on invalid restoration; never silently fall back to full rerun; never re-execute preserved prior steps without explicit future user intent
+**Scale/Scope**: One runtime story for `MoonMind.Run` failed-step Resume execution; excludes backend eligibility gating already covered by MM-633 except where execution requires validated checkpoint evidence.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The story strengthens MoonMind orchestration around existing agents rather than creating a new agent engine.
+- **II. One-Click Agent Deployment**: PASS. No new external service, secret, or deployment prerequisite is planned.
+- **III. Avoid Vendor Lock-In**: PASS. Resume execution state is MoonMind workflow state, not provider-specific behavior.
+- **IV. Own Your Data**: PASS. Resume evidence remains in MoonMind-owned records and artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime contract changes are planned.
+- **VI. Scaffolds Are Replaceable, Tests Are the Anchor**: PASS. The plan requires boundary tests before implementation changes.
+- **VII. Powerful Runtime Configurability**: PASS. No hardcoded external configuration is introduced.
+- **VIII. Modular and Extensible Architecture**: PASS. Planned work stays inside existing schema, service, workflow, ledger, API, and UI boundaries.
+- **IX. Resilient by Default**: PASS. The story improves deterministic recovery and no-fallback behavior.
+- **X. Facilitate Continuous Improvement**: PASS. Artifacts preserve outcome and traceability for verification.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Planning derives from the single-story spec.
+- **XII. Documentation Separation**: PASS. Planning artifacts stay under `specs/328-execute-resume-failed-step/`.
+- **XIII. Pre-Release Compatibility Policy**: PASS. Internal contracts may be tightened, with compatibility-sensitive Temporal payload changes covered by tests or explicit cutover notes.
+
+Re-check after Phase 1 design: PASS. `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/328-execute-resume-failed-step/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── resume-execution.md
+├── checklists/
+│   └── requirements.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── executions.py
+
+moonmind/
+├── schemas/
+│   └── temporal_models.py
+└── workflows/
+    └── temporal/
+        ├── service.py
+        ├── step_ledger.py
+        └── workflows/
+            └── run.py
+
+frontend/
+└── src/
+    └── entrypoints/
+        ├── task-detail.tsx
+        └── task-detail.test.tsx
+
+tests/
+├── unit/
+│   ├── api/routers/test_executions.py
+│   └── workflows/temporal/
+│       ├── test_temporal_service.py
+│       └── workflows/test_run_resume_from_failed_step.py
+└── integration/
+    └── workflows/temporal/workflows/test_run_resume_from_failed_step.py
+```
+
+**Structure Decision**: Use the existing Resume API, Temporal service, checkpoint schema, step ledger, `MoonMind.Run` workflow initialization, and Task Detail display surfaces. Add tests first around execution ordering, restored state, preserved provenance, and no re-execution before production changes.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/328-execute-resume-failed-step/quickstart.md
+++ b/specs/328-execute-resume-failed-step/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Execute Resume From the Failed Step Only
+
+## Source
+
+Use Jira issue `MM-634` and the canonical Jira preset brief preserved in `spec.md` as the source of truth.
+
+## Focused Verification
+
+1. Add or run unit tests for checkpoint validation and linked resumed execution creation:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py
+   ```
+
+2. Add or run unit tests for preserved-step ledger materialization:
+
+   ```bash
+   ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+   ```
+
+3. If Task Detail display or schema changes, run the focused UI test through the unit runner:
+
+   ```bash
+   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+   ```
+
+4. Add or run hermetic integration coverage for resumed-run ordering and no re-execution:
+
+   ```bash
+   pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short
+   ```
+
+5. Finish with the required full unit suite:
+
+   ```bash
+   ./tools/test_unit.sh
+   ```
+
+6. Finish with required hermetic integration verification when Docker is available:
+
+   ```bash
+   ./tools/test_integration.sh
+   ```
+
+## End-to-End Story Checks
+
+- Submit Resume with a valid checkpoint and verify the resumed execution uses the original snapshot unchanged.
+- Verify checkpoint source workflow ID, source run ID, snapshot identity, and plan identity are validated before any step executes.
+- Verify workspace, branch, commit, or equivalent runtime state is restored before retrying the failed step.
+- Verify prior completed source steps appear as preserved progress with source workflow ID, source run ID, logical step ID, and attempt.
+- Verify preserved outputs are available to the retried failed step and downstream steps.
+- Verify the failed step is the first newly executed step.
+- Verify downstream steps execute normally after the failed step succeeds and produce fresh resumed-run evidence.
+- Verify invalid restoration fails before execution, creates no full rerun, and does not re-execute preserved steps.
+
+## Final Verification Notes
+
+Final `/speckit.verify` must mention Jira issue `MM-634`, the preserved Jira preset brief in `spec.md`, FR-001 through FR-013, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-005.

--- a/specs/328-execute-resume-failed-step/research.md
+++ b/specs/328-execute-resume-failed-step/research.md
@@ -1,0 +1,89 @@
+# Research: Execute Resume From the Failed Step Only
+
+## Classification
+
+Decision: Single-story runtime feature request.
+Evidence: `specs/328-execute-resume-failed-step/spec.md` preserves MM-634 and defines exactly one `## User Story - Failed-Step Resume Execution`.
+Rationale: The Jira brief selects one operator outcome: Resume should preserve completed work, retry the failed step first, and continue later steps without input mutation or full-rerun fallback.
+Alternatives considered: Running `moonspec-breakdown` was rejected because the brief is already a bounded story.
+Test implications: Unit and integration tests are required.
+
+## Current Resume Execution Surface
+
+Decision: Reuse the existing Resume API, checkpoint schema, Temporal service, step ledger, and Task Detail surfaces.
+Evidence: `moonmind/schemas/temporal_models.py` defines `ResumeCheckpointModel`, `ResumeSourceModel`, and preserved-step models; `moonmind/workflows/temporal/service.py` creates linked resumed executions; `moonmind/workflows/temporal/step_ledger.py` materializes preserved rows; `moonmind/workflows/temporal/workflows/run.py` initializes preserved rows from `resumeSource`; `frontend/src/entrypoints/task-detail.tsx` renders `preservedFrom`.
+Rationale: The story is an execution correctness layer over already-introduced failed-step Resume contracts.
+Alternatives considered: Creating a new recovery workflow was rejected because `MoonMind.Run` is the canonical workflow for failed-step Resume.
+Test implications: Focus tests on existing boundaries instead of adding new public surfaces.
+
+## FR-001 Original Input And No Authoring Form
+
+Decision: Implemented but unverified.
+Evidence: `create_failed_step_resume_execution()` derives `resumeSource.sourceTaskInputSnapshotRef` from the failed source memo and creates a linked execution from existing source parameters; Task Detail submits Resume from the failed task surface instead of opening Create.
+Rationale: The behavior appears present, but the story needs explicit proof that no editable task payload is accepted or submitted.
+Alternatives considered: Marking verified was rejected because current evidence is scattered across service and UI tests.
+Test implications: Unit and UI tests.
+
+## FR-002 FR-003 Identity Validation And Pre-Execution Failure
+
+Decision: Implemented but unverified.
+Evidence: Service validation rejects checkpoint ref mismatch, workflow/run mismatch, snapshot mismatch, plan ref mismatch, plan digest mismatch, and invalid payloads before creating a new execution.
+Rationale: Validation is present, but integration coverage should prove these failures happen before any workflow step executes.
+Alternatives considered: Treating MM-633 eligibility tests as enough was rejected because MM-634 covers resumed execution behavior after eligibility.
+Test implications: Unit plus integration boundary tests.
+
+## FR-004 Workspace Restoration
+
+Decision: Missing.
+Evidence: `ResumeCheckpointModel.resume_workspace` requires compact workspace evidence, but current search found no tested `MoonMind.Run` restoration action before the failed step.
+Rationale: Validating evidence is not the same as restoring runtime state immediately before new work.
+Alternatives considered: Treating checkpoint presence as restoration was rejected because the acceptance criteria require runtime state restoration before retrying the failed step.
+Test implications: Unit/integration tests must fail first until restoration behavior is implemented or exposed.
+
+## FR-005 FR-006 Preserved Progress Provenance
+
+Decision: Partial.
+Evidence: `materialize_preserved_steps()` marks source rows preserved with source workflow ID, run ID, and attempt; current `preservedFrom` does not include the preserved logical step ID required by MM-634.
+Rationale: Preserved progress exists but provenance is incomplete for final traceability.
+Alternatives considered: Relying on the row's own `logicalStepId` was rejected because the provenance object should remain self-describing when rendered or exported.
+Test implications: Unit, integration, and possible UI type/schema tests.
+
+## FR-007 Preserved Output Injection
+
+Decision: Partial.
+Evidence: Preserved artifact refs are copied into ledger row artifacts, and dependency refresh can unblock the failed step. No current boundary test proves those artifacts are consumed by failed/downstream step context as continuous-run outputs.
+Rationale: Ledger representation alone does not prove runtime context delivery.
+Alternatives considered: Assuming context generation reads ledger artifacts was rejected because this story is explicitly about continuous-run contracts.
+Test implications: Unit/integration tests around context preparation or workflow step inputs.
+
+## FR-008 FR-009 Failed Step First And Downstream Progression
+
+Decision: Partial.
+Evidence: Helper tests show a two-step graph where a preserved first step unblocks the failed step; normal workflow progression should run later steps, but no full workflow test asserts execution order for resumed runs.
+Rationale: The story requires failed step as the first newly executed step and later steps as fresh resumed-run work.
+Alternatives considered: Treating `ready` status as enough was rejected because execution order must be proven at the workflow boundary.
+Test implications: Hermetic integration test.
+
+## FR-010 FR-011 No Full Rerun And No Preserved Re-Execution
+
+Decision: Partial.
+Evidence: Service invalid evidence paths do not call `create_execution()`, and preserved rows are marked with attempt `0`; however, workflow-level tests do not yet prove preserved rows never enter running/executed states.
+Rationale: No-fallback and no-reexecution are compatibility-sensitive recovery guarantees.
+Alternatives considered: Relying on code inspection was rejected because failures here can be expensive and destructive.
+Test implications: Unit and integration tests.
+
+## FR-012 Operator Progress Display
+
+Decision: Implemented but unverified.
+Evidence: Task Detail renders `Preserved from source run` when row `preservedFrom` is present.
+Rationale: The display exists, but should be refreshed if provenance shape gains logical step identity.
+Alternatives considered: No UI changes were planned unless data shape changes; this remains verification-first.
+Test implications: UI unit test if schema/display changes.
+
+## Traceability
+
+Decision: Preserve MM-634 and source design coverage through all artifacts.
+Evidence: `spec.md` and this research preserve the issue key and canonical Jira preset brief.
+Rationale: Final verification must compare implementation against the original Jira source.
+Alternatives considered: Storing only the issue key was rejected because `/speckit.verify` needs the preserved brief.
+Test implications: Final verification.

--- a/specs/328-execute-resume-failed-step/spec.md
+++ b/specs/328-execute-resume-failed-step/spec.md
@@ -1,0 +1,178 @@
+# Feature Specification: Execute Resume From the Failed Step Only
+
+**Feature Branch**: `328-execute-resume-failed-step`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-634 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-634 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-634
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Execute Resume from the failed step only
+- Priority: Medium
+- Labels: `moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; potentially related custom fields `Implementation plan`, `Backout plan`, `Test plan`, and `Source` were present but empty.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-634 from MM project
+Summary: Execute Resume from the failed step only
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-634 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-634: Execute Resume from the failed step only
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.6 Failed-step resume is not full rerun
+- 7.3 Resume from failed step
+- 8.6 Resume execution responsibilities
+- 11 Invariants
+- 12.1 MoonMind.Run
+
+Coverage IDs:
+- DESIGN-REQ-014
+- DESIGN-REQ-015
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+
+As a user pressing Resume, I want MoonMind to restore completed work, retry the last failed step, and continue later steps without silently rerunning preserved steps or changing original input.
+
+Acceptance Criteria:
+- Resume uses the original task input snapshot unchanged and exposes no editable authoring form in v1.
+- The resumed execution validates checkpoint source, snapshot, and plan identity before executing any step.
+- The runtime restores workspace/branch/commit state immediately before the failed step.
+- Completed prior steps are preserved with source workflowId, runId, logical step ID, and attempt provenance.
+- Preserved outputs are injected so failed and downstream steps observe continuous-run contracts.
+- The failed step is retried as the first newly executed step and later steps execute normally.
+- Restoration failure does not fall back to full rerun or re-execute preserved steps.
+
+Requirements:
+- Resume cannot edit or silently mutate instructions, steps, attachments, runtime, publish mode, branch, dependencies, or preset metadata.
+- A resumed execution imports completed prior steps, retries the failed step first, and continues later steps normally.
+- Missing, stale, unauthorized, corrupted, or inconsistent resume evidence must block Resume or fail before execution, never full-rerun silently.
+- MoonMind.Run owns progression, prepare orchestration, context generation, target-aware context delivery, ledgers, checkpoints, and full/resumed starts.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Runtime decision: Jira Orchestrate always runs as a runtime implementation workflow, and `docs/Tasks/TaskArchitecture.md` is treated as runtime source requirements.
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-634 Jira preset brief defines one user story with one recovery execution goal, bounded acceptance criteria, and explicit failure behavior.
+- Resume decision: No existing Moon Spec artifact set for `MM-634` was found under `specs/`; specification was the first incomplete stage.
+
+## User Story - Failed-Step Resume Execution
+
+**Summary**: As a user pressing Resume on a failed task, I want MoonMind to restore completed work, retry only the last failed step, and then continue later steps normally so that preserved prior work is not silently rerun and the original task input remains unchanged.
+
+**Goal**: A resumed execution validates its pinned checkpoint, restores the source run state immediately before the failed step, marks prior completed steps as preserved from the source run, retries the failed step as the first newly executed step, and proceeds through downstream steps without falling back to full rerun behavior.
+
+**Independent Test**: Start a Resume attempt from a failed task with complete checkpoint evidence, then verify the resumed run preserves prior completed steps with source provenance, restores the workspace or branch state before the failed step, injects preserved outputs into the retried step, executes the failed step first, continues later steps normally, and fails before execution rather than full-rerunning when restoration evidence is invalid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a failed task has a valid resume checkpoint for completed prior work and the last failed step, **When** the user presses Resume, **Then** the resumed execution starts from the original task input snapshot without presenting an editable authoring form.
+2. **Given** the resume checkpoint references a source workflow, source run, original snapshot, and plan identity, **When** the resumed execution starts, **Then** those identities are validated before any step executes.
+3. **Given** workspace, branch, commit, or equivalent runtime state was checkpointed immediately before the failed step, **When** the resumed execution starts, **Then** the runtime restores that state before retrying the failed step.
+4. **Given** completed steps exist before the failed step, **When** the resumed execution records progress, **Then** those steps are marked as preserved from the source run with source workflow ID, run ID, logical step ID, and attempt provenance.
+5. **Given** preserved completed steps produced outputs needed by later steps, **When** the failed step and downstream steps execute, **Then** preserved outputs are injected so those steps observe the same contracts as a continuous run.
+6. **Given** the failed step is identified by the source run's ledger, **When** the resumed execution begins new work, **Then** the failed step is retried as the first newly executed step and later steps execute normally after it succeeds.
+7. **Given** checkpoint validation or restoration fails because evidence is missing, stale, unauthorized, corrupted, or inconsistent, **When** Resume is attempted, **Then** execution fails explicitly before the failed step and does not fall back to full rerun or re-execute preserved prior steps.
+
+### Edge Cases
+
+- The resume request references a source workflow ID without the matching source run ID.
+- The source run's original task input snapshot does not match the checkpoint's snapshot reference.
+- The plan identity or digest in the checkpoint differs from the plan used to identify the failed step.
+- Workspace, branch, commit, or equivalent runtime state cannot be restored before the failed step.
+- A preserved prior step lacks output refs needed by the failed or downstream steps.
+- The failed step succeeds on retry, but a later downstream step fails and must be recorded as fresh resumed-run work rather than source-run preserved work.
+- A restoration failure occurs after checkpoint validation but before the first newly executed step starts.
+
+## Assumptions
+
+- Backend eligibility and durable checkpoint creation are handled by the adjacent evidence-gating story; this story covers what the resumed execution does after a checkpoint is selected.
+- Existing task, artifact, and execution authorization rules apply to resume checkpoint reads and preserved output injection.
+- Resume v1 is intentionally not an edit flow; any task input change requires an edited full retry instead.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: `docs/Tasks/TaskArchitecture.md` section 3.6, lines 101-109): Resume is a distinct failed-task recovery workflow that does not open an authoring form, retries the last failed step using the original task input and durable completed work, never silently edits task input metadata, and must be unavailable or fail explicitly when prior work cannot be restored faithfully. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-010, FR-011, FR-012.
+- **DESIGN-REQ-002** (Source: `docs/Tasks/TaskArchitecture.md` section 7.3, lines 397-415): Resume must pin source workflow and run identity, identify the last failed step, use a checkpoint containing completed-step output refs, prepared input refs, and workspace or branch state, import prior steps as preserved progress, retry the failed step as a new attempt, continue later steps normally, and fail before execution when evidence is incomplete, corrupted, unauthorized, or inconsistent. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012.
+- **DESIGN-REQ-003** (Source: `docs/Tasks/TaskArchitecture.md` section 8.6, lines 515-534): `MoonMind.Run` owns checkpoint validation, source identity verification, workspace restoration, preserved-step marking, preserved-output injection, failed-step retry, fresh ledgers for retried and later steps, no fallback to full rerun, and provenance for preserved rows. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012.
+- **DESIGN-REQ-004** (Source: `docs/Tasks/TaskArchitecture.md` section 11, lines 574-624): System invariants require explicit recovery intent, unchanged original inputs for Resume, checkpointed progress, no silent re-execution of preserved steps, and pinned source workflow/run identity. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-009, FR-010, FR-011, FR-012.
+- **DESIGN-REQ-005** (Source: `docs/Tasks/TaskArchitecture.md` section 12.1, lines 630-637): `MoonMind.Run` is the canonical workflow that produces step ledger state and resume checkpoints, may start at a failed step when given a validated resume checkpoint, and owns checkpoint durability even when step execution delegates to child workflows. Scope: in scope. Maps to FR-002, FR-004, FR-005, FR-008, FR-009, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Resume MUST use the original task input snapshot unchanged and MUST NOT expose an editable authoring form in v1.
+- **FR-002**: A resumed execution MUST validate the resume checkpoint source workflow ID, source run ID, original snapshot identity, and plan identity before executing any step.
+- **FR-003**: A resumed execution MUST fail explicitly before executing the failed step when checkpoint validation finds missing, stale, unauthorized, corrupted, or inconsistent evidence.
+- **FR-004**: A resumed execution MUST restore workspace, branch, commit, or equivalent runtime state immediately before the failed step before newly executing work.
+- **FR-005**: Completed steps before the failed step MUST be imported as preserved progress rather than re-executed by the resumed run.
+- **FR-006**: Preserved completed steps MUST carry provenance for source workflow ID, source run ID, logical step ID, and source attempt.
+- **FR-007**: Preserved outputs from completed prior steps MUST be injected so the retried failed step and downstream steps observe the same contracts as a continuous run.
+- **FR-008**: The failed step MUST be retried as the first newly executed step in the resumed execution.
+- **FR-009**: Steps after the retried failed step MUST execute normally after the failed step succeeds, producing fresh resumed-run ledger rows, artifacts, and checkpoints.
+- **FR-010**: Resume restoration failure MUST NOT fall back to full rerun behavior.
+- **FR-011**: Resume MUST NOT re-execute preserved prior steps unless a future explicit user action requests that behavior.
+- **FR-012**: Task detail or equivalent operator progress surfaces MUST distinguish preserved prior steps from newly executed resumed-run steps.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-634` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Resumed Execution**: The new execution created when a user chooses Resume for a failed task.
+- **Source Execution Identity**: The pinned source workflow ID and run ID of the failed task being resumed.
+- **Resume Checkpoint**: The durable evidence binding source execution, original snapshot, plan identity, completed-step refs, prepared inputs, and workspace or branch state.
+- **Preserved Step**: A completed source-run step represented in the resumed execution as reused progress rather than newly executed work.
+- **Retried Failed Step**: The last failed source-run step executed as the first new attempt in the resumed execution.
+- **Downstream Step**: A later planned step that executes normally after the retried failed step succeeds.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid resumed execution tests preserve the original task input snapshot unchanged and expose no editable authoring form.
+- **SC-002**: 100% of resumed execution starts validate source workflow ID, source run ID, original snapshot identity, and plan identity before the first newly executed step.
+- **SC-003**: 100% of valid resume cases restore workspace, branch, commit, or equivalent runtime state before retrying the failed step.
+- **SC-004**: 100% of completed source steps before the failed step are represented as preserved progress with source workflow ID, run ID, logical step ID, and attempt provenance.
+- **SC-005**: 100% of retried failed-step and downstream-step cases receive preserved outputs needed to satisfy continuous-run contracts.
+- **SC-006**: 100% of valid resume cases execute the failed step as the first newly executed step and later steps only after that step succeeds.
+- **SC-007**: 0 invalid restoration cases fall back to full rerun behavior or re-execute preserved prior steps.
+- **SC-008**: Traceability review confirms `MM-634`, the canonical Jira preset brief, and source coverage IDs DESIGN-REQ-014 through DESIGN-REQ-017 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/328-execute-resume-failed-step/tasks.md
+++ b/specs/328-execute-resume-failed-step/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Execute Resume From the Failed Step Only
+
+**Input**: Design documents from `specs/328-execute-resume-failed-step/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Organization**: Tasks are grouped around one independently testable story: Failed-Step Resume Execution.
+
+**Source Traceability**: MM-634 and the original Jira preset brief are preserved in `spec.md`. Tasks cover FR-001 through FR-013, acceptance scenarios 1-7, edge cases, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-005.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Focused UI tests when Task Detail display changes: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and has no dependency on incomplete work
+- Each task includes exact file paths and requirement, scenario, or source IDs when applicable
+- This task list covers exactly one story and must not add hidden scope beyond MM-634
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm active artifacts and test targets before writing red-first tests.
+
+- [ ] T001 Confirm `specs/328-execute-resume-failed-step/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are present and preserve MM-634 traceability. (FR-013, SC-008)
+- [ ] T002 Confirm `specs/328-execute-resume-failed-step/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-008)
+- [ ] T003 Identify current focused test targets and fixtures in `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/api/routers/test_executions.py`, and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001 through FR-012)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prepare reusable fixture coverage for resumed execution ordering, workspace restoration, preserved provenance, and no-fallback behavior.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T004 [P] Extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` with complete resume workspace evidence, plan identity, preserved outputs, and invalid restoration cases. (FR-002, FR-003, FR-004, FR-007, FR-010)
+- [ ] T005 [P] Extend preserved-step ledger fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for source logical step provenance, preserved output refs, and skipped re-execution assertions. (FR-005, FR-006, FR-007, FR-011)
+- [ ] T006 [P] Extend hermetic integration fixtures in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for a three-step graph where the first step is preserved, the second step is retried, and the third step runs downstream. (FR-004, FR-008, FR-009, DESIGN-REQ-003)
+- [ ] T007 [P] Extend Task Detail UI mock payload helpers in `frontend/src/entrypoints/task-detail.test.tsx` only if preserved provenance shape changes. (FR-012)
+
+**Checkpoint**: Test fixtures are ready; story tests and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Failed-Step Resume Execution
+
+**Summary**: As a user pressing Resume on a failed task, I want completed prior work restored and preserved, the failed step retried first, and later steps continued normally without silent input mutation or full-rerun fallback.
+
+**Independent Test**: Start a Resume attempt from a failed task with complete checkpoint evidence, then verify the resumed run preserves prior completed steps with source provenance, restores state before the failed step, injects preserved outputs, executes the failed step first, continues later steps normally, and fails before execution for invalid restoration evidence.
+
+**Traceability**: FR-001 through FR-013; acceptance scenarios 1-7; SC-001 through SC-008; DESIGN-REQ-001 through DESIGN-REQ-005.
+
+**Unit Test Plan**:
+
+- Temporal service tests for identity validation before creation and no execution creation on invalid restoration.
+- Step ledger tests for preserved source workflow/run/logical-step/attempt provenance.
+- Step ledger or workflow helper tests proving preserved artifact refs are retained for failed/downstream steps.
+- Task Detail tests if preserved provenance display shape changes.
+
+**Integration Test Plan**:
+
+- Hermetic resumed-run ordering test proving preserved prior step is not executed, failed step is first newly executable, and downstream step runs after success.
+- Hermetic invalid-restoration test proving no full rerun and no preserved-step re-execution.
+- Hermetic workspace restoration boundary test proving workspace/branch/commit evidence is applied before new work.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them and confirm they fail for the expected reason before production implementation.
+
+- [ ] T008 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving Resume validates source workflow ID, source run ID, snapshot identity, and plan identity before creating a resumed execution. (FR-002, FR-003, SC-002, DESIGN-REQ-002)
+- [ ] T009 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving invalid restoration evidence creates no resumed execution and cannot call any full-rerun path. (FR-003, FR-010, SC-007, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T010 [P] Add failing step ledger unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` requiring `preservedFrom.logicalStepId` in addition to source workflow ID, run ID, and attempt. (FR-006, SC-004, DESIGN-REQ-003)
+- [ ] T011 [P] Add failing unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved artifact refs and state checkpoint refs remain on preserved rows for downstream consumption. (FR-005, FR-007, SC-005, DESIGN-REQ-002)
+- [ ] T012 [P] Add failing Task Detail UI test in `frontend/src/entrypoints/task-detail.test.tsx` if `preservedFrom.logicalStepId` changes the rendered contract or parsing schema. (FR-012)
+- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and confirm T008-T011 fail for the expected MM-634 reasons before production changes. (FR-001 through FR-012)
+- [ ] T014 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T012 fails only if UI work is needed. (FR-012)
+
+### Integration Tests (write first)
+
+- [ ] T015 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved prior steps are not executed and the failed step is the first newly executable step. (FR-005, FR-008, FR-011, SC-006, DESIGN-REQ-002, DESIGN-REQ-003)
+- [ ] T016 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving workspace, branch, commit, or equivalent `resumeWorkspace` evidence is applied before the failed step starts. (FR-004, SC-003, DESIGN-REQ-003, DESIGN-REQ-005)
+- [ ] T017 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving invalid restoration fails before execution without full-rerun fallback or preserved-step re-execution. (FR-003, FR-010, FR-011, SC-007, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T018 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving downstream steps execute normally after the retried failed step succeeds and produce fresh resumed-run evidence. (FR-007, FR-009, SC-005, DESIGN-REQ-002)
+- [ ] T019 Run `./tools/test_integration.sh` or `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` and confirm T015-T018 fail for the expected MM-634 reasons before production changes. (FR-004 through FR-011)
+
+### Red-First Confirmation
+
+- [ ] T020 Record expected failing unit test names and failure reasons in `specs/328-execute-resume-failed-step/tasks.md` before changing production code. (FR-001 through FR-012)
+- [ ] T021 Record expected failing integration test names and failure reasons in `specs/328-execute-resume-failed-step/tasks.md` before changing production code. (FR-004 through FR-011)
+
+### Conditional Verification Tasks for Implemented-Unverified Rows
+
+- [ ] T022 If T008 proves current identity validation already satisfies FR-002, preserve the evidence and skip redundant service implementation; otherwise keep T026 in scope. (FR-002)
+- [ ] T023 If T009 proves invalid restoration already creates no execution and no full-rerun fallback, preserve the evidence and skip redundant no-fallback implementation; otherwise keep T030 in scope. (FR-003, FR-010)
+- [ ] T024 If T012 is unnecessary because the UI schema already renders the existing provenance shape without contract changes, record that no UI implementation is required; otherwise keep T031 in scope. (FR-012)
+
+### Implementation
+
+- [ ] T025 Update preserved-step provenance in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/schemas/temporal_models.py` so preserved rows carry source workflow ID, source run ID, logical step ID, and source attempt. (FR-006, SC-004, DESIGN-REQ-003)
+- [ ] T026 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to keep validation before resumed execution creation and cover any missing identity/restoration preconditions exposed by T008-T009. (FR-002, FR-003, FR-010, DESIGN-REQ-001, DESIGN-REQ-002)
+- [ ] T027 Implement or expose workspace, branch, commit, or equivalent restoration from `resumeWorkspace` before the failed step in `moonmind/workflows/temporal/workflows/run.py` or the selected runtime restoration boundary. (FR-004, SC-003, DESIGN-REQ-003, DESIGN-REQ-005)
+- [ ] T028 Update preserved output propagation in `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/workflows/run.py`, or the selected context generation boundary so failed and downstream steps receive preserved outputs as continuous-run inputs. (FR-007, SC-005, DESIGN-REQ-002)
+- [ ] T029 Update resumed-run step progression in `moonmind/workflows/temporal/workflows/run.py` so preserved prior steps are skipped, the failed step is first newly executed, and downstream steps produce fresh resumed-run ledger rows, artifacts, and checkpoints. (FR-005, FR-008, FR-009, FR-011, DESIGN-REQ-002, DESIGN-REQ-003)
+- [ ] T030 Add explicit no-fallback/no-reexecution guardrails in `moonmind/workflows/temporal/service.py` or `moonmind/workflows/temporal/workflows/run.py` for restoration failures that occur after checkpoint validation but before the failed step starts. (FR-003, FR-010, FR-011, DESIGN-REQ-001, DESIGN-REQ-004)
+- [ ] T031 Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/generated/openapi.ts` only if provenance schema or display behavior changes require UI contract updates. (FR-012)
+
+### Story Validation
+
+- [ ] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and make T008-T011 pass. (FR-001 through FR-012)
+- [ ] T033 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and make T012 pass if UI work was needed. (FR-012)
+- [ ] T034 Run `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` and make T015-T018 pass. (FR-004 through FR-011)
+- [ ] T035 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after focused tests pass. (FR-001 through FR-013)
+- [ ] T036 Run `./tools/test_integration.sh` for required hermetic integration verification or record the exact Docker/environment blocker. (FR-001 through FR-013)
+- [ ] T037 Validate the story against `specs/328-execute-resume-failed-step/quickstart.md`, confirming original input reuse, checkpoint validation, workspace restoration, preserved progress, failed-step-first execution, downstream progression, and no fallback. (FR-001 through FR-013, SC-001 through SC-008)
+
+**Checkpoint**: The story is functionally complete, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding scope beyond MM-634.
+
+- [ ] T038 [P] Review `specs/328-execute-resume-failed-step/data-model.md` and `contracts/resume-execution.md` against the final implementation; update only if behavior changed during implementation. (FR-013, SC-008)
+- [ ] T039 [P] Review operator-facing error text and logs in `moonmind/workflows/temporal/service.py` and `moonmind/workflows/temporal/workflows/run.py` to ensure no raw checkpoint payloads, credentials, or large/binary content are emitted. (FR-003, FR-010, DESIGN-REQ-001)
+- [ ] T040 [P] Review compatibility-sensitive payload changes in `moonmind/schemas/temporal_models.py`, `moonmind/workflows/temporal/service.py`, and `moonmind/workflows/temporal/workflows/run.py`; document explicit cutover notes in `specs/328-execute-resume-failed-step/research.md` or `plan.md` if in-flight compatibility cannot be preserved. (DESIGN-REQ-001 through DESIGN-REQ-005)
+- [ ] T041 Preserve MM-634 and the original Jira preset brief in implementation notes, verification output, commit text, and pull request metadata. (FR-013, SC-008)
+- [ ] T042 Run `/moonspec-verify` after implementation and tests pass, validating against `specs/328-execute-resume-failed-step/spec.md`, `plan.md`, `tasks.md`, and the preserved MM-634 Jira preset brief. (FR-001 through FR-013, SC-001 through SC-008, DESIGN-REQ-001 through DESIGN-REQ-005)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; start immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks story tests and implementation.
+- **Story (Phase 3)**: Depends on Phase 2; tests must be written and confirmed red before production changes.
+- **Polish & Verification (Phase 4)**: Depends on story implementation and tests passing.
+
+### Within The Story
+
+- Unit tests T008-T012 must be written before implementation.
+- Integration tests T015-T018 must be written before implementation.
+- Red-first confirmations T020-T021 must complete before production changes T025-T031.
+- Conditional verification tasks T022-T024 decide which fallback implementation work remains necessary.
+- Provenance/schema work T025 should happen before UI/schema display work T031.
+- Runtime restoration/output/progression work T027-T030 should happen after service validation gaps are understood by T026.
+- Story validation T032-T037 must pass before polish and `/moonspec-verify`.
+
+### Parallel Opportunities
+
+- T004-T007 can run in parallel because they touch different fixture files.
+- T008-T012 can run in parallel after foundational fixtures are ready.
+- T015-T018 can run in parallel because they cover distinct integration scenarios.
+- T038-T040 can run in parallel after story validation because they review different files.
+
+## Parallel Example: Story Test Authoring
+
+```bash
+Task: "Add failing service identity/no-fallback tests in tests/unit/workflows/temporal/test_temporal_service.py"
+Task: "Add failing preserved provenance tests in tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py"
+Task: "Add failing resumed-run ordering integration tests in tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py"
+Task: "Add failing Task Detail preserved provenance test in frontend/src/entrypoints/task-detail.test.tsx if UI shape changes"
+```
+
+## Implementation Strategy
+
+1. Confirm and preserve existing behavior that already satisfies implemented-unverified rows.
+2. Add red-first tests for the missing/partial rows: workspace restoration, logical step provenance, output injection, failed-step-first execution, downstream fresh evidence, and no re-execution.
+3. Implement the smallest changes at existing boundaries: checkpoint service validation, step ledger provenance/materialization, `MoonMind.Run` resume initialization/restoration, and Task Detail display only if needed.
+4. Run focused tests, then full unit and hermetic integration verification.
+5. Run `/moonspec-verify` against the preserved MM-634 brief and all generated artifacts.

--- a/specs/328-execute-resume-failed-step/tasks.md
+++ b/specs/328-execute-resume-failed-step/tasks.md
@@ -26,9 +26,9 @@
 
 **Purpose**: Confirm active artifacts and test targets before writing red-first tests.
 
-- [ ] T001 Confirm `specs/328-execute-resume-failed-step/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are present and preserve MM-634 traceability. (FR-013, SC-008)
-- [ ] T002 Confirm `specs/328-execute-resume-failed-step/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-008)
-- [ ] T003 Identify current focused test targets and fixtures in `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/api/routers/test_executions.py`, and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001 through FR-012)
+- [X] T001 Confirm `specs/328-execute-resume-failed-step/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are present and preserve MM-634 traceability. (FR-013, SC-008)
+- [X] T002 Confirm `specs/328-execute-resume-failed-step/spec.md` has exactly one `## User Story` section and no `[NEEDS CLARIFICATION]` markers. (FR-013, SC-008)
+- [X] T003 Identify current focused test targets and fixtures in `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/api/routers/test_executions.py`, and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001 through FR-012)
 
 ---
 
@@ -38,9 +38,9 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T004 [P] Extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` with complete resume workspace evidence, plan identity, preserved outputs, and invalid restoration cases. (FR-002, FR-003, FR-004, FR-007, FR-010)
-- [ ] T005 [P] Extend preserved-step ledger fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for source logical step provenance, preserved output refs, and skipped re-execution assertions. (FR-005, FR-006, FR-007, FR-011)
-- [ ] T006 [P] Extend hermetic integration fixtures in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for a three-step graph where the first step is preserved, the second step is retried, and the third step runs downstream. (FR-004, FR-008, FR-009, DESIGN-REQ-003)
+- [X] T004 [P] Extend Resume checkpoint fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` with complete resume workspace evidence, plan identity, preserved outputs, and invalid restoration cases. (FR-002, FR-003, FR-004, FR-007, FR-010)
+- [X] T005 [P] Extend preserved-step ledger fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for source logical step provenance, preserved output refs, and skipped re-execution assertions. (FR-005, FR-006, FR-007, FR-011)
+- [X] T006 [P] Extend hermetic integration fixtures in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` for a three-step graph where the first step is preserved, the second step is retried, and the third step runs downstream. (FR-004, FR-008, FR-009, DESIGN-REQ-003)
 - [ ] T007 [P] Extend Task Detail UI mock payload helpers in `frontend/src/entrypoints/task-detail.test.tsx` only if preserved provenance shape changes. (FR-012)
 
 **Checkpoint**: Test fixtures are ready; story tests and implementation work can now begin.
@@ -72,17 +72,17 @@
 
 > Write these tests FIRST. Run them and confirm they fail for the expected reason before production implementation.
 
-- [ ] T008 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving Resume validates source workflow ID, source run ID, snapshot identity, and plan identity before creating a resumed execution. (FR-002, FR-003, SC-002, DESIGN-REQ-002)
-- [ ] T009 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving invalid restoration evidence creates no resumed execution and cannot call any full-rerun path. (FR-003, FR-010, SC-007, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T010 [P] Add failing step ledger unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` requiring `preservedFrom.logicalStepId` in addition to source workflow ID, run ID, and attempt. (FR-006, SC-004, DESIGN-REQ-003)
-- [ ] T011 [P] Add failing unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved artifact refs and state checkpoint refs remain on preserved rows for downstream consumption. (FR-005, FR-007, SC-005, DESIGN-REQ-002)
+- [X] T008 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving Resume validates source workflow ID, source run ID, snapshot identity, and plan identity before creating a resumed execution. (FR-002, FR-003, SC-002, DESIGN-REQ-002)
+- [X] T009 [P] Add failing service tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving invalid restoration evidence creates no resumed execution and cannot call any full-rerun path. (FR-003, FR-010, SC-007, DESIGN-REQ-001, DESIGN-REQ-004)
+- [X] T010 [P] Add failing step ledger unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` requiring `preservedFrom.logicalStepId` in addition to source workflow ID, run ID, and attempt. (FR-006, SC-004, DESIGN-REQ-003)
+- [X] T011 [P] Add failing unit tests in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved artifact refs and state checkpoint refs remain on preserved rows for downstream consumption. (FR-005, FR-007, SC-005, DESIGN-REQ-002)
 - [ ] T012 [P] Add failing Task Detail UI test in `frontend/src/entrypoints/task-detail.test.tsx` if `preservedFrom.logicalStepId` changes the rendered contract or parsing schema. (FR-012)
-- [ ] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and confirm T008-T011 fail for the expected MM-634 reasons before production changes. (FR-001 through FR-012)
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and confirm T008-T011 fail for the expected MM-634 reasons before production changes. (FR-001 through FR-012)
 - [ ] T014 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T012 fails only if UI work is needed. (FR-012)
 
 ### Integration Tests (write first)
 
-- [ ] T015 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved prior steps are not executed and the failed step is the first newly executable step. (FR-005, FR-008, FR-011, SC-006, DESIGN-REQ-002, DESIGN-REQ-003)
+- [X] T015 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving preserved prior steps are not executed and the failed step is the first newly executable step. (FR-005, FR-008, FR-011, SC-006, DESIGN-REQ-002, DESIGN-REQ-003)
 - [ ] T016 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving workspace, branch, commit, or equivalent `resumeWorkspace` evidence is applied before the failed step starts. (FR-004, SC-003, DESIGN-REQ-003, DESIGN-REQ-005)
 - [ ] T017 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving invalid restoration fails before execution without full-rerun fallback or preserved-step re-execution. (FR-003, FR-010, FR-011, SC-007, DESIGN-REQ-001, DESIGN-REQ-004)
 - [ ] T018 [P] Add failing hermetic integration test in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` proving downstream steps execute normally after the retried failed step succeeds and produce fresh resumed-run evidence. (FR-007, FR-009, SC-005, DESIGN-REQ-002)
@@ -90,35 +90,50 @@
 
 ### Red-First Confirmation
 
-- [ ] T020 Record expected failing unit test names and failure reasons in `specs/328-execute-resume-failed-step/tasks.md` before changing production code. (FR-001 through FR-012)
+- [X] T020 Record expected failing unit test names and failure reasons in `specs/328-execute-resume-failed-step/tasks.md` before changing production code. (FR-001 through FR-012)
 - [ ] T021 Record expected failing integration test names and failure reasons in `specs/328-execute-resume-failed-step/tasks.md` before changing production code. (FR-004 through FR-011)
+
+**Red-first evidence captured before production edits**:
+
+- Unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`
+- Unit failures observed: `test_failed_step_resume_creates_linked_execution_with_source_identity` failed because `resumeSource.resumeWorkspace` was absent; `test_materialize_preserved_steps_marks_source_provenance_without_new_attempt` and `test_materialize_preserved_steps_keeps_outputs_for_downstream_steps` failed because `preservedFrom.logicalStepId` was absent.
+- Integration command: `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short`
+- Integration failures observed: `test_failed_step_resume_preserves_prior_steps_and_unblocks_failed_step` and `test_failed_step_resume_preserves_only_prior_steps_before_downstream_work` failed because preserved provenance did not include `logicalStepId`.
+- Conditional evidence: existing service tests already rejected invalid checkpoint payloads, checkpoint ref mismatches, source run mismatches, plan ref mismatches, and plan digest mismatches before creating a resumed execution. No Task Detail rendered-contract test was required because the display did not change; the parsing schema now accepts optional `preservedFrom.logicalStepId`.
 
 ### Conditional Verification Tasks for Implemented-Unverified Rows
 
-- [ ] T022 If T008 proves current identity validation already satisfies FR-002, preserve the evidence and skip redundant service implementation; otherwise keep T026 in scope. (FR-002)
-- [ ] T023 If T009 proves invalid restoration already creates no execution and no full-rerun fallback, preserve the evidence and skip redundant no-fallback implementation; otherwise keep T030 in scope. (FR-003, FR-010)
-- [ ] T024 If T012 is unnecessary because the UI schema already renders the existing provenance shape without contract changes, record that no UI implementation is required; otherwise keep T031 in scope. (FR-012)
+- [X] T022 If T008 proves current identity validation already satisfies FR-002, preserve the evidence and skip redundant service implementation; otherwise keep T026 in scope. (FR-002)
+- [X] T023 If T009 proves invalid restoration already creates no execution and no full-rerun fallback, preserve the evidence and skip redundant no-fallback implementation; otherwise keep T030 in scope. (FR-003, FR-010)
+- [X] T024 If T012 is unnecessary because the UI schema already renders the existing provenance shape without contract changes, record that no UI implementation is required; otherwise keep T031 in scope. (FR-012)
 
 ### Implementation
 
-- [ ] T025 Update preserved-step provenance in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/schemas/temporal_models.py` so preserved rows carry source workflow ID, source run ID, logical step ID, and source attempt. (FR-006, SC-004, DESIGN-REQ-003)
-- [ ] T026 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to keep validation before resumed execution creation and cover any missing identity/restoration preconditions exposed by T008-T009. (FR-002, FR-003, FR-010, DESIGN-REQ-001, DESIGN-REQ-002)
+- [X] T025 Update preserved-step provenance in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/schemas/temporal_models.py` so preserved rows carry source workflow ID, source run ID, logical step ID, and source attempt. (FR-006, SC-004, DESIGN-REQ-003)
+- [X] T026 Update `TemporalExecutionService.create_failed_step_resume_execution()` in `moonmind/workflows/temporal/service.py` to keep validation before resumed execution creation and cover any missing identity/restoration preconditions exposed by T008-T009. (FR-002, FR-003, FR-010, DESIGN-REQ-001, DESIGN-REQ-002)
 - [ ] T027 Implement or expose workspace, branch, commit, or equivalent restoration from `resumeWorkspace` before the failed step in `moonmind/workflows/temporal/workflows/run.py` or the selected runtime restoration boundary. (FR-004, SC-003, DESIGN-REQ-003, DESIGN-REQ-005)
-- [ ] T028 Update preserved output propagation in `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/workflows/run.py`, or the selected context generation boundary so failed and downstream steps receive preserved outputs as continuous-run inputs. (FR-007, SC-005, DESIGN-REQ-002)
+- [X] T028 Update preserved output propagation in `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/workflows/run.py`, or the selected context generation boundary so failed and downstream steps receive preserved outputs as continuous-run inputs. (FR-007, SC-005, DESIGN-REQ-002)
 - [ ] T029 Update resumed-run step progression in `moonmind/workflows/temporal/workflows/run.py` so preserved prior steps are skipped, the failed step is first newly executed, and downstream steps produce fresh resumed-run ledger rows, artifacts, and checkpoints. (FR-005, FR-008, FR-009, FR-011, DESIGN-REQ-002, DESIGN-REQ-003)
 - [ ] T030 Add explicit no-fallback/no-reexecution guardrails in `moonmind/workflows/temporal/service.py` or `moonmind/workflows/temporal/workflows/run.py` for restoration failures that occur after checkpoint validation but before the failed step starts. (FR-003, FR-010, FR-011, DESIGN-REQ-001, DESIGN-REQ-004)
-- [ ] T031 Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/generated/openapi.ts` only if provenance schema or display behavior changes require UI contract updates. (FR-012)
+- [X] T031 Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/generated/openapi.ts` only if provenance schema or display behavior changes require UI contract updates. (FR-012)
 
 ### Story Validation
 
-- [ ] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and make T008-T011 pass. (FR-001 through FR-012)
+- [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and make T008-T011 pass. (FR-001 through FR-012)
 - [ ] T033 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and make T012 pass if UI work was needed. (FR-012)
 - [ ] T034 Run `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` and make T015-T018 pass. (FR-004 through FR-011)
-- [ ] T035 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after focused tests pass. (FR-001 through FR-013)
-- [ ] T036 Run `./tools/test_integration.sh` for required hermetic integration verification or record the exact Docker/environment blocker. (FR-001 through FR-013)
+- [X] T035 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after focused tests pass. (FR-001 through FR-013)
+- [X] T036 Run `./tools/test_integration.sh` for required hermetic integration verification or record the exact Docker/environment blocker. (FR-001 through FR-013)
 - [ ] T037 Validate the story against `specs/328-execute-resume-failed-step/quickstart.md`, confirming original input reuse, checkpoint validation, workspace restoration, preserved progress, failed-step-first execution, downstream progression, and no fallback. (FR-001 through FR-013, SC-001 through SC-008)
 
 **Checkpoint**: The story is functionally complete, covered by unit and integration tests, and independently testable.
+
+**Implementation validation evidence**:
+
+- Focused unit verification passed: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` completed with 101 Python tests passed, followed by 20 frontend test files passed.
+- Focused integration verification passed: `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` completed with 3 tests passed.
+- Full unit verification passed: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` completed with 4601 Python tests passed, 1 xpassed, 16 subtests passed, and 20 frontend test files passed.
+- Required hermetic integration script blocker: `./tools/test_integration.sh` created `.env` from `.env-template`, then Docker compose failed before pytest execution with `Docker Compose requires buildx plugin to be installed` and daemon response `403 Forbidden: Request forbidden by administrative rules`.
 
 ---
 

--- a/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -42,9 +42,55 @@ def test_failed_step_resume_preserves_prior_steps_and_unblocks_failed_step() -> 
     refresh_ready_steps(rows, updated_at=now)
 
     assert rows[0]["preservedFrom"]["workflowId"] == "mm:source"
+    assert rows[0]["preservedFrom"]["logicalStepId"] == "prepare"
     assert rows[0]["artifacts"]["outputSummary"] == "artifact://prepare-summary"
     assert rows[0]["stateCheckpointRef"] == "artifact://workspace/prepare"
     assert rows[1]["status"] == "ready"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_failed_step_resume_preserves_only_prior_steps_before_downstream_work() -> None:
+    now = datetime.now(UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {"id": "prepare", "title": "Prepare"},
+            {"id": "implement", "title": "Implement"},
+            {"id": "verify", "title": "Verify"},
+        ],
+        dependency_map={"implement": ["prepare"], "verify": ["implement"]},
+        updated_at=now,
+    )
+
+    materialize_preserved_steps(
+        rows,
+        source_workflow_id="mm:source",
+        source_run_id="run-source",
+        preserved_steps=[
+            {
+                "logicalStepId": "prepare",
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {"outputSummary": "artifact://prepare-summary"},
+                "stateCheckpointRef": "artifact://workspace/prepare",
+            }
+        ],
+        updated_at=now,
+    )
+    refresh_ready_steps(rows, updated_at=now)
+
+    assert rows[0]["attempt"] == 0
+    assert rows[0]["preservedFrom"] == {
+        "workflowId": "mm:source",
+        "runId": "run-source",
+        "logicalStepId": "prepare",
+        "attempt": 1,
+    }
+    assert rows[1]["logicalStepId"] == "implement"
+    assert rows[1]["status"] == "ready"
+    assert "preservedFrom" not in rows[1]
+    assert rows[2]["logicalStepId"] == "verify"
+    assert rows[2]["status"] == "pending"
 
 
 @pytest.mark.integration

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2182,6 +2182,13 @@ async def test_failed_step_resume_creates_linked_execution_with_source_identity(
         assert resumed.parameters["resumeSource"]["sourceWorkflowId"] == created.workflow_id
         assert resumed.parameters["resumeSource"]["sourceRunId"] == created.run_id
         assert resumed.parameters["resumeSource"]["failedStepId"] == "implement"
+        assert resumed.parameters["resumeSource"]["resumeWorkspace"] == {
+            "branch": "feature",
+            "commit": "abc123",
+        }
+        assert resumed.parameters["resumeSource"]["preservedSteps"][0][
+            "logicalStepId"
+        ] == "plan"
         assert "taskRunId" not in resumed.parameters
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -44,8 +44,56 @@ def test_materialize_preserved_steps_marks_source_provenance_without_new_attempt
     assert rows[0]["preservedFrom"] == {
         "workflowId": "mm:source",
         "runId": "run-source",
+        "logicalStepId": "plan",
         "attempt": 2,
     }
     assert rows[0]["artifacts"]["outputSummary"] == "artifact://summary"
     assert rows[0]["stateCheckpointRef"] == "artifact://workspace/before-plan"
     assert rows[1]["status"] == "ready"
+
+
+def test_materialize_preserved_steps_keeps_outputs_for_downstream_steps() -> None:
+    now = datetime.now(UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {"id": "prepare", "title": "Prepare"},
+            {"id": "implement", "title": "Implement"},
+            {"id": "verify", "title": "Verify"},
+        ],
+        dependency_map={"implement": ["prepare"], "verify": ["implement"]},
+        updated_at=now,
+    )
+
+    materialize_preserved_steps(
+        rows,
+        source_workflow_id="mm:source",
+        source_run_id="run-source",
+        preserved_steps=[
+            {
+                "logicalStepId": "prepare",
+                "order": 1,
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {
+                    "outputSummary": "artifact://prepare-summary",
+                    "outputPrimary": "artifact://prepare-output",
+                },
+                "stateCheckpointRef": "artifact://workspace/before-prepare",
+            }
+        ],
+        updated_at=now,
+    )
+    refresh_ready_steps(rows, updated_at=now)
+
+    assert rows[0]["attempt"] == 0
+    assert rows[0]["preservedFrom"] == {
+        "workflowId": "mm:source",
+        "runId": "run-source",
+        "logicalStepId": "prepare",
+        "attempt": 1,
+    }
+    assert rows[0]["artifacts"]["outputSummary"] == "artifact://prepare-summary"
+    assert rows[0]["artifacts"]["outputPrimary"] == "artifact://prepare-output"
+    assert rows[0]["stateCheckpointRef"] == "artifact://workspace/before-prepare"
+    assert rows[1]["status"] == "ready"
+    assert rows[2]["status"] == "pending"


### PR DESCRIPTION
## Summary

Publishes the MM-634 MoonSpec artifacts and implementation slice for failed-step Resume execution. The branch preserves the original Jira preset brief, adds resume source workspace/provenance fields, and expands unit/integration coverage for preserved step metadata.

## Jira

- Jira issue key: MM-634

## MoonSpec

- Active MoonSpec feature path: `specs/328-execute-resume-failed-step`

## Verification Verdict

- `ADDITIONAL_WORK_NEEDED` from the final MoonSpec verification gate.

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` - passed in the implementation step.
- `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` - passed in the implementation step.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - passed in the implementation step.
- `./tools/test_integration.sh` - blocked in the implementation step by Docker/buildx and daemon 403 environment restrictions.
- Final `/moonspec-verify` - `ADDITIONAL_WORK_NEEDED`; full-suite rerun blocked by active `.gemini/skills` projection contamination in the managed workspace.

## Remaining Risks

- Runtime restoration from `resumeWorkspace` before the failed step still needs implementation/evidence.
- Preserved output injection into retried and downstream step input context is only partially proven.
- Full workflow evidence for failed-step-first execution, downstream fresh evidence, and no fallback/no preserved-step reexecution remains incomplete.
- The managed workspace had a projection symlink on `.gemini/skills`; it was restored locally before PR publication.
