### PR TITLE
MM-635 Show attachment and recovery diagnostics by target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,8 @@ Key diagnostics:
 - Existing Temporal execution records, canonical execution parameters/memo/search attributes, Temporal artifact metadata/content store, and existing original task input snapshot artifacts; no new persistent tables planned (326-expose-distinct-full-retry-recovery-actions)
 - Python 3.12; TypeScript/React for Mission Control UI where availability display is affected + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest (327-gate-resume-checkpoint-evidence)
 - Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned (327-gate-resume-checkpoint-evidence)
+- Python 3.12; TypeScript/React + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest (329-show-attachment-recovery-diagnostics-by-target)
+- Existing Temporal execution records, task input snapshot artifacts, Temporal artifact metadata/content, and existing step ledger/projection payloads; no new persistent tables planned (329-show-attachment-recovery-diagnostics-by-target)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -233,6 +233,8 @@ Key diagnostics:
 - Existing artifact store plus workspace-local prepared files/manifest refs; no new persistent database tables planned (325-prepare-target-aware-inputs)
 - Python 3.12; TypeScript/React for Mission Control UI where availability display is affected + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, Zod, Vitest, pytest (327-gate-resume-checkpoint-evidence)
 - Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, step ledger/checkpoint artifacts; no new persistent database table planned (327-gate-resume-checkpoint-evidence)
+- Python 3.12; TypeScript/React + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest (329-show-attachment-recovery-diagnostics-by-target)
+- Existing Temporal execution records, task input snapshot artifacts, Temporal artifact metadata/content, and existing step ledger/projection payloads; no new persistent tables planned (329-show-attachment-recovery-diagnostics-by-target)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1769,6 +1769,11 @@ def _serialize_execution(
     )
     resume_summary = _build_resume_summary(record, actions=actions)
     related_runs = _build_resume_related_runs(record, params=params)
+    target_diagnostics = _build_target_diagnostics(
+        record,
+        params=params,
+        resume_summary=resume_summary,
+    )
     proposal_summary = _proposal_summary_from_memo(memo)
     proposal_outcomes = _proposal_outcomes_from_summary(proposal_summary)
 
@@ -1857,6 +1862,7 @@ def _serialize_execution(
         actions=actions,
         resume=resume_summary,
         related_runs=related_runs,
+        target_diagnostics=target_diagnostics,
         proposal_summary=proposal_summary,
         proposal_outcomes=proposal_outcomes,
         debug_fields=debug_fields,
@@ -2137,6 +2143,383 @@ def _build_resume_related_runs(
             href=f"/tasks/{source_workflow_id}",
         )
     ]
+
+def _target_diagnostics_block(
+    *,
+    params: Mapping[str, Any],
+    memo: Mapping[str, Any],
+    search_attributes: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    for source in (params, memo, search_attributes):
+        for key in ("targetDiagnostics", "target_diagnostics"):
+            value = source.get(key)
+            if isinstance(value, Mapping):
+                return value
+    return {}
+
+def _attachment_ref_from_payload(value: Mapping[str, Any]) -> str | None:
+    for key in ("artifactRef", "artifact_ref", "artifactId", "artifact_id", "ref"):
+        candidate = str(value.get(key) or "").strip()
+        if candidate:
+            return candidate
+    return None
+
+def _normalize_target_attachment(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, str):
+        ref = value.strip()
+        if not ref:
+            return None
+        return {"artifactRef": ref, "previewAvailable": True}
+    if not isinstance(value, Mapping):
+        return None
+    artifact_ref = _attachment_ref_from_payload(value)
+    filename = str(
+        value.get("filename") or value.get("name") or value.get("fileName") or ""
+    ).strip() or None
+    content_type = str(
+        value.get("contentType")
+        or value.get("content_type")
+        or value.get("mimeType")
+        or ""
+    ).strip() or None
+    size_bytes = value.get("sizeBytes", value.get("size_bytes"))
+    try:
+        normalized_size = int(size_bytes) if size_bytes is not None else None
+    except (TypeError, ValueError):
+        normalized_size = None
+    return {
+        "artifactRef": artifact_ref,
+        "filename": filename,
+        "contentType": content_type,
+        "sizeBytes": normalized_size,
+        "previewAvailable": bool(value.get("previewAvailable", bool(artifact_ref))),
+    }
+
+def _target_attachment_payloads(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        return []
+    candidates: list[Any] = []
+    for key in (
+        "attachmentRefs",
+        "attachment_refs",
+        "attachments",
+        "inputAttachments",
+        "input_attachments",
+    ):
+        raw = value.get(key)
+        if isinstance(raw, list):
+            candidates.extend(raw)
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in candidates:
+        attachment = _normalize_target_attachment(item)
+        if attachment is None:
+            continue
+        identity = str(
+            attachment.get("artifactRef") or attachment.get("filename") or len(seen)
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        normalized.append(attachment)
+    return normalized
+
+def _normalize_target_refs(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, list):
+        return []
+    refs: list[dict[str, Any]] = []
+    for item in values:
+        if isinstance(item, str):
+            ref = item.strip()
+            if ref:
+                refs.append({"refKind": "artifact", "artifactRef": ref})
+            continue
+        if not isinstance(item, Mapping):
+            continue
+        ref_kind = str(
+            item.get("refKind") or item.get("ref_kind") or item.get("kind") or "artifact"
+        ).strip()
+        artifact_ref = str(
+            item.get("artifactRef") or item.get("artifact_ref") or item.get("ref") or ""
+        ).strip() or None
+        path = str(item.get("path") or "").strip() or None
+        if ref_kind and (artifact_ref or path):
+            refs.append({"refKind": ref_kind, "artifactRef": artifact_ref, "path": path})
+    return refs
+
+def _normalize_attachment_failure_phase(value: Any) -> str:
+    phase = str(value or "").strip().lower().replace("-", "_")
+    if phase in {"upload", "validation", "materialization", "context_generation"}:
+        return phase
+    if phase in {"context", "context_generation_failed", "generated_context"}:
+        return "context_generation"
+    if phase in {"materialize", "prepare", "download", "download_failed"}:
+        return "materialization"
+    if phase in {"validate", "invalid", "schema"}:
+        return "validation"
+    if phase in {"create", "submit", "submitted"}:
+        return "upload"
+    return "materialization"
+
+def _normalize_target_failures(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, list):
+        return []
+    failures: list[dict[str, Any]] = []
+    for item in values:
+        if not isinstance(item, Mapping):
+            continue
+        message = str(item.get("message") or item.get("summary") or "").strip()
+        if not message:
+            continue
+        phase = _normalize_attachment_failure_phase(
+            item.get("phase") or item.get("kind")
+        )
+        evidence_ref = str(
+            item.get("evidenceRef") or item.get("evidence_ref") or item.get("artifactRef") or ""
+        ).strip() or None
+        failures.append(
+            {"phase": phase, "message": message, "evidenceRef": evidence_ref}
+        )
+    return failures
+
+def _target_step_id(value: Mapping[str, Any], fallback: str) -> str:
+    return str(
+        value.get("id")
+        or value.get("stepId")
+        or value.get("step_id")
+        or value.get("logicalStepId")
+        or fallback
+    ).strip()
+
+def _target_step_label(value: Mapping[str, Any], step_id: str, index: int) -> str:
+    return (
+        str(value.get("title") or value.get("label") or value.get("name") or "").strip()
+        or step_id
+        or f"Step {index}"
+    )
+
+def _merge_target_overlay(
+    targets: list[dict[str, Any]],
+    *,
+    target_kind: str,
+    step_id: str | None,
+    overlay: Mapping[str, Any],
+) -> None:
+    if not overlay:
+        return
+    for target in targets:
+        if target.get("targetKind") != target_kind:
+            continue
+        if target_kind == "step" and target.get("stepId") != step_id:
+            continue
+        if overlay.get("label"):
+            target["label"] = str(overlay.get("label"))
+        target["attachments"] = [
+            *target.get("attachments", []),
+            *_target_attachment_payloads(overlay),
+        ]
+        target["refs"] = [
+            *target.get("refs", []),
+            *_normalize_target_refs(overlay.get("refs")),
+        ]
+        target["failures"] = [
+            *target.get("failures", []),
+            *_normalize_target_failures(overlay.get("failures")),
+        ]
+        return
+
+    label = str(overlay.get("label") or "").strip()
+    if not label:
+        label = "Task objective" if target_kind == "objective" else step_id or "Step"
+    targets.append(
+        {
+            "targetKind": target_kind,
+            "stepId": step_id,
+            "label": label,
+            "attachments": _target_attachment_payloads(overlay),
+            "refs": _normalize_target_refs(overlay.get("refs")),
+            "failures": _normalize_target_failures(overlay.get("failures")),
+        }
+    )
+
+def _preserved_steps_from_resume_source(
+    resume_source: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    raw_steps = resume_source.get("preservedSteps") or resume_source.get(
+        "preserved_steps"
+    )
+    if not isinstance(raw_steps, list):
+        return []
+    preserved_steps: list[dict[str, Any]] = []
+    for item in raw_steps:
+        if not isinstance(item, Mapping):
+            continue
+        logical_step_id = str(
+            item.get("logicalStepId")
+            or item.get("logical_step_id")
+            or item.get("stepId")
+            or item.get("step_id")
+            or ""
+        ).strip()
+        if not logical_step_id:
+            continue
+        source_attempt = item.get("sourceAttempt", item.get("attempt"))
+        try:
+            normalized_attempt = (
+                int(source_attempt) if source_attempt is not None else None
+            )
+        except (TypeError, ValueError):
+            normalized_attempt = None
+        preserved_steps.append(
+            {
+                "logicalStepId": logical_step_id,
+                "title": str(item.get("title") or "").strip() or None,
+                "sourceAttempt": normalized_attempt,
+                "sourceWorkflowId": str(
+                    item.get("sourceWorkflowId")
+                    or item.get("source_workflow_id")
+                    or resume_source.get("sourceWorkflowId")
+                    or resume_source.get("source_workflow_id")
+                    or ""
+                ).strip()
+                or None,
+                "sourceRunId": str(
+                    item.get("sourceRunId")
+                    or item.get("source_run_id")
+                    or resume_source.get("sourceRunId")
+                    or resume_source.get("source_run_id")
+                    or ""
+                ).strip()
+                or None,
+            }
+        )
+    return preserved_steps
+
+def _failed_resume_phase(disabled_reason: str | None) -> str | None:
+    if not disabled_reason:
+        return None
+    if disabled_reason == "workspace_checkpoint_missing":
+        return "workspace_restoration"
+    if disabled_reason == "completed_step_refs_missing":
+        return "preserved_output_injection"
+    if disabled_reason in {
+        "resume_checkpoint_missing",
+        "failed_step_identity_missing",
+        "plan_identity_missing",
+    }:
+        return "checkpoint_validation"
+    return "failed_step_execution"
+
+def _build_target_diagnostics(
+    record,
+    *,
+    params: Mapping[str, Any],
+    resume_summary: ExecutionResumeSummaryModel | None,
+) -> dict[str, Any] | None:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    task_payload = params.get("task") if isinstance(params.get("task"), Mapping) else {}
+    diagnostics_block = _target_diagnostics_block(
+        params=params,
+        memo=memo,
+        search_attributes=search_attributes,
+    )
+
+    targets: list[dict[str, Any]] = []
+    objective_attachments = _target_attachment_payloads(task_payload)
+    if objective_attachments or diagnostics_block:
+        targets.append(
+            {
+                "targetKind": "objective",
+                "label": "Task objective",
+                "attachments": objective_attachments,
+                "refs": [],
+                "failures": [],
+            }
+        )
+
+    raw_steps = task_payload.get("steps") if isinstance(task_payload, Mapping) else None
+    if isinstance(raw_steps, list):
+        for index, raw_step in enumerate(raw_steps, start=1):
+            if not isinstance(raw_step, Mapping):
+                continue
+            step_id = _target_step_id(raw_step, f"step-{index}")
+            step_target = {
+                "targetKind": "step",
+                "stepId": step_id,
+                "label": _target_step_label(raw_step, step_id, index),
+                "attachments": _target_attachment_payloads(raw_step),
+                "refs": [],
+                "failures": [],
+            }
+            if step_target["attachments"] or diagnostics_block:
+                targets.append(step_target)
+
+    raw_overlay_targets = diagnostics_block.get("targets")
+    if isinstance(raw_overlay_targets, list):
+        for overlay in raw_overlay_targets:
+            if not isinstance(overlay, Mapping):
+                continue
+            target_kind = str(overlay.get("targetKind") or overlay.get("target_kind") or "").strip()
+            if target_kind not in {"objective", "step"}:
+                continue
+            step_id = (
+                str(overlay.get("stepId") or overlay.get("step_id") or "").strip()
+                or None
+            )
+            _merge_target_overlay(
+                targets,
+                target_kind=target_kind,
+                step_id=step_id,
+                overlay=overlay,
+            )
+
+    resume_source = _resume_source_block_from_record(record)
+    source_workflow_id = str(
+        resume_source.get("sourceWorkflowId")
+        or resume_source.get("source_workflow_id")
+        or ""
+    ).strip() or None
+    source_run_id = str(
+        resume_source.get("sourceRunId") or resume_source.get("source_run_id") or ""
+    ).strip() or None
+    recovery = None
+    has_resume_evidence = bool(
+        resume_source
+        or (
+            resume_summary
+            and (
+                resume_summary.checkpoint_ref
+                or resume_summary.failed_step_id
+                or resume_summary.disabled_reason
+            )
+        )
+    )
+    if has_resume_evidence:
+        recovery = {
+            "resumed": bool(source_workflow_id or source_run_id or resume_source),
+            "sourceWorkflowId": source_workflow_id,
+            "sourceRunId": source_run_id,
+            "checkpointRef": resume_summary.checkpoint_ref if resume_summary else None,
+            "preservedSteps": _preserved_steps_from_resume_source(resume_source),
+            "failedResumePhase": _failed_resume_phase(
+                resume_summary.disabled_reason if resume_summary else None
+            ),
+        }
+
+    degraded_reason = str(
+        diagnostics_block.get("degradedReason")
+        or diagnostics_block.get("degraded_reason")
+        or ""
+    ).strip() or None
+
+    if not targets and not recovery and not degraded_reason:
+        return None
+    return {
+        "targets": targets,
+        "recovery": recovery,
+        "degradedReason": degraded_reason,
+    }
 
 async def _enrich_execution_dependencies(
     execution: ExecutionModel,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2249,7 +2249,13 @@ def _normalize_target_refs(values: Any) -> list[dict[str, Any]]:
 
 def _normalize_attachment_failure_phase(value: Any) -> str:
     phase = str(value or "").strip().lower().replace("-", "_")
-    if phase in {"upload", "validation", "materialization", "context_generation"}:
+    if phase in {
+        "upload",
+        "validation",
+        "materialization",
+        "context_generation",
+        "degraded",
+    }:
         return phase
     if phase in {"context", "context_generation_failed", "generated_context"}:
         return "context_generation"
@@ -2259,7 +2265,7 @@ def _normalize_attachment_failure_phase(value: Any) -> str:
         return "validation"
     if phase in {"create", "submit", "submitted"}:
         return "upload"
-    return "materialization"
+    return "degraded"
 
 def _normalize_target_failures(values: Any) -> list[dict[str, Any]]:
     if not isinstance(values, list):
@@ -2408,7 +2414,7 @@ def _failed_resume_phase(disabled_reason: str | None) -> str | None:
         "plan_identity_missing",
     }:
         return "checkpoint_validation"
-    return "failed_step_execution"
+    return None
 
 def _build_target_diagnostics(
     record,
@@ -2483,6 +2489,9 @@ def _build_target_diagnostics(
     source_run_id = str(
         resume_source.get("sourceRunId") or resume_source.get("source_run_id") or ""
     ).strip() or None
+    failed_resume_phase = _failed_resume_phase(
+        resume_summary.disabled_reason if resume_summary else None
+    )
     recovery = None
     has_resume_evidence = bool(
         resume_source
@@ -2491,7 +2500,7 @@ def _build_target_diagnostics(
             and (
                 resume_summary.checkpoint_ref
                 or resume_summary.failed_step_id
-                or resume_summary.disabled_reason
+                or failed_resume_phase
             )
         )
     )
@@ -2502,9 +2511,7 @@ def _build_target_diagnostics(
             "sourceRunId": source_run_id,
             "checkpointRef": resume_summary.checkpoint_ref if resume_summary else None,
             "preservedSteps": _preserved_steps_from_resume_source(resume_source),
-            "failedResumePhase": _failed_resume_phase(
-                resume_summary.disabled_reason if resume_summary else None
-            ),
+            "failedResumePhase": failed_resume_phase,
         }
 
     degraded_reason = str(

--- a/artifacts.root-owned.1778272918/context/rag-context-1a4570d41255.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-1a4570d41255.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. frontend/src/vite-config.test.ts (score: 1.000, trust: canonical)\n    line 2: import { createRequire } from \"node:module\";\n2. api_service/db/models.py (score: 1.000, trust: canonical)\n    line 56: # For this implementation, we'll stick to UUIDs as it's more common with fastapi-users.\n3. frontend/src/components/settings/ProviderProfilesManager.tsx (score: 1.000, trust: canonical)\n    line 535: throw new Error('Profile ID is required.');\n4. moonmind/claude/runtime.py (score: 1.000, trust: canonical)\n    line 14: \"targetRuntime=claude requires ANTHROPIC_API_KEY to be configured\"\n5. docs/Temporal/ops-runbook.md (score: 1.000, trust: canonical)\n    line 8: Keys for model providers (e.g. Google and OpenAI) are injected from this user's profile when Agent tasks execute. In `disabled` auth mode, the values from `.env` seed this profile on startup.\n6. docs/Temporal/RunHistoryAndRerunSemantics.md (score: 1.000, trust: canonical)\n    line 3: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.\n7. docs/Temporal/IntegrationsMonitoringDesign.md (score: 1.000, trust: canonical)\n    line 3: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.\n8. docs/Development/FrontendDevelopment.md (score: 1.000, trust: canonical)\n    line 15: Use the production-like workflow when you need another person to review a",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "frontend/src/vite-config.test.ts",
+      "text": "line 2: import { createRequire } from \"node:module\";",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 2,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/db/models.py",
+      "text": "line 56: # For this implementation, we'll stick to UUIDs as it's more common with fastapi-users.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 56,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/components/settings/ProviderProfilesManager.tsx",
+      "text": "line 535: throw new Error('Profile ID is required.');",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 535,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/claude/runtime.py",
+      "text": "line 14: \"targetRuntime=claude requires ANTHROPIC_API_KEY to be configured\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 14,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Temporal/ops-runbook.md",
+      "text": "line 8: Keys for model providers (e.g. Google and OpenAI) are injected from this user's profile when Agent tasks execute. In `disabled` auth mode, the values from `.env` seed this profile on startup.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Temporal/RunHistoryAndRerunSemantics.md",
+      "text": "line 3: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Temporal/IntegrationsMonitoringDesign.md",
+      "text": "line 3: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Development/FrontendDevelopment.md",
+      "text": "line 15: Use the production-like workflow when you need another person to review a",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 15,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:24:50Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-29ee7b00398f.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-29ee7b00398f.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. tests/helpers/codex_session_runtime.py (score: 1.000, trust: canonical)\n    line 13: omit_turns_when_incomplete: bool = False,\n2. moonmind/rag/guardrails.py (score: 1.000, trust: canonical)\n    line 11: \"\"\"Raised when a required guardrail fails.\"\"\"\n3. docs/MoonMindArchitecture.md (score: 1.000, trust: canonical)\n    line 6: **Purpose:** Top-level architecture for MoonMind's Temporal-native agent orchestration model, including managed runtime runs, Codex managed sessions, Claude Code workflows, external agents, artifacts, provider profiles, and workload containers.\n4. docs/ManagedAgents/CodexManagedSessionPlane.md (score: 1.000, trust: canonical)\n    line 1: # Codex Managed Session Plane\n5. docs/ManagedAgents/ClaudeAnthropicOAuth.md (score: 1.000, trust: canonical)\n    line 39: Provider Profiles and the shared managed-runtime retry/cooldown policy whenever\n6. docs/ManagedAgents/AgentSessionDeploymentSafetyCutover.md (score: 1.000, trust: canonical)\n    line 3: Operator playbook for **replay-safe rollout** of durable `AgentSession` workflow changes. The deployment-safety gate expects this file to mention the topics below when sensitive workflow paths change.\n7. docs/ManagedAgents/WorkerVectorEmbedding.md (score: 1.000, trust: canonical)\n    line 10: - [`docs/Temporal/WorkflowArtifactSystemDesign.md`](../Temporal/WorkflowArtifactSystemDesign.md)\n8. docs/ManagedAgents/CodexCliManagedSessions.md (score: 1.000, trust: canonical)\n    line 14: This document defines the desired-state architecture contract for the **Codex managed session plane**.",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "tests/helpers/codex_session_runtime.py",
+      "text": "line 13: omit_turns_when_incomplete: bool = False,",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 13,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/rag/guardrails.py",
+      "text": "line 11: \"\"\"Raised when a required guardrail fails.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 11,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/MoonMindArchitecture.md",
+      "text": "line 6: **Purpose:** Top-level architecture for MoonMind's Temporal-native agent orchestration model, including managed runtime runs, Codex managed sessions, Claude Code workflows, external agents, artifacts, provider profiles, and workload containers.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 6,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/CodexManagedSessionPlane.md",
+      "text": "line 1: # Codex Managed Session Plane",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ClaudeAnthropicOAuth.md",
+      "text": "line 39: Provider Profiles and the shared managed-runtime retry/cooldown policy whenever",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 39,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/AgentSessionDeploymentSafetyCutover.md",
+      "text": "line 3: Operator playbook for **replay-safe rollout** of durable `AgentSession` workflow changes. The deployment-safety gate expects this file to mention the topics below when sensitive workflow paths change.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/WorkerVectorEmbedding.md",
+      "text": "line 10: - [`docs/Temporal/WorkflowArtifactSystemDesign.md`](../Temporal/WorkflowArtifactSystemDesign.md)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 10,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/CodexCliManagedSessions.md",
+      "text": "line 14: This document defines the desired-state architecture contract for the **Codex managed session plane**.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 14,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:15:21Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-2f5c4b54fad5.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-2f5c4b54fad5.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/ui_assets.py (score: 1.000, trust: canonical)\n    line 27: return Path(__file__).resolve().parent / \"static\" / \"task_dashboard\" / \"dist\"\n2. api_service/test_ui_route.py (score: 1.000, trust: canonical)\n    line 8: @router.get(\"/test-tasks-home\", response_class=HTMLResponse)\n3. api_service/core/encryption.py (score: 1.000, trust: canonical)\n    line 21: MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=0 to disable generation).\n4. api_service/core/sync.py (score: 1.000, trust: canonical)\n    line 97: typically does not repeat ``targetRuntime`` or task tool snapshots. The canonical row\n5. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 106: if \"embedContent\" in model.supported_generation_methods\n6. api_service/db/models.py (score: 1.000, trust: canonical)\n    line 144: class RecurringTaskScheduleType(str, enum.Enum):\n7. moonmind/utils/metrics.py (score: 1.000, trust: canonical)\n    line 15: \"\"\"Best-effort StatsD emitter used for workflow task instrumentation.\"\"\"\n8. moonmind/utils/logging.py (score: 1.000, trust: canonical)\n    line 79: \"\"\"Scrub common credential-shaped values from browser/artifact text.\"\"\"",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/ui_assets.py",
+      "text": "line 27: return Path(__file__).resolve().parent / \"static\" / \"task_dashboard\" / \"dist\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 27,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/test_ui_route.py",
+      "text": "line 8: @router.get(\"/test-tasks-home\", response_class=HTMLResponse)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/core/encryption.py",
+      "text": "line 21: MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=0 to disable generation).",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 21,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/core/sync.py",
+      "text": "line 97: typically does not repeat ``targetRuntime`` or task tool snapshots. The canonical row",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 97,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 106: if \"embedContent\" in model.supported_generation_methods",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 106,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/db/models.py",
+      "text": "line 144: class RecurringTaskScheduleType(str, enum.Enum):",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 144,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/utils/metrics.py",
+      "text": "line 15: \"\"\"Best-effort StatsD emitter used for workflow task instrumentation.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 15,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/utils/logging.py",
+      "text": "line 79: \"\"\"Scrub common credential-shaped values from browser/artifact text.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 79,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:22:46Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-483d11a508e7.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-483d11a508e7.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. docs/ManagedAgents/OAuthTerminal.md (score: 1.000, trust: canonical)\n    line 4: **Status:** Desired state, Codex-focused current target\n2. docs/ManagedAgents/CodexManagedSessionPlane.md (score: 1.000, trust: canonical)\n    line 3: Status: Desired state\n3. docs/ManagedAgents/ClaudeAnthropicOAuth.md (score: 1.000, trust: canonical)\n    line 3: **Status:** Desired state\n4. docs/Development/PreCommitWorkflow.md (score: 1.000, trust: canonical)\n    line 49: CI does **not** currently run a dedicated `pre-commit` step, so local `pre-commit` runs are still the main way to catch formatting and auto-fixable lint issues before pushing.\n5. docs/Steps/SkillSystem.md (score: 1.000, trust: canonical)\n    line 3: Status: Desired State\n6. docs/ManagedAgents/WorkerVectorEmbedding.md (score: 1.000, trust: canonical)\n    line 3: Status: Desired state\n7. docs/Artifacts/ArtifactPresentationContract.md (score: 1.000, trust: canonical)\n    line 3: Status: Desired state\n8. docs/Steps/StepTypes.md (score: 1.000, trust: canonical)\n    line 3: Status: Desired-state architecture",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/OAuthTerminal.md",
+      "text": "line 4: **Status:** Desired state, Codex-focused current target",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 4,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/CodexManagedSessionPlane.md",
+      "text": "line 3: Status: Desired state",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ClaudeAnthropicOAuth.md",
+      "text": "line 3: **Status:** Desired state",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Development/PreCommitWorkflow.md",
+      "text": "line 49: CI does **not** currently run a dedicated `pre-commit` step, so local `pre-commit` runs are still the main way to catch formatting and auto-fixable lint issues before pushing.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 49,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Steps/SkillSystem.md",
+      "text": "line 3: Status: Desired State",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/WorkerVectorEmbedding.md",
+      "text": "line 3: Status: Desired state",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Artifacts/ArtifactPresentationContract.md",
+      "text": "line 3: Status: Desired state",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Steps/StepTypes.md",
+      "text": "line 3: Status: Desired-state architecture",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:08:21Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-4be8ee4ab31a.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-4be8ee4ab31a.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. docs/MoonMindRoadmap.md (score: 1.000, trust: canonical)\n    line 35: - Claude API key gate removed — Claude runtime available without API key (#795)\n2. docs/Tasks/ImageSystem.md (score: 1.000, trust: canonical)\n    line 222: - retention follows the execution’s artifact retention policy unless overridden by a more specific policy\n3. docs/UI/MissionControlArchitecture.md (score: 1.000, trust: canonical)\n    line 53: - expose exact execution state without forcing users to think in raw Temporal or provider-native terms unless they choose advanced/debug detail surfaces\n4. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 402: finally:\n5. moonmind/schemas/manifest_v0_models.py (score: 1.000, trust: canonical)\n    line 126: \"\"\"A retrieval metric with optional threshold gate.\"\"\"\n6. api_service/scripts/ensure_codex_config.py (score: 1.000, trust: canonical)\n    line 113: finally:\n7. api_service/db/base.py (score: 1.000, trust: canonical)\n    line 32: finally:\n8. api_service/docker/README.md (score: 1.000, trust: canonical)\n    line 21: The final runtime image copies the produced launchers, the Node runtime, supporting `node_modules`, and license files from the builder. It intentionally relies on the platform-specific optional dependency already installed under `@openai/codex` rather than copying an extra Codex vendor tree into the image.",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "docs/MoonMindRoadmap.md",
+      "text": "line 35: - Claude API key gate removed — Claude runtime available without API key (#795)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 35,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Tasks/ImageSystem.md",
+      "text": "line 222: - retention follows the execution’s artifact retention policy unless overridden by a more specific policy",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 222,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/UI/MissionControlArchitecture.md",
+      "text": "line 53: - expose exact execution state without forcing users to think in raw Temporal or provider-native terms unless they choose advanced/debug detail surfaces",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 53,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 402: finally:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 402,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/schemas/manifest_v0_models.py",
+      "text": "line 126: \"\"\"A retrieval metric with optional threshold gate.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 126,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/scripts/ensure_codex_config.py",
+      "text": "line 113: finally:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 113,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/db/base.py",
+      "text": "line 32: finally:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 32,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/docker/README.md",
+      "text": "line 21: The final runtime image copies the produced launchers, the Node runtime, supporting `node_modules`, and license files from the builder. It intentionally relies on the platform-specific optional dependency already installed under `@openai/codex` rather than copying an extra Codex vendor tree into the image.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 21,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:35:51Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-4c554abcbae1.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-4c554abcbae1.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth_providers.py (score: 1.000, trust: canonical)\n    line 20: from moonmind.auth import AuthProviderManager, EnvAuthProvider, ProfileAuthProvider\n2. api_service/test_ui_route.py (score: 1.000, trust: canonical)\n    line 23: <script id=\"moonmind-ui-boot\" type=\"application/json\">\n3. api_service/migrations/env.py (score: 1.000, trust: canonical)\n    line 27: from moonmind.config.settings import AppSettings  # Import AppSettings class\n4. api_service/db/base.py (score: 1.000, trust: canonical)\n    line 8: from moonmind.config.settings import settings\n5. moonmind/utils/build_info.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Runtime helpers for MoonMind build metadata.\"\"\"\n6. docs/ExternalAgents/ExternalAgentIntegrationSystem.md (score: 1.000, trust: canonical)\n    line 15: Define one canonical architecture for MoonMind external-agent integrations.\n7. moonmind/schemas/agent_runtime_models.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Canonical contracts for managed and external agent runtime execution.\"\"\"\n8. docs/ManagedAgents/ClaudeAnthropicOAuth.md (score: 1.000, trust: canonical)\n    line 9: Code through Claude's own interactive login flow in a MoonMind browser terminal,",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth_providers.py",
+      "text": "line 20: from moonmind.auth import AuthProviderManager, EnvAuthProvider, ProfileAuthProvider",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 20,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/test_ui_route.py",
+      "text": "line 23: <script id=\"moonmind-ui-boot\" type=\"application/json\">",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 23,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/migrations/env.py",
+      "text": "line 27: from moonmind.config.settings import AppSettings  # Import AppSettings class",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 27,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/db/base.py",
+      "text": "line 8: from moonmind.config.settings import settings",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/utils/build_info.py",
+      "text": "line 1: \"\"\"Runtime helpers for MoonMind build metadata.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ExternalAgents/ExternalAgentIntegrationSystem.md",
+      "text": "line 15: Define one canonical architecture for MoonMind external-agent integrations.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 15,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/schemas/agent_runtime_models.py",
+      "text": "line 1: \"\"\"Canonical contracts for managed and external agent runtime execution.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ClaudeAnthropicOAuth.md",
+      "text": "line 9: Code through Claude's own interactive login flow in a MoonMind browser terminal,",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 9,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:10:56Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-5393b77e3886.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-5393b77e3886.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. moonmind/mcp/__init__.py (score: 1.000, trust: canonical)\n    line 3: from moonmind.mcp.jira_tool_registry import (\n2. moonmind/mcp/jira_tool_registry.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Jira MCP tool registry and dispatcher.\"\"\"\n3. moonmind/indexers/jira_indexer.py (score: 1.000, trust: canonical)\n    line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)\n4. frontend/src/entrypoints/dashboard-alerts.test.tsx (score: 1.000, trust: canonical)\n    line 17: function mockDashboardAlertFetch(\n5. frontend/src/generated/openapi.ts (score: 1.000, trust: canonical)\n    line 139: \"/v1/planning/jira\": {\n6. frontend/src/entrypoints/skills.tsx (score: 1.000, trust: canonical)\n    line 172: const response = await fetch('/api/tasks/skills?includeContent=true', {\n7. docs/ManagedAgents/ManagedAgentArchitecture.md (score: 1.000, trust: canonical)\n    line 36: - **Context** is assembled by MoonMind and delivered into the session through artifact refs, workspace materialization, and runtime-specific input delivery.\n8. docs/MoonMindRoadmap.md (score: 1.000, trust: canonical)\n    line 114: **README claim:** *\"Ground agents with built-in loaders for GitHub, Jira, Confluence, Google Drive, and local files.\"*",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "moonmind/mcp/__init__.py",
+      "text": "line 3: from moonmind.mcp.jira_tool_registry import (",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/mcp/jira_tool_registry.py",
+      "text": "line 1: \"\"\"Jira MCP tool registry and dispatcher.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/indexers/jira_indexer.py",
+      "text": "line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/entrypoints/dashboard-alerts.test.tsx",
+      "text": "line 17: function mockDashboardAlertFetch(",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 17,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/generated/openapi.ts",
+      "text": "line 139: \"/v1/planning/jira\": {",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 139,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/entrypoints/skills.tsx",
+      "text": "line 172: const response = await fetch('/api/tasks/skills?includeContent=true', {",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 172,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ManagedAgentArchitecture.md",
+      "text": "line 36: - **Context** is assembled by MoonMind and delivered into the session through artifact refs, workspace materialization, and runtime-specific input delivery.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 36,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/MoonMindRoadmap.md",
+      "text": "line 114: **README claim:** *\"Ground agents with built-in loaders for GitHub, Jira, Confluence, Google Drive, and local files.\"*",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 114,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:09:04Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-95f6d08e2cc7.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-95f6d08e2cc7.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/services/agent_skills_service.py (score: 1.000, trust: canonical)\n    line 22: from moonmind.workflows.temporal import TemporalArtifactService\n2. moonmind/core/artifacts.py (score: 1.000, trust: canonical)\n    line 3: class TemporalArtifactStorageBackend(str, enum.Enum):\n3. moonmind/codex_cloud/settings.py (score: 1.000, trust: canonical)\n    line 23: missing: tuple[str, ...]\n4. moonmind/config/logging.py (score: 1.000, trust: canonical)\n    line 89: structured: When true, emit JSON logs that preserve ``extra`` fields.\n5. moonmind/indexers/jira_indexer.py (score: 1.000, trust: canonical)\n    line 135: # and will only stop when JiraReader returns an empty list.\n6. moonmind/claude/runtime.py (score: 1.000, trust: canonical)\n    line 16: \"\"\"Canonical error text for disabled Claude runtime (ANTHROPIC/CLAUDE API key missing).\"\"\"\n7. moonmind/indexers/local_data_indexer.py (score: 1.000, trust: canonical)\n    line 110: # After reviewing LlamaIndex docs, VectorStoreIndex constructor when given nodes\n8. moonmind/config/settings.py (score: 1.000, trust: canonical)\n    line 79: activity_artifacts_task_queue: str = Field(",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/services/agent_skills_service.py",
+      "text": "line 22: from moonmind.workflows.temporal import TemporalArtifactService",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 22,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/core/artifacts.py",
+      "text": "line 3: class TemporalArtifactStorageBackend(str, enum.Enum):",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/codex_cloud/settings.py",
+      "text": "line 23: missing: tuple[str, ...]",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 23,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/config/logging.py",
+      "text": "line 89: structured: When true, emit JSON logs that preserve ``extra`` fields.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 89,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/indexers/jira_indexer.py",
+      "text": "line 135: # and will only stop when JiraReader returns an empty list.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 135,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/claude/runtime.py",
+      "text": "line 16: \"\"\"Canonical error text for disabled Claude runtime (ANTHROPIC/CLAUDE API key missing).\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 16,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/indexers/local_data_indexer.py",
+      "text": "line 110: # After reviewing LlamaIndex docs, VectorStoreIndex constructor when given nodes",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 110,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/config/settings.py",
+      "text": "line 79: activity_artifacts_task_queue: str = Field(",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 79,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:19:52Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-976a28d384dd.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-976a28d384dd.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth.py (score: 1.000, trust: canonical)\n    line 96: Falls back to built-in default ID and email unless overridden in settings.\n2. api_service/main.py (score: 1.000, trust: canonical)\n    line 45: from api_service.api.routers.jira_browser import router as jira_browser_router\n3. moonmind/indexers/jira_indexer.py (score: 1.000, trust: canonical)\n    line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)\n4. moonmind/planning/__init__.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Planning utilities for generating Jira stories.\"\"\"\n5. moonmind/planning/jira_story_planner.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Skeleton for planning Jira stories from high level text.\"\"\"\n6. docs/Memory/MemoryResearch.md (score: 1.000, trust: canonical)\n    line 88: - Cons: Still bounded; often brittle under long-horizon tasks unless paired with durable stores.\n7. docs/Rag/LlamaIndexManifestSystem.md (score: 1.000, trust: canonical)\n    line 54: * Ingest/indexing: `moonmind/indexers/*` (Jira, Google Drive, Local, GitHub)\n8. docs/Temporal/RunHistoryAndRerunSemantics.md (score: 1.000, trust: canonical)\n    line 66: This document makes those semantics explicit and treats them as the v1 default unless a later doc intentionally changes them.",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth.py",
+      "text": "line 96: Falls back to built-in default ID and email unless overridden in settings.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 96,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/main.py",
+      "text": "line 45: from api_service.api.routers.jira_browser import router as jira_browser_router",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 45,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/indexers/jira_indexer.py",
+      "text": "line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/planning/__init__.py",
+      "text": "line 1: \"\"\"Planning utilities for generating Jira stories.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/planning/jira_story_planner.py",
+      "text": "line 1: \"\"\"Skeleton for planning Jira stories from high level text.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Memory/MemoryResearch.md",
+      "text": "line 88: - Cons: Still bounded; often brittle under long-horizon tasks unless paired with durable stores.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 88,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Rag/LlamaIndexManifestSystem.md",
+      "text": "line 54: * Ingest/indexing: `moonmind/indexers/*` (Jira, Google Drive, Local, GitHub)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 54,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Temporal/RunHistoryAndRerunSemantics.md",
+      "text": "line 66: This document makes those semantics explicit and treats them as the v1 default unless a later doc intentionally changes them.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 66,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:12:07Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-a19baa9629c8.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-a19baa9629c8.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth_providers.py (score: 1.000, trust: canonical)\n    line 49: • **However** when running under unit-test environments the database is often\n2. docs/Api/ExecutionsApiContract.md (score: 1.000, trust: canonical)\n    line 10: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.\n3. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 31: # Ensure __init__ is only run once for the singleton\n4. docs/Development/FrontendDevelopment.md (score: 1.000, trust: canonical)\n    line 15: Use the production-like workflow when you need another person to review a\n5. docs/Development/PreCommitWorkflow.md (score: 1.000, trust: canonical)\n    line 41: That script is the source of truth for unit-test execution. It does **not** invoke `pre-commit` itself, so run `pre-commit` separately when you want the same formatting and lint guardrail outside the PowerShell wrappers.\n6. moonmind/summarization/repo_summary.py (score: 1.000, trust: canonical)\n    line 105: # Poetry dependencies can be a dict, we only want keys\n7. moonmind/jules/runtime.py (score: 1.000, trust: canonical)\n    line 44: Returns ``True``/``False`` when explicitly set, or ``None`` when unset\n8. moonmind/schemas/task_proposal_models.py (score: 1.000, trust: canonical)\n    line 41: preset_provenance: Optional[str] = Field(None, alias=\"presetProvenance\")",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth_providers.py",
+      "text": "line 49: • **However** when running under unit-test environments the database is often",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 49,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Api/ExecutionsApiContract.md",
+      "text": "line 10: **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 10,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 31: # Ensure __init__ is only run once for the singleton",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 31,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Development/FrontendDevelopment.md",
+      "text": "line 15: Use the production-like workflow when you need another person to review a",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 15,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Development/PreCommitWorkflow.md",
+      "text": "line 41: That script is the source of truth for unit-test execution. It does **not** invoke `pre-commit` itself, so run `pre-commit` separately when you want the same formatting and lint guardrail outside the PowerShell wrappers.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 41,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/summarization/repo_summary.py",
+      "text": "line 105: # Poetry dependencies can be a dict, we only want keys",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 105,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/jules/runtime.py",
+      "text": "line 44: Returns ``True``/``False`` when explicitly set, or ``None`` when unset",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 44,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/schemas/task_proposal_models.py",
+      "text": "line 41: preset_provenance: Optional[str] = Field(None, alias=\"presetProvenance\")",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 41,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:14:33Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.root-owned.1778272918/context/rag-context-af0b05ba07d3.json
+++ b/artifacts.root-owned.1778272918/context/rag-context-af0b05ba07d3.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/core/sync.py (score: 1.000, trust: canonical)\n    line 160: WorkflowExecutionStatus.COMPLETED: (\n2. moonmind/services/skills_on_demand.py (score: 1.000, trust: canonical)\n    line 14: SkillsOnDemandRequestAuditResult,\n3. moonmind/manifest/validator.py (score: 1.000, trust: canonical)\n    line 38: class ValidationIssue:\n4. moonmind/workflows/provider_failures.py (score: 1.000, trust: canonical)\n    line 18: \"too many requests\",\n5. moonmind/workflows/__init__.py (score: 1.000, trust: canonical)\n    line 37: from moonmind.integrations.jira.tool import JiraToolService\n6. moonmind/workflows/task_proposals/__init__.py (score: 1.000, trust: canonical)\n    line 7: ProposalDeliveryRequest,\n7. moonmind/workflows/task_proposals/delivery.py (score: 1.000, trust: canonical)\n    line 4: issues are review artifacts with bounded controls and links back to evidence.\n8. moonmind/workflows/task_proposals/repositories.py (score: 1.000, trust: canonical)\n    line 14: \"\"\"Raised when a proposal cannot be found for the requested id.\"\"\"",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/core/sync.py",
+      "text": "line 160: WorkflowExecutionStatus.COMPLETED: (",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 160,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/services/skills_on_demand.py",
+      "text": "line 14: SkillsOnDemandRequestAuditResult,",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 14,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/manifest/validator.py",
+      "text": "line 38: class ValidationIssue:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 38,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workflows/provider_failures.py",
+      "text": "line 18: \"too many requests\",",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 18,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workflows/__init__.py",
+      "text": "line 37: from moonmind.integrations.jira.tool import JiraToolService",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 37,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workflows/task_proposals/__init__.py",
+      "text": "line 7: ProposalDeliveryRequest,",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 7,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workflows/task_proposals/delivery.py",
+      "text": "line 4: issues are review artifacts with bounded controls and links back to evidence.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 4,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workflows/task_proposals/repositories.py",
+      "text": "line 14: \"\"\"Raised when a proposal cannot be found for the requested id.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 14,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-08T20:38:43Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1675,6 +1675,111 @@ describe('Task Detail Entrypoint', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/executions/test-123?source=temporal');
   });
 
+  it('renders target attachment diagnostics without replacing raw diagnostics', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      taskRunId: '123e4567-e89b-12d3-a456-426614174000',
+      title: 'Target diagnostic task',
+      summary: 'Attachment preparation degraded.',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      targetDiagnostics: {
+        targets: [
+          {
+            targetKind: 'objective',
+            label: 'Task objective',
+            attachments: [
+              {
+                artifactRef: 'artifact://input/objective',
+                filename: 'objective.png',
+                contentType: 'image/png',
+                previewAvailable: true,
+              },
+            ],
+            refs: [{ refKind: 'attachment_manifest', artifactRef: 'artifact://diagnostics/input-manifest' }],
+            failures: [],
+          },
+          {
+            targetKind: 'step',
+            stepId: 'inspect',
+            label: 'Inspect screenshot',
+            attachments: [],
+            refs: [],
+            failures: [
+              {
+                phase: 'materialization',
+                message: 'Attachment download failed before step execution.',
+                evidenceRef: 'artifact://diagnostics/prepare',
+              },
+            ],
+          },
+        ],
+        recovery: {
+          resumed: true,
+          sourceWorkflowId: 'mm:source',
+          sourceRunId: 'run-source',
+          checkpointRef: 'artifact://resume/checkpoint',
+          preservedSteps: [
+            {
+              logicalStepId: 'prepare',
+              title: 'Prepare context',
+              sourceAttempt: 1,
+              sourceWorkflowId: 'mm:source',
+              sourceRunId: 'run-source',
+            },
+          ],
+          failedResumePhase: null,
+        },
+        degradedReason: 'step_attachment_missing',
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/diagnostics')) {
+        return Promise.resolve({ ok: true, text: async () => '{"raw":"diagnostics"}' } as Response);
+      }
+      if (url.includes('/logs/') || url.includes('/observability')) {
+        return Promise.resolve({ ok: true, text: async () => '' } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Target diagnostic task')).toBeTruthy();
+    });
+    expect(screen.getByRole('heading', { name: 'Target Diagnostics' })).toBeTruthy();
+    expect(screen.getAllByText('Task objective').length).toBeGreaterThan(0);
+    expect(screen.getByText('objective.png')).toBeTruthy();
+    expect(screen.getByText('Inspect screenshot')).toBeTruthy();
+    expect(screen.getByText('Attachment download failed before step execution.')).toBeTruthy();
+    expect(screen.getByText('artifact://diagnostics/input-manifest')).toBeTruthy();
+    expect(screen.getByText('Resumed from mm:source')).toBeTruthy();
+    expect(screen.getByText('Prepare context')).toBeTruthy();
+    expect(screen.getByText('artifact://resume/checkpoint')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Diagnostics'));
+    await waitFor(() => {
+      expect(screen.getByText(/\{"raw":"diagnostics"\}/)).toBeTruthy();
+    });
+  });
+
   it('renders remediation create action, relationships, evidence, and degraded states', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -307,7 +307,13 @@ const TargetDiagnosticsSchema = z
               .array(
                 z
                   .object({
-                    phase: z.string(),
+                    phase: z.enum([
+                      'upload',
+                      'validation',
+                      'materialization',
+                      'context_generation',
+                      'degraded',
+                    ]),
                     message: z.string(),
                     evidenceRef: z.string().nullable().optional(),
                   })
@@ -337,7 +343,15 @@ const TargetDiagnosticsSchema = z
               .passthrough(),
           )
           .default([]),
-        failedResumePhase: z.string().nullable().optional(),
+        failedResumePhase: z
+          .enum([
+            'checkpoint_validation',
+            'workspace_restoration',
+            'preserved_output_injection',
+            'failed_step_execution',
+          ])
+          .nullable()
+          .optional(),
       })
       .passthrough()
       .nullable()

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -270,6 +270,82 @@ const ProposalSummarySchema = z
   })
   .passthrough();
 
+const TargetDiagnosticsSchema = z
+  .object({
+    targets: z
+      .array(
+        z
+          .object({
+            targetKind: z.enum(['objective', 'step']),
+            stepId: z.string().nullable().optional(),
+            label: z.string(),
+            attachments: z
+              .array(
+                z
+                  .object({
+                    artifactRef: z.string().nullable().optional(),
+                    filename: z.string().nullable().optional(),
+                    contentType: z.string().nullable().optional(),
+                    sizeBytes: z.number().nullable().optional(),
+                    previewAvailable: z.boolean().optional(),
+                  })
+                  .passthrough(),
+              )
+              .default([]),
+            refs: z
+              .array(
+                z
+                  .object({
+                    refKind: z.string(),
+                    artifactRef: z.string().nullable().optional(),
+                    path: z.string().nullable().optional(),
+                  })
+                  .passthrough(),
+              )
+              .default([]),
+            failures: z
+              .array(
+                z
+                  .object({
+                    phase: z.string(),
+                    message: z.string(),
+                    evidenceRef: z.string().nullable().optional(),
+                  })
+                  .passthrough(),
+              )
+              .default([]),
+          })
+          .passthrough(),
+      )
+      .default([]),
+    recovery: z
+      .object({
+        resumed: z.boolean().optional(),
+        sourceWorkflowId: z.string().nullable().optional(),
+        sourceRunId: z.string().nullable().optional(),
+        checkpointRef: z.string().nullable().optional(),
+        preservedSteps: z
+          .array(
+            z
+              .object({
+                logicalStepId: z.string(),
+                title: z.string().nullable().optional(),
+                sourceAttempt: z.number().nullable().optional(),
+                sourceWorkflowId: z.string().nullable().optional(),
+                sourceRunId: z.string().nullable().optional(),
+              })
+              .passthrough(),
+          )
+          .default([]),
+        failedResumePhase: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+    degradedReason: z.string().nullable().optional(),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string(),
@@ -386,6 +462,7 @@ const ExecutionDetailSchema = z
       )
       .default([])
       .optional(),
+    targetDiagnostics: TargetDiagnosticsSchema.nullable().optional(),
     interventionAudit: z
       .array(
         z
@@ -3038,6 +3115,127 @@ function DiagnosticsPanel({
   );
 }
 
+function TargetDiagnosticsPanel({
+  diagnostics,
+}: {
+  diagnostics: z.infer<typeof TargetDiagnosticsSchema> | null | undefined;
+}) {
+  if (!diagnostics) return null;
+  const hasTargets = diagnostics.targets.length > 0;
+  const recovery = diagnostics.recovery;
+
+  if (!hasTargets && !recovery && !diagnostics.degradedReason) return null;
+
+  return (
+    <section className="stack td-evidence-region">
+      <h3>Target Diagnostics</h3>
+      {diagnostics.degradedReason ? (
+        <p className="small">Degraded: {formatStatusLabel(diagnostics.degradedReason)}</p>
+      ) : null}
+      {hasTargets ? (
+        <div className="grid-2">
+          {diagnostics.targets.map((target, index) => (
+            <div
+              className="card"
+              key={`${target.targetKind}-${target.stepId || index}`}
+            >
+              <h4>{target.label}</h4>
+              <p className="small">
+                {target.targetKind === 'objective' ? 'Task objective' : `Step ${formatOptionalValue(target.stepId)}`}
+              </p>
+              {target.attachments.length > 0 ? (
+                <ul className="step-detail-list">
+                  {target.attachments.map((attachment, attachmentIndex) => (
+                    <li key={`${attachment.artifactRef || attachment.filename || attachmentIndex}`}>
+                      <strong>{attachment.filename || 'Attachment'}</strong>
+                      {attachment.contentType ? <span className="small"> {attachment.contentType}</span> : null}
+                      {attachment.artifactRef ? (
+                        <>
+                          {' '}
+                          <code className="text-xs break-all">{attachment.artifactRef}</code>
+                        </>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="small">No attachments recorded for this target.</p>
+              )}
+              {target.refs.length > 0 ? (
+                <div>
+                  <h5>Evidence</h5>
+                  <ul className="step-detail-list">
+                    {target.refs.map((ref, refIndex) => (
+                      <li key={`${ref.refKind}-${ref.artifactRef || ref.path || refIndex}`}>
+                        <span>{formatStatusLabel(ref.refKind)}</span>{' '}
+                        <code className="text-xs break-all">{ref.artifactRef || ref.path}</code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {target.failures.length > 0 ? (
+                <div>
+                  <h5>Failures</h5>
+                  <ul className="step-detail-list">
+                    {target.failures.map((failure, failureIndex) => (
+                      <li key={`${failure.phase}-${failureIndex}`}>
+                        <strong>{formatStatusLabel(failure.phase)}:</strong> {failure.message}
+                        {failure.evidenceRef ? (
+                          <>
+                            {' '}
+                            <code className="text-xs break-all">{failure.evidenceRef}</code>
+                          </>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="small">No target diagnostics were recorded.</p>
+      )}
+      {recovery ? (
+        <div>
+          <h4>Recovery</h4>
+          {recovery.resumed && recovery.sourceWorkflowId ? (
+            <p>Resumed from {recovery.sourceWorkflowId}</p>
+          ) : recovery.resumed ? (
+            <p>Resumed from a previous run.</p>
+          ) : null}
+          <ul className="step-detail-list">
+            {recovery.sourceRunId ? (
+              <li><strong>Source run:</strong> <code className="text-xs break-all">{recovery.sourceRunId}</code></li>
+            ) : null}
+            {recovery.checkpointRef ? (
+              <li><strong>Checkpoint:</strong> <code className="text-xs break-all">{recovery.checkpointRef}</code></li>
+            ) : null}
+            {recovery.failedResumePhase ? (
+              <li><strong>Failed phase:</strong> {formatStatusLabel(recovery.failedResumePhase)}</li>
+            ) : null}
+          </ul>
+          {recovery.preservedSteps.length > 0 ? (
+            <div>
+              <h5>Preserved Steps</h5>
+              <ul className="step-detail-list">
+                {recovery.preservedSteps.map((step) => (
+                  <li key={`${step.logicalStepId}-${step.sourceRunId || ''}`}>
+                    <strong>{step.title || step.logicalStepId}</strong>
+                    {step.sourceAttempt ? <span className="small"> attempt {step.sourceAttempt}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function SessionContinuityPanel({
   apiBase,
   taskRunId,
@@ -4628,6 +4826,8 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               onSendMessage={onSendMessage}
             />
           ) : null}
+
+          <TargetDiagnosticsPanel diagnostics={execution.targetDiagnostics} />
 
           {resolvedTaskRunId ? (
             <SessionContinuityPanel

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4236,6 +4236,7 @@ export interface components {
             resume?: components["schemas"]["ExecutionResumeSummaryModel"] | null;
             /** Relatedruns */
             relatedRuns?: components["schemas"]["ExecutionRelatedRunModel"][];
+            targetDiagnostics?: components["schemas"]["ExecutionTargetDiagnosticsModel"] | null;
             /** Proposalsummary */
             proposalSummary?: {
                 [key: string]: unknown;
@@ -4576,6 +4577,121 @@ export interface components {
             contentRef?: string | null;
             /** Contentdigest */
             contentDigest?: string | null;
+        };
+        /**
+         * ExecutionTargetDiagnosticAttachmentModel
+         * @description Attachment bound to the objective or a single executable step.
+         */
+        ExecutionTargetDiagnosticAttachmentModel: {
+            /** Artifactref */
+            artifactRef?: string | null;
+            /** Filename */
+            filename?: string | null;
+            /** Contenttype */
+            contentType?: string | null;
+            /** Sizebytes */
+            sizeBytes?: number | null;
+            /**
+             * Previewavailable
+             * @default false
+             */
+            previewAvailable: boolean;
+        };
+        /**
+         * ExecutionTargetDiagnosticFailureModel
+         * @description Failure evidence for upload, validation, materialization, or context build.
+         */
+        ExecutionTargetDiagnosticFailureModel: {
+            /**
+             * Phase
+             * @enum {string}
+             */
+            phase: "upload" | "validation" | "materialization" | "context_generation" | "degraded";
+            /** Message */
+            message: string;
+            /** Evidenceref */
+            evidenceRef?: string | null;
+        };
+        /**
+         * ExecutionTargetDiagnosticRefModel
+         * @description Semantic evidence ref associated with target preparation.
+         */
+        ExecutionTargetDiagnosticRefModel: {
+            /** Refkind */
+            refKind: string;
+            /** Artifactref */
+            artifactRef?: string | null;
+            /** Path */
+            path?: string | null;
+        };
+        /**
+         * ExecutionTargetDiagnosticTargetModel
+         * @description Diagnostics for one target scope: objective or individual step.
+         */
+        ExecutionTargetDiagnosticTargetModel: {
+            /**
+             * Targetkind
+             * @enum {string}
+             */
+            targetKind: "objective" | "step";
+            /** Stepid */
+            stepId?: string | null;
+            /** Label */
+            label: string;
+            /** Attachments */
+            attachments?: components["schemas"]["ExecutionTargetDiagnosticAttachmentModel"][];
+            /** Refs */
+            refs?: components["schemas"]["ExecutionTargetDiagnosticRefModel"][];
+            /** Failures */
+            failures?: components["schemas"]["ExecutionTargetDiagnosticFailureModel"][];
+        };
+        /**
+         * ExecutionTargetDiagnosticsModel
+         * @description Target-aware task diagnostics surfaced on execution detail.
+         */
+        ExecutionTargetDiagnosticsModel: {
+            /** Targets */
+            targets?: components["schemas"]["ExecutionTargetDiagnosticTargetModel"][];
+            recovery?: components["schemas"]["ExecutionTargetDiagnosticsRecoveryModel"] | null;
+            /** Degradedreason */
+            degradedReason?: string | null;
+        };
+        /**
+         * ExecutionTargetDiagnosticsPreservedStepModel
+         * @description Source provenance for a step output preserved into a resumed run.
+         */
+        ExecutionTargetDiagnosticsPreservedStepModel: {
+            /** Logicalstepid */
+            logicalStepId: string;
+            /** Title */
+            title?: string | null;
+            /** Sourceattempt */
+            sourceAttempt?: number | null;
+            /** Sourceworkflowid */
+            sourceWorkflowId?: string | null;
+            /** Sourcerunid */
+            sourceRunId?: string | null;
+        };
+        /**
+         * ExecutionTargetDiagnosticsRecoveryModel
+         * @description Failed-step Resume provenance and degraded recovery diagnostics.
+         */
+        ExecutionTargetDiagnosticsRecoveryModel: {
+            /**
+             * Resumed
+             * @default false
+             */
+            resumed: boolean;
+            /** Sourceworkflowid */
+            sourceWorkflowId?: string | null;
+            /** Sourcerunid */
+            sourceRunId?: string | null;
+            /** Checkpointref */
+            checkpointRef?: string | null;
+            /** Preservedsteps */
+            preservedSteps?: components["schemas"]["ExecutionTargetDiagnosticsPreservedStepModel"][];
+            /** Failedresumephase */
+            failedResumePhase?: ("checkpoint_validation" | "workspace_restoration" | "preserved_output_injection" | "failed_step_execution") | null;
         };
         /**
          * GitHubCredentialStatus

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1228,6 +1228,102 @@ class ExecutionRelatedRunModel(BaseModel):
     created_at: Optional[datetime] = Field(None, alias="createdAt")
     href: str = Field(..., alias="href", min_length=1)
 
+class ExecutionTargetDiagnosticAttachmentModel(BaseModel):
+    """Attachment bound to the objective or a single executable step."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    artifact_ref: str | None = Field(None, alias="artifactRef")
+    filename: str | None = Field(None, alias="filename")
+    content_type: str | None = Field(None, alias="contentType")
+    size_bytes: int | None = Field(None, alias="sizeBytes", ge=0)
+    preview_available: bool = Field(False, alias="previewAvailable")
+
+class ExecutionTargetDiagnosticRefModel(BaseModel):
+    """Semantic evidence ref associated with target preparation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    ref_kind: str = Field(..., alias="refKind", min_length=1)
+    artifact_ref: str | None = Field(None, alias="artifactRef")
+    path: str | None = Field(None, alias="path")
+
+class ExecutionTargetDiagnosticFailureModel(BaseModel):
+    """Failure evidence for upload, validation, materialization, or context build."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    phase: Literal[
+        "upload",
+        "validation",
+        "materialization",
+        "context_generation",
+    ] = Field(..., alias="phase")
+    message: str = Field(..., alias="message", min_length=1)
+    evidence_ref: str | None = Field(None, alias="evidenceRef")
+
+class ExecutionTargetDiagnosticTargetModel(BaseModel):
+    """Diagnostics for one target scope: objective or individual step."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    target_kind: Literal["objective", "step"] = Field(..., alias="targetKind")
+    step_id: str | None = Field(None, alias="stepId")
+    label: str = Field(..., alias="label", min_length=1)
+    attachments: list[ExecutionTargetDiagnosticAttachmentModel] = Field(
+        default_factory=list,
+        alias="attachments",
+    )
+    refs: list[ExecutionTargetDiagnosticRefModel] = Field(
+        default_factory=list,
+        alias="refs",
+    )
+    failures: list[ExecutionTargetDiagnosticFailureModel] = Field(
+        default_factory=list,
+        alias="failures",
+    )
+
+class ExecutionTargetDiagnosticsPreservedStepModel(BaseModel):
+    """Source provenance for a step output preserved into a resumed run."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    title: str | None = Field(None, alias="title")
+    source_attempt: int | None = Field(None, alias="sourceAttempt", ge=1)
+    source_workflow_id: str | None = Field(None, alias="sourceWorkflowId")
+    source_run_id: str | None = Field(None, alias="sourceRunId")
+
+class ExecutionTargetDiagnosticsRecoveryModel(BaseModel):
+    """Failed-step Resume provenance and degraded recovery diagnostics."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resumed: bool = Field(False, alias="resumed")
+    source_workflow_id: str | None = Field(None, alias="sourceWorkflowId")
+    source_run_id: str | None = Field(None, alias="sourceRunId")
+    checkpoint_ref: str | None = Field(None, alias="checkpointRef")
+    preserved_steps: list[ExecutionTargetDiagnosticsPreservedStepModel] = Field(
+        default_factory=list,
+        alias="preservedSteps",
+    )
+    failed_resume_phase: str | None = Field(None, alias="failedResumePhase")
+
+class ExecutionTargetDiagnosticsModel(BaseModel):
+    """Target-aware task diagnostics surfaced on execution detail."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    targets: list[ExecutionTargetDiagnosticTargetModel] = Field(
+        default_factory=list,
+        alias="targets",
+    )
+    recovery: ExecutionTargetDiagnosticsRecoveryModel | None = Field(
+        None,
+        alias="recovery",
+    )
+    degraded_reason: str | None = Field(None, alias="degradedReason")
+
 class ExecutionModel(BaseModel):
     """Materialized execution view returned by lifecycle APIs."""
 
@@ -1329,6 +1425,9 @@ class ExecutionModel(BaseModel):
     resume: ExecutionResumeSummaryModel | None = Field(None, alias="resume")
     related_runs: list[ExecutionRelatedRunModel] = Field(
         default_factory=list, alias="relatedRuns"
+    )
+    target_diagnostics: ExecutionTargetDiagnosticsModel | None = Field(
+        None, alias="targetDiagnostics"
     )
     proposal_summary: dict[str, Any] | None = Field(None, alias="proposalSummary")
     proposal_outcomes: list[dict[str, Any]] = Field(

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1258,6 +1258,7 @@ class ExecutionTargetDiagnosticFailureModel(BaseModel):
         "validation",
         "materialization",
         "context_generation",
+        "degraded",
     ] = Field(..., alias="phase")
     message: str = Field(..., alias="message", min_length=1)
     evidence_ref: str | None = Field(None, alias="evidenceRef")
@@ -1307,7 +1308,12 @@ class ExecutionTargetDiagnosticsRecoveryModel(BaseModel):
         default_factory=list,
         alias="preservedSteps",
     )
-    failed_resume_phase: str | None = Field(None, alias="failedResumePhase")
+    failed_resume_phase: Literal[
+        "checkpoint_validation",
+        "workspace_restoration",
+        "preserved_output_injection",
+        "failed_step_execution",
+    ] | None = Field(None, alias="failedResumePhase")
 
 class ExecutionTargetDiagnosticsModel(BaseModel):
     """Target-aware task diagnostics surfaced on execution detail."""

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/checklists/requirements.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Show Attachment and Recovery Diagnostics By Target
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves Jira issue `MM-635`, the original Jira preset brief, runtime intent, source coverage IDs DESIGN-REQ-023 and DESIGN-REQ-024, and exactly one independently testable user story.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/contracts/task-detail-target-diagnostics.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/contracts/task-detail-target-diagnostics.md
@@ -1,0 +1,98 @@
+# Contract: Task Detail Target Diagnostics
+
+## Surface
+
+The task detail API response and task detail UI expose a bounded target diagnostics summary for `MoonMind.Run` executions when target-aware evidence exists.
+
+## Execution Detail Shape
+
+Add or populate a compact optional object on execution detail responses:
+
+```json
+{
+  "targetDiagnostics": {
+    "targets": [
+      {
+        "targetKind": "objective",
+        "label": "Task objective",
+        "attachments": [
+          {
+            "artifactRef": "artifact://input/objective-1",
+            "filename": "wireframe.png",
+            "contentType": "image/png",
+            "sizeBytes": 12345,
+            "previewAvailable": true
+          }
+        ],
+        "refs": [
+          {
+            "refKind": "attachment_manifest",
+            "artifactRef": "artifact://manifest/attachments"
+          },
+          {
+            "refKind": "generated_context",
+            "artifactRef": "artifact://vision/context-index"
+          }
+        ],
+        "failures": []
+      },
+      {
+        "targetKind": "step",
+        "stepId": "inspect",
+        "label": "Inspect screenshot",
+        "attachments": [],
+        "refs": [],
+        "failures": [
+          {
+            "phase": "materialization",
+            "message": "Attachment download failed before step execution.",
+            "evidenceRef": "artifact://diagnostics/prepare"
+          }
+        ]
+      }
+    ],
+    "recovery": {
+      "resumed": true,
+      "sourceWorkflowId": "mm:source",
+      "sourceRunId": "run-source",
+      "checkpointRef": "artifact://resume/checkpoint",
+      "preservedSteps": [
+        {
+          "logicalStepId": "prepare",
+          "title": "Prepare context",
+          "sourceAttempt": 1,
+          "sourceWorkflowId": "mm:source",
+          "sourceRunId": "run-source"
+        }
+      ],
+      "failedResumePhase": null
+    },
+    "degradedReason": null
+  }
+}
+```
+
+## UI Behavior
+
+- Render objective target diagnostics separately from step target diagnostics.
+- For each target, show attachment metadata, target-owned refs, and failures in the same target group.
+- Show an explicit empty state when a known target has no attachments.
+- Show generated context and manifest refs as refs, not embedded artifact bodies.
+- Show Resume provenance and preserved prior steps near recovery information.
+- Show failed Resume phases using bounded labels:
+  - checkpoint validation
+  - workspace restoration
+  - preserved-output injection
+  - failed-step execution
+- Keep raw diagnostics panels available for deep troubleshooting, but do not require raw diagnostics parsing for the primary target ownership and phase information.
+
+## Failure And Degraded Evidence
+
+- If target evidence is unavailable, expose a bounded `degradedReason`.
+- If a failure has no known target, display degraded evidence instead of assigning it to an arbitrary target.
+- If a raw event has an unknown phase, preserve a bounded message and mark the phase as degraded rather than adding a new public phase silently.
+
+## Traceability
+
+- This contract supports MM-635.
+- It covers FR-001 through FR-012, SC-001 through SC-005, DESIGN-REQ-023, and DESIGN-REQ-024.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/data-model.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: Show Attachment and Recovery Diagnostics By Target
+
+## Task Target
+
+Represents the owner of attachment-related metadata or diagnostics.
+
+- `targetKind`: `objective` or `step`.
+- `stepId`: stable logical step identifier when `targetKind` is `step`.
+- `stepTitle`: operator-facing step title when available.
+- `attachmentCount`: number of attachment metadata items associated with this target.
+- `hasDiagnostics`: whether any diagnostic evidence exists for this target.
+
+Validation rules:
+
+- Objective targets must not include `stepId`.
+- Step targets must include a stable step identifier or documented degraded reason.
+- Empty targets are valid and distinct from missing diagnostics.
+
+## Target Attachment Metadata
+
+Represents safe, bounded metadata for one input attachment.
+
+- `artifactRef` or `artifactId`: compact artifact reference.
+- `filename`: display filename when available.
+- `contentType`: safe content type label when available.
+- `sizeBytes`: byte size when available.
+- `target`: owning Task Target.
+- `previewAvailable`: whether normal artifact preview/download rules can apply.
+
+Validation rules:
+
+- Metadata must not include raw binary content.
+- Metadata must not bypass artifact authorization or redaction.
+- Target ownership must come from the task contract or prepared context evidence, not filename inference.
+
+## Target Diagnostic Reference
+
+Represents a compact ref or summary for target-owned evidence.
+
+- `target`: owning Task Target.
+- `refKind`: `attachment_manifest`, `generated_context`, `runtime_diagnostics`, `step_artifact`, or `resume_checkpoint`.
+- `artifactRef`: compact artifact reference when available.
+- `path`: workspace-local path only when safe and already exposed by runtime diagnostics.
+- `degradedReason`: bounded reason when the ref should exist but is unavailable.
+
+Validation rules:
+
+- Large bodies remain in artifacts; task detail receives refs and bounded metadata.
+- Missing refs must be represented as degraded evidence only when a target had expected evidence.
+
+## Attachment Failure Diagnostic
+
+Represents a bounded attachment-related failure.
+
+- `target`: affected Task Target.
+- `phase`: `upload`, `validation`, `materialization`, or `context_generation`.
+- `message`: bounded operator-facing message.
+- `evidenceRef`: optional artifact or diagnostics ref.
+
+Validation rules:
+
+- Every failure must include exactly one affected target and exactly one bounded phase.
+- Unknown raw event names must be normalized or exposed as degraded evidence, not silently omitted.
+
+## Recovery Provenance
+
+Represents failed-step Resume evidence shown on task detail.
+
+- `sourceWorkflowId`: source execution workflow ID.
+- `sourceRunId`: source execution run ID.
+- `checkpointRef`: resume checkpoint ref when available.
+- `preservedSteps`: completed prior steps reused from the source execution.
+- `failedResumePhase`: optional phase when a Resume attempt failed: `checkpoint_validation`, `workspace_restoration`, `preserved_output_injection`, or `failed_step_execution`.
+
+Validation rules:
+
+- Preserved steps must retain source workflow ID, run ID, logical step ID, and attempt provenance.
+- Failed Resume phase labels must be bounded and operator-facing.
+
+## State Transitions
+
+- Target diagnostics can be absent when no target-aware evidence exists.
+- Target diagnostics can be populated when snapshot, prepared context, artifact, or ledger evidence is available.
+- Target diagnostics can be degraded when evidence was expected but missing, unauthorized, or failed before generation.
+- Recovery provenance can be unavailable, available, or degraded depending on Resume evidence.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/moonspec_align_report.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/moonspec_align_report.md
@@ -1,0 +1,30 @@
+# MoonSpec Alignment Report: Show Attachment and Recovery Diagnostics By Target
+
+**Source**: MM-635 canonical Jira preset brief preserved in `spec.md`
+**Feature**: `specs/329-show-attachment-recovery-diagnostics-by-target`
+**Date**: 2026-05-08
+
+## Result
+
+PASS after one conservative remediation.
+
+## Finding And Remediation
+
+| Finding | Decision | Artifact Updated |
+| --- | --- | --- |
+| `tasks.md` placed a production schema task in the foundational phase before red-first unit and integration tests, while a later implementation task already owned production schema changes. | Preserve the test-first workflow by changing the foundational task to define test fixture shape from the contract, leaving production schema implementation in the implementation phase after red-first confirmation. | `tasks.md` T006 |
+
+## Gate Recheck
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Prerequisites | PASS | `check-prerequisites.sh --json --require-tasks --include-tasks` found `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `tasks.md`. |
+| Single story | PASS | `spec.md` has one user story and `tasks.md` has one story phase. |
+| Task format | PASS | 47 tasks, sequential T001-T047, no malformed checklist lines. |
+| TDD ordering | PASS | Unit tests, integration tests, and red-first confirmation precede production implementation tasks. |
+| Traceability | PASS | `tasks.md` preserves MM-635 and covers FR-001 through FR-013, SC-001 through SC-006, DESIGN-REQ-023, and DESIGN-REQ-024. |
+| Final verification | PASS | `tasks.md` includes final `/moonspec-verify` work. |
+
+## Remaining Risks
+
+- No application code or tests were run; this alignment step edited MoonSpec artifacts only.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/plan.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Show Attachment and Recovery Diagnostics By Target
+
+**Branch**: `329-show-attachment-recovery-diagnostics-by-target` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:1f8186c7-7b34-49ec-bf2f-fee2e3d290af/repo/specs/329-show-attachment-recovery-diagnostics-by-target/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted, but the managed runtime branch `run-jira-orchestrate-for-mm-635-show-att-48c11b06` is rejected by the helper's `###-feature-name` branch-name guard. Planning continued from `.specify/feature.json`, which points at this feature directory.
+
+## Summary
+
+Task detail already has generic diagnostics panels, step artifacts, failed-step Resume actions, related-run links, and preserved-step ledger rows, while the worker and vision services already produce target-aware attachment and context artifacts. The remaining story is to expose a bounded, target-aware diagnostics contract on task detail so operators can see attachment ownership, manifest/generated context refs, recovery provenance, and failure phases without reading raw workflow history. The implementation should add verification tests first, then backend/UI contract changes where existing projections are partial.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `api_service/api/routers/executions.py` preserves snapshot attachment refs; `frontend/src/entrypoints/task-detail.tsx` lacks target-grouped attachment display | add target-grouped attachment diagnostics projection and task-detail rendering | unit + integration |
+| FR-002 | missing | no target-empty/populated distinction found in task-detail UI | add explicit empty/populated target states | unit + integration |
+| FR-003 | partial | step artifacts and runtime diagnostics refs render generically; image docs require manifest refs | surface manifest refs in target diagnostics | unit + integration |
+| FR-004 | partial | `moonmind/vision/service.py` writes target context index; task detail does not expose generated context refs by target | project generated context refs into task detail diagnostics | unit + integration |
+| FR-005 | partial | worker materialization records target-aware diagnostics, but task detail does not render target failure ownership | expose affected target for attachment failures | unit + integration |
+| FR-006 | partial | docs and worker events mention prepare phases; task detail shows raw diagnostics text only | normalize and render bounded upload/validation/materialization/context generation phases | unit + integration |
+| FR-007 | partial | step ledger distinguishes steps, but not current-step attachment context | add current-step attachment context section distinct from unrelated inputs | unit + integration |
+| FR-008 | implemented_unverified | execution projection has `resume`; task detail has failed-step Resume and related-run tests | add/extend verification for resumed execution provenance in target diagnostics context | unit + integration |
+| FR-009 | implemented_unverified | `StepLedgerRowSchema.preservedFrom` renders source workflow/run/attempt; workflow tests assert preserved rows | strengthen task-detail test for preserved prior-step reuse display | unit + integration |
+| FR-010 | partial | backend exposes disabled reasons; task detail does not present the requested failed Resume phase taxonomy | add failed Resume phase diagnostics using bounded labels | unit + integration |
+| FR-011 | partial | architecture docs list subsystem boundaries; task detail lacks a specific boundary-preserving diagnostics contract | include contract-owned labels/refs without redefining subsystem internals | unit |
+| FR-012 | partial | generic diagnostics panels still require raw text inspection for many cases | add structured diagnostics summary before raw logs/history | unit + integration |
+| FR-013 | implemented_unverified | `spec.md` preserves MM-635 and the original brief | preserve traceability in plan, tasks, implementation notes, verification, commit, and PR metadata | final verify |
+| SC-001 | partial | target ownership exists at worker/vision layers, not task detail | validate every displayed attachment metadata item has owning target | unit + integration |
+| SC-002 | partial | phase evidence exists in docs/events, not structured detail display | validate each failure shows one target and one phase | unit + integration |
+| SC-003 | partial | context refs exist in vision index, not operator detail | validate target-owned manifest/context refs | unit + integration |
+| SC-004 | implemented_unverified | related runs and preserved rows exist | verify source execution and preserved prior steps are visible | unit + integration |
+| SC-005 | missing | no failed Resume phase display taxonomy found | validate failed Resume phase labels | unit + integration |
+| SC-006 | implemented_unverified | `spec.md` and this plan preserve MM-635 and source IDs | preserve in later artifacts and final evidence | final verify |
+| DESIGN-REQ-023 | partial | `docs/Tasks/TaskArchitecture.md` lines 200-204 and 660-671; partial worker/UI evidence | implement target-aware metadata, refs, target failure, and phase display | unit + integration |
+| DESIGN-REQ-024 | partial | `docs/Tasks/TaskArchitecture.md` lines 671-689; partial Resume and ledger evidence | finish current-step context, Resume provenance, failure phase, and boundary contract | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest  
+**Storage**: Existing Temporal execution records, task input snapshot artifacts, Temporal artifact metadata/content, and existing step ledger/projection payloads; no new persistent tables planned  
+**Unit Testing**: `./tools/test_unit.sh`; focused frontend iteration with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`; focused backend pytest through `./tools/test_unit.sh tests/unit/api/routers/test_executions.py`  
+**Integration Testing**: `./tools/test_integration.sh`; targeted hermetic coverage should include existing integration-ci surfaces for vision context artifacts and workflow resume where feasible  
+**Target Platform**: MoonMind Mission Control web UI backed by FastAPI and Temporal execution projections  
+**Project Type**: Full-stack web application and orchestration control plane  
+**Performance Goals**: Task detail should remain scan-friendly; diagnostics summaries must be bounded and avoid loading raw workflow history for normal inspection  
+**Constraints**: Preserve artifact authorization/redaction behavior; do not embed large diagnostics or artifact bodies in execution projections; use refs and compact metadata; keep Resume and attachment subsystem semantics owned by their existing contracts  
+**Scale/Scope**: One task-detail story covering objective targets, step targets, generated context refs, attachment failure phases, resumed execution provenance, and failed Resume phase labels
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Result | Notes |
+| --- | --- | --- |
+| I. Orchestrate, Don't Recreate | PASS | Extends existing Mission Control projections and artifact refs rather than replacing workflow runtimes. |
+| II. One-Click Agent Deployment | PASS | No new mandatory external service or secret. |
+| III. Avoid Vendor Lock-In | PASS | Uses generic task targets, artifacts, and diagnostics metadata. |
+| IV. Own Your Data | PASS | Keeps evidence in MoonMind-owned execution/artifact stores and passes refs to the UI. |
+| V. Skills Are First-Class and Easy to Add | PASS | No skill runtime changes. |
+| VI. Delete/Replaceable Scaffolding | PASS | Adds bounded contracts and tests around existing surfaces. |
+| VII. Runtime Configurability | PASS | Uses existing feature/config patterns; no hardcoded provider coupling. |
+| VIII. Modular and Extensible Architecture | PASS | Keeps projection, schema, and UI responsibilities separate. |
+| IX. Resilient by Default | PASS | Uses compact refs and explicit degraded/failure states. |
+| X. Facilitate Continuous Improvement | PASS | Improves operator diagnostics and final evidence. |
+| XI. Spec-Driven Development | PASS | Planning starts from `spec.md` and preserves traceability. |
+| XII. Canonical Documentation Separation | PASS | Implementation tracking stays in this spec directory. |
+| XIII. Pre-Release Velocity | PASS | Plan should update active contracts directly, not add compatibility aliases. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/329-show-attachment-recovery-diagnostics-by-target/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-detail-target-diagnostics.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/routers/executions.py
+
+moonmind/
+├── schemas/temporal_models.py
+├── vision/service.py
+└── agents/codex_worker/worker.py
+
+frontend/src/
+├── entrypoints/task-detail.tsx
+└── entrypoints/task-detail.test.tsx
+
+tests/
+├── unit/api/routers/test_executions.py
+├── unit/agents/codex_worker/test_attachment_materialization.py
+├── unit/moonmind/vision/test_service.py
+└── integration/vision/test_context_artifacts.py
+```
+
+**Structure Decision**: This is a full-stack Mission Control feature. Backend work belongs in execution projection/schema boundaries, UI work belongs in task detail, and tests should cover both projection contracts and rendered operator behavior.
+
+## Complexity Tracking
+
+No constitution violations requiring complexity exceptions.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Show Attachment and Recovery Diagnostics By Target
+
+Use Jira issue `MM-635` and the canonical Jira preset brief preserved in `spec.md` as the source of truth.
+
+## Test-First Plan
+
+1. Add backend unit tests in `tests/unit/api/routers/test_executions.py` that build execution records with objective and step attachment evidence, generated context refs, attachment failure diagnostics, Resume provenance, and degraded evidence.
+2. Add frontend unit tests in `frontend/src/entrypoints/task-detail.test.tsx` that render:
+   - objective and step target groups,
+   - targets with no attachments,
+   - manifest and generated context refs,
+   - upload, validation, materialization, and context-generation failure phases,
+   - resumed execution source and preserved prior steps,
+   - failed Resume phase labels.
+3. Add or extend integration evidence for target-aware generated context artifacts and failed-step Resume preservation.
+4. Confirm the new tests fail before implementation, then implement the projection/UI changes.
+
+## Unit Test Commands
+
+Focused backend:
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_executions.py
+```
+
+Focused frontend:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+```
+
+Final unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Integration Test Commands
+
+Focused hermetic integration candidates:
+
+```bash
+pytest tests/integration/vision/test_context_artifacts.py -m 'integration_ci' -q --tb=short
+pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short
+```
+
+Final hermetic integration verification when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-To-End Validation
+
+1. Create or fixture a task with objective-scoped and step-scoped attachments.
+2. Ensure task detail shows each attachment under its owning objective or step target.
+3. Ensure manifest and generated context refs are visible by target when available.
+4. Simulate attachment failures for upload, validation, materialization, and context generation; verify each failure shows one target and one bounded phase.
+5. Simulate a resumed execution; verify the source workflow/run and preserved prior steps are visible.
+6. Simulate failed Resume diagnostics; verify the displayed phase is checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution.
+7. Confirm raw diagnostics remain available but are not required for the above checks.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/research.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/research.md
@@ -1,0 +1,113 @@
+# Research: Show Attachment and Recovery Diagnostics By Target
+
+## FR-001 Target-Grouped Attachment Metadata
+
+Decision: partial; add target-grouped attachment diagnostics to the execution projection and render it in task detail.
+Evidence: `api_service/api/routers/executions.py` snapshots compact `attachmentRefs`; `tests/unit/agents/codex_worker/test_attachment_materialization.py` verifies objective and step target collection; `frontend/src/entrypoints/task-detail.tsx` does not render attachment metadata by target.
+Rationale: Target ownership exists before and during runtime preparation, but the operator-facing detail surface does not expose it in the requested grouped form.
+Alternatives considered: Showing raw task input snapshots was rejected because the spec requires no raw workflow-history parsing and normal redaction/preview behavior.
+Test implications: unit + integration.
+
+## FR-002 Empty And Populated Target States
+
+Decision: missing; add explicit display behavior for targets with and without attachment diagnostics.
+Evidence: No task-detail component or test was found that distinguishes populated attachment targets from empty targets.
+Rationale: Operators need to know whether a target has no attachments versus whether diagnostics are missing or degraded.
+Alternatives considered: Hiding empty targets was rejected because it makes missing evidence ambiguous.
+Test implications: unit + integration.
+
+## FR-003 Manifest References
+
+Decision: partial; surface compact manifest refs in target diagnostics where available.
+Evidence: `docs/Tasks/ImageSystem.md` lines 438-441 require manifest paths discoverable from task diagnostics; `frontend/src/entrypoints/task-detail.tsx` renders generic step artifact refs and raw diagnostics panels but not target-owned attachment manifest refs.
+Rationale: Manifest refs are existing evidence, but operators need target context to interpret them safely.
+Alternatives considered: Embedding manifest contents was rejected because refs preserve artifact authorization and avoid large projection payloads.
+Test implications: unit + integration.
+
+## FR-004 Generated Context References
+
+Decision: partial; expose generated context refs from the target-aware vision context index.
+Evidence: `tests/integration/vision/test_context_artifacts.py` verifies `.moonmind/vision/image_context_index.json` with objective and step targets; task detail does not display these refs by target.
+Rationale: The generation layer already knows target ownership; task detail needs a compact projection of those refs.
+Alternatives considered: Recomputing context in the UI was rejected because generated context is an artifact-backed runtime output.
+Test implications: unit + integration.
+
+## FR-005 Target Failure Ownership
+
+Decision: partial; project the affected objective or step target for attachment failures.
+Evidence: `tests/unit/agents/codex_worker/test_attachment_materialization.py` records prepare diagnostics; `docs/Tasks/TaskArchitecture.md` lines 666-670 require target and phase; task detail currently shows raw diagnostics text.
+Rationale: Existing diagnostics can describe failures, but not in a structured operator-facing field.
+Alternatives considered: Requiring operators to inspect diagnostic JSON was rejected by FR-012.
+Test implications: unit + integration.
+
+## FR-006 Attachment Failure Phase
+
+Decision: partial; normalize attachment failure phase labels to upload, validation, materialization, and context generation.
+Evidence: `docs/Tasks/ImageSystem.md` lines 426-436 defines recommended event classes; task detail diagnostics panel is raw text.
+Rationale: A bounded phase taxonomy is needed for consistent UI and tests.
+Alternatives considered: Reusing arbitrary event names directly was rejected because it would make user-visible labels unstable.
+Test implications: unit + integration.
+
+## FR-007 Current Step Attachment Context
+
+Decision: partial; add a current-step target diagnostics section distinct from objective and unrelated step inputs.
+Evidence: `frontend/src/entrypoints/task-detail.tsx` renders step ledger rows and artifacts; there is no current-step attachment context display.
+Rationale: Step-aware surfaces already exist but need attachment-specific target context.
+Alternatives considered: Listing all step attachments together was rejected because it hides current-step ownership.
+Test implications: unit + integration.
+
+## FR-008 Resume Source Provenance
+
+Decision: implemented_unverified; keep existing projection and add targeted verification in the new diagnostics context.
+Evidence: `api_service/api/routers/executions.py` builds `resume` and `relatedRuns`; `frontend/src/entrypoints/task-detail.test.tsx` covers failed-step Resume action and related-run link.
+Rationale: The base Resume source fields exist, but this story needs them verified alongside diagnostics presentation.
+Alternatives considered: Reworking Resume semantics was rejected because subsystem contracts own Resume execution behavior.
+Test implications: unit + integration.
+
+## FR-009 Preserved Prior Steps
+
+Decision: implemented_unverified; use existing step ledger `preservedFrom` and add targeted task-detail coverage.
+Evidence: `frontend/src/entrypoints/task-detail.tsx` renders `preservedFrom` workflow/run/attempt; `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` asserts preserved rows in workflow execution.
+Rationale: Preserved-step data is present, but planning should require operator-facing verification under this feature.
+Alternatives considered: Duplicating preserved-step state into a new model was rejected because the ledger is the existing source of truth.
+Test implications: unit + integration.
+
+## FR-010 Failed Resume Phase
+
+Decision: partial; add display of bounded failed Resume phase labels.
+Evidence: `api_service/api/routers/executions.py` exposes disabled reasons such as `resume_checkpoint_missing`, `workspace_checkpoint_missing`, and `plan_identity_missing`; the spec requires checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution phase labels.
+Rationale: Existing reasons are eligibility-focused and need mapping to operator-facing failed Resume phases.
+Alternatives considered: Showing internal disabled reason codes only was rejected because the spec asks for phase identification.
+Test implications: unit + integration.
+
+## FR-011 Boundary-Preserving Contract
+
+Decision: partial; define a task-detail diagnostics contract that references subsystem evidence without redefining subsystem internals.
+Evidence: `docs/Tasks/TaskArchitecture.md` lines 677-689 lists related docs for detailed behavior; current task detail has generic artifacts and diagnostics panels.
+Rationale: The feature should expose compact summaries and refs while keeping upload, vision, Temporal, ledger, and rerun behavior owned by their documents.
+Alternatives considered: Inlining full subsystem details into task detail was rejected because it would drift from canonical docs.
+Test implications: unit.
+
+## FR-012 Structured Diagnostics Before Raw History
+
+Decision: partial; add structured diagnostics summary above or beside raw diagnostics panels.
+Evidence: `frontend/src/entrypoints/task-detail.tsx` has copy/download raw diagnostics panels; no structured target-aware summary was found.
+Rationale: Raw diagnostics remain useful, but normal inspection should not require parsing them.
+Alternatives considered: Removing raw diagnostics was rejected because detailed troubleshooting still needs raw artifacts.
+Test implications: unit + integration.
+
+## FR-013 Traceability
+
+Decision: implemented_unverified; preserve MM-635 and the original preset brief through all artifacts and final evidence.
+Evidence: `spec.md` preserves the original Jira preset brief; `plan.md` and this research preserve MM-635.
+Rationale: Final verification depends on comparing implementation evidence against the original issue brief.
+Alternatives considered: Issue-key-only traceability was rejected because the original brief contains source mappings and acceptance criteria.
+Test implications: final verify.
+
+## Test Strategy
+
+Decision: use separate unit and integration strategies.
+Evidence: Repo instructions require `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration CI; existing frontend tests use Vitest/Testing Library through `--ui-args`.
+Rationale: The story crosses backend projection, UI rendering, attachment preparation, vision context artifacts, and Resume ledger evidence.
+Alternatives considered: Frontend-only testing was rejected because projection shape and artifact refs are part of the operator contract.
+Test implications: unit + integration.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/spec.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Show Attachment and Recovery Diagnostics By Target
+
+**Feature Branch**: `329-show-attachment-recovery-diagnostics-by-target`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-635 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-635 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-635
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Show attachment and recovery diagnostics by target
+- Priority: Medium
+- Labels: `moonmind-workflow-mm-86f66178-893d-469b-ba39-7bf1a3a19bb6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; potentially related custom fields `Implementation plan`, `Backout plan`, `Test plan`, and `Source` were present but empty.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-635 from MM project
+Summary: Show attachment and recovery diagnostics by target
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-635 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-635: Show attachment and recovery diagnostics by target
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 5.6 User-facing reads
+- 13 Observability and operator surfaces
+- 14 Boundary with page-level and subsystem docs
+
+Coverage IDs:
+- DESIGN-REQ-023
+- DESIGN-REQ-024
+
+As an operator inspecting task details, I want target-aware attachment metadata, generated context refs, recovery provenance, and explicit failure phases so I can understand outcomes without parsing raw workflow history.
+
+Acceptance Criteria
+- Task detail exposes attachment metadata by objective and step target.
+- Diagnostics identify upload, validation, materialization, or context generation failures and which target failed.
+- Step-aware surfaces identify current step attachment context separately from unrelated inputs.
+- Task detail identifies resumed executions and preserved prior steps reused from source.
+- Failed Resume diagnostics identify checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution phases.
+- Detailed behavior remains delegated to related subsystem docs.
+
+Requirements
+- Details and diagnostics expose target-aware metadata, refs, recovery provenance, and failure phases without raw history parsing.
+- This document is the architecture contract; detailed UI, image, skill, Temporal, ledger, and rerun behavior belongs in related docs.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Runtime decision: Jira Orchestrate always runs as a runtime implementation workflow, and `docs/Tasks/TaskArchitecture.md` is treated as runtime source requirements.
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-635 Jira preset brief defines one independently testable operator-facing diagnostics story.
+- Resume decision: No existing Moon Spec artifact set for `MM-635` was found under `specs/`; specification was the first incomplete stage.
+
+## User Story - Target-Aware Task Diagnostics
+
+**Summary**: As an operator inspecting task details, I want attachment metadata, generated context references, recovery provenance, and failure phases grouped by target so that I can understand task outcomes without parsing raw workflow history.
+
+**Goal**: Operators can open task details and see which objective or step target owns each attachment-related input, prepared context reference, resume provenance item, and diagnostic failure phase.
+
+**Independent Test**: Can be fully tested by viewing task details for attachment-aware tasks, step-aware tasks, resumed executions, and failed Resume attempts, then confirming the displayed metadata and diagnostics identify the relevant objective or step target and explain outcomes without requiring raw workflow-history inspection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task has objective-scoped and step-scoped attachments, **When** an operator opens task details, **Then** the attachment metadata is grouped by objective target and by each step target.
+2. **Given** attachment preparation produced manifest or generated context references, **When** an operator reviews diagnostics, **Then** the relevant references are visible with enough context to identify the target they describe.
+3. **Given** an attachment-related failure occurs, **When** the failure is shown in task details, **Then** the diagnostic identifies the affected target and whether the failure happened during upload, validation, materialization, or context generation.
+4. **Given** an operator inspects a step-aware surface, **When** the current step has attachment context, **Then** that step's attachment context is distinguished from unrelated objective or other-step inputs.
+5. **Given** a task detail view represents a resumed execution, **When** the operator reviews its recovery provenance, **Then** the view identifies the source execution and shows prior completed steps that were reused from that source.
+6. **Given** a Resume attempt fails, **When** the operator reviews failure diagnostics, **Then** the view identifies whether the failure phase was checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution.
+
+### Edge Cases
+
+- A task can have no attachments; task details should avoid implying missing diagnostic evidence when no target-aware attachment data exists.
+- Some targets can have attachments while others do not; empty targets must not hide populated target groups.
+- Generated context references can be unavailable because preparation failed; diagnostics must expose the failure phase instead of requiring raw history parsing.
+- A resumed execution can reuse some prior steps while executing later steps normally; preserved and newly executed steps must remain distinguishable.
+- Detailed behavior can be governed by related page-level or subsystem docs; this story must preserve the architecture-level boundary rather than redefining every subsystem rule.
+
+## Assumptions
+
+- Task details are the primary operator surface for this story because the Jira brief asks operators to inspect task details.
+- Normal artifact preview, download, authorization, and redaction policies continue to apply to any displayed references.
+- Objective targets and step targets use the product's established task terminology.
+- The story is limited to operator-visible details and diagnostics; attachment upload, storage, preparation, and Resume execution semantics remain owned by their subsystem contracts.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-023** (`docs/Tasks/TaskArchitecture.md` lines 200-204 and 660-671): User-facing reads and operator diagnostics must expose attachment metadata by target, generated context or manifest references where appropriate, and attachment failure target plus failure phase. Scope: in scope. Mapped to FR-001, FR-002, FR-003, FR-004, FR-005, and FR-006.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskArchitecture.md` lines 671-689): Step-aware surfaces, resumed execution details, failed Resume diagnostics, and architecture-to-subsystem boundaries must be visible without replacing the detailed contracts in related docs. Scope: in scope. Mapped to FR-007, FR-008, FR-009, FR-010, and FR-011.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Task details MUST expose attachment metadata grouped by objective target and by step target when those attachments exist.
+- **FR-002**: Task details MUST clearly distinguish targets with attachments from targets without attachments.
+- **FR-003**: Diagnostics MUST expose attachment manifest references when they are available and relevant to the target being inspected.
+- **FR-004**: Diagnostics MUST expose generated context references when they are available and relevant to the target being inspected.
+- **FR-005**: Attachment-related diagnostics MUST identify which objective or step target failed.
+- **FR-006**: Attachment-related diagnostics MUST identify whether a failure occurred during upload, validation, materialization, or context generation.
+- **FR-007**: Step-aware task surfaces MUST identify the current step's attachment context separately from objective-level inputs and unrelated step inputs.
+- **FR-008**: Task details for resumed executions MUST identify that the execution was resumed and expose source execution provenance.
+- **FR-009**: Task details for resumed executions MUST show completed prior steps that were reused from the source execution.
+- **FR-010**: Failed Resume diagnostics MUST identify whether the failure occurred during checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution.
+- **FR-011**: Operator-visible details MUST preserve the architecture-level boundary by linking or deferring detailed subsystem behavior to the relevant page-level, image, skill, Temporal, ledger, and rerun contracts.
+- **FR-012**: Operator-facing diagnostics MUST avoid requiring raw workflow-history parsing to identify target ownership, generated context references, recovery provenance, or failure phases.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-635` and the original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Task Target**: The task objective target or a declared step target that can own attachment metadata, prepared context references, or diagnostics.
+- **Attachment Diagnostic**: Operator-visible evidence describing attachment metadata, generated context references, manifest references, or failure phase for a target.
+- **Recovery Provenance**: Operator-visible evidence that identifies a resumed execution, its source execution, and prior completed steps reused from that source.
+- **Failure Phase**: The bounded stage label that explains where an attachment or Resume failure occurred.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In validation scenarios with objective-scoped and step-scoped attachments, operators can identify the owning target for every displayed attachment metadata item.
+- **SC-002**: In validation scenarios with attachment preparation failures, every displayed failure identifies exactly one affected target and one bounded failure phase.
+- **SC-003**: In validation scenarios with generated context or manifest references, operators can identify which target each reference describes without reading raw workflow history.
+- **SC-004**: In validation scenarios with resumed executions, operators can identify the source execution and each preserved prior step shown as reused.
+- **SC-005**: In validation scenarios with failed Resume attempts, operators can identify the failed Resume phase from the bounded set of checkpoint validation, workspace restoration, preserved-output injection, and failed-step execution.
+- **SC-006**: Traceability review confirms `MM-635`, the original Jira preset brief, DESIGN-REQ-023, and DESIGN-REQ-024 are preserved in MoonSpec artifacts and final evidence.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
@@ -1,0 +1,211 @@
+# Tasks: Show Attachment and Recovery Diagnostics By Target
+
+**Input**: Design documents from `/work/agent_jobs/mm:1f8186c7-7b34-49ec-bf2f-fee2e3d290af/repo/specs/329-show-attachment-recovery-diagnostics-by-target/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/task-detail-target-diagnostics.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single user story "Target-Aware Task Diagnostics" so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: MM-635 and the original Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-013, acceptance scenarios 1-6, edge cases, SC-001 through SC-006, DESIGN-REQ-023, DESIGN-REQ-024, and `contracts/task-detail-target-diagnostics.md`.
+
+**Requirement Status Summary**:
+
+- Code + tests for partial/missing rows: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-010, FR-011, FR-012, SC-001, SC-002, SC-003, SC-005, DESIGN-REQ-023, DESIGN-REQ-024
+- Verification-first with conditional fallback implementation: FR-008, FR-009, FR-013, SC-004, SC-006
+- Already verified rows: none
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py`; `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`; final `./tools/test_unit.sh`
+- Integration tests: `pytest tests/integration/vision/test_context_artifacts.py -m 'integration_ci' -q --tb=short`; `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short`; final `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Path Conventions
+
+- Backend: `api_service/`, `moonmind/`, `tests/unit/api/`, `tests/contract/`, `tests/integration/`
+- Frontend: `frontend/src/entrypoints/`
+- Feature artifacts: `specs/329-show-attachment-recovery-diagnostics-by-target/`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm active artifacts and test entry points before red-first work begins
+
+- [ ] T001 Confirm `specs/329-show-attachment-recovery-diagnostics-by-target/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-detail-target-diagnostics.md`, and `quickstart.md` are present and still reference MM-635, FR-001 through FR-013, DESIGN-REQ-023, and DESIGN-REQ-024
+- [ ] T002 Confirm backend, frontend, and integration test commands from `specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md` are runnable in the current environment before editing production files
+- [ ] T003 [P] Review existing backend projection helpers in `api_service/api/routers/executions.py` for extension points for compact `targetDiagnostics` refs and degraded evidence
+- [ ] T004 [P] Review existing task detail schemas and render sections in `frontend/src/entrypoints/task-detail.tsx` for the target diagnostics panel insertion point
+- [ ] T005 [P] Review existing target-aware attachment and vision evidence in `moonmind/agents/codex_worker/worker.py`, `moonmind/vision/service.py`, and `tests/integration/vision/test_context_artifacts.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the shared schema and fixture shape that unit, integration, backend, and UI work will use
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T006 Define the compact target diagnostics response contract in `moonmind/schemas/temporal_models.py` for Task Target, Target Attachment Metadata, Target Diagnostic Reference, Attachment Failure Diagnostic, and Recovery Provenance (FR-001 through FR-012, SC-001 through SC-005)
+- [ ] T007 Add reusable backend fixture builders for objective targets, step targets, manifest refs, generated context refs, attachment failure phases, and recovery provenance in `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T008 Add reusable frontend fixture payloads for populated targets, empty targets, degraded target diagnostics, Resume provenance, preserved steps, and failed Resume phases in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-012, SC-001 through SC-005)
+- [ ] T009 [P] Add contract fixture examples matching `contracts/task-detail-target-diagnostics.md` in `tests/contract/test_temporal_execution_api.py` or the nearest existing execution API contract test file (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Target-Aware Task Diagnostics
+
+**Summary**: As an operator inspecting task details, I want attachment metadata, generated context references, recovery provenance, and failure phases grouped by target so that I can understand task outcomes without parsing raw workflow history.
+
+**Independent Test**: View task details for attachment-aware tasks, step-aware tasks, resumed executions, and failed Resume attempts; confirm displayed metadata and diagnostics identify the relevant objective or step target and explain outcomes without requiring raw workflow-history inspection.
+
+**Traceability**: FR-001 through FR-013, acceptance scenarios 1-6, edge cases, SC-001 through SC-006, DESIGN-REQ-023, DESIGN-REQ-024, MM-635
+
+**Test Plan**:
+
+- Unit: backend projection/schema validation, bounded phase normalization, degraded evidence handling, frontend rendering, empty/populated targets, current-step context, Resume provenance, preserved prior steps, traceability
+- Integration: execution API contract shape, target-aware generated context artifacts, task-detail operator journey, failed-step Resume preservation, final quickstart validation
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [ ] T010 [P] Add failing backend unit tests for `targetDiagnostics.targets` grouping objective and step attachment metadata in `tests/unit/api/routers/test_executions.py` (FR-001, FR-002, SC-001, DESIGN-REQ-023)
+- [ ] T011 [P] Add failing backend unit tests for manifest refs, generated context refs, degraded refs, target failure ownership, and bounded attachment phases in `tests/unit/api/routers/test_executions.py` (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-023)
+- [ ] T012 [P] Add failing backend unit tests for Resume provenance, preserved prior steps, failed Resume phase labels, and raw-history-free structured diagnostics in `tests/unit/api/routers/test_executions.py` (FR-008, FR-009, FR-010, FR-012, SC-004, SC-005, DESIGN-REQ-024)
+- [ ] T013 [P] Add failing frontend unit tests rendering objective target diagnostics, step target diagnostics, empty target states, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001, SC-002, SC-003)
+- [ ] T014 [P] Add failing frontend unit tests rendering resumed execution source, preserved prior steps, failed Resume phases, and MM-635 traceability-adjacent labels where operator-visible evidence appears in `frontend/src/entrypoints/task-detail.test.tsx` (FR-008, FR-009, FR-010, FR-013, SC-004, SC-005, SC-006)
+- [ ] T015 [P] Add failing schema unit tests for target diagnostics validation, bounded phase values, empty target handling, and degraded evidence in `tests/unit/schemas/test_temporal_models.py` (FR-002, FR-005, FR-006, FR-010, DESIGN-REQ-023, DESIGN-REQ-024)
+
+### Integration Tests (write first)
+
+- [ ] T016 [P] Add failing execution API contract or route test for the compact `targetDiagnostics` response shape in `tests/contract/test_temporal_execution_api.py` or `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T017 [P] Extend target-aware generated context integration coverage in `tests/integration/vision/test_context_artifacts.py` so the generated index provides refs that can be projected by target diagnostics (FR-003, FR-004, SC-003, DESIGN-REQ-023)
+- [ ] T018 [P] Extend failed-step Resume integration coverage in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` to preserve source execution and prior-step evidence expected by task detail diagnostics (FR-008, FR-009, SC-004, DESIGN-REQ-024)
+- [ ] T019 [P] Add task-detail integration-style UI test coverage in `frontend/src/entrypoints/task-detail.test.tsx` for the full operator journey across attachment targets, refs, failure phases, Resume provenance, and raw diagnostics fallback (acceptance scenarios 1-6, FR-001 through FR-012)
+
+### Red-First Confirmation
+
+- [ ] T020 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and confirm T010-T012 fail for missing target diagnostics behavior before backend implementation (FR-001 through FR-012)
+- [ ] T021 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and confirm T013-T014 and T019 fail for missing task-detail target diagnostics UI before frontend implementation (FR-001 through FR-012)
+- [ ] T022 Run the focused schema unit test command for `tests/unit/schemas/test_temporal_models.py` through `./tools/test_unit.sh tests/unit/schemas/test_temporal_models.py` and confirm T015 fails before schema implementation (FR-002, FR-005, FR-006, FR-010)
+- [ ] T023 Run focused integration commands for `tests/integration/vision/test_context_artifacts.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, documenting any environment blocker, and confirm T017-T018 fail or identify verification-only pass evidence before production changes (FR-003, FR-004, FR-008, FR-009)
+
+### Conditional Fallback Implementation For Implemented-Unverified Rows
+
+- [ ] T024 If FR-008 or SC-004 verification fails, update Resume source projection in `api_service/api/routers/executions.py` and related frontend rendering in `frontend/src/entrypoints/task-detail.tsx` to expose source workflow/run provenance in target diagnostics (FR-008, SC-004, DESIGN-REQ-024)
+- [ ] T025 If FR-009 verification fails, update step ledger projection or task-detail rendering in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` so preserved prior steps remain visible with source workflow ID, run ID, logical step ID, and attempt provenance (FR-009, SC-004, DESIGN-REQ-024)
+- [ ] T026 If FR-013 or SC-006 traceability verification fails, update `specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md`, implementation notes, and later verification output to preserve MM-635 and the original Jira preset brief (FR-013, SC-006)
+
+### Implementation
+
+- [ ] T027 Implement target diagnostics Pydantic models and serialization aliases in `moonmind/schemas/temporal_models.py` (FR-001 through FR-012, SC-001 through SC-005)
+- [ ] T028 Implement bounded attachment and Resume phase normalization helpers in `api_service/api/routers/executions.py` (FR-005, FR-006, FR-010, SC-002, SC-005, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T029 Implement target diagnostics extraction from task input snapshot, execution parameters, memo/search attributes, artifact refs, step ledger rows, and Resume summary in `api_service/api/routers/executions.py` (FR-001 through FR-010, FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T030 Wire `targetDiagnostics` into execution detail responses without embedding large artifact bodies in `api_service/api/routers/executions.py` and `moonmind/schemas/temporal_models.py` (FR-003, FR-004, FR-011, FR-012)
+- [ ] T031 Update task detail Zod schemas for target diagnostics in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-012)
+- [ ] T032 Implement target diagnostics UI sections for objective targets, step targets, empty targets, attachment metadata, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001 through SC-003)
+- [ ] T033 Implement Recovery Provenance UI for resumed execution source, preserved prior steps, checkpoint refs, and failed Resume phases in `frontend/src/entrypoints/task-detail.tsx` (FR-008, FR-009, FR-010, SC-004, SC-005, DESIGN-REQ-024)
+- [ ] T034 Preserve raw diagnostics panels while adding structured diagnostics summaries in `frontend/src/entrypoints/task-detail.tsx` (FR-012, acceptance scenarios 2-3, acceptance scenario 6)
+- [ ] T035 Keep generated context and manifest evidence as refs and preserve artifact authorization/redaction behavior in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` (FR-003, FR-004, FR-011, DESIGN-REQ-023)
+- [ ] T036 Update or add integration fixture plumbing for target-aware generated context refs and Resume preserved-step evidence in `tests/integration/vision/test_context_artifacts.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` only as needed to support T017-T018 (FR-003, FR-004, FR-008, FR-009)
+
+### Story Validation
+
+- [ ] T037 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend target diagnostics unit coverage passes (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T038 Run `./tools/test_unit.sh tests/unit/schemas/test_temporal_models.py` and verify schema validation coverage passes (FR-002, FR-005, FR-006, FR-010)
+- [ ] T039 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and verify task-detail target diagnostics UI coverage passes (acceptance scenarios 1-6, FR-001 through FR-012)
+- [ ] T040 Run focused integration coverage from `quickstart.md` for vision target context artifacts and failed-step Resume preservation, documenting Docker or Temporal test-server blockers if present (SC-003, SC-004, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T041 Validate the story end-to-end against `specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md`, confirming raw diagnostics remain available but are not required for target ownership, refs, recovery provenance, or failure phase inspection (FR-001 through FR-012, SC-001 through SC-005)
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without adding hidden scope
+
+- [ ] T042 [P] Review `specs/329-show-attachment-recovery-diagnostics-by-target/plan.md`, `research.md`, `data-model.md`, `contracts/task-detail-target-diagnostics.md`, and `quickstart.md` for drift after implementation and update only if behavior changed (FR-013, SC-006)
+- [ ] T043 [P] Review task-detail copy and accessibility semantics in `frontend/src/entrypoints/task-detail.tsx` so target groups, failure phases, refs, and empty/degraded states are scannable and do not require raw history parsing (FR-002, FR-006, FR-012)
+- [ ] T044 [P] Review backend projection output in `api_service/api/routers/executions.py` for bounded metadata, no secret leakage, no large artifact bodies, and no hidden fallback semantics (FR-003, FR-004, FR-011, DESIGN-REQ-023, DESIGN-REQ-024)
+- [ ] T045 Run final unit verification with `./tools/test_unit.sh`, documenting any blocker with exact failing command and reason (FR-001 through FR-013)
+- [ ] T046 Run final hermetic integration verification with `./tools/test_integration.sh`, or document Docker/socket/environment blocker and focused integration evidence already collected (SC-001 through SC-006)
+- [ ] T047 Run `/moonspec-verify` to validate the final implementation against MM-635, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, required tests, DESIGN-REQ-023, and DESIGN-REQ-024 (FR-013, SC-006)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish (Phase 4)**: Depends on story implementation and story validation.
+
+### Within The Story
+
+- Unit tests T010-T015 must be written before implementation.
+- Integration tests T016-T019 must be written before implementation.
+- Red-first confirmation T020-T023 must complete before production implementation tasks T027-T036.
+- Conditional fallback tasks T024-T026 apply only if verification-first tests fail.
+- Backend schema/projection tasks T027-T030 should precede frontend schema/render tasks T031-T035.
+- Integration fixture task T036 follows the backend/UI contract shape.
+- Story validation T037-T041 follows implementation.
+
+### Parallel Opportunities
+
+- T003, T004, and T005 can run in parallel during setup.
+- T009 can run in parallel with T006-T008 after the contract is understood.
+- T010-T015 can be authored in parallel because they touch separate test scopes or independent sections.
+- T016-T019 can be authored in parallel because they cover different integration/contract surfaces.
+- T042-T044 can run in parallel after story validation.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch red-first test authoring together:
+Task: "T010 add backend projection unit tests in tests/unit/api/routers/test_executions.py"
+Task: "T013 add frontend rendering unit tests in frontend/src/entrypoints/task-detail.test.tsx"
+Task: "T017 extend vision integration coverage in tests/integration/vision/test_context_artifacts.py"
+
+# Launch polish reviews together:
+Task: "T042 review MoonSpec artifacts for drift"
+Task: "T043 review task-detail accessibility and copy"
+Task: "T044 review backend projection bounded metadata"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and foundational schema/fixture tasks.
+2. Write backend, frontend, schema, contract, and integration tests first.
+3. Run red-first commands and confirm failures for missing or partial requirements.
+4. Run verification-first tests for implemented-unverified Resume and traceability rows; skip conditional fallback implementation only when those tests pass.
+5. Implement backend target diagnostics models, projection, phase normalization, and compact refs.
+6. Implement task-detail schemas and UI sections.
+7. Validate the story with focused unit and integration commands.
+8. Complete polish, full unit verification, hermetic integration verification or documented blocker, and final `/moonspec-verify`.
+
+---
+
+## Notes
+
+- This task list covers one story only: Target-Aware Task Diagnostics.
+- Every missing or partial requirement has red-first unit and/or integration test coverage plus implementation tasks.
+- Every implemented-unverified row has verification-first tasks and conditional fallback implementation tasks.
+- No rows are treated as already verified.
+- Preserve MM-635 and the original Jira preset brief in implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
@@ -37,10 +37,10 @@
 
 **Purpose**: Confirm active artifacts and test entry points before red-first work begins
 
-- [ ] T001 Confirm `specs/329-show-attachment-recovery-diagnostics-by-target/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-detail-target-diagnostics.md`, and `quickstart.md` are present and still reference MM-635, FR-001 through FR-013, DESIGN-REQ-023, and DESIGN-REQ-024
+- [X] T001 Confirm `specs/329-show-attachment-recovery-diagnostics-by-target/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-detail-target-diagnostics.md`, and `quickstart.md` are present and still reference MM-635, FR-001 through FR-013, DESIGN-REQ-023, and DESIGN-REQ-024
 - [ ] T002 Confirm backend, frontend, and integration test commands from `specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md` are runnable in the current environment before editing production files
-- [ ] T003 [P] Review existing backend projection helpers in `api_service/api/routers/executions.py` for extension points for compact `targetDiagnostics` refs and degraded evidence
-- [ ] T004 [P] Review existing task detail schemas and render sections in `frontend/src/entrypoints/task-detail.tsx` for the target diagnostics panel insertion point
+- [X] T003 [P] Review existing backend projection helpers in `api_service/api/routers/executions.py` for extension points for compact `targetDiagnostics` refs and degraded evidence
+- [X] T004 [P] Review existing task detail schemas and render sections in `frontend/src/entrypoints/task-detail.tsx` for the target diagnostics panel insertion point
 - [ ] T005 [P] Review existing target-aware attachment and vision evidence in `moonmind/agents/codex_worker/worker.py`, `moonmind/vision/service.py`, and `tests/integration/vision/test_context_artifacts.py`
 
 ---
@@ -51,10 +51,10 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T006 Define the compact target diagnostics fixture shape in `tests/unit/api/routers/test_executions.py` from `contracts/task-detail-target-diagnostics.md` without editing production schemas yet (FR-001 through FR-012, SC-001 through SC-005)
+- [X] T006 Define the compact target diagnostics fixture shape in `tests/unit/api/routers/test_executions.py` from `contracts/task-detail-target-diagnostics.md` without editing production schemas yet (FR-001 through FR-012, SC-001 through SC-005)
 - [ ] T007 Add reusable backend fixture builders for objective targets, step targets, manifest refs, generated context refs, attachment failure phases, and recovery provenance in `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T008 Add reusable frontend fixture payloads for populated targets, empty targets, degraded target diagnostics, Resume provenance, preserved steps, and failed Resume phases in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-012, SC-001 through SC-005)
-- [ ] T009 [P] Add contract fixture examples matching `contracts/task-detail-target-diagnostics.md` in `tests/contract/test_temporal_execution_api.py` or the nearest existing execution API contract test file (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T009 [P] Add contract fixture examples matching `contracts/task-detail-target-diagnostics.md` in `tests/contract/test_temporal_execution_api.py` or the nearest existing execution API contract test file (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -77,19 +77,19 @@
 
 > Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
 
-- [ ] T010 [P] Add failing backend unit tests for `targetDiagnostics.targets` grouping objective and step attachment metadata in `tests/unit/api/routers/test_executions.py` (FR-001, FR-002, SC-001, DESIGN-REQ-023)
-- [ ] T011 [P] Add failing backend unit tests for manifest refs, generated context refs, degraded refs, target failure ownership, and bounded attachment phases in `tests/unit/api/routers/test_executions.py` (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-023)
-- [ ] T012 [P] Add failing backend unit tests for Resume provenance, preserved prior steps, failed Resume phase labels, and raw-history-free structured diagnostics in `tests/unit/api/routers/test_executions.py` (FR-008, FR-009, FR-010, FR-012, SC-004, SC-005, DESIGN-REQ-024)
-- [ ] T013 [P] Add failing frontend unit tests rendering objective target diagnostics, step target diagnostics, empty target states, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001, SC-002, SC-003)
-- [ ] T014 [P] Add failing frontend unit tests rendering resumed execution source, preserved prior steps, failed Resume phases, and MM-635 traceability-adjacent labels where operator-visible evidence appears in `frontend/src/entrypoints/task-detail.test.tsx` (FR-008, FR-009, FR-010, FR-013, SC-004, SC-005, SC-006)
+- [X] T010 [P] Add failing backend unit tests for `targetDiagnostics.targets` grouping objective and step attachment metadata in `tests/unit/api/routers/test_executions.py` (FR-001, FR-002, SC-001, DESIGN-REQ-023)
+- [X] T011 [P] Add failing backend unit tests for manifest refs, generated context refs, degraded refs, target failure ownership, and bounded attachment phases in `tests/unit/api/routers/test_executions.py` (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, DESIGN-REQ-023)
+- [X] T012 [P] Add failing backend unit tests for Resume provenance, preserved prior steps, failed Resume phase labels, and raw-history-free structured diagnostics in `tests/unit/api/routers/test_executions.py` (FR-008, FR-009, FR-010, FR-012, SC-004, SC-005, DESIGN-REQ-024)
+- [X] T013 [P] Add failing frontend unit tests rendering objective target diagnostics, step target diagnostics, empty target states, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001, SC-002, SC-003)
+- [X] T014 [P] Add failing frontend unit tests rendering resumed execution source, preserved prior steps, failed Resume phases, and MM-635 traceability-adjacent labels where operator-visible evidence appears in `frontend/src/entrypoints/task-detail.test.tsx` (FR-008, FR-009, FR-010, FR-013, SC-004, SC-005, SC-006)
 - [ ] T015 [P] Add failing schema unit tests for target diagnostics validation, bounded phase values, empty target handling, and degraded evidence in `tests/unit/schemas/test_temporal_models.py` (FR-002, FR-005, FR-006, FR-010, DESIGN-REQ-023, DESIGN-REQ-024)
 
 ### Integration Tests (write first)
 
-- [ ] T016 [P] Add failing execution API contract or route test for the compact `targetDiagnostics` response shape in `tests/contract/test_temporal_execution_api.py` or `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T016 [P] Add failing execution API contract or route test for the compact `targetDiagnostics` response shape in `tests/contract/test_temporal_execution_api.py` or `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T017 [P] Extend target-aware generated context integration coverage in `tests/integration/vision/test_context_artifacts.py` so the generated index provides refs that can be projected by target diagnostics (FR-003, FR-004, SC-003, DESIGN-REQ-023)
 - [ ] T018 [P] Extend failed-step Resume integration coverage in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` to preserve source execution and prior-step evidence expected by task detail diagnostics (FR-008, FR-009, SC-004, DESIGN-REQ-024)
-- [ ] T019 [P] Add task-detail integration-style UI test coverage in `frontend/src/entrypoints/task-detail.test.tsx` for the full operator journey across attachment targets, refs, failure phases, Resume provenance, and raw diagnostics fallback (acceptance scenarios 1-6, FR-001 through FR-012)
+- [X] T019 [P] Add task-detail integration-style UI test coverage in `frontend/src/entrypoints/task-detail.test.tsx` for the full operator journey across attachment targets, refs, failure phases, Resume provenance, and raw diagnostics fallback (acceptance scenarios 1-6, FR-001 through FR-012)
 
 ### Red-First Confirmation
 
@@ -100,28 +100,28 @@
 
 ### Conditional Fallback Implementation For Implemented-Unverified Rows
 
-- [ ] T024 If FR-008 or SC-004 verification fails, update Resume source projection in `api_service/api/routers/executions.py` and related frontend rendering in `frontend/src/entrypoints/task-detail.tsx` to expose source workflow/run provenance in target diagnostics (FR-008, SC-004, DESIGN-REQ-024)
-- [ ] T025 If FR-009 verification fails, update step ledger projection or task-detail rendering in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` so preserved prior steps remain visible with source workflow ID, run ID, logical step ID, and attempt provenance (FR-009, SC-004, DESIGN-REQ-024)
+- [X] T024 If FR-008 or SC-004 verification fails, update Resume source projection in `api_service/api/routers/executions.py` and related frontend rendering in `frontend/src/entrypoints/task-detail.tsx` to expose source workflow/run provenance in target diagnostics (FR-008, SC-004, DESIGN-REQ-024)
+- [X] T025 If FR-009 verification fails, update step ledger projection or task-detail rendering in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` so preserved prior steps remain visible with source workflow ID, run ID, logical step ID, and attempt provenance (FR-009, SC-004, DESIGN-REQ-024)
 - [ ] T026 If FR-013 or SC-006 traceability verification fails, update `specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md`, implementation notes, and later verification output to preserve MM-635 and the original Jira preset brief (FR-013, SC-006)
 
 ### Implementation
 
-- [ ] T027 Implement target diagnostics Pydantic models and serialization aliases in `moonmind/schemas/temporal_models.py` (FR-001 through FR-012, SC-001 through SC-005)
-- [ ] T028 Implement bounded attachment and Resume phase normalization helpers in `api_service/api/routers/executions.py` (FR-005, FR-006, FR-010, SC-002, SC-005, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T027 Implement target diagnostics Pydantic models and serialization aliases in `moonmind/schemas/temporal_models.py` (FR-001 through FR-012, SC-001 through SC-005)
+- [X] T028 Implement bounded attachment and Resume phase normalization helpers in `api_service/api/routers/executions.py` (FR-005, FR-006, FR-010, SC-002, SC-005, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T029 Implement target diagnostics extraction from task input snapshot, execution parameters, memo/search attributes, artifact refs, step ledger rows, and Resume summary in `api_service/api/routers/executions.py` (FR-001 through FR-010, FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
-- [ ] T030 Wire `targetDiagnostics` into execution detail responses without embedding large artifact bodies in `api_service/api/routers/executions.py` and `moonmind/schemas/temporal_models.py` (FR-003, FR-004, FR-011, FR-012)
-- [ ] T031 Update task detail Zod schemas for target diagnostics in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-012)
-- [ ] T032 Implement target diagnostics UI sections for objective targets, step targets, empty targets, attachment metadata, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001 through SC-003)
-- [ ] T033 Implement Recovery Provenance UI for resumed execution source, preserved prior steps, checkpoint refs, and failed Resume phases in `frontend/src/entrypoints/task-detail.tsx` (FR-008, FR-009, FR-010, SC-004, SC-005, DESIGN-REQ-024)
-- [ ] T034 Preserve raw diagnostics panels while adding structured diagnostics summaries in `frontend/src/entrypoints/task-detail.tsx` (FR-012, acceptance scenarios 2-3, acceptance scenario 6)
-- [ ] T035 Keep generated context and manifest evidence as refs and preserve artifact authorization/redaction behavior in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` (FR-003, FR-004, FR-011, DESIGN-REQ-023)
+- [X] T030 Wire `targetDiagnostics` into execution detail responses without embedding large artifact bodies in `api_service/api/routers/executions.py` and `moonmind/schemas/temporal_models.py` (FR-003, FR-004, FR-011, FR-012)
+- [X] T031 Update task detail Zod schemas for target diagnostics in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-012)
+- [X] T032 Implement target diagnostics UI sections for objective targets, step targets, empty targets, attachment metadata, refs, failures, and degraded evidence in `frontend/src/entrypoints/task-detail.tsx` (FR-001 through FR-007, FR-011, FR-012, SC-001 through SC-003)
+- [X] T033 Implement Recovery Provenance UI for resumed execution source, preserved prior steps, checkpoint refs, and failed Resume phases in `frontend/src/entrypoints/task-detail.tsx` (FR-008, FR-009, FR-010, SC-004, SC-005, DESIGN-REQ-024)
+- [X] T034 Preserve raw diagnostics panels while adding structured diagnostics summaries in `frontend/src/entrypoints/task-detail.tsx` (FR-012, acceptance scenarios 2-3, acceptance scenario 6)
+- [X] T035 Keep generated context and manifest evidence as refs and preserve artifact authorization/redaction behavior in `api_service/api/routers/executions.py` and `frontend/src/entrypoints/task-detail.tsx` (FR-003, FR-004, FR-011, DESIGN-REQ-023)
 - [ ] T036 Update or add integration fixture plumbing for target-aware generated context refs and Resume preserved-step evidence in `tests/integration/vision/test_context_artifacts.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` only as needed to support T017-T018 (FR-003, FR-004, FR-008, FR-009)
 
 ### Story Validation
 
-- [ ] T037 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend target diagnostics unit coverage passes (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T037 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py` and verify backend target diagnostics unit coverage passes (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T038 Run `./tools/test_unit.sh tests/unit/schemas/test_temporal_models.py` and verify schema validation coverage passes (FR-002, FR-005, FR-006, FR-010)
-- [ ] T039 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and verify task-detail target diagnostics UI coverage passes (acceptance scenarios 1-6, FR-001 through FR-012)
+- [X] T039 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` and verify task-detail target diagnostics UI coverage passes (acceptance scenarios 1-6, FR-001 through FR-012)
 - [ ] T040 Run focused integration coverage from `quickstart.md` for vision target context artifacts and failed-step Resume preservation, documenting Docker or Temporal test-server blockers if present (SC-003, SC-004, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T041 Validate the story end-to-end against `specs/329-show-attachment-recovery-diagnostics-by-target/quickstart.md`, confirming raw diagnostics remain available but are not required for target ownership, refs, recovery provenance, or failure phase inspection (FR-001 through FR-012, SC-001 through SC-005)
 
@@ -134,8 +134,8 @@
 **Purpose**: Strengthen the completed story without adding hidden scope
 
 - [ ] T042 [P] Review `specs/329-show-attachment-recovery-diagnostics-by-target/plan.md`, `research.md`, `data-model.md`, `contracts/task-detail-target-diagnostics.md`, and `quickstart.md` for drift after implementation and update only if behavior changed (FR-013, SC-006)
-- [ ] T043 [P] Review task-detail copy and accessibility semantics in `frontend/src/entrypoints/task-detail.tsx` so target groups, failure phases, refs, and empty/degraded states are scannable and do not require raw history parsing (FR-002, FR-006, FR-012)
-- [ ] T044 [P] Review backend projection output in `api_service/api/routers/executions.py` for bounded metadata, no secret leakage, no large artifact bodies, and no hidden fallback semantics (FR-003, FR-004, FR-011, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T043 [P] Review task-detail copy and accessibility semantics in `frontend/src/entrypoints/task-detail.tsx` so target groups, failure phases, refs, and empty/degraded states are scannable and do not require raw history parsing (FR-002, FR-006, FR-012)
+- [X] T044 [P] Review backend projection output in `api_service/api/routers/executions.py` for bounded metadata, no secret leakage, no large artifact bodies, and no hidden fallback semantics (FR-003, FR-004, FR-011, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T045 Run final unit verification with `./tools/test_unit.sh`, documenting any blocker with exact failing command and reason (FR-001 through FR-013)
 - [ ] T046 Run final hermetic integration verification with `./tools/test_integration.sh`, or document Docker/socket/environment blocker and focused integration evidence already collected (SC-001 through SC-006)
 - [ ] T047 Run `/moonspec-verify` to validate the final implementation against MM-635, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, required tests, DESIGN-REQ-023, and DESIGN-REQ-024 (FR-013, SC-006)

--- a/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
+++ b/specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md
@@ -51,7 +51,7 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T006 Define the compact target diagnostics response contract in `moonmind/schemas/temporal_models.py` for Task Target, Target Attachment Metadata, Target Diagnostic Reference, Attachment Failure Diagnostic, and Recovery Provenance (FR-001 through FR-012, SC-001 through SC-005)
+- [ ] T006 Define the compact target diagnostics fixture shape in `tests/unit/api/routers/test_executions.py` from `contracts/task-detail-target-diagnostics.md` without editing production schemas yet (FR-001 through FR-012, SC-001 through SC-005)
 - [ ] T007 Add reusable backend fixture builders for objective targets, step targets, manifest refs, generated context refs, attachment failure phases, and recovery provenance in `tests/unit/api/routers/test_executions.py` (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)
 - [ ] T008 Add reusable frontend fixture payloads for populated targets, empty targets, degraded target diagnostics, Resume provenance, preserved steps, and failed Resume phases in `frontend/src/entrypoints/task-detail.test.tsx` (FR-001 through FR-012, SC-001 through SC-005)
 - [ ] T009 [P] Add contract fixture examples matching `contracts/task-detail-target-diagnostics.md` in `tests/contract/test_temporal_execution_api.py` or the nearest existing execution API contract test file (FR-001 through FR-012, DESIGN-REQ-023, DESIGN-REQ-024)

--- a/tests/integration/schemas/test_execution_target_diagnostics_boundary.py
+++ b/tests/integration/schemas/test_execution_target_diagnostics_boundary.py
@@ -1,0 +1,93 @@
+"""Schema boundary coverage for execution target diagnostics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from moonmind.schemas.temporal_models import ExecutionModel
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _base_execution_payload() -> dict[str, object]:
+    now = datetime.now(UTC)
+    return {
+        "taskId": "mm:wf-1",
+        "namespace": "moonmind",
+        "workflowId": "mm:wf-1",
+        "runId": "run-1",
+        "temporalRunId": "run-1",
+        "workflowType": "MoonMind.Run",
+        "entry": "run",
+        "ownerType": "user",
+        "ownerId": "user-1",
+        "title": "Target diagnostics",
+        "summary": "Execution updated.",
+        "status": "failed",
+        "dashboardStatus": "failed",
+        "state": "failed",
+        "rawState": "failed",
+        "temporalStatus": "failed",
+        "createdAt": now,
+        "updatedAt": now,
+        "detailHref": "/tasks/mm:wf-1",
+    }
+
+
+def test_execution_model_preserves_target_diagnostics_alias_contract() -> None:
+    execution = ExecutionModel(
+        **_base_execution_payload(),
+        targetDiagnostics={
+            "targets": [
+                {
+                    "targetKind": "objective",
+                    "label": "Task objective",
+                    "attachments": [
+                        {
+                            "artifactRef": "artifact://input/objective",
+                            "filename": "objective.png",
+                            "contentType": "image/png",
+                            "previewAvailable": True,
+                        }
+                    ],
+                    "refs": [
+                        {
+                            "refKind": "generated_context",
+                            "artifactRef": "artifact://context/objective",
+                        }
+                    ],
+                    "failures": [],
+                }
+            ],
+            "recovery": {
+                "resumed": True,
+                "sourceWorkflowId": "mm:source",
+                "sourceRunId": "run-source",
+                "checkpointRef": "artifact://resume/checkpoint",
+                "preservedSteps": [
+                    {
+                        "logicalStepId": "prepare",
+                        "title": "Prepare context",
+                        "sourceAttempt": 1,
+                        "sourceWorkflowId": "mm:source",
+                        "sourceRunId": "run-source",
+                    }
+                ],
+                "failedResumePhase": None,
+            },
+            "degradedReason": None,
+        },
+    )
+
+    payload = execution.model_dump(by_alias=True)
+
+    assert payload["targetDiagnostics"]["targets"][0]["targetKind"] == "objective"
+    assert (
+        payload["targetDiagnostics"]["targets"][0]["attachments"][0]["artifactRef"]
+        == "artifact://input/objective"
+    )
+    assert payload["targetDiagnostics"]["recovery"]["preservedSteps"][0][
+        "logicalStepId"
+    ] == "prepare"

--- a/tests/integration/schemas/test_execution_target_diagnostics_boundary.py
+++ b/tests/integration/schemas/test_execution_target_diagnostics_boundary.py
@@ -58,7 +58,12 @@ def test_execution_model_preserves_target_diagnostics_alias_contract() -> None:
                             "artifactRef": "artifact://context/objective",
                         }
                     ],
-                    "failures": [],
+                    "failures": [
+                        {
+                            "phase": "degraded",
+                            "message": "Raw event used an unknown target phase.",
+                        }
+                    ],
                 }
             ],
             "recovery": {
@@ -75,7 +80,7 @@ def test_execution_model_preserves_target_diagnostics_alias_contract() -> None:
                         "sourceRunId": "run-source",
                     }
                 ],
-                "failedResumePhase": None,
+                "failedResumePhase": "checkpoint_validation",
             },
             "degradedReason": None,
         },
@@ -91,3 +96,11 @@ def test_execution_model_preserves_target_diagnostics_alias_contract() -> None:
     assert payload["targetDiagnostics"]["recovery"]["preservedSteps"][0][
         "logicalStepId"
     ] == "prepare"
+    assert (
+        payload["targetDiagnostics"]["targets"][0]["failures"][0]["phase"]
+        == "degraded"
+    )
+    assert (
+        payload["targetDiagnostics"]["recovery"]["failedResumePhase"]
+        == "checkpoint_validation"
+    )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6382,6 +6382,116 @@ def test_describe_execution_exposes_failed_step_resume_distinct_from_lifecycle_r
     assert body["resume"]["sourceRunId"] == "run-2"
 
 
+def test_describe_execution_exposes_target_attachment_and_recovery_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.parameters = {
+        "task": {
+            "instructions": "Review the screenshot.",
+            "attachmentRefs": [
+                {
+                    "artifactRef": "artifact://input/objective-image",
+                    "filename": "objective.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 12345,
+                }
+            ],
+            "steps": [
+                {
+                    "id": "inspect",
+                    "title": "Inspect screenshot",
+                    "attachmentRefs": [
+                        {
+                            "artifactRef": "artifact://input/step-image",
+                            "filename": "step.png",
+                            "contentType": "image/png",
+                        }
+                    ],
+                }
+            ],
+        },
+        "targetDiagnostics": {
+            "targets": [
+                {
+                    "targetKind": "objective",
+                    "refs": [
+                        {
+                            "refKind": "attachment_manifest",
+                            "artifactRef": "artifact://diagnostics/input-manifest",
+                        }
+                    ],
+                },
+                {
+                    "targetKind": "step",
+                    "stepId": "inspect",
+                    "failures": [
+                        {
+                            "phase": "materialization",
+                            "message": "Attachment download failed before step execution.",
+                            "evidenceRef": "artifact://diagnostics/prepare",
+                        }
+                    ],
+                },
+            ],
+            "degradedReason": "step_attachment_missing",
+        },
+        "resumeSource": {
+            "sourceWorkflowId": "mm:source",
+            "sourceRunId": "run-source",
+            "preservedSteps": [
+                {
+                    "logicalStepId": "prepare",
+                    "title": "Prepare context",
+                    "sourceAttempt": 1,
+                    "sourceWorkflowId": "mm:source",
+                    "sourceRunId": "run-source",
+                }
+            ],
+        },
+    }
+    record.memo = {
+        **record.memo,
+        "resume_checkpoint_ref": "artifact://resume/checkpoint",
+        "resume_failed_step_id": "inspect",
+        "resume_workspace_checkpoint_ref": "artifact://workspace/checkpoint",
+        "resume_plan_digest": "sha256:plan",
+        "resume_completed_step_refs": ["artifact://completed/prepare"],
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(settings.temporal_dashboard, "temporal_task_editing_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    diagnostics = response.json()["targetDiagnostics"]
+    assert diagnostics["degradedReason"] == "step_attachment_missing"
+    objective = diagnostics["targets"][0]
+    assert objective["targetKind"] == "objective"
+    assert objective["label"] == "Task objective"
+    assert objective["attachments"][0]["artifactRef"] == "artifact://input/objective-image"
+    assert objective["refs"][0]["artifactRef"] == "artifact://diagnostics/input-manifest"
+    step = diagnostics["targets"][1]
+    assert step["targetKind"] == "step"
+    assert step["stepId"] == "inspect"
+    assert step["label"] == "Inspect screenshot"
+    assert step["attachments"][0]["filename"] == "step.png"
+    assert step["failures"][0]["phase"] == "materialization"
+    assert diagnostics["recovery"]["resumed"] is True
+    assert diagnostics["recovery"]["sourceWorkflowId"] == "mm:source"
+    assert diagnostics["recovery"]["sourceRunId"] == "run-source"
+    assert diagnostics["recovery"]["checkpointRef"] == "artifact://resume/checkpoint"
+    assert diagnostics["recovery"]["preservedSteps"][0]["logicalStepId"] == "prepare"
+
+
 @pytest.mark.parametrize(
     ("memo_updates", "expected_reason"),
     [

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6433,6 +6433,10 @@ def test_describe_execution_exposes_target_attachment_and_recovery_diagnostics(
                             "phase": "materialization",
                             "message": "Attachment download failed before step execution.",
                             "evidenceRef": "artifact://diagnostics/prepare",
+                        },
+                        {
+                            "phase": "unknown-provider-phase",
+                            "message": "Provider returned an unrecognized phase.",
                         }
                     ],
                 },
@@ -6485,11 +6489,48 @@ def test_describe_execution_exposes_target_attachment_and_recovery_diagnostics(
     assert step["label"] == "Inspect screenshot"
     assert step["attachments"][0]["filename"] == "step.png"
     assert step["failures"][0]["phase"] == "materialization"
+    assert step["failures"][1]["phase"] == "degraded"
     assert diagnostics["recovery"]["resumed"] is True
     assert diagnostics["recovery"]["sourceWorkflowId"] == "mm:source"
     assert diagnostics["recovery"]["sourceRunId"] == "run-source"
     assert diagnostics["recovery"]["checkpointRef"] == "artifact://resume/checkpoint"
     assert diagnostics["recovery"]["preservedSteps"][0]["logicalStepId"] == "prepare"
+
+
+def test_describe_execution_omits_recovery_for_routine_resume_action_gating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "task": {
+            "instructions": "Review the screenshot.",
+            "attachmentRefs": [
+                {
+                    "artifactRef": "artifact://input/objective-image",
+                    "filename": "objective.png",
+                    "contentType": "image/png",
+                }
+            ],
+        }
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(settings.temporal_dashboard, "temporal_task_editing_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resume"]["disabledReason"] == "state_not_eligible"
+    assert body["targetDiagnostics"]["targets"][0]["targetKind"] == "objective"
+    assert body["targetDiagnostics"]["recovery"] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Jira

- Jira issue key: MM-635

## MoonSpec

- Active feature path: `specs/329-show-attachment-recovery-diagnostics-by-target`

## Verification verdict

- ADDITIONAL_WORK_NEEDED from `/moonspec-verify`: focused implementation evidence passes, but final verification noted remaining coverage/full-suite evidence risks.

## Tests run

- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py` - PASS
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-detail.test.tsx` - PASS
- `./node_modules/.bin/tsc --noEmit --project frontend/tsconfig.json` - PASS
- `pytest tests/integration/vision/test_context_artifacts.py -m 'integration_ci' -q --tb=short` - PASS
- `pytest tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q --tb=short` - PASS
- `pytest tests/integration/schemas/test_execution_target_diagnostics_boundary.py -q --tb=short` - PASS
- `git diff --check -- api_service/api/routers/executions.py moonmind/schemas/temporal_models.py frontend/src/entrypoints/task-detail.tsx frontend/src/entrypoints/task-detail.test.tsx tests/unit/api/routers/test_executions.py tests/integration/schemas/test_execution_target_diagnostics_boundary.py specs/329-show-attachment-recovery-diagnostics-by-target/tasks.md` - PASS

## Remaining risks

- Full `./tools/test_unit.sh` and `./tools/test_integration.sh` were not run in the final verification pass.
- `/moonspec-verify` identified remaining validation gaps for generated-context UI assertions, all bounded attachment failure phases, all failed Resume phase labels, and degraded handling for unknown attachment phases.
- Local remote-tracking ref update after force-push hit a workspace `.git/logs` permission error, but the remote branch push completed.

## Summary

- Adds a compact `targetDiagnostics` execution detail projection for objective/step attachments, target-owned refs, failures, and Resume recovery provenance.
- Adds task-detail UI rendering for target diagnostics while preserving raw diagnostics panels.
- Adds backend, frontend, and schema-boundary tests for the new contract.
