### PR TITLE
The fix is to stop deriving execution-level `started_at` from Temporal’s workflow start time and instead write a MoonMind semantic “real work started”

### DIFF
--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -46,6 +46,23 @@ LOCAL_ONLY_EXECUTION_FIELDS = (
     "last_update_response",
 )
 
+# Lifecycle states where the workflow has not yet begun real work. When a
+# workflow is in one of these states and has not stamped mm_started_at, the
+# projection must not synthesize a started_at from Temporal's workflow
+# start_time / execution_time — those fire as soon as the workflow is
+# scheduled, even while it is awaiting capacity. ``mm_started_at`` is the
+# canonical source for "real work began"; see
+# moonmind.workflows.temporal.workflows.run.MoonMindRunWorkflow._mark_real_work_started.
+PRE_WORK_STATES = frozenset(
+    {
+        MoonMindWorkflowState.SCHEDULED,
+        MoonMindWorkflowState.INITIALIZING,
+        MoonMindWorkflowState.WAITING_ON_DEPENDENCIES,
+        MoonMindWorkflowState.PLANNING,
+        MoonMindWorkflowState.AWAITING_SLOT,
+    }
+)
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -252,12 +269,23 @@ async def map_temporal_state_to_projection(
     scheduled_for = _parse_temporal_datetime(
         search_attributes.get("mm_scheduled_for")
     )
-    started_at = desc.execution_time or desc.start_time
-    if scheduled_for is not None:
-        if state_value == MoonMindWorkflowState.SCHEDULED:
-            started_at = None
-        elif started_at is not None and started_at < scheduled_for:
-            started_at = scheduled_for
+    semantic_started_at = _parse_temporal_datetime(
+        search_attributes.get("mm_started_at")
+    )
+    # Pre-work lifecycle states must not surface a started_at, even on the
+    # legacy fallback path. Once the workflow is running real work, the
+    # workflow stamps mm_started_at; that value wins for all current
+    # workflows. Older in-flight workflows that pre-date the search attribute
+    # fall back to the legacy Temporal lifecycle timestamps.
+    if semantic_started_at is not None:
+        started_at = semantic_started_at
+    elif state_value in PRE_WORK_STATES:
+        started_at = None
+    else:
+        started_at = desc.execution_time or desc.start_time
+        if scheduled_for is not None:
+            if started_at is not None and started_at < scheduled_for:
+                started_at = scheduled_for
     sanitized_memo = _sanitize_for_json(dict(memo))
     return {
         "workflow_id": desc.id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -201,6 +201,9 @@ RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
 RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
+# Replay-stable patch id for stamping mm_started_at when real work begins.
+RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
+MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
@@ -323,6 +326,13 @@ class MoonMindRunWorkflow:
 
         self._scheduled_for: Optional[str] = None
         self._reschedule_requested = False
+
+        # Semantic "real work began" timestamp. Stamped exactly once when the
+        # workflow first crosses from waiting/queue states into actual work
+        # (first running step, or child run launching/running). Distinct from
+        # Temporal's workflow start_time / execution_time, which fire as soon
+        # as Temporal schedules the workflow even if it is awaiting a slot.
+        self._started_at: datetime | None = None
 
         # Proposal tracking
         self._proposals_generated = 0
@@ -669,6 +679,11 @@ class MoonMindRunWorkflow:
             set_started_at=True,
         ):
             return
+        # First time a logical step crosses into "running" is the closest
+        # existing semantic boundary for "real work began". Stamp the
+        # execution-level mm_started_at exactly once here.
+        if workflow.patched(RUN_REAL_STARTED_AT_PATCH):
+            self._mark_real_work_started(now=updated_at)
         self._sync_progress_snapshot(updated_at=updated_at)
 
     def _mark_step_waiting(
@@ -6010,6 +6025,36 @@ class MoonMindRunWorkflow:
             metadata["dependency_failure"] = dict(self._dependency_failure)
         return metadata
 
+    def _mark_real_work_started(self, *, now: datetime | None = None) -> None:
+        """Stamp ``mm_started_at`` once, when the workflow first does real work.
+
+        This is the MoonMind semantic "started" timestamp; do not use Temporal's
+        workflow ``start_time`` / ``execution_time`` for this — they fire when
+        the workflow is scheduled, even while it is still awaiting a provider
+        slot. Idempotent across replay and across cooldown/requeue cycles: once
+        set, it is never overwritten.
+        """
+        if self._started_at is not None:
+            return
+        started_at = now or workflow.now()
+        self._started_at = started_at
+        try:
+            workflow.upsert_search_attributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_datetime(
+                            MM_STARTED_AT_SEARCH_ATTRIBUTE
+                        ),
+                        started_at,
+                    )
+                ]
+            )
+        except Exception as exc:
+            self._get_logger().warning(
+                "Failed to upsert mm_started_at search attribute",
+                extra={"error": str(exc)},
+            )
+
     def _update_search_attributes(self) -> None:
         memo: dict[str, Any] = {
             "waiting_reason": self._waiting_reason,
@@ -6139,10 +6184,14 @@ class MoonMindRunWorkflow:
         elif new_state == "launching":
             self._waiting_reason = None
             self._attention_required = False
+            if workflow.patched(RUN_REAL_STARTED_AT_PATCH):
+                self._mark_real_work_started()
             self._set_state(STATE_EXECUTING, summary="Launching agent...")
         elif new_state == "running":
             self._waiting_reason = None
             self._attention_required = False
+            if workflow.patched(RUN_REAL_STARTED_AT_PATCH):
+                self._mark_real_work_started()
             self._set_state(STATE_EXECUTING, summary="Agent is running.")
         elif new_state in ("completed", "failed", "canceled", "timed_out"):
             # Child has reached a terminal state. If we have an assigned profile

--- a/services/temporal/scripts/bootstrap-namespace.sh
+++ b/services/temporal/scripts/bootstrap-namespace.sh
@@ -190,6 +190,7 @@ mm_owner_id:Keyword
 mm_owner_type:Keyword
 mm_state:Keyword
 mm_updated_at:Datetime
+mm_started_at:Datetime
 mm_repo:Keyword
 mm_integration:Keyword
 mm_scheduled_for:Datetime

--- a/tests/integration/temporal/test_namespace_retention.py
+++ b/tests/integration/temporal/test_namespace_retention.py
@@ -16,6 +16,7 @@ REQUIRED_SEARCH_ATTRIBUTES = {
     "mm_owner_type": "Keyword",
     "mm_state": "Keyword",
     "mm_updated_at": "Datetime",
+    "mm_started_at": "Datetime",
     "mm_repo": "Keyword",
     "mm_integration": "Keyword",
     "mm_scheduled_for": "Datetime",
@@ -34,6 +35,7 @@ LEGACY_SEARCH_ATTRIBUTES = {
     if (
         not key.startswith("mm_dependency_")
         and key != "mm_has_dependencies"
+        and key != "mm_started_at"
         and key
         not in {
             "TaskRunId",
@@ -329,9 +331,10 @@ def test_namespace_bootstrap_registers_missing_search_attributes_on_upgrade(
     assert "SessionEpoch" in result.stdout
     assert "SessionStatus" in result.stdout
     assert "IsDegraded" in result.stdout
+    assert "mm_started_at" in result.stdout
 
     calls = (state_dir / "calls.log").read_text(encoding="utf-8")
-    assert calls.count("search-attribute create") == 8
+    assert calls.count("search-attribute create") == 9
 
     registered = (state_dir / "search-attributes.txt").read_text(encoding="utf-8")
     for name, attr_type in REQUIRED_SEARCH_ATTRIBUTES.items():

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -579,3 +579,126 @@ def test_merged_memo_with_empty_temporal_memo_returns_canonical_memo():
     merged = merged_memo_for_projection(payload, canonical)
     assert merged["taskRunId"] == "abc"
     assert merged["title"] == "task"
+
+# --- mm_started_at semantic timestamp tests ---
+
+def _make_running_desc(
+    *,
+    workflow_id: str,
+    start_time: datetime,
+    search_attributes: dict[str, "object"],
+    memo_data: dict[str, "object"] | None = None,
+) -> Mock:
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = workflow_id
+    desc.run_id = f"run-{workflow_id}"
+    desc.namespace = "moonmind"
+    desc.workflow_type = "MoonMind.Run"
+    desc.status = WorkflowExecutionStatus.RUNNING
+    desc.start_time = start_time
+    desc.execution_time = start_time
+    desc.close_time = None
+    desc.search_attributes = search_attributes
+
+    payload = memo_data or {"entry": "run", "owner_id": "owner-1", "owner_type": "user"}
+
+    async def _memo() -> dict[str, object]:
+        return payload
+
+    desc.memo = _memo
+    return desc
+
+def test_started_at_is_none_for_awaiting_slot_without_mm_started_at():
+    """Running Temporal workflow with mm_state=awaiting_slot must not surface
+    a started_at: Temporal's start_time fires when the workflow is created,
+    even while it is still waiting for a provider profile slot."""
+    start_time = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    desc = _make_running_desc(
+        workflow_id="mm:awaiting-slot",
+        start_time=start_time,
+        search_attributes={
+            "mm_state": "awaiting_slot",
+            "mm_entry": "run",
+        },
+    )
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.AWAITING_SLOT
+    assert result["started_at"] is None
+
+def test_started_at_uses_mm_started_at_when_present():
+    """When the workflow has stamped mm_started_at, the projection prefers
+    it over Temporal's lifecycle timestamps."""
+    start_time = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    semantic_started_at = datetime(2026, 5, 1, 12, 7, tzinfo=UTC)
+    desc = _make_running_desc(
+        workflow_id="mm:executing-with-mm-started",
+        start_time=start_time,
+        search_attributes={
+            "mm_state": "executing",
+            "mm_entry": "run",
+            "mm_started_at": semantic_started_at.isoformat(),
+        },
+    )
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.EXECUTING
+    assert _as_utc(result["started_at"]) == semantic_started_at
+
+def test_started_at_legacy_fallback_for_executing_without_mm_started_at():
+    """In-flight workflows that pre-date mm_started_at must keep working:
+    when the workflow is in a real-work state but no semantic timestamp is
+    available, fall back to the Temporal lifecycle timestamp."""
+    start_time = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    desc = _make_running_desc(
+        workflow_id="mm:executing-legacy",
+        start_time=start_time,
+        search_attributes={
+            "mm_state": "executing",
+            "mm_entry": "run",
+        },
+    )
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.EXECUTING
+    assert _as_utc(result["started_at"]) == start_time
+
+def test_started_at_none_for_planning_state():
+    """PLANNING is a pre-work state; no started_at without mm_started_at."""
+    start_time = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    desc = _make_running_desc(
+        workflow_id="mm:planning",
+        start_time=start_time,
+        search_attributes={
+            "mm_state": "planning",
+            "mm_entry": "run",
+        },
+    )
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.PLANNING
+    assert result["started_at"] is None
+
+def test_started_at_persists_through_awaiting_slot_after_work_began():
+    """Cooldown / requeue can return the workflow to awaiting_slot after work
+    has already begun. Once mm_started_at is stamped, it must keep winning."""
+    start_time = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    semantic_started_at = datetime(2026, 5, 1, 12, 5, tzinfo=UTC)
+    desc = _make_running_desc(
+        workflow_id="mm:cooldown-requeue",
+        start_time=start_time,
+        search_attributes={
+            "mm_state": "awaiting_slot",
+            "mm_entry": "run",
+            "mm_started_at": semantic_started_at.isoformat(),
+        },
+    )
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.AWAITING_SLOT
+    assert _as_utc(result["started_at"]) == semantic_started_at

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -492,6 +492,7 @@ def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
     workflow_instance = MoonMindRunWorkflow()
     monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
     monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: False)
 
     workflow_instance.child_state_changed(
         "awaiting_slot",
@@ -514,6 +515,64 @@ def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
 
     assert workflow_instance._waiting_reason is None
     assert workflow_instance._attention_required is False
+
+def test_mm_started_at_stamped_on_launch_and_immutable_across_requeue(monkeypatch):
+    """``mm_started_at`` is set exactly once when the child reports it has
+    crossed from awaiting_slot into launching/running. A subsequent return to
+    ``awaiting_slot`` (cooldown/requeue) and re-launch must not overwrite it.
+    """
+    workflow_instance = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
+    upserts: list = []
+    monkeypatch.setattr(
+        workflow,
+        "upsert_search_attributes",
+        lambda pairs: upserts.append(pairs),
+    )
+
+    launch_now = datetime(2026, 5, 1, 12, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(workflow, "now", lambda: launch_now)
+
+    workflow_instance.child_state_changed(
+        "awaiting_slot", "Managed provider capacity exhausted."
+    )
+    assert workflow_instance._started_at is None
+
+    workflow_instance.child_state_changed("launching", "Slot acquired.")
+    first_started = workflow_instance._started_at
+    assert first_started == launch_now
+    assert len(upserts) == 1
+
+    # Cooldown returns the run to awaiting_slot, then it relaunches. The
+    # semantic started_at must persist.
+    workflow_instance.child_state_changed("awaiting_slot", "Cooldown.")
+    workflow_instance.child_state_changed("running", "Agent restarted.")
+    assert workflow_instance._started_at == first_started
+    assert len(upserts) == 1
+
+def test_mm_started_at_not_stamped_for_awaiting_slot(monkeypatch):
+    """Awaiting a provider slot must not stamp mm_started_at — that is
+    exactly the case the legacy behavior got wrong."""
+    workflow_instance = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
+    upserts: list = []
+    monkeypatch.setattr(
+        workflow,
+        "upsert_search_attributes",
+        lambda pairs: upserts.append(pairs),
+    )
+    monkeypatch.setattr(
+        workflow, "now", lambda: datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    )
+
+    workflow_instance.child_state_changed("awaiting_slot", "No slot.")
+
+    assert workflow_instance._started_at is None
+    assert upserts == []
 
 @pytest.mark.asyncio
 async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypatch):

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -40,6 +40,7 @@ def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
         "upsert_search_attributes",
         search_updates.append,
     )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
     return memo_updates
 
 def _ordered_nodes() -> list[dict]:
@@ -165,6 +166,67 @@ def test_run_progress_query_exposes_current_run_id(
 
     assert progress["runId"] == "run-1"
     assert progress["total"] == 2
+
+def test_first_step_running_stamps_mm_started_at_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_mark_step_running`` is the closest existing semantic boundary for
+    "real work began" — when a logical step first transitions to running, the
+    workflow must stamp ``mm_started_at``. Subsequent step transitions and
+    retries must not move the timestamp."""
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    upserts: list[object] = []
+    monkeypatch.setattr(
+        run_module.workflow, "upsert_search_attributes", upserts.append
+    )
+    workflow = MoonMindRunWorkflow()
+    first_now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    later = datetime(2026, 4, 7, 12, 1, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=first_now,
+    )
+    upserts.clear()
+
+    workflow._mark_step_running(
+        "prepare", updated_at=first_now, summary="Preparing"
+    )
+    assert workflow._started_at == first_now
+
+    # Find the mm_started_at upsert. _set_state-driven upserts do not include
+    # the semantic timestamp; the dedicated upsert from _mark_real_work_started
+    # contains exactly one pair carrying the value.
+    started_at_upserts = [
+        pairs
+        for pairs in upserts
+        if any(
+            getattr(p.key, "name", None) == run_module.MM_STARTED_AT_SEARCH_ATTRIBUTE
+            for p in (pairs if isinstance(pairs, list) else [])
+        )
+    ]
+    assert len(started_at_upserts) == 1
+
+    workflow._mark_step_terminal(
+        "prepare", status="succeeded", updated_at=first_now, summary="Done"
+    )
+    workflow._refresh_step_readiness(updated_at=later)
+    workflow._mark_step_running(
+        "run-tests", updated_at=later, summary="Running tests"
+    )
+    # mm_started_at is set exactly once; later step transitions never overwrite it.
+    assert workflow._started_at == first_now
+    started_at_upserts = [
+        pairs
+        for pairs in upserts
+        if any(
+            getattr(p.key, "name", None) == run_module.MM_STARTED_AT_SEARCH_ATTRIBUTE
+            for p in (pairs if isinstance(pairs, list) else [])
+        )
+    ]
+    assert len(started_at_upserts) == 1
 
 def test_run_tracks_status_transitions_and_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure_workflow_runtime(monkeypatch)


### PR DESCRIPTION
Automated changes by MoonMind.