### PR TITLE
Wire default task runtime + provider profile settings into Create page

### DIFF
--- a/api_service/api/routers/task_dashboard.py
+++ b/api_service/api/routers/task_dashboard.py
@@ -36,7 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.db.base import get_async_session
 from api_service.api.routers.task_dashboard_view_model import (
     build_repository_branch_options,
-    build_runtime_config,
+    resolve_dashboard_runtime_config,
 )
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
@@ -286,13 +286,15 @@ def _vite_assets_or_error(page: str) -> HTMLResponse | str:
     except MissionControlUIAssetsError as exc:
         return _mission_control_ui_error_response(page, str(exc))
 
-def _render_react_page(
+async def _render_react_page(
     request: Request,
     page: str,
     current_path: str,
     initial_data: dict | None = None,
     *,
     data_wide_panel: bool = False,
+    session: AsyncSession | None = None,
+    user: User | None = None,
 ) -> HTMLResponse:
     boot_initial_data = dict(initial_data or {})
     boot_layout = dict(boot_initial_data.get("layout") or {})
@@ -300,7 +302,9 @@ def _render_react_page(
     boot_initial_data["layout"] = boot_layout
     dashboard_config = dict(boot_initial_data.get("dashboardConfig") or {})
     if not dashboard_config:
-        dashboard_config = build_runtime_config(current_path)
+        dashboard_config = await resolve_dashboard_runtime_config(
+            current_path, session=session, user=user
+        )
         boot_initial_data["dashboardConfig"] = dashboard_config
 
     boot_payload = generate_boot_payload(page, initial_data=boot_initial_data)
@@ -628,26 +632,40 @@ async def task_dashboard_root(
 @router.get("/tasks/proposals", response_class=HTMLResponse)
 async def task_proposals_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered proposals page."""
-    return _render_react_page(request, "proposals", "/tasks/proposals", data_wide_panel=True)
+    return await _render_react_page(
+        request,
+        "proposals",
+        "/tasks/proposals",
+        data_wide_panel=True,
+        session=session,
+        user=_user,
+    )
 
 @router.get("/tasks/schedules", response_class=HTMLResponse)
 async def task_schedules_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered schedules page."""
-    return _render_react_page(request, "schedules", "/tasks/schedules")
+    return await _render_react_page(
+        request, "schedules", "/tasks/schedules", session=session, user=_user
+    )
 
 @router.get("/tasks/manifests", response_class=HTMLResponse)
 async def task_manifests_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered manifests page."""
-    return _render_react_page(request, "manifests", "/tasks/manifests")
+    return await _render_react_page(
+        request, "manifests", "/tasks/manifests", session=session, user=_user
+    )
 
 @router.get("/tasks/manifests/new", status_code=307, response_class=RedirectResponse)
 async def task_manifest_submit_route(
@@ -660,16 +678,22 @@ async def task_manifest_submit_route(
 @router.get("/tasks/list", response_class=HTMLResponse)
 async def task_list_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered tasks list page."""
     list_path = "/tasks/list"
-    return _render_react_page(
+    dashboard_config = await resolve_dashboard_runtime_config(
+        list_path, session=session, user=_user
+    )
+    return await _render_react_page(
         request,
         "tasks-list",
         list_path,
-        initial_data={"dashboardConfig": build_runtime_config(list_path)},
+        initial_data={"dashboardConfig": dashboard_config},
         data_wide_panel=True,
+        session=session,
+        user=_user,
     )
 
 @router.get("/tasks/tasks-list")
@@ -691,10 +715,13 @@ async def task_workers_route(
 @router.get("/tasks/settings", response_class=HTMLResponse)
 async def task_settings_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered settings page."""
-    runtime_config = build_runtime_config("/tasks/settings")
+    runtime_config = await resolve_dashboard_runtime_config(
+        "/tasks/settings", session=session, user=_user
+    )
     initial_data = {
         "workerPause": {
             "get": "/api/system/worker-pause",
@@ -702,41 +729,52 @@ async def task_settings_route(
         },
         "runtimeConfig": runtime_config,
     }
-    return _render_react_page(
+    return await _render_react_page(
         request,
         "settings",
         "/tasks/settings",
         initial_data=initial_data,
+        session=session,
+        user=_user,
     )
 
 @router.get("/oauth-terminal", response_class=HTMLResponse)
 async def oauth_terminal_route(
     request: Request,
     session_id: str = Query("", alias="session_id"),
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the OAuth terminal shell launched from Settings."""
     current_path = "/oauth-terminal"
-    return _render_react_page(
+    return await _render_react_page(
         request,
         "oauth-terminal",
         current_path,
         initial_data={"sessionId": session_id},
         data_wide_panel=True,
+        session=session,
+        user=_user,
     )
 
 @router.get("/tasks/new", response_class=HTMLResponse)
 async def task_create_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered task create page."""
     current_path = "/tasks/new"
-    return _render_react_page(
+    dashboard_config = await resolve_dashboard_runtime_config(
+        current_path, session=session, user=_user
+    )
+    return await _render_react_page(
         request,
         "task-create",
         current_path,
-        initial_data={"dashboardConfig": build_runtime_config(current_path)},
+        initial_data={"dashboardConfig": dashboard_config},
+        session=session,
+        user=_user,
     )
 
 @router.get("/tasks/create")
@@ -750,15 +788,19 @@ async def task_create_alias_route(
 @router.get("/tasks/skills", response_class=HTMLResponse)
 async def task_skills_route(
     request: Request,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered skills page."""
-    return _render_react_page(request, "skills", "/tasks/skills")
+    return await _render_react_page(
+        request, "skills", "/tasks/skills", session=session, user=_user
+    )
 
 @router.get("/tasks/{dashboard_path:path}", response_class=HTMLResponse)
 async def task_dashboard_route(
     request: Request,
     dashboard_path: str,
+    session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve dashboard sub-routes from one HTML shell."""
@@ -768,11 +810,16 @@ async def task_dashboard_route(
         _raise_dashboard_route_not_found()
 
     detail_path = f"/tasks/{normalized}"
-    return _render_react_page(
+    dashboard_config = await resolve_dashboard_runtime_config(
+        detail_path, session=session, user=_user
+    )
+    return await _render_react_page(
         request,
         "task-detail",
         detail_path,
-        initial_data={"dashboardConfig": build_runtime_config(detail_path)},
+        initial_data={"dashboardConfig": dashboard_config},
+        session=session,
+        user=_user,
     )
 
 @router.get("/api/tasks/skills", response_model=DashboardSkillListResponse)

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import os
 import re
 import time
+import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Mapping
 from urllib.parse import urlparse
+from uuid import UUID
 
 import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from moonmind.config.settings import WorkflowSettings, settings
 from moonmind.utils.build_info import resolve_moonmind_build_id
@@ -21,6 +24,8 @@ from moonmind.workflows.tasks.runtime_defaults import (
     resolve_default_task_runtime,
     resolve_runtime_defaults,
 )
+
+logger = logging.getLogger(__name__)
 
 _POLL_INTERVALS_MS = {
     "list": 5000,
@@ -526,15 +531,34 @@ def _build_jira_runtime_config() -> dict[str, Any] | None:
         },
     }
 
-def build_runtime_config(initial_path: str) -> dict[str, Any]:
-    """Build runtime config consumed by dashboard JavaScript."""
+def build_runtime_config(
+    initial_path: str,
+    *,
+    default_task_runtime_override: str | None = None,
+    default_provider_profile_ref: str | None = None,
+) -> dict[str, Any]:
+    """Build runtime config consumed by dashboard JavaScript.
+
+    ``default_task_runtime_override`` and ``default_provider_profile_ref`` come
+    from the per-request effective settings (user/workspace overrides resolved
+    by ``SettingsCatalogService``). When omitted, behavior matches the legacy
+    env+settings-only resolution.
+    """
 
     supported_task_runtimes = _build_supported_task_runtimes()
     temporal_dashboard = settings.temporal_dashboard
+    runtime_override = (
+        normalize_runtime_id(default_task_runtime_override)
+        if isinstance(default_task_runtime_override, str)
+        and default_task_runtime_override.strip()
+        else ""
+    )
     configured_runtime = normalize_runtime_id(
         str(os.environ.get("MOONMIND_WORKER_RUNTIME", "")).strip().lower() or None
     ) if os.environ.get("MOONMIND_WORKER_RUNTIME", "").strip() else ""
-    if configured_runtime in supported_task_runtimes:
+    if runtime_override in supported_task_runtimes:
+        default_task_runtime = runtime_override
+    elif configured_runtime in supported_task_runtimes:
         default_task_runtime = configured_runtime
     else:
         configured_default = resolve_default_task_runtime(settings.workflow)
@@ -680,6 +704,12 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "detail": "/api/v1/provider-profiles/{profileId}",
                 "update": "/api/v1/provider-profiles/{profileId}",
                 "delete": "/api/v1/provider-profiles/{profileId}",
+                **(
+                    {"defaultProfileRef": default_provider_profile_ref}
+                    if isinstance(default_provider_profile_ref, str)
+                    and default_provider_profile_ref.strip()
+                    else {}
+                ),
             },
             "attachmentPolicy": {
                 "enabled": bool(settings.workflow.agent_job_attachment_enabled),
@@ -696,10 +726,100 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
         },
     }
 
+_PROVIDER_PROFILE_INVALID_DIAGNOSTIC_CODES = frozenset(
+    {"provider_profile_not_found", "provider_profile_disabled"}
+)
+
+
+def _coerce_uuid(value: Any) -> UUID | None:
+    if isinstance(value, UUID):
+        return value
+    if value is None:
+        return None
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+async def resolve_dashboard_runtime_config(
+    initial_path: str,
+    *,
+    session: AsyncSession | None,
+    user: Any = None,
+) -> dict[str, Any]:
+    """Resolve runtime config with user/workspace setting overrides applied.
+
+    Falls back to the legacy ``build_runtime_config`` behavior when the session
+    is unavailable or the settings catalog cannot be reached. Settings consumed:
+
+    - ``workflow.default_task_runtime`` (workspace scope)
+    - ``workflow.default_provider_profile_ref`` (user scope, falls back to
+      workspace and env). Refs are dropped when their diagnostics indicate the
+      profile is missing or disabled, so the frontend can fall back to its
+      ``is_default`` lookup instead of selecting a stale ID.
+    """
+
+    if session is None:
+        return build_runtime_config(initial_path)
+
+    # Local imports keep the view-model importable without DB models loaded
+    # for tests that exercise build_runtime_config directly.
+    from api_service.services.settings_catalog import SettingsCatalogService
+
+    workspace_id = _coerce_uuid(getattr(user, "workspace_id", None))
+    user_id = _coerce_uuid(getattr(user, "id", None))
+
+    runtime_override: str | None = None
+    profile_ref: str | None = None
+
+    try:
+        service = SettingsCatalogService(
+            session=session,
+            workspace_id=workspace_id,
+            user_id=user_id,
+        )
+        runtime_eff = await service.effective_value_async(
+            "workflow.default_task_runtime", scope="workspace"
+        )
+        if isinstance(runtime_eff.value, str) and runtime_eff.value.strip():
+            runtime_override = runtime_eff.value.strip()
+
+        profile_scope = "user" if user_id is not None else "workspace"
+        profile_eff = await service.effective_value_async(
+            "workflow.default_provider_profile_ref", scope=profile_scope
+        )
+        if isinstance(profile_eff.value, str) and profile_eff.value.strip():
+            invalid = any(
+                diag.code in _PROVIDER_PROFILE_INVALID_DIAGNOSTIC_CODES
+                for diag in profile_eff.diagnostics
+            )
+            if not invalid:
+                profile_ref = profile_eff.value.strip()
+    except Exception:
+        # Settings overrides are best-effort. If the DB is unreachable or the
+        # catalog service raises, fall back to the env/settings-only defaults
+        # so the dashboard still renders. The route still has the boot payload
+        # to send back; we just don't get user/workspace personalization.
+        logger.debug(
+            "resolve_dashboard_runtime_config: falling back to defaults",
+            exc_info=True,
+        )
+        runtime_override = None
+        profile_ref = None
+
+    return build_runtime_config(
+        initial_path,
+        default_task_runtime_override=runtime_override,
+        default_provider_profile_ref=profile_ref,
+    )
+
+
 __all__ = [
     "build_live_logs_feature_config",
     "build_repository_branch_options",
     "build_runtime_config",
+    "resolve_dashboard_runtime_config",
     "normalize_status",
     "BranchOption",
     "RepositoryOption",

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -22,6 +22,7 @@ import {
   ARTIFACT_COMPLETE_RETRY_DELAYS_MS,
   LIQUID_GL_OPTIONS,
   preferredTemplate,
+  resolveDefaultProviderProfileId,
   resolveObjectiveInstructions,
   TaskCreatePage,
 } from "./task-create";
@@ -14770,5 +14771,40 @@ describe("Task Create governed Tool authoring", () => {
     });
     expect((within(step).getByLabelText("Tool ID") as HTMLInputElement).value)
       .toBe("jira.get_issue");
+  });
+});
+
+describe("resolveDefaultProviderProfileId", () => {
+  const profiles = [
+    { profile_id: "claude-anthropic", is_default: false, enabled: true },
+    { profile_id: "codex", is_default: true, enabled: true },
+  ];
+
+  it("prefers the configured default ref over the is_default flag", () => {
+    expect(
+      resolveDefaultProviderProfileId(profiles, "claude-anthropic"),
+    ).toBe("claude-anthropic");
+  });
+
+  it("falls back to is_default when the configured ref does not match", () => {
+    expect(
+      resolveDefaultProviderProfileId(profiles, "missing-profile"),
+    ).toBe("codex");
+  });
+
+  it("falls back to is_default when the configured ref is blank", () => {
+    expect(resolveDefaultProviderProfileId(profiles, "   ")).toBe("codex");
+    expect(resolveDefaultProviderProfileId(profiles, null)).toBe("codex");
+    expect(resolveDefaultProviderProfileId(profiles, undefined)).toBe("codex");
+  });
+
+  it("falls back to is_default when the configured profile is disabled", () => {
+    const disabled = [
+      { profile_id: "claude-anthropic", is_default: false, enabled: false },
+      { profile_id: "codex", is_default: true, enabled: true },
+    ];
+    expect(
+      resolveDefaultProviderProfileId(disabled, "claude-anthropic"),
+    ).toBe("codex");
   });
 });

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -224,6 +224,7 @@ interface DashboardConfig {
     };
     providerProfiles?: {
       list?: string;
+      defaultProfileRef?: string | null;
     };
     taskTemplateCatalog?: {
       enabled?: boolean;
@@ -363,6 +364,7 @@ interface ProviderProfile {
   account_label?: string | null;
   default_model?: string | null;
   is_default?: boolean;
+  enabled?: boolean;
 }
 
 interface BranchOption {
@@ -381,9 +383,19 @@ interface BranchListResponse {
   defaultBranch?: string | null;
 }
 
-function resolveDefaultProviderProfileId(
+export function resolveDefaultProviderProfileId(
   profiles: ProviderProfile[],
+  configuredDefaultRef?: string | null,
 ): string {
+  const trimmedRef = configuredDefaultRef?.trim?.() || "";
+  if (trimmedRef) {
+    const configured = profiles.find(
+      (profile) => profile.profile_id === trimmedRef && profile.enabled !== false,
+    );
+    if (configured) {
+      return configured.profile_id;
+    }
+  }
   const explicitDefault = profiles.find((profile) => profile.is_default);
   if (explicitDefault) {
     return explicitDefault.profile_id;
@@ -3380,6 +3392,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     dashboardConfig.system?.providerProfiles?.list ||
       "/api/v1/provider-profiles",
   );
+  const configuredDefaultProviderProfileRef =
+    dashboardConfig.system?.providerProfiles?.defaultProfileRef ?? null;
   const taskTemplateCatalog = dashboardConfig.system?.taskTemplateCatalog;
   const taskTemplateCatalogEnabled = Boolean(taskTemplateCatalog?.enabled);
   const taskTemplateSaveEnabled = Boolean(
@@ -3771,7 +3785,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    const defaultProfileId = resolveDefaultProviderProfileId(profiles);
+    const defaultProfileId = resolveDefaultProviderProfileId(
+      profiles,
+      configuredDefaultProviderProfileRef,
+    );
     if (defaultProfileId && providerProfile !== defaultProfileId) {
       setProviderProfile(defaultProfileId);
     }
@@ -3781,6 +3798,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     providerProfilesQuery.data,
     providerProfilesQuery.isFetching,
     providerProfilesQuery.isLoading,
+    configuredDefaultProviderProfileRef,
   ]);
 
   useEffect(() => {

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
 import pytest
 
 import api_service.api.routers.task_dashboard_view_model as dashboard_view_model
+from api_service.services.settings_catalog import (
+    EffectiveSettingValue,
+    SettingDiagnostic,
+)
 from moonmind.config.settings import settings
 
 def test_normalize_status_maps_temporal_awaiting_external_to_action() -> None:
@@ -879,3 +888,163 @@ def test_normalize_status_maps_temporal_awaiting_slot_to_queued() -> None:
 def test_normalize_status_maps_temporal_waiting_on_dependencies_to_waiting() -> None:
     """waiting_on_dependencies should map to waiting on the dashboard."""
     assert dashboard_view_model.normalize_status("temporal", "waiting_on_dependencies") == "waiting"
+
+
+def test_build_runtime_config_runtime_override_wins_over_settings(monkeypatch) -> None:
+    """An effective workflow.default_task_runtime override should win over settings."""
+
+    monkeypatch.delenv("MOONMIND_WORKER_RUNTIME", raising=False)
+    monkeypatch.setattr(settings.workflow, "default_task_runtime", "codex_cli")
+
+    config = dashboard_view_model.build_runtime_config(
+        "/tasks/new",
+        default_task_runtime_override="claude_code",
+    )
+
+    assert config["system"]["defaultTaskRuntime"] == "claude_code"
+
+
+def test_build_runtime_config_runtime_override_ignored_when_unsupported(
+    monkeypatch,
+) -> None:
+    """Unsupported runtime overrides fall back to env/settings resolution."""
+
+    monkeypatch.delenv("MOONMIND_WORKER_RUNTIME", raising=False)
+    monkeypatch.setattr(settings.workflow, "default_task_runtime", "codex_cli")
+
+    config = dashboard_view_model.build_runtime_config(
+        "/tasks/new",
+        default_task_runtime_override="not_a_real_runtime",
+    )
+
+    assert config["system"]["defaultTaskRuntime"] == "codex_cli"
+
+
+def test_build_runtime_config_includes_provider_profile_ref_when_set() -> None:
+    """A non-empty provider profile ref appears under system.providerProfiles."""
+
+    config = dashboard_view_model.build_runtime_config(
+        "/tasks/new",
+        default_provider_profile_ref="claude-anthropic",
+    )
+
+    assert (
+        config["system"]["providerProfiles"]["defaultProfileRef"]
+        == "claude-anthropic"
+    )
+
+
+def test_build_runtime_config_omits_provider_profile_ref_when_blank() -> None:
+    """Blank/whitespace refs are omitted so the frontend keeps its is_default fallback."""
+
+    config = dashboard_view_model.build_runtime_config(
+        "/tasks/new",
+        default_provider_profile_ref="   ",
+    )
+
+    assert "defaultProfileRef" not in config["system"]["providerProfiles"]
+
+
+def _effective(value: Any, *, diagnostics: list[SettingDiagnostic] | None = None) -> EffectiveSettingValue:
+    return EffectiveSettingValue(
+        key="workflow.default_provider_profile_ref",
+        scope="user",
+        value=value,
+        source="user_override",
+        source_explanation="user override",
+        apply_mode="next_launch",
+        activation_state="pending_next_boundary",
+        active=False,
+        diagnostics=diagnostics or [],
+    )
+
+
+def _runtime_effective(value: Any) -> EffectiveSettingValue:
+    return EffectiveSettingValue(
+        key="workflow.default_task_runtime",
+        scope="workspace",
+        value=value,
+        source="workspace_override",
+        source_explanation="workspace override",
+        apply_mode="next_task",
+        activation_state="pending_next_boundary",
+        active=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dashboard_runtime_config_propagates_overrides() -> None:
+    """Effective settings flow into build_runtime_config for the route layer."""
+
+    user = SimpleNamespace(
+        id=UUID("11111111-1111-1111-1111-111111111111"),
+        workspace_id=UUID("22222222-2222-2222-2222-222222222222"),
+    )
+    fake_session = object()
+
+    async def fake_effective_value_async(self, key, *, scope):
+        if key == "workflow.default_task_runtime":
+            return _runtime_effective("claude_code")
+        if key == "workflow.default_provider_profile_ref":
+            return _effective("claude-anthropic")
+        raise AssertionError(f"unexpected key: {key}")
+
+    with patch(
+        "api_service.services.settings_catalog.SettingsCatalogService.effective_value_async",
+        new=fake_effective_value_async,
+    ):
+        config = await dashboard_view_model.resolve_dashboard_runtime_config(
+            "/tasks/new", session=fake_session, user=user
+        )
+
+    assert config["system"]["defaultTaskRuntime"] == "claude_code"
+    assert (
+        config["system"]["providerProfiles"]["defaultProfileRef"]
+        == "claude-anthropic"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dashboard_runtime_config_drops_invalid_profile_ref() -> None:
+    """Provider profile diagnostics flag missing/disabled refs; we omit them."""
+
+    user = SimpleNamespace(id=None, workspace_id=None)
+    fake_session = object()
+
+    async def fake_effective_value_async(self, key, *, scope):
+        if key == "workflow.default_task_runtime":
+            return _runtime_effective(None)
+        if key == "workflow.default_provider_profile_ref":
+            return _effective(
+                "stale-profile",
+                diagnostics=[
+                    SettingDiagnostic(
+                        code="provider_profile_not_found",
+                        message="missing",
+                        severity="error",
+                    )
+                ],
+            )
+        raise AssertionError(f"unexpected key: {key}")
+
+    with patch(
+        "api_service.services.settings_catalog.SettingsCatalogService.effective_value_async",
+        new=fake_effective_value_async,
+    ):
+        config = await dashboard_view_model.resolve_dashboard_runtime_config(
+            "/tasks/new", session=fake_session, user=user
+        )
+
+    assert "defaultProfileRef" not in config["system"]["providerProfiles"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_dashboard_runtime_config_no_session_falls_back() -> None:
+    """Without a session, the resolver returns the legacy build_runtime_config result."""
+
+    config = await dashboard_view_model.resolve_dashboard_runtime_config(
+        "/tasks/new", session=None
+    )
+
+    # Default config still has providerProfiles but no defaultProfileRef.
+    assert "defaultProfileRef" not in config["system"]["providerProfiles"]


### PR DESCRIPTION
## Summary
- The settings catalog has had `workflow.default_task_runtime` and `workflow.default_provider_profile_ref` for a while, but neither flowed into the Mission Control Create page. `default_task_runtime` was only read from env/settings (skipping user/workspace overrides), and `default_provider_profile_ref` was never read or sent to the frontend — the Create page picked whichever profile had `is_default = true` regardless of what the user set.
- New `resolve_dashboard_runtime_config(...)` helper resolves both settings via `SettingsCatalogService.effective_value_async` at the dashboard route boundary, drops profile refs whose diagnostics flag the profile as missing/disabled, and falls back gracefully if the catalog/DB is unavailable.
- The Create page reads `system.providerProfiles.defaultProfileRef` and prefers it when the matching profile exists and is enabled, otherwise keeps the existing `is_default` fallback.

## Test plan
- [x] `./tools/test_unit.sh` (Python: 4430 passed; Vitest: 330 passed including 4 new `resolveDefaultProviderProfileId` cases and 6 new view-model cases).
- [ ] Smoke in the running app: set Settings → User/Workspace → "Default Provider Profile" to a Claude Anthropic profile and verify the Create page picks it on load (and falls back to `is_default` when the configured profile is later disabled or removed).
- [ ] Smoke: set Settings → User/Workspace → "Default Task Runtime" to e.g. Claude Code and verify the Create page defaults to that runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)