### PR TITLE
[codex] Fix document update child task submission

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1963,17 +1963,15 @@ def _document_update_task_payload(
     runtime = _mapping(task_payload.get("runtime"))
     publish = _mapping(task_payload.get("publish"))
     repository = _string(task_payload.get("repository") or task_payload.get("repo"))
+    task_inputs = {
+        "document_path": document_path,
+        "source_directory": source_directory,
+    }
     task: dict[str, Any] = {
         "title": f"Document update: {Path(document_path).name}",
         "instructions": instructions,
-        "inputs": {
-            "document_path": document_path,
-            "source_directory": source_directory,
-        },
-        "taskTemplate": {
-            "slug": "document-update",
-            "version": "1.0.0",
-        },
+        "inputs": dict(task_inputs),
+        "skill": {"id": "document-update", "args": dict(task_inputs)},
     }
     if runtime:
         task["runtime"] = runtime

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1971,7 +1971,11 @@ def _document_update_task_payload(
         "title": f"Document update: {Path(document_path).name}",
         "instructions": instructions,
         "inputs": dict(task_inputs),
-        "skill": {"id": "document-update", "args": dict(task_inputs)},
+        "skill": {
+            "name": "document-update",
+            "version": "1.0.0",
+            "args": dict(task_inputs),
+        },
     }
     if runtime:
         task["runtime"] = runtime

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1663,7 +1663,8 @@ async def test_create_document_update_tasks_from_inline_paths():
     assert first_task["publish"]["mergeAutomation"]["enabled"] is True
     assert "taskTemplate" not in first_task
     assert first_task["skill"] == {
-        "id": "document-update",
+        "name": "document-update",
+        "version": "1.0.0",
         "args": {
             "document_path": "/docs/readme.md",
             "source_directory": "/docs",

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1659,9 +1659,16 @@ async def test_create_document_update_tasks_from_inline_paths():
     assert second["dependsOn"] == [first["workflowId"]]
 
     first_task = creator.requests[0]["initial_parameters"]["task"]
-    assert first_task["taskTemplate"]["slug"] == "document-update"
     assert first_task["publish"]["mode"] == "pr"
     assert first_task["publish"]["mergeAutomation"]["enabled"] is True
+    assert "taskTemplate" not in first_task
+    assert first_task["skill"] == {
+        "id": "document-update",
+        "args": {
+            "document_path": "/docs/readme.md",
+            "source_directory": "/docs",
+        },
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Submit per-document child runs as direct `document-update` skill tasks instead of referencing a nonexistent `document-update` task template.
- Preserve document path and source directory inputs in both `task.inputs` and `skill.args`.
- Update story-output coverage to assert the child task no longer carries task-template provenance.

## Root Cause

The document-update orchestration preset successfully discovered documents, but downstream creation tried to expand `taskTemplate.slug = document-update`. Only `document-update-orchestrate` is seeded in the task-template catalog, so child task creation failed with `Template not found` and no additional tasks were produced.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
- `./tools/test_unit.sh`
