### PR TITLE
Route claude_code through canonical skill projection

### DIFF
--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -472,6 +472,8 @@ Responsibilities:
 * resolve runtime profile and provider profile
 * prepare local workspace/runtime context
 * materialize any active skill snapshot into the managed runtime environment
+* prepend the canonical activation summary (`docs/Steps/SkillSystem.md` §14.5)
+  to the runtime instruction payload before launch
 * launch the runtime asynchronously
 * interpret runtime/supervisor state as canonical `AgentRunStatus`
 * fetch final outputs, logs, and diagnostics as `AgentRunResult`
@@ -479,7 +481,10 @@ Responsibilities:
 
 The managed adapter delegates to lower-level runtime execution components such as:
 
-* `ManagedRuntimeLauncher`
+* `ManagedRuntimeLauncher` — runs the active skill snapshot through
+  `AgentSkillMaterializer` and `ensure_shared_skill_links` per
+  `docs/Steps/SkillSystem.md` §14, then projects at `.agents/skills` and
+  prepends the activation summary to the runtime instruction
 * `ManagedRuntimeProfile`
 * `ManagedAgentProviderProfile`
 * `ManagedRunSupervisor`

--- a/moonmind/workflows/skills/__init__.py
+++ b/moonmind/workflows/skills/__init__.py
@@ -80,6 +80,14 @@ from .skill_registry import (
     parse_skill_registry,
     validate_skill_registry,
 )
+from .run_projection import (
+    SkillProjectionError,
+    build_skill_activation_summary,
+    load_resolved_skillset,
+    materialize_run_skill_snapshot,
+    prepend_skill_activation_summary,
+    verify_skill_projection,
+)
 from .workspace_links import (
     SkillWorkspaceError,
     SkillWorkspaceLinks,
@@ -151,4 +159,10 @@ __all__ = [
     "SkillWorkspaceError",
     "ensure_shared_skill_links",
     "validate_shared_skill_links",
+    "SkillProjectionError",
+    "build_skill_activation_summary",
+    "load_resolved_skillset",
+    "materialize_run_skill_snapshot",
+    "prepend_skill_activation_summary",
+    "verify_skill_projection",
 ]

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -16,6 +16,7 @@ the activity class.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Mapping
 from pathlib import Path
@@ -30,8 +31,10 @@ from moonmind.schemas.agent_skill_models import (
 from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
+from moonmind.workflows.temporal.artifacts import TemporalArtifactError
 
 AUTO_SKILL_SENTINEL = "auto"
+ACTIVE_SKILL_SNAPSHOT_HEADER = "Active MoonMind skill snapshot:"
 
 
 class SkillProjectionError(RuntimeError):
@@ -62,7 +65,13 @@ async def load_resolved_skillset(
         )
         data = json.loads(payload.decode("utf-8"))
         return ResolvedSkillSet.model_validate(data)
-    except (OSError, TypeError, ValueError, ValidationError) as exc:
+    except (
+        OSError,
+        TemporalArtifactError,
+        TypeError,
+        ValueError,
+        ValidationError,
+    ) as exc:
         raise SkillProjectionError(
             f"skill projection failed before runtime launch: failed to read "
             f"resolvedSkillsetRef {skillset_ref}: {exc}"
@@ -109,6 +118,7 @@ async def materialize_run_skill_snapshot(
         ) from exc
 
     metadata = dict(materialization.metadata or {})
+    metadata.setdefault("snapshotId", resolved_skillset.snapshot_id)
     if not str(metadata.get("visiblePath") or "").strip():
         raise SkillProjectionError(
             "skill projection failed before runtime launch: "
@@ -117,7 +127,7 @@ async def materialize_run_skill_snapshot(
     return metadata
 
 
-def verify_skill_projection(
+async def verify_skill_projection(
     *,
     materialization_metadata: Mapping[str, Any],
     resolved_skillset: ResolvedSkillSet,
@@ -153,7 +163,10 @@ def verify_skill_projection(
             f"active skill manifest is missing at {manifest_path}"
         )
     try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest_text = await asyncio.to_thread(
+            manifest_path.read_text, encoding="utf-8"
+        )
+        manifest = json.loads(manifest_text)
         if not isinstance(manifest, Mapping):
             raise ValueError(f"manifest at {manifest_path} is not a mapping")
     except (OSError, TypeError, ValueError) as exc:
@@ -220,10 +233,12 @@ def build_skill_activation_summary(
         return ""
 
     visible_path = str(materialization_metadata.get("visiblePath") or "").strip()
-    skill_doc = f"{visible_path}/{selected_skill}/SKILL.md" if visible_path else ""
+    skill_doc = (
+        str(Path(visible_path) / selected_skill / "SKILL.md") if visible_path else ""
+    )
     alias_available = bool(materialization_metadata.get("canonicalAliasAvailable"))
     block = (
-        "Active MoonMind skill snapshot:\n"
+        f"{ACTIVE_SKILL_SNAPSHOT_HEADER}\n"
         f"- Selected skill: {selected_skill}\n"
         f"- Full active MoonMind skill content is available at: {visible_path}\n"
         f"- Read `{skill_doc}` first and follow that active snapshot.\n"
@@ -252,7 +267,7 @@ def prepend_skill_activation_summary(
 ) -> str:
     """Prepend the activation summary to ``instructions`` if applicable."""
 
-    if "Active MoonMind skill snapshot:" in instructions:
+    if ACTIVE_SKILL_SNAPSHOT_HEADER in instructions:
         return instructions
     block = build_skill_activation_summary(
         parameters=parameters,
@@ -266,6 +281,7 @@ def prepend_skill_activation_summary(
 
 __all__ = [
     "AUTO_SKILL_SENTINEL",
+    "ACTIVE_SKILL_SNAPSHOT_HEADER",
     "SkillProjectionError",
     "build_skill_activation_summary",
     "load_resolved_skillset",

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -1,0 +1,275 @@
+"""Per-run skill snapshot projection for managed runtimes.
+
+Shared helpers used at the activity/launcher boundary to materialize an
+immutable :class:`ResolvedSkillSet` snapshot into a run-scoped active backing
+store, project it at ``.agents/skills``, verify the projection, and prepend the
+canonical activation summary to the runtime instruction payload.
+
+These helpers implement the contract in ``docs/Steps/SkillSystem.md`` §14 for
+managed runtimes that launch through :class:`ManagedAgentAdapter` /
+:class:`ManagedRuntimeLauncher` (notably ``claude_code``). The codex
+managed-session path uses an equivalent flow inside
+:class:`TemporalAgentRuntimeActivities`; the helpers here are the same logic
+exposed at module scope so the launcher can consume them without depending on
+the activity class.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from moonmind.schemas.agent_skill_models import (
+    ResolvedSkillSet,
+    RuntimeMaterializationMode,
+)
+from moonmind.services.skill_materialization import AgentSkillMaterializer
+from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
+from moonmind.workflows.agent_skills.selection import selected_agent_skill
+
+AUTO_SKILL_SENTINEL = "auto"
+
+
+class SkillProjectionError(RuntimeError):
+    """Raised when run-scoped skill projection cannot be completed safely.
+
+    The launcher converts these into typed activity failures so the workflow
+    sees a ``skill_projection_failed`` classification rather than a generic
+    ``user_error`` after the runtime exits with a missing result artifact.
+    """
+
+
+async def load_resolved_skillset(
+    artifact_service: Any,
+    skillset_ref: str,
+) -> ResolvedSkillSet:
+    """Read and validate a :class:`ResolvedSkillSet` from artifact storage."""
+
+    if artifact_service is None:
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            "artifact service is required to read request.resolvedSkillsetRef"
+        )
+    try:
+        _artifact, payload = await artifact_service.read(
+            artifact_id=skillset_ref,
+            principal="agent_runtime",
+            allow_restricted_raw=True,
+        )
+        data = json.loads(payload.decode("utf-8"))
+        return ResolvedSkillSet.model_validate(data)
+    except (OSError, TypeError, ValueError, ValidationError) as exc:
+        raise SkillProjectionError(
+            f"skill projection failed before runtime launch: failed to read "
+            f"resolvedSkillsetRef {skillset_ref}: {exc}"
+        ) from exc
+
+
+async def materialize_run_skill_snapshot(
+    *,
+    workspace_path: str | Path,
+    run_root: str | Path,
+    runtime_id: str,
+    resolved_skillset: ResolvedSkillSet,
+    artifact_service: Any,
+    mode: RuntimeMaterializationMode = RuntimeMaterializationMode.HYBRID,
+) -> dict[str, Any]:
+    """Materialize a resolved snapshot for one run and return its metadata.
+
+    The active backing store lives at
+    ``<run_root>/runtime/skills_active/<snapshot_id>``. The canonical
+    runtime-visible alias is created at ``<workspace_path>/.agents/skills``
+    when projection is safe (see ``§14.4`` and ``§14.7`` collision policy).
+    """
+
+    workspace = Path(workspace_path).expanduser().resolve()
+    root = Path(run_root).expanduser().resolve()
+    backing_root = root / "runtime" / "skills_active" / resolved_skillset.snapshot_id
+    source_preservation_root = root / "runtime" / "skill_sources" / "repo_agents_skills"
+
+    materializer = AgentSkillMaterializer(
+        workspace_root=str(workspace),
+        artifact_service=artifact_service,
+        backing_root=str(backing_root),
+        source_preservation_root=str(source_preservation_root),
+    )
+    try:
+        materialization = await materializer.materialize(
+            resolved_skillset=resolved_skillset,
+            runtime_id=runtime_id or "managed-runtime",
+            mode=mode,
+        )
+    except (RuntimeError, OSError, ValueError, ValidationError) as exc:
+        raise SkillProjectionError(
+            f"skill projection failed before runtime launch: {exc}"
+        ) from exc
+
+    metadata = dict(materialization.metadata or {})
+    if not str(metadata.get("visiblePath") or "").strip():
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            "active skills visiblePath metadata is missing"
+        )
+    return metadata
+
+
+def verify_skill_projection(
+    *,
+    materialization_metadata: Mapping[str, Any],
+    resolved_skillset: ResolvedSkillSet,
+    selected_skill: str | None = None,
+) -> None:
+    """Fail before runtime launch if the runtime-visible projection is wrong.
+
+    Checks the contract in ``docs/Steps/SkillSystem.md`` §14.7.2 hard
+    invariants: the active visible path resolves, ``_manifest.json`` is
+    present and matches the supplied snapshot id, the manifest lists the
+    expected skill names, and (when a ``selected_skill`` is named) its
+    ``SKILL.md`` is materialized. Raises :class:`SkillProjectionError` so the
+    activity boundary can surface a ``skill_projection_failed`` classification.
+    """
+
+    visible_path_raw = str(materialization_metadata.get("visiblePath") or "").strip()
+    if not visible_path_raw:
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            "active skills visiblePath metadata is missing"
+        )
+    visible_skills_dir = Path(visible_path_raw).expanduser()
+    if not visible_skills_dir.exists() or not visible_skills_dir.is_dir():
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            f"active skills visiblePath is missing at {visible_skills_dir}"
+        )
+
+    manifest_path = visible_skills_dir / "_manifest.json"
+    if not manifest_path.exists() or not manifest_path.is_file():
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            f"active skill manifest is missing at {manifest_path}"
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(manifest, Mapping):
+            raise ValueError(f"manifest at {manifest_path} is not a mapping")
+    except (OSError, TypeError, ValueError) as exc:
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            f"active skill manifest is unreadable at {manifest_path}: {exc}"
+        ) from exc
+
+    snapshot_id = str(manifest.get("snapshot_id") or "").strip()
+    if snapshot_id != resolved_skillset.snapshot_id:
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            "active skill manifest snapshot_id does not match resolvedSkillsetRef "
+            f"({snapshot_id!r} != {resolved_skillset.snapshot_id!r})"
+        )
+
+    manifest_skills = {
+        str(entry.get("name") or "").strip()
+        for entry in manifest.get("skills", [])
+        if isinstance(entry, Mapping)
+    }
+    expected_skills = {entry.skill_name for entry in resolved_skillset.skills}
+    missing = expected_skills - manifest_skills
+    if missing:
+        raise SkillProjectionError(
+            "skill projection failed before runtime launch: "
+            "active skill manifest is missing expected skills: "
+            f"{sorted(missing)}"
+        )
+
+    if selected_skill and selected_skill != AUTO_SKILL_SENTINEL:
+        if selected_skill not in manifest_skills:
+            raise SkillProjectionError(
+                "skill projection failed before runtime launch: "
+                f"active skill manifest does not include selected skill '{selected_skill}'"
+            )
+        selected_skill_doc = visible_skills_dir / selected_skill / "SKILL.md"
+        if not selected_skill_doc.exists() or not selected_skill_doc.is_file():
+            raise SkillProjectionError(
+                "skill projection failed before runtime launch: "
+                f"selected skill '{selected_skill}' is missing {selected_skill_doc}"
+            )
+
+
+def build_skill_activation_summary(
+    *,
+    parameters: Mapping[str, Any] | None,
+    materialization_metadata: Mapping[str, Any] | None,
+    skills_on_demand_enabled: bool,
+) -> str:
+    """Render the canonical inline activation summary for a runtime turn.
+
+    Returns an empty string when no selected skill is in scope. The summary
+    follows ``docs/Steps/SkillSystem.md`` §14.5: active skill names, the
+    materialized ``visiblePath``, first-read hint at ``SKILL.md``, and the
+    repo-authored ``.agents/skills`` non-mutation rule when the canonical
+    alias is unavailable.
+    """
+
+    if not materialization_metadata:
+        return ""
+    selected_skill = selected_agent_skill(parameters)
+    if not selected_skill or selected_skill == AUTO_SKILL_SENTINEL:
+        return ""
+
+    visible_path = str(materialization_metadata.get("visiblePath") or "").strip()
+    skill_doc = f"{visible_path}/{selected_skill}/SKILL.md" if visible_path else ""
+    alias_available = bool(materialization_metadata.get("canonicalAliasAvailable"))
+    block = (
+        "Active MoonMind skill snapshot:\n"
+        f"- Selected skill: {selected_skill}\n"
+        f"- Full active MoonMind skill content is available at: {visible_path}\n"
+        f"- Read `{skill_doc}` first and follow that active snapshot.\n"
+        "- Do not discover skills from repo-local or local-only source folders during execution.\n"
+    )
+    disabled_instruction = skills_on_demand_disabled_instruction(
+        enabled=skills_on_demand_enabled
+    )
+    if disabled_instruction:
+        block = block + f"{disabled_instruction}\n"
+    if not alias_available:
+        block = block + (
+            "- The repository also contains `.agents/skills`; that directory "
+            "is repo-authored source and must not be modified or treated as "
+            "the active selected skill snapshot.\n"
+        )
+    return block + "\n"
+
+
+def prepend_skill_activation_summary(
+    instructions: str,
+    *,
+    parameters: Mapping[str, Any] | None,
+    materialization_metadata: Mapping[str, Any] | None,
+    skills_on_demand_enabled: bool,
+) -> str:
+    """Prepend the activation summary to ``instructions`` if applicable."""
+
+    if "Active MoonMind skill snapshot:" in instructions:
+        return instructions
+    block = build_skill_activation_summary(
+        parameters=parameters,
+        materialization_metadata=materialization_metadata,
+        skills_on_demand_enabled=skills_on_demand_enabled,
+    )
+    if not block:
+        return instructions
+    return block + instructions
+
+
+__all__ = [
+    "AUTO_SKILL_SENTINEL",
+    "SkillProjectionError",
+    "build_skill_activation_summary",
+    "load_resolved_skillset",
+    "materialize_run_skill_snapshot",
+    "prepend_skill_activation_summary",
+    "verify_skill_projection",
+]

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -23,7 +23,6 @@ from moonmind.schemas.agent_runtime_models import (
 )
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.skills.run_projection import (
-    SkillProjectionError,
     load_resolved_skillset,
     materialize_run_skill_snapshot,
     prepend_skill_activation_summary,
@@ -724,13 +723,6 @@ class ManagedRuntimeLauncher:
         skillset_ref = str(request.resolved_skillset_ref or "").strip()
         if not skillset_ref or resolved_workspace_path is None:
             return None
-        if self._artifact_service is None:
-            logger.warning(
-                "Skipping skill projection for run with resolvedSkillsetRef=%s: "
-                "launcher has no artifact_service",
-                skillset_ref,
-            )
-            return None
 
         from moonmind.config.settings import settings as _mm_settings
 
@@ -750,7 +742,7 @@ class ManagedRuntimeLauncher:
         from moonmind.workflows.agent_skills.selection import selected_agent_skill
 
         selected_skill_name = selected_agent_skill(params) or None
-        verify_skill_projection(
+        await verify_skill_projection(
             materialization_metadata=materialization_metadata,
             resolved_skillset=resolved_skillset,
             selected_skill=selected_skill_name,
@@ -910,7 +902,7 @@ class ManagedRuntimeLauncher:
                 metadata={
                     "source": "launcher",
                     "snapshotId": skill_materialization_metadata.get(
-                        "activeSkills"
+                        "snapshotId"
                     ),
                     "visiblePath": str(
                         skill_materialization_metadata.get("visiblePath") or ""

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import shutil
 import tempfile
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,13 @@ from moonmind.schemas.agent_runtime_models import (
     TERMINAL_AGENT_RUN_STATES,
 )
 from moonmind.utils.logging import SecretRedactor
+from moonmind.workflows.skills.run_projection import (
+    SkillProjectionError,
+    load_resolved_skillset,
+    materialize_run_skill_snapshot,
+    prepend_skill_activation_summary,
+    verify_skill_projection,
+)
 
 from .github_auth_broker import GitHubAuthBrokerManager
 from .git_auth import build_github_token_git_environment
@@ -44,11 +52,13 @@ class ManagedRuntimeLauncher:
         self,
         store: ManagedRunStore,
         log_streamer: RuntimeLogStreamer | None = None,
+        artifact_service: Any | None = None,
     ) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
+        self._artifact_service = artifact_service
 
     @staticmethod
     def _build_managed_runtime_base_env() -> dict[str, str]:
@@ -684,6 +694,82 @@ class ManagedRuntimeLauncher:
 
         return cmd
 
+    async def _project_run_skill_snapshot(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        profile: ManagedRuntimeProfile,
+        resolved_workspace_path: str | None,
+    ) -> dict[str, Any] | None:
+        """Materialize, verify, and announce the resolved skill snapshot.
+
+        Implements ``docs/Steps/SkillSystem.md`` §14 for managed runtimes
+        launched through this launcher (notably ``claude_code``). When
+        ``request.resolved_skillset_ref`` is set:
+
+        1. load the immutable :class:`ResolvedSkillSet` from artifact storage,
+        2. materialize it into ``<run_root>/runtime/skills_active/<snapshot_id>``,
+        3. project at ``.agents/skills`` per the §14.4 strategy order (handled
+           by :class:`AgentSkillMaterializer`),
+        4. verify the runtime-visible projection matches the snapshot (§14.7.2),
+        5. prepend the canonical activation summary (§14.5) to
+           ``request.instruction_ref`` so the runtime sees it inline.
+
+        Returns the materialization metadata for downstream callers, or
+        ``None`` when no snapshot was requested. Raises
+        :class:`SkillProjectionError` so the activity converts that into a
+        typed ``skill_projection_failed`` classification.
+        """
+
+        skillset_ref = str(request.resolved_skillset_ref or "").strip()
+        if not skillset_ref or resolved_workspace_path is None:
+            return None
+        if self._artifact_service is None:
+            logger.warning(
+                "Skipping skill projection for run with resolvedSkillsetRef=%s: "
+                "launcher has no artifact_service",
+                skillset_ref,
+            )
+            return None
+
+        from moonmind.config.settings import settings as _mm_settings
+
+        run_root = Path(resolved_workspace_path).resolve().parent
+        resolved_skillset = await load_resolved_skillset(
+            self._artifact_service, skillset_ref
+        )
+        materialization_metadata = await materialize_run_skill_snapshot(
+            workspace_path=resolved_workspace_path,
+            run_root=str(run_root),
+            runtime_id=str(profile.runtime_id or "managed-runtime"),
+            resolved_skillset=resolved_skillset,
+            artifact_service=self._artifact_service,
+        )
+
+        params = request.parameters if isinstance(request.parameters, Mapping) else {}
+        from moonmind.workflows.agent_skills.selection import selected_agent_skill
+
+        selected_skill_name = selected_agent_skill(params) or None
+        verify_skill_projection(
+            materialization_metadata=materialization_metadata,
+            resolved_skillset=resolved_skillset,
+            selected_skill=selected_skill_name,
+        )
+
+        existing_instructions = str(request.instruction_ref or "")
+        prepared = prepend_skill_activation_summary(
+            existing_instructions,
+            parameters=params,
+            materialization_metadata=materialization_metadata,
+            skills_on_demand_enabled=bool(
+                _mm_settings.workflow.skills_on_demand_enabled
+            ),
+        )
+        if prepared != existing_instructions:
+            request.instruction_ref = prepared
+
+        return materialization_metadata
+
     async def launch(
         self,
         *,
@@ -782,48 +868,17 @@ class ManagedRuntimeLauncher:
             env_overrides = strategy.shape_environment(env_overrides, profile)
 
         # Invoke strategy-level workspace preparation hook (e.g. RAG context
-        # injection for Codex).
+        # injection for Codex/Claude). RAG injection mutates
+        # request.instruction_ref before the skill activation summary is
+        # prepended, so retrieved context lands inside the task block and the
+        # activation summary stays at the top.
         if resolved_workspace_path is not None and strategy is not None:
-            claude_md_path = None
-            claude_md_pre_existing = False
-            if strategy.runtime_id == "claude_code" and request.instruction_ref:
-                claude_md_path = Path(resolved_workspace_path) / "CLAUDE.md"
-                claude_md_pre_existing = (
-                    claude_md_path.exists() or claude_md_path.is_symlink()
-                )
-
             try:
                 await strategy.prepare_workspace(
                     Path(resolved_workspace_path),
                     request,
                     environment=env_overrides,
                 )
-
-                if claude_md_path is not None:
-                    if claude_md_pre_existing:
-                        self._emit_system_annotation(
-                            run_id=run_id,
-                            workspace_path=resolved_workspace_path,
-                            annotation_type="workspace_preparation_skipped",
-                            text="Launcher: skipped writing CLAUDE.md because the file already exists or is a symlink.",
-                            metadata={
-                                "source": "launcher",
-                                "target": "CLAUDE.md",
-                                "reason": "preexisting_or_symlink",
-                            },
-                        )
-                    elif claude_md_path.exists():
-                        self._emit_system_annotation(
-                            run_id=run_id,
-                            workspace_path=resolved_workspace_path,
-                            annotation_type="workspace_preparation_applied",
-                            text="Launcher: workspace instructions written to CLAUDE.md.",
-                            metadata={
-                                "source": "launcher",
-                                "target": "CLAUDE.md",
-                                "reason": "workspace_preparation",
-                            },
-                        )
             except Exception:
                 logger.warning(
                     "strategy.prepare_workspace failed for run_id=%s runtime=%s",
@@ -832,30 +887,53 @@ class ManagedRuntimeLauncher:
                     exc_info=True,
                 )
 
+        # Project the resolved skill snapshot into the canonical .agents/skills
+        # path and prepend the activation summary to request.instruction_ref
+        # before the runtime command is built (docs/Steps/SkillSystem.md §14).
+        # SkillProjectionError is propagated so the activity boundary can
+        # surface a typed skill_projection_failed classification rather than
+        # letting the run exit 0 with no result artifact.
+        skill_materialization_metadata = await self._project_run_skill_snapshot(
+            request=request,
+            profile=profile,
+            resolved_workspace_path=resolved_workspace_path,
+        )
+        if skill_materialization_metadata is not None:
+            self._emit_system_annotation(
+                run_id=run_id,
+                workspace_path=resolved_workspace_path,
+                annotation_type="skill_projection_applied",
+                text=(
+                    "Launcher: projected resolved skill snapshot at "
+                    f"{skill_materialization_metadata.get('visiblePath')}."
+                ),
+                metadata={
+                    "source": "launcher",
+                    "snapshotId": skill_materialization_metadata.get(
+                        "activeSkills"
+                    ),
+                    "visiblePath": str(
+                        skill_materialization_metadata.get("visiblePath") or ""
+                    ),
+                    "canonicalAliasAvailable": str(
+                        bool(
+                            skill_materialization_metadata.get(
+                                "canonicalAliasAvailable"
+                            )
+                        )
+                    ).lower(),
+                    "reason": "skill_projection",
+                },
+            )
+
         cmd = self.build_command(profile, request, strategy=strategy)
         self._reset_live_log_spool(resolved_workspace_path)
 
-        # Expose active skills projection if present
-        run_root: Path | None = None
-        if resolved_workspace_path is not None:
-            run_root = Path(resolved_workspace_path).resolve().parent
-            active_skills_dir = run_root / ".agents" / "skills_active"
-            if active_skills_dir.exists():
-                workspace_agents_dir = Path(resolved_workspace_path) / ".agents"
-                target_skills_dir = workspace_agents_dir / "skills"
-                try:
-                    workspace_agents_dir.mkdir(parents=True, exist_ok=True)
-                    if target_skills_dir.lexists():
-                        if target_skills_dir.is_symlink() or target_skills_dir.is_file():
-                            target_skills_dir.unlink()
-                        else:
-                            shutil.rmtree(target_skills_dir)
-                    target_skills_dir.symlink_to(
-                        active_skills_dir,
-                        target_is_directory=True,
-                    )
-                except OSError as ex:
-                    logger.warning("Failed to link active skills directory: %s", ex)
+        run_root: Path | None = (
+            Path(resolved_workspace_path).resolve().parent
+            if resolved_workspace_path is not None
+            else None
+        )
 
         for key in profile.passthrough_env_keys:
             value = os.environ.get(key)

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -65,15 +65,15 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         request: Any,
         environment: Mapping[str, str] | None = None,
     ) -> None:
-        """Inject shared retrieval context and write CLAUDE.md in the workspace.
+        """Inject shared retrieval context for Claude Code.
 
-        If CLAUDE.md already exists as a symlink (e.g. CLAUDE.md -> AGENTS.md),
-        skip writing — following the symlink would overwrite AGENTS.md and destroy
-        the project's coding standards. Instructions are still passed via ``-p`` so
-        CLAUDE.md can continue to provide project context through the symlink.
-
-        Only write CLAUDE.md when it does not yet exist, ensuring repos that have
-        no CLAUDE.md still receive task instructions as project context.
+        The turn instruction (and any prepended skill activation summary built
+        by :meth:`ManagedRuntimeLauncher._project_run_skill_snapshot`) is
+        passed to the Claude CLI via ``-p`` in :meth:`build_command`. Writing
+        the same content into ``CLAUDE.md`` would conflate it with project
+        context — Claude Code reads ``CLAUDE.md`` as untrusted retrieved
+        instructions when it ships under a SAFETY NOTICE wrapper, so the task
+        is delivered as a first-class user prompt instead.
         """
         if not getattr(request, "instruction_ref", None):
             return
@@ -87,8 +87,3 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
             request=request,
             workspace_path=workspace_path,
         )
-
-        instruction_path = workspace_path / "CLAUDE.md"
-        if instruction_path.exists() or instruction_path.is_symlink():
-            return
-        instruction_path.write_text(request.instruction_ref, encoding="utf-8")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1622,7 +1622,10 @@ def _positive_int_env(name: str) -> int | None:
         raise RuntimeError(f"{name} must be a positive integer")
     return value
 
-def _build_agent_runtime_deps() -> tuple[
+def _build_agent_runtime_deps(
+    *,
+    artifact_service: Any | None = None,
+) -> tuple[
     ManagedRunStore,
     ManagedRunSupervisor,
     ManagedRuntimeLauncher,
@@ -1667,7 +1670,11 @@ def _build_agent_runtime_deps() -> tuple[
     artifact_storage = LocalRuntimeArtifactStorage(artifact_root)
     log_streamer = RuntimeLogStreamer(artifact_storage)
     supervisor = ManagedRunSupervisor(store, log_streamer)
-    launcher = ManagedRuntimeLauncher(store, log_streamer=log_streamer)
+    launcher = ManagedRuntimeLauncher(
+        store,
+        log_streamer=log_streamer,
+        artifact_service=artifact_service,
+    )
     session_store = ManagedSessionStore(
         os.path.join(
             os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
@@ -1808,7 +1815,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 session_controller,
                 workload_registry,
                 workload_launcher,
-            ) = _build_agent_runtime_deps()
+            ) = _build_agent_runtime_deps(artifact_service=artifact_service)
             reconciled = await run_supervisor.reconcile()
             if reconciled:
                 logger.info(

--- a/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
+++ b/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
@@ -40,7 +40,7 @@ def _make_request(**overrides) -> AgentExecutionRequest:
 
 
 @patch("moonmind.rag.context_injection.ContextInjectionService")
-async def test_claude_launcher_uses_shared_context_injection_before_writing_claude_md(
+async def test_claude_launcher_uses_shared_context_injection_for_prompt(
     mock_service_class,
     tmp_path,
     monkeypatch,
@@ -104,8 +104,11 @@ async def test_claude_launcher_uses_shared_context_injection_before_writing_clau
     )
     await process.wait()
 
+    # The injected retrieval context lands in request.instruction_ref and is
+    # passed to the Claude CLI via -p; CLAUDE.md remains project context and
+    # is never written by the launcher.
     assert any(arg == "Injected retrieval context" for arg in captured_args)
-    assert (workspace / "CLAUDE.md").read_text(encoding="utf-8") == "Injected retrieval context"
+    assert not (workspace / "CLAUDE.md").exists()
 
 
 @pytest.mark.parametrize("transport", ["direct", "gateway"])
@@ -191,7 +194,6 @@ async def test_claude_launcher_publishes_context_artifact_reference_for_runtime_
     moonmind_meta = request.parameters["metadata"]["moonmind"]
     artifact_ref = moonmind_meta["retrievedContextArtifactPath"]
     artifact_path = workspace / artifact_ref
-    claude_md = (workspace / "CLAUDE.md").read_text(encoding="utf-8")
 
     assert artifact_ref.startswith("artifacts/context/rag-context-")
     assert moonmind_meta["retrievedContextTransport"] == transport
@@ -203,13 +205,16 @@ async def test_claude_launcher_publishes_context_artifact_reference_for_runtime_
     assert f'"transport": "{transport}"' in artifact_text
     assert '"initiation_mode": "automatic"' in artifact_text
     assert '"truncated": false' in artifact_text
-    assert "BEGIN_RETRIEVED_CONTEXT" in claude_md
-    assert "Retrieved context artifact: artifacts/context/" in claude_md
-    assert "Original instruction" in claude_md
+    # The retrieval prompt (BEGIN_RETRIEVED_CONTEXT, artifact ref, and original
+    # instruction) flows through request.instruction_ref to the Claude CLI via
+    # -p — not CLAUDE.md, which is project context and must not be overwritten.
+    assert not (workspace / "CLAUDE.md").exists()
+    prompt_args = [arg for arg in captured_args if isinstance(arg, str)]
+    assert any("BEGIN_RETRIEVED_CONTEXT" in arg for arg in prompt_args)
     assert any(
-        isinstance(arg, str) and "Retrieved context artifact: artifacts/context/" in arg
-        for arg in captured_args
+        "Retrieved context artifact: artifacts/context/" in arg for arg in prompt_args
     )
+    assert any("Original instruction" in arg for arg in prompt_args)
 
 
 async def test_claude_launcher_marks_local_fallback_as_degraded_retrieval(
@@ -295,14 +300,13 @@ async def test_claude_launcher_marks_local_fallback_as_degraded_retrieval(
     await process.wait()
 
     moonmind_meta = request.parameters["metadata"]["moonmind"]
-    claude_md = (workspace / "CLAUDE.md").read_text(encoding="utf-8")
 
     assert moonmind_meta["retrievedContextTransport"] == "local_fallback"
     assert moonmind_meta["retrievalMode"] == "degraded_local_fallback"
     assert moonmind_meta["retrievalDegradedReason"] == "collection_unavailable"
     assert moonmind_meta["retrievalInitiationMode"] == "automatic"
     assert moonmind_meta["retrievalContextTruncated"] is False
-    assert "Retrieved context mode: degraded local fallback" in claude_md
+    assert not (workspace / "CLAUDE.md").exists()
     assert any(
         isinstance(arg, str) and "Retrieved context mode: degraded local fallback" in arg
         for arg in captured_args

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1111,9 +1111,16 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
     assert launch_kwargs.get("cwd") == expected_workspace
 
 @pytest.mark.asyncio
-async def test_launch_emits_workspace_preparation_applied_annotation(
+async def test_launch_does_not_write_claude_md_for_claude_code(
     tmp_path, monkeypatch
 ):
+    """The launcher must not create CLAUDE.md from request.instruction_ref.
+
+    CLAUDE.md is project context (canonical: ``docs/Steps/SkillSystem.md``);
+    the turn instruction is delivered as a first-class user prompt via the
+    Claude CLI's ``-p`` flag.
+    """
+
     monkeypatch.setattr(os, "geteuid", lambda: 1000)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
@@ -1166,16 +1173,18 @@ async def test_launch_emits_workspace_preparation_applied_annotation(
     await process.wait()
     assert process is not None
     assert record.workspace_path == str(workspace_path)
-    assert (workspace_path / "CLAUDE.md").read_text(encoding="utf-8") == "Run task"
-    assert any(
-        emission.get("annotation_type") == "workspace_preparation_applied"
+    assert not (workspace_path / "CLAUDE.md").exists()
+    assert all(
+        emission.get("annotation_type") != "workspace_preparation_applied"
         for emission in log_streamer.emissions
     )
 
 @pytest.mark.asyncio
-async def test_launch_emits_workspace_preparation_skipped_annotation_for_existing_file(
+async def test_launch_preserves_existing_claude_md_for_claude_code(
     tmp_path, monkeypatch
 ):
+    """An existing CLAUDE.md (project context) is left untouched."""
+
     monkeypatch.setattr(os, "geteuid", lambda: 1000)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
@@ -1230,10 +1239,6 @@ async def test_launch_emits_workspace_preparation_skipped_annotation_for_existin
     assert process is not None
     assert record.workspace_path == str(workspace_path)
     assert (workspace_path / "CLAUDE.md").read_text(encoding="utf-8") == "already there"
-    assert any(
-        emission.get("annotation_type") == "workspace_preparation_skipped"
-        for emission in log_streamer.emissions
-    )
 
 @pytest.mark.asyncio
 async def test_launch_reuses_existing_new_branch_when_present(tmp_path, monkeypatch):
@@ -2485,5 +2490,290 @@ async def test_launch_builds_claude_command_after_workspace_preparation(
     )
     await process.wait()
 
+    # RAG injection mutates request.instruction_ref; the launcher passes that
+    # to the Claude CLI via -p. CLAUDE.md is project context and must not be
+    # overwritten with the turn instruction.
     assert any(arg == "Injected retrieval context" for arg in captured_args)
-    assert (workspace / "CLAUDE.md").read_text(encoding="utf-8") == "Injected retrieval context"
+    assert not (workspace / "CLAUDE.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Skill projection (docs/Steps/SkillSystem.md §14): the launcher routes
+# resolved snapshots through AgentSkillMaterializer + ensure_shared_skill_links
+# and prepends the §14.5 activation summary to request.instruction_ref so the
+# Claude CLI sees it inline via ``-p``.
+# ---------------------------------------------------------------------------
+
+
+def _build_skill_snapshot_artifact(
+    snapshot_id: str, skill_names: list[str]
+) -> tuple[bytes, dict[str, bytes]]:
+    """Build a JSON-encoded ResolvedSkillSet payload and skill-content payloads."""
+
+    import hashlib
+    from datetime import UTC, datetime as _dt
+
+    from moonmind.schemas.agent_skill_models import (
+        AgentSkillProvenance,
+        AgentSkillSourceKind,
+        ResolvedSkillEntry,
+        ResolvedSkillSet,
+    )
+
+    skill_payloads: dict[str, bytes] = {}
+    entries: list[ResolvedSkillEntry] = []
+    for name in skill_names:
+        body = f"---\nname: {name}\n---\n".encode("utf-8")
+        ref = f"art-{name}"
+        skill_payloads[ref] = body
+        entries.append(
+            ResolvedSkillEntry(
+                skill_name=name,
+                version="1.0.0",
+                content_ref=ref,
+                content_digest="sha256:" + hashlib.sha256(body).hexdigest(),
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.DEPLOYMENT
+                ),
+            )
+        )
+    skillset = ResolvedSkillSet(
+        snapshot_id=snapshot_id,
+        resolved_at=_dt.now(tz=UTC),
+        skills=entries,
+    )
+    return skillset.model_dump_json().encode("utf-8"), skill_payloads
+
+
+class _SkillArtifactService:
+    """Async artifact-service stub backed by an in-memory dict."""
+
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ) -> tuple[object, bytes]:
+        del principal, allow_restricted_raw
+        return object(), self._payloads[artifact_id]
+
+
+@pytest.mark.asyncio
+async def test_launch_projects_resolved_skill_snapshot_for_claude_code(
+    tmp_path, monkeypatch
+):
+    """``claude_code`` runs through the canonical materializer when a snapshot is set."""
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    snapshot_payload, skill_payloads = _build_skill_snapshot_artifact(
+        "snap-claude-1", ["pr-resolver"]
+    )
+    artifact_service = _SkillArtifactService(
+        {"resolved-set-1": snapshot_payload, **skill_payloads}
+    )
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store, artifact_service=artifact_service)
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(
+        instruction_ref="Resolve the PR.",
+        resolved_skillset_ref="resolved-set-1",
+        parameters={"selectedSkill": "pr-resolver"},
+    )
+    workspace = tmp_path / "workspaces" / "run-snap" / "repo"
+    workspace.mkdir(parents=True)
+
+    captured_args: tuple[object, ...] = ()
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4242
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    _record, process, _cleanup, _deferred = await launcher.launch(
+        run_id="run-snap",
+        request=request,
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    # The §14.5 activation summary is prepended to instruction_ref and
+    # delivered to the Claude CLI via -p.
+    prompt_args = [arg for arg in captured_args if isinstance(arg, str)]
+    assert any("Active MoonMind skill snapshot:" in arg for arg in prompt_args)
+    assert any("Selected skill: pr-resolver" in arg for arg in prompt_args)
+    assert any("Resolve the PR." in arg for arg in prompt_args)
+
+    # Materialization landed in the run-scoped backing store, not in the repo.
+    backing_dir = (
+        workspace.parent / "runtime" / "skills_active" / "snap-claude-1"
+    )
+    assert (backing_dir / "_manifest.json").is_file()
+    assert (backing_dir / "pr-resolver" / "SKILL.md").is_file()
+
+    # The canonical alias .agents/skills resolves to the backing store.
+    agents_skills = workspace / ".agents" / "skills"
+    assert agents_skills.is_symlink()
+    assert agents_skills.resolve() == backing_dir.resolve()
+
+
+@pytest.mark.asyncio
+async def test_launch_skips_skill_projection_when_no_snapshot_ref(tmp_path, monkeypatch):
+    """Without ``resolved_skillset_ref`` the launcher leaves instruction_ref alone."""
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(
+        store, artifact_service=_SkillArtifactService({})
+    )
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(instruction_ref="Plain task")
+    workspace = tmp_path / "workspaces" / "run-no-snap" / "repo"
+    workspace.mkdir(parents=True)
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4243
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    _record, process, _cleanup, _deferred = await launcher.launch(
+        run_id="run-no-snap",
+        request=request,
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    prompt_args = [arg for arg in captured_args if isinstance(arg, str)]
+    assert "Plain task" in prompt_args
+    assert not any(
+        "Active MoonMind skill snapshot:" in arg for arg in prompt_args
+    )
+    assert not (workspace / ".agents" / "skills").exists()
+
+
+@pytest.mark.asyncio
+async def test_launch_fails_fast_when_skill_projection_errors(tmp_path, monkeypatch):
+    """Materialization failure surfaces as ``SkillProjectionError`` pre-launch."""
+
+    from moonmind.workflows.skills.run_projection import SkillProjectionError
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    snapshot_payload, _skill_payloads = _build_skill_snapshot_artifact(
+        "snap-broken", ["pr-resolver"]
+    )
+
+    class _BrokenArtifactService:
+        async def read(
+            self,
+            *,
+            artifact_id: str,
+            principal: str,
+            allow_restricted_raw: bool,
+        ) -> tuple[object, bytes]:
+            del principal, allow_restricted_raw
+            if artifact_id == "broken-set":
+                return object(), snapshot_payload
+            raise OSError("artifact backing store unreachable")
+
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(
+        store, artifact_service=_BrokenArtifactService()
+    )
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(
+        instruction_ref="Resolve.",
+        resolved_skillset_ref="broken-set",
+        parameters={"selectedSkill": "pr-resolver"},
+    )
+    workspace = tmp_path / "workspaces" / "run-broken" / "repo"
+    workspace.mkdir(parents=True)
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    with pytest.raises(SkillProjectionError):
+        await launcher.launch(
+            run_id="run-broken",
+            request=request,
+            profile=profile,
+            workspace_path=str(workspace),
+        )

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2721,6 +2721,48 @@ async def test_launch_skips_skill_projection_when_no_snapshot_ref(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_launch_fails_fast_when_snapshot_ref_has_no_artifact_service(
+    tmp_path, monkeypatch
+):
+    """A requested skill snapshot requires an artifact service."""
+
+    from moonmind.workflows.skills.run_projection import SkillProjectionError
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(
+        instruction_ref="Resolve.",
+        resolved_skillset_ref="missing-service",
+        parameters={"selectedSkill": "pr-resolver"},
+    )
+    workspace = tmp_path / "workspaces" / "run-no-service" / "repo"
+    workspace.mkdir(parents=True)
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    with pytest.raises(SkillProjectionError, match="artifact service is required"):
+        await launcher.launch(
+            run_id="run-no-service",
+            request=request,
+            profile=profile,
+            workspace_path=str(workspace),
+        )
+
+
+@pytest.mark.asyncio
 async def test_launch_fails_fast_when_skill_projection_errors(tmp_path, monkeypatch):
     """Materialization failure surfaces as ``SkillProjectionError`` pre-launch."""
 

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -237,25 +237,27 @@ async def test_verify_accepts_valid_projection(tmp_path: Path) -> None:
         artifact_service=_StaticArtifactService(payloads),
     )
 
-    verify_skill_projection(
+    await verify_skill_projection(
         materialization_metadata=metadata,
         resolved_skillset=skillset,
         selected_skill="pr-resolver",
     )
 
 
-def test_verify_raises_when_visible_path_missing(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_verify_raises_when_visible_path_missing(tmp_path: Path) -> None:
     skillset = _resolved_skillset(
         "snap-x", [("pr-resolver", "art-pr")], {"art-pr": _skill_payload("pr-resolver")}
     )
     with pytest.raises(SkillProjectionError, match="visiblePath is missing"):
-        verify_skill_projection(
+        await verify_skill_projection(
             materialization_metadata={"visiblePath": str(tmp_path / "nope")},
             resolved_skillset=skillset,
         )
 
 
-def test_verify_raises_on_snapshot_id_mismatch(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_verify_raises_on_snapshot_id_mismatch(tmp_path: Path) -> None:
     visible = tmp_path / ".agents" / "skills"
     (visible / "pr-resolver").mkdir(parents=True)
     (visible / "pr-resolver" / "SKILL.md").write_text("x", encoding="utf-8")
@@ -271,13 +273,14 @@ def test_verify_raises_on_snapshot_id_mismatch(tmp_path: Path) -> None:
         {"art-pr": _skill_payload("pr-resolver")},
     )
     with pytest.raises(SkillProjectionError, match="snapshot_id does not match"):
-        verify_skill_projection(
+        await verify_skill_projection(
             materialization_metadata={"visiblePath": str(visible)},
             resolved_skillset=skillset,
         )
 
 
-def test_verify_raises_when_selected_skill_doc_missing(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_verify_raises_when_selected_skill_doc_missing(tmp_path: Path) -> None:
     visible = tmp_path / ".agents" / "skills"
     visible.mkdir(parents=True)
     (visible / "_manifest.json").write_text(
@@ -292,14 +295,17 @@ def test_verify_raises_when_selected_skill_doc_missing(tmp_path: Path) -> None:
         {"art-pr": _skill_payload("pr-resolver")},
     )
     with pytest.raises(SkillProjectionError, match="missing"):
-        verify_skill_projection(
+        await verify_skill_projection(
             materialization_metadata={"visiblePath": str(visible)},
             resolved_skillset=skillset,
             selected_skill="pr-resolver",
         )
 
 
-def test_verify_raises_when_manifest_missing_expected_skill(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_verify_raises_when_manifest_missing_expected_skill(
+    tmp_path: Path,
+) -> None:
     visible = tmp_path / ".agents" / "skills"
     (visible / "alpha").mkdir(parents=True)
     (visible / "alpha" / "SKILL.md").write_text("x", encoding="utf-8")
@@ -313,7 +319,7 @@ def test_verify_raises_when_manifest_missing_expected_skill(tmp_path: Path) -> N
         {"art-a": _skill_payload("alpha"), "art-b": _skill_payload("beta")},
     )
     with pytest.raises(SkillProjectionError, match="missing expected skills"):
-        verify_skill_projection(
+        await verify_skill_projection(
             materialization_metadata={"visiblePath": str(visible)},
             resolved_skillset=skillset,
         )
@@ -426,3 +432,22 @@ async def test_load_resolved_skillset_raises_on_invalid_payload() -> None:
         await load_resolved_skillset(
             _StaticArtifactService({"bad": b"not-json"}), "bad"
         )
+
+
+@pytest.mark.asyncio
+async def test_load_resolved_skillset_wraps_artifact_errors() -> None:
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactStateError
+
+    class _BrokenArtifactService:
+        async def read(
+            self,
+            *,
+            artifact_id: str,
+            principal: str,
+            allow_restricted_raw: bool,
+        ) -> tuple[object, bytes]:
+            del artifact_id, principal, allow_restricted_raw
+            raise TemporalArtifactStateError("artifact is not readable")
+
+    with pytest.raises(SkillProjectionError, match="failed to read"):
+        await load_resolved_skillset(_BrokenArtifactService(), "bad-ref")

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -1,0 +1,428 @@
+"""Tests for moonmind.workflows.skills.run_projection.
+
+Covers the activity/launcher-boundary helpers that materialize a resolved
+skill snapshot for a managed run, verify the projection, and prepend the
+canonical activation summary defined in ``docs/Steps/SkillSystem.md`` §14.5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
+)
+from moonmind.workflows.skills.run_projection import (
+    SkillProjectionError,
+    build_skill_activation_summary,
+    load_resolved_skillset,
+    materialize_run_skill_snapshot,
+    prepend_skill_activation_summary,
+    verify_skill_projection,
+)
+
+
+def _digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _skill_entry(name: str, content_ref: str, payload: bytes) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name=name,
+        version="1.0.0",
+        content_ref=content_ref,
+        content_digest=_digest(payload),
+        provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT),
+    )
+
+
+class _StaticArtifactService:
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ) -> tuple[object, bytes]:
+        del principal, allow_restricted_raw
+        return object(), self._payloads[artifact_id]
+
+
+def _skill_payload(name: str) -> bytes:
+    return f"---\nname: {name}\ndescription: test\n---\n".encode("utf-8")
+
+
+def _resolved_skillset(
+    snapshot_id: str,
+    skills: list[tuple[str, str]],
+    payloads: dict[str, bytes],
+) -> ResolvedSkillSet:
+    entries: list[ResolvedSkillEntry] = []
+    for name, ref in skills:
+        entries.append(_skill_entry(name, ref, payloads[ref]))
+    return ResolvedSkillSet(
+        snapshot_id=snapshot_id,
+        resolved_at=datetime.now(tz=UTC),
+        skills=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# materialize_run_skill_snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_materialize_writes_canonical_layout(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace" / "repo"
+    workspace.mkdir(parents=True)
+    run_root = tmp_path / "workspace"
+
+    payloads = {"art-pr-resolver": _skill_payload("pr-resolver")}
+    skillset = _resolved_skillset(
+        "snap-aaa", [("pr-resolver", "art-pr-resolver")], payloads
+    )
+
+    metadata = await materialize_run_skill_snapshot(
+        workspace_path=workspace,
+        run_root=run_root,
+        runtime_id="claude_code",
+        resolved_skillset=skillset,
+        artifact_service=_StaticArtifactService(payloads),
+    )
+
+    backing_dir = run_root / "runtime" / "skills_active" / "snap-aaa"
+    assert backing_dir.is_dir()
+    assert (backing_dir / "_manifest.json").is_file()
+    assert (backing_dir / "pr-resolver" / "SKILL.md").is_file()
+    visible = Path(metadata["visiblePath"])
+    assert (visible / "pr-resolver" / "SKILL.md").is_file()
+    assert metadata["canonicalAliasAvailable"] is True
+    manifest = json.loads((backing_dir / "_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["snapshot_id"] == "snap-aaa"
+    assert {entry["name"] for entry in manifest["skills"]} == {"pr-resolver"}
+
+
+@pytest.mark.asyncio
+async def test_materialize_only_includes_selected_skills(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws" / "repo"
+    workspace.mkdir(parents=True)
+    payloads = {
+        "art-alpha": _skill_payload("alpha"),
+        "art-beta": _skill_payload("beta"),
+    }
+    skillset = _resolved_skillset(
+        "snap-multi",
+        [("alpha", "art-alpha"), ("beta", "art-beta")],
+        payloads,
+    )
+
+    metadata = await materialize_run_skill_snapshot(
+        workspace_path=workspace,
+        run_root=workspace.parent,
+        runtime_id="claude_code",
+        resolved_skillset=skillset,
+        artifact_service=_StaticArtifactService(payloads),
+    )
+
+    visible = Path(metadata["visiblePath"])
+    assert sorted(p.name for p in visible.iterdir()) == [
+        "_manifest.json",
+        "alpha",
+        "beta",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_materialize_does_not_rewrite_repo_authored_skills_dir(
+    tmp_path: Path,
+) -> None:
+    """Spec 314 (MM-608) noninterference: repo-authored ``.agents/skills`` is preserved."""
+
+    workspace = tmp_path / "ws" / "repo"
+    workspace.mkdir(parents=True)
+    repo_authored = workspace / ".agents" / "skills" / "repo-only"
+    repo_authored.mkdir(parents=True)
+    (repo_authored / "SKILL.md").write_text(
+        "---\nname: repo-only\n---\n", encoding="utf-8"
+    )
+
+    payloads = {"art-pr": _skill_payload("pr-resolver")}
+    skillset = _resolved_skillset(
+        "snap-noninterference", [("pr-resolver", "art-pr")], payloads
+    )
+
+    metadata = await materialize_run_skill_snapshot(
+        workspace_path=workspace,
+        run_root=workspace.parent,
+        runtime_id="claude_code",
+        resolved_skillset=skillset,
+        artifact_service=_StaticArtifactService(payloads),
+    )
+
+    repo_skills_dir = workspace / ".agents" / "skills"
+    assert repo_skills_dir.is_dir()
+    assert not repo_skills_dir.is_symlink()
+    assert (repo_skills_dir / "repo-only" / "SKILL.md").is_file()
+    visible = Path(metadata["visiblePath"])
+    assert visible != repo_skills_dir
+    assert (visible / "pr-resolver" / "SKILL.md").is_file()
+    assert metadata["canonicalAliasAvailable"] is False
+    assert metadata["repoSkillSourcePreserved"] is True
+
+
+@pytest.mark.asyncio
+async def test_materialize_raises_skill_projection_error_on_failure(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws" / "repo"
+    workspace.mkdir(parents=True)
+    payloads = {"art-pr": _skill_payload("pr-resolver")}
+    skillset = _resolved_skillset(
+        "snap-bad", [("pr-resolver", "art-pr")], payloads
+    )
+
+    # An artifact service that always raises simulates an unreachable backing
+    # store. The helper must convert it into a typed SkillProjectionError so
+    # the activity can surface a skill_projection_failed classification.
+    class _BrokenArtifactService:
+        async def read(
+            self,
+            *,
+            artifact_id: str,
+            principal: str,
+            allow_restricted_raw: bool,
+        ) -> tuple[object, bytes]:
+            del artifact_id, principal, allow_restricted_raw
+            raise OSError("artifact backing store unavailable")
+
+    with pytest.raises(SkillProjectionError):
+        await materialize_run_skill_snapshot(
+            workspace_path=workspace,
+            run_root=workspace.parent,
+            runtime_id="claude_code",
+            resolved_skillset=skillset,
+            artifact_service=_BrokenArtifactService(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# verify_skill_projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_valid_projection(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws" / "repo"
+    workspace.mkdir(parents=True)
+    payloads = {"art-pr": _skill_payload("pr-resolver")}
+    skillset = _resolved_skillset("snap-ok", [("pr-resolver", "art-pr")], payloads)
+
+    metadata = await materialize_run_skill_snapshot(
+        workspace_path=workspace,
+        run_root=workspace.parent,
+        runtime_id="claude_code",
+        resolved_skillset=skillset,
+        artifact_service=_StaticArtifactService(payloads),
+    )
+
+    verify_skill_projection(
+        materialization_metadata=metadata,
+        resolved_skillset=skillset,
+        selected_skill="pr-resolver",
+    )
+
+
+def test_verify_raises_when_visible_path_missing(tmp_path: Path) -> None:
+    skillset = _resolved_skillset(
+        "snap-x", [("pr-resolver", "art-pr")], {"art-pr": _skill_payload("pr-resolver")}
+    )
+    with pytest.raises(SkillProjectionError, match="visiblePath is missing"):
+        verify_skill_projection(
+            materialization_metadata={"visiblePath": str(tmp_path / "nope")},
+            resolved_skillset=skillset,
+        )
+
+
+def test_verify_raises_on_snapshot_id_mismatch(tmp_path: Path) -> None:
+    visible = tmp_path / ".agents" / "skills"
+    (visible / "pr-resolver").mkdir(parents=True)
+    (visible / "pr-resolver" / "SKILL.md").write_text("x", encoding="utf-8")
+    (visible / "_manifest.json").write_text(
+        json.dumps(
+            {"snapshot_id": "wrong-id", "skills": [{"name": "pr-resolver"}]}
+        ),
+        encoding="utf-8",
+    )
+    skillset = _resolved_skillset(
+        "expected-id",
+        [("pr-resolver", "art-pr")],
+        {"art-pr": _skill_payload("pr-resolver")},
+    )
+    with pytest.raises(SkillProjectionError, match="snapshot_id does not match"):
+        verify_skill_projection(
+            materialization_metadata={"visiblePath": str(visible)},
+            resolved_skillset=skillset,
+        )
+
+
+def test_verify_raises_when_selected_skill_doc_missing(tmp_path: Path) -> None:
+    visible = tmp_path / ".agents" / "skills"
+    visible.mkdir(parents=True)
+    (visible / "_manifest.json").write_text(
+        json.dumps(
+            {"snapshot_id": "snap-x", "skills": [{"name": "pr-resolver"}]}
+        ),
+        encoding="utf-8",
+    )
+    skillset = _resolved_skillset(
+        "snap-x",
+        [("pr-resolver", "art-pr")],
+        {"art-pr": _skill_payload("pr-resolver")},
+    )
+    with pytest.raises(SkillProjectionError, match="missing"):
+        verify_skill_projection(
+            materialization_metadata={"visiblePath": str(visible)},
+            resolved_skillset=skillset,
+            selected_skill="pr-resolver",
+        )
+
+
+def test_verify_raises_when_manifest_missing_expected_skill(tmp_path: Path) -> None:
+    visible = tmp_path / ".agents" / "skills"
+    (visible / "alpha").mkdir(parents=True)
+    (visible / "alpha" / "SKILL.md").write_text("x", encoding="utf-8")
+    (visible / "_manifest.json").write_text(
+        json.dumps({"snapshot_id": "snap-y", "skills": [{"name": "alpha"}]}),
+        encoding="utf-8",
+    )
+    skillset = _resolved_skillset(
+        "snap-y",
+        [("alpha", "art-a"), ("beta", "art-b")],
+        {"art-a": _skill_payload("alpha"), "art-b": _skill_payload("beta")},
+    )
+    with pytest.raises(SkillProjectionError, match="missing expected skills"):
+        verify_skill_projection(
+            materialization_metadata={"visiblePath": str(visible)},
+            resolved_skillset=skillset,
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_skill_activation_summary / prepend_skill_activation_summary
+# ---------------------------------------------------------------------------
+
+
+def test_activation_summary_empty_without_selected_skill() -> None:
+    summary = build_skill_activation_summary(
+        parameters={"selectedSkill": ""},
+        materialization_metadata={"visiblePath": "/work/skills"},
+        skills_on_demand_enabled=False,
+    )
+    assert summary == ""
+
+
+def test_activation_summary_empty_without_metadata() -> None:
+    summary = build_skill_activation_summary(
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata=None,
+        skills_on_demand_enabled=False,
+    )
+    assert summary == ""
+
+
+def test_activation_summary_includes_required_fields() -> None:
+    summary = build_skill_activation_summary(
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata={
+            "visiblePath": "/work/agent_jobs/workspaces/r1/runtime/skills_active/snap-1",
+            "canonicalAliasAvailable": True,
+        },
+        skills_on_demand_enabled=False,
+    )
+    assert "Active MoonMind skill snapshot:" in summary
+    assert "Selected skill: pr-resolver" in summary
+    assert "Full active MoonMind skill content is available at:" in summary
+    assert "/work/agent_jobs/workspaces/r1/runtime/skills_active/snap-1/pr-resolver/SKILL.md" in summary
+
+
+def test_activation_summary_warns_when_alias_unavailable() -> None:
+    summary = build_skill_activation_summary(
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata={
+            "visiblePath": "/work/skills/snap",
+            "canonicalAliasAvailable": False,
+        },
+        skills_on_demand_enabled=False,
+    )
+    assert "repo-authored source and must not be modified" in summary
+
+
+def test_prepend_is_idempotent() -> None:
+    metadata = {"visiblePath": "/work/skills/snap", "canonicalAliasAvailable": True}
+    once = prepend_skill_activation_summary(
+        "do the thing",
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata=metadata,
+        skills_on_demand_enabled=False,
+    )
+    twice = prepend_skill_activation_summary(
+        once,
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata=metadata,
+        skills_on_demand_enabled=False,
+    )
+    assert once == twice
+
+
+def test_prepend_returns_unchanged_when_no_skill() -> None:
+    out = prepend_skill_activation_summary(
+        "task",
+        parameters={"selectedSkill": "auto"},
+        materialization_metadata={"visiblePath": "/x"},
+        skills_on_demand_enabled=False,
+    )
+    assert out == "task"
+
+
+# ---------------------------------------------------------------------------
+# load_resolved_skillset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_resolved_skillset_round_trips() -> None:
+    skillset = _resolved_skillset(
+        "snap-load",
+        [("pr-resolver", "art-pr")],
+        {"art-pr": _skill_payload("pr-resolver")},
+    )
+    payloads = {"snap-ref": skillset.model_dump_json().encode("utf-8")}
+    loaded = await load_resolved_skillset(_StaticArtifactService(payloads), "snap-ref")
+    assert loaded.snapshot_id == "snap-load"
+    assert [entry.skill_name for entry in loaded.skills] == ["pr-resolver"]
+
+
+@pytest.mark.asyncio
+async def test_load_resolved_skillset_raises_on_missing_service() -> None:
+    with pytest.raises(SkillProjectionError, match="artifact service is required"):
+        await load_resolved_skillset(None, "any-ref")
+
+
+@pytest.mark.asyncio
+async def test_load_resolved_skillset_raises_on_invalid_payload() -> None:
+    with pytest.raises(SkillProjectionError, match="failed to read"):
+        await load_resolved_skillset(
+            _StaticArtifactService({"bad": b"not-json"}), "bad"
+        )

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -173,19 +173,23 @@ class TestClaudeCodeBuildCommand:
 # ---------------------------------------------------------------------------
 
 class TestClaudeCodePrepareWorkspace:
+    """The strategy must not write CLAUDE.md from request.instruction_ref.
+
+    CLAUDE.md is project context (per ``docs/Steps/SkillSystem.md``); the turn
+    instruction is delivered to the Claude CLI via ``-p`` so it cannot be
+    treated as untrusted retrieved content. RAG context injection still mutates
+    ``request.instruction_ref`` so the prompt carries retrieved context inline.
+    """
+
     @pytest.mark.asyncio
-    async def test_creates_claude_md_when_absent(self, tmp_path) -> None:
-        """When CLAUDE.md does not exist, it is created with the instruction ref."""
+    async def test_does_not_create_claude_md_when_absent(self, tmp_path) -> None:
         s = ClaudeCodeStrategy()
         request = _make_request(instruction_ref="Do the task")
         await s.prepare_workspace(tmp_path, request)
-        claude_md = tmp_path / "CLAUDE.md"
-        assert claude_md.is_file() and not claude_md.is_symlink()
-        assert claude_md.read_text() == "Do the task"
+        assert not (tmp_path / "CLAUDE.md").exists()
 
     @pytest.mark.asyncio
     async def test_does_not_overwrite_existing_regular_file(self, tmp_path) -> None:
-        """When CLAUDE.md already exists as a regular file, it is left unchanged."""
         s = ClaudeCodeStrategy()
         claude_md = tmp_path / "CLAUDE.md"
         claude_md.write_text("existing project context")
@@ -195,8 +199,7 @@ class TestClaudeCodePrepareWorkspace:
 
     @pytest.mark.asyncio
     async def test_does_not_follow_symlink_to_agents_md(self, tmp_path) -> None:
-        """When CLAUDE.md is a symlink (e.g. -> AGENTS.md), it must not be followed.
-        AGENTS.md must remain intact after prepare_workspace runs."""
+        """An existing ``CLAUDE.md -> AGENTS.md`` symlink must remain intact."""
         s = ClaudeCodeStrategy()
         agents_md = tmp_path / "AGENTS.md"
         agents_md.write_text("# Agent coding standards\n\nDo not break me.")
@@ -204,14 +207,11 @@ class TestClaudeCodePrepareWorkspace:
         claude_md.symlink_to("AGENTS.md")
         request = _make_request(instruction_ref="Task instructions")
         await s.prepare_workspace(tmp_path, request)
-        # AGENTS.md must be untouched
         assert agents_md.read_text() == "# Agent coding standards\n\nDo not break me."
-        # CLAUDE.md symlink must still point to AGENTS.md
         assert claude_md.is_symlink()
 
     @pytest.mark.asyncio
     async def test_no_op_without_instruction_ref(self, tmp_path) -> None:
-        """When instruction_ref is absent, nothing is written."""
         s = ClaudeCodeStrategy()
         request = _make_request()
         await s.prepare_workspace(tmp_path, request)
@@ -219,11 +219,12 @@ class TestClaudeCodePrepareWorkspace:
 
     @pytest.mark.asyncio
     @patch("moonmind.rag.context_injection.ContextInjectionService")
-    async def test_injects_context_before_creating_claude_md(
+    async def test_injects_context_into_instruction_ref(
         self,
         mock_service_class,
         tmp_path,
     ) -> None:
+        """RAG context still mutates ``request.instruction_ref`` for the prompt."""
         mock_service = mock_service_class.return_value
 
         async def _inject_context(*, request, workspace_path):
@@ -240,7 +241,7 @@ class TestClaudeCodePrepareWorkspace:
             workspace_path=tmp_path,
         )
         assert request.instruction_ref == "Injected retrieval context"
-        assert (tmp_path / "CLAUDE.md").read_text() == "Injected retrieval context"
+        assert not (tmp_path / "CLAUDE.md").exists()
 
 # ---------------------------------------------------------------------------
 # CodexCliStrategy

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2548,7 +2548,7 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
         resolve_external_adapter,
         external_adapter_execution_style,
     ]
-    mock_build_deps.assert_called_once_with()
+    mock_build_deps.assert_called_once_with(artifact_service=ANY)
     run_supervisor.reconcile.assert_awaited_once()
     session_controller.reconcile.assert_awaited_once()
     deployment_handler_calls = [


### PR DESCRIPTION
## Summary

- Brings `claude_code` (and any other `ManagedAgentAdapter` runtime) under the canonical skill-projection contract in `docs/Steps/SkillSystem.md` §14: materialize the resolved snapshot into a run-scoped backing store, project at `.agents/skills`, verify it, and prepend the §14.5 activation summary to `request.instruction_ref` so the Claude CLI sees it inline via `-p`.
- Replaces the bespoke `<run_root>/.agents/skills_active` fallback in `ManagedRuntimeLauncher` (which silently no-op'd when no snapshot was materialized) with a typed `SkillProjectionError` that fails fast pre-launch — closing the failure mode where `claude_code` runs would exit 0 with no result artifact and be surfaced downstream as a vague `user_error`.
- Stops `ClaudeCodeStrategy.prepare_workspace` from writing the turn instruction into `CLAUDE.md`. The instruction (with any RAG-injected context and the activation summary on top) flows to the Claude CLI via `-p`. `CLAUDE.md` remains project context only.

## What changed

**New** — `moonmind/workflows/skills/run_projection.py`:
- `materialize_run_skill_snapshot(...)`, `verify_skill_projection(...)`, `build_skill_activation_summary(...)`, `prepend_skill_activation_summary(...)`, `load_resolved_skillset(...)`, `SkillProjectionError`.

**Modified**:
- `ManagedRuntimeLauncher` now accepts `artifact_service`, runs `_project_run_skill_snapshot(...)` after `strategy.prepare_workspace`, emits a `skill_projection_applied` annotation, and drops the legacy fallback.
- `ClaudeCodeStrategy.prepare_workspace` no longer writes `instruction_ref` into `CLAUDE.md`.
- `_build_agent_runtime_deps(...)` threads `artifact_service` through to the launcher.
- `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` §6.3 names `ManagedRuntimeLauncher` as the component that runs the canonical materializer.

**Tests** (21 new, 4 rewritten):
- `tests/unit/workflows/skills/test_run_projection.py` — 18 unit tests covering canonical layout, multi-skill snapshot, repo-authored `.agents/skills` non-interference (spec 314), error paths, manifest mismatch, missing skill doc, idempotent prepend, snapshot loader.
- `tests/unit/services/temporal/runtime/test_launcher.py` — 3 new adapter-boundary tests: `claude_code` with a snapshot ref produces the activation summary in subprocess args + projects `.agents/skills` to the run-scoped backing store; missing snapshot ref leaves things untouched; broken artifact service raises `SkillProjectionError`.
- Rewrote 3 legacy `CLAUDE.md`-write tests in `test_launcher.py` and `test_remaining_strategies.py` to assert the new contract.
- Updated 3 integration tests in `test_managed_session_retrieval_context.py` for the same contract change.
- Updated 1 worker_runtime test for the new `artifact_service` kwarg.

The codex managed-session path (`CodexSessionAdapter` → `agent_runtime.launch_session` → `prepare_turn_instructions`) is unchanged; this PR only touches the `ManagedAgentAdapter` → `agent_runtime.launch` → `RunLauncher.launch` path.

## Test plan

- [x] `./tools/test_unit.sh --python-only` (full unit suite passes — 4642+ tests)
- [x] `tests/unit/workflows/skills/test_run_projection.py` (new, 18 passing)
- [x] `tests/unit/services/temporal/runtime/test_launcher.py` (51 passing including 3 new skill-projection tests)
- [x] `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py`
- [x] `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- [ ] Hermetic integration suite: `./tools/test_integration.sh` — not run locally (requires Docker socket per CLAUDE.md "No Docker Assumption in Agent Jobs"); CI will exercise.
- [ ] End-to-end verification: re-submit a `claude_code` task with a `pr-resolver` skill snapshot and confirm `.agents/skills/_manifest.json` is materialized and the activation summary lands in the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)