### PR TITLE
Wait through prerequisite reruns instead of cascade-failing

### DIFF
--- a/docs/Tasks/TaskDependencies.md
+++ b/docs/Tasks/TaskDependencies.md
@@ -20,7 +20,7 @@ Task dependencies allow one `MoonMind.Run` execution to wait on one or more othe
 - For Temporal-backed task surfaces, `taskId == workflowId`.
 - `runId` is diagnostic only and is never a valid dependency target.
 - A prerequisite is satisfied only when it reaches terminal MoonMind state `completed`.
-- Any other terminal prerequisite outcome causes the dependent run to fail with a dependency-specific failure.
+- Any other prerequisite terminal outcome — `failed`, `canceled`, `terminated`, `timed_out`, or runtime unresolvable — keeps the dependent run blocked in `waiting_on_dependencies` until the same prerequisite `workflowId` later reaches `completed`. The dependent never auto-fails on a prerequisite failure. The only way out without prerequisite success is for an operator to cancel the dependent run or bypass the dependency.
 - Dependencies are **non-transitive** at the contract level: if C depends on B and B depends on A, C waits on B only.
 
 ### 2.1 Contract boundaries
@@ -119,9 +119,9 @@ When dependencies are present, the workflow must:
 3. initialize local dependency-tracking state for all declared prerequisite IDs,
 4. perform an immediate status check for each prerequisite using durable execution state,
 5. mark prerequisites already in `completed` as satisfied immediately,
-6. fail immediately if any prerequisite is already in a non-success terminal state,
+6. record any prerequisite already in a non-success terminal state as a retryable outcome (`waiting_for_successful_rerun`) and continue waiting,
 7. wait for explicit dependency-resolution notifications for the remaining unresolved prerequisites,
-8. proceed only after all declared prerequisites resolve successfully.
+8. proceed only after all declared prerequisites reach `completed` (possibly after one or more prerequisite reruns), or after an operator cancels the dependent run or bypasses the dependency.
 
 ### 4.3 Dependency resolution signals
 
@@ -165,33 +165,48 @@ Cancellation and pause behavior during dependency waiting is:
 * dependency waiting never cancels, terminates, or mutates prerequisite runs,
 * pausing the dependent run does not stop prerequisite runs,
 * pausing the dependent run does not suppress receipt of dependency-resolution signals,
-* while paused, the workflow may continue recording dependency outcomes, but it must not leave the dependency gate or enter active planning/execution until unpaused,
-* if a prerequisite reaches a non-success terminal outcome while the dependent run is paused, the dependent run fails immediately with a dependency-specific failure,
+* while paused, the workflow continues recording dependency outcomes, but it must not leave the dependency gate or enter active planning/execution until unpaused,
+* a prerequisite non-success terminal outcome while the dependent is paused does not fail the dependent; the outcome is recorded as `waiting_for_successful_rerun` and the dependent stays blocked until prerequisites complete, the dependent is canceled, or the dependency is bypassed,
 * scheduled runs do not begin dependency resolution until they leave `scheduled` and enter `initializing`.
 
-### 4.6 Failure behavior
+### 4.6 Wait-through-rerun behavior
 
-A dependent run clears the dependency gate only when **every** declared prerequisite completes successfully.
+A dependent run clears the dependency gate only when **every** declared prerequisite reaches MoonMind terminal state `completed`.
 
-Any other prerequisite terminal outcome is a dependency failure, including:
+A prerequisite non-success terminal outcome is **not** a dependency failure under the current contract. The following terminal outcomes keep the dependent in `waiting_on_dependencies`:
 
 * `failed`,
 * `canceled`,
 * `terminated`,
 * `timed_out`,
-* runtime inability to resolve a dependency after successful create-time validation.
+* runtime inability to resolve a dependency.
 
-The first observed non-success terminal prerequisite outcome ends the dependency gate and fails the dependent run.
+For each non-success terminal outcome the workflow records a structured per-dependency entry that surfaces:
 
-Dependency failures must be structured rather than generic. At minimum, the failure record must identify:
+* `workflowId`,
+* latest prerequisite terminal MoonMind state,
+* latest prerequisite Temporal close status when available,
+* failure category,
+* `failureCount` — number of distinct non-success terminal observations for this prerequisite,
+* `lastFailedAt` — most recent non-success terminal timestamp,
+* human-readable message,
+* `resolution = "waiting_for_successful_rerun"`.
 
-* `failedDependencyId`,
-* prerequisite terminal MoonMind state,
-* prerequisite Temporal close status when available,
-* dependency failure category,
-* human-readable message.
+If the same prerequisite later reaches `completed` (under the same `workflowId` after rerun), the per-dependency entry transitions to `resolution = "satisfied_after_rerun"` and the prerequisite is removed from the unresolved set. Once every prerequisite is satisfied, the gate clears.
 
-A dependency failure must never degrade into an infinite wait.
+The only ways to leave the dependency gate without prerequisite success are:
+
+* an operator cancels the dependent run,
+* an operator bypasses the dependency wait (`BypassDependencies` signal),
+* an operator manually skips the wait (`SkipDependencyWait` update).
+
+A dependent run that has been waiting for a rerun and never receives one will stay in `waiting_on_dependencies` until standard workflow timeouts apply or an operator intervenes.
+
+Stale or duplicate dependency-resolution signals must be ignored:
+
+* a `completed` signal that arrives after the prerequisite is already recorded as `satisfied` or `satisfied_after_rerun` is a no-op,
+* a non-success terminal observation with the same `resolvedAt` as the prerequisite's already-recorded `lastFailedAt` does not increment `failureCount`,
+* a non-success terminal signal that arrives after the prerequisite is already recorded as `satisfied`, `satisfied_after_rerun`, or `bypassed` is a no-op and never reverts the prior resolution.
 
 ### 4.7 Continue-As-New and replay safety
 
@@ -244,11 +259,15 @@ At minimum, the `dependencies` block must include:
 * `failedDependencyId`,
 * `outcomes`.
 
-Recommended `resolution` values are:
+Recommended top-level `resolution` values are:
 
-* `not_applicable`,
-* `satisfied`,
-* `dependency_failed`.
+* `not_applicable` — no dependencies declared,
+* `satisfied` — every prerequisite cleared on its first observed terminal outcome,
+* `satisfied_after_rerun` — at least one prerequisite reached `completed` only after one or more prior non-success terminal outcomes,
+* `bypassed` — operator bypassed the dependency wait,
+* `manual_override` — operator manually skipped the dependency wait.
+
+Per-dependency outcomes carry their own `resolution` field that may also include the non-terminal marker `waiting_for_successful_rerun` while the workflow is still active.
 
 When no dependencies are declared, the stable empty shape is:
 
@@ -265,7 +284,9 @@ When no dependencies are declared, the stable empty shape is:
 }
 ```
 
-When dependencies are declared, the summary should capture per-dependency outcomes when known. Example:
+When dependencies are declared, the summary should capture per-dependency outcomes when known. Each per-dependency outcome carries `workflowId`, `terminalState`, `closeStatus`, `resolvedAt`, `resolution`, `failureCount`, `lastFailedAt`, `failureCategory`, and `message` fields when applicable.
+
+Example: every prerequisite cleared on first observation.
 
 ```json
 {
@@ -279,15 +300,65 @@ When dependencies are declared, the summary should capture per-dependency outcom
       {
         "workflowId": "mm:01ABC...",
         "terminalState": "completed",
-        "resolvedAt": "2026-04-03T17:24:16Z"
+        "closeStatus": "completed",
+        "resolvedAt": "2026-04-03T17:24:16Z",
+        "resolution": "satisfied",
+        "failureCount": 0,
+        "lastFailedAt": null
       },
       {
         "workflowId": "mm:01DEF...",
         "terminalState": "completed",
-        "resolvedAt": "2026-04-03T17:24:18Z"
+        "closeStatus": "completed",
+        "resolvedAt": "2026-04-03T17:24:18Z",
+        "resolution": "satisfied",
+        "failureCount": 0,
+        "lastFailedAt": null
       }
     ]
   }
+}
+```
+
+Example: a prerequisite failed and was rerun to success.
+
+```json
+{
+  "dependencies": {
+    "declaredIds": ["mm:01ABC..."],
+    "waited": true,
+    "waitDurationMs": 945000,
+    "resolution": "satisfied_after_rerun",
+    "failedDependencyId": null,
+    "outcomes": [
+      {
+        "workflowId": "mm:01ABC...",
+        "terminalState": "completed",
+        "closeStatus": "completed",
+        "resolvedAt": "2026-04-03T17:39:18Z",
+        "resolution": "satisfied_after_rerun",
+        "failureCount": 1,
+        "lastFailedAt": "2026-04-03T17:24:16Z",
+        "message": "Prerequisite completed after rerun."
+      }
+    ]
+  }
+}
+```
+
+While the workflow is active and a prerequisite is currently failed, the per-dependency outcome carries the non-terminal marker `waiting_for_successful_rerun`:
+
+```json
+{
+  "workflowId": "mm:01ABC...",
+  "terminalState": "failed",
+  "closeStatus": "failed",
+  "resolvedAt": null,
+  "resolution": "waiting_for_successful_rerun",
+  "failureCount": 1,
+  "lastFailedAt": "2026-04-03T17:24:16Z",
+  "failureCategory": "dependency_failed",
+  "message": "Prerequisite execution 'mm:01ABC...' reached terminal state 'failed'; waiting for successful rerun."
 }
 ```
 
@@ -305,12 +376,13 @@ The create UX should provide:
 * client-side enforcement of the 10-item limit,
 * duplicate prevention,
 * clear validation messaging for invalid targets,
-* clear messaging that the new run will remain blocked until prerequisites complete successfully.
+* clear messaging that the new run stays blocked while a prerequisite is running, failed, canceled, terminated, timed out, or unresolvable, and unblocks once the prerequisite completes successfully — and that the only ways out without prerequisite success are canceling the dependent run or bypassing the dependency wait.
 
 ### 6.2 List and detail surfaces
 
 * `waiting_on_dependencies` maps to dashboard status `waiting`.
 * Task detail shows a **Dependencies** panel with prerequisite links, titles, statuses, and terminal outcomes.
+* When a per-dependency outcome carries `resolution = "waiting_for_successful_rerun"`, the panel must surface a clear "Prerequisite failed; waiting for successful rerun" indicator alongside the failure count and last-failed timestamp.
 * Prerequisite detail shows a **Dependents** panel or equivalent reverse-lookup view.
 * List and quick-view surfaces may show a compact blocked-by summary when useful.
 
@@ -342,9 +414,10 @@ Task dependencies block one workflow on the terminal outcome of another workflow
 ## 8. Edge Cases and Failure Modes
 
 * **Prerequisite already completed:** resolve immediately and continue if all prerequisites are satisfied.
-* **Prerequisite already terminal and non-successful:** fail immediately with a dependency-specific failure.
-* **Duplicate or stale notifications:** ignore idempotently.
-* **Missing runtime target after validation:** fail the dependent run; do not wait forever.
+* **Prerequisite already terminal and non-successful:** record a `waiting_for_successful_rerun` outcome and keep the dependent blocked. The dependent does not auto-fail.
+* **Prerequisite cycles between failed and completed across reruns:** the gate ratchets — once a prerequisite is recorded as `satisfied` or `satisfied_after_rerun`, subsequent stale failure observations are ignored.
+* **Duplicate or stale notifications:** ignore idempotently. Duplicate non-success observations sharing the same `resolvedAt` do not increment `failureCount`.
+* **Missing runtime target after validation:** record `waiting_for_successful_rerun` with `failureCategory = "dependency_unresolved"`. The dependent stays blocked until the prerequisite resolves to a `completed` outcome, the dependent is canceled, or the dependency is bypassed.
 * **Signal delivery uncertainty:** use bounded reconciliation against durable execution state; do not rely on unbounded polling loops.
-* **Workflow timeout while waiting:** standard workflow timeout behavior still applies.
+* **Workflow timeout while waiting:** standard workflow timeout behavior still applies. A run that waits indefinitely can still be timed out by ordinary workflow timeouts or operator cancel.
 * **Long waits or long chains:** preserve dependency context across Continue-As-New; the direct-dependency limit remains 10 per run.

--- a/docs/Tasks/TaskDependenciesOperatorGuide.md
+++ b/docs/Tasks/TaskDependenciesOperatorGuide.md
@@ -12,8 +12,8 @@ A `MoonMind.Run` execution can declare up to **10 prerequisite `workflowId` valu
 2. Enters `waiting_on_dependencies` state.
 3. Performs an immediate durable status reconciliation for each prerequisite.
 4. Waits durably for explicit `DependencyResolved` signals from any unresolved prerequisites.
-5. Proceeds only when **every** prerequisite reaches terminal MoonMind state `completed`.
-6. Fails with structured metadata if any prerequisite reaches a non-success terminal outcome.
+5. Proceeds only when **every** prerequisite reaches terminal MoonMind state `completed` — possibly after one or more prerequisite reruns.
+6. **Never auto-fails on a prerequisite failure.** A prerequisite reaching `failed`, `canceled`, `terminated`, `timed_out`, or runtime-unresolvable keeps the dependent in `waiting_on_dependencies` and records a `waiting_for_successful_rerun` outcome for that prerequisite. The only ways to leave the gate without prerequisite success are operator cancel, operator bypass, or operator manual skip.
 
 Each dependent run is a **top-level, independently visible, cancelable, and rerunnable** execution — not a child workflow.
 
@@ -33,27 +33,35 @@ Each dependent run is a **top-level, independently visible, cancelable, and reru
 
 ---
 
-## 3. Failure Propagation Rules
+## 3. Wait-Through-Rerun Behavior
 
 A prerequisite satisfies the dependency gate **only** when it reaches MoonMind terminal state `completed`.
 
-Any other terminal prerequisite outcome causes **immediate failure** of the dependent run:
+Under the unified wait-through-rerun model, no prerequisite terminal outcome auto-fails the dependent. The dependent stays in `waiting_on_dependencies` and records structured per-dependency diagnostics until either prerequisites complete, an operator cancels the dependent, or an operator bypasses the dependency wait.
 
 | Prerequisite Terminal State | Dependent Run Behavior |
 |---|---|
 | `completed` | Gate satisfied for that prerequisite |
-| `failed` | Dependent run fails immediately |
-| `canceled` | Dependent run fails immediately |
-| `terminated` | Dependent run fails immediately |
-| `timed_out` | Dependent run fails immediately |
-| Unresolvable (not found) | Dependent run fails on reconciliation (often immediately at startup) |
+| `failed` | Dependent stays in `waiting_on_dependencies`; records `waiting_for_successful_rerun` |
+| `canceled` | Dependent stays in `waiting_on_dependencies`; records `waiting_for_successful_rerun` |
+| `terminated` | Dependent stays in `waiting_on_dependencies`; records `waiting_for_successful_rerun` |
+| `timed_out` | Dependent stays in `waiting_on_dependencies`; records `waiting_for_successful_rerun` |
+| Unresolvable (not found) | Dependent stays in `waiting_on_dependencies`; records `waiting_for_successful_rerun` with `failureCategory = "dependency_unresolved"` |
 
-When a prerequisite fails, the dependent run records a structured `DependencyFailureError` with:
-- `failedDependencyId`
-- Prerequisite terminal MoonMind state
-- Prerequisite close status
-- Dependency failure category
-- Human-readable message
+When a prerequisite fails, the dependent records bounded per-dependency metadata:
+
+- prerequisite `workflowId`,
+- latest terminal MoonMind state,
+- latest close status,
+- `failureCategory`,
+- `failureCount` (number of distinct non-success terminal observations),
+- `lastFailedAt` (most recent non-success terminal timestamp),
+- human-readable message,
+- `resolution = "waiting_for_successful_rerun"`.
+
+When the same prerequisite is later rerun and reaches `completed` under the same `workflowId`, the per-dependency entry transitions to `resolution = "satisfied_after_rerun"` and the prerequisite is removed from the unresolved set. Once every prerequisite is satisfied, the gate clears and the dependent proceeds.
+
+The top-level run summary `resolution` will be `satisfied_after_rerun` if any prerequisite required at least one rerun cycle, or `satisfied` if every prerequisite cleared on first observation.
 
 ---
 
@@ -63,18 +71,19 @@ When a prerequisite fails, the dependent run records a structured `DependencyFai
 
 | Action | Effect |
 |---|---|
-| **Cancel** dependent run | Cancels only the dependent run. Prerequisites are untouched. |
+| **Cancel** dependent run | Cancels only the dependent run. Prerequisites are untouched. The only routine way to release a dependent that is waiting on a prerequisite that will never complete. |
 | **Bypass dependency wait** | Manually clears the dependency gate and lets the dependent run continue even if one or more prerequisites are still unresolved. Prerequisites are untouched. |
-| **Pause** dependent run | Pauses progression through the dependency gate. Signals continue to be received and recorded; if a prerequisite failure is recorded while paused, the dependent run fails immediately. |
-| **Resume** dependent run | If all prerequisites resolved successfully while paused, proceeds normally. Any prerequisite failure recorded during pause would already have failed the dependent run before resume. |
-| Cancel/prerequisite run | **Never** affected by dependent run's state. |
+| **Manual skip** (`SkipDependencyWait`) | Operator-only update that clears unresolved prerequisites and lets the dependent advance with `resolution = manual_override`. |
+| **Pause** dependent run | Pauses progression through the dependency gate. Signals continue to be received and recorded; non-success terminal outcomes recorded while paused do **not** fail the run, they accumulate as `waiting_for_successful_rerun` entries. |
+| **Resume** dependent run | If all prerequisites resolved successfully while paused, proceeds normally. Otherwise the dependent re-enters its waiting loop with the recorded outcomes intact. |
+| Cancel/terminate prerequisite run | **Never** affects the dependent run's state automatically. The dependent will continue waiting for that prerequisite to be rerun to success, or for an operator to cancel/bypass on the dependent side. |
 
 ### Key Guarantees
 
 - Pausing the dependent run does **not** suppress receipt of `DependencyResolved` signals.
 - While paused, dependency outcomes continue to be recorded in local state.
-- Pausing does **not** defer dependency-failure propagation; a prerequisite failure recorded while paused fails the dependent run immediately.
-- While paused, the workflow does **not** leave the dependency gate and enter planning or execution unless it is failed by dependency resolution.
+- A prerequisite non-success terminal observation never fails the dependent under the wait-through-rerun contract — neither while running, nor while paused.
+- While paused, the workflow does **not** leave the dependency gate and enter planning or execution.
 - Bypassing the dependency wait is an explicit operator override for cases where the remaining prerequisites are no longer required for reasons MoonMind cannot infer automatically. The run summary records dependency resolution as `bypassed`.
 
 ---
@@ -87,8 +96,10 @@ The following structured log events are emitted during dependency lifecycle:
 |---|---|---|---|
 | `dependency_gate_entered` | INFO | Workflow | `dependency_count`, `dependency_ids` |
 | `dependency_gate_satisfied` | INFO | Workflow | `dependency_count`, `wait_duration_ms` |
+| `dependency_gate_waiting_for_rerun` | INFO | Workflow | `prerequisite_workflow_id`, `terminal_state`, `close_status`, `failure_count` |
+| `dependency_gate_satisfied_after_rerun` | INFO | Workflow | `prerequisite_workflow_id`, `failure_count`, `wait_duration_ms` |
 | `dependency_gate_bypassed` | INFO | Workflow | `dependency_count`, `unresolved_dependency_count`, `wait_duration_ms` |
-| `dependency_gate_failed` | ERROR | Workflow | `failed_dependency_id`, `terminal_state`, `close_status`, `failure_category`, `wait_duration_ms` |
+| `dependency_gate_failed` | ERROR | Workflow | (Legacy fail-fast path; emitted only by in-flight workflows whose history predates `dependency-wait-through-rerun-v1`.) |
 | `dependency_signal_received` | INFO | Workflow | `prerequisite_workflow_id`, `terminal_state`, `close_status` |
 | `dependency_signal_failure` | WARNING | Workflow | `prerequisite_workflow_id`, `terminal_state`, `close_status`, `failure_category` |
 | `dependency_signal_ignored_undeclared` | WARNING | Workflow | `prerequisite_workflow_id` |
@@ -107,12 +118,26 @@ The following structured log events are emitted during dependency lifecycle:
 3. **Check reconciliation**: The workflow reconciles every 30 seconds via `execution.dependency_status_snapshot` activity. If the activity is failing, the workflow won't detect completed prerequisites via reconciliation.
 4. **Worker health**: If the Temporal worker is down, signals queue up and reconcile activities won't execute. Check worker logs and container health.
 
-### A Dependent Run Failed Due to a Prerequisite Failure
+### A Dependent Run Is Waiting Because a Prerequisite Failed
+
+Under the wait-through-rerun contract, a failed prerequisite does **not** fail the dependent. Instead the dependent stays in `waiting_on_dependencies` with a per-dependency outcome marked `waiting_for_successful_rerun`.
+
+1. Open the dependent's task detail panel (or read `reports/run_summary.json` under `dependencies.outcomes`) and find any per-dependency outcome with `resolution = "waiting_for_successful_rerun"`.
+2. The `failureCount` and `lastFailedAt` fields tell you how many failure cycles have happened and when the most recent failure occurred.
+3. The `terminalState`, `closeStatus`, and `failureCategory` fields explain the nature of the most recent failure.
+4. **Remediation paths:**
+   - Rerun the failed prerequisite. Once it reaches `completed` under the same `workflowId`, the dependent unblocks automatically. The dependent's resolution becomes `satisfied_after_rerun`.
+   - If the prerequisite cannot be recovered, **cancel the dependent run** or use **Bypass Dependency Wait** to advance the dependent without that prerequisite.
+   - Do **not** wait for the dependent to fail itself: under wait-through-rerun, it never will.
+
+### A Dependent Run Failed Due to a Legacy Prerequisite Failure
+
+Workflows that started **before** `dependency-wait-through-rerun-v1` was deployed may still fail-fast on a prerequisite failure. For those legacy runs:
 
 1. Check the `DependencyFailureError` detail in the run summary artifact (`reports/run_summary.json`) under the `dependencies` block.
 2. The `failedDependencyId` field identifies which prerequisite caused the failure.
 3. The `terminalState` and `failureCategory` fields explain the nature of the failure.
-4. **Remediation**: Fix or rerun the failed prerequisite, then rerun the dependent task.
+4. **Remediation**: Fix or rerun the failed prerequisite, then rerun the dependent task. Newly created dependent runs use the wait-through-rerun behavior automatically.
 
 ### Reverse Lookup Shows No Dependents
 
@@ -125,12 +150,14 @@ Dependents are stored in the `execution_dependencies` durable edge table. If rev
 
 ## 7. Deployment and Replay Safety
 
-The dependency gate is deployed under a Temporal patch:
+The dependency gate is deployed under cooperating Temporal patches:
 
-- **Patch ID**: `dependency-gate-v1`
-- Workflows started **before** the patch was deployed skip the dependency wait entirely (backward compatible).
-- Workflows started **after** the patch is deployed execute the full dependency gate.
-- Future dependency-gate changes must keep replay behavior explicit through patch gates, replay tests, or a documented cutover.
+- **`dependency-gate-v1`** — installs the dependency gate itself. Workflows started before this patch was deployed skip the gate entirely (backward compatible).
+- **`dependency-wait-through-rerun-v1`** — installs the unified wait-through-rerun behavior. The first time a workflow under this patch records a prerequisite outcome, Temporal records a marker that pins the workflow to the new behavior across replays.
+  - Workflows started **after** `dependency-wait-through-rerun-v1` was deployed never auto-fail on a prerequisite failure.
+  - Workflows whose history predates `dependency-wait-through-rerun-v1` continue to use the legacy fail-fast code path until they terminate. Their `_dependency_failure` paths and `dependency_gate_failed` events remain accurate for those runs only.
+
+Future dependency-gate changes must keep replay behavior explicit through patch gates, replay tests, or a documented cutover.
 
 ---
 
@@ -173,10 +200,13 @@ Sent to dependent workflows when a prerequisite reaches terminal state.
 ## 9. Known Non-Goals (V1)
 
 - Editing dependencies after create
+- Retargeting a dependency to a different `workflowId` after create
 - Cross-workflow-type dependencies
 - Template-authored dependency graphs
 - Automatic transitive dependency expansion
 - Auto-canceling prerequisite runs
+- Auto-rerunning failed prerequisites
+- Auto-creating remediation tasks for failed prerequisites
 - Dependency-based priority or queue-order guarantees
 - Replacing child workflows with task dependencies
 - Storing large dependency history in Search Attributes
@@ -185,7 +215,11 @@ Sent to dependent workflows when a prerequisite reaches terminal state.
 
 ## 10. Recommended Remediation When a Prerequisite Fails
 
-1. Identify the failed prerequisite from the dependent run's summary artifact or Mission Control detail view.
-2. Diagnose and resolve the prerequisite failure (rerun, fix input, etc.).
-3. Once the prerequisite reaches `completed` state, **rerun the dependent task** — dependencies are create-time only and cannot be edited.
-4. If the prerequisite cannot be recovered, create a new dependent run with corrected prerequisites.
+1. Identify the failed prerequisite from the dependent run's task detail dependency panel or run summary artifact (look for an outcome with `resolution = "waiting_for_successful_rerun"`).
+2. Diagnose the prerequisite failure (its terminal state, close status, failure category, and message are surfaced on the prerequisite link, and `failureCount` / `lastFailedAt` on the dependent's outcome).
+3. **Rerun the prerequisite task** — keeping the same `workflowId` is automatic when you use the standard rerun action.
+4. Once the prerequisite reaches `completed`, the dependent unblocks itself; no action is required on the dependent. Its dependency resolution becomes `satisfied_after_rerun`.
+5. If the prerequisite cannot be recovered:
+   - **Bypass the dependency wait** on the dependent if the remaining prerequisites are no longer required, or
+   - **Cancel the dependent run** if it should not proceed without the prerequisite, then create a new dependent run with corrected prerequisites.
+6. Dependencies are create-time only and cannot be edited or retargeted after create. To change which `workflowId` a dependent waits on, cancel and recreate.

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -8968,7 +8968,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             <p className="small">No prerequisites selected.</p>
           )}
           <p className={dependencyMessage ? "notice error" : "small"}>
-            {dependencyMessage || "Direct dependencies only. Dependency failures propagate immediately to the dependent run."}
+            {dependencyMessage || "Direct dependencies only. The new run stays blocked while a prerequisite is running, failed, canceled, terminated, timed out, or unresolvable, and unblocks once the prerequisite completes successfully. Cancel this run or bypass the dependency to proceed without that prerequisite."}
           </p>
         </section>
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -131,6 +131,9 @@ const DependencyOutcomeSchema = z
     resolvedAt: z.string().nullable().optional(),
     failureCategory: z.string().nullable().optional(),
     message: z.string().nullable().optional(),
+    resolution: z.string().nullable().optional(),
+    failureCount: z.number().nullable().optional(),
+    lastFailedAt: z.string().nullable().optional(),
   })
   .passthrough();
 
@@ -4627,7 +4630,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               </div>
               {execution.blockedOnDependencies ? (
                 <div className="notice">
-                  <strong>Blocked on prerequisites.</strong> This run will not advance until every prerequisite reaches <code>completed</code>.
+                  <strong>Blocked on prerequisites.</strong> This run keeps waiting until every prerequisite reaches <code>completed</code>. Failed, canceled, terminated, or timed-out prerequisites do not fail this run automatically — rerun the prerequisite, cancel this run, or bypass the dependency.
                   {actionsOn && actions?.canBypassDependencies ? (
                     <div className="actions" style={{ marginTop: '0.75rem' }}>
                       <button
@@ -4650,7 +4653,13 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   <ul className="stack" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                     {prerequisiteRows.map((item) => {
                       const outcome = dependencyOutcomesById.get(item.workflowId);
-                      const stateLabel = outcome?.terminalState || item.state || 'unknown';
+                      const isWaitingForRerun =
+                        outcome?.resolution === 'waiting_for_successful_rerun';
+                      const stateLabel = isWaitingForRerun
+                        ? 'waiting_for_successful_rerun'
+                        : outcome?.terminalState || item.state || 'unknown';
+                      const failureCount = outcome?.failureCount ?? null;
+                      const lastFailedAt = outcome?.lastFailedAt ?? null;
                       return (
                         <li key={item.workflowId} className="card">
                           <div className="stack gap-1">
@@ -4659,6 +4668,15 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                             </a>
                             <code className="text-xs break-all">{item.workflowId}</code>
                             <span {...executionStatusPillProps(stateLabel)}>{formatStatusLabel(stateLabel)}</span>
+                            {isWaitingForRerun ? (
+                              <p className="small">
+                                <strong>Prerequisite failed; waiting for successful rerun.</strong>{' '}
+                                {failureCount && failureCount > 0
+                                  ? `Failure count: ${failureCount}.`
+                                  : null}
+                                {lastFailedAt ? ` Last failed at ${lastFailedAt}.` : null}
+                              </p>
+                            ) : null}
                             {item.summary ? <p className="small">{item.summary}</p> : null}
                             {outcome?.message ? <p className="small">{outcome.message}</p> : null}
                             {outcome?.failureCategory ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3896,6 +3896,12 @@ export interface components {
             failureCategory?: string | null;
             /** Message */
             message?: string | null;
+            /** Resolution */
+            resolution?: string | null;
+            /** Failurecount */
+            failureCount?: number | null;
+            /** Lastfailedat */
+            lastFailedAt?: string | null;
         };
         /**
          * ExecutionDependencySummaryModel

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -873,6 +873,9 @@ class ExecutionDependencyOutcomeModel(BaseModel):
     resolved_at: Optional[datetime] = Field(None, alias="resolvedAt")
     failure_category: Optional[str] = Field(None, alias="failureCategory")
     message: Optional[str] = Field(None, alias="message")
+    resolution: Optional[str] = Field(None, alias="resolution")
+    failure_count: Optional[int] = Field(None, alias="failureCount")
+    last_failed_at: Optional[datetime] = Field(None, alias="lastFailedAt")
 
 class ExecutionDependencySummaryModel(BaseModel):
     """Compact linked execution metadata for prerequisites or dependents."""

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1288,11 +1288,19 @@ class MoonMindRunWorkflow:
             str(existing.get("resolution") or "") if existing else ""
         )
 
+        if self._dependency_resolution in (
+            DEPENDENCY_RESOLUTION_BYPASSED,
+            DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
+        ):
+            return
+
         if terminal_state == STATE_COMPLETED:
             # Idempotency: stale completed signals after already satisfied are no-ops.
             if existing_resolution in (
                 DEPENDENCY_RESOLUTION_SATISFIED,
                 DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
+                DEPENDENCY_RESOLUTION_BYPASSED,
+                DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
             ):
                 return
 
@@ -1347,14 +1355,27 @@ class MoonMindRunWorkflow:
             DEPENDENCY_RESOLUTION_SATISFIED,
             DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
             DEPENDENCY_RESOLUTION_BYPASSED,
+            DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
         ):
             return
 
         last_failed_at = self._dependency_last_failed_at.get(
             prerequisite_workflow_id
         )
+        existing_waiting = (
+            existing_resolution == DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN
+        )
+        existing_message = str(existing.get("message") or "") if existing else ""
+        incoming_message = str(message or "")
         is_duplicate_observation = (
-            last_failed_at is not None and last_failed_at == resolved_at
+            last_failed_at == resolved_at
+            or (
+                existing_waiting
+                and existing.get("terminalState") == terminal_state
+                and existing.get("closeStatus") == close_status
+                and existing.get("failureCategory") == failure_category
+                and existing_message == incoming_message
+            )
         )
         if not is_duplicate_observation:
             self._dependency_failure_counts[prerequisite_workflow_id] = (
@@ -1401,14 +1422,29 @@ class MoonMindRunWorkflow:
     def _compute_top_level_resolution(self) -> str:
         if not self._declared_dependencies:
             return DEPENDENCY_RESOLUTION_NOT_APPLICABLE
+
+        if self._dependency_resolution in (
+            DEPENDENCY_RESOLUTION_BYPASSED,
+            DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
+        ):
+            return self._dependency_resolution
+
+        any_rerun = False
         for workflow_id in self._declared_dependencies:
             outcome = self._dependency_outcomes_by_id.get(workflow_id, {})
-            if (
-                outcome.get("resolution")
-                == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
-            ):
-                return DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
-        return DEPENDENCY_RESOLUTION_SATISFIED
+            resolution = outcome.get("resolution")
+            if resolution == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE:
+                return DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+            if resolution == DEPENDENCY_RESOLUTION_BYPASSED:
+                return DEPENDENCY_RESOLUTION_BYPASSED
+            if resolution == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN:
+                any_rerun = True
+
+        return (
+            DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+            if any_rerun
+            else DEPENDENCY_RESOLUTION_SATISFIED
+        )
 
     def _record_missing_dependency(self, prerequisite_workflow_id: str) -> None:
         self._record_dependency_outcome(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -151,9 +151,11 @@ CLOSE_STATUS_CANCELED = "canceled"
 CLOSE_STATUS_FAILED = "failed"
 DEPENDENCY_RESOLUTION_NOT_APPLICABLE = "not_applicable"
 DEPENDENCY_RESOLUTION_SATISFIED = "satisfied"
+DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN = "satisfied_after_rerun"
 DEPENDENCY_RESOLUTION_FAILED = "dependency_failed"
 DEPENDENCY_RESOLUTION_BYPASSED = "bypassed"
 DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE = "manual_override"
+DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN = "waiting_for_successful_rerun"
 MERGE_AUTOMATION_SUCCESS_STATUSES = frozenset({"merged", "already_merged"})
 MERGE_AUTOMATION_FAILURE_STATUSES = frozenset({"blocked", "failed", "expired"})
 MERGE_AUTOMATION_CANCELED_STATUS = "canceled"
@@ -192,6 +194,12 @@ RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH = (
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
+# Replay-stable patch id for unified wait-through-rerun dependency behavior.
+# Under this patch, a non-success prerequisite terminal outcome (failed,
+# canceled, terminated, timed_out, unresolvable) keeps the dependent run
+# blocked in waiting_on_dependencies until the prerequisite is rerun and
+# completes, the dependent is canceled, or an operator bypasses the gate.
+DEPENDENCY_WAIT_THROUGH_RERUN_PATCH = "dependency-wait-through-rerun-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
 NATIVE_PR_BRANCH_DEFAULTS_PATCH = "native-pr-branch-defaults-v1"
 NATIVE_PR_PUSH_STATUS_GATE_PATCH = "native-pr-push-status-gate-v1"
@@ -293,6 +301,13 @@ class MoonMindRunWorkflow:
         self._dependency_wait_started_at: datetime | None = None
         self._dependency_failure: dict[str, Any] | None = None
         self._dependency_manual_override_unresolved_count: int = 0
+        # Per-prerequisite tracking under wait-through-rerun. failureCount
+        # increments on each distinct non-success terminal observation;
+        # lastFailedAt records the most recent failure resolved-at timestamp
+        # for the prerequisite. Both are surfaced in dependency outcomes for
+        # operator diagnosis even after the prerequisite later succeeds.
+        self._dependency_failure_counts: dict[str, int] = {}
+        self._dependency_last_failed_at: dict[str, str] = {}
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -1214,6 +1229,20 @@ class MoonMindRunWorkflow:
     ) -> None:
         if prerequisite_workflow_id not in self._declared_dependencies:
             return
+
+        if workflow.patched(DEPENDENCY_WAIT_THROUGH_RERUN_PATCH):
+            self._record_dependency_outcome_wait_through_rerun(
+                prerequisite_workflow_id=prerequisite_workflow_id,
+                terminal_state=terminal_state,
+                close_status=close_status,
+                resolved_at=resolved_at,
+                failure_category=failure_category,
+                message=message,
+            )
+            return
+
+        # Legacy fail-fast path preserved for in-flight workflows whose history
+        # predates DEPENDENCY_WAIT_THROUGH_RERUN_PATCH.
         if prerequisite_workflow_id in self._dependency_outcomes_by_id:
             return
 
@@ -1243,6 +1272,143 @@ class MoonMindRunWorkflow:
             "message": message,
         }
         self._unresolved_dependency_ids.discard(prerequisite_workflow_id)
+
+    def _record_dependency_outcome_wait_through_rerun(
+        self,
+        *,
+        prerequisite_workflow_id: str,
+        terminal_state: str,
+        close_status: str | None,
+        resolved_at: str,
+        failure_category: str | None,
+        message: str | None,
+    ) -> None:
+        existing = self._dependency_outcomes_by_id.get(prerequisite_workflow_id)
+        existing_resolution = (
+            str(existing.get("resolution") or "") if existing else ""
+        )
+
+        if terminal_state == STATE_COMPLETED:
+            # Idempotency: stale completed signals after already satisfied are no-ops.
+            if existing_resolution in (
+                DEPENDENCY_RESOLUTION_SATISFIED,
+                DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
+            ):
+                return
+
+            had_failures = (
+                self._dependency_failure_counts.get(prerequisite_workflow_id, 0) > 0
+            )
+            per_dep_resolution = (
+                DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+                if had_failures
+                else DEPENDENCY_RESOLUTION_SATISFIED
+            )
+
+            outcome: dict[str, Any] = {
+                "workflowId": prerequisite_workflow_id,
+                "terminalState": terminal_state,
+                "closeStatus": close_status,
+                "resolvedAt": resolved_at,
+                "failureCategory": None,
+                "message": message,
+                "resolution": per_dep_resolution,
+                "failureCount": self._dependency_failure_counts.get(
+                    prerequisite_workflow_id, 0
+                ),
+                "lastFailedAt": self._dependency_last_failed_at.get(
+                    prerequisite_workflow_id
+                ),
+            }
+            self._dependency_outcomes_by_id[prerequisite_workflow_id] = outcome
+            self._unresolved_dependency_ids.discard(prerequisite_workflow_id)
+
+            if not self._unresolved_dependency_ids:
+                self._dependency_resolution = self._compute_top_level_resolution()
+
+            if had_failures:
+                self._get_logger().info(
+                    "Dependency gate satisfied after rerun",
+                    extra={
+                        "event": "dependency_gate_satisfied_after_rerun",
+                        "prerequisite_workflow_id": prerequisite_workflow_id,
+                        "failure_count": self._dependency_failure_counts.get(
+                            prerequisite_workflow_id, 0
+                        ),
+                        "wait_duration_ms": self._dependency_wait_duration_ms,
+                    },
+                )
+            return
+
+        # Non-success terminal: stay blocked, accumulate diagnostics. Stale
+        # failure observations after the prerequisite is already satisfied
+        # or the gate was bypassed are ignored.
+        if existing_resolution in (
+            DEPENDENCY_RESOLUTION_SATISFIED,
+            DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
+            DEPENDENCY_RESOLUTION_BYPASSED,
+        ):
+            return
+
+        last_failed_at = self._dependency_last_failed_at.get(
+            prerequisite_workflow_id
+        )
+        is_duplicate_observation = (
+            last_failed_at is not None and last_failed_at == resolved_at
+        )
+        if not is_duplicate_observation:
+            self._dependency_failure_counts[prerequisite_workflow_id] = (
+                self._dependency_failure_counts.get(prerequisite_workflow_id, 0)
+                + 1
+            )
+            self._dependency_last_failed_at[prerequisite_workflow_id] = resolved_at
+
+        failure_count = self._dependency_failure_counts.get(
+            prerequisite_workflow_id, 0
+        )
+        last_failed = self._dependency_last_failed_at.get(prerequisite_workflow_id)
+
+        diagnostic_message = message or (
+            f"Prerequisite execution '{prerequisite_workflow_id}' reached "
+            f"terminal state '{terminal_state}'; waiting for successful rerun."
+        )
+
+        outcome = {
+            "workflowId": prerequisite_workflow_id,
+            "terminalState": terminal_state,
+            "closeStatus": close_status,
+            "resolvedAt": None,
+            "failureCategory": failure_category,
+            "message": diagnostic_message,
+            "resolution": DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN,
+            "failureCount": failure_count,
+            "lastFailedAt": last_failed,
+        }
+        self._dependency_outcomes_by_id[prerequisite_workflow_id] = outcome
+
+        if not is_duplicate_observation:
+            self._get_logger().info(
+                "Dependency gate waiting for successful rerun",
+                extra={
+                    "event": "dependency_gate_waiting_for_rerun",
+                    "prerequisite_workflow_id": prerequisite_workflow_id,
+                    "terminal_state": terminal_state,
+                    "close_status": close_status,
+                    "failure_count": failure_count,
+                },
+            )
+
+    def _compute_top_level_resolution(self) -> str:
+        if not self._declared_dependencies:
+            return DEPENDENCY_RESOLUTION_NOT_APPLICABLE
+        for workflow_id in self._declared_dependencies:
+            outcome = self._dependency_outcomes_by_id.get(workflow_id, {})
+            if (
+                outcome.get("resolution")
+                == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+            ):
+                return DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+        return DEPENDENCY_RESOLUTION_SATISFIED
 
     def _record_missing_dependency(self, prerequisite_workflow_id: str) -> None:
         self._record_dependency_outcome(
@@ -1349,6 +1515,13 @@ class MoonMindRunWorkflow:
                 "resolvedAt": bypassed_at,
                 "failureCategory": None,
                 "message": reason,
+                "resolution": DEPENDENCY_RESOLUTION_BYPASSED,
+                "failureCount": self._dependency_failure_counts.get(
+                    prerequisite_workflow_id, 0
+                ),
+                "lastFailedAt": self._dependency_last_failed_at.get(
+                    prerequisite_workflow_id
+                ),
             }
 
         self._unresolved_dependency_ids.clear()
@@ -1476,6 +1649,8 @@ class MoonMindRunWorkflow:
         self._dependency_failure = None
         self._dependency_outcomes_by_id = {}
         self._unresolved_dependency_ids = set(dependency_ids)
+        self._dependency_failure_counts = {}
+        self._dependency_last_failed_at = {}
         self._waiting_reason = "dependency_wait"
         self._set_state(
             STATE_WAITING_ON_DEPENDENCIES,

--- a/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
@@ -31,6 +31,7 @@ from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 from moonmind.workflows.temporal.workflows.run import (
     DEPENDENCY_GATE_PATCH,
     DEPENDENCY_RESOLUTION_BYPASSED,
+    DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
     DEPENDENCY_RESOLUTION_NOT_APPLICABLE,
     DEPENDENCY_RESOLUTION_SATISFIED,
     DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
@@ -419,6 +420,132 @@ def test_bypass_records_per_outcome_resolution_bypassed(monkeypatch) -> None:
     assert dep2["resolution"] == DEPENDENCY_RESOLUTION_BYPASSED
     assert dep2["failureCount"] == 0
 
+
+
+def test_late_completed_signal_after_bypass_preserves_bypassed_resolution(
+    monkeypatch,
+) -> None:
+    """A late completed signal must not erase an operator bypass audit trail."""
+
+    fixed_now = datetime(2026, 5, 8, 13, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {DEPENDENCY_GATE_PATCH, DEPENDENCY_WAIT_THROUGH_RERUN_PATCH},
+    )
+    monkeypatch.setattr(workflow, "now", lambda: fixed_now)
+
+    wf = MoonMindRunWorkflow()
+    wf._declared_dependencies = ["dep-1"]
+    wf._unresolved_dependency_ids = {"dep-1"}
+    wf._state = STATE_WAITING_ON_DEPENDENCIES
+    wf._dependency_wait_started_at = fixed_now
+    monkeypatch.setattr(wf, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(wf, "_update_memo", lambda: None)
+
+    wf._bypass_dependencies({"reason": "operator override"})
+    before = dict(wf._dependency_outcomes_by_id["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T13:15:00Z",
+        failure_category=None,
+        message="late completion",
+    )
+
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_BYPASSED
+    assert wf._dependency_outcomes_by_id["dep-1"] == before
+
+
+def test_late_signals_after_manual_override_preserve_manual_resolution(
+    monkeypatch,
+) -> None:
+    """Late dependency signals must not rewrite a manual skip decision."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+    monkeypatch.setattr(wf, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(wf, "_update_memo", lambda: None)
+    wf._state = STATE_WAITING_ON_DEPENDENCIES
+
+    wf.skip_dependency_wait()
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T13:15:00Z",
+        failure_category=None,
+        message="late completion",
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T13:30:00Z",
+        failure_category="dependency_failed",
+        message="late failure",
+    )
+
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+    assert wf._dependency_outcomes_by_id == {}
+    assert wf._dependency_failure is None
+
+
+def test_top_level_resolution_preserves_override_outcomes(monkeypatch) -> None:
+    """Top-level rollup prioritizes operator override outcomes over satisfaction."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1", "dep-2"])
+    wf._dependency_outcomes_by_id["dep-1"] = {
+        "workflowId": "dep-1",
+        "resolution": DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
+    }
+    wf._dependency_outcomes_by_id["dep-2"] = {
+        "workflowId": "dep-2",
+        "resolution": DEPENDENCY_RESOLUTION_BYPASSED,
+    }
+
+    assert wf._compute_top_level_resolution() == DEPENDENCY_RESOLUTION_BYPASSED
+
+    wf._dependency_outcomes_by_id["dep-2"]["resolution"] = (
+        DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+    )
+
+    assert (
+        wf._compute_top_level_resolution()
+        == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+    )
+
+
+def test_repeated_reconcile_observation_with_new_timestamp_is_not_new_failure(
+    monkeypatch,
+) -> None:
+    """Fresh reconcile timestamps for the same failed prerequisite are idempotent."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="upstream broken",
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:30:00Z",
+        failure_category="dependency_failed",
+        message="upstream broken",
+    )
+
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["failureCount"] == 1
+    assert outcome["lastFailedAt"] == "2026-05-08T12:00:00Z"
 
 # ---------------------------------------------------------------------------
 # Backwards-compatibility: legacy fail-fast path

--- a/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
@@ -1,0 +1,599 @@
+"""Tests for the unified wait-through-rerun dependency gate behavior.
+
+Under DEPENDENCY_WAIT_THROUGH_RERUN_PATCH, a non-success terminal prerequisite
+outcome (failed, canceled, terminated, timed_out, unresolvable) keeps the
+dependent run blocked in waiting_on_dependencies until the same prerequisite
+workflowId later reaches completed, the dependent is canceled, or an operator
+bypasses the gate.
+
+Tests in this file fall into two layers:
+
+1. Direct method-level tests that monkey-patch workflow.patched/workflow.now
+   and call _record_dependency_outcome to exercise the gate's state machine
+   without spinning up a Temporal time-skipping environment. Fast.
+
+2. One end-to-end test using WorkflowEnvironment.start_time_skipping() that
+   verifies a failed prerequisite, observed via reconciliation, keeps the
+   dependent waiting until a later DependencyResolved completed signal
+   unblocks it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from temporalio import workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker, UnsandboxedWorkflowRunner
+
+from moonmind.workflows.temporal.workflows.run import (
+    DEPENDENCY_GATE_PATCH,
+    DEPENDENCY_RESOLUTION_BYPASSED,
+    DEPENDENCY_RESOLUTION_NOT_APPLICABLE,
+    DEPENDENCY_RESOLUTION_SATISFIED,
+    DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN,
+    DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN,
+    DEPENDENCY_WAIT_THROUGH_RERUN_PATCH,
+    MoonMindRunWorkflow,
+    STATE_WAITING_ON_DEPENDENCIES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Direct method-level tests
+# ---------------------------------------------------------------------------
+
+
+def _make_workflow_under_rerun_patch(
+    monkeypatch,
+    *,
+    declared: list[str],
+    now: datetime | None = None,
+) -> MoonMindRunWorkflow:
+    """Build a workflow instance with rerun patch enabled and gate primed."""
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {DEPENDENCY_GATE_PATCH, DEPENDENCY_WAIT_THROUGH_RERUN_PATCH},
+    )
+    fixed_now = now or datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(workflow, "now", lambda: fixed_now)
+
+    instance = MoonMindRunWorkflow()
+    instance._declared_dependencies = list(declared)
+    instance._unresolved_dependency_ids = set(declared)
+    instance._dependency_resolution = DEPENDENCY_RESOLUTION_NOT_APPLICABLE
+    return instance
+
+
+def test_failed_prerequisite_keeps_dependent_waiting(monkeypatch) -> None:
+    """A 'failed' prerequisite terminal observation does not fail the dependent."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="upstream broken",
+    )
+
+    assert wf._dependency_failure is None
+    assert wf._failed_dependency_id is None
+    assert "dep-1" in wf._unresolved_dependency_ids
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN
+    assert outcome["failureCount"] == 1
+    assert outcome["lastFailedAt"] == "2026-05-08T12:00:00Z"
+    assert outcome["terminalState"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "terminal_state,close_status",
+    [
+        ("canceled", "canceled"),
+        ("terminated", "terminated"),
+        ("timed_out", "timed_out"),
+    ],
+)
+def test_non_failed_terminals_keep_dependent_waiting(
+    monkeypatch, terminal_state: str, close_status: str
+) -> None:
+    """canceled/terminated/timed_out prerequisites also keep the dependent waiting."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state=terminal_state,
+        close_status=close_status,
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=f"dependency_{terminal_state}",
+        message=None,
+    )
+
+    assert wf._dependency_failure is None
+    assert "dep-1" in wf._unresolved_dependency_ids
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN
+    assert outcome["terminalState"] == terminal_state
+    assert outcome["closeStatus"] == close_status
+    assert outcome["failureCount"] == 1
+
+
+def test_unresolvable_prerequisite_keeps_dependent_waiting(monkeypatch) -> None:
+    """An unresolvable prerequisite (missing-from-snapshot) keeps the dependent waiting."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_missing_dependency("dep-1")
+
+    assert wf._dependency_failure is None
+    assert "dep-1" in wf._unresolved_dependency_ids
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN
+    assert outcome["failureCategory"] == "dependency_unresolved"
+    assert outcome["failureCount"] == 1
+
+
+def test_prerequisite_completion_after_failure_unblocks_dependent(monkeypatch) -> None:
+    """A completed observation after a failed observation transitions to satisfied_after_rerun."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="upstream broken",
+    )
+
+    assert "dep-1" in wf._unresolved_dependency_ids
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:15:00Z",
+        failure_category=None,
+        message="completed after rerun",
+    )
+
+    assert wf._dependency_failure is None
+    assert "dep-1" not in wf._unresolved_dependency_ids
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+    assert outcome["terminalState"] == "completed"
+    assert outcome["resolvedAt"] == "2026-05-08T12:15:00Z"
+    assert outcome["failureCount"] == 1
+    assert outcome["lastFailedAt"] == "2026-05-08T12:00:00Z"
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+
+
+def test_first_try_completion_yields_satisfied_resolution(monkeypatch) -> None:
+    """A clean completion with no prior failures yields per-dep satisfied (not after_rerun)."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=None,
+        message=None,
+    )
+
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_SATISFIED
+    assert outcome["failureCount"] == 0
+    assert outcome["lastFailedAt"] is None
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED
+
+
+def test_stale_failed_signal_after_satisfied_is_ignored(monkeypatch) -> None:
+    """A late failed signal arriving after a satisfied outcome must not revert resolution."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=None,
+        message=None,
+    )
+    assert "dep-1" not in wf._unresolved_dependency_ids
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:30:00Z",
+        failure_category="dependency_failed",
+        message="late stale failed signal",
+    )
+
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_SATISFIED
+    assert outcome["terminalState"] == "completed"
+    assert "dep-1" not in wf._unresolved_dependency_ids
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED
+    assert wf._dependency_failure is None
+
+
+def test_duplicate_failure_observation_does_not_increment_count(monkeypatch) -> None:
+    """Reconciliation that re-observes the same failure cycle must not double-count."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="first observation",
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="duplicate observation",
+    )
+
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["failureCount"] == 1
+    assert outcome["lastFailedAt"] == "2026-05-08T12:00:00Z"
+
+
+def test_distinct_failure_cycles_increment_count(monkeypatch) -> None:
+    """Two distinct non-success terminals (different resolved_at) increment failureCount."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message=None,
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:30:00Z",
+        failure_category="dependency_failed",
+        message=None,
+    )
+
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["failureCount"] == 2
+    assert outcome["lastFailedAt"] == "2026-05-08T12:30:00Z"
+
+
+def test_top_level_resolution_satisfied_when_all_prereqs_succeed_first_try(
+    monkeypatch,
+) -> None:
+    """When every prerequisite succeeds without failures, top-level resolution is satisfied."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1", "dep-2"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=None,
+        message=None,
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-2",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:01:00Z",
+        failure_category=None,
+        message=None,
+    )
+
+    assert wf._unresolved_dependency_ids == set()
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED
+
+
+def test_top_level_resolution_satisfied_after_rerun_when_any_prereq_failed(
+    monkeypatch,
+) -> None:
+    """When any prerequisite failed before satisfaction, top-level rolls up to satisfied_after_rerun."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1", "dep-2"])
+
+    # dep-1 succeeds first try
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=None,
+        message=None,
+    )
+    # dep-2 fails then succeeds
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-2",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message=None,
+    )
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-2",
+        terminal_state="completed",
+        close_status="completed",
+        resolved_at="2026-05-08T12:30:00Z",
+        failure_category=None,
+        message=None,
+    )
+
+    assert wf._unresolved_dependency_ids == set()
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED_AFTER_RERUN
+
+
+def test_dependency_metadata_includes_per_outcome_diagnostic_fields(monkeypatch) -> None:
+    """run_summary / memo dependency block surfaces failureCount and lastFailedAt."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="upstream broken",
+    )
+
+    metadata = wf._dependency_metadata()
+    deps = metadata["dependencies"]
+    assert deps["declaredIds"] == ["dep-1"]
+    assert deps["resolution"] == DEPENDENCY_RESOLUTION_NOT_APPLICABLE
+    assert len(deps["outcomes"]) == 1
+    outcome = deps["outcomes"][0]
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN
+    assert outcome["failureCount"] == 1
+    assert outcome["lastFailedAt"] == "2026-05-08T12:00:00Z"
+
+
+def test_bypass_records_per_outcome_resolution_bypassed(monkeypatch) -> None:
+    """Bypassing the dependency wait records bypassed resolution per outcome."""
+
+    fixed_now = datetime(2026, 5, 8, 13, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {DEPENDENCY_GATE_PATCH, DEPENDENCY_WAIT_THROUGH_RERUN_PATCH},
+    )
+    monkeypatch.setattr(workflow, "now", lambda: fixed_now)
+
+    wf = MoonMindRunWorkflow()
+    wf._declared_dependencies = ["dep-1", "dep-2"]
+    wf._unresolved_dependency_ids = {"dep-1", "dep-2"}
+    wf._state = STATE_WAITING_ON_DEPENDENCIES
+    wf._dependency_wait_started_at = fixed_now
+    monkeypatch.setattr(wf, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(wf, "_update_memo", lambda: None)
+
+    # First record a failure observation for dep-1 so we can verify
+    # failureCount/lastFailedAt are preserved into the bypassed outcome.
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message=None,
+    )
+
+    wf._bypass_dependencies({"reason": "operator override"})
+
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_BYPASSED
+    assert wf._unresolved_dependency_ids == set()
+    dep1 = wf._dependency_outcomes_by_id["dep-1"]
+    dep2 = wf._dependency_outcomes_by_id["dep-2"]
+    assert dep1["resolution"] == DEPENDENCY_RESOLUTION_BYPASSED
+    assert dep1["failureCount"] == 1
+    assert dep1["lastFailedAt"] == "2026-05-08T12:00:00Z"
+    assert dep2["resolution"] == DEPENDENCY_RESOLUTION_BYPASSED
+    assert dep2["failureCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility: legacy fail-fast path
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_workflows_without_rerun_patch_still_fail_fast(monkeypatch) -> None:
+    """In-flight workflows whose history predates the rerun patch keep fail-fast."""
+
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
+    monkeypatch.setattr(
+        workflow,
+        "now",
+        lambda: datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    wf = MoonMindRunWorkflow()
+    wf._declared_dependencies = ["dep-1"]
+    wf._unresolved_dependency_ids = {"dep-1"}
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="failed",
+        close_status="failed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category="dependency_failed",
+        message="legacy upstream broken",
+    )
+
+    assert wf._dependency_failure is not None
+    assert wf._failed_dependency_id == "dep-1"
+    assert "dep-1" not in wf._unresolved_dependency_ids
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: failed prereq + later DependencyResolved completed signal
+# ---------------------------------------------------------------------------
+
+
+async def _fake_execute_activity(activity_name, *args, **kwargs):
+    if activity_name == "artifact.read":
+        import json
+
+        return json.dumps(
+            {
+                "plan_version": "1.0",
+                "metadata": {"title": "Test"},
+                "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                "tools": [],
+                "nodes": [],
+                "edges": [],
+            }
+        ).encode("utf-8")
+    return {}
+
+
+@pytest.fixture
+def mock_run_environment(monkeypatch):
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_trusted_owner_metadata",
+        lambda self: ("user", "user-1"),
+    )
+    monkeypatch.setattr(workflow, "execute_activity", _fake_execute_activity)
+    monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: None)
+
+    async def fake_planning_stage(*args, **kwargs):
+        return "ref-123"
+
+    async def fake_execution_stage(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(
+        MoonMindRunWorkflow, "_run_planning_stage", fake_planning_stage
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow, "_run_execution_stage", fake_execution_stage
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_prereq_then_completed_signal_unblocks_dependent(
+    mock_run_environment,
+    monkeypatch,
+):
+    """Reconciliation observes a failed prereq; later a completed signal unblocks the run."""
+
+    reconcile_call_count = 0
+
+    async def fake_reconcile(self, dependency_ids):
+        nonlocal reconcile_call_count
+        reconcile_call_count += 1
+        # Always observe failed terminal — the gate must keep waiting under
+        # the rerun patch, not auto-fail.
+        for workflow_id in dependency_ids:
+            self._record_dependency_outcome(
+                prerequisite_workflow_id=workflow_id,
+                terminal_state="failed",
+                close_status="failed",
+                resolved_at=f"2026-05-08T12:0{reconcile_call_count}:00Z",
+                failure_category="dependency_failed",
+                message="upstream broken",
+            )
+
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {DEPENDENCY_GATE_PATCH, DEPENDENCY_WAIT_THROUGH_RERUN_PATCH},
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow, "_reconcile_dependencies", fake_reconcile
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-rerun",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-rerun-1"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-rerun",
+                task_queue="test-task-queue-rerun",
+            )
+
+            # Wait until the workflow enters the dependency-wait state.
+            for _ in range(50):
+                status = await handle.query("get_status")
+                if status.get("state") == "waiting_on_dependencies":
+                    break
+                await asyncio.sleep(0.01)
+
+            status = await handle.query("get_status")
+            assert status.get("state") == "waiting_on_dependencies", (
+                f"workflow did not enter dependency wait, got {status}"
+            )
+
+            # Advance virtual time enough to fire at least one reconcile cycle
+            # so the failed observation is recorded. The dependent must NOT
+            # auto-fail under the rerun patch — it should remain in
+            # waiting_on_dependencies.
+            await env.sleep(35)
+
+            status = await handle.query("get_status")
+            assert status.get("state") == "waiting_on_dependencies", (
+                "Failed prerequisite under wait-through-rerun must not fail "
+                f"the dependent. Got state={status.get('state')!r}"
+            )
+
+            # Now send a completed signal to simulate a successful rerun.
+            await handle.signal(
+                "DependencyResolved",
+                {
+                    "prerequisiteWorkflowId": "dep-rerun-1",
+                    "terminalState": "completed",
+                    "closeStatus": "completed",
+                    "resolvedAt": "2026-05-08T13:00:00Z",
+                    "failureCategory": None,
+                    "message": "completed after rerun",
+                },
+            )
+
+            result = await handle.result()
+
+    assert result["status"] == "success"
+    assert reconcile_call_count >= 1

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -516,7 +516,14 @@ def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
     assert workflow_instance._attention_required is False
 
 @pytest.mark.asyncio
-async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypatch):
+async def test_legacy_wait_for_dependencies_raises_dependency_specific_failure(monkeypatch):
+    """Legacy fail-fast path: in-flight workflows whose history predates the
+    wait-through-rerun patch must continue raising on a failed prerequisite."""
+    from moonmind.workflows.temporal.workflows.run import (
+        DEPENDENCY_GATE_PATCH,
+        DEPENDENCY_WAIT_THROUGH_RERUN_PATCH,
+    )
+
     workflow_instance = MoonMindRunWorkflow()
     workflow_instance._owner_id = "owner-1"
     workflow_instance._owner_type = "user"
@@ -540,7 +547,13 @@ async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypa
     monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
     monkeypatch.setattr(workflow, "upsert_memo", lambda memo: None)
-    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
+    # Enable only the gate patch, not the wait-through-rerun patch, so we
+    # exercise the legacy fail-fast code path.
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
     monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
     workflow_info = type(
         "WorkflowInfo",
@@ -604,6 +617,9 @@ async def test_wait_for_dependencies_can_be_bypassed_by_operator_signal(monkeypa
             "resolvedAt": workflow_instance._dependency_outcomes_by_id["dep-1"]["resolvedAt"],
             "failureCategory": None,
             "message": "No longer needed.",
+            "resolution": "bypassed",
+            "failureCount": 0,
+            "lastFailedAt": None,
         },
         {
             "workflowId": "dep-2",
@@ -612,6 +628,9 @@ async def test_wait_for_dependencies_can_be_bypassed_by_operator_signal(monkeypa
             "resolvedAt": workflow_instance._dependency_outcomes_by_id["dep-2"]["resolvedAt"],
             "failureCategory": None,
             "message": "No longer needed.",
+            "resolution": "bypassed",
+            "failureCount": 0,
+            "lastFailedAt": None,
         },
     ]
     assert all(


### PR DESCRIPTION
## Summary

- Unified wait-through-rerun behavior for `MoonMind.Run` task dependencies. A dependent run no longer auto-fails when a prerequisite reaches a non-success terminal state (`failed`, `canceled`, `terminated`, `timed_out`, or runtime-unresolvable). It stays in `waiting_on_dependencies` until the prerequisite is rerun to `completed`, the dependent is canceled, or an operator bypasses the dependency.
- New replay-stable patch `dependency-wait-through-rerun-v1`. Legacy fail-fast path preserved for in-flight workflows whose history predates the patch.
- Per-dependency outcomes now carry `resolution` (`waiting_for_successful_rerun`, `satisfied`, `satisfied_after_rerun`, `bypassed`), `failureCount`, and `lastFailedAt` for operator diagnosis. Top-level `dependencies.resolution` rolls up to `satisfied_after_rerun` if any prerequisite required at least one rerun cycle.
- Mission Control task detail now surfaces a "Prerequisite failed; waiting for successful rerun" indicator with failure count and last-failed timestamp. "Blocked on prerequisites" notice and the create-page dependency helper text were updated to reflect the new contract.
- Canonical doc (`docs/Tasks/TaskDependencies.md`) and operator guide (`docs/Tasks/TaskDependenciesOperatorGuide.md`) rewritten: §4.6 wait-through-rerun behavior, §5.3 resolution vocabulary including `satisfied_after_rerun` and the non-terminal `waiting_for_successful_rerun` per-dep marker, edge-cases section, and the two-patch deployment story.

## Test plan

- [x] `tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py` (16 new tests): failed/canceled/terminated/timed_out/unresolvable prerequisites all keep the dependent waiting; completion after failure transitions to `satisfied_after_rerun`; stale failed signal after satisfied is ignored; duplicate failure observation does not double-count `failureCount`; top-level resolution rollup correct; bypass preserves diagnostics; legacy workflows still fail-fast when only `dependency-gate-v1` is patched.
- [x] End-to-end time-skipping test: failed prereq + later DependencyResolved completed signal unblocks the dependent.
- [x] Existing dependency tests still pass (`test_run_scheduling.py`, `test_run_dependency_signals.py`, `test_run_signals_updates.py`, `test_run_artifacts.py`, `test_temporal_service.py`, executions-router dependency tests) — broader Python slice 1,749 tests, 0 failures.
- [x] Frontend Vitest suites pass: `task-detail.test.tsx` (89/89), `task-create.test.tsx` (30/30 + 225 skipped).
- [ ] After deploy: confirm a chained jira-orchestrate task whose prerequisite fails stays in `waiting_on_dependencies` rather than cascade-failing; rerun the prerequisite and confirm the dependent unblocks with `satisfied_after_rerun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)