### PR TITLE
Change Jira issue MM-652 to status In Progress before implementation starts.

### DIFF
--- a/specs/331-transition-mm652-in-pr/checklists/requirements.md
+++ b/specs/331-transition-mm652-in-pr/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Transition Jira Issue MM-652 to "In PR"
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Intent classification: `runtime`. The brief asks the system to perform a Jira workflow status transition and verify the resulting state, which is observable system behavior rather than a docs-only change.
+- Source design mapping: The user brief `"Change Jira issue MM-652 to status 'In PR'."` is the sole source. DESIGN-REQ-001..003 are all in scope and each maps to at least one functional requirement.
+- Single-story scope: The brief describes one independently testable operation against a single issue key (`MM-652`) with one target status (`In PR`); no additional stories were collapsed into this spec.
+- Implementation-detail check: Mentions of "trusted Jira tooling" describe a credential boundary (no raw secrets in the agent runtime), not a specific framework, library, or API contract; this is retained as a security/scope constraint rather than an implementation choice.

--- a/specs/331-transition-mm652-in-pr/checklists/requirements.md
+++ b/specs/331-transition-mm652-in-pr/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Transition Jira Issue MM-652 to "In PR"
+# Specification Quality Checklist: Transition Jira Issue MM-652 to "In Progress"
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-05-09
@@ -37,6 +37,6 @@
 ## Notes
 
 - Intent classification: `runtime`. The brief asks the system to perform a Jira workflow status transition and verify the resulting state, which is observable system behavior rather than a docs-only change.
-- Source design mapping: The user brief `"Change Jira issue MM-652 to status 'In PR'."` is the sole source. DESIGN-REQ-001..003 are all in scope and each maps to at least one functional requirement.
-- Single-story scope: The brief describes one independently testable operation against a single issue key (`MM-652`) with one target status (`In PR`); no additional stories were collapsed into this spec.
+- Source design mapping: The user brief `"Change Jira issue MM-652 to status 'In Progress'."` is the sole source. DESIGN-REQ-001..003 are all in scope and each maps to at least one functional requirement.
+- Single-story scope: The brief describes one independently testable operation against a single issue key (`MM-652`) with one target status (`In Progress`); no additional stories were collapsed into this spec.
 - Implementation-detail check: Mentions of "trusted Jira tooling" describe a credential boundary (no raw secrets in the agent runtime), not a specific framework, library, or API contract; this is retained as a security/scope constraint rather than an implementation choice.

--- a/specs/331-transition-mm652-in-pr/spec.md
+++ b/specs/331-transition-mm652-in-pr/spec.md
@@ -1,0 +1,83 @@
+# Feature Specification: Transition Jira Issue MM-652 to "In PR"
+
+**Feature Branch**: `change-jira-issue-mm-652-to-status-in-pr-60e1a2aa`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: User description: "Change Jira issue MM-652 to status 'In PR'."
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Move MM-652 into "In PR"
+
+**Summary**: As a delivery operator, I want the system to move Jira issue MM-652 to the "In PR" workflow status so that the issue tracker reflects that the change associated with MM-652 is awaiting pull-request review.
+
+**Goal**: After the workflow runs, MM-652's Jira workflow status is "In PR", with no other fields on MM-652 mutated and no other Jira issues modified.
+
+**Independent Test**: Can be fully tested by running the workflow against issue key `MM-652` and then re-fetching the issue from the Jira tracker to confirm its current status reads "In PR" (or, if it was already "In PR", that the workflow recorded a no-op rather than performing a redundant transition).
+
+**Acceptance Scenarios**:
+
+1. **Given** MM-652 is in a workflow status from which an "In PR" transition is available, **When** the workflow runs against `MM-652`, **Then** MM-652's status becomes "In PR" and the result reports the issue key, the prior status, the chosen transition, and the verified post-transition status.
+2. **Given** MM-652 is already in status "In PR", **When** the workflow runs against `MM-652`, **Then** no transition is performed, no other fields are changed, and the result reports a no-op with the current status.
+3. **Given** MM-652 is in a workflow status from which no transition leads to "In PR", **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit "no matching transition" error, MM-652 is not modified, and the report names the available transition options.
+4. **Given** MM-652 has more than one available transition whose target status name matches "In PR" (case-insensitive), **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit ambiguity error, MM-652 is not modified, and the report lists the candidate transitions for operator selection.
+
+### Edge Cases
+
+- The trusted Jira tool surface is unavailable or not registered in the runtime: the workflow stops with an explicit "Jira tools unavailable" error and performs no mutation.
+- Authentication or authorization to view/modify MM-652 fails: the workflow stops with a sanitized auth/permission error and performs no mutation; no credentials, tokens, or auth headers appear in any output.
+- Jira returns a transient failure (rate limit or 5xx) during transition discovery or transition execution: the workflow surfaces the failure without retrying through ad-hoc HTTP and without claiming success.
+- The post-transition verification fetch shows a status other than "In PR" (for example, the workflow advanced through an intermediate state): the workflow reports the actual final status and flags the result as not matching the requested target.
+- Jira's transition requires additional fields (such as a resolution or comment) before it will execute: the workflow stops with the named missing fields and performs no mutation rather than guessing values.
+
+## Assumptions
+
+- "In PR" is a discoverable Jira workflow status reachable from MM-652's current status on the project that owns MM-652.
+- The runtime executing this workflow already has access to MoonMind's trusted Jira tool surface (e.g., `jira.get_issue`, `jira.get_transitions`, `jira.transition_issue`); raw Jira REST credentials are not provided to or used by the agent runtime.
+- The brief targets a status transition only — no description, label, assignee, or other field updates are implied by "Change ... to status 'In PR'".
+- Status name matching is case-insensitive and ignores surrounding whitespace, but otherwise compares against the literal target name `In PR`.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: The system MUST update only the Jira issue identified by the literal key `MM-652`.
+  - Source: User brief — `"Change Jira issue MM-652 to status 'In PR'."`
+  - Scope: in scope
+  - Mapped FR: FR-001, FR-008
+- **DESIGN-REQ-002**: The system MUST drive MM-652 to the workflow status named `In PR`.
+  - Source: User brief — `"... to status 'In PR'."`
+  - Scope: in scope
+  - Mapped FR: FR-003, FR-005, FR-006
+- **DESIGN-REQ-003**: The system MUST treat the request as a status change only, not as a description, comment, or other field edit.
+  - Source: User brief verb `"Change ... status"`
+  - Scope: in scope
+  - Mapped FR: FR-008
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST resolve the update target to the literal Jira issue key `MM-652` and reject any attempt to operate on a different issue key inferred from surrounding text.
+- **FR-002**: System MUST discover MM-652's currently available workflow transitions before performing any mutation.
+- **FR-003**: System MUST select a transition whose target workflow status name equals `In PR` (case-insensitive, trimmed) and whose identity is unambiguous.
+- **FR-004**: System MUST execute the selected transition exclusively through MoonMind's trusted Jira tooling, never through ad-hoc HTTP calls or raw Jira credentials in the agent runtime.
+- **FR-005**: System MUST verify the post-transition status by re-reading MM-652 and report the verified final status.
+- **FR-006**: System MUST treat the case where MM-652 is already in status `In PR` as a successful no-op, reporting the current status without invoking a transition.
+- **FR-007**: System MUST stop with an explicit, named error and perform no mutation when (a) no available transition matches `In PR`, (b) more than one available transition matches `In PR`, or (c) Jira reports required transition fields whose values were not supplied.
+- **FR-008**: System MUST NOT modify any field on MM-652 other than its workflow status, and MUST NOT modify any issue other than MM-652.
+- **FR-009**: System MUST NOT emit Jira credentials, API tokens, auth headers, cookies, or full environment dumps in any user-visible output, log, or artifact, including failure reports.
+- **FR-010**: System MUST report, on completion, the issue key, the prior status, the action taken (transitioned, no-op, or stopped with reason), and the verified final status.
+
+### Key Entities
+
+- **Jira Issue (MM-652)**: The single tracked work item being acted on; identified by its issue key, with attributes for current workflow status and a list of currently available workflow transitions.
+- **Workflow Transition**: A named operation exposed by Jira that moves an issue from its current status to a target status; identified by transition ID and target status name.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After a successful run, 100% of operator verifications of MM-652 in the Jira tracker show the workflow status as `In PR`.
+- **SC-002**: 100% of runs end in exactly one of three outcomes — transitioned, no-op (already `In PR`), or stopped with a named error — with zero partial mutations of MM-652.
+- **SC-003**: Across all run outputs, logs, and artifacts, zero secrets (API tokens, auth headers, cookies, raw credentials) are exposed.
+- **SC-004**: No Jira issue other than MM-652 is modified by the run, verifiable by inspecting the run report and Jira change history.
+- **SC-005**: The run completes within a single operator-observed cycle (no manual follow-up to retry the same status change is required when MM-652 is in an eligible source status).

--- a/specs/331-transition-mm652-in-pr/spec.md
+++ b/specs/331-transition-mm652-in-pr/spec.md
@@ -1,50 +1,50 @@
-# Feature Specification: Transition Jira Issue MM-652 to "In PR"
+# Feature Specification: Transition Jira Issue MM-652 to "In Progress"
 
 **Feature Branch**: `change-jira-issue-mm-652-to-status-in-pr-60e1a2aa`
 **Created**: 2026-05-09
 **Status**: Draft
-**Input**: User description: "Change Jira issue MM-652 to status 'In PR'."
+**Input**: User description: "Change Jira issue MM-652 to status 'In Progress'."
 
 <!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
 
-## User Story - Move MM-652 into "In PR"
+## User Story - Move MM-652 into "In Progress"
 
-**Summary**: As a delivery operator, I want the system to move Jira issue MM-652 to the "In PR" workflow status so that the issue tracker reflects that the change associated with MM-652 is awaiting pull-request review.
+**Summary**: As a delivery operator, I want the system to move Jira issue MM-652 to the "In Progress" workflow status so that the issue tracker reflects that implementation has started.
 
-**Goal**: After the workflow runs, MM-652's Jira workflow status is "In PR", with no other fields on MM-652 mutated and no other Jira issues modified.
+**Goal**: After the workflow runs, MM-652's Jira workflow status is "In Progress", with no other fields on MM-652 mutated and no other Jira issues modified.
 
-**Independent Test**: Can be fully tested by running the workflow against issue key `MM-652` and then re-fetching the issue from the Jira tracker to confirm its current status reads "In PR" (or, if it was already "In PR", that the workflow recorded a no-op rather than performing a redundant transition).
+**Independent Test**: Can be fully tested by running the workflow against issue key `MM-652` and then re-fetching the issue from the Jira tracker to confirm its current status reads "In Progress" (or, if it was already "In Progress", that the workflow recorded a no-op rather than performing a redundant transition).
 
 **Acceptance Scenarios**:
 
-1. **Given** MM-652 is in a workflow status from which an "In PR" transition is available, **When** the workflow runs against `MM-652`, **Then** MM-652's status becomes "In PR" and the result reports the issue key, the prior status, the chosen transition, and the verified post-transition status.
-2. **Given** MM-652 is already in status "In PR", **When** the workflow runs against `MM-652`, **Then** no transition is performed, no other fields are changed, and the result reports a no-op with the current status.
-3. **Given** MM-652 is in a workflow status from which no transition leads to "In PR", **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit "no matching transition" error, MM-652 is not modified, and the report names the available transition options.
-4. **Given** MM-652 has more than one available transition whose target status name matches "In PR" (case-insensitive), **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit ambiguity error, MM-652 is not modified, and the report lists the candidate transitions for operator selection.
+1. **Given** MM-652 is in a workflow status from which an "In Progress" transition is available, **When** the workflow runs against `MM-652`, **Then** MM-652's status becomes "In Progress" and the result reports the issue key, the prior status, the chosen transition, and the verified post-transition status.
+2. **Given** MM-652 is already in status "In Progress", **When** the workflow runs against `MM-652`, **Then** no transition is performed, no other fields are changed, and the result reports a no-op with the current status.
+3. **Given** MM-652 is in a workflow status from which no transition leads to "In Progress", **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit "no matching transition" error, MM-652 is not modified, and the report names the available transition options.
+4. **Given** MM-652 has more than one available transition whose target status name matches "In Progress" (case-insensitive), **When** the workflow runs against `MM-652`, **Then** the workflow stops with an explicit ambiguity error, MM-652 is not modified, and the report lists the candidate transitions for operator selection.
 
 ### Edge Cases
 
 - The trusted Jira tool surface is unavailable or not registered in the runtime: the workflow stops with an explicit "Jira tools unavailable" error and performs no mutation.
 - Authentication or authorization to view/modify MM-652 fails: the workflow stops with a sanitized auth/permission error and performs no mutation; no credentials, tokens, or auth headers appear in any output.
 - Jira returns a transient failure (rate limit or 5xx) during transition discovery or transition execution: the workflow surfaces the failure without retrying through ad-hoc HTTP and without claiming success.
-- The post-transition verification fetch shows a status other than "In PR" (for example, the workflow advanced through an intermediate state): the workflow reports the actual final status and flags the result as not matching the requested target.
+- The post-transition verification fetch shows a status other than "In Progress" (for example, the workflow advanced through an intermediate state): the workflow reports the actual final status and flags the result as not matching the requested target.
 - Jira's transition requires additional fields (such as a resolution or comment) before it will execute: the workflow stops with the named missing fields and performs no mutation rather than guessing values.
 
 ## Assumptions
 
-- "In PR" is a discoverable Jira workflow status reachable from MM-652's current status on the project that owns MM-652.
+- "In Progress" is a discoverable Jira workflow status reachable from MM-652's current status on the project that owns MM-652.
 - The runtime executing this workflow already has access to MoonMind's trusted Jira tool surface (e.g., `jira.get_issue`, `jira.get_transitions`, `jira.transition_issue`); raw Jira REST credentials are not provided to or used by the agent runtime.
-- The brief targets a status transition only — no description, label, assignee, or other field updates are implied by "Change ... to status 'In PR'".
-- Status name matching is case-insensitive and ignores surrounding whitespace, but otherwise compares against the literal target name `In PR`.
+- The brief targets a status transition only — no description, label, assignee, or other field updates are implied by "Change ... to status 'In Progress'".
+- Status name matching is case-insensitive and ignores surrounding whitespace, but otherwise compares against the literal target name `In Progress`.
 
 ## Source Design Requirements
 
 - **DESIGN-REQ-001**: The system MUST update only the Jira issue identified by the literal key `MM-652`.
-  - Source: User brief — `"Change Jira issue MM-652 to status 'In PR'."`
+  - Source: User brief — `"Change Jira issue MM-652 to status 'In Progress'."`
   - Scope: in scope
   - Mapped FR: FR-001, FR-008
-- **DESIGN-REQ-002**: The system MUST drive MM-652 to the workflow status named `In PR`.
-  - Source: User brief — `"... to status 'In PR'."`
+- **DESIGN-REQ-002**: The system MUST drive MM-652 to the workflow status named `In Progress`.
+  - Source: User brief — `"... to status 'In Progress'."`
   - Scope: in scope
   - Mapped FR: FR-003, FR-005, FR-006
 - **DESIGN-REQ-003**: The system MUST treat the request as a status change only, not as a description, comment, or other field edit.
@@ -58,11 +58,11 @@
 
 - **FR-001**: System MUST resolve the update target to the literal Jira issue key `MM-652` and reject any attempt to operate on a different issue key inferred from surrounding text.
 - **FR-002**: System MUST discover MM-652's currently available workflow transitions before performing any mutation.
-- **FR-003**: System MUST select a transition whose target workflow status name equals `In PR` (case-insensitive, trimmed) and whose identity is unambiguous.
+- **FR-003**: System MUST select a transition whose target workflow status name equals `In Progress` (case-insensitive, trimmed) and whose identity is unambiguous.
 - **FR-004**: System MUST execute the selected transition exclusively through MoonMind's trusted Jira tooling, never through ad-hoc HTTP calls or raw Jira credentials in the agent runtime.
 - **FR-005**: System MUST verify the post-transition status by re-reading MM-652 and report the verified final status.
-- **FR-006**: System MUST treat the case where MM-652 is already in status `In PR` as a successful no-op, reporting the current status without invoking a transition.
-- **FR-007**: System MUST stop with an explicit, named error and perform no mutation when (a) no available transition matches `In PR`, (b) more than one available transition matches `In PR`, or (c) Jira reports required transition fields whose values were not supplied.
+- **FR-006**: System MUST treat the case where MM-652 is already in status `In Progress` as a successful no-op, reporting the current status without invoking a transition.
+- **FR-007**: System MUST stop with an explicit, named error and perform no mutation when (a) no available transition matches `In Progress`, (b) more than one available transition matches `In Progress`, or (c) Jira reports required transition fields whose values were not supplied.
 - **FR-008**: System MUST NOT modify any field on MM-652 other than its workflow status, and MUST NOT modify any issue other than MM-652.
 - **FR-009**: System MUST NOT emit Jira credentials, API tokens, auth headers, cookies, or full environment dumps in any user-visible output, log, or artifact, including failure reports.
 - **FR-010**: System MUST report, on completion, the issue key, the prior status, the action taken (transitioned, no-op, or stopped with reason), and the verified final status.
@@ -76,8 +76,8 @@
 
 ### Measurable Outcomes
 
-- **SC-001**: After a successful run, 100% of operator verifications of MM-652 in the Jira tracker show the workflow status as `In PR`.
-- **SC-002**: 100% of runs end in exactly one of three outcomes — transitioned, no-op (already `In PR`), or stopped with a named error — with zero partial mutations of MM-652.
+- **SC-001**: After a successful run, 100% of operator verifications of MM-652 in the Jira tracker show the workflow status as `In Progress`.
+- **SC-002**: 100% of runs end in exactly one of three outcomes — transitioned, no-op (already `In Progress`), or stopped with a named error — with zero partial mutations of MM-652.
 - **SC-003**: Across all run outputs, logs, and artifacts, zero secrets (API tokens, auth headers, cookies, raw credentials) are exposed.
 - **SC-004**: No Jira issue other than MM-652 is modified by the run, verifiable by inspecting the run report and Jira change history.
 - **SC-005**: The run completes within a single operator-observed cycle (no manual follow-up to retry the same status change is required when MM-652 is in an eligible source status).


### PR DESCRIPTION
Change Jira issue MM-652 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.