### PR TITLE
Any of the statuses that are currently colored blue similar to executing, e.g. initializing, planning, etc., should also receive the same shimmer effe

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -406,18 +406,19 @@ describe('Tasks List Entrypoint', () => {
         document.querySelectorAll(
           '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
         ),
-      ).toHaveLength(4);
+      ).toHaveLength(6);
     });
 
     const activePills = document.querySelectorAll<HTMLElement>(
       '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
     );
-    expect(activePills).toHaveLength(4);
+    expect(activePills).toHaveLength(6);
     expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'planning')).toHaveLength(2);
     expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'executing')).toHaveLength(2);
+    expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'finalizing')).toHaveLength(2);
     for (const pill of activePills) {
       const label = pill.dataset.state;
-      if (label !== 'planning' && label !== 'executing') {
+      if (label !== 'planning' && label !== 'executing' && label !== 'finalizing') {
         throw new Error(`Unexpected active status pill state: ${label}`);
       }
       expect(pill.dataset.state).toBe(label);
@@ -456,11 +457,6 @@ describe('Tasks List Entrypoint', () => {
       expect(pill.dataset.effect).toBeUndefined();
     }
 
-    const finalizingPills = nonExecutingStatusPills.filter((pill) => pill.textContent === 'finalizing');
-    expect(finalizingPills.length).toBeGreaterThan(0);
-    for (const pill of finalizingPills) {
-      expect(pill.dataset.effect).toBeUndefined();
-    }
   });
 
   it('keeps started time out of the task list presentation', async () => {

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -58,7 +58,6 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('awaiting_external')).toEqual({
       className: 'status status-awaiting_action',
     });
-    expect(executionStatusPillProps('finalizing').className).toBe('status status-running is-finalizing');
     expect(executionStatusPillProps('paused')).toEqual({ className: 'status status-neutral' });
     expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-cancelled' });
   });

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -6,7 +6,7 @@ import {
 } from './executionStatusPillClasses';
 
 describe('executionStatusPillProps', () => {
-  it('adds shimmer selector metadata for executing and planning status pills', () => {
+  it('adds shimmer selector metadata for blue running status pills', () => {
     expect(executionStatusPillProps('executing')).toMatchObject({
       className: 'status status-running is-executing',
       'data-state': 'executing',
@@ -21,8 +21,25 @@ describe('executionStatusPillProps', () => {
       'data-shimmer-label': 'planning',
     });
 
-    expect(executionStatusPillProps('running')).toEqual({
-      className: 'status status-running',
+    expect(executionStatusPillProps('running')).toMatchObject({
+      className: 'status status-running is-running',
+      'data-state': 'running',
+      'data-effect': 'shimmer-sweep',
+      'data-shimmer-label': 'running',
+    });
+
+    expect(executionStatusPillProps('initializing')).toMatchObject({
+      className: 'status status-running is-initializing',
+      'data-state': 'initializing',
+      'data-effect': 'shimmer-sweep',
+      'data-shimmer-label': 'initializing',
+    });
+
+    expect(executionStatusPillProps('finalizing')).toMatchObject({
+      className: 'status status-running is-finalizing',
+      'data-state': 'finalizing',
+      'data-effect': 'shimmer-sweep',
+      'data-shimmer-label': 'finalizing',
     });
     expect(executionStatusPillProps('waiting')).toEqual({
       className: 'status status-waiting',
@@ -41,9 +58,7 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('awaiting_external')).toEqual({
       className: 'status status-awaiting_action',
     });
-    expect(executionStatusPillProps('finalizing')).toEqual({
-      className: 'status status-running',
-    });
+    expect(executionStatusPillProps('finalizing').className).toBe('status status-running is-finalizing');
     expect(executionStatusPillProps('paused')).toEqual({ className: 'status status-neutral' });
     expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-cancelled' });
   });

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -14,9 +14,11 @@ export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   ],
 });
 
+type ShimmerSweepStatusKey = 'executing' | 'planning' | 'running' | 'initializing' | 'finalizing';
+
 export type ExecutionStatusPillProps = Readonly<{
   className: string;
-  'data-state'?: 'executing' | 'planning';
+  'data-state'?: ShimmerSweepStatusKey;
   'data-effect'?: 'shimmer-sweep';
   'data-shimmer-label'?: string;
 }>;
@@ -51,11 +53,23 @@ function executionStatusVisibleLabel(status: string | null | undefined): string 
   return formatStatusLabel(status, 'executing');
 }
 
+const SHIMMER_SWEEP_STATUS_KEYS = new Set<ShimmerSweepStatusKey>([
+  'executing',
+  'planning',
+  'running',
+  'initializing',
+  'finalizing',
+]);
+
+function isShimmerSweepStatusKey(key: string): key is ShimmerSweepStatusKey {
+  return SHIMMER_SWEEP_STATUS_KEYS.has(key as ShimmerSweepStatusKey);
+}
+
 export function executionStatusPillProps(status: string | null | undefined): ExecutionStatusPillProps {
   const key = normalizedExecutionStatusKey(status);
   const className = executionStatusBaseClasses(key);
 
-  if (key === 'executing' || key === 'planning') {
+  if (isShimmerSweepStatusKey(key)) {
     return {
       className: `${className} is-${key}`,
       'data-state': key,

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -14,7 +14,8 @@ export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   ],
 });
 
-type ShimmerSweepStatusKey = 'executing' | 'planning' | 'running' | 'initializing' | 'finalizing';
+const SHIMMER_SWEEP_KEYS = ['executing', 'planning', 'running', 'initializing', 'finalizing'] as const;
+type ShimmerSweepStatusKey = (typeof SHIMMER_SWEEP_KEYS)[number];
 
 export type ExecutionStatusPillProps = Readonly<{
   className: string;
@@ -53,16 +54,10 @@ function executionStatusVisibleLabel(status: string | null | undefined): string 
   return formatStatusLabel(status, 'executing');
 }
 
-const SHIMMER_SWEEP_STATUS_KEYS = new Set<ShimmerSweepStatusKey>([
-  'executing',
-  'planning',
-  'running',
-  'initializing',
-  'finalizing',
-]);
+const SHIMMER_SWEEP_STATUS_KEYS = new Set<string>(SHIMMER_SWEEP_KEYS);
 
 function isShimmerSweepStatusKey(key: string): key is ShimmerSweepStatusKey {
-  return SHIMMER_SWEEP_STATUS_KEYS.has(key as ShimmerSweepStatusKey);
+  return SHIMMER_SWEEP_STATUS_KEYS.has(key);
 }
 
 export function executionStatusPillProps(status: string | null | undefined): ExecutionStatusPillProps {


### PR DESCRIPTION
Any of the statuses that are currently colored blue similar to executing, e.g. initializing, planning, etc., should also receive the same shimmer effect used with executing.