### PR TITLE
Run Jira Orchestrate for MM-572: Preview and apply Preset steps

### DIFF
--- a/specs/331-preview-apply-preset-steps-mm-572/checklists/requirements.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/checklists/requirements.md
@@ -1,0 +1,24 @@
+# Requirements Quality Checklist: Preview and Apply Preset Steps
+
+**Feature**: `specs/331-preview-apply-preset-steps-mm-572`  
+**Reviewed**: 2026-05-09
+
+## Content Quality
+
+- [X] No implementation details in `spec.md` requirements.
+- [X] User value and acceptance scenarios are clear.
+- [X] Requirements are testable.
+- [X] Edge cases are identified.
+- [X] Source traceability preserves `MM-572`, `STORY-004`, and `manual-mm-569-mm-574`.
+
+## Current Step Boundary
+
+- [X] Handoff artifacts are created.
+- [X] Implementation is not run inline.
+- [X] Downstream tasks clearly identify remaining Jira Orchestrate work.
+
+## Readiness
+
+- [X] Requirements have no story-critical unresolved clarifications.
+- [X] Success criteria are measurable.
+- [X] Source design references are mapped.

--- a/specs/331-preview-apply-preset-steps-mm-572/contracts/create-page-preset-preview-apply.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/contracts/create-page-preset-preview-apply.md
@@ -1,0 +1,28 @@
+# Contract: Create Page Preset Preview and Apply
+
+## Authoring Contract
+
+The Create page must expose `Preset` as a Step Type in the step editor alongside `Tool` and `Skill`.
+
+Required behavior:
+
+1. Selecting `Preset` shows a preset selector and schema-driven input form.
+2. The form is driven by preset capability metadata, not preset-specific Create page branches.
+3. Preview requests call the backend-owned preset expansion path with the selected preset, version, and inputs.
+4. Preview renders generated step titles, generated Step Types, warnings, and blocking errors before draft mutation.
+5. Apply replaces the temporary Preset step with concrete Tool and/or Skill steps only when preview is valid.
+6. Generated steps remain editable and validate under their own Tool or Skill rules.
+7. Submission rejects unresolved Preset placeholders by default.
+
+## Failure Contract
+
+Preview or apply failure must:
+
+- leave the existing draft unchanged,
+- show visible author feedback,
+- preserve editable Preset step inputs,
+- prevent stale preview data from being applied.
+
+## Management Separation
+
+Preset use for the current task belongs in the step editor. The Presets management area may manage catalog lifecycle and audit, but must not be required to choose, preview, or apply a preset to the current draft.

--- a/specs/331-preview-apply-preset-steps-mm-572/data-model.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Preview and Apply Preset Steps
+
+## Preset Step Draft
+
+Temporary authoring state for a step whose Step Type is `Preset`.
+
+Fields:
+
+- `stepType`: normalized value `preset`
+- `presetId`: selected preset/capability identifier
+- `version`: selected active or previewable preset version
+- `inputs`: schema-validated preset input values
+- `previewState`: optional current preview result or stale/error state
+
+Validation:
+
+- `presetId` must resolve to an existing preset.
+- `version` must be active or explicitly previewable.
+- `inputs` must satisfy the selected preset input schema.
+- Stale preview data must not be applied after `presetId`, `version`, or `inputs` change.
+
+## Preset Expansion Preview
+
+Deterministic generated step list plus warnings or errors shown before application.
+
+Fields:
+
+- `generatedSteps`: ordered Tool and/or Skill step previews with titles and Step Types
+- `warnings`: visible non-blocking expansion warnings
+- `errors`: blocking expansion or validation errors
+- `sourcePreset`: preset identity/version and input snapshot used for expansion
+
+Validation:
+
+- Generated steps must satisfy their Tool or Skill contracts before application succeeds.
+- Policy and step limits must be enforced before generated steps are inserted into the draft.
+
+## Preset-Derived Executable Step
+
+Concrete Tool or Skill step inserted by applying a valid preset expansion.
+
+Fields:
+
+- `stepType`: `tool` or `skill`
+- `title`: editable generated title
+- `tool` or `skill`: executable binding and inputs
+- `provenance`: preset source metadata when available
+
+Validation:
+
+- The step validates under its own Tool or Skill rules before executable submission.
+- Provenance is audit/reconstruction metadata, not hidden runtime work.
+
+## Submission Boundary
+
+Executable submission state derived from the authored draft.
+
+Rules:
+
+- Unresolved Preset steps must be expanded or rejected before runtime execution.
+- Generated Tool and Skill steps submit as executable steps.
+- Runtime workflows must not execute unresolved Preset steps by catalog lookup unless a separate linked-preset mode is explicitly introduced.

--- a/specs/331-preview-apply-preset-steps-mm-572/data-model.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/data-model.md
@@ -10,7 +10,7 @@ Fields:
 - `presetId`: selected preset/capability identifier
 - `version`: selected active or previewable preset version
 - `inputs`: schema-validated preset input values
-- `previewState`: optional current preview result or stale/error state
+- `previewState`: optional current Preset Expansion Preview or stale/error state
 
 Validation:
 
@@ -44,7 +44,7 @@ Fields:
 - `stepType`: `tool` or `skill`
 - `title`: editable generated title
 - `tool` or `skill`: executable binding and inputs
-- `provenance`: preset source metadata when available
+- `provenance`: preset source metadata preserved from the applied expansion
 
 Validation:
 

--- a/specs/331-preview-apply-preset-steps-mm-572/plan.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Preview and Apply Preset Steps
+
+**Branch**: `run-jira-orchestrate-for-mm-572-preview-d49b5fcf` | **Date**: 2026-05-09 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story Jira Orchestrate handoff for `MM-572` / `STORY-004`
+
+## Summary
+
+`MM-572` asks Jira Orchestrate to handle the "Preview and apply Preset steps" story from the `manual-mm-569-mm-574` source set. This current task is the task creation/handoff step, so implementation is intentionally not run inline. The feature artifacts preserve the `MM-572` source and define the downstream runtime work that the existing Jira Orchestrate/MoonSpec workflow should resume.
+
+Prior related MoonSpec features exist for this product area:
+
+- `specs/278-preview-apply-preset-steps` (`MM-558`)
+- `specs/284-preview-apply-preset-executable-steps` (`MM-565`)
+- `specs/291-preview-apply-preset-steps` (`MM-578`)
+
+Those artifacts may provide implementation evidence when the downstream implementation/verification step is authorized, but they do not replace this `MM-572` traceability record.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | pending_downstream_verification | `docs/Steps/StepTypes.md` defines `preset` as a Step Type. | Verify/create step-editor Preset selection. | Focused Create page tests |
+| FR-002 | pending_downstream_verification | Existing task-template services are expected to own detail/expand validation. | Verify preset existence/version/input validation. | Focused UI/API tests as needed |
+| FR-003 | pending_downstream_verification | Design requires deterministic expansion preview. | Verify generated title/type/warning preview. | Focused Create page tests |
+| FR-004 | pending_downstream_verification | Design requires apply to replace Preset placeholder. | Verify replacement with concrete Tool/Skill steps. | Focused Create page tests |
+| FR-005 | pending_downstream_verification | Design requires generated steps to remain ordinary editable steps. | Verify editability after apply. | Focused Create page tests |
+| FR-006 | pending_downstream_verification | Design requires unresolved Preset steps not to execute by default. | Verify unresolved submission block and generated step validation. | Focused Create page tests |
+| FR-007 | pending_downstream_verification | Design separates management from use. | Verify Presets management is not required for authoring apply. | Focused Create page tests |
+| FR-008 | pending_downstream_verification | Design requires visible validation feedback. | Verify failed preview/apply leaves draft unchanged. | Focused Create page tests |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present in the repository  
+**Primary Dependencies**: React, TanStack Query, existing task-template catalog/detail/expand endpoints, Vitest and Testing Library  
+**Storage**: Existing task draft and submission payload state only; no new persistent storage planned  
+**Unit Testing**: `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: Create page render/submission tests exercise the UI state, mocked task-template API calls, and submit payload boundary  
+**Target Platform**: Mission Control web UI  
+**Project Type**: Web application frontend in the existing repository  
+**Constraints**: Preserve task-template expansion endpoint semantics, generated step mapping, and separation between preset management and preset use  
+**Current Step Boundary**: Handoff/spec artifact creation only; no implementation, Jira transitions, PR creation, or publish work in this step
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. This handoff points to existing Jira Orchestrate and task-template expansion flows.
+- II. One-Click Agent Deployment: PASS. No deployment prerequisite changes.
+- III. Avoid Vendor Lock-In: PASS. Preset behavior is provider-neutral.
+- IV. Own Your Data: PASS. Uses repo-local spec artifacts and MoonMind-owned task state.
+- V. Skills Are First-Class and Easy to Add: PASS. Generated Skill steps remain first-class executable steps.
+- VI. Scientific Method: PASS. Downstream work is framed as testable verification and implementation.
+- VII. Runtime Configurability: PASS. No hardcoded runtime/provider behavior added.
+- VIII. Modular and Extensible Architecture: PASS. Work stays within Create page/task-template boundaries.
+- IX. Resilient by Default: PASS. Runtime execution of unresolved Preset placeholders is explicitly disallowed.
+- X. Facilitate Continuous Improvement: PASS. The handoff records source and next action.
+- XI. Spec-Driven Development: PASS. `MM-572` spec and plan precede implementation.
+- XII. Canonical Documentation Separation: PASS. Runtime delivery artifacts stay under `specs/`.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden transforms are introduced.
+
+## Project Structure
+
+```text
+specs/331-preview-apply-preset-steps-mm-572/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-preset-preview-apply.md
+├── tasks.md
+├── checklists/
+│   └── requirements.md
+└── verification.md
+```
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Current Step Outcome
+
+This step creates `MM-572` MoonSpec/Jira Orchestrate handoff artifacts only. Downstream implementation remains pending for the existing Jira Orchestrate workflow.

--- a/specs/331-preview-apply-preset-steps-mm-572/plan.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/plan.md
@@ -23,7 +23,7 @@ Those artifacts may provide implementation evidence when the downstream implemen
 | FR-002 | pending_downstream_verification | Existing task-template services are expected to own detail/expand validation. | Verify preset existence/version/input validation. | Focused UI/API tests as needed |
 | FR-003 | pending_downstream_verification | Design requires deterministic expansion preview. | Verify generated title/type/warning preview. | Focused Create page tests |
 | FR-004 | pending_downstream_verification | Design requires apply to replace Preset placeholder. | Verify replacement with concrete Tool/Skill steps. | Focused Create page tests |
-| FR-005 | pending_downstream_verification | Design requires generated steps to remain ordinary editable steps. | Verify editability after apply. | Focused Create page tests |
+| FR-005 | pending_downstream_verification | Design requires generated steps to remain ordinary editable steps with audit provenance. | Verify editability and provenance preservation after apply. | Focused Create page tests |
 | FR-006 | pending_downstream_verification | Design requires unresolved Preset steps not to execute by default. | Verify unresolved submission block and generated step validation. | Focused Create page tests |
 | FR-007 | pending_downstream_verification | Design separates management from use. | Verify Presets management is not required for authoring apply. | Focused Create page tests |
 | FR-008 | pending_downstream_verification | Design requires visible validation feedback. | Verify failed preview/apply leaves draft unchanged. | Focused Create page tests |

--- a/specs/331-preview-apply-preset-steps-mm-572/quickstart.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: Preview and Apply Preset Steps
+
+## Current Step
+
+This task creation step is complete when the `MM-572` MoonSpec handoff artifacts exist and preserve:
+
+- target Jira issue `MM-572`,
+- source story `STORY-004`,
+- source Jira issue `manual-mm-569-mm-574`,
+- original brief reference `Jira issue MM-572 recommended preset brief`,
+- explicit note that implementation was not run inline.
+
+## Downstream Verification Commands
+
+Run these only when the Jira Orchestrate implementation or verification step is authorized:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected result: focused Create page coverage proves Preset selection, preview, apply, failure handling, and unresolved submission blocking for the `MM-572` story or identifies the remaining implementation gap.

--- a/specs/331-preview-apply-preset-steps-mm-572/research.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/research.md
@@ -1,0 +1,27 @@
+# Research: Preview and Apply Preset Steps
+
+## Decision: Preserve a separate MM-572 feature directory
+
+Decision: Create `specs/331-preview-apply-preset-steps-mm-572` rather than reusing the existing `MM-558`, `MM-565`, or `MM-578` feature directories.
+
+Rationale: Existing related artifacts cover the same product area but preserve different Jira issue keys. The task instruction explicitly requires `MM-572`, `STORY-004`, and `manual-mm-569-mm-574` traceability.
+
+Alternatives considered: Updating an existing related feature directory was rejected because it would blur source traceability across Jira issues.
+
+## Decision: Treat docs/Steps/StepTypes.md as the source design
+
+Decision: Use `docs/Steps/StepTypes.md` as the source design for Step Type and Preset behavior.
+
+Rationale: The document is the canonical desired-state Step Type model and defines `tool`, `skill`, and `preset` semantics, including authoring-time expansion, validation, and runtime boundaries.
+
+## Decision: Stop at handoff artifacts in this step
+
+Decision: Do not implement, verify, transition Jira, create a pull request, or publish in this task creation step.
+
+Rationale: The current managed step boundary and `MM-572` brief explicitly say not to run implementation inline inside the task creation step. The proper next runtime action is the existing Jira Orchestrate/MoonSpec workflow.
+
+## Decision: Preserve prior related artifacts as evidence candidates
+
+Decision: Record prior related specs as possible downstream evidence, not as substitutes for `MM-572`.
+
+Rationale: `specs/291-preview-apply-preset-steps` contains verification-focused evidence for a closely related story, but `MM-572` still needs its own traceable handoff and downstream verification decision.

--- a/specs/331-preview-apply-preset-steps-mm-572/spec.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/spec.md
@@ -34,7 +34,7 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 
 **Goal**: Task authors can use reusable Presets transparently during task authoring while generated executable Tool and Skill steps remain editable and unresolved Preset placeholders do not reach runtime execution.
 
-**Independent Test**: Render the task authoring surface, choose Step Type `Preset`, select and configure an available preset, preview generated steps and warnings, apply the preset, and verify the draft contains editable executable Tool and/or Skill steps while unresolved Preset submission remains blocked.
+**Independent Test**: Render the task authoring surface, choose Step Type `Preset`, and verify that submission is blocked. Select and configure an available preset, preview generated steps and warnings, apply the preset, and verify the draft contains editable executable Tool and/or Skill steps.
 
 **Acceptance Scenarios**:
 
@@ -80,7 +80,7 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **FR-002**: The system MUST validate that the selected preset exists, the selected version is active or explicitly previewable, and input values are valid before preview or apply succeeds.
 - **FR-003**: The system MUST preview configured Preset expansion deterministically and list generated step titles, Step Types, and warnings before application.
 - **FR-004**: Applying a valid Preset expansion MUST replace the temporary Preset placeholder with concrete executable Tool and/or Skill steps.
-- **FR-005**: Preset-derived generated steps MUST remain editable like ordinary executable steps after application.
+- **FR-005**: Preset-derived generated steps MUST remain editable like ordinary executable steps after application and MUST include provenance metadata for audit purposes.
 - **FR-006**: Generated Tool and Skill steps MUST validate under their own rules before executable submission, and unresolved Preset steps MUST be rejected by default.
 - **FR-007**: Preset management and preset use MUST remain separate; the Presets management section MUST NOT be required for choosing and applying a preset to the current task draft.
 - **FR-008**: Preview/apply failure states MUST leave the current draft unchanged and show visible author feedback.
@@ -89,7 +89,7 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 
 - **Preset Step Draft**: Temporary authored step with Step Type `Preset`, selected preset identity/version, and input values.
 - **Preset Expansion Preview**: Deterministic generated step list plus warnings or errors shown before application.
-- **Preset-Derived Executable Step**: Concrete Tool or Skill step inserted by applying a preset, including available provenance metadata.
+- **Preset-Derived Executable Step**: Concrete Tool or Skill step inserted by applying a preset, including preserved provenance metadata.
 
 ## Success Criteria
 

--- a/specs/331-preview-apply-preset-steps-mm-572/spec.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Preview and Apply Preset Steps
+
+**Feature Branch**: `run-jira-orchestrate-for-mm-572-preview-d49b5fcf`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Input**: Jira Orchestrate handoff for `MM-572`.
+
+Preserved source:
+
+- Source story: `STORY-004`
+- Source summary: Preview and apply Preset steps
+- Source Jira issue: `manual-mm-569-mm-574`
+- Target Jira issue: `MM-572`
+- Original brief reference: Jira issue `MM-572` recommended preset brief
+
+Current step boundary: create the Jira Orchestrate/MoonSpec handoff artifacts for `MM-572` only. Implementation, verification, Jira transition, pull request creation, and downstream publish work are intentionally not run inline in this task creation step.
+
+## Original Preset Brief
+
+```text
+Run Jira Orchestrate for MM-572.
+
+Source story: STORY-004.
+Source summary: Preview and apply Preset steps.
+Source Jira issue: manual-mm-569-mm-574.
+Original brief reference: Jira issue MM-572 recommended preset brief.
+
+Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside this task creation step.
+```
+
+## User Story - Preview and Apply Preset Steps
+
+**Summary**: As a task author, I can select a Preset inside the step editor, configure inputs, preview generated steps, and apply the preset into ordinary executable steps.
+
+**Goal**: Task authors can use reusable Presets transparently during task authoring while generated executable Tool and Skill steps remain editable and unresolved Preset placeholders do not reach runtime execution.
+
+**Independent Test**: Render the task authoring surface, choose Step Type `Preset`, select and configure an available preset, preview generated steps and warnings, apply the preset, and verify the draft contains editable executable Tool and/or Skill steps while unresolved Preset submission remains blocked.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author is editing a step, **When** they choose Step Type `Preset`, **Then** the step editor lets them select and configure a preset from the same authoring surface used for Tool and Skill steps.
+2. **Given** a configured Preset step, **When** the author requests preview, **Then** the system lists generated steps before application and shows visible expansion warnings or errors.
+3. **Given** the previewed expansion is valid, **When** the author applies the preset, **Then** the temporary Preset placeholder is replaced by concrete editable Tool and/or Skill steps.
+4. **Given** generated steps came from a preset, **When** the author reviews or edits the draft, **Then** generated steps validate under their own Tool or Skill rules before executable submission.
+5. **Given** a Preset step remains unresolved, **When** the author submits the task, **Then** submission is rejected by default with visible feedback.
+6. **Given** Preset management exists elsewhere, **When** the author is choosing and applying a preset to the current task, **Then** the separate Presets management section is not required.
+
+### Edge Cases
+
+- The selected preset is missing, inactive, or not previewable; preview and apply are blocked with visible feedback.
+- Preset inputs fail validation; the draft remains unchanged and the author sees actionable feedback.
+- Deterministic expansion fails or generated Tool/Skill steps are invalid; apply is blocked and the Preset step remains editable.
+- Expansion succeeds with warnings; warnings are visible before the author applies the preset.
+- The author changes the selected preset or inputs after preview; stale preview data is invalidated before apply.
+
+## Assumptions
+
+- Runtime mode applies because this story changes task authoring and submission behavior, not only documentation.
+- `docs/Steps/StepTypes.md` is the canonical design source for Step Type and Preset semantics.
+- Existing task-template catalog/detail/expand services are the authoritative source for preset preview and application.
+- Prior related artifacts for `MM-558`, `MM-565`, and `MM-578` may provide implementation evidence, but this feature directory preserves `MM-572` traceability separately.
+- Preset management remains separate from preset use; this story does not require new preset catalog management screens.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Steps/StepTypes.md` sections 2, 4, 6.3 | `preset` is a canonical Step Type and an authoring-time composition step. | In scope | FR-001, FR-006 |
+| DESIGN-REQ-002 | `docs/Steps/StepTypes.md` sections 5, 6.3 | Capability input contracts and schema-driven forms drive preset configuration without preset-specific UI branches. | In scope | FR-001, FR-002 |
+| DESIGN-REQ-003 | `docs/Steps/StepTypes.md` sections 6.3, 8.4 | Preset expansion is deterministic and validated before execution. | In scope | FR-002, FR-003, FR-008 |
+| DESIGN-REQ-004 | `docs/Steps/StepTypes.md` sections 4, 7.1 | Runtime workflows must not execute unresolved Preset steps by default. | In scope | FR-006 |
+| DESIGN-REQ-005 | `docs/Steps/StepTypes.md` sections 3, 4 | Preset provenance is audit/reconstruction metadata, not hidden runtime work. | In scope | FR-004, FR-005 |
+| DESIGN-REQ-006 | `docs/Steps/StepTypes.md` sections 6.3, 12 | Preset management and preset use are separate experiences. | In scope | FR-007 |
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The step editor MUST allow authors to select Step Type `Preset` and choose/configure a preset from the same authoring surface used for Tool and Skill steps.
+- **FR-002**: The system MUST validate that the selected preset exists, the selected version is active or explicitly previewable, and input values are valid before preview or apply succeeds.
+- **FR-003**: The system MUST preview configured Preset expansion deterministically and list generated step titles, Step Types, and warnings before application.
+- **FR-004**: Applying a valid Preset expansion MUST replace the temporary Preset placeholder with concrete executable Tool and/or Skill steps.
+- **FR-005**: Preset-derived generated steps MUST remain editable like ordinary executable steps after application.
+- **FR-006**: Generated Tool and Skill steps MUST validate under their own rules before executable submission, and unresolved Preset steps MUST be rejected by default.
+- **FR-007**: Preset management and preset use MUST remain separate; the Presets management section MUST NOT be required for choosing and applying a preset to the current task draft.
+- **FR-008**: Preview/apply failure states MUST leave the current draft unchanged and show visible author feedback.
+
+### Key Entities
+
+- **Preset Step Draft**: Temporary authored step with Step Type `Preset`, selected preset identity/version, and input values.
+- **Preset Expansion Preview**: Deterministic generated step list plus warnings or errors shown before application.
+- **Preset-Derived Executable Step**: Concrete Tool or Skill step inserted by applying a preset, including available provenance metadata.
+
+## Success Criteria
+
+- **SC-001**: Frontend tests cover selecting Step Type `Preset`, configuring a preset, previewing generated steps, and applying expansion into the draft.
+- **SC-002**: Validation tests cover missing/failing preset expansion, generated-step validation failure, stale preview invalidation, and unresolved Preset submission blocking.
+- **SC-003**: Preview shows generated step titles, Step Types, and expansion warnings before apply.
+- **SC-004**: Applied preset-derived Tool and Skill steps are editable and submit as executable steps rather than Preset placeholders.
+- **SC-005**: The task author can apply a preset from the step editor without using a separate Presets management section.

--- a/specs/331-preview-apply-preset-steps-mm-572/tasks.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Preview and Apply Preset Steps
+
+**Input**: Design documents from `/specs/331-preview-apply-preset-steps-mm-572/`  
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/
+
+**Current Step Boundary**: This task creation step creates handoff artifacts only. Downstream implementation, verification, Jira transitions, pull request creation, and publish work must run only when the existing Jira Orchestrate workflow authorizes those steps.
+
+**Source Traceability**: `MM-572`, `STORY-004`, `manual-mm-569-mm-574`, FR-001..FR-008, SC-001..SC-005, DESIGN-REQ-001..DESIGN-REQ-006.
+
+## Phase 1: Handoff Setup
+
+- [X] T001 Create the `MM-572` MoonSpec feature directory using the next global spec number.
+- [X] T002 Preserve target Jira issue `MM-572`, source story `STORY-004`, source Jira issue `manual-mm-569-mm-574`, and the original brief reference in `spec.md`.
+- [X] T003 Record that this step does not run implementation inline and must defer implementation to the existing Jira Orchestrate workflow.
+
+## Phase 2: Downstream Planning
+
+- [ ] T004 Confirm whether prior related artifacts for `MM-558`, `MM-565`, or `MM-578` already satisfy the `MM-572` source requirements.
+- [ ] T005 If implementation evidence is insufficient, add or update focused Create page tests for Preset selection, preview, apply, failure handling, and unresolved submission blocking.
+- [ ] T006 If focused tests fail, update `frontend/src/entrypoints/task-create.tsx` within the existing task-template preview/apply boundaries.
+
+## Phase 3: Downstream Verification
+
+- [ ] T007 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`.
+- [ ] T008 Run final MoonSpec verification against `MM-572` and record the verdict in `verification.md`.
+
+## Dependencies & Execution Order
+
+T001-T003 are complete in this task creation step. T004-T008 are intentionally pending for the downstream Jira Orchestrate implementation/verification step.

--- a/specs/331-preview-apply-preset-steps-mm-572/verification.md
+++ b/specs/331-preview-apply-preset-steps-mm-572/verification.md
@@ -1,0 +1,31 @@
+# MoonSpec Verification Report
+
+**Feature**: Preview and Apply Preset Steps  
+**Spec**: `specs/331-preview-apply-preset-steps-mm-572/spec.md`  
+**Original Request Source**: Jira Orchestrate handoff for `MM-572` / `STORY-004` from `manual-mm-569-mm-574`  
+**Verdict**: HANDOFF_ONLY  
+**Confidence**: HIGH for task-creation completion; no determination for implementation completion
+
+## Current Step Result
+
+This task creation step created traceable `MM-572` MoonSpec/Jira Orchestrate handoff artifacts and did not run implementation inline.
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Artifact sanity | `git diff --check` | PASS | No whitespace errors found. |
+| Implementation tests | Not run | SKIPPED | Implementation and verification are outside this task creation step. |
+
+## Coverage Status
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Source traceability | VERIFIED | `MM-572`, `STORY-004`, `manual-mm-569-mm-574`, and original brief reference are preserved. |
+| Spec/plan/task handoff | VERIFIED | Downstream tasks identify the remaining Jira Orchestrate work. |
+| Runtime implementation | NOT_RUN | Explicitly deferred by the current step boundary. |
+| Final MoonSpec verification | NOT_RUN | Must run in the downstream Jira Orchestrate implementation/verification step. |
+
+## Remaining Work
+
+Run the existing Jira Orchestrate/MoonSpec implementation and verification flow for `MM-572`, starting from these artifacts and resuming at the first incomplete downstream task.


### PR DESCRIPTION
Run Jira Orchestrate for MM-572.

Source story: STORY-004.
Source summary: Preview and apply Preset steps.
Source Jira issue: manual-mm-569-mm-574.
Original brief reference: Jira issue MM-572 recommended preset brief.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside this task creation step.