### PR TITLE
MM-573: Compile executable steps into runtime plans

### DIFF
--- a/specs/332-compile-executable-runtime-plans/checklists/requirements.md
+++ b/specs/332-compile-executable-runtime-plans/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Compile Executable Steps into Runtime Plans
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves `MM-573`, source issue `manual-mm-569-mm-574`, the canonical Jira preset brief, and source design mappings for DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, and DESIGN-REQ-022.
+- PASS: The request is classified as a single-story runtime feature request focused on compiling flattened executable Tool and Skill steps into runtime plans.

--- a/specs/332-compile-executable-runtime-plans/contracts/runtime-step-plan-contract.md
+++ b/specs/332-compile-executable-runtime-plans/contracts/runtime-step-plan-contract.md
@@ -1,0 +1,119 @@
+# Contract: Runtime Step Plan Compilation
+
+## Scope
+
+This contract covers MM-573 runtime payload and proposal promotion boundaries. It preserves target Jira issue `MM-573`, source issue `manual-mm-569-mm-574`, and the original Jira preset brief as traceability inputs.
+
+## Executable Task Payload
+
+Executable payloads submitted to runtime planning must use flattened step entries:
+
+```json
+{
+  "task": {
+    "steps": [
+      {
+        "id": "fetch-issue",
+        "type": "tool",
+        "instructions": "Fetch the Jira issue.",
+        "tool": {
+          "id": "jira.get_issue",
+          "version": "1.0.0",
+          "inputs": {"issueKey": "MM-573"}
+        },
+        "source": {
+          "kind": "preset-derived",
+          "presetSlug": "jira-orchestrate",
+          "presetVersion": "1.0.0"
+        }
+      },
+      {
+        "id": "implement-story",
+        "type": "skill",
+        "instructions": "Implement the selected story.",
+        "skill": {
+          "id": "moonspec-implement",
+          "version": "1.0.0",
+          "inputs": {}
+        }
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `task.steps[].type` must be `tool` or `skill` at executable runtime boundaries.
+- Tool steps require `tool.id` or `tool.name` and may carry versioned inputs.
+- Skill steps require an executable skill selector.
+- `source` and `authoredPresets` are audit metadata, not live runtime catalog lookups.
+- `type: "preset"`, include nodes, or unresolved preset placeholders are rejected before runtime execution.
+
+## Runtime Plan Node Output
+
+Planning converts each executable step to a runtime node:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "fetch-issue",
+      "tool": {
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0"
+      },
+      "inputs": {
+        "instructions": "Fetch the Jira issue.",
+        "selectedSkill": "jira.get_issue",
+        "type": "tool",
+        "issueKey": "MM-573"
+      }
+    }
+  ],
+  "edges": []
+}
+```
+
+Rules:
+
+- Tool steps map to typed tool invocation plan nodes.
+- Skill steps map to plan nodes, skill activities, child workflows, or managed-session requests as selected by runtime policy.
+- Step order is preserved with sequential edges for multi-step plans.
+- Unsupported runtime node executor types fail explicitly.
+
+## Proposal Promotion Boundary
+
+Promotion from reviewed proposal to execution must use the stored reviewed task payload:
+
+```json
+{
+  "task": {
+    "authoredPresets": [{"presetId": "runtime-quality-followup"}],
+    "steps": [
+      {
+        "id": "step-1",
+        "type": "skill",
+        "instructions": "Run reviewed work.",
+        "skill": {"id": "auto"},
+        "source": {"kind": "preset-derived"}
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- Promotion validates the reviewed flat payload.
+- Promotion preserves preset provenance.
+- Promotion rejects unresolved `type: "preset"` steps.
+- Promotion must not call live preset expansion or silently refresh to the latest catalog definition.
+
+## Required Verification
+
+- Unit: task contract rejects unresolved Preset/include steps.
+- Unit: runtime planner maps Tool and Skill steps to expected plan nodes/materialization inputs.
+- Unit: proposal promotion preserves reviewed flattened payload and does not live re-expand.
+- Integration: task-shaped submission boundary preserves flattened steps and provenance if API/execution boundary behavior changes.

--- a/specs/332-compile-executable-runtime-plans/data-model.md
+++ b/specs/332-compile-executable-runtime-plans/data-model.md
@@ -1,0 +1,96 @@
+# Data Model: Compile Executable Steps into Runtime Plans
+
+## Executable Step
+
+Durable task step that can be compiled into runtime work without additional authoring expansion.
+
+Fields:
+
+- `id`: stable step identifier used for plan node identity and step ledger rows.
+- `type`: canonical executable Step Type; valid runtime values are `tool` and `skill`.
+- `title`: optional operator-facing label.
+- `instructions`: step-scoped instructions or fallback task instructions.
+- `tool`: Tool step binding with id/name, optional version, and inputs.
+- `skill`: Skill step binding with id/name, optional version, and inputs.
+- `source`: optional preset/source provenance metadata.
+
+Validation:
+
+- `type` must be `tool` or `skill` for executable payloads.
+- `tool` steps require a valid tool payload and must not carry conflicting skill payloads.
+- `skill` steps require a valid skill payload or accepted skill selector shape.
+- `preset` and unresolved include work are rejected before runtime plan execution.
+
+## Runtime Plan Node
+
+Runtime representation derived from one executable step.
+
+Fields:
+
+- `id`: plan node id, normally from the step id.
+- `tool.type`: runtime executor discriminator such as `skill` or `agent_runtime`.
+- `tool.name`: selected tool, skill, activity, or runtime mode name.
+- `tool.version`: selected version when applicable.
+- `inputs`: merged task, step, tool, skill, source, and instruction inputs needed for execution.
+- `edges`: sequential dependencies between generated nodes when multiple steps are present.
+
+Validation:
+
+- Tool nodes must carry enough identity and input data to resolve a typed execution path.
+- Skill nodes may materialize as skill activities, child workflows, plan nodes, or managed-session requests.
+- Unsupported `tool.type` values fail explicitly.
+
+## Preset Provenance
+
+Audit and reconstruction metadata attached to preset-derived executable work.
+
+Fields:
+
+- `kind`: `manual`, `preset-derived`, `preset-include`, or `detached`.
+- `presetId` or `presetSlug`: source preset identity.
+- `presetVersion`: source preset version.
+- `includePath`: ordered preset include path when the step came from recursive composition.
+- `originalStepId`: step id from the source preset when available.
+
+Validation:
+
+- Provenance is optional for manual work.
+- Provenance does not authorize runtime catalog lookup after expansion.
+- Provenance must stay compact and safe for workflow payloads and proposal metadata.
+
+## Promoted Proposal Payload
+
+Reviewed task payload promoted from a proposal into execution.
+
+Fields:
+
+- `task.steps`: flattened executable Tool/Skill steps.
+- `task.authoredPresets`: optional authored preset bindings.
+- `task.appliedStepTemplates`: optional applied template summary and composition metadata.
+- `task.sourceSteps`: optional compact source-step metadata for proposal candidates.
+
+Validation:
+
+- Promotion validates the stored reviewed payload.
+- Promotion rejects unresolved Preset steps and preset-derived steps that are not flattened executable steps.
+- Promotion must not silently re-expand a live preset catalog entry.
+
+## State Transitions
+
+```text
+Draft Preset Step
+  -> preview/apply or submit-time expansion
+  -> Executable Step list with provenance
+  -> Durable task payload / reviewed proposal payload
+  -> Runtime Plan Nodes
+  -> Temporal activity, child workflow, managed session, or typed tool execution
+```
+
+Invalid path:
+
+```text
+Unresolved Preset Step
+  -> runtime plan node
+```
+
+This path is rejected unless a future explicit linked-preset runtime mode is specified in a separate story.

--- a/specs/332-compile-executable-runtime-plans/plan.md
+++ b/specs/332-compile-executable-runtime-plans/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Compile Executable Steps into Runtime Plans
+
+**Branch**: `332-compile-executable-runtime-plans` | **Date**: 2026-05-09 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story runtime specification from the MM-573 Jira preset brief.  
+**Jira**: MM-573; source issue `manual-mm-569-mm-574`
+
+## Summary
+
+MM-573 requires execution to run from reviewed, flattened executable Tool and Skill steps rather than unresolved Preset placeholders or live catalog re-expansion. The current repository already has substantial contract and boundary behavior: canonical task step validation rejects unresolved `preset`/include steps, runtime planning turns explicit Tool/Skill steps into plan nodes, child Jira Orchestrate runs expand stored task-template provenance before execution, recursive preset metadata is preserved at task-shaped submission boundaries, and proposal promotion rejects unresolved preset steps while preserving preset provenance.
+
+The remaining planning focus is to preserve MM-573 traceability and add focused verification coverage where the current evidence is indirect: Skill-step runtime materialization, promotion's no-live-reexpansion rule, and end-to-end evidence that durable executable payloads remain independent of live preset catalog changes after review/submit. Implementation should start test-first and only change code if those verification tests expose a gap.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `TaskStepSpec` rejects non-Tool/Skill step types; task-shaped submission tests assert no `preset` step remains after compiled preset submission. | Add/confirm boundary tests for durable executable payloads containing only Tool/Skill steps after submit and promotion. | unit + integration |
+| FR-002 | implemented_verified | `_build_runtime_planner()` maps explicit Tool steps into typed skill/tool invocation plan nodes; `test_runtime_planner_preserves_authored_task_plan_tool_nodes` asserts tool identity, inputs, type, and source. | No code expected; keep traceability in tasks and final verify. | none beyond final verify |
+| FR-003 | implemented_unverified | Runtime planner supports explicit multi-step payloads and `MoonMind.Run` dispatches `agent_runtime` child workflows or skill activities, but MM-573-specific Skill-step mapping proof should be explicit. | Add focused runtime planner test for explicit Skill step mapping to managed-session/activity materialization without changing Step Type semantics. | unit |
+| FR-004 | implemented_verified | `TaskStepSource`, `AuthoredPresetBinding`, API/router tests, integration tests, and worker-runtime expansion preserve preset source/authored metadata without requiring live catalog for already-expanded steps. | No code expected unless final verify finds a missing field. | none beyond final verify |
+| FR-005 | implemented_unverified | Proposal service tests preserve preset provenance and reject unresolved preset steps; provider approval test creates execution from stored snapshot. | Add/confirm promotion test that reviewed flattened payload is promoted as-is and does not re-expand from live preset catalog. | unit |
+| FR-006 | implemented_verified | `TaskExecutionSpec` rejects `type: preset` and unresolved include work; plan parser rejects unresolved preset include nodes; proposal service rejects unresolved preset promotion. | No code expected; preserve regression coverage. | none beyond final verify |
+| FR-007 | missing | `spec.md` preserves MM-573 and `manual-mm-569-mm-574`; this plan begins downstream preservation. | Preserve issue keys and original brief through plan, tasks, implementation notes, verification, commit text, and PR metadata. | final verify |
+| SCN-001 | implemented_unverified | Runtime planner handles explicit executable steps. | Verify Tool and Skill plan node compilation together in an MM-573-focused test. | unit |
+| SCN-002 | implemented_verified | Tool-step runtime planner test covers typed tool plan node mapping. | No new implementation expected. | none beyond final verify |
+| SCN-003 | implemented_unverified | Runtime supports agent child workflow and skill activity dispatch, but explicit Skill-step mapping should be tested at planner boundary. | Add focused Skill-step runtime planner test. | unit |
+| SCN-004 | implemented_verified | Preset provenance and authored preset metadata are preserved by task contract, API, integration, and proposal tests. | No new implementation expected. | none beyond final verify |
+| SCN-005 | implemented_unverified | Proposal promotion tests preserve provenance and reject unresolved preset steps. | Add no-live-reexpansion assertion using a stored reviewed payload. | unit |
+| SCN-006 | implemented_verified | Contract, plan parser, and proposal service reject unresolved Preset/include work. | No new implementation expected. | none beyond final verify |
+| SC-001 | implemented_unverified | Tool-step compilation and unresolved-preset rejection are covered separately. | Add combined runtime compilation test for Tool/Skill and unresolved Preset behavior. | unit |
+| SC-002 | implemented_verified | Existing recursive preset/API/integration tests preserve preset-derived source/authored metadata and do not require live catalog after expanded payload submission. | No new implementation expected. | none beyond final verify |
+| SC-003 | implemented_unverified | Proposal tests cover preservation/rejection but not an explicit no-live-reexpansion negative control. | Add promotion regression that changing/removing catalog data cannot alter reviewed flattened payload. | unit |
+| SC-004 | implemented_verified | Contract and proposal validation reject unresolved preset payloads with explicit errors. | No new implementation expected. | none beyond final verify |
+| SC-005 | missing | Traceability is present in `spec.md` and this plan only. | Preserve traceability in all remaining MoonSpec artifacts and delivery metadata. | final verify |
+| DESIGN-REQ-006 | implemented_unverified | Task contract rejects non-executable step types; submission tests assert expanded payload contains no `preset` steps. | Add/confirm MM-573-focused executable payload test. | unit + integration |
+| DESIGN-REQ-007 | implemented_verified | Runtime planner test covers Tool step to typed plan node mapping. | No new implementation expected. | none beyond final verify |
+| DESIGN-REQ-012 | implemented_unverified | Runtime planner and `MoonMind.Run` support skill/agent materialization paths. | Add explicit Skill-step mapping test. | unit |
+| DESIGN-REQ-018 | implemented_verified | Contract, plan parser, and proposal tests reject unresolved Preset/include work. | No new implementation expected. | none beyond final verify |
+| DESIGN-REQ-020 | implemented_verified | Task source/authored preset models and API/integration/proposal tests preserve provenance while executing flattened steps. | No new implementation expected. | none beyond final verify |
+| DESIGN-REQ-021 | implemented_unverified | Proposal promotion validates stored payload and preserves provenance. | Add no-live-reexpansion promotion test. | unit |
+| DESIGN-REQ-022 | implemented_unverified | Existing proposal tests reject unresolved preset steps but do not explicitly simulate live catalog drift. | Add explicit no-live-reexpansion regression. | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12 for task contract, runtime planner, Temporal workflow, proposal service, API route, and tests; TypeScript/React only if Create-page submit behavior regresses.  
+**Primary Dependencies**: Pydantic v2 task contract models, FastAPI execution route/service boundary, Temporal Python SDK runtime planner and workflow dispatch, existing task-template catalog, task proposal service, pytest.  
+**Storage**: Existing Temporal execution records, artifact-backed original task input snapshots, task payload metadata, and proposal stored payloads only; no new persistent tables planned.  
+**Unit Testing**: `./tools/test_unit.sh`; focused iteration with `pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q`.  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci` coverage when API/execution boundary behavior changes; focused local check with `pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -m integration_ci -q` when needed.  
+**Target Platform**: MoonMind API service and Temporal managed task execution on Linux containers.  
+**Project Type**: Python backend workflow/control plane with existing React authoring surfaces.  
+**Performance Goals**: Runtime planning remains linear in step count and bounded by existing step limits; no live preset catalog lookup after executable payload review/submit.  
+**Constraints**: Preserve Temporal payload safety, avoid embedding large preset content in workflow history, do not mutate checked-in skill folders, do not add internal compatibility aliases, fail explicitly for unsupported runtime step types, preserve MM-573 and `manual-mm-569-mm-574` traceability.  
+**Scale/Scope**: One runtime-contract slice spanning canonical task step validation, runtime plan generation, proposal promotion, and execution-boundary verification.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The plan strengthens MoonMind orchestration contracts and uses existing agent/runtime adapters.
+- II. One-Click Agent Deployment: PASS. No new services, secrets, or deployment prerequisites.
+- III. Avoid Vendor Lock-In: PASS. Tool/Skill/Preset semantics are provider-neutral and adapter-backed.
+- IV. Own Your Data: PASS. Durable executable payloads, provenance, and snapshots remain MoonMind-owned data.
+- V. Skills Are First-Class: PASS. Skill steps remain first-class executable runtime units.
+- VI. Replaceable Scaffolding / Thick Contracts: PASS. Work centers on explicit task and runtime plan contracts.
+- VII. Runtime Configurability: PASS. Runtime/profile selection remains payload/config driven; no hardcoded provider behavior.
+- VIII. Modular and Extensible Architecture: PASS. Work stays inside task contract, runtime planner, proposal, and boundary tests.
+- IX. Resilient by Default: PASS. Unresolved Preset work fails before execution and reviewed executable payloads avoid catalog drift.
+- X. Continuous Improvement: PASS. Planning preserves evidence and final verification requirements.
+- XI. Spec-Driven Development: PASS. `spec.md`, this plan, and design artifacts preserve MM-573 before implementation.
+- XII. Canonical Docs vs Tmp: PASS. Source docs remain desired-state; rollout and implementation notes live under `specs/332-compile-executable-runtime-plans/`.
+- XIII. Pre-release Compatibility: PASS. No compatibility aliases or hidden transforms are planned; unsupported step types fail explicitly.
+
+**Post-design re-check**: PASS. Phase 1 artifacts keep the same boundaries and introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/332-compile-executable-runtime-plans/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── runtime-step-plan-contract.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+└── workflows/
+    ├── tasks/task_contract.py
+    ├── temporal/worker_runtime.py
+    ├── temporal/workflows/run.py
+    └── task_proposals/service.py
+
+api_service/
+└── api/routers/executions.py
+
+tests/
+├── unit/workflows/tasks/test_task_contract.py
+├── unit/workflows/temporal/test_temporal_worker_runtime.py
+├── unit/workflows/task_proposals/test_service.py
+├── unit/api/routers/test_executions.py
+└── integration/temporal/test_task_shaped_submission_normalization.py
+```
+
+## Complexity Tracking
+
+No constitution violations or extra complexity accepted.

--- a/specs/332-compile-executable-runtime-plans/quickstart.md
+++ b/specs/332-compile-executable-runtime-plans/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Compile Executable Steps into Runtime Plans
+
+## Preconditions
+
+- Work from `specs/332-compile-executable-runtime-plans/spec.md`.
+- Preserve `MM-573`, source issue `manual-mm-569-mm-574`, and the original preset brief in downstream artifacts and delivery metadata.
+- Use test-first implementation. Add failing unit or integration tests before changing production code when a requirement is not already verified.
+
+## Focused Unit Verification
+
+Run focused tests while iterating:
+
+```bash
+pytest tests/unit/workflows/tasks/test_task_contract.py \
+  tests/unit/workflows/temporal/test_temporal_worker_runtime.py \
+  tests/unit/workflows/task_proposals/test_service.py -q
+```
+
+Expected coverage:
+
+- `TaskExecutionSpec` rejects unresolved `preset` and include work.
+- Runtime planner maps explicit Tool steps to typed plan nodes.
+- Runtime planner maps explicit Skill steps to acceptable runtime materialization inputs.
+- Proposal promotion rejects unresolved preset steps.
+- Proposal promotion preserves reviewed flattened payload and preset provenance without live re-expansion.
+
+## Full Unit Verification
+
+Before completing implementation, run:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Hermetic Integration Verification
+
+Run when API/execution-boundary behavior changes:
+
+```bash
+./tools/test_integration.sh
+```
+
+Focused integration target when iterating locally:
+
+```bash
+pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -m integration_ci -q
+```
+
+Expected coverage:
+
+- Submitted task-shaped payloads preserve flattened executable steps.
+- Preset-derived source/authored metadata remains compact and durable.
+- Manual-only submissions do not gain fabricated preset metadata.
+
+## End-to-End Story Check
+
+1. Build or select a reviewed task payload derived from a preset.
+2. Confirm durable `task.steps` contains only `tool` and `skill` step types.
+3. Confirm each Tool step maps to a typed tool plan node.
+4. Confirm each Skill step maps to an accepted runtime materialization path without changing the Step Type contract.
+5. Confirm preset provenance is present for audit but no live preset catalog lookup is required to execute.
+6. Confirm promotion validates the reviewed payload and rejects unresolved Preset steps.
+7. Confirm final verification compares behavior against the preserved MM-573 Jira preset brief.
+
+## Expected Next Step
+
+After this plan is accepted, run `/speckit.tasks` or the active `moonspec-tasks` workflow to generate TDD-first tasks from `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, and this quickstart.

--- a/specs/332-compile-executable-runtime-plans/research.md
+++ b/specs/332-compile-executable-runtime-plans/research.md
@@ -1,0 +1,65 @@
+# Research: Compile Executable Steps into Runtime Plans
+
+## FR-001 / Durable Payload Uses Executable Steps
+
+Decision: implemented_unverified; existing contract and submission boundaries reject unresolved preset work, but MM-573 should add or confirm focused executable-payload evidence.
+Evidence: `moonmind/workflows/tasks/task_contract.py` rejects `task.steps[].type` values outside `tool` and `skill`; `tests/integration/temporal/test_task_shaped_submission_normalization.py` asserts compiled recursive preset submissions contain no `preset` steps.
+Rationale: Current evidence is strong across adjacent stories, but MM-573 specifically needs runtime-plan traceability for flattened executable payloads.
+Alternatives considered: Treat existing recursive-preset evidence as complete; rejected because final verification should compare directly against MM-573.
+Test implications: unit plus hermetic integration when boundary behavior changes.
+
+## FR-002 / Tool Step Runtime Plan Mapping
+
+Decision: implemented_verified; no implementation expected unless final verification finds a drift.
+Evidence: `moonmind/workflows/temporal/worker_runtime.py` selects explicit step type and tool payloads when building multi-step plan nodes; `tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_preserves_authored_task_plan_tool_nodes` asserts Tool step identity, inputs, selected skill, type, and source are preserved in the generated plan node.
+Rationale: The current test directly covers Tool step to typed plan-node mapping with provenance.
+Alternatives considered: Rework runtime plan format; rejected because the existing plan node contract is already accepted by `MoonMind.Run`.
+Test implications: none beyond final verify.
+
+## FR-003 / Skill Step Runtime Materialization
+
+Decision: implemented_unverified; add a focused unit test for explicit Skill step mapping.
+Evidence: `moonmind/workflows/temporal/worker_runtime.py` builds multi-step plan nodes and `moonmind/workflows/temporal/workflows/run.py` dispatches `agent_runtime` nodes to child workflows and `skill` nodes to activities. Existing tests cover surrounding paths but MM-573 needs a direct Skill-step mapping assertion.
+Rationale: Skill mapping can be satisfied by multiple runtime materializations, so test evidence should assert the contract without overfitting to one adapter.
+Alternatives considered: Mark verified from workflow dispatch code alone; rejected because plan skill guidance requires tests for unverified behavior.
+Test implications: unit.
+
+## FR-004 / Preset Provenance Without Live Runtime Lookup
+
+Decision: implemented_verified; no implementation expected.
+Evidence: `TaskStepSource` and `AuthoredPresetBinding` models preserve preset provenance; API and integration tests preserve recursive preset metadata; worker-runtime child expansion writes flattened `steps`, `authoredPresets`, `appliedStepTemplates`, and `composition`; proposal tests preserve preset-derived source metadata.
+Rationale: Provenance is structured metadata attached to executable steps and task payloads, not a runtime lookup dependency.
+Alternatives considered: Re-expand from live catalog during runtime; rejected because source design forbids catalog drift from changing executable intent.
+Test implications: none beyond final verify.
+
+## FR-005 / Proposal Promotion Uses Reviewed Flat Payload
+
+Decision: implemented_unverified; add a no-live-reexpansion regression around proposal promotion.
+Evidence: `tests/unit/workflows/task_proposals/test_service.py` covers preserved preset provenance, rejection of preset-derived steps without flat type, and rejection of unresolved preset steps; `tests/integration/temporal/test_proposal_review_delivery.py` shows provider approval creates one run from the stored snapshot and ignores edited provider text.
+Rationale: Existing tests cover most promotion semantics but should explicitly prove the promoted execution is not recomputed from a live preset catalog entry.
+Alternatives considered: Trust stored snapshot tests only; rejected because MM-573 explicitly calls out silent live re-expansion.
+Test implications: unit.
+
+## FR-006 / Unresolved Preset Steps Are Rejected Or Expanded Before Execution
+
+Decision: implemented_verified; no implementation expected.
+Evidence: `tests/unit/workflows/tasks/test_task_contract.py` rejects unresolved include work and non-executable `preset` step types; `tests/unit/workflows/test_skill_plan_runtime.py` rejects unresolved preset include nodes in plan definitions; `tests/unit/workflows/task_proposals/test_service.py` rejects unresolved preset promotion.
+Rationale: The repository already fails explicitly before runtime plan execution for unresolved preset/include work.
+Alternatives considered: Allow runtime linked-preset fallback; rejected because linked-preset execution is out of scope and would violate the source design.
+Test implications: none beyond final verify.
+
+## FR-007 / MM-573 Traceability
+
+Decision: missing until all downstream artifacts and final delivery metadata preserve it.
+Evidence: `specs/332-compile-executable-runtime-plans/spec.md` preserves MM-573, `manual-mm-569-mm-574`, and the original Jira preset brief; this plan and design artifacts continue that chain.
+Rationale: Final verification and PR metadata must be able to compare the implementation against the original brief.
+Alternatives considered: Preserve only the issue key; rejected because `/speckit.verify` compares against the original brief.
+Test implications: final verify.
+
+## Test Strategy
+
+Decision: use unit tests for task contract, runtime planner, and proposal promotion; use hermetic integration tests only when API/execution boundary behavior changes.
+Evidence: Existing suites already cover task contract validation, worker runtime planning, task proposal promotion, API task-shaped submission, and integration normalization.
+Rationale: Most likely remaining work is verification-first unit coverage; integration is needed if new code changes API submission or worker execution boundaries.
+Alternatives considered: Provider verification; rejected because MM-573 is local task/runtime contract behavior and needs no external credentials.
+Test implications: `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` if boundary changes are made.

--- a/specs/332-compile-executable-runtime-plans/spec.md
+++ b/specs/332-compile-executable-runtime-plans/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Compile Executable Steps into Runtime Plans
+
+**Feature Branch**: `332-compile-executable-runtime-plans`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Input**: User description: """
+Use the Jira preset brief for MM-573 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+Preserve source issue manual-mm-569-mm-574 traceability.
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-573 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-573
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Compile executable steps into runtime plans
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; potentially related custom fields `Implementation plan`, `Backout plan`, and `Test plan` were present but empty.
+- Trusted response artifact: `/work/agent_jobs/mm:e2310203-c332-4714-9c20-66bf68a3f43f/artifacts/moonspec-inputs/MM-573-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-573 from MM project
+Summary: Compile executable steps into runtime plans
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+Source Jira issue: manual-mm-569-mm-574
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-573 and source issue manual-mm-569-mm-574 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-573: Compile executable steps into runtime plans
+
+Source Reference
+Source Document: docs/Steps/StepTypes.md
+Source Title: Step Types
+Source Sections:
+- 7.1 Authoring payload
+- 7.2 Runtime plan mapping
+- 11. API Shape
+- 13. Proposal and Promotion Semantics
+- 14. Migration Guidance
+- 15. Non-Goals
+
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-012
+- DESIGN-REQ-018
+- DESIGN-REQ-020
+- DESIGN-REQ-021
+- DESIGN-REQ-022
+
+As an operator, submitted tasks execute from flattened Tool and Skill steps so runtime correctness does not depend on unresolved presets or live catalog re-expansion.
+
+Acceptance Criteria
+- Executable submissions normally accept only Tool and Skill steps.
+- Tool steps map to typed tool plan nodes.
+- Skill steps map to plan nodes, child workflows, activities, or managed sessions without changing the Step Type UI contract.
+- Preset steps produce no runtime node by default.
+- Preset provenance is retained for audit and reconstruction but is not required to execute.
+- Promotion validates the reviewed flat payload and never silently re-expands a live preset.
+
+Requirements
+- Durable execution payloads should contain expanded executable steps by default.
+- Preset-derived execution must not depend on live catalog lookup at runtime.
+- Proposal promotion must preserve executable intent.
+
+## MoonSpec Classification Input
+
+Classify this as a single-story runtime feature request for Step Type runtime execution: submitted and promoted tasks must execute from flattened executable Tool and Skill steps, map those steps into runtime plan nodes or runtime execution boundaries, retain Preset provenance for audit, and avoid unresolved Preset runtime nodes or live catalog re-expansion during execution.
+"""
+
+Preserved source traceability:
+
+- Target Jira issue: `MM-573`
+- Source Jira issue: `manual-mm-569-mm-574`
+- Source design: `docs/Steps/StepTypes.md`
+- Original orchestration input artifact: `/work/agent_jobs/mm:e2310203-c332-4714-9c20-66bf68a3f43f/artifacts/moonspec-inputs/MM-573-moonspec-orchestration-input.md`
+- Classification: single-story runtime feature request.
+- Resume decision: no existing Moon Spec feature directory preserved `MM-573`, so Specify is the first incomplete stage.
+
+## User Story - Runtime Executes Flattened Steps
+
+**Summary**: As an operator, I want submitted and promoted tasks to execute from flattened Tool and Skill steps so runtime correctness does not depend on unresolved presets or live catalog re-expansion.
+
+**Goal**: Executable submissions and promoted proposals carry a durable, reviewed, flattened step payload that the runtime can compile into executable plan nodes while preserving preset provenance for audit and reconstruction.
+
+**Independent Test**: Submit or promote a task that originated from a preset, inspect the durable execution payload and runtime plan, and verify that only Tool and Skill steps are executable, each maps to the expected runtime materialization, preset provenance remains available, and no live preset catalog lookup is needed to execute the task.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task submission contains concrete Tool and Skill steps, **When** the runtime accepts the executable payload, **Then** it compiles only those executable steps into runtime plan nodes.
+2. **Given** an executable Tool step is present, **When** the runtime plan is built, **Then** the step maps to a typed tool invocation with the reviewed input payload and required governance metadata.
+3. **Given** an executable Skill step is present, **When** the runtime plan is built, **Then** the step maps to a plan node, child workflow, activity, or managed-session request without changing the user-facing Step Type contract.
+4. **Given** preset-derived work reaches runtime, **When** the durable execution payload is inspected, **Then** preset provenance is retained for audit and reconstruction while unresolved Preset steps produce no runtime node by default.
+5. **Given** a reviewed proposal is promoted to execution, **When** promotion validates the stored payload, **Then** it preserves executable intent and does not silently re-expand a live preset catalog entry.
+6. **Given** a payload still contains unresolved Preset steps where executable steps are required, **When** runtime compilation is attempted, **Then** execution is rejected or expansion is completed before workflow creation rather than treating the Preset step as hidden runtime work.
+
+### Edge Cases
+
+- A preset-derived task can be reconstructed for audit from provenance without needing that provenance to execute.
+- A live preset catalog entry may change after a task or proposal is reviewed; existing executable payloads still run from the reviewed flattened content.
+- Skill steps may use different runtime materializations across adapters, but the Step Type UI contract and durable executable intent remain stable.
+- A draft-authoring payload may contain Preset steps, but executable workflow creation must not depend on unresolved Preset runtime nodes.
+- Legacy payload readers may exist during migration, but new durable executable payloads should prefer flattened Tool and Skill steps.
+
+## Assumptions
+
+- Runtime intent applies because the Jira brief asks for executable submission and proposal promotion behavior, not documentation-only changes.
+- `docs/Steps/StepTypes.md` is the source design for Step Type runtime semantics.
+- The related source set `manual-mm-569-mm-574` is a traceability source and does not change the selected target issue, which is `MM-573`.
+- Preset preview and application authoring behavior is covered by the related `MM-572` story; this story focuses on runtime compilation and promotion semantics.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | `docs/Steps/StepTypes.md` sections 9.3 and 9.4 | Runtime execution payloads should contain only executable Tool and Skill steps by default. | In scope | FR-001, FR-004 |
+| DESIGN-REQ-007 | `docs/Steps/StepTypes.md` section 9.4 | Tool steps must map to typed runtime tool invocation plan nodes. | In scope | FR-002 |
+| DESIGN-REQ-012 | `docs/Steps/StepTypes.md` section 9.4 | Skill steps may map to plan nodes, child workflows, activities, or managed-session requests without changing the Step Type UI contract. | In scope | FR-003 |
+| DESIGN-REQ-018 | `docs/Steps/StepTypes.md` sections 9.3, 9.4, and 17 | Preset steps produce no runtime node by default and presets must not become hidden runtime work. | In scope | FR-004, FR-006 |
+| DESIGN-REQ-020 | `docs/Steps/StepTypes.md` sections 9.3 and 16 phase 4 | Preset-derived runtime steps retain provenance but do not require preset catalog lookup for runtime correctness. | In scope | FR-004, FR-005 |
+| DESIGN-REQ-021 | `docs/Steps/StepTypes.md` sections 15 and 16 phase 5 | Proposal promotion preserves executable intent and validates the reviewed payload. | In scope | FR-005 |
+| DESIGN-REQ-022 | `docs/Steps/StepTypes.md` section 15 | Promotion must not silently re-expand a live preset catalog entry; refreshing from a preset is explicit. | In scope | FR-005 |
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Durable executable task payloads MUST contain flattened executable steps by default, limited to Tool and Skill step types unless a separate authoring expansion path completes before workflow creation.
+- **FR-002**: The runtime plan compiler MUST map each Tool step to a typed tool invocation plan node using the reviewed tool identity, version when available, inputs, and required governance metadata.
+- **FR-003**: The runtime plan compiler MUST map each Skill step to the appropriate runtime materialization, such as a plan node, child workflow, activity, or managed-session request, while preserving the Step Type contract visible to authors.
+- **FR-004**: Preset-derived executable steps MUST retain provenance metadata sufficient for audit and reconstruction, but runtime execution MUST NOT require live preset catalog lookup after expansion.
+- **FR-005**: Proposal promotion MUST validate and execute the reviewed flattened payload, preserve executable intent, and avoid silent live preset re-expansion.
+- **FR-006**: The system MUST reject or pre-expand unresolved Preset steps before executable workflow creation; unresolved Preset steps MUST NOT compile into hidden runtime nodes by default.
+- **FR-007**: Downstream artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve target Jira issue `MM-573`, source issue `manual-mm-569-mm-574`, and this original Jira preset brief.
+
+### Key Entities
+
+- **Executable Step**: A durable Tool or Skill step that can be compiled into runtime work without additional authoring expansion.
+- **Runtime Plan Node**: Runtime representation of executable work produced from a Tool or Skill step.
+- **Preset Provenance**: Metadata attached to preset-derived executable steps that identifies preset origin, version or inputs when available, and reconstruction context.
+- **Promoted Proposal Payload**: Reviewed flattened task payload promoted from a proposal into execution.
+
+## Success Criteria
+
+- **SC-001**: Runtime compilation tests show Tool and Skill steps compile into executable plan nodes while unresolved Preset steps do not produce runtime nodes by default.
+- **SC-002**: Tests or verification evidence demonstrate that preset-derived executable steps retain provenance without requiring live preset catalog lookup during runtime execution.
+- **SC-003**: Promotion tests show reviewed flattened proposal payloads execute without silent live preset re-expansion.
+- **SC-004**: Invalid executable submissions containing unresolved Preset steps are rejected or expanded before workflow creation with operator-visible failure details when expansion cannot complete.
+- **SC-005**: Source traceability review confirms `MM-573`, `manual-mm-569-mm-574`, the canonical Jira preset brief, and DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, and DESIGN-REQ-022 are preserved in MoonSpec artifacts.

--- a/specs/332-compile-executable-runtime-plans/tasks.md
+++ b/specs/332-compile-executable-runtime-plans/tasks.md
@@ -13,16 +13,16 @@ Requirement status from `plan.md`: implemented_unverified rows require verificat
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm active feature directory is `specs/332-compile-executable-runtime-plans` in `.specify/feature.json` and that `spec.md` contains exactly one `## User Story` section. (FR-007, SC-005)
-- [ ] T002 Confirm `specs/332-compile-executable-runtime-plans/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, and `quickstart.md` exist before implementation. (FR-007, SC-005)
-- [ ] T003 Review existing runtime plan, task contract, proposal promotion, API normalization, and integration evidence in `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/task_proposals/service.py`, `api_service/api/routers/executions.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, FR-003, FR-005, DESIGN-REQ-006, DESIGN-REQ-012, DESIGN-REQ-021, DESIGN-REQ-022)
+- [X] T001 Confirm active feature directory is `specs/332-compile-executable-runtime-plans` in `.specify/feature.json` and that `spec.md` contains exactly one `## User Story` section. (FR-007, SC-005)
+- [X] T002 Confirm `specs/332-compile-executable-runtime-plans/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, and `quickstart.md` exist before implementation. (FR-007, SC-005)
+- [X] T003 Review existing runtime plan, task contract, proposal promotion, API normalization, and integration evidence in `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/task_proposals/service.py`, `api_service/api/routers/executions.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, FR-003, FR-005, DESIGN-REQ-006, DESIGN-REQ-012, DESIGN-REQ-021, DESIGN-REQ-022)
 
 ## Phase 2: Foundational
 
-- [ ] T004 Identify reusable runtime planner fixtures in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` for explicit Tool and Skill step payloads without changing production behavior. (FR-001, FR-002, FR-003, SC-001)
-- [ ] T005 Identify reusable task proposal fixtures in `tests/unit/workflows/task_proposals/test_service.py` for reviewed flattened payload promotion and unresolved Preset rejection. (FR-005, FR-006, SC-003, SC-004)
-- [ ] T006 Identify reusable task-shaped submission fixture coverage in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for flattened steps and preset provenance. (FR-001, FR-004, SC-002, DESIGN-REQ-020)
-- [ ] T007 Confirm no database migration, new persistent table, or provider credential setup is required by reviewing `plan.md`, `data-model.md`, and `contracts/runtime-step-plan-contract.md`. (Constitution II, IV, XII)
+- [X] T004 Identify reusable runtime planner fixtures in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` for explicit Tool and Skill step payloads without changing production behavior. (FR-001, FR-002, FR-003, SC-001)
+- [X] T005 Identify reusable task proposal fixtures in `tests/unit/workflows/task_proposals/test_service.py` for reviewed flattened payload promotion and unresolved Preset rejection. (FR-005, FR-006, SC-003, SC-004)
+- [X] T006 Identify reusable task-shaped submission fixture coverage in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for flattened steps and preset provenance. (FR-001, FR-004, SC-002, DESIGN-REQ-020)
+- [X] T007 Confirm no database migration, new persistent table, or provider credential setup is required by reviewing `plan.md`, `data-model.md`, and `contracts/runtime-step-plan-contract.md`. (Constitution II, IV, XII)
 
 ## Phase 3: Story - Runtime Executes Flattened Steps
 
@@ -38,54 +38,54 @@ Requirement status from `plan.md`: implemented_unverified rows require verificat
 
 ### Unit Tests First
 
-- [ ] T008 [P] Add a verification unit test for explicit Skill step runtime planner mapping in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-003, SCN-003, SC-001, DESIGN-REQ-012)
-- [ ] T009 [P] Add a verification unit test that one multi-step executable payload containing both Tool and Skill steps compiles into ordered runtime plan nodes in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-001, FR-002, FR-003, SCN-001, SCN-002, SCN-003, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012)
-- [ ] T010 [P] Add a verification unit test that runtime planner inputs preserve preset-derived source metadata without requiring catalog access in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
-- [ ] T011 [P] Add a proposal promotion unit test proving a reviewed flattened task payload is promoted as stored even when a same-named preset catalog definition would differ or be unavailable in `tests/unit/workflows/task_proposals/test_service.py`. (FR-005, SCN-005, SC-003, DESIGN-REQ-021, DESIGN-REQ-022)
-- [ ] T012 [P] Add or confirm task contract unit coverage that `type: preset`, unresolved include work, and conflicting executable step payloads fail explicitly in `tests/unit/workflows/tasks/test_task_contract.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
-- [ ] T013 [P] Add or confirm proposal promotion unit coverage that unresolved Preset steps and preset-derived steps without flat executable type are rejected in `tests/unit/workflows/task_proposals/test_service.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
+- [X] T008 [P] Add a verification unit test for explicit Skill step runtime planner mapping in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-003, SCN-003, SC-001, DESIGN-REQ-012)
+- [X] T009 [P] Add a verification unit test that one multi-step executable payload containing both Tool and Skill steps compiles into ordered runtime plan nodes in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-001, FR-002, FR-003, SCN-001, SCN-002, SCN-003, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012)
+- [X] T010 [P] Add a verification unit test that runtime planner inputs preserve preset-derived source metadata without requiring catalog access in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
+- [X] T011 [P] Add a proposal promotion unit test proving a reviewed flattened task payload is promoted as stored even when a same-named preset catalog definition would differ or be unavailable in `tests/unit/workflows/task_proposals/test_service.py`. (FR-005, SCN-005, SC-003, DESIGN-REQ-021, DESIGN-REQ-022)
+- [X] T012 [P] Add or confirm task contract unit coverage that `type: preset`, unresolved include work, and conflicting executable step payloads fail explicitly in `tests/unit/workflows/tasks/test_task_contract.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
+- [X] T013 [P] Add or confirm proposal promotion unit coverage that unresolved Preset steps and preset-derived steps without flat executable type are rejected in `tests/unit/workflows/task_proposals/test_service.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
 
 ### Integration Tests First
 
-- [ ] T014 [P] Add or confirm hermetic integration coverage that task-shaped submission preserves flattened Tool/Skill steps and no `preset` step remains in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, SCN-001, SC-004, SC-001, DESIGN-REQ-006)
-- [ ] T015 [P] Add or confirm hermetic integration coverage that preset-derived provenance and authored preset metadata remain compact and durable in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
-- [ ] T016 [P] Add or confirm hermetic integration regression that manual-only task submissions do not gain fabricated preset metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Edge case: manual work, SC-002)
+- [X] T014 [P] Add or confirm hermetic integration coverage that task-shaped submission preserves flattened Tool/Skill steps and no `preset` step remains in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, SCN-001, SC-004, SC-001, DESIGN-REQ-006)
+- [X] T015 [P] Add or confirm hermetic integration coverage that preset-derived provenance and authored preset metadata remain compact and durable in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
+- [X] T016 [P] Add or confirm hermetic integration regression that manual-only task submissions do not gain fabricated preset metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Edge case: manual work, SC-002)
 
 ### Red-First Confirmation
 
-- [ ] T017 Run focused runtime planner tests and confirm the new MM-573 verification tests fail only when expected behavior is missing using `python -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`. (FR-001, FR-002, FR-003, FR-004, SC-001, SC-002)
-- [ ] T018 Run focused proposal promotion tests and confirm the no-live-reexpansion verification fails only if promotion recomputes from live preset data using `python -m pytest tests/unit/workflows/task_proposals/test_service.py -q`. (FR-005, FR-006, SC-003, SC-004)
-- [ ] T019 Run focused task contract tests and confirm unresolved Preset/include rejection coverage remains passing or fails for a real gap using `python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q`. (FR-006, SC-004, DESIGN-REQ-018)
-- [ ] T020 Run focused hermetic integration coverage and confirm task-shaped submission behavior using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci`. (FR-001, FR-004, SC-001, SC-002)
+- [X] T017 Run focused runtime planner tests and confirm the new MM-573 verification tests fail only when expected behavior is missing using `python -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`. (FR-001, FR-002, FR-003, FR-004, SC-001, SC-002)
+- [X] T018 Run focused proposal promotion tests and confirm the no-live-reexpansion verification fails only if promotion recomputes from live preset data using `python -m pytest tests/unit/workflows/task_proposals/test_service.py -q`. (FR-005, FR-006, SC-003, SC-004)
+- [X] T019 Run focused task contract tests and confirm unresolved Preset/include rejection coverage remains passing or fails for a real gap using `python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q`. (FR-006, SC-004, DESIGN-REQ-018)
+- [X] T020 Run focused hermetic integration coverage and confirm task-shaped submission behavior using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci`. (FR-001, FR-004, SC-001, SC-002)
 
 ### Conditional Fallback Implementation For Implemented-Unverified Rows
 
-- [ ] T021 If T008 or T009 fails because explicit Skill steps do not produce acceptable runtime materialization inputs, update multi-step planning in `moonmind/workflows/temporal/worker_runtime.py`. (FR-003, DESIGN-REQ-012)
-- [ ] T022 If T009 or T014 fails because executable payloads can contain unresolved Preset steps at runtime boundaries, tighten validation or normalization in `moonmind/workflows/tasks/task_contract.py` or `api_service/api/routers/executions.py`. (FR-001, DESIGN-REQ-006)
-- [ ] T023 If T010 or T015 fails because preset provenance requires live catalog lookup or is lost before execution, update provenance preservation in `moonmind/workflows/temporal/worker_runtime.py` or `api_service/api/routers/executions.py`. (FR-004, DESIGN-REQ-020)
-- [ ] T024 If T011 fails because promotion re-expands or mutates the reviewed payload, update promotion validation in `moonmind/workflows/task_proposals/service.py`. (FR-005, DESIGN-REQ-021, DESIGN-REQ-022)
-- [ ] T025 If T012 or T013 fails because unresolved Preset/include work is accepted, tighten rejection behavior in `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/task_proposals/service.py`, or `moonmind/workflows/temporal/worker_runtime.py`. (FR-006, DESIGN-REQ-018)
+- [X] T021 Confirm T008 and T009 pass without fallback changes; explicit Skill steps already produce acceptable runtime materialization inputs in `moonmind/workflows/temporal/worker_runtime.py`. (FR-003, DESIGN-REQ-012)
+- [X] T022 Confirm T009 and T014 pass without fallback changes; executable payload boundaries do not retain unresolved Preset steps. (FR-001, DESIGN-REQ-006)
+- [X] T023 Confirm T010 and T015 pass without fallback changes; preset provenance is preserved without live catalog lookup. (FR-004, DESIGN-REQ-020)
+- [X] T024 Confirm T011 passes without fallback changes; promotion uses the reviewed flattened payload without live re-expansion. (FR-005, DESIGN-REQ-021, DESIGN-REQ-022)
+- [X] T025 Confirm T012 and T013 pass without fallback changes; unresolved Preset/include work is rejected before execution. (FR-006, DESIGN-REQ-018)
 
 ### Production Implementation
 
-- [ ] T026 Implement only the minimal runtime planner changes proven necessary by T017 in `moonmind/workflows/temporal/worker_runtime.py`. (FR-001, FR-003, SCN-001, SCN-003)
-- [ ] T027 Implement only the minimal task contract or API normalization changes proven necessary by T019 or T020 in `moonmind/workflows/tasks/task_contract.py` or `api_service/api/routers/executions.py`. (FR-001, FR-006, SCN-006)
-- [ ] T028 Implement only the minimal proposal promotion changes proven necessary by T018 in `moonmind/workflows/task_proposals/service.py`. (FR-005, SCN-005)
-- [ ] T029 Preserve MM-573 and `manual-mm-569-mm-574` references in implementation notes, test names or comments where useful, and final delivery metadata without adding noisy runtime fields in `specs/332-compile-executable-runtime-plans/tasks.md`. (FR-007, SC-005)
+- [X] T026 Confirm no runtime planner production changes were necessary after T017 passed in `moonmind/workflows/temporal/worker_runtime.py`. (FR-001, FR-003, SCN-001, SCN-003)
+- [X] T027 Confirm no task contract or API normalization production changes were necessary after T019 and T020 passed. (FR-001, FR-006, SCN-006)
+- [X] T028 Confirm no proposal promotion production changes were necessary after T018 passed. (FR-005, SCN-005)
+- [X] T029 Preserve MM-573 and `manual-mm-569-mm-574` references in implementation notes, test names or comments where useful, and final delivery metadata without adding noisy runtime fields in `specs/332-compile-executable-runtime-plans/tasks.md`. (FR-007, SC-005)
 
 ### Story Validation
 
-- [ ] T030 Re-run focused unit tests with `python -m pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q`. (FR-001 through FR-006, SC-001 through SC-004)
-- [ ] T031 Re-run focused hermetic integration coverage with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` if any API/execution-boundary task changed production behavior. (FR-001, FR-004, SC-001, SC-002)
-- [ ] T032 Verify `contracts/runtime-step-plan-contract.md` is satisfied by comparing task contract validation, runtime planner output, and proposal promotion behavior against `specs/332-compile-executable-runtime-plans/contracts/runtime-step-plan-contract.md`. (FR-001 through FR-006)
-- [ ] T033 Verify `MM-573`, `manual-mm-569-mm-574`, and the original Jira preset brief remain preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, `quickstart.md`, and `tasks.md`. (FR-007, SC-005)
+- [X] T030 Re-run focused unit tests with `python -m pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q`. (FR-001 through FR-006, SC-001 through SC-004)
+- [X] T031 Re-run focused hermetic integration coverage with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` if any API/execution-boundary task changed production behavior. (FR-001, FR-004, SC-001, SC-002)
+- [X] T032 Verify `contracts/runtime-step-plan-contract.md` is satisfied by comparing task contract validation, runtime planner output, and proposal promotion behavior against `specs/332-compile-executable-runtime-plans/contracts/runtime-step-plan-contract.md`. (FR-001 through FR-006)
+- [X] T033 Verify `MM-573`, `manual-mm-569-mm-574`, and the original Jira preset brief remain preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, `quickstart.md`, and `tasks.md`. (FR-007, SC-005)
 
 ## Final Phase: Polish And Verification
 
-- [ ] T034 Refactor any duplicated test fixtures introduced for MM-573 while keeping behavior unchanged in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/workflows/task_proposals/test_service.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Constitution VI, VIII)
-- [ ] T035 Run the full required unit suite with `./tools/test_unit.sh`. (FR-001 through FR-007)
-- [ ] T036 Run the required hermetic integration suite with `./tools/test_integration.sh` if production code or API/execution-boundary behavior changed; otherwise record why focused integration coverage is sufficient in `specs/332-compile-executable-runtime-plans/verification.md`. (FR-001, FR-004, SC-001, SC-002)
-- [ ] T037 Confirm no provider verification or credentialed tests are required for MM-573 and document any intentionally skipped provider checks in `specs/332-compile-executable-runtime-plans/verification.md`. (Constitution II, III)
+- [X] T034 Refactor any duplicated test fixtures introduced for MM-573 while keeping behavior unchanged in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/workflows/task_proposals/test_service.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Constitution VI, VIII)
+- [X] T035 Run the full required unit suite with `./tools/test_unit.sh`. (FR-001 through FR-007)
+- [X] T036 Run the required hermetic integration suite with `./tools/test_integration.sh` if production code or API/execution-boundary behavior changed; otherwise record why focused integration coverage is sufficient in `specs/332-compile-executable-runtime-plans/verification.md`. (FR-001, FR-004, SC-001, SC-002)
+- [X] T037 Confirm no provider verification or credentialed tests are required for MM-573 and document any intentionally skipped provider checks in `specs/332-compile-executable-runtime-plans/verification.md`. (Constitution II, III)
 - [ ] T038 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-573, `manual-mm-569-mm-574`, the original Jira preset brief, FR-001 through FR-007, acceptance scenarios 1 through 6, SC-001 through SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, commands run, and remaining risks. (FR-007, SC-005)
 
 ## Dependencies And Execution Order

--- a/specs/332-compile-executable-runtime-plans/tasks.md
+++ b/specs/332-compile-executable-runtime-plans/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Compile Executable Steps into Runtime Plans
+
+**Input**: `specs/332-compile-executable-runtime-plans/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, `quickstart.md`  
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, and `quickstart.md` exist for exactly one story.  
+**Unit Test Command**: `./tools/test_unit.sh`  
+**Integration Test Command**: `./tools/test_integration.sh`
+
+## Source Traceability
+
+Target Jira issue `MM-573`, source issue `manual-mm-569-mm-574`, and the original Jira preset brief are preserved in `spec.md`. This task list covers exactly one story: Runtime Executes Flattened Steps. Traceability spans FR-001 through FR-007, acceptance scenarios 1 through 6, edge cases, SC-001 through SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, and `contracts/runtime-step-plan-contract.md`.
+
+Requirement status from `plan.md`: implemented_unverified rows require verification tests first plus conditional fallback implementation if verification fails; implemented_verified rows keep traceability and final validation without new implementation by default; missing traceability requires final verification evidence. No requirement is classified as partial.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm active feature directory is `specs/332-compile-executable-runtime-plans` in `.specify/feature.json` and that `spec.md` contains exactly one `## User Story` section. (FR-007, SC-005)
+- [ ] T002 Confirm `specs/332-compile-executable-runtime-plans/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, and `quickstart.md` exist before implementation. (FR-007, SC-005)
+- [ ] T003 Review existing runtime plan, task contract, proposal promotion, API normalization, and integration evidence in `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/task_proposals/service.py`, `api_service/api/routers/executions.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, FR-003, FR-005, DESIGN-REQ-006, DESIGN-REQ-012, DESIGN-REQ-021, DESIGN-REQ-022)
+
+## Phase 2: Foundational
+
+- [ ] T004 Identify reusable runtime planner fixtures in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` for explicit Tool and Skill step payloads without changing production behavior. (FR-001, FR-002, FR-003, SC-001)
+- [ ] T005 Identify reusable task proposal fixtures in `tests/unit/workflows/task_proposals/test_service.py` for reviewed flattened payload promotion and unresolved Preset rejection. (FR-005, FR-006, SC-003, SC-004)
+- [ ] T006 Identify reusable task-shaped submission fixture coverage in `tests/integration/temporal/test_task_shaped_submission_normalization.py` for flattened steps and preset provenance. (FR-001, FR-004, SC-002, DESIGN-REQ-020)
+- [ ] T007 Confirm no database migration, new persistent table, or provider credential setup is required by reviewing `plan.md`, `data-model.md`, and `contracts/runtime-step-plan-contract.md`. (Constitution II, IV, XII)
+
+## Phase 3: Story - Runtime Executes Flattened Steps
+
+**Story Summary**: As an operator, I want submitted and promoted tasks to execute from flattened Tool and Skill steps so runtime correctness does not depend on unresolved presets or live catalog re-expansion.
+
+**Independent Test**: Submit or promote a task that originated from a preset, inspect the durable execution payload and runtime plan, and verify that only Tool and Skill steps are executable, each maps to the expected runtime materialization, preset provenance remains available, and no live preset catalog lookup is needed to execute the task.
+
+**Traceability IDs**: FR-001 through FR-007; acceptance scenarios 1 through 6; SC-001 through SC-005; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022.
+
+**Unit Test Plan**: Add or confirm runtime planner tests for explicit Tool and Skill steps, task contract tests for executable-only step validation, and proposal promotion tests for reviewed flat payload preservation without live preset re-expansion.
+
+**Integration Test Plan**: Confirm existing hermetic integration coverage for task-shaped submission preserves flattened executable steps and compact preset provenance; add coverage only if API/execution-boundary behavior changes.
+
+### Unit Tests First
+
+- [ ] T008 [P] Add a verification unit test for explicit Skill step runtime planner mapping in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-003, SCN-003, SC-001, DESIGN-REQ-012)
+- [ ] T009 [P] Add a verification unit test that one multi-step executable payload containing both Tool and Skill steps compiles into ordered runtime plan nodes in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-001, FR-002, FR-003, SCN-001, SCN-002, SCN-003, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012)
+- [ ] T010 [P] Add a verification unit test that runtime planner inputs preserve preset-derived source metadata without requiring catalog access in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
+- [ ] T011 [P] Add a proposal promotion unit test proving a reviewed flattened task payload is promoted as stored even when a same-named preset catalog definition would differ or be unavailable in `tests/unit/workflows/task_proposals/test_service.py`. (FR-005, SCN-005, SC-003, DESIGN-REQ-021, DESIGN-REQ-022)
+- [ ] T012 [P] Add or confirm task contract unit coverage that `type: preset`, unresolved include work, and conflicting executable step payloads fail explicitly in `tests/unit/workflows/tasks/test_task_contract.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
+- [ ] T013 [P] Add or confirm proposal promotion unit coverage that unresolved Preset steps and preset-derived steps without flat executable type are rejected in `tests/unit/workflows/task_proposals/test_service.py`. (FR-006, SCN-006, SC-004, DESIGN-REQ-018)
+
+### Integration Tests First
+
+- [ ] T014 [P] Add or confirm hermetic integration coverage that task-shaped submission preserves flattened Tool/Skill steps and no `preset` step remains in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-001, SCN-001, SC-004, SC-001, DESIGN-REQ-006)
+- [ ] T015 [P] Add or confirm hermetic integration coverage that preset-derived provenance and authored preset metadata remain compact and durable in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (FR-004, SCN-004, SC-002, DESIGN-REQ-020)
+- [ ] T016 [P] Add or confirm hermetic integration regression that manual-only task submissions do not gain fabricated preset metadata in `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Edge case: manual work, SC-002)
+
+### Red-First Confirmation
+
+- [ ] T017 Run focused runtime planner tests and confirm the new MM-573 verification tests fail only when expected behavior is missing using `python -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`. (FR-001, FR-002, FR-003, FR-004, SC-001, SC-002)
+- [ ] T018 Run focused proposal promotion tests and confirm the no-live-reexpansion verification fails only if promotion recomputes from live preset data using `python -m pytest tests/unit/workflows/task_proposals/test_service.py -q`. (FR-005, FR-006, SC-003, SC-004)
+- [ ] T019 Run focused task contract tests and confirm unresolved Preset/include rejection coverage remains passing or fails for a real gap using `python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q`. (FR-006, SC-004, DESIGN-REQ-018)
+- [ ] T020 Run focused hermetic integration coverage and confirm task-shaped submission behavior using `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci`. (FR-001, FR-004, SC-001, SC-002)
+
+### Conditional Fallback Implementation For Implemented-Unverified Rows
+
+- [ ] T021 If T008 or T009 fails because explicit Skill steps do not produce acceptable runtime materialization inputs, update multi-step planning in `moonmind/workflows/temporal/worker_runtime.py`. (FR-003, DESIGN-REQ-012)
+- [ ] T022 If T009 or T014 fails because executable payloads can contain unresolved Preset steps at runtime boundaries, tighten validation or normalization in `moonmind/workflows/tasks/task_contract.py` or `api_service/api/routers/executions.py`. (FR-001, DESIGN-REQ-006)
+- [ ] T023 If T010 or T015 fails because preset provenance requires live catalog lookup or is lost before execution, update provenance preservation in `moonmind/workflows/temporal/worker_runtime.py` or `api_service/api/routers/executions.py`. (FR-004, DESIGN-REQ-020)
+- [ ] T024 If T011 fails because promotion re-expands or mutates the reviewed payload, update promotion validation in `moonmind/workflows/task_proposals/service.py`. (FR-005, DESIGN-REQ-021, DESIGN-REQ-022)
+- [ ] T025 If T012 or T013 fails because unresolved Preset/include work is accepted, tighten rejection behavior in `moonmind/workflows/tasks/task_contract.py`, `moonmind/workflows/task_proposals/service.py`, or `moonmind/workflows/temporal/worker_runtime.py`. (FR-006, DESIGN-REQ-018)
+
+### Production Implementation
+
+- [ ] T026 Implement only the minimal runtime planner changes proven necessary by T017 in `moonmind/workflows/temporal/worker_runtime.py`. (FR-001, FR-003, SCN-001, SCN-003)
+- [ ] T027 Implement only the minimal task contract or API normalization changes proven necessary by T019 or T020 in `moonmind/workflows/tasks/task_contract.py` or `api_service/api/routers/executions.py`. (FR-001, FR-006, SCN-006)
+- [ ] T028 Implement only the minimal proposal promotion changes proven necessary by T018 in `moonmind/workflows/task_proposals/service.py`. (FR-005, SCN-005)
+- [ ] T029 Preserve MM-573 and `manual-mm-569-mm-574` references in implementation notes, test names or comments where useful, and final delivery metadata without adding noisy runtime fields in `specs/332-compile-executable-runtime-plans/tasks.md`. (FR-007, SC-005)
+
+### Story Validation
+
+- [ ] T030 Re-run focused unit tests with `python -m pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q`. (FR-001 through FR-006, SC-001 through SC-004)
+- [ ] T031 Re-run focused hermetic integration coverage with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` if any API/execution-boundary task changed production behavior. (FR-001, FR-004, SC-001, SC-002)
+- [ ] T032 Verify `contracts/runtime-step-plan-contract.md` is satisfied by comparing task contract validation, runtime planner output, and proposal promotion behavior against `specs/332-compile-executable-runtime-plans/contracts/runtime-step-plan-contract.md`. (FR-001 through FR-006)
+- [ ] T033 Verify `MM-573`, `manual-mm-569-mm-574`, and the original Jira preset brief remain preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-step-plan-contract.md`, `quickstart.md`, and `tasks.md`. (FR-007, SC-005)
+
+## Final Phase: Polish And Verification
+
+- [ ] T034 Refactor any duplicated test fixtures introduced for MM-573 while keeping behavior unchanged in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/workflows/task_proposals/test_service.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Constitution VI, VIII)
+- [ ] T035 Run the full required unit suite with `./tools/test_unit.sh`. (FR-001 through FR-007)
+- [ ] T036 Run the required hermetic integration suite with `./tools/test_integration.sh` if production code or API/execution-boundary behavior changed; otherwise record why focused integration coverage is sufficient in final verification notes. (FR-001, FR-004, SC-001, SC-002)
+- [ ] T037 Confirm no provider verification or credentialed tests are required for MM-573 and document any intentionally skipped provider checks in final verification notes. (Constitution II, III)
+- [ ] T038 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-573, `manual-mm-569-mm-574`, the original Jira preset brief, FR-001 through FR-007, acceptance scenarios 1 through 6, SC-001 through SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, commands run, and remaining risks. (FR-007, SC-005)
+
+## Dependencies And Execution Order
+
+1. Phase 1 setup tasks T001-T003 must complete first.
+2. Phase 2 foundational tasks T004-T007 prepare fixture and boundary review.
+3. Unit tests T008-T013 and integration tests T014-T016 are written before any production implementation.
+4. Red-first confirmation T017-T020 runs before conditional fallback tasks.
+5. Conditional fallback tasks T021-T025 are executed only if verification tests expose gaps.
+6. Production implementation tasks T026-T029 are executed only for confirmed gaps.
+7. Story validation T030-T033 proves the single story before final polish.
+8. Final verification T034-T038 closes the feature.
+
+## Parallel Examples
+
+- T008, T011, T012, and T014 can be drafted in parallel because they target different test files or independent coverage areas.
+- T021 and T024 can run in parallel only if both are needed because they touch different production files.
+- T021 and T026 both touch `moonmind/workflows/temporal/worker_runtime.py`; do not run them in parallel.
+- T030 must wait for all required focused tests and any conditional implementation work.
+
+## Implementation Strategy
+
+Start with verification tests for implemented_unverified rows: explicit Skill-step mapping, combined Tool/Skill runtime plan compilation, no-live-reexpansion proposal promotion, and executable payload boundary coverage. Treat implemented_verified rows as traceability and final validation work unless a new verification test reveals drift. Execute fallback implementation tasks only for failing verification tests, keep changes scoped to the runtime planner, task contract/API normalization, or proposal service, and preserve compact preset provenance without adding live catalog dependencies.

--- a/specs/332-compile-executable-runtime-plans/tasks.md
+++ b/specs/332-compile-executable-runtime-plans/tasks.md
@@ -84,8 +84,8 @@ Requirement status from `plan.md`: implemented_unverified rows require verificat
 
 - [ ] T034 Refactor any duplicated test fixtures introduced for MM-573 while keeping behavior unchanged in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/workflows/task_proposals/test_service.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`. (Constitution VI, VIII)
 - [ ] T035 Run the full required unit suite with `./tools/test_unit.sh`. (FR-001 through FR-007)
-- [ ] T036 Run the required hermetic integration suite with `./tools/test_integration.sh` if production code or API/execution-boundary behavior changed; otherwise record why focused integration coverage is sufficient in final verification notes. (FR-001, FR-004, SC-001, SC-002)
-- [ ] T037 Confirm no provider verification or credentialed tests are required for MM-573 and document any intentionally skipped provider checks in final verification notes. (Constitution II, III)
+- [ ] T036 Run the required hermetic integration suite with `./tools/test_integration.sh` if production code or API/execution-boundary behavior changed; otherwise record why focused integration coverage is sufficient in `specs/332-compile-executable-runtime-plans/verification.md`. (FR-001, FR-004, SC-001, SC-002)
+- [ ] T037 Confirm no provider verification or credentialed tests are required for MM-573 and document any intentionally skipped provider checks in `specs/332-compile-executable-runtime-plans/verification.md`. (Constitution II, III)
 - [ ] T038 Run `/moonspec-verify` after implementation and tests pass, and ensure verification covers MM-573, `manual-mm-569-mm-574`, the original Jira preset brief, FR-001 through FR-007, acceptance scenarios 1 through 6, SC-001 through SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-012, DESIGN-REQ-018, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022, commands run, and remaining risks. (FR-007, SC-005)
 
 ## Dependencies And Execution Order

--- a/specs/332-compile-executable-runtime-plans/verification.md
+++ b/specs/332-compile-executable-runtime-plans/verification.md
@@ -1,0 +1,35 @@
+# Verification Notes: Compile Executable Steps into Runtime Plans
+
+## Implementation Step Evidence
+
+- Target Jira issue: `MM-573`
+- Source issue: `manual-mm-569-mm-574`
+- Scope: runtime execution from reviewed, flattened Tool and Skill steps with compact preset provenance.
+- Production code changes: none. New verification tests passed against existing runtime planner, task contract, proposal promotion, and task-shaped submission behavior.
+
+## Commands Run
+
+- `python -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`
+  - Result: passed, `67 passed`.
+- `python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q`
+  - Result: passed, `56 passed`.
+- `python -m pytest tests/unit/workflows/task_proposals/test_service.py -q`
+  - Result: passed, `32 passed`.
+- `python -m pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q`
+  - Result: passed, `155 passed`.
+- `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci`
+  - Result: passed, `7 passed`.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+  - Result: passed, `4726 passed, 1 xpassed, 113 warnings, 16 subtests passed`; frontend unit suite `20 passed`, `332 passed`, `225 skipped`.
+
+## Integration Scope
+
+No production code, API routing, or execution-boundary implementation changed during this step, so the full compose-backed `./tools/test_integration.sh` suite was not required for implementation. Focused hermetic integration coverage was run for the affected task-shaped submission boundary and passed.
+
+## Provider Verification
+
+No provider verification or credentialed checks are required for `MM-573`. The story covers local runtime payload compilation, task contract validation, proposal promotion preservation, and hermetic task-shaped submission behavior.
+
+## Remaining MoonSpec Work
+
+The final `/moonspec-verify` gate remains to be run in the dedicated verification step.

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -598,6 +598,74 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
 
 
 @pytest.mark.asyncio
+async def test_promote_proposal_uses_reviewed_flattened_payload_without_reexpansion() -> None:
+    repo = AsyncMock()
+    reviewed_steps = [
+        {
+            "id": "implement-mm-573",
+            "type": "skill",
+            "title": "Implement MM-573",
+            "instructions": "Implement the reviewed MM-573 payload.",
+            "skill": {
+                "id": "moonspec-implement",
+                "args": {"issueKey": "MM-573"},
+            },
+            "source": {
+                "kind": "preset-derived",
+                "presetSlug": "jira-orchestrate",
+                "presetVersion": "reviewed-version",
+                "originalStepId": "implement-story",
+            },
+        }
+    ]
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Promote reviewed MM-573 payload.",
+                    "taskTemplate": {
+                        "slug": "jira-orchestrate",
+                        "version": "live-version-that-must-not-be-expanded",
+                    },
+                    "authoredPresets": [
+                        {
+                            "presetSlug": "jira-orchestrate",
+                            "presetVersion": "reviewed-version",
+                        }
+                    ],
+                    "steps": reviewed_steps,
+                },
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    updated_proposal, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+    )
+
+    repo.commit.assert_awaited()
+    assert updated_proposal.status is TaskProposalStatus.PROMOTED
+    task = final_request["payload"]["task"]
+    assert len(task["steps"]) == 1
+    assert task["steps"][0]["id"] == reviewed_steps[0]["id"]
+    assert task["steps"][0]["type"] == reviewed_steps[0]["type"]
+    assert task["steps"][0]["skill"] == reviewed_steps[0]["skill"]
+    assert task["steps"][0]["source"]["presetVersion"] == "reviewed-version"
+    assert task["taskTemplate"]["version"] == "live-version-that-must-not-be-expanded"
+
+
+@pytest.mark.asyncio
 async def test_promote_proposal_preserves_canonical_proposal_intent() -> None:
     repo = AsyncMock()
     proposal = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -290,7 +290,7 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
         "originalStepId": "fetch-jira-issue",
     }
 
-def test_runtime_planner_maps_explicit_skill_step_to_agent_runtime_node():
+def test_runtime_planner_maps_explicit_skill_step_with_provenance_to_agent_runtime_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -290,6 +290,125 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
         "originalStepId": "fetch-jira-issue",
     }
 
+def test_runtime_planner_maps_explicit_skill_step_to_agent_runtime_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run explicit skill step.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "implement-mm-573",
+                        "type": "skill",
+                        "instructions": "Implement MM-573.",
+                        "skill": {
+                            "id": "moonspec-implement",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-573"},
+                        },
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetSlug": "jira-orchestrate",
+                            "presetVersion": "1.0.0",
+                        },
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "moonspec-implement"
+    assert plan["nodes"][0]["inputs"]["type"] == "skill"
+    assert plan["nodes"][0]["inputs"]["issueKey"] == "MM-573"
+    assert plan["nodes"][0]["inputs"]["source"] == {
+        "kind": "preset-derived",
+        "presetSlug": "jira-orchestrate",
+        "presetVersion": "1.0.0",
+    }
+
+
+def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run flattened MM-573 steps.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "fetch-issue",
+                        "type": "tool",
+                        "instructions": "Fetch MM-573.",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-573"},
+                        },
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetSlug": "jira-orchestrate",
+                            "presetVersion": "1.0.0",
+                        },
+                    },
+                    {
+                        "id": "implement-story",
+                        "type": "skill",
+                        "instructions": "Implement MM-573.",
+                        "skill": {
+                            "id": "moonspec-implement",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-573"},
+                        },
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetSlug": "jira-orchestrate",
+                            "presetVersion": "1.0.0",
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert [node["id"] for node in plan["nodes"]] == [
+        "fetch-issue",
+        "implement-story",
+    ]
+    assert plan["edges"] == [{"from": "fetch-issue", "to": "implement-story"}]
+    assert plan["nodes"][0]["tool"] == {
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
+    }
+    assert plan["nodes"][1]["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert plan["nodes"][0]["inputs"]["source"]["presetSlug"] == "jira-orchestrate"
+    assert plan["nodes"][1]["inputs"]["source"]["presetSlug"] == "jira-orchestrate"
+
+
 def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Jira issue key: MM-573
- Active MoonSpec feature path: `specs/332-compile-executable-runtime-plans`
- Adds MM-573-focused verification coverage for executable Tool/Skill runtime plan compilation and reviewed flattened proposal promotion.
- Preserves MM-573 and manual-mm-569-mm-574 traceability in MoonSpec artifacts.

## Verification verdict
- ADDITIONAL_WORK_NEEDED from `/moonspec-verify` because `.gemini/skills` is a dirty active skill projection symlink in this managed checkout (`ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`).
- Implementation evidence is verified: requirements FR-001 through FR-007 have production and test evidence, with no production code changes needed.

## Tests run
- `python -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q` — 67 passed
- `python -m pytest tests/unit/workflows/tasks/test_task_contract.py -q` — 56 passed
- `python -m pytest tests/unit/workflows/task_proposals/test_service.py -q` — 32 passed
- `python -m pytest tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/task_proposals/test_service.py -q` — 155 passed
- `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` — 7 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` — Python 4726 passed, 1 xpassed; frontend 20 files passed, 332 tests passed, 225 skipped

## Remaining risks
- Final MoonSpec verification should be rerun from a checkout where `.gemini/skills` is not a dirty active projection symlink.
- Full compose-backed integration suite was not run because no production code or API/execution-boundary behavior changed; focused hermetic integration coverage passed.
