### PR TITLE
MM-574: Step Type Input Validation with Field-Addressable Errors

### DIFF
--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,1 +1,1 @@
-../../runtime/skills_active/skillset_mm:cb694bd3-cdd3-4b04-8c08-2807a84ad4a6_15
+../../runtime/skills_active/skillset_mm:fac9baaf-d35d-4966-8530-adeacbb46d66_12

--- a/specs/333-step-type-input-validation/plan.md
+++ b/specs/333-step-type-input-validation/plan.md
@@ -30,17 +30,27 @@ The existing `TaskContractError` already carries a `diagnostic` field for struct
 
 **File**: `moonmind/workflows/tasks/task_contract.py`
 
-Add two new Pydantic models alongside the existing `TaskContractError`:
+Add two new Pydantic models alongside the existing `TaskContractError`. The `code` field is constrained by an `Enum` to keep error codes consistent and typo-resistant; the `errors` field uses `Field(default_factory=list)` to follow the existing convention in this module (see `moonmind/workflows/tasks/task_contract.py` line 1075).
+
+The `path` field is rooted at the **request body** for the submission endpoint, so frontends can address fields directly from the submitted payload (e.g. `payload.task.steps[0].tool.inputs.issueKey`). The plan uses the `steps[i]...` shorthand below for brevity; the API contract documents the full root.
 
 ```python
+class ValidationErrorCode(str, Enum):
+    REQUIRED = "required"
+    TYPE = "type"
+    TOOL_NOT_FOUND = "tool_not_found"
+    SKILL_NOT_FOUND = "skill_not_found"
+    PRESET_NOT_FOUND = "preset_not_found"
+    SCHEMA_VIOLATION = "schema_violation"
+
 class ValidationFieldError(BaseModel):
-    path: str        # dot-bracket notation, e.g. "steps[0].tool.inputs.issueKey"
-    message: str     # human-readable description
-    code: str        # machine-readable, e.g. "required", "tool_not_found"
+    path: str                  # dot-bracket notation rooted at the request body, e.g. "payload.task.steps[0].tool.inputs.issueKey"
+    message: str               # human-readable description
+    code: ValidationErrorCode  # machine-readable error code
 
 class StepValidationResult(BaseModel):
     is_valid: bool
-    errors: list[ValidationFieldError] = []
+    errors: list[ValidationFieldError] = Field(default_factory=list)
 ```
 
 ### 2. Add step input validation collectors
@@ -57,21 +67,23 @@ Add a new function `validate_step_inputs(steps, step_idx)` that:
 
 **File**: `moonmind/workflows/tasks/task_contract.py` (task submission normalization path)
 
-Update the existing step-level validation to collect all `ValidationFieldError` instances instead of raising `TaskContractError` on the first failure. Raise a single `TaskContractError` carrying the full `errors` list once all steps have been checked.
+Update the existing step-level validation to collect all `ValidationFieldError` instances instead of raising `TaskContractError` on the first failure. Raise a single `TaskContractError` carrying the full `errors` list once all steps have been checked. Store the collected list on the existing `TaskContractError.diagnostic` field so the API layer can extract it from the standard error-handling pathway without a new sidecar attribute.
 
 ### 4. Update the 422 response shape
 
 **File**: `api_service/api/routers/executions.py`
 
-Update `_invalid_task_request()` (line ~3236) to include a `validation_errors` key in the 422 response body when the incoming `TaskContractError` carries field-level errors:
+The current signature of `_invalid_task_request()` (line ~3236) only accepts a `message: str`. Extend the signature to accept an optional `validation_errors: list[ValidationFieldError] | None = None` parameter so callers can pass structured field errors through. Update all existing call sites to keep working with the message-only form.
+
+When `validation_errors` is provided, include it as a `validation_errors` array in the 422 response body. Each entry uses paths rooted at the request body (e.g. `payload.task.steps[i]...`):
 
 ```json
 {
   "code": "invalid_execution_request",
   "message": "Step validation failed: 2 field error(s).",
   "validation_errors": [
-    {"path": "steps[0].tool.inputs.issueKey", "message": "Field 'issueKey' is required.", "code": "required"},
-    {"path": "steps[1].skill.inputs.repository", "message": "Field 'repository' must be a string.", "code": "type"}
+    {"path": "payload.task.steps[0].tool.inputs.issueKey", "message": "Field 'issueKey' is required.", "code": "required"},
+    {"path": "payload.task.steps[1].skill.inputs.repository", "message": "Field 'repository' must be a string.", "code": "type"}
   ]
 }
 ```

--- a/specs/333-step-type-input-validation/plan.md
+++ b/specs/333-step-type-input-validation/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Step Type Input Validation with Field-Addressable Errors
+
+**Branch**: `change-jira-issue-mm-574-to-status-in-pr-e1677d0e` | **Date**: 2026-05-09 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add a structured `ValidationFieldError` model and propagate field-addressable errors through task step validation so the submission API returns a `validation_errors` array with `path`, `message`, and `code` fields instead of opaque error strings.
+
+The existing `TaskContractError` already carries a `diagnostic` field for structured context. The existing task submission endpoint already returns HTTP 422 on validation failures. This plan extends both to surface field paths in the response, adds collect-all-errors behavior across multiple steps, and wires preset input schema validation into the submit-time expansion path.
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. No agent behavior is created; this adds structured error output to existing validation boundaries.
+- **II. One-Click Agent Deployment**: PASS. No new services or infrastructure dependencies.
+- **III. Avoid Vendor Lock-In**: PASS. Validation is fully internal; no vendor-specific API changes.
+- **IV. Own Your Data**: PASS. No data storage changes; errors are transient response objects.
+- **V. Skills Are First-Class**: PASS. Skill step validation reuses the existing skill contract; errors are now field-addressable.
+- **VI. Evolving Scaffolds**: PASS. The error model is a thin, stable contract. Existing string-only error messages are replaced (not shimmed).
+- **VII. Runtime Configurability**: PASS. No new config options; validation behavior is deterministic.
+- **VIII. Modular Architecture**: PASS. Changes are isolated to the task validation layer and the submission endpoint response shape.
+- **IX. Resilient by Default**: PASS. Collect-all-errors behavior means callers receive complete feedback in a single round trip.
+- **X. Continuous Improvement**: PASS. Structured error codes enable future analytics on common submission failures.
+- **XI. Spec-Driven Development**: PASS. This plan, spec, and tasks track the change.
+- **XII. Canonical Documentation Separation**: PASS. No migration backlog is added to canonical docs.
+- **XIII. Pre-Release Compatibility**: PASS. The old opaque error string is replaced entirely; no backward-compat shim is introduced.
+
+## Implementation Scope
+
+### 1. Add `ValidationFieldError` and `StepValidationResult` models
+
+**File**: `moonmind/workflows/tasks/task_contract.py`
+
+Add two new Pydantic models alongside the existing `TaskContractError`:
+
+```python
+class ValidationFieldError(BaseModel):
+    path: str        # dot-bracket notation, e.g. "steps[0].tool.inputs.issueKey"
+    message: str     # human-readable description
+    code: str        # machine-readable, e.g. "required", "tool_not_found"
+
+class StepValidationResult(BaseModel):
+    is_valid: bool
+    errors: list[ValidationFieldError] = []
+```
+
+### 2. Add step input validation collectors
+
+**File**: `moonmind/workflows/tasks/task_contract.py`
+
+Add a new function `validate_step_inputs(steps, step_idx)` that:
+- Resolves the tool/skill/preset `inputSchema` from the catalog (or existing annotation logic)
+- Validates `step.tool.inputs` / `step.skill.inputs` / `step.preset.inputs` against the resolved schema
+- Returns a list of `ValidationFieldError` with correct path prefixes: `steps[{idx}].tool.inputs.{field}` etc.
+- Adds `code: "tool_not_found"` / `code: "skill_not_found"` / `code: "preset_not_found"` when the selected capability cannot be resolved
+
+### 3. Collect errors across all steps before failing
+
+**File**: `moonmind/workflows/tasks/task_contract.py` (task submission normalization path)
+
+Update the existing step-level validation to collect all `ValidationFieldError` instances instead of raising `TaskContractError` on the first failure. Raise a single `TaskContractError` carrying the full `errors` list once all steps have been checked.
+
+### 4. Update the 422 response shape
+
+**File**: `api_service/api/routers/executions.py`
+
+Update `_invalid_task_request()` (line ~3236) to include a `validation_errors` key in the 422 response body when the incoming `TaskContractError` carries field-level errors:
+
+```json
+{
+  "code": "invalid_execution_request",
+  "message": "Step validation failed: 2 field error(s).",
+  "validation_errors": [
+    {"path": "steps[0].tool.inputs.issueKey", "message": "Field 'issueKey' is required.", "code": "required"},
+    {"path": "steps[1].skill.inputs.repository", "message": "Field 'repository' must be a string.", "code": "type"}
+  ]
+}
+```
+
+When no field errors are present (e.g., a contract-level failure), `validation_errors` is omitted.
+
+### 5. Wire preset input schema validation into submit-time expansion
+
+**File**: `moonmind/workflows/tasks/task_contract.py` (or preset expansion helper)
+
+Before expanding an unresolved Preset step at submit time, validate the step's `preset.inputs` against the preset's declared `inputSchema`. Return `ValidationFieldError` entries with paths `steps[{idx}].preset.inputs.{field}` when validation fails, and skip expansion for that step.
+
+## Validation
+
+- `pytest tests/unit/workflows/tasks/test_task_contract.py -q`
+- `pytest tests/integration/ -m integration_ci -q -k "submission or task_contract or step"` (focused)
+- `./tools/test_unit.sh`
+
+## Complexity Tracking
+
+No cross-cutting changes; the scope is confined to `task_contract.py` and the submission endpoint response shape. No Temporal workflow or activity signature changes. No database schema changes.

--- a/specs/333-step-type-input-validation/spec.md
+++ b/specs/333-step-type-input-validation/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Step Type Input Validation with Field-Addressable Errors
+
+**Feature Branch**: `change-jira-issue-mm-574-to-status-in-pr-e1677d0e`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: Jira Orchestrate handoff for `MM-574`.
+
+Preserved source traceability:
+
+- Target Jira issue: `MM-574`
+- Source Jira issue: `manual-mm-569-mm-574`
+- Source design: `docs/Steps/StepTypes.md`
+- Canonical source: synthesized from StepTypes.md section 10 (Validation Rules) because MM-574 is not accessible from the connected Atlassian workspace (gaudhammer.atlassian.net does not expose the MM project)
+- Classification: single-story runtime feature request
+- Resume decision: no existing Moon Spec feature directory preserved `MM-574`; Specify is the first incomplete stage
+
+## Original Preset Brief (Synthesized)
+
+MM-574 is STORY-006 in the `manual-mm-569-mm-574` batch, the final story in the StepTypes.md migration coverage set. The preceding stories covered:
+
+- STORY-001 (MM-569): Phase 1 — UI terminology (rename step selector to "Step Type")
+- STORY-002 (MM-570): Phase 2 — Schema-driven step editor forms
+- STORY-003 (MM-571): Phase 3 — Draft model normalization (explicit `step.type`)
+- STORY-004 (MM-572): Phase 4 — Preview and Apply Preset Steps
+- STORY-005 (MM-573): Phase 5 — Compile executable steps into runtime plans
+
+STORY-006 (MM-574) covers the remaining implementation gap: field-addressable step type validation errors (StepTypes.md section 10). The backend currently returns opaque error strings when step inputs fail validation. This story introduces a structured `ValidationFieldError` response model with `path`, `message`, and `code` fields so the Create page and API consumers can display targeted inline feedback for each invalid field.
+
+## User Story — Field-Addressable Step Validation Errors
+
+**Summary**: As a task author submitting a task with invalid step inputs, I receive structured validation errors that identify the exact step index, field path, and failure code so I can correct my submission without guessing which field or step is invalid.
+
+**Goal**: The submission API and preset expansion service return validation errors in a consistent structured shape (`path`, `message`, `code`) for every step type violation, and the backend enforces all Tool, Skill, and Preset validation rules from StepTypes.md section 10 at submission time.
+
+**Independent Test**: Submit a task with a Tool step missing a required input field and verify the API response contains a `validation_errors` array with at least one entry matching `{"path": "steps[0].tool.inputs.<field>", "message": "<readable message>", "code": "required"}`. The test is independent because it only requires the task submission endpoint and a catalog entry for the selected tool.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task submission contains a Tool step with a missing required input, **When** the backend validates the step payload, **Then** the API returns a 422 response with a `validation_errors` array containing an entry with a non-empty `path`, `message`, and `code`.
+2. **Given** a task submission contains a Skill step with inputs that fail the skill's input schema, **When** the backend validates the step payload, **Then** the API returns a structured error pointing to the exact failing input field path under `steps[idx].skill.inputs.<field>`.
+3. **Given** a preset expansion request contains inputs that violate the preset's `inputSchema`, **When** the backend validates the expansion request, **Then** the expansion endpoint returns structured field errors pointing to the violating preset input path under `steps[idx].preset.inputs.<field>` and does not proceed to expansion.
+4. **Given** a step payload passes all validation rules, **When** the submission is processed, **Then** no `validation_errors` are included and the submission proceeds normally.
+5. **Given** multiple steps have independent validation failures, **When** the submission is processed, **Then** all field errors are collected and returned together rather than stopping at the first failure.
+6. **Given** a Tool step's selected tool does not exist in the registry, **When** the backend validates the step, **Then** a structured error is returned with `code: "tool_not_found"` and a path targeting the tool identifier field.
+
+### Edge Cases
+
+- A Tool step that omits a required field nested inside an object input (e.g., `tool.inputs.jira_issue.key`) produces an error path of `steps[0].tool.inputs.jira_issue.key`.
+- A Preset step where the preset catalog entry is missing or inactive produces `code: "preset_not_found"` before schema validation is attempted.
+- An error that cannot be mapped to a specific field (e.g., a tool registry timeout) is returned with `path: "steps[idx]"` and `code: "validation_error"`.
+- When submit-time expansion of a Preset step fails, errors from expansion are included in the same `validation_errors` array alongside other step errors.
+
+## Assumptions
+
+- Step type validation runs server-side at task submission time.
+- Tool and Skill input schema resolution is available from the existing task template / capability catalog service.
+- Preset expansion validation reuses the existing preset expansion service, adding structured error output.
+- The existing `TaskContractError` class is extended or replaced with the structured error shape; existing string-only errors are updated to include field paths.
+- Frontend rendering of field-level errors is out of scope for MM-574; this story defines and implements the backend error contract and API response shape. Frontend integration is a follow-on story.
+
+## Source Design Requirements
+
+| ID | Source | Requirement Summary | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Steps/StepTypes.md` section 10.1 | Every step must expose validation errors before submission succeeds. | In scope | FR-001, FR-005 |
+| DESIGN-REQ-002 | `docs/Steps/StepTypes.md` section 10.2 | A Tool step is valid only when inputs validate against the tool schema; errors are field-addressable. | In scope | FR-002, FR-006 |
+| DESIGN-REQ-003 | `docs/Steps/StepTypes.md` section 10.3 | A Skill step is valid only when skill inputs validate against the skill contract; errors are field-addressable. | In scope | FR-003 |
+| DESIGN-REQ-004 | `docs/Steps/StepTypes.md` section 10.4 | A Preset step expansion is blocked when inputs fail validation; errors are field-addressable and expansion warnings are visible. | In scope | FR-004 |
+| DESIGN-REQ-005 | `docs/Steps/StepTypes.md` section 10.4 (example) | Validation errors must carry `path`, `message`, and `code` fields using dot-bracket notation for nested inputs. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-006 | `docs/Steps/StepTypes.md` section 8.3 | When preset expansion fails at submit time, field-addressable errors are returned and the draft is preserved. | In scope | FR-004, FR-005 |
+| DESIGN-REQ-007 | `docs/Steps/StepTypes.md` section 10.4 (example) | Downstream artifacts, verification output, commit text, and PR metadata MUST preserve MM-574, manual-mm-569-mm-574, and this preset brief. | In scope | FR-007 |
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The task submission API MUST return a structured `validation_errors` array when any step fails validation, where each entry contains a non-empty `path` (dot-bracket notation targeting the failing field), a human-readable `message`, and a machine-readable `code`.
+- **FR-002**: Tool step validation MUST verify that inputs satisfy the tool's declared input schema and MUST return field errors with paths of the form `steps[{idx}].tool.inputs.{field}` when validation fails.
+- **FR-003**: Skill step validation MUST verify that inputs satisfy the skill's declared input schema and MUST return field errors with paths of the form `steps[{idx}].skill.inputs.{field}` when validation fails.
+- **FR-004**: Preset step expansion at submit time MUST validate inputs against the preset's `inputSchema` before expansion and MUST return field errors with paths of the form `steps[{idx}].preset.inputs.{field}` when inputs are invalid; expansion MUST NOT proceed for invalid preset inputs.
+- **FR-005**: Validation MUST collect all field errors across all steps before returning, rather than stopping at the first error, so authors receive a complete picture of what needs to be corrected.
+- **FR-006**: When a Tool or Skill selected in a step cannot be resolved in the registry, the validation response MUST include an error with `code: "tool_not_found"` or `code: "skill_not_found"` and a path targeting the selector field.
+- **FR-007**: Downstream artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve target Jira issue `MM-574`, source issue `manual-mm-569-mm-574`, and this original synthesized preset brief.
+
+### Key Entities
+
+- **`ValidationFieldError`**: The structured error shape returned in `validation_errors` arrays. Contains `path` (string, dot-bracket notation), `message` (string, human-readable), and `code` (string, machine-readable, e.g., `"required"`, `"pattern"`, `"tool_not_found"`, `"skill_not_found"`, `"preset_not_found"`, `"validation_error"`).
+- **`StepValidationResult`**: The aggregate result of validating all steps in a submission. Contains `is_valid` (bool) and `errors` (list of `ValidationFieldError`).
+- **Tool/Skill Input Schema**: The `inputSchema` declared by each tool or skill in the capability catalog, used to validate `tool.inputs` or `skill.inputs` at submission time.
+- **Preset Input Schema**: The `inputSchema` declared by a preset (e.g., in the seeded YAML), used to validate `preset.inputs` before expansion at submit time.
+
+## Success Criteria
+
+- **SC-001**: Unit tests demonstrate that a Tool step with a missing required input produces a `ValidationFieldError` with a `path` matching `steps[0].tool.inputs.<field>`, `code: "required"`, and a non-empty `message`.
+- **SC-002**: Unit tests demonstrate that a Skill step with an invalid input produces a field error with the correct path pattern.
+- **SC-003**: Unit tests demonstrate that a Preset step with invalid inputs is blocked from expansion and returns field errors with the correct path pattern.
+- **SC-004**: Unit tests demonstrate that multiple validation failures across multiple steps are all collected and returned together.
+- **SC-005**: Integration tests at the task submission boundary confirm that a submission with an invalid Tool step returns a 422 response with a `validation_errors` array.
+- **SC-006**: Source traceability review confirms `MM-574`, `manual-mm-569-mm-574`, and DESIGN-REQ-001 through DESIGN-REQ-007 are preserved in MoonSpec artifacts.

--- a/specs/333-step-type-input-validation/tasks.md
+++ b/specs/333-step-type-input-validation/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Step Type Input Validation with Field-Addressable Errors
+
+**Input**: Design documents from `/specs/333-step-type-input-validation/`
+
+## Phase 1: Error Model and Validation Core
+
+- [ ] T001 Add `ValidationFieldError` and `StepValidationResult` Pydantic models to `moonmind/workflows/tasks/task_contract.py`
+- [ ] T002 Add `validate_step_inputs(steps, step_idx)` that resolves tool/skill/preset `inputSchema` and returns `list[ValidationFieldError]` with correct path prefixes
+- [ ] T003 Add `code: "tool_not_found"`, `code: "skill_not_found"`, `code: "preset_not_found"` errors when selected capabilities cannot be resolved
+- [ ] T004 Update step-level validation to collect all field errors across all steps before raising `TaskContractError`
+
+## Phase 2: API Response Shape
+
+- [ ] T005 Update `_invalid_task_request()` in `api_service/api/routers/executions.py` to include `validation_errors` array in 422 response when `TaskContractError` carries field errors
+- [ ] T006 Wire preset input schema validation into submit-time expansion: validate `preset.inputs` against `inputSchema` before expansion and return `ValidationFieldError` entries on failure
+
+## Phase 3: Tests
+
+- [ ] T007 Add unit tests in `tests/unit/workflows/tasks/test_task_contract.py` for Tool step with missing required input → `ValidationFieldError` with correct path and `code: "required"`
+- [ ] T008 Add unit tests for Skill step with invalid input → field error with correct path pattern
+- [ ] T009 Add unit tests for Preset step with invalid inputs → blocked expansion and field errors with correct path pattern
+- [ ] T010 Add unit tests proving multiple validation failures across multiple steps are all collected before returning
+- [ ] T011 Add unit test for unknown tool identity → `code: "tool_not_found"` with path targeting selector field
+- [ ] T012 Add integration test in `tests/integration/` (marked `integration_ci`) proving that a task submission with an invalid Tool step returns HTTP 422 with a `validation_errors` array
+
+## Phase 4: Validation
+
+- [ ] T013 Run `pytest tests/unit/workflows/tasks/test_task_contract.py -q` — all tests pass
+- [ ] T014 Run `./tools/test_unit.sh` — full unit suite passes


### PR DESCRIPTION
## Jira Issue

**MM-574** — Step Type Input Validation with Field-Addressable Errors
Source batch: \`manual-mm-569-mm-574\` (STORY-006 of 6)
Source design: \`docs/Steps/StepTypes.md\` section 10 (Validation Rules)

## Active MoonSpec Feature Path

\`specs/333-step-type-input-validation/\`

- \`spec.md\` — user story, acceptance scenarios, functional requirements (FR-001–FR-007), success criteria (SC-001–SC-006)
- \`plan.md\` — implementation scope: \`ValidationFieldError\` + \`StepValidationResult\` models in \`task_contract.py\`, collect-all-errors step validation, structured 422 response shape, preset input schema validation before expansion
- \`tasks.md\` — phased task list (T001–T014) covering error model, API shape, unit tests, integration tests

## Verification Verdict

MoonSpec artifacts delivered. The spec, plan, and tasks define the full field-addressable validation contract for Tool, Skill, and Preset steps. Implementation tasks (T001–T012) remain open for the coding phase. MoonSpec Specify stage: complete. Implementation stage: not started.

## Tests Run

- No application code written in this MoonSpec authoring step; no unit or integration tests are run at this stage.
- Required tests are specified in \`tasks.md\` (T007–T012): unit tests for \`test_task_contract.py\` and an \`integration_ci\`-marked integration test for the 422 submission boundary.

## Remaining Risks

- Input schema resolution: \`validate_step_inputs()\` must resolve tool/skill/preset \`inputSchema\` from the existing capability catalog. If schema resolution is inconsistent across catalog paths, field paths may be incomplete.
- Preset expansion interaction: Blocking expansion on invalid preset inputs (T006) may interact with the existing submit-time expansion path in unexpected ways if expansion short-circuits before all steps are validated.
- Backward compatibility: Replacing opaque \`TaskContractError\` strings with structured \`validation_errors\` is a breaking change for any client that parses the 422 body. Per Constitution Principle XIII (pre-release, no compat shims), the old shape is removed entirely.
- Spec number collision: \`specs/333-step-type-input-validation/\` shares prefix \`333\` with \`specs/333-transition-mm653-in-pr/\` already in main. Both directories coexist; a renaming pass should be done before the implementation PR is merged.

Generated with Claude Code