### PR TITLE
Handle completed codex turns with no assistant output as success

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -93,6 +93,9 @@ class CodexSessionRuntimeState(BaseModel):
     last_turn_id: str | None = Field(None, alias="lastTurnId")
     last_turn_status: str | None = Field(None, alias="lastTurnStatus")
     last_turn_error: str | None = Field(None, alias="lastTurnError")
+    last_assistant_text_missing: bool = Field(
+        False, alias="lastAssistantTextMissing"
+    )
 
 class CodexAppServerRpcClient:
     """Minimal JSON-RPC stdio client for ``codex app-server``."""
@@ -500,6 +503,8 @@ class CodexManagedSessionRuntime:
             merged.setdefault("lastTurnStatus", state.last_turn_status)
         if state.last_turn_error:
             merged.setdefault("lastTurnError", state.last_turn_error)
+        if state.last_assistant_text_missing:
+            merged.setdefault("assistantTextMissing", True)
         return CodexManagedSessionHandle(
             sessionState=self._session_state(state),
             status=status,
@@ -1471,12 +1476,16 @@ class CodexManagedSessionRuntime:
         assistant_text: str | None = None,
         error_text: str | None = None,
         append_assistant_to_spool: bool = True,
+        assistant_text_missing: bool = False,
     ) -> None:
         previous_status = state.last_turn_status
         state.active_turn_id = None
         state.last_turn_id = turn_id
         state.last_turn_status = status
         state.last_turn_error = error_text
+        state.last_assistant_text_missing = bool(
+            status == "completed" and assistant_text_missing
+        )
         if status == "completed":
             state.last_assistant_text = assistant_text or None
         self._save_state(state)
@@ -1561,20 +1570,15 @@ class CodexManagedSessionRuntime:
                     else None
                 ),
             )
-            if status == "failed":
-                self._append_spool(
-                    "stderr",
-                    (
-                        "codex app-server turn completed without assistant output: "
-                        f"{active_turn_id}\n"
-                    ),
-                )
         self._finalize_turn(
             state=state,
             turn_id=active_turn_id,
             status=status,
             assistant_text=assistant_text,
             error_text=error_text,
+            assistant_text_missing=(
+                status == "completed" and not assistant_text and bool(error_text)
+            ),
         )
         return state
 
@@ -1727,15 +1731,7 @@ class CodexManagedSessionRuntime:
                     vendor_turn_id=vendor_turn_id,
                     rollout_scan=completed_turn_inspection.rollout_scan,
                 )
-                if status == "failed":
-                    self._append_spool(
-                        "stderr",
-                        (
-                            "codex app-server turn completed without assistant output: "
-                            f"{vendor_turn_id}\n"
-                        ),
-                    )
-                else:
+                if status != "failed":
                     metadata["assistantTextMissing"] = True
             else:
                 metadata["assistantText"] = assistant_text
@@ -1750,6 +1746,7 @@ class CodexManagedSessionRuntime:
             append_assistant_to_spool=(
                 assistant_text.strip() not in rollout_mirror.emitted_assistant_texts
             ),
+            assistant_text_missing=bool(metadata.get("assistantTextMissing")),
         )
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),
@@ -1907,6 +1904,7 @@ class CodexManagedSessionRuntime:
                 "lastTurnId": state.last_turn_id,
                 "lastTurnStatus": state.last_turn_status,
                 "lastTurnError": state.last_turn_error,
+                "assistantTextMissing": state.last_assistant_text_missing,
             },
         )
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1166,7 +1166,7 @@ class CodexManagedSessionRuntime:
             if recovered_error:
                 return "failed", recovered_error
             return (
-                "failed",
+                "completed",
                 "codex app-server task_complete produced no assistant output",
             )
         if scan.assistant_text:
@@ -1198,10 +1198,10 @@ class CodexManagedSessionRuntime:
             if recovered_error:
                 return "failed", recovered_error
             return (
-                "failed",
+                "completed",
                 "codex app-server task_complete produced no assistant output",
             )
-        return "failed", "codex app-server turn/completed produced no assistant output"
+        return "completed", "codex app-server turn/completed produced no assistant output"
 
     def _resolved_rollout_path(
         self,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -422,6 +422,7 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
     )
     assert handle.status == "ready"
     assert handle.metadata["lastTurnStatus"] == "completed"
+    assert handle.metadata["assistantTextMissing"] is True
     assert (
         handle.metadata["lastTurnError"]
         == "codex app-server turn/completed produced no assistant output"
@@ -437,6 +438,7 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
         state_payload.get("lastTurnError")
         == "codex app-server turn/completed produced no assistant output"
     )
+    assert state_payload.get("lastAssistantTextMissing") is True
     stderr_path = Path(request.artifact_spool_path) / "stderr.log"
     assert not stderr_path.exists() or "turn completed without assistant output" not in stderr_path.read_text(
         encoding="utf-8"
@@ -753,6 +755,7 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
     )
     assert handle.status == "ready"
     assert handle.metadata["lastTurnStatus"] == "completed"
+    assert handle.metadata["assistantTextMissing"] is True
     assert (
         handle.metadata["lastTurnError"]
         == "codex app-server task_complete produced no assistant output"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -405,7 +405,8 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
         )
     )
 
-    assert response.status == "failed"
+    assert response.status == "completed"
+    assert response.metadata["assistantTextMissing"] is True
     assert (
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"
@@ -419,7 +420,8 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
             threadId="logical-thread-1",
         )
     )
-    assert handle.status == "failed"
+    assert handle.status == "ready"
+    assert handle.metadata["lastTurnStatus"] == "completed"
     assert (
         handle.metadata["lastTurnError"]
         == "codex app-server turn/completed produced no assistant output"
@@ -436,7 +438,7 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
         == "codex app-server turn/completed produced no assistant output"
     )
     stderr_path = Path(request.artifact_spool_path) / "stderr.log"
-    assert "turn completed without assistant output" in stderr_path.read_text(
+    assert not stderr_path.exists() or "turn completed without assistant output" not in stderr_path.read_text(
         encoding="utf-8"
     )
 
@@ -736,9 +738,10 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
         )
     )
 
-    assert response.status == "failed"
+    assert response.status == "completed"
     assert response.metadata == {
-        "reason": "codex app-server task_complete produced no assistant output"
+        "assistantTextMissing": True,
+        "reason": "codex app-server task_complete produced no assistant output",
     }
     handle = runtime.session_status(
         CodexManagedSessionLocator(
@@ -748,7 +751,12 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
             threadId="logical-thread-1",
         )
     )
-    assert handle.status == "failed"
+    assert handle.status == "ready"
+    assert handle.metadata["lastTurnStatus"] == "completed"
+    assert (
+        handle.metadata["lastTurnError"]
+        == "codex app-server task_complete produced no assistant output"
+    )
     assert "lastAssistantText" not in handle.metadata
 
 def test_runtime_send_turn_fails_empty_task_complete_with_structured_error(
@@ -956,9 +964,9 @@ def test_runtime_session_status_fails_empty_task_complete_after_running_turn(
         )
     )
 
-    assert handle.status == "failed"
+    assert handle.status == "ready"
     assert handle.session_state.active_turn_id is None
-    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.metadata["lastTurnStatus"] == "completed"
     assert (
         handle.metadata["lastTurnError"]
         == "codex app-server task_complete produced no assistant output"
@@ -1307,7 +1315,8 @@ def test_runtime_send_turn_ignores_stale_terminal_rollout_without_turn_reference
         )
     )
 
-    assert response.status == "failed"
+    assert response.status == "completed"
+    assert response.metadata["assistantTextMissing"] is True
     assert (
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"
@@ -1320,8 +1329,8 @@ def test_runtime_send_turn_ignores_stale_terminal_rollout_without_turn_reference
             threadId="logical-thread-1",
         )
     )
-    assert handle.status == "failed"
-    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.status == "ready"
+    assert handle.metadata["lastTurnStatus"] == "completed"
 
 def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     tmp_path: Path,
@@ -1386,7 +1395,8 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
         )
     )
 
-    assert response.status == "failed"
+    assert response.status == "completed"
+    assert response.metadata["assistantTextMissing"] is True
     assert (
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"
@@ -1399,8 +1409,8 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
             threadId="logical-thread-1",
         )
     )
-    assert handle.status == "failed"
-    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.status == "ready"
+    assert handle.metadata["lastTurnStatus"] == "completed"
 
 def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
     tmp_path: Path,
@@ -1456,7 +1466,8 @@ def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
         )
     )
 
-    assert response.status == "failed"
+    assert response.status == "completed"
+    assert response.metadata["assistantTextMissing"] is True
     assert (
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"


### PR DESCRIPTION
## Why
Fixes workflow failures where Codex turns complete without assistant text but should not hard-fail runtime workflow execution.

## Change
- Updated codex session runtime to treat  and  with no assistant output as  (non-failure) while preserving  / reason metadata.
- Updated unit tests in  that previously asserted failure for this case.

## Validation
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/d/code/MoonMind
configfile: pyproject.toml
plugins: anyio-4.13.0, mock-3.15.1, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 47 items

tests/unit/services/temporal/runtime/test_codex_session_runtime.py ..... [ 10%]
..........................................                               [100%]

============================== 47 passed in 2.79s ==============================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/d/code/MoonMind
configfile: pyproject.toml
plugins: anyio-4.13.0, mock-3.15.1, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py . [100%]

=============================== warnings summary ===============================
tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py::test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference
  /home/nsticco/.local/lib/python3.12/site-packages/temporalio/converter/_payload_converter.py:629: UserWarning: If you're using Pydantic v2, use temporalio.contrib.pydantic.pydantic_data_converter. If you're using Pydantic v1 and cannot upgrade, refer to https://github.com/temporalio/samples-python/tree/main/pydantic_converter_v1 for better v1 support.
    warnings.warn(

tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py: 14 warnings
  /home/nsticco/.local/lib/python3.12/site-packages/temporalio/converter/_payload_converter.py:541: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    return dict_fn()

tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py::test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference
tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py::test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference
tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py::test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference
  /home/nsticco/.local/lib/python3.12/site-packages/temporalio/converter/_payload_converter.py:878: PydanticDeprecatedSince20: The `parse_obj` method is deprecated; use `model_validate` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    return getattr(hint, "parse_obj")(value)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 1 passed, 18 warnings in 2.70s ========================