### PR TITLE
Isolate task dependencies on fresh rerun

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6703,8 +6703,9 @@ async def rerun_execution(
             },
         )
 
-    # Use canonical parameters which have targetRuntime, targetSkill, etc.
-    initial_params = dict(canonical.parameters or {})
+    # Use canonical parameters with rerun-specific sanitization to avoid carrying
+    # task dependency edges and recovery metadata from a prior execution.
+    initial_params = service._full_rerun_parameters(canonical.parameters or {})
 
     # Generate a new idempotency key based on the original workflow ID
     new_idempotency_key = f"rerun:{workflow_id}:{_uuid4()}"

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2591,6 +2591,16 @@ class TemporalExecutionService:
             params.pop(key, None)
         for key in FULL_RERUN_RECOVERY_CARRYOVER_PARAM_KEYS:
             params.pop(key, None)
+
+        task_payload = params.get("task")
+        if isinstance(task_payload, Mapping):
+            task_params = dict(task_payload)
+            task_params.pop("dependsOn", None)
+            if task_params:
+                params["task"] = task_params
+            else:
+                params.pop("task", None)
+        params.pop("dependsOn", None)
         return params
 
     async def create_failed_step_resume_execution(


### PR DESCRIPTION
## Summary
- Isolate dependency metadata during rerun parameter cloning so fresh reruns do not inherit dependsOn from source runs.
- Add rerun-parameter sanitization for task-level and top-level dependsOn fields when rehydrating from canonical parameters.

## Testing
- Not run (not requested).