### PR TITLE
Seeing all of these filter options at the top on mobile is ugly. I’d like for them to be hidden inside a filter menu or similar where you have to open

### DIFF
--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -486,6 +486,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
   const [hasEditedFilters, setHasEditedFilters] = useState(false);
   const [openFilter, setOpenFilter] = useState<FilterField | null>(null);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [pendingFocusField, setPendingFocusField] = useState<FilterField | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -1311,10 +1312,26 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
             </div>
           </div>
         ) : null}
-        <div className="task-list-mobile-filter-controls" aria-label="Mobile task filters">
-          {TABLE_COLUMNS.map(([field]) =>
-            isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
-          )}
+        <div className="task-list-mobile-filter-disclosure">
+          <button
+            type="button"
+            className="task-list-mobile-filter-toggle"
+            aria-expanded={mobileFiltersOpen}
+            aria-controls="task-list-mobile-filter-panel"
+            onClick={() => setMobileFiltersOpen((open) => !open)}
+          >
+            {mobileFiltersOpen ? 'Hide filters' : 'Show filters'}
+            {hasActiveFilters ? ` (${activeFilters.length})` : ''}
+          </button>
+          <div
+            id="task-list-mobile-filter-panel"
+            className={`task-list-mobile-filter-controls${mobileFiltersOpen ? ' is-open' : ''}`}
+            aria-label="Mobile task filters"
+          >
+            {TABLE_COLUMNS.map(([field]) =>
+              isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
+            )}
+          </div>
         </div>
       </section>
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -956,6 +956,36 @@ h1 {
   flex: 0 0 auto;
 }
 
+.task-list-mobile-filter-disclosure {
+  display: none;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.task-list-mobile-filter-toggle {
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--mm-control-border);
+  border-radius: 0.85rem;
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-ink));
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
+}
+
+.task-list-mobile-filter-toggle:hover,
+.task-list-mobile-filter-toggle:focus-visible {
+  border-color: rgb(var(--mm-accent) / 0.7);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+}
+
 .task-list-mobile-filter-controls {
   display: none;
   gap: 0.7rem;
@@ -1510,7 +1540,11 @@ tr[data-proposal-id].proposal-consuming td {
     width: 100%;
   }
 
-  .task-list-mobile-filter-controls {
+  .task-list-mobile-filter-disclosure {
+    display: flex;
+  }
+
+  .task-list-mobile-filter-controls.is-open {
     display: grid;
   }
 


### PR DESCRIPTION
Seeing all of these filter options at the top on mobile is ugly. I’d like for them to be hidden inside a filter menu or similar where you have to open the menu to see them instead of them appearing by default