### PR TITLE
Inherit parent model when child tasks opt into runtime inheritance

### DIFF
--- a/moonmind/workflows/tasks/runtime_inheritance.py
+++ b/moonmind/workflows/tasks/runtime_inheritance.py
@@ -414,6 +414,7 @@ def apply_inherited_runtime_to_payload(
     explicit_profile_id = (
         _coerce_str(runtime_block.get("profileId"))
         or _coerce_str(runtime_block.get("providerProfile"))
+        or _coerce_str(runtime_block.get("executionProfileRef"))
         or _coerce_str(payload.get("profileId"))
         or _coerce_str(payload.get("providerProfile"))
         or _coerce_str(task_payload.get("profileId"))

--- a/moonmind/workflows/tasks/runtime_inheritance.py
+++ b/moonmind/workflows/tasks/runtime_inheritance.py
@@ -393,6 +393,13 @@ def apply_inherited_runtime_to_payload(
     providerProfile}``, or top-level ``profileId`` / ``providerProfile``)
     is preserved; inheritance only fills in the gaps.  The downstream
     runtime resolution path then sees the merged request.
+
+    Note: when the caller has supplied an explicit profile selector
+    (``profileId`` / ``providerProfile`` anywhere in the payload),
+    ``executionProfileRef`` is *also* left blank.  Downstream selection
+    prefers ``executionProfileRef`` over ``profileId``/``providerProfile``
+    (see ``run.py``), so backfilling the parent's ref would silently
+    override the child's explicit profile.
     """
 
     runtime_block = (
@@ -420,8 +427,10 @@ def apply_inherited_runtime_to_payload(
         runtime_block["model"] = inherited.model
     if inherited.effort and not _coerce_str(runtime_block.get("effort")):
         runtime_block["effort"] = inherited.effort
-    if inherited.execution_profile_ref and not _coerce_str(
-        runtime_block.get("executionProfileRef")
+    if (
+        inherited.execution_profile_ref
+        and not _coerce_str(runtime_block.get("executionProfileRef"))
+        and not explicit_profile_id
     ):
         runtime_block["executionProfileRef"] = inherited.execution_profile_ref
     if inherited.profile_id and not explicit_profile_id:

--- a/moonmind/workflows/tasks/runtime_inheritance.py
+++ b/moonmind/workflows/tasks/runtime_inheritance.py
@@ -308,15 +308,20 @@ async def resolve_child_runtime_inheritance(
     Returns the ``InheritedRuntime`` to apply, or ``None`` when the
     existing default runtime resolution should run unchanged.
 
-    Resolution order (matches the story's contract):
+    Resolution order:
 
-    1. If the request carries any explicit runtime selector, inheritance
-       is skipped – the existing path validates the selector.
-    2. If ``runtimeInheritance = "caller"`` and the principal is a task
+    1. If ``runtimeInheritance = "caller"`` and the principal is a task
        principal with the required scopes, copy the caller task's runtime.
-    3. If ``runtimeInheritance = "parent"`` and ``parentWorkflowId`` is
+    2. If ``runtimeInheritance = "parent"`` and ``parentWorkflowId`` is
        provided, copy the parent's runtime after verifying ownership.
-    4. Otherwise return ``None``.
+    3. Otherwise return ``None``.
+
+    The inherited runtime is applied non-destructively by
+    ``apply_inherited_runtime_to_payload`` – explicit fields on the request
+    are preserved and inheritance only fills in the gaps. This means a
+    caller that opts into inheritance via the directive will pick up the
+    parent's model, effort, and provider profile even when it has stamped
+    an explicit ``targetRuntime`` or partial ``task.runtime`` block.
     """
 
     if task_payload is None and isinstance(request_payload, Mapping):
@@ -326,9 +331,6 @@ async def resolve_child_runtime_inheritance(
             else {}
         )
     task_payload = task_payload or {}
-
-    if has_explicit_child_runtime(request_payload, task_payload):
-        return None
 
     directive, parent_workflow_id_hint = extract_inheritance_directive(
         request_payload, task_payload
@@ -385,29 +387,44 @@ def apply_inherited_runtime_to_payload(
 ) -> None:
     """Stamp ``inherited`` runtime fields onto a normalised task payload.
 
-    Mutates ``payload`` and ``task_payload`` in place.  The downstream
-    runtime resolution path then sees the request *as if it had explicitly
-    contained* the inherited fields (which is the contract documented in
-    the story).
+    Mutates ``payload`` and ``task_payload`` in place.  Applied strictly
+    non-destructively: any field the caller already set (``targetRuntime``,
+    ``task.runtime.{mode,model,effort,executionProfileRef,profileId,
+    providerProfile}``, or top-level ``profileId`` / ``providerProfile``)
+    is preserved; inheritance only fills in the gaps.  The downstream
+    runtime resolution path then sees the merged request.
     """
-
-    if inherited.target_runtime:
-        payload["targetRuntime"] = inherited.target_runtime
 
     runtime_block = (
         dict(task_payload.get("runtime"))
         if isinstance(task_payload.get("runtime"), Mapping)
         else {}
     )
-    if inherited.target_runtime:
+
+    explicit_target_runtime = _coerce_str(
+        payload.get("targetRuntime")
+    ) or _coerce_str(runtime_block.get("mode"))
+    explicit_profile_id = (
+        _coerce_str(runtime_block.get("profileId"))
+        or _coerce_str(runtime_block.get("providerProfile"))
+        or _coerce_str(payload.get("profileId"))
+        or _coerce_str(payload.get("providerProfile"))
+        or _coerce_str(task_payload.get("profileId"))
+        or _coerce_str(task_payload.get("providerProfile"))
+    )
+
+    if inherited.target_runtime and not explicit_target_runtime:
+        payload["targetRuntime"] = inherited.target_runtime
         runtime_block["mode"] = inherited.target_runtime
-    if inherited.model and not runtime_block.get("model"):
+    if inherited.model and not _coerce_str(runtime_block.get("model")):
         runtime_block["model"] = inherited.model
-    if inherited.effort and not runtime_block.get("effort"):
+    if inherited.effort and not _coerce_str(runtime_block.get("effort")):
         runtime_block["effort"] = inherited.effort
-    if inherited.execution_profile_ref and not runtime_block.get("executionProfileRef"):
+    if inherited.execution_profile_ref and not _coerce_str(
+        runtime_block.get("executionProfileRef")
+    ):
         runtime_block["executionProfileRef"] = inherited.execution_profile_ref
-    if inherited.profile_id and not runtime_block.get("profileId"):
+    if inherited.profile_id and not explicit_profile_id:
         runtime_block["profileId"] = inherited.profile_id
 
     if runtime_block:

--- a/tests/unit/workflows/tasks/test_runtime_inheritance.py
+++ b/tests/unit/workflows/tasks/test_runtime_inheritance.py
@@ -484,6 +484,35 @@ def test_apply_inherited_runtime_skips_execution_profile_ref_when_explicit_profi
     assert "executionProfileRef" not in task_payload["runtime"]
 
 
+def test_apply_inherited_runtime_skips_profile_backfill_when_child_sets_execution_profile_ref() -> None:
+    """Explicit child executionProfileRef counts as a profile selector.
+
+    Backfilling the parent's profileId on top of the child's
+    executionProfileRef would leave the merged runtime block carrying a
+    stale parent profileId — confusing for consumers that read it, even
+    though downstream selection prefers executionProfileRef.
+    """
+
+    payload: dict[str, Any] = {
+        "task": {"runtime": {"executionProfileRef": "child-explicit"}}
+    }
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="codex_cli",
+        profile_id="parent-default",
+        execution_profile_ref="parent-default",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert task_payload["runtime"]["executionProfileRef"] == "child-explicit"
+    assert "profileId" not in task_payload["runtime"]
+
+
 def test_apply_inherited_runtime_skips_execution_profile_ref_for_top_level_provider_profile() -> None:
     payload: dict[str, Any] = {"providerProfile": "child-explicit", "task": {}}
     task_payload = payload["task"]

--- a/tests/unit/workflows/tasks/test_runtime_inheritance.py
+++ b/tests/unit/workflows/tasks/test_runtime_inheritance.py
@@ -157,7 +157,16 @@ async def test_caller_inheritance_copies_parent_runtime() -> None:
 
 
 @pytest.mark.asyncio
-async def test_explicit_child_runtime_short_circuits_inheritance() -> None:
+async def test_directive_runs_inheritance_alongside_explicit_runtime_fields() -> None:
+    """An explicit targetRuntime must not block inheritance for other fields.
+
+    When a caller sends ``runtimeInheritance="caller"`` together with a
+    partial explicit runtime (e.g. ``targetRuntime`` only), inheritance still
+    runs so that missing fields like ``model`` and ``effort`` are copied
+    from the parent.  ``apply_inherited_runtime_to_payload`` preserves the
+    caller's explicit fields.
+    """
+
     service = _FakeService({"mm:parent": _parent_record()})
     principal = ExecutionPrincipal(
         user_id="user-1",
@@ -177,7 +186,12 @@ async def test_explicit_child_runtime_short_circuits_inheritance() -> None:
         service=service,
     )
 
-    assert inherited is None
+    assert inherited is not None
+    # Parent's model/effort/profile are surfaced regardless of the
+    # caller's explicit targetRuntime override.
+    assert inherited.model == "gpt-5.4"
+    assert inherited.effort == "high"
+    assert inherited.execution_profile_ref == "codex_default"
 
 
 @pytest.mark.asyncio
@@ -411,3 +425,61 @@ def test_apply_inherited_runtime_does_not_overwrite_existing_runtime_fields() ->
     # New fields are filled in.
     assert task_payload["runtime"]["effort"] == "high"
     assert task_payload["runtime"]["executionProfileRef"] == "codex_default"
+
+
+def test_apply_inherited_runtime_preserves_explicit_target_runtime() -> None:
+    """An explicit ``targetRuntime`` must survive inheritance."""
+
+    payload: dict[str, Any] = {
+        "targetRuntime": "claude_code",
+        "task": {"runtime": {"mode": "claude_code"}},
+    }
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="codex_cli",
+        model="gpt-5.4",
+        effort="high",
+        execution_profile_ref="codex_default",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert payload["targetRuntime"] == "claude_code"
+    assert task_payload["runtime"]["mode"] == "claude_code"
+    # The other gaps still fill in from the parent.
+    assert task_payload["runtime"]["model"] == "gpt-5.4"
+    assert task_payload["runtime"]["effort"] == "high"
+    assert task_payload["runtime"]["executionProfileRef"] == "codex_default"
+
+
+def test_apply_inherited_runtime_fills_model_when_only_runtime_mode_is_explicit() -> None:
+    """Regression: parent sonnet-4-6 must carry over when child sets only mode.
+
+    Mirrors the batch-pr-resolver scenario where the request stamps
+    ``targetRuntime`` / ``task.runtime.mode`` as a fallback but leaves
+    ``model`` empty because the parent's task_context.json lacked it.
+    Inheritance should still fill in the missing model from the parent's
+    resolved parameters.
+    """
+
+    payload: dict[str, Any] = {
+        "targetRuntime": "claude_code",
+        "task": {"runtime": {"mode": "claude_code"}},
+    }
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="claude_code",
+        model="sonnet-4-6",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert task_payload["runtime"]["model"] == "sonnet-4-6"

--- a/tests/unit/workflows/tasks/test_runtime_inheritance.py
+++ b/tests/unit/workflows/tasks/test_runtime_inheritance.py
@@ -456,6 +456,54 @@ def test_apply_inherited_runtime_preserves_explicit_target_runtime() -> None:
     assert task_payload["runtime"]["executionProfileRef"] == "codex_default"
 
 
+def test_apply_inherited_runtime_skips_execution_profile_ref_when_explicit_profile_id() -> None:
+    """Explicit child profileId must not be silently overridden by the parent ref.
+
+    Downstream selection prefers ``executionProfileRef`` over
+    ``profileId``/``providerProfile``, so backfilling the parent's ref
+    when the child supplied an explicit profile selector would route the
+    child to the wrong provider profile.
+    """
+
+    payload: dict[str, Any] = {"task": {"runtime": {"profileId": "child-explicit"}}}
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="codex_cli",
+        model="gpt-5.4",
+        profile_id="parent-default",
+        execution_profile_ref="parent-default",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert task_payload["runtime"]["profileId"] == "child-explicit"
+    assert "executionProfileRef" not in task_payload["runtime"]
+
+
+def test_apply_inherited_runtime_skips_execution_profile_ref_for_top_level_provider_profile() -> None:
+    payload: dict[str, Any] = {"providerProfile": "child-explicit", "task": {}}
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="codex_cli",
+        profile_id="parent-default",
+        execution_profile_ref="parent-default",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    runtime = task_payload.get("runtime", {})
+    assert "executionProfileRef" not in runtime
+    assert "profileId" not in runtime
+
+
 def test_apply_inherited_runtime_fills_model_when_only_runtime_mode_is_explicit() -> None:
     """Regression: parent sonnet-4-6 must carry over when child sets only mode.
 


### PR DESCRIPTION
## Summary
- The runtime-inheritance contract from #2082 short-circuited whenever the child request carried any explicit runtime selector. batch-pr-resolver always stamps a `targetRuntime` and `task.runtime` fallback alongside `runtimeInheritance: "caller"`, so the server-side path never ran and the parent's resolved model was never copied — a sonnet-4-6 parent ended up spawning opus-4-7 children.
- `resolve_child_runtime_inheritance` now runs inheritance whenever a directive is present, and `apply_inherited_runtime_to_payload` is strictly non-destructive: it fills in missing `targetRuntime` / `task.runtime.{mode,model,effort,profileId,executionProfileRef}` and leaves any explicit caller value untouched.
- Updated the test that pinned the old short-circuit, added regression coverage for explicit-runtime + inherited-model, and confirmed all 235 tests in the affected unit suites still pass.

## Test plan
- [x] `./tools/test_unit.sh tests/unit/workflows/tasks/test_runtime_inheritance.py`
- [x] `./tools/test_unit.sh tests/unit/test_batch_pr_resolver.py tests/unit/agents/codex_worker/test_worker.py tests/unit/api/test_execution_principal.py tests/unit/workflows/tasks/test_runtime_inheritance.py`
- [ ] Manual: spawn a child task from a sonnet-4-6 parent via batch-pr-resolver and confirm the child runs on sonnet-4-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)