### PR TITLE
When I apply a filter to the status column and I choose "AWAITING TASK", the filtered results also show CANCELED and FAILED tasks. Additionally, when…

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -535,16 +535,19 @@ def _state_include_clause(values: list[str]) -> str | None:
     """
     if not values:
         return None
-    deduped: list[str] = []
-    for value in values:
-        if value and value not in deduped:
-            deduped.append(value)
+    deduped = list(dict.fromkeys(v for v in values if v))
     non_terminal = [value for value in deduped if value in _NON_TERMINAL_MM_STATES]
-    terminal_statuses: list[str] = []
-    for value in deduped:
-        for status_value in _TERMINAL_EXECUTION_STATUSES_BY_MM_STATE.get(value, ()):  # noqa: E501
-            if status_value not in terminal_statuses:
-                terminal_statuses.append(status_value)
+    terminal_statuses = list(dict.fromkeys(
+        status
+        for value in deduped
+        for status in _TERMINAL_EXECUTION_STATUSES_BY_MM_STATE.get(value, ())
+    ))
+    unknown = [
+        value
+        for value in deduped
+        if value not in _NON_TERMINAL_MM_STATES
+        and value not in _TERMINAL_EXECUTION_STATUSES_BY_MM_STATE
+    ]
     parts: list[str] = []
     mm_clause = _any_temporal_query("mm_state", non_terminal)
     if mm_clause is not None:
@@ -552,6 +555,9 @@ def _state_include_clause(values: list[str]) -> str | None:
     status_clause = _any_temporal_query("ExecutionStatus", terminal_statuses)
     if status_clause is not None:
         parts.append(status_clause)
+    unknown_clause = _any_temporal_query("mm_state", unknown)
+    if unknown_clause is not None:
+        parts.append(unknown_clause)
     if not parts:
         return None
     if len(parts) == 1:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -206,6 +206,24 @@ _TEMPORAL_STATUS_VALUES = (
     "failed",
     "canceled",
 )
+_NON_TERMINAL_MM_STATES = frozenset(
+    {
+        "scheduled",
+        "initializing",
+        "waiting_on_dependencies",
+        "planning",
+        "awaiting_slot",
+        "executing",
+        "proposals",
+        "awaiting_external",
+        "finalizing",
+    }
+)
+_TERMINAL_EXECUTION_STATUSES_BY_MM_STATE = {
+    "completed": ("Completed",),
+    "failed": ("Failed", "Terminated", "TimedOut"),
+    "canceled": ("Canceled",),
+}
 
 
 class RemediationApprovalStateModel(BaseModel):
@@ -501,6 +519,87 @@ def _any_temporal_query(attr: str, values: list[str]) -> str | None:
     ) + ")"
 
 
+def _state_include_clause(values: list[str]) -> str | None:
+    """Build a Temporal visibility clause matching the effective workflow state.
+
+    Filtering only on the ``mm_state`` search attribute is unsafe for terminal
+    states: when a workflow is canceled, terminated, or times out without
+    re-entering the workflow code, ``mm_state`` is left at whatever value the
+    workflow last published (often a non-terminal one like
+    ``waiting_on_dependencies``). The executions list serializer then derives
+    the displayed state from the Temporal ``ExecutionStatus``, which means a
+    closed workflow can leak into "AWAITING TASK" or any other non-terminal
+    filter result. Anchor non-terminal states to ``ExecutionStatus="Running"``
+    and map terminal states to their Temporal ``ExecutionStatus`` so the
+    server-side filter agrees with the rendered status.
+    """
+    if not values:
+        return None
+    deduped: list[str] = []
+    for value in values:
+        if value and value not in deduped:
+            deduped.append(value)
+    non_terminal = [value for value in deduped if value in _NON_TERMINAL_MM_STATES]
+    terminal_statuses: list[str] = []
+    for value in deduped:
+        for status_value in _TERMINAL_EXECUTION_STATUSES_BY_MM_STATE.get(value, ()):  # noqa: E501
+            if status_value not in terminal_statuses:
+                terminal_statuses.append(status_value)
+    parts: list[str] = []
+    mm_clause = _any_temporal_query("mm_state", non_terminal)
+    if mm_clause is not None:
+        parts.append(f'({mm_clause} AND ExecutionStatus="Running")')
+    status_clause = _any_temporal_query("ExecutionStatus", terminal_statuses)
+    if status_clause is not None:
+        parts.append(status_clause)
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return "(" + " OR ".join(parts) + ")"
+
+
+def _append_state_temporal_filter(
+    query_parts: list[str],
+    *,
+    exact: str | None = None,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> None:
+    exact_value = str(exact or "").strip()
+    if exact_value:
+        if len(exact_value) > _EXECUTION_FILTER_VALUE_MAX_LENGTH:
+            raise TemporalExecutionValidationError(
+                f"mm_state exact value must be {_EXECUTION_FILTER_VALUE_MAX_LENGTH} characters or fewer."
+            )
+        clause = _state_include_clause([exact_value])
+        if clause is not None:
+            query_parts.append(clause)
+        return
+    include_clause = _state_include_clause(include or [])
+    if include_clause is not None:
+        query_parts.append(include_clause)
+    for value in exclude or []:
+        normalized = str(value or "").strip()
+        if not normalized:
+            continue
+        if normalized in _NON_TERMINAL_MM_STATES:
+            escaped = _escape_temporal_value(normalized)
+            query_parts.append(
+                f'(mm_state!="{escaped}" OR ExecutionStatus!="Running")'
+            )
+            continue
+        terminal_statuses = _TERMINAL_EXECUTION_STATUSES_BY_MM_STATE.get(
+            normalized, ()
+        )
+        if terminal_statuses:
+            for status_value in terminal_statuses:
+                escaped = _escape_temporal_value(status_value)
+                query_parts.append(f'ExecutionStatus!="{escaped}"')
+            continue
+        query_parts.append(f'mm_state!="{_escape_temporal_value(normalized)}"')
+
+
 def _append_exact_or_multi_temporal_filter(
     query_parts: list[str],
     attr: str,
@@ -644,11 +743,12 @@ def _build_temporal_execution_query(
         )
     elif workflow_type and not scope_query:
         query_parts.append(f'WorkflowType="{_escape_temporal_value(workflow_type)}"')
+    legacy_state_exact = None
     if state and not excluded("state") and not (state_in_values or state_not_in_values):
-        query_parts.append(f'mm_state="{_escape_temporal_value(state)}"')
-    _append_exact_or_multi_temporal_filter(
+        legacy_state_exact = state
+    _append_state_temporal_filter(
         query_parts,
-        "mm_state",
+        exact=legacy_state_exact,
         include=state_in_values,
         exclude=state_not_in_values,
     )

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -252,8 +252,13 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
 
     const runtimeFilter = screen.getByLabelText('Runtime filter value') as HTMLSelectElement;
-    expect(runtimeFilter.multiple).toBe(true);
-    expect(Array.from(runtimeFilter.options).map((option) => option.value)).toEqual([
+    expect(runtimeFilter.multiple).toBe(false);
+    // Skip the leading placeholder option that prompts the user to add a value.
+    expect(
+      Array.from(runtimeFilter.options)
+        .map((option) => option.value)
+        .filter((value) => value !== ''),
+    ).toEqual([
       'codex_cli',
       'codex',
       'claude_code',
@@ -550,10 +555,15 @@ describe('Tasks List Entrypoint', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
-    const options = Array.from(statusFilter.options).map((option) => option.value);
-    const optionLabels = Array.from(statusFilter.options).map((option) => option.textContent);
+    // Skip the leading placeholder option that prompts the user to add a value.
+    const options = Array.from(statusFilter.options)
+      .map((option) => option.value)
+      .filter((value) => value !== '');
+    const optionLabels = Array.from(statusFilter.options)
+      .filter((option) => option.value !== '')
+      .map((option) => option.textContent);
 
-    expect(statusFilter.multiple).toBe(true);
+    expect(statusFilter.multiple).toBe(false);
     expect(options).toEqual([
       'scheduled',
       'initializing',
@@ -596,6 +606,34 @@ describe('Tasks List Entrypoint', () => {
     expect(lastExecutionListUrl()).toBe(
       '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed',
     );
+  });
+
+  it('builds status filters as removable pills', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
+
+    fireEvent.change(statusFilter, { target: { value: 'completed' } });
+    fireEvent.change(statusFilter, { target: { value: 'failed' } });
+
+    const pillList = screen.getByLabelText('Selected status filters');
+    expect(pillList.textContent).toContain('completed');
+    expect(pillList.textContent).toContain('failed');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove completed' }));
+    expect(pillList.textContent).not.toContain('completed');
+    expect(pillList.textContent).toContain('failed');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=failed',
+      );
+    });
   });
 
   it('stages status changes until Apply and discards them on cancel, Escape, or outside click', async () => {
@@ -722,10 +760,8 @@ describe('Tasks List Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
 
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
-    for (const option of Array.from(statusFilter.options)) {
-      option.selected = option.value === 'completed' || option.value === 'failed';
-    }
-    fireEvent.change(statusFilter);
+    fireEvent.change(statusFilter, { target: { value: 'completed' } });
+    fireEvent.change(statusFilter, { target: { value: 'failed' } });
     fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
 
     await waitFor(() => {
@@ -954,7 +990,9 @@ describe('Tasks List Entrypoint', () => {
     expect(pageSizeLabel?.classList.contains('queue-page-size-selector')).toBe(true);
     expect(pageSizeLabel?.classList.contains('queue-inline-filter')).toBe(false);
     expect(tableWrapper).toBeTruthy();
-    expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('hidden');
+    // The slab intentionally allows overflow so the column filter popover
+    // can extend below the table without being clipped.
+    expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).overflowX).toBe('auto');
     expect(getComputedStyle(tableWrapper as HTMLElement).overflowY).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');
@@ -1000,7 +1038,9 @@ describe('Tasks List Entrypoint', () => {
 
     const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
-    expect(dataSlabStyles.overflow).toBe('hidden');
+    // The slab intentionally allows overflow so the column filter popover
+    // can extend below the table without being clipped by the data slab.
+    expect(dataSlabStyles.overflow).toBe('visible');
     expect(dataSlabStyles.paddingTop).toBe('0px');
 
     const tableWrapperStyles = getComputedStyle(tableWrapper as HTMLElement);

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -502,7 +502,7 @@ function FilterPillMultiSelect({
         onChange={(event) => {
           const next = event.target.value;
           if (!next) return;
-          onChange(uniqueValues([...values, next]));
+          onChange([...values, next]);
         }}
       >
         <option value="">

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -441,6 +441,83 @@ function facetForFilterField(field: FilterField | null): ExecutionFacetResponse[
   return null;
 }
 
+type PillMultiSelectProps = {
+  id?: string;
+  values: string[];
+  options: string[];
+  formatValue?: (value: string) => string;
+  disabled?: boolean;
+  ariaLabelAdd: string;
+  ariaLabelSelected: string;
+  addPlaceholder?: string;
+  emptyMessage?: string;
+  onChange: (next: string[]) => void;
+};
+
+function FilterPillMultiSelect({
+  id,
+  values,
+  options,
+  formatValue,
+  disabled,
+  ariaLabelAdd,
+  ariaLabelSelected,
+  addPlaceholder = 'Add value',
+  emptyMessage = 'No values selected',
+  onChange,
+}: PillMultiSelectProps) {
+  const fmt = formatValue || ((value: string) => value);
+  const available = options.filter((option) => !values.includes(option));
+  const noneSelected = values.length === 0;
+  return (
+    <div className="task-list-pill-multiselect">
+      <ul
+        className={`task-list-pill-list${noneSelected ? ' is-empty' : ''}`}
+        aria-label={ariaLabelSelected}
+      >
+        {noneSelected ? (
+          <li className="task-list-pill-empty small">{emptyMessage}</li>
+        ) : (
+          values.map((value) => (
+            <li key={value} className="task-list-pill">
+              <span className="task-list-pill-label">{fmt(value)}</span>
+              <button
+                type="button"
+                className="task-list-pill-remove"
+                disabled={disabled}
+                aria-label={`Remove ${fmt(value)}`}
+                onClick={() => onChange(values.filter((entry) => entry !== value))}
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </li>
+          ))
+        )}
+      </ul>
+      <select
+        id={id}
+        aria-label={ariaLabelAdd}
+        value=""
+        disabled={disabled || available.length === 0}
+        onChange={(event) => {
+          const next = event.target.value;
+          if (!next) return;
+          onChange(uniqueValues([...values, next]));
+        }}
+      >
+        <option value="">
+          {available.length === 0 ? 'All values selected' : addPlaceholder}
+        </option>
+        {available.map((option) => (
+          <option key={option} value={option}>
+            {fmt(option)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
 function filterSummary(field: FilterField, filters: ColumnFilters): string {
   const summarizeValues = (filter: ValueFilter, formatter = (value: string) => value) => {
     if (filter.blank === 'include' && filter.values.length === 0) return 'blank';
@@ -965,28 +1042,21 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               <option value="exclude">Exclude selected</option>
             </select>
           </label>
-          <label>
-            {labelPrefix}Status filter value
-            <select
-              multiple
-              value={draft.values}
-              size={Math.min(TEMPORAL_STATUSES.length, 8)}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                const next = Array.from(event.target.selectedOptions).map((option) =>
-                  option.value.toLowerCase(),
-                );
-                if (isMobile) applyMobileValues('status', next);
-                else updateDraftValues('status', next);
-              }}
-            >
-              {TEMPORAL_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {formatStatusLabel(status)}
-                </option>
-              ))}
-            </select>
-          </label>
+          <FilterPillMultiSelect
+            values={draft.values}
+            options={[...TEMPORAL_STATUSES]}
+            formatValue={formatStatusLabel}
+            disabled={!listEnabled}
+            ariaLabelAdd={`${labelPrefix}Status filter value`}
+            ariaLabelSelected={`${labelPrefix}Selected status filters`}
+            addPlaceholder="Add status"
+            emptyMessage="No status filters selected"
+            onChange={(next) => {
+              const normalized = next.map((value) => value.toLowerCase());
+              if (isMobile) applyMobileValues('status', normalized);
+              else updateDraftValues('status', normalized);
+            }}
+          />
           {renderFacetNotice('status')}
         </div>
       );
@@ -1061,26 +1131,20 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               <option value="exclude">Exclude selected</option>
             </select>
           </label>
-          <label>
-            {labelPrefix}Runtime filter value
-            <select
-              multiple
-              value={draft.values}
-              size={Math.min(Math.max(runtimeOptions.length, 1), 8)}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                const next = Array.from(event.target.selectedOptions).map((option) => option.value);
-                if (isMobile) applyMobileValues('targetRuntime', next);
-                else updateDraftValues('targetRuntime', next);
-              }}
-            >
-              {runtimeOptions.map((runtime) => (
-                <option key={runtime} value={runtime}>
-                  {formatRuntimeLabel(runtime)}
-                </option>
-              ))}
-            </select>
-          </label>
+          <FilterPillMultiSelect
+            values={draft.values}
+            options={runtimeOptions}
+            formatValue={formatRuntimeLabel}
+            disabled={!listEnabled}
+            ariaLabelAdd={`${labelPrefix}Runtime filter value`}
+            ariaLabelSelected={`${labelPrefix}Selected runtime filters`}
+            addPlaceholder="Add runtime"
+            emptyMessage="No runtime filters selected"
+            onChange={(next) => {
+              if (isMobile) applyMobileValues('targetRuntime', next);
+              else updateDraftValues('targetRuntime', next);
+            }}
+          />
           {renderFacetNotice('targetRuntime')}
         </div>
       );
@@ -1106,26 +1170,19 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
               <option value="exclude">Exclude selected</option>
             </select>
           </label>
-          <label>
-            {labelPrefix}Skill filter value
-            <select
-              multiple
-              value={draft.values}
-              size={Math.min(Math.max(skillOptions.length, 1), 8)}
-              disabled={!listEnabled}
-              onChange={(event) => {
-                const next = Array.from(event.target.selectedOptions).map((option) => option.value);
-                if (isMobile) applyMobileValues('targetSkill', next);
-                else updateDraftValues('targetSkill', next);
-              }}
-            >
-              {skillOptions.map((skill) => (
-                <option key={skill} value={skill}>
-                  {skill}
-                </option>
-              ))}
-            </select>
-          </label>
+          <FilterPillMultiSelect
+            values={draft.values}
+            options={skillOptions}
+            disabled={!listEnabled}
+            ariaLabelAdd={`${labelPrefix}Skill filter value`}
+            ariaLabelSelected={`${labelPrefix}Selected skill filters`}
+            addPlaceholder="Add skill"
+            emptyMessage="No skill filters selected"
+            onChange={(next) => {
+              if (isMobile) applyMobileValues('targetSkill', next);
+              else updateDraftValues('targetSkill', next);
+            }}
+          />
           {renderFacetNotice('targetSkill')}
         </div>
       );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -658,7 +658,7 @@ h1 {
   position: absolute;
   top: calc(100% + 0.35rem);
   left: 0;
-  z-index: 8;
+  z-index: 80;
   width: min(22rem, calc(100vw - 2rem));
   padding: 0.85rem;
   border: 1px solid rgb(var(--mm-border) / 0.84);
@@ -722,6 +722,82 @@ h1 {
   margin-top: 0.85rem;
   padding-top: 0.75rem;
   border-top: 1px solid rgb(var(--mm-border) / 0.7);
+}
+
+.task-list-pill-multiselect {
+  display: grid;
+  gap: 0.45rem;
+  width: 100%;
+}
+
+.task-list-pill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-height: 2.1rem;
+  border: 1px dashed rgb(var(--mm-border) / 0.7);
+  border-radius: 0.4rem;
+  background: rgb(var(--mm-panel) / 0.6);
+}
+
+.task-list-pill-list.is-empty {
+  align-items: center;
+  border-style: dashed;
+}
+
+.task-list-pill-empty {
+  margin: 0;
+  padding: 0 0.35rem;
+  opacity: 0.7;
+}
+
+.task-list-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.25rem 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgb(var(--mm-accent) / 0.18);
+  border: 1px solid rgb(var(--mm-accent) / 0.45);
+  font-size: 0.78rem;
+  line-height: 1.25;
+  color: rgb(var(--mm-ink));
+}
+
+.task-list-pill-label {
+  white-space: nowrap;
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-list-pill-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.task-list-pill-remove:hover:not(:disabled),
+.task-list-pill-remove:focus-visible {
+  background: rgb(var(--mm-accent) / 0.35);
+}
+
+.task-list-pill-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .stack {
@@ -1053,7 +1129,7 @@ tbody tr:hover {
 
 .task-list-data-slab {
   gap: 0;
-  overflow: hidden;
+  overflow: visible;
   padding: 0;
   border-color: rgb(var(--mm-border) / 0.45);
   background: rgb(var(--mm-panel) / 0.96);
@@ -1093,6 +1169,8 @@ tbody tr:hover {
 }
 
 .task-list-data-slab .task-list-results-footer {
+  position: relative;
+  z-index: 1;
   border-top: 1px solid rgb(var(--mm-border) / 0.28);
   border-bottom: 0;
 }
@@ -1152,6 +1230,8 @@ tbody tr:hover {
 }
 
 .task-list-data-slab .queue-table-wrapper {
+  position: relative;
+  z-index: 5;
   border: 0;
   border-radius: 0;
   background: transparent;

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -383,7 +383,97 @@ def test_list_executions_temporal_query_includes_canonical_state_filters() -> No
     query = temporal_client.count_workflows.await_args.kwargs["query"]
     assert 'WorkflowType="MoonMind.Run"' in query
     assert 'mm_entry="run"' in query
-    assert '(mm_state="completed" OR mm_state="failed")' in query
+    # ``completed`` and ``failed`` are terminal states; the executions list
+    # filter resolves them to the Temporal ``ExecutionStatus`` so closed
+    # workflows whose ``mm_state`` search attribute was never updated still
+    # match the user's selection.
+    assert 'ExecutionStatus="Completed"' in query
+    assert 'ExecutionStatus="Failed"' in query
+    assert 'ExecutionStatus="Terminated"' in query
+    assert 'ExecutionStatus="TimedOut"' in query
+    assert 'mm_state="completed"' not in query
+    assert 'mm_state="failed"' not in query
+
+
+def test_list_executions_temporal_query_anchors_non_terminal_state_to_running_status() -> None:
+    """Selecting ``AWAITING TASK`` must not match closed workflows whose
+    ``mm_state`` search attribute was left at ``waiting_on_dependencies``
+    when they were canceled or failed.
+    """
+
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scope": "tasks",
+                "stateIn": "waiting_on_dependencies",
+            },
+        )
+
+    assert response.status_code == 200
+    query = temporal_client.count_workflows.await_args.kwargs["query"]
+    assert 'mm_state="waiting_on_dependencies"' in query
+    assert 'ExecutionStatus="Running"' in query
+    assert 'ExecutionStatus="Failed"' not in query
+    assert 'ExecutionStatus="Canceled"' not in query
+
+
+def test_list_executions_temporal_query_mixes_terminal_and_non_terminal_state_filters() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "scope": "tasks",
+                "stateIn": "waiting_on_dependencies,canceled",
+            },
+        )
+
+    assert response.status_code == 200
+    query = temporal_client.count_workflows.await_args.kwargs["query"]
+    assert 'mm_state="waiting_on_dependencies"' in query
+    assert 'ExecutionStatus="Running"' in query
+    assert 'ExecutionStatus="Canceled"' in query
+
 
 def test_list_executions_temporal_query_supports_repeated_canonical_filters() -> None:
     app = FastAPI()
@@ -457,7 +547,8 @@ def test_list_executions_temporal_query_ignores_empty_canonical_state_for_legacy
 
     assert response.status_code == 200
     query = temporal_client.count_workflows.await_args.kwargs["query"]
-    assert 'mm_state="completed"' in query
+    assert 'ExecutionStatus="Completed"' in query
+    assert 'mm_state="completed"' not in query
 
 def test_list_executions_temporal_query_rejects_contradictory_canonical_filters() -> None:
     app = FastAPI()
@@ -567,7 +658,10 @@ def test_list_executions_temporal_query_prefers_canonical_filters_over_legacy_ex
 
     assert response.status_code == 200
     query = temporal_client.count_workflows.await_args.kwargs["query"]
-    assert 'mm_state="completed"' in query
+    assert (
+        '(ExecutionStatus="Completed")' in query
+        or 'ExecutionStatus="Completed"' in query
+    )
     assert 'mm_state="executing"' not in query
     assert 'mm_repo="owner/repo"' in query
     assert 'mm_repo="legacy/repo"' not in query


### PR DESCRIPTION
When I apply a filter to the status column and I choose "AWAITING TASK", the filtered results also show CANCELED and FAILED tasks. Additionally, when there are not many filtered results, the bottom bar of the table which includes the live updates and pagination controls seems to appear on top of the filter pop-up, which is strange and inconvenient. Lastly, it is possible to multi-select now, but I would prefer a multi-select interface which as you select options adds label pills which can be X'd away if you decide you don't want one, as opposed to requiring a shift or ctrl click to select more than one.