### PR TITLE
MM-654 Sparse settings override persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,8 @@ Key diagnostics:
 - Existing task-template catalog tables and execution payload/artifact records only; no new persistent storage planned. (331-model-step-type-payloads)
 - Python 3.12 (existing MoonMind runtime); adds `moonmind/workflows/temporal/transition_mm667.py` for the one-shot MM-667 orchestration. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (334-transition-mm667-in-pr)
 - N/A — this is a one-shot tool-driven workflow. The only persisted artifact is the run's structured outcome report (artifact-backed run output); no new persistent tables. (334-transition-mm667-in-pr)
+- Python 3.12 + FastAPI, Pydantic v2, SQLAlchemy async ORM, Alembic, pytest, httpx ASGI test transport (339-sparse-settings-overrides)
+- Existing SQLAlchemy/Alembic database tables `settings_overrides` and `settings_audit_events`; no new persistent table expected (339-sparse-settings-overrides)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -239,6 +239,8 @@ Key diagnostics:
 - Existing task-template catalog tables and execution payload/artifact records only; no new persistent storage planned. (331-model-step-type-payloads)
 - Python 3.12 (existing MoonMind runtime); adds `moonmind/workflows/temporal/transition_mm667.py` for the one-shot MM-667 orchestration. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (334-transition-mm667-in-pr)
 - N/A — this is a one-shot tool-driven workflow. The only persisted artifact is the run's structured outcome report (artifact-backed run output); no new persistent tables. (334-transition-mm667-in-pr)
+- Python 3.12 + FastAPI, Pydantic v2, SQLAlchemy async ORM, Alembic, pytest, httpx ASGI test transport (339-sparse-settings-overrides)
+- Existing SQLAlchemy/Alembic database tables `settings_overrides` and `settings_audit_events`; no new persistent table expected (339-sparse-settings-overrides)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -44,6 +45,7 @@ SettingActivationState = Literal[
 SettingMigrationState = Literal["renamed", "deprecated", "removed", "type_changed"]
 _DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
 _PERSISTED_SCOPES: set[SettingScope] = {"user", "workspace"}
+_MAX_OVERRIDE_VALUE_BYTES = 16 * 1024
 _SECRET_PREFIXES = ("ghp_", "github_pat_", "AIza", "AKIA")
 _UNSAFE_FIELD_TOKENS = (
     "secret",
@@ -60,6 +62,16 @@ _UNSAFE_FIELD_TOKENS = (
     "command_history",
     "operational_history",
     "decrypted",
+)
+_UNSAFE_STRING_TOKENS = (
+    "oauth_session",
+    "decrypted_credential",
+    "generated_config",
+    "password=",
+    "private_key",
+    "large_artifact",
+    "workflow_payload",
+    "command_history",
 )
 
 SETTINGS_PERMISSION_NAMES: frozenset[str] = frozenset(
@@ -1705,6 +1717,8 @@ class SettingsCatalogService:
         return f"Resolved from {source}."
 
     def _validate_override_value(self, entry: SettingRegistryEntry, value: Any) -> None:
+        if self._override_value_size(value) > _MAX_OVERRIDE_VALUE_BYTES:
+            raise ValueError("invalid_setting_value")
         if self._contains_unsafe_payload(value):
             raise ValueError("invalid_setting_value")
         if value is None:
@@ -1735,9 +1749,23 @@ class SettingsCatalogService:
         else:
             raise ValueError("invalid_setting_value")
 
+    def _override_value_size(self, value: Any) -> int:
+        return len(
+            json.dumps(
+                value,
+                default=str,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+
     def _contains_unsafe_payload(self, value: Any) -> bool:
         if isinstance(value, str):
-            return any(prefix in value for prefix in _SECRET_PREFIXES)
+            normalized = value.lower()
+            return any(prefix in value for prefix in _SECRET_PREFIXES) or any(
+                token in normalized for token in _UNSAFE_STRING_TOKENS
+            )
         if isinstance(value, dict):
             for key, nested in value.items():
                 normalized = str(key).lower()

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -67,11 +67,20 @@ _UNSAFE_STRING_TOKENS = (
     "oauth_session",
     "decrypted_credential",
     "generated_config",
+    "token=",
+    "secret=",
+    "api_key=",
+    "apikey=",
     "password=",
     "private_key",
     "large_artifact",
     "workflow_payload",
     "command_history",
+)
+_UNSAFE_PROFILE_REF_ASSIGNMENT_RE = re.compile(
+    r"(secret|token|password|api_key|apikey|credential|private_key|refresh|oauth|"
+    r"workflow_payload|artifact|command_history|operational_history|decrypted|"
+    r"generated_config|large_artifact)\w*\s*[:=]"
 )
 
 SETTINGS_PERMISSION_NAMES: frozenset[str] = frozenset(
@@ -1719,7 +1728,11 @@ class SettingsCatalogService:
     def _validate_override_value(self, entry: SettingRegistryEntry, value: Any) -> None:
         if self._override_value_size(value) > _MAX_OVERRIDE_VALUE_BYTES:
             raise ValueError("invalid_setting_value")
-        if self._contains_unsafe_payload(value):
+        if self._contains_unsafe_payload(
+            value,
+            allow_profile_ref_string_tokens=entry.key
+            == "workflow.default_provider_profile_ref",
+        ):
             raise ValueError("invalid_setting_value")
         if value is None:
             return
@@ -1760,9 +1773,18 @@ class SettingsCatalogService:
             ).encode("utf-8")
         )
 
-    def _contains_unsafe_payload(self, value: Any) -> bool:
+    def _contains_unsafe_payload(
+        self,
+        value: Any,
+        *,
+        allow_profile_ref_string_tokens: bool = False,
+    ) -> bool:
         if isinstance(value, str):
             normalized = value.lower()
+            if allow_profile_ref_string_tokens:
+                return any(prefix in value for prefix in _SECRET_PREFIXES) or bool(
+                    _UNSAFE_PROFILE_REF_ASSIGNMENT_RE.search(normalized)
+                )
             return any(prefix in value for prefix in _SECRET_PREFIXES) or any(
                 token in normalized for token in _UNSAFE_STRING_TOKENS
             )

--- a/specs/339-sparse-settings-overrides/checklists/requirements.md
+++ b/specs/339-sparse-settings-overrides/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Sparse Settings Override Persistence and Reset
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The generated specification defines one runtime story for `MM-654`.
+- PASS: The original Jira preset brief is preserved verbatim in `**Input**` for downstream verification. Implementation-oriented terms that appear in that preserved source block are intentionally retained for traceability; the generated story, source mappings, requirements, and success criteria remain behavior-focused.
+- PASS: In-scope source design requirements map to functional requirements FR-001 through FR-013.

--- a/specs/339-sparse-settings-overrides/contracts/settings-overrides-api.md
+++ b/specs/339-sparse-settings-overrides/contracts/settings-overrides-api.md
@@ -1,0 +1,114 @@
+# Contract: Settings Override API
+
+This contract describes the existing public settings surfaces relevant to `MM-654`.
+
+## Read Effective Setting
+
+```http
+GET /api/v1/settings/effective/{key}?scope={scope}
+```
+
+Parameters:
+
+- `key`: setting key.
+- `scope`: `user` or `workspace` for this story.
+
+Successful response:
+
+```json
+{
+  "key": "workflow.default_publish_mode",
+  "scope": "workspace",
+  "value": "branch",
+  "source": "workspace_override",
+  "source_explanation": "Resolved from a workspace override.",
+  "value_version": 1,
+  "diagnostics": []
+}
+```
+
+Required behavior:
+
+- If no override exists, return the inherited effective value and inherited source.
+- If an override exists, return the override value, source, and version metadata.
+- Do not reveal secret plaintext in values, diagnostics, or errors.
+
+## Save Overrides
+
+```http
+PATCH /api/v1/settings/{scope}
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "changes": {
+    "workflow.default_publish_mode": "branch"
+  },
+  "expected_versions": {
+    "workflow.default_publish_mode": 1
+  },
+  "reason": "Use branch publishing for workspace tasks."
+}
+```
+
+Successful response:
+
+```json
+{
+  "scope": "workspace",
+  "values": {
+    "workflow.default_publish_mode": {
+      "key": "workflow.default_publish_mode",
+      "scope": "workspace",
+      "value": "branch",
+      "source": "workspace_override",
+      "value_version": 1,
+      "diagnostics": []
+    }
+  }
+}
+```
+
+Failure responses:
+
+- `400 invalid_setting_value`: value is larger than 16 KiB when serialized, off-schema, or contains unsafe payload data.
+- `400 invalid_scope`: setting is not editable at the requested scope.
+- `404 setting_not_exposed`: setting key is not exposed.
+- `409 version_conflict`: expected version does not match current version; no partial changes are persisted.
+- `423 read_only_setting`: setting is exposed but not writable.
+
+Required behavior:
+
+- Validate every change before persistence.
+- Reject the whole batch if any change is invalid or stale.
+- Store SecretRef/resource references as references only.
+- Never store raw secret plaintext, OAuth session blobs, decrypted credentials, generated secret-bearing config, large artifacts, workflow payloads, or operational command history.
+
+## Reset Override
+
+```http
+DELETE /api/v1/settings/{scope}/{key}
+```
+
+Successful response:
+
+```json
+{
+  "key": "workflow.default_publish_mode",
+  "scope": "workspace",
+  "value": "none",
+  "source": "config_or_default",
+  "value_version": 1,
+  "diagnostics": []
+}
+```
+
+Required behavior:
+
+- Delete only the matching override.
+- Return the inherited effective value after reset.
+- Preserve defaults, provider profiles, managed secrets, OAuth credential volumes, and settings audit history.
+- Return structured settings outcomes or errors for unknown, ineligible, read-only, already absent, or invalid-scope requests without deleting unrelated resources.

--- a/specs/339-sparse-settings-overrides/data-model.md
+++ b/specs/339-sparse-settings-overrides/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Sparse Settings Override Persistence and Reset
+
+## Setting Override
+
+Purpose: Stores one sparse override for one setting key at user or workspace scope.
+
+Fields:
+
+- `id`: unique identifier for the override row.
+- `scope`: `user` or `workspace`.
+- `workspace_id`: workspace subject for the override, or the default subject marker when not applicable.
+- `user_id`: user subject for the override, or the default subject marker when not applicable.
+- `key`: stable setting key.
+- `value_json`: stored override value. May be null to represent an intentional null override.
+- `schema_version`: stored value schema version.
+- `value_version`: optimistic concurrency version.
+- `created_by` / `updated_by`: optional actor identity.
+- `created_at` / `updated_at`: audit timestamps.
+
+Relationships and constraints:
+
+- Unique by `scope`, `workspace_id`, `user_id`, and `key`.
+- Only user and workspace scopes are persisted by this story.
+- Absence of a row means inherit; absence is distinct from a row whose value is null.
+
+Validation rules:
+
+- Values must match the registered setting schema.
+- Values must stay within the configured serialized size limit of 16 KiB.
+- Values must not contain raw secret plaintext, OAuth session data, decrypted credentials, generated config containing secrets, large artifacts, workflow payloads, or operational command history.
+- SecretRef and resource-reference values are stored only as references and are not resolved to plaintext during override persistence.
+
+## Effective Setting Value
+
+Purpose: Represents the resolved setting returned to callers.
+
+Fields:
+
+- `key`: setting key.
+- `scope`: requested effective scope.
+- `value`: resolved value.
+- `source`: one of inherited/configured/default, `workspace_override`, `user_override`, or intentional-null override source.
+- `source_explanation`: human-readable source explanation.
+- `value_version`: version of the winning override or inherited baseline.
+- `diagnostics`: structured validation, migration, or resolution diagnostics.
+
+State transitions:
+
+- No override -> inherited effective value.
+- Workspace override saved -> workspace effective source becomes `workspace_override`.
+- User override saved -> user effective source becomes `user_override`.
+- User override reset -> user effective value inherits workspace override or default.
+- Workspace override reset -> workspace effective value inherits configured/default value.
+
+## Settings Audit Event
+
+Purpose: Records non-secret settings changes and reset events.
+
+Fields:
+
+- `event_type`: override update or reset event.
+- `key`: setting key.
+- `scope`: user or workspace.
+- `workspace_id` / `user_id`: scoped subject identity.
+- `actor_user_id`: optional actor identity.
+- `old_value_json` / `new_value_json`: redacted or stored values according to audit policy.
+- `redacted`: whether values were redacted.
+- `reason`: optional operator-provided reason.
+- `created_at`: event timestamp.
+
+Validation rules:
+
+- Audit events must not expose raw secret values.
+- Reset writes an audit event but must not delete existing audit history.

--- a/specs/339-sparse-settings-overrides/moonspec_align_report.md
+++ b/specs/339-sparse-settings-overrides/moonspec_align_report.md
@@ -1,0 +1,28 @@
+# MoonSpec Alignment Report: Sparse Settings Override Persistence and Reset
+
+**Feature**: `specs/339-sparse-settings-overrides`
+**Source**: `MM-654` canonical Jira preset brief preserved in `spec.md`
+**Run Type**: Post-task-generation conservative alignment
+
+## Findings And Remediation
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| `tasks.md` covered the primary validation gaps but did not explicitly name every edge case from `spec.md`, including user/workspace reset inheritance variants, unknown/ineligible/already-absent reset outcomes, SecretRef reference handling, and multi-setting atomicity. | Medium | Updated T008, T012, and T023 in `tasks.md` to name those edge cases and bind them to unit, integration, and manual validation coverage. |
+| `quickstart.md` validated the happy path and unsafe writes but omitted several edge-case checks from `spec.md`. | Medium | Expanded the manual end-to-end checklist with reset-inheritance, multi-setting atomicity, SecretRef reference, and unknown/ineligible/already-absent reset checks. |
+| `contracts/settings-overrides-api.md` named unknown and ineligible reset failures but not already-absent reset outcomes. | Low | Updated the reset contract to include already-absent structured outcomes without changing the public API shape. |
+
+## Gate Re-Check
+
+- Single story: PASS
+- Original input and `MM-654` preservation: PASS
+- Unit test tasks before implementation: PASS
+- Integration test tasks before implementation: PASS
+- Red-first confirmation before implementation: PASS
+- Final `/speckit.verify` task: PASS
+- Source design and edge-case coverage: PASS after remediation
+- Downstream regeneration needed: No. Changes were limited to `tasks.md`, `quickstart.md`, contract wording, and this report; no `spec.md` or `plan.md` requirement/status change made downstream artifacts stale.
+
+## Remaining Risks
+
+- Application implementation still needs to prove the partial validation rows identified in `plan.md`: explicit serialized size limits and exhaustive unsafe-payload fixture coverage for `FR-008`, `FR-011`, `SCN-005`, `SC-004`, and `DESIGN-REQ-006`.

--- a/specs/339-sparse-settings-overrides/plan.md
+++ b/specs/339-sparse-settings-overrides/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Sparse Settings Override Persistence and Reset
+
+**Branch**: `339-sparse-settings-overrides` | **Date**: 2026-05-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/339-sparse-settings-overrides/spec.md`
+
+## Summary
+
+Implement `MM-654` by completing and verifying sparse user/workspace settings override persistence, inheritance-aware effective reads, reset-by-delete behavior, safe value validation, and optimistic concurrency. Repo analysis found the core persistence, reset, audit, and version-conflict behavior already implemented and covered by focused service/API unit tests from the prior scoped-override work. Remaining delivery risk is concentrated in the `MM-654`-specific validation breadth: explicit size-limit enforcement and fixture coverage for every disallowed payload class named by the Jira brief.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `SettingsCatalogService._resolve_value_async`; `tests/unit/services/test_settings_catalog.py::test_workspace_override_persists_and_reports_version` | no new implementation | final verify |
+| FR-002 | implemented_verified | `SettingsOverride` model; `SettingsCatalogService.apply_overrides`; workspace API test | no new implementation | final verify |
+| FR-003 | implemented_verified | user override storage in `apply_overrides`; `test_user_override_wins_and_null_override_is_intentional`; API user override test | no new implementation | final verify |
+| FR-004 | implemented_verified | reset/delete path removes override rows only; tests verify inherited/default values remain | no new implementation | final verify |
+| FR-005 | implemented_verified | `reset_override`; service/API reset tests | no new implementation | final verify |
+| FR-006 | implemented_verified | effective value source handling for inherited, workspace, user, migrated, and intentional null overrides | no new implementation | final verify |
+| FR-007 | implemented_verified | `value_version` model field and increment behavior; workspace version tests | no new implementation | final verify |
+| FR-008 | partial | `_validate_override_value` validates type/schema for registered scalar settings, but no explicit serialized size limit evidence was found | add size-limit policy and tests if absent | unit + API |
+| FR-009 | implemented_verified | reset tests preserve managed secret and audit rows | no new implementation | final verify |
+| FR-010 | implemented_verified | expected-version checks and atomic conflict tests in service/API suites | no new implementation | final verify |
+| FR-011 | partial | raw secret and workflow-payload rejection exists; explicit fixture coverage for OAuth session blobs, decrypted credentials, generated credential config, large artifacts, and command history is incomplete | add exhaustive unsafe-payload fixtures and implementation hardening if tests expose gaps | unit + API |
+| FR-012 | partial | many existing tests cover the story, but `MM-654` requires focused final evidence for all acceptance bullets | add or run focused verification tests, then final verify | unit + integration as applicable |
+| FR-013 | implemented_unverified | `spec.md` preserves `MM-654`; later artifacts must continue preserving it | preserve key and brief in plan/tasks/verification/PR metadata | final verify |
+| SCN-001 | implemented_verified | inherited effective values return configured/default source without creating override rows | no new implementation | final verify |
+| SCN-002 | implemented_verified | workspace override persistence and source/version tests | no new implementation | final verify |
+| SCN-003 | implemented_verified | user override wins over workspace inheritance in service/API tests | no new implementation | final verify |
+| SCN-004 | implemented_verified | reset returns inherited value and preserves adjacent resources | no new implementation | final verify |
+| SCN-005 | partial | unsafe raw secret and workflow-payload rejection exists; size and full disallowed-class fixture set need proof | add validation tests and hardening | unit + API |
+| SCN-006 | implemented_verified | stale expected version fails atomically in service/API tests | no new implementation | final verify |
+| SCN-007 | implemented_unverified | `spec.md` and this plan preserve `MM-654`; downstream artifacts not generated yet | preserve traceability through tasks, implementation notes, verification, and PR metadata | final verify |
+| SC-001 | implemented_verified | workspace override round-trip and metadata tests | no new implementation | final verify |
+| SC-002 | implemented_verified | user override inheritance/reset behavior covered by service/API tests except final `MM-654` traceability run | no new implementation | final verify |
+| SC-003 | implemented_verified | reset preservation tests for managed secrets and audit rows | no new implementation | final verify |
+| SC-004 | partial | current fixtures do not prove every named unsafe category and explicit size boundary | add exhaustive validation fixtures | unit + API |
+| SC-005 | implemented_verified | version-conflict atomicity tests | no new implementation | final verify |
+| SC-006 | implemented_unverified | current artifacts preserve `MM-654`; final verification not yet produced | preserve and verify traceability | final verify |
+| DESIGN-REQ-001 | implemented_verified | defaults inherited and reset-by-delete behavior in service/API tests | no new implementation | final verify |
+| DESIGN-REQ-002 | implemented_verified | persisted scopes limited to user/workspace by model/service validation | no new implementation | final verify |
+| DESIGN-REQ-003 | implemented_verified | sparse override absence/inheritance behavior in effective reads | no new implementation | final verify |
+| DESIGN-REQ-004 | implemented_verified | effective source and source explanation fields | no new implementation | final verify |
+| DESIGN-REQ-005 | implemented_verified | model uniqueness, version, and audit fields plus migration | no new implementation | final verify |
+| DESIGN-REQ-006 | partial | allowed scalar/SecretRef validation exists; no explicit size limit and incomplete disallowed-class fixtures | add tests and implementation hardening for all payload classes | unit + API |
+| DESIGN-REQ-007 | implemented_verified | reset deletes only relevant override and preserves defaults/secrets/audit | no new implementation | final verify |
+| DESIGN-REQ-008 | implemented_verified | reset validation covered by tests | no new implementation | final verify |
+| DESIGN-REQ-009 | implemented_verified | `SettingsCatalogService` persists and retrieves scoped overrides | no new implementation | final verify |
+| DESIGN-REQ-010 | implemented_verified | user reset inheritance flow covered by effective-read and reset tests | no new implementation | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, Pydantic v2, SQLAlchemy async ORM, Alembic, pytest, httpx ASGI test transport  
+**Storage**: Existing SQLAlchemy/Alembic database tables `settings_overrides` and `settings_audit_events`; no new persistent table expected  
+**Unit Testing**: `./tools/test_unit.sh`; focused iteration with `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic `integration_ci`; no external credentials required  
+**Target Platform**: MoonMind API service in Linux containers  
+**Project Type**: Backend web service  
+**Performance Goals**: Settings override reads/writes remain bounded to small indexed rows and small serialized payloads  
+**Constraints**: Do not store raw secrets, OAuth blobs, decrypted credentials, generated secret-bearing config, large artifacts, workflow payloads, or operational command history; reset must not delete adjacent resources; stale writes must fail atomically  
+**Scale/Scope**: Single user/workspace settings override story for existing catalog entries and API surfaces
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS - this story supports runtime configuration without replacing agent behavior.
+- II. One-Click Agent Deployment: PASS - uses existing database and local test tooling.
+- III. Avoid Vendor Lock-In: PASS - settings override behavior is provider-neutral and uses existing SecretRef/resource-reference concepts.
+- IV. Own Your Data: PASS - settings data and audit evidence remain operator-controlled.
+- V. Skills Are First-Class and Easy to Add: PASS - no skill source mutation is planned.
+- VI. Evolving Scaffold: PASS - changes stay behind service/router contracts and tests.
+- VII. Runtime Configurability: PASS - this story implements runtime user/workspace configuration behavior.
+- VIII. Modular and Extensible Architecture: PASS - storage, service, router, and tests remain in existing module boundaries.
+- IX. Resilient by Default: PASS - optimistic concurrency and atomic batches prevent stale partial writes.
+- X. Facilitate Continuous Improvement: PASS - audit and verification evidence make outcomes inspectable.
+- XI. Spec-Driven Development: PASS - work is driven by `specs/339-sparse-settings-overrides/spec.md`.
+- XII. Canonical Documentation Separation: PASS - planning details remain under `specs/`.
+- XIII. Pre-Release Velocity: PASS - no compatibility aliases or fallback semantics are planned.
+
+Re-check after Phase 1 design: PASS. Generated data model, contract, and quickstart preserve the same boundaries and add no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/339-sparse-settings-overrides/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── settings-overrides-api.md
+└── tasks.md              # created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/settings.py
+├── db/models.py
+├── migrations/versions/268_settings_overrides.py
+└── services/settings_catalog.py
+
+tests/
+└── unit/
+    ├── api_service/api/routers/test_settings_api.py
+    └── services/test_settings_catalog.py
+```
+
+**Structure Decision**: Backend-only settings persistence story using existing service, route, model, migration, and unit/API test surfaces. No frontend work is expected for `MM-654`.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/339-sparse-settings-overrides/quickstart.md
+++ b/specs/339-sparse-settings-overrides/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Sparse Settings Override Persistence and Reset
+
+## Scope
+
+Validate the single `MM-654` story from `spec.md`: user/workspace overrides persist sparsely, reset restores inherited values, validation rejects unsafe or oversized values before persistence, and stale writes fail without partial changes.
+
+## Focused Unit Iteration
+
+Use focused tests while implementing validation gaps:
+
+```bash
+pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q
+```
+
+Expected coverage:
+
+- Workspace override persists and reports source/version metadata.
+- User override wins over workspace inheritance and intentional null is distinct from absence.
+- Reset deletes only the matching override and preserves secrets plus audit rows.
+- Stale expected versions return `version_conflict` and preserve prior values.
+- Unsafe payload fixtures for raw secrets, OAuth sessions, decrypted credentials, generated credential config, large artifacts, workflow payloads, and operational command history are rejected.
+- Oversized payload fixtures larger than 16 KiB when serialized are rejected before persistence.
+
+## Final Unit Verification
+
+Before completing implementation, run the repo-standard unit suite:
+
+```bash
+./tools/test_unit.sh
+```
+
+The final verification report should cite this command and the focused settings tests above.
+
+## Hermetic Integration Strategy
+
+Run the compose-backed integration suite when the implementation changes persistence, migrations, startup database behavior, or API contracts:
+
+```bash
+./tools/test_integration.sh
+```
+
+This suite is expected to run only `integration_ci` tests and must not require external credentials.
+
+## Manual End-to-End Check
+
+1. Read an eligible workspace setting with no override and confirm it reports inherited source.
+2. Save a workspace override with the current expected version.
+3. Read the same setting and confirm `workspace_override` source and version metadata.
+4. Save a user override for an eligible user setting.
+5. Read user scope and confirm `user_override` wins over workspace inheritance.
+6. Reset the user override and confirm the effective source falls back to workspace or default.
+7. Reset the workspace override and confirm defaults and adjacent resources remain intact.
+8. Save a workspace override and user override for the same eligible key, reset only the workspace override, and confirm the user override remains readable in user scope.
+9. Attempt a multi-setting write with one invalid or stale entry and confirm no requested entry is partially persisted.
+10. Save a SecretRef/resource reference override and confirm only the reference is stored and no plaintext is exposed.
+11. Request reset for unknown, ineligible, and already absent overrides and confirm each returns a structured outcome without deleting unrelated settings or resources.
+12. Attempt stale-version, oversized, and unsafe-payload writes and confirm each fails without partial persistence.
+
+## Traceability
+
+Every downstream artifact and final report must preserve Jira issue key `MM-654` and the original Jira preset brief preserved in `spec.md`.

--- a/specs/339-sparse-settings-overrides/research.md
+++ b/specs/339-sparse-settings-overrides/research.md
@@ -1,0 +1,81 @@
+# Research: Sparse Settings Override Persistence and Reset
+
+## FR-001 / Sparse Inheritance
+
+Decision: `implemented_verified`; absence of an override resolves to inherited configured/default values without creating an override row.
+Evidence: `api_service/services/settings_catalog.py` `_resolve_value_async`; `tests/unit/services/test_settings_catalog.py::test_workspace_override_persists_and_reports_version`.
+Rationale: The resolver checks persisted overrides first and falls back to configured/default resolution with version `1` when none exists.
+Alternatives considered: Add new inheritance logic for `MM-654`; rejected because current implementation already matches the spec.
+Test implications: none beyond final verify.
+
+## FR-002 / Workspace Overrides
+
+Decision: `implemented_verified`; workspace overrides persist independently by key and workspace subject.
+Evidence: `api_service/db/models.py` `SettingsOverride`; `api_service/services/settings_catalog.py::apply_overrides`; `tests/unit/api_service/api/routers/test_settings_api.py::test_patch_workspace_setting_persists_override`.
+Rationale: The model stores scope, workspace ID, user ID, key, value, and version metadata with a uniqueness constraint.
+Alternatives considered: New storage model; rejected because existing storage matches the story.
+Test implications: none beyond final verify.
+
+## FR-003 / User Overrides
+
+Decision: `implemented_verified`; user overrides persist independently and win over workspace inheritance when eligible.
+Evidence: `tests/unit/services/test_settings_catalog.py::test_user_override_wins_and_null_override_is_intentional`; `tests/unit/api_service/api/routers/test_settings_api.py::test_patch_user_setting_wins_over_workspace_inheritance`.
+Rationale: Current resolver checks user override before workspace override for user scope.
+Alternatives considered: Add separate user override store; rejected because existing scoped rows already distinguish user/workspace subjects.
+Test implications: none beyond final verify.
+
+## FR-004, FR-005, FR-009 / Reset-By-Delete Preservation
+
+Decision: `implemented_verified`; reset deletes only the override and returns inherited effective value while preserving adjacent resources.
+Evidence: `api_service/services/settings_catalog.py::reset_override`; `tests/unit/services/test_settings_catalog.py::test_reset_deletes_only_override_and_preserves_secret_and_audit`; `tests/unit/api_service/api/routers/test_settings_api.py::test_delete_reset_preserves_secret_and_audit`.
+Rationale: The reset path deletes the specific override row, writes an audit event, commits, and re-reads the effective value.
+Alternatives considered: Soft-delete override rows; rejected because source design requires sparse reset-by-delete semantics.
+Test implications: none beyond final verify.
+
+## FR-006 / Effective Source Explainability
+
+Decision: `implemented_verified`; effective reads report inherited, workspace override, user override, migrated override, and intentional null states.
+Evidence: `EffectiveSettingValue.source`; `source_explanation`; service tests for environment/default, workspace, user, and null override cases.
+Rationale: The spec requires source visibility, and the current model exposes source and diagnostics on effective values.
+Alternatives considered: Add separate explanation endpoint; not needed for this story.
+Test implications: none beyond final verify.
+
+## FR-007, FR-010 / Version Metadata And Atomic Concurrency
+
+Decision: `implemented_verified`; override rows maintain `value_version`, and stale expected versions fail atomically.
+Evidence: `SettingsOverride.value_version`; `apply_overrides` expected-version checks; `tests/unit/services/test_settings_catalog.py::test_version_conflict_is_atomic`; `tests/unit/api_service/api/routers/test_settings_api.py::test_version_conflict_returns_error_and_does_not_partially_persist`.
+Rationale: Existing tests cover both service and API behavior for stale writes and no partial persistence.
+Alternatives considered: Add row-level compatibility fallback; rejected by the pre-release compatibility policy and because existing behavior is explicit.
+Test implications: none beyond final verify.
+
+## FR-008, FR-011, SC-004, DESIGN-REQ-006 / Value Safety And Size Limits
+
+Decision: `partial`; current validation rejects raw secret-looking values, invalid SecretRefs, wrong scalar types, and unsafe nested payload keys, but explicit serialized size limits and full fixture coverage for every disallowed payload class are missing.
+Evidence: `api_service/services/settings_catalog.py::_validate_override_value`; `_contains_unsafe_payload`; `tests/unit/services/test_settings_catalog.py::test_unsafe_values_rejected_but_secret_refs_are_allowed`; `tests/unit/api_service/api/routers/test_settings_api.py::test_secret_ref_reference_allowed_but_raw_secret_rejected`.
+Rationale: `MM-654` explicitly requires size limits and fixture proof for raw secrets, OAuth session blobs, decrypted credentials, generated config containing secrets, large artifacts, workflow payloads, and operational command history. The current tests cover only a subset.
+Alternatives considered: Treat prior `MM-538` tests as sufficient; rejected because the Jira brief names additional validation categories and size limits that need direct evidence.
+Test implications: add unit and API tests first; harden validation if any fixture is accepted.
+
+## FR-012 / Verification Evidence
+
+Decision: `partial`; existing focused tests cover most behavior, but final `MM-654` verification evidence has not been produced.
+Evidence: prior service/API tests; `specs/339-sparse-settings-overrides/spec.md`.
+Rationale: Verification evidence is a deliverable, not just code presence. It must explicitly cite `MM-654`.
+Alternatives considered: Mark verified based on prior `MM-538` verification; rejected because issue traceability differs.
+Test implications: run focused tests, then full unit suite when implementation tasks complete; final verification should summarize results.
+
+## FR-013 / Traceability
+
+Decision: `implemented_unverified`; `spec.md`, `plan.md`, and this research preserve `MM-654`, but downstream artifacts do not exist yet.
+Evidence: `specs/339-sparse-settings-overrides/spec.md`; `specs/339-sparse-settings-overrides/plan.md`.
+Rationale: Traceability must continue through tasks, implementation notes, verification output, commit text, and PR metadata.
+Alternatives considered: Rely on the related `MM-538` artifacts; rejected because final verification must compare against `MM-654`.
+Test implications: final verification only.
+
+## Test Tooling
+
+Decision: use repo-standard unit and hermetic integration tiers.
+Evidence: repository instructions require `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for compose-backed `integration_ci`.
+Rationale: Service/API behavior can iterate with focused pytest, but final evidence must use the repo test runner.
+Alternatives considered: Provider verification; not applicable because this story needs no external credentials.
+Test implications: unit tests are required; integration tests are required if implementation changes affect compose-backed persistence or migration behavior.

--- a/specs/339-sparse-settings-overrides/spec.md
+++ b/specs/339-sparse-settings-overrides/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Sparse Settings Override Persistence and Reset
+
+**Feature Branch**: `339-sparse-settings-overrides`
+**Created**: 2026-05-11
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-654 as the canonical Moon Spec orchestration input.
+
+MM-654: Scoped overrides persistence with sparse storage and reset
+
+Source Reference:
+- Source Document: docs/Security/SettingsSystem.md
+- Source Title: Settings System
+- Source Sections: 5.4 Scoped Overrides, Not Mutable Defaults; 7.3 Scope; 7.4 Override; 11 Persistence Model; 27.3 Reset User Override
+- Coverage IDs: S5.4, S7.3, S7.4, S11.1, S11.3, S11.4, S22.4, S22.10, S25.11, S26.SettingsOverrideStore, S27.3, S29.9
+
+Persist user/workspace setting overrides in a `settings_overrides` table keyed by `(scope, workspace_id, user_id, key)` with `value_json`, `schema_version`, `value_version`, audit columns, and uniqueness. Defaults remain immutable; overrides are sparse and absence means "inherit." Reset deletes the override row and reverts the effective value to the inherited source without touching defaults, profiles, secrets, OAuth volumes, or audit history.
+
+Persistence rules: rows may store booleans, numbers, strings, enums, lists, small structured JSON, SecretRef strings, and resource references. Rows must not store raw secrets, OAuth session blobs, decrypted credentials, generated config containing secrets, large artifacts, workflow payloads, or operational command history beyond audit metadata.
+
+Acceptance:
+- Workspace and user overrides are persisted independently and round-trip correctly.
+- Reset endpoints delete only the relevant override row and return the inherited effective value.
+- Size limits and schema validation are enforced before persistence; oversized or off-schema writes are rejected.
+- Stored payloads never contain secret plaintext; a fixture verifies the payload contract.
+- Concurrent writes are guarded by `value_version` for optimistic concurrency.
+
+Preserve Jira issue key MM-654 in downstream spec artifacts, implementation notes, verification output, commit text, and pull request metadata."
+
+Preserved source Jira preset brief: `MM-654` from the trusted `jira.get_issue` response, reproduced verbatim in `**Input**` above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-654`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserving the `MM-654` implementation brief was found under `specs/`; `Specify` is the first incomplete stage.
+
+## User Story - Save, Read, and Reset Sparse Settings Overrides
+
+**Summary**: As a workspace administrator or user, I want workspace and user settings overrides to be saved sparsely and reset independently so configuration can inherit predictably without changing defaults or adjacent credential resources.
+
+**Goal**: MoonMind persists user and workspace setting overrides independently, resolves inherited effective values when overrides are absent or reset, rejects invalid or unsafe override values before saving, and prevents stale concurrent writes from partially changing settings.
+
+**Independent Test**: Save a workspace override and a user override for eligible settings, verify each can be read back with the expected effective source and version metadata, reset each override, confirm the effective value inherits from the next source, and verify unsafe, oversized, off-schema, or stale-version writes are rejected without storing secret plaintext or partially changing other overrides.
+
+**Acceptance Scenarios**:
+
+1. **Given** no user or workspace override exists for an eligible setting, **When** a client reads the effective setting value, **Then** the response shows the inherited value and identifies the inherited source rather than creating a stored override.
+2. **Given** a workspace override is saved for an eligible setting, **When** workspace or task resolution reads that setting, **Then** the workspace value is returned with version metadata and without mutating the default value.
+3. **Given** a user override is saved for an eligible user setting, **When** user resolution reads that setting, **Then** the user value is returned independently from the workspace override while preserving the workspace value for inheritance when no user override exists.
+4. **Given** a user or workspace override exists, **When** the matching reset action is requested, **Then** only that override is removed and the response returns the inherited effective value.
+5. **Given** a write contains an oversized, off-schema, raw secret, OAuth session, decrypted credential, generated credential config, large artifact, workflow payload, or operational history value, **When** validation runs, **Then** the write is rejected before persistence and no unsafe value is stored.
+6. **Given** a write is submitted with a stale version expectation, **When** the system compares it with the current override version, **Then** the write is rejected as a version conflict and no partial setting change is persisted.
+7. **Given** downstream artifacts or delivery metadata are produced for this work, **When** traceability is reviewed, **Then** Jira issue key `MM-654` and this preserved preset brief remain available for comparison.
+
+### Edge Cases
+
+- An override value is intentionally null; the system distinguishes that stored override from no override existing.
+- A user override is reset while a workspace override still exists; the effective value inherits from the workspace source.
+- A workspace override is reset while a user override still exists; the user override remains intact and can still be read in user scope.
+- A multi-setting write contains one invalid or stale entry; none of the requested entries are partially persisted.
+- A SecretRef or resource reference is stored as a reference only and is never resolved into plaintext as part of override storage.
+- Reset is requested for an unknown, ineligible, or already absent override; the system returns a structured outcome without deleting unrelated settings or resources.
+
+## Assumptions
+
+- The selected story is limited to user and workspace settings overrides; system and operator scopes remain outside normal user-editable behavior for this feature.
+- Existing authentication and authorization rules decide who may read, write, or reset settings; this story validates persistence, inheritance, reset, safety, and concurrency behavior after an operation is permitted.
+- Adjacent resources include defaults, provider profiles, managed secrets, OAuth credential volumes, and settings audit history, and they must survive override resets.
+- The source design remains authoritative when choosing between ambiguous behavior and an implementation detail in the Jira preset brief.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Security/SettingsSystem.md` §5.4 | User and workspace changes are stored as overrides; defaults remain immutable and reset removes only the override so the value inherits again. | In scope | FR-001, FR-004, FR-005, FR-009 |
+| DESIGN-REQ-002 | `docs/Security/SettingsSystem.md` §7.3 | Supported settings scopes include user, workspace, system, and operator, with user and workspace as the normal editable scopes for most users. | In scope | FR-002, FR-003 |
+| DESIGN-REQ-003 | `docs/Security/SettingsSystem.md` §7.4 | Overrides are sparse persisted scoped values; absence of an override means inherit. | In scope | FR-001, FR-002, FR-003, FR-005 |
+| DESIGN-REQ-004 | `docs/Security/SettingsSystem.md` §7.5-§7.6 | Effective values must explain which source supplied the value and whether it was inherited or overridden. | In scope | FR-006 |
+| DESIGN-REQ-005 | `docs/Security/SettingsSystem.md` §11.1 | Override storage must keep one value per scope, subject, and setting key with version and audit metadata. | In scope | FR-002, FR-003, FR-007, FR-010 |
+| DESIGN-REQ-006 | `docs/Security/SettingsSystem.md` §11.3 | Override values may include allowed primitive, list, small structured, SecretRef, and resource-reference values, but must not include raw secrets, OAuth state, credential files, generated credential config, large artifacts, workflow payloads, or operational command history beyond audit metadata. | In scope | FR-008, FR-011 |
+| DESIGN-REQ-007 | `docs/Security/SettingsSystem.md` §11.4 | Resetting a setting deletes the relevant override and does not delete inherited defaults, provider profiles, managed secrets, OAuth volumes, or audit history. | In scope | FR-005, FR-009 |
+| DESIGN-REQ-008 | `docs/Security/SettingsSystem.md` §25, item 11 | Validation must prove reset removes overrides and restores inherited values. | In scope | FR-005, FR-012 |
+| DESIGN-REQ-009 | `docs/Security/SettingsSystem.md` §26 | The system must provide a durable capability for persisting and retrieving scoped overrides. | In scope | FR-002, FR-003, FR-005 |
+| DESIGN-REQ-010 | `docs/Security/SettingsSystem.md` §27.3 | Resetting a user override returns the inherited workspace or default value and updates the visible source accordingly. | In scope | FR-005, FR-006 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST treat absence of a user or workspace override as inheritance from the next applicable configured source, without creating a stored override.
+- **FR-002**: The system MUST persist workspace override values independently by workspace and setting key for eligible workspace-scoped settings.
+- **FR-003**: The system MUST persist user override values independently by user, workspace context when applicable, and setting key for eligible user-scoped settings.
+- **FR-004**: The system MUST keep built-in or configured default values immutable when user or workspace overrides are saved or reset.
+- **FR-005**: Resetting a user or workspace override MUST delete only the matching override and return the inherited effective value for the requested setting.
+- **FR-006**: Effective setting reads MUST report whether the value came from inheritance, a workspace override, a user override, or an intentional null override.
+- **FR-007**: Override writes MUST maintain version metadata that changes when the stored override changes.
+- **FR-008**: The system MUST validate override size and schema before persistence and reject oversized or off-schema writes.
+- **FR-009**: Reset behavior MUST NOT delete inherited defaults, provider profiles, managed secrets, OAuth credential volumes, or settings audit history.
+- **FR-010**: Concurrent writes MUST be guarded by expected version checks, and stale writes MUST fail without partial persistence.
+- **FR-011**: Stored override values MUST NOT contain raw secret plaintext, OAuth session blobs, decrypted credentials, generated credential config containing secrets, large artifacts, workflow payloads, or operational command history beyond audit metadata.
+- **FR-012**: Verification evidence for this feature MUST include checks that workspace and user overrides round-trip independently, reset restores inherited values, validation rejects unsafe values, and stale writes fail without partial persistence.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-654` and the original preset brief.
+
+### Key Entities
+
+- **Setting Override**: A sparse scoped value for one setting key at user or workspace scope, including subject identity, stored value, version metadata, and audit metadata.
+- **Effective Setting Value**: The resolved setting value presented to a client, including its source and whether it is inherited, overridden, or intentionally null.
+- **Settings Validation Result**: The structured outcome produced before saving an override, identifying accepted values or the reason a value is unsafe, oversized, off-schema, or stale.
+- **Reset Outcome**: The structured result of removing an override, including the inherited effective value and source after reset.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of tested workspace override writes can be read back independently with the expected source and version metadata.
+- **SC-002**: 100% of tested user override writes can be read back independently from workspace overrides, and user reset restores the inherited workspace or default value.
+- **SC-003**: 100% of tested reset operations delete only the targeted override and leave defaults, provider profiles, managed secrets, OAuth credential volumes, and audit history intact.
+- **SC-004**: 100% of oversized, off-schema, raw-secret, OAuth-session, credential-config, large-artifact, workflow-payload, and disallowed operational-history fixture values are rejected before persistence.
+- **SC-005**: 100% of stale expected-version write attempts return a version-conflict outcome and persist zero partial setting changes.
+- **SC-006**: Traceability review confirms `MM-654`, the original preset brief, and all in-scope source design requirements remain preserved in MoonSpec artifacts and final verification evidence.

--- a/specs/339-sparse-settings-overrides/tasks.md
+++ b/specs/339-sparse-settings-overrides/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: Sparse Settings Override Persistence and Reset
+
+**Input**: Design documents from `specs/339-sparse-settings-overrides/`
+**Prerequisites**: `specs/339-sparse-settings-overrides/plan.md`, `specs/339-sparse-settings-overrides/spec.md`, `specs/339-sparse-settings-overrides/research.md`, `specs/339-sparse-settings-overrides/data-model.md`, `specs/339-sparse-settings-overrides/contracts/`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one independently testable story: save, read, reset, validate, and verify sparse user/workspace settings overrides for `MM-654`.
+
+**Source Traceability**: Original Jira issue `MM-654` and the preserved preset brief are in `spec.md`. Tasks cover FR-001 through FR-013, SCN-001 through SCN-007, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-010. Plan status summary: 27 implemented_verified rows require final validation only, 6 partial rows require red-first tests plus implementation hardening, and 3 implemented_unverified traceability rows require verification-first coverage with conditional artifact updates if verification fails.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh`
+- Focused unit iteration: `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`
+- Integration tests: `./tools/test_integration.sh`
+- Focused integration iteration: `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and has no dependency on incomplete work.
+- Every task includes exact file paths and requirement, scenario, success, or source IDs where applicable.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active one-story planning context and baseline evidence before adding tests.
+
+- [X] T001 Confirm `specs/339-sparse-settings-overrides/spec.md` still contains exactly one `## User Story -` section and preserves `MM-654` for FR-013/SCN-007/SC-006.
+- [X] T002 Confirm `specs/339-sparse-settings-overrides/plan.md`, `specs/339-sparse-settings-overrides/research.md`, `specs/339-sparse-settings-overrides/data-model.md`, `specs/339-sparse-settings-overrides/contracts/settings-overrides-api.md`, and `specs/339-sparse-settings-overrides/quickstart.md` exist before implementation planning continues.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish the exact current validation boundary and test locations that block story work.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T003 Inspect current override validation and unsafe-payload detection in `api_service/services/settings_catalog.py` for FR-008/FR-011/SCN-005/SC-004/DESIGN-REQ-006.
+- [X] T004 Inspect current service validation tests in `tests/unit/services/test_settings_catalog.py` for existing coverage of size limits and unsafe payload classes for FR-008/FR-011/SC-004/DESIGN-REQ-006.
+- [X] T005 Inspect current API contract tests in `tests/unit/api_service/api/routers/test_settings_api.py` and integration test markers in `tests/integration/api/` to place the MM-654 API boundary tests for contracts/settings-overrides-api.md.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Save, Read, and Reset Sparse Settings Overrides
+
+**Summary**: Workspace administrators and users can persist sparse settings overrides, read inherited effective values, reset overrides safely, reject unsafe values, and prevent stale concurrent writes.
+
+**Independent Test**: Save workspace and user overrides, verify effective sources and version metadata, reset each override, confirm inherited values return, reject oversized/unsafe/stale writes, and confirm no secret plaintext or partial persistence occurs.
+
+**Traceability**: FR-001 through FR-013; SCN-001 through SCN-007; SC-001 through SC-006; DESIGN-REQ-001 through DESIGN-REQ-010.
+
+**Test Plan**:
+
+- Unit: service validation, size limits, unsafe payload fixture set, stale writes, reset preservation, traceability guards.
+- Integration: API contract for PATCH/DELETE/effective reads, invalid payload rejection, no partial persistence, hermetic `integration_ci` boundary.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T006 [P] Add failing unit tests for explicit serialized size-limit rejection in `tests/unit/services/test_settings_catalog.py` covering FR-008/SCN-005/SC-004/DESIGN-REQ-006.
+- [X] T007 [P] Add failing unit tests for unsafe OAuth session, decrypted credential, generated credential config, large artifact, workflow payload, and operational command history fixtures in `tests/unit/services/test_settings_catalog.py` covering FR-011/SCN-005/SC-004/DESIGN-REQ-006.
+- [X] T008 [P] Add unit verification tests that already-implemented inheritance, workspace/user override, intentional null, user reset while workspace override exists, workspace reset while user override exists, unknown/ineligible/already-absent reset outcomes, SecretRef reference storage, multi-setting atomicity, version, and audit behavior still satisfy FR-001 through FR-007, FR-009, FR-010, SCN-001 through SCN-004, SCN-006, SC-001 through SC-003, SC-005, and DESIGN-REQ-001 through DESIGN-REQ-005, DESIGN-REQ-007 through DESIGN-REQ-010 in `tests/unit/services/test_settings_catalog.py`.
+- [X] T009 Run `pytest tests/unit/services/test_settings_catalog.py -q` and confirm T006-T007 fail for missing MM-654 validation behavior while T008 passes or identifies only verification gaps.
+
+### Integration Tests (write first)
+
+- [X] T010 [P] Add failing API test coverage for oversized override payload rejection and unchanged effective values in `tests/unit/api_service/api/routers/test_settings_api.py` covering FR-008/SCN-005/SC-004/contracts/settings-overrides-api.md.
+- [X] T011 [P] Add failing API test coverage for every disallowed unsafe payload category and redacted error responses in `tests/unit/api_service/api/routers/test_settings_api.py` covering FR-011/SCN-005/SC-004/contracts/settings-overrides-api.md.
+- [X] T012 [P] Add hermetic integration contract tests for effective read, PATCH save, DELETE reset, user/workspace reset inheritance, unknown/ineligible/already-absent reset outcomes, stale write conflict, multi-setting atomicity, SecretRef reference storage, oversized payload rejection, and unsafe payload rejection in `tests/integration/api/test_settings_overrides_contract.py` with `@pytest.mark.integration` and `@pytest.mark.integration_ci` covering FR-001 through FR-012, SCN-001 through SCN-006, all edge cases, and contracts/settings-overrides-api.md.
+- [X] T013 Run `pytest tests/unit/api_service/api/routers/test_settings_api.py -q` and confirm T010-T011 fail for the intended missing validation behavior before production changes.
+- [X] T014 Run `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q` and confirm T012 fails for the intended missing validation behavior or passes already-verified API behavior before production changes.
+
+### Red-First Confirmation
+
+- [X] T015 Record the red-first outcome from T009, T013, and T014 in `specs/339-sparse-settings-overrides/tasks.md` implementation notes or a local handoff artifact under `artifacts/` before editing production code for FR-008/FR-011/SCN-005/SC-004/DESIGN-REQ-006.
+
+### Conditional Fallback For Implemented-Unverified Traceability
+
+- [X] T016 If traceability checks fail, update `specs/339-sparse-settings-overrides/tasks.md` to preserve `MM-654` and the preset brief references for FR-013/SCN-007/SC-006 before final verification.
+
+### Implementation
+
+- [X] T017 Define and enforce a small serialized override payload size limit in `api_service/services/settings_catalog.py` for FR-008/SCN-005/SC-004/DESIGN-REQ-006.
+- [X] T018 Harden unsafe payload detection in `api_service/services/settings_catalog.py` so raw secrets, OAuth session blobs, decrypted credentials, generated credential config containing secrets, large artifacts, workflow payloads, and operational command history are rejected for FR-011/SCN-005/SC-004/DESIGN-REQ-006.
+- [X] T019 Ensure API error handling in `api_service/api/routers/settings.py` returns structured `invalid_setting_value` responses without echoing unsafe payload content for FR-011/SCN-005/SC-004/contracts/settings-overrides-api.md.
+- [X] T020 If T012 reveals integration fixture gaps, add the minimal hermetic fixtures needed by `tests/integration/api/test_settings_overrides_contract.py` without changing unrelated test infrastructure.
+
+### Story Validation
+
+- [X] T021 Run `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q` and fix only MM-654 scoped failures in `api_service/services/settings_catalog.py`, `api_service/api/routers/settings.py`, `tests/unit/services/test_settings_catalog.py`, and `tests/unit/api_service/api/routers/test_settings_api.py`.
+- [X] T022 Run `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q` and fix only MM-654 scoped integration failures in `api_service/services/settings_catalog.py`, `api_service/api/routers/settings.py`, and `tests/integration/api/test_settings_overrides_contract.py`.
+- [X] T023 Validate the independent story manually against `specs/339-sparse-settings-overrides/quickstart.md`, including user reset inheritance, workspace reset preservation, multi-setting atomicity, SecretRef reference handling, unknown/ineligible/already-absent reset outcomes, and unsafe/oversized rejection, then record any deviations in `specs/339-sparse-settings-overrides/verification.md` draft notes for FR-012/SC-006.
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [X] T024 [P] Review `specs/339-sparse-settings-overrides/contracts/settings-overrides-api.md` against the final API behavior and update only if the contract drifted during implementation.
+- [X] T025 [P] Review `specs/339-sparse-settings-overrides/data-model.md` against final validation and state-transition behavior and update only if the model drifted during implementation.
+- [X] T026 Run `./tools/test_unit.sh` for final unit verification and capture the result in `specs/339-sparse-settings-overrides/verification.md` for FR-012/SC-001 through SC-006.
+- [X] T027 Run `./tools/test_integration.sh` if T012 introduced or changed `integration_ci` coverage, and capture the result in `specs/339-sparse-settings-overrides/verification.md` for contracts/settings-overrides-api.md and FR-012.
+- [ ] T028 Run `/speckit.verify` for `specs/339-sparse-settings-overrides/spec.md` after implementation and tests pass, producing final verification evidence that preserves `MM-654`, the original preset brief, FR-001 through FR-013, SCN-001 through SCN-007, SC-001 through SC-006, and DESIGN-REQ-001 through DESIGN-REQ-010.
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- Phase 1 setup has no dependencies.
+- Phase 2 foundational inspection depends on Phase 1.
+- Phase 3 story work depends on Phase 2.
+- Phase 4 polish and verification depends on Phase 3 tests and implementation passing.
+
+### Within The Story
+
+- T006 through T008 must be written before T009.
+- T010 through T012 must be written before T013 and T014.
+- T015 must complete before production changes T017 through T020.
+- T017 through T020 depend on red-first evidence from T009, T013, and T014.
+- T021 through T023 validate the completed story after implementation.
+- T028 is final and must run only after T026 and required T027 evidence is available.
+
+### Parallel Opportunities
+
+- T006, T007, and T008 can run in parallel if coordinated carefully because they add distinct test cases in `tests/unit/services/test_settings_catalog.py`.
+- T010, T011, and T012 can run in parallel because API unit tests and integration contract tests are separate files.
+- T024 and T025 can run in parallel because contract and data-model docs are separate artifacts.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch API and integration test authoring together:
+Task: "Add failing API oversized payload tests in tests/unit/api_service/api/routers/test_settings_api.py"
+Task: "Add integration contract tests in tests/integration/api/test_settings_overrides_contract.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 to confirm the active artifacts and current validation boundary.
+2. Write red-first unit tests for the partial rows: FR-008, FR-011, SCN-005, SC-004, and DESIGN-REQ-006.
+3. Write API and hermetic integration tests for the same partial rows and the public contract.
+4. Confirm the new validation tests fail for the expected reason before production changes.
+5. Implement only the size-limit and unsafe-payload hardening needed to satisfy the failing tests.
+6. Run focused service, API, and integration tests until the single story passes.
+7. Run final `./tools/test_unit.sh` and required `./tools/test_integration.sh` evidence.
+8. Run `/speckit.verify` to validate the completed implementation against the original `MM-654` preset brief.
+
+### Status Handling
+
+- Code-and-test work: FR-008, FR-011, SCN-005, SC-004, DESIGN-REQ-006.
+- Verification-only work: FR-001 through FR-007, FR-009, FR-010, SCN-001 through SCN-004, SCN-006, SC-001 through SC-003, SC-005, DESIGN-REQ-001 through DESIGN-REQ-005, DESIGN-REQ-007 through DESIGN-REQ-010.
+- Conditional fallback work: FR-013, SCN-007, SC-006 traceability updates if verification finds missing `MM-654` references.
+- Final verification work: FR-012 and all success criteria through `/speckit.verify`.
+
+## Notes
+
+- This task list covers one story only.
+- Do not implement unrelated settings UI changes.
+- Do not add new persistent tables unless validation work proves existing override/audit tables cannot satisfy the story.
+- Preserve Jira issue key `MM-654` in all implementation notes, verification output, commit text, and pull request metadata.
+
+## Implementation Evidence
+
+- Red-first unit service evidence: `pytest tests/unit/services/test_settings_catalog.py -q` failed before production changes with `test_oversized_override_value_rejected_before_persistence` and `test_unsafe_payload_classes_rejected_before_persistence` because no `ValueError` was raised.
+- Red-first API evidence: `pytest tests/unit/api_service/api/routers/test_settings_api.py -q` failed before production changes with oversized and unsafe override payload requests returning HTTP 200 instead of 400.
+- Red-first integration evidence: `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q` failed before production changes with oversized override payload returning HTTP 200 instead of 400.

--- a/specs/339-sparse-settings-overrides/verification.md
+++ b/specs/339-sparse-settings-overrides/verification.md
@@ -1,0 +1,49 @@
+# Verification: Sparse Settings Override Persistence and Reset
+
+**Feature**: `specs/339-sparse-settings-overrides`
+**Original Request Source**: Jira issue `MM-654` preset brief preserved in `spec.md`
+**Verdict**: PARTIAL - implementation and focused unit/API/integration evidence pass; full compose-backed integration command is blocked by Docker administrative policy in this managed environment.
+
+## Implementation Summary
+
+Implemented the remaining `MM-654` validation gaps by enforcing a 16 KiB serialized override payload limit and rejecting unsafe string payloads that indicate OAuth session blobs, decrypted credentials, generated secret-bearing config, large artifacts, workflow payloads, private keys, or command history. The existing scoped override persistence, reset, inheritance, audit, and optimistic concurrency behavior remains unchanged.
+
+## Requirement Coverage
+
+| Scope | Status | Evidence |
+| --- | --- | --- |
+| FR-001 through FR-007, FR-009, FR-010 | VERIFIED | Existing service/API behavior plus focused tests passed. |
+| FR-008 | VERIFIED | Oversized override payloads are rejected before persistence in service/API/integration tests. |
+| FR-011 | VERIFIED | Unsafe payload classes are rejected without echoing unsafe values in service/API/integration tests. |
+| FR-012 | PARTIAL | Focused and full unit verification passed; full compose integration was attempted but blocked by Docker administrative rules. |
+| FR-013 | VERIFIED | `MM-654` is preserved in `spec.md`, `plan.md`, `tasks.md`, and this verification report. |
+| SCN-001 through SCN-006 | VERIFIED | Focused service/API tests and `tests/integration/api/test_settings_overrides_contract.py` cover inheritance, save, reset, stale writes, unsafe writes, SecretRef references, and atomicity. |
+| SCN-007 / SC-006 | VERIFIED | Traceability artifacts preserve `MM-654` and the original preset brief. |
+| DESIGN-REQ-001 through DESIGN-REQ-010 | VERIFIED | Source design mappings are covered by existing scoped override implementation plus the new validation tests. |
+
+## Test Evidence
+
+- RED then PASS: `pytest tests/unit/services/test_settings_catalog.py -q`
+  - Red-first failure before production changes: oversized and unsafe payload tests did not raise `ValueError`.
+  - Final result: `57 passed`.
+- RED then PASS: `pytest tests/unit/api_service/api/routers/test_settings_api.py -q`
+  - Red-first failure before production changes: oversized and unsafe payload requests returned HTTP 200.
+  - Final result: `26 passed`.
+- RED then PASS: `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q`
+  - Red-first failure before production changes: oversized payload returned HTTP 200.
+  - Final result: `2 passed`.
+- PASS: `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q`
+  - Final combined focused result: `83 passed`.
+- PASS: `./tools/test_unit.sh`
+  - Python unit result: `4866 passed, 1 xpassed, 114 warnings, 16 subtests passed`.
+  - Frontend result: `20 passed` test files, `337 passed`, `227 skipped`.
+- BLOCKED: `./tools/test_integration.sh`
+  - Docker compose integration command started, created `.env` from `.env-template`, then failed with Docker administrative policy: `403 Forbidden` and `Request forbidden by administrative rules`.
+
+## Quickstart Validation
+
+The focused service/API/integration tests cover the quickstart scenarios: inherited reads, workspace/user saves, user reset inheritance, workspace reset preservation, multi-setting atomicity, SecretRef reference handling, unknown/ineligible/already-absent reset outcomes, stale writes, oversized writes, and unsafe-payload rejection.
+
+## Remaining Work
+
+Run `./tools/test_integration.sh` in an environment where Docker compose/build access is permitted, then rerun `/speckit.verify` for a full PASS verdict.

--- a/tests/integration/api/test_settings_overrides_contract.py
+++ b/tests/integration/api/test_settings_overrides_contract.py
@@ -4,10 +4,10 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from api_service.api.routers import settings as settings_router
 from api_service.auth_providers import get_current_user
 from api_service.db import base as db_base
 from api_service.db.models import Base
@@ -18,18 +18,13 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integrat
 SETTINGS_USER_DEP = get_current_user()
 
 
-@pytest.fixture
-def settings_contract_db(tmp_path):
+@pytest_asyncio.fixture
+async def settings_contract_db(tmp_path):
     engine = create_async_engine(
         f"sqlite+aiosqlite:///{tmp_path}/settings-contract.db"
     )
-
-    async def _setup():
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-
-    asyncio_run = __import__("asyncio").run
-    asyncio_run(_setup())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
     original = db_base.async_session_maker
     db_base.async_session_maker = session_maker
@@ -51,7 +46,7 @@ def settings_contract_db(tmp_path):
     finally:
         app.dependency_overrides.pop(SETTINGS_USER_DEP, None)
         db_base.async_session_maker = original
-        asyncio_run(engine.dispose())
+        await engine.dispose()
 
 
 async def test_settings_override_contract_round_trips_and_resets(

--- a/tests/integration/api/test_settings_overrides_contract.py
+++ b/tests/integration/api/test_settings_overrides_contract.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.api.routers import settings as settings_router
+from api_service.auth_providers import get_current_user
+from api_service.db import base as db_base
+from api_service.db.models import Base
+from api_service.main import app
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+SETTINGS_USER_DEP = get_current_user()
+
+
+@pytest.fixture
+def settings_contract_db(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/settings-contract.db"
+    )
+
+    async def _setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio_run = __import__("asyncio").run
+    asyncio_run(_setup())
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    original = db_base.async_session_maker
+    db_base.async_session_maker = session_maker
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="settings-contract@example.com",
+        is_superuser=True,
+        settings_permissions={
+            "settings.catalog.read",
+            "settings.effective.read",
+            "settings.user.write",
+            "settings.workspace.write",
+        },
+        workspace_id=uuid4(),
+    )
+    app.dependency_overrides[SETTINGS_USER_DEP] = lambda: user
+    try:
+        yield session_maker
+    finally:
+        app.dependency_overrides.pop(SETTINGS_USER_DEP, None)
+        db_base.async_session_maker = original
+        asyncio_run(engine.dispose())
+
+
+async def test_settings_override_contract_round_trips_and_resets(
+    settings_contract_db,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        inherited = await client.get(
+            "/api/v1/settings/effective/integrations.github.token_ref",
+            params={"scope": "user"},
+        )
+        workspace = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"integrations.github.token_ref": "env://WORKSPACE_TOKEN"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        user = await client.patch(
+            "/api/v1/settings/user",
+            json={
+                "changes": {"integrations.github.token_ref": "env://USER_TOKEN"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        workspace_reset = await client.delete(
+            "/api/v1/settings/workspace/integrations.github.token_ref"
+        )
+        user_after_workspace_reset = await client.get(
+            "/api/v1/settings/effective/integrations.github.token_ref",
+            params={"scope": "user"},
+        )
+        user_reset = await client.delete(
+            "/api/v1/settings/user/integrations.github.token_ref"
+        )
+        absent_reset = await client.delete(
+            "/api/v1/settings/user/integrations.github.token_ref"
+        )
+
+    assert inherited.status_code == 200
+    assert inherited.json()["source"] in {"config_or_default", "environment", "default"}
+    assert workspace.status_code == 200
+    assert workspace.json()["values"]["integrations.github.token_ref"]["source"] == (
+        "workspace_override"
+    )
+    assert user.status_code == 200
+    assert user.json()["values"]["integrations.github.token_ref"]["source"] == (
+        "user_override"
+    )
+    assert workspace_reset.status_code == 200
+    assert user_after_workspace_reset.json()["value"] == "env://USER_TOKEN"
+    assert user_after_workspace_reset.json()["source"] == "user_override"
+    assert user_reset.status_code == 200
+    assert user_reset.json()["source"] in {"config_or_default", "environment", "default"}
+    assert absent_reset.status_code == 200
+    assert absent_reset.json()["source"] in {
+        "config_or_default",
+        "environment",
+        "default",
+    }
+
+
+async def test_settings_override_contract_rejects_stale_unsafe_and_oversized_writes(
+    settings_contract_db,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_publish_mode": "branch",
+                    "skills.canary_percent": 25,
+                },
+                "expected_versions": {
+                    "workflow.default_publish_mode": 1,
+                    "skills.canary_percent": 1,
+                },
+            },
+        )
+        conflict = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_publish_mode": "none",
+                    "skills.canary_percent": 50,
+                },
+                "expected_versions": {
+                    "workflow.default_publish_mode": 99,
+                    "skills.canary_percent": 1,
+                },
+            },
+        )
+        oversized = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_provider_profile_ref": "x" * 20000},
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+        unsafe = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_provider_profile_ref": "oauth_session_blob={...}"
+                },
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+        publish_mode = await client.get(
+            "/api/v1/settings/effective/workflow.default_publish_mode",
+            params={"scope": "workspace"},
+        )
+        canary = await client.get(
+            "/api/v1/settings/effective/skills.canary_percent",
+            params={"scope": "workspace"},
+        )
+
+    assert conflict.status_code == 409
+    assert conflict.json()["error"] == "version_conflict"
+    assert oversized.status_code == 400
+    assert oversized.json()["error"] == "invalid_setting_value"
+    assert "x" * 64 not in oversized.text
+    assert unsafe.status_code == 400
+    assert unsafe.json()["error"] == "invalid_setting_value"
+    assert "oauth_session_blob" not in unsafe.text
+    assert publish_mode.json()["value"] == "branch"
+    assert canary.json()["value"] == 25

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -586,6 +586,10 @@ async def test_unsafe_override_payload_classes_are_rejected_and_redacted(
         "oauth_session_blob={...}",
         "decrypted_credential_file=/tmp/credential.json",
         "generated_config password=plaintext",
+        "token=plaintext",
+        "secret=plaintext",
+        "api_key=plaintext",
+        "apikey=plaintext",
         "large_artifact:" + ("x" * 20000),
         "workflow_payload={\"steps\": []}",
         "operational command_history: rm -rf /",
@@ -604,6 +608,29 @@ async def test_unsafe_override_payload_classes_are_rejected_and_redacted(
             assert rejected.status_code == 400
             assert rejected.json()["error"] == "invalid_setting_value"
             assert unsafe_value[:32] not in rejected.text
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_ref_allows_literal_profile_ids_with_sensitive_words(
+    settings_api_db,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        accepted = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_provider_profile_ref": "oauth_session-prod"
+                },
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+
+    assert accepted.status_code == 200
+    assert accepted.json()["values"]["workflow.default_provider_profile_ref"]["value"] == (
+        "oauth_session-prod"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -553,6 +553,60 @@ async def test_secret_ref_reference_allowed_but_raw_secret_rejected(settings_api
 
 
 @pytest.mark.asyncio
+async def test_oversized_override_payload_rejected_and_effective_value_unchanged(
+    settings_api_db,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        rejected = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_provider_profile_ref": "x" * 20000},
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+        effective = await client.get(
+            "/api/v1/settings/effective/workflow.default_provider_profile_ref",
+            params={"scope": "workspace"},
+        )
+
+    assert rejected.status_code == 400
+    assert rejected.json()["error"] == "invalid_setting_value"
+    assert "x" * 64 not in rejected.text
+    assert effective.status_code == 200
+    assert effective.json()["source"] in {"config_or_default", "environment", "default"}
+
+
+@pytest.mark.asyncio
+async def test_unsafe_override_payload_classes_are_rejected_and_redacted(
+    settings_api_db,
+):
+    unsafe_values = [
+        "oauth_session_blob={...}",
+        "decrypted_credential_file=/tmp/credential.json",
+        "generated_config password=plaintext",
+        "large_artifact:" + ("x" * 20000),
+        "workflow_payload={\"steps\": []}",
+        "operational command_history: rm -rf /",
+    ]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        for unsafe_value in unsafe_values:
+            rejected = await client.patch(
+                "/api/v1/settings/workspace",
+                json={
+                    "changes": {"workflow.default_provider_profile_ref": unsafe_value},
+                    "expected_versions": {"workflow.default_provider_profile_ref": 1},
+                },
+            )
+            assert rejected.status_code == 400
+            assert rejected.json()["error"] == "invalid_setting_value"
+            assert unsafe_value[:32] not in rejected.text
+
+
+@pytest.mark.asyncio
 async def test_settings_catalog_requires_catalog_read_permission(settings_user_override):
     settings_user_override(permissions={"settings.effective.read"})
 

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -1004,6 +1004,145 @@ async def _unsafe_values_rejected_but_secret_refs_are_allowed(settings_session):
 
 
 @pytest.mark.asyncio
+async def test_oversized_override_value_rejected_before_persistence(
+    settings_session_maker,
+):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.large_payload",
+            title="Large Payload",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default",
+            order=1,
+            apply_mode="immediate",
+        ),
+    )
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            session=settings_session,
+        )
+
+        with pytest.raises(ValueError, match="invalid_setting_value"):
+            await service.apply_overrides(
+                scope="workspace",
+                changes={"test.large_payload": "x" * 20000},
+                expected_versions={"test.large_payload": 1},
+            )
+
+        rows = (await settings_session.execute(select(SettingsOverride))).scalars().all()
+        effective = await service.effective_value_async(
+            "test.large_payload", scope="workspace"
+        )
+
+    assert rows == []
+    assert effective.value == "default"
+    assert effective.source == "default"
+
+
+@pytest.mark.asyncio
+async def test_unsafe_payload_classes_rejected_before_persistence(
+    settings_session_maker,
+):
+    entry_type = SettingsCatalogService(env={})._registry[0].__class__
+    registry = (
+        entry_type(
+            key="test.payload_guard",
+            title="Payload Guard",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="safe",
+            order=1,
+            apply_mode="immediate",
+        ),
+    )
+    unsafe_values = [
+        "oauth_session_blob={...}",
+        "decrypted_credential_file=/tmp/credential.json",
+        "generated_config password=plaintext",
+        "large_artifact:" + ("x" * 20000),
+        "workflow_payload={\"steps\": []}",
+        "operational command_history: rm -rf /",
+    ]
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(
+            env={},
+            registry=registry,
+            session=settings_session,
+        )
+
+        for unsafe_value in unsafe_values:
+            with pytest.raises(ValueError, match="invalid_setting_value"):
+                await service.apply_overrides(
+                    scope="workspace",
+                    changes={"test.payload_guard": unsafe_value},
+                    expected_versions={"test.payload_guard": 1},
+                )
+
+        rows = (await settings_session.execute(select(SettingsOverride))).scalars().all()
+        effective = await service.effective_value_async(
+            "test.payload_guard", scope="workspace"
+        )
+
+    assert rows == []
+    assert effective.value == "safe"
+    assert effective.source == "default"
+
+
+@pytest.mark.asyncio
+async def test_reset_edge_cases_preserve_sparse_scope_boundaries(
+    settings_session_maker,
+):
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(env={}, session=settings_session)
+        await service.apply_overrides(
+            scope="workspace",
+            changes={"integrations.github.token_ref": "env://WORKSPACE_TOKEN"},
+            expected_versions={"integrations.github.token_ref": 1},
+        )
+        await service.apply_overrides(
+            scope="user",
+            changes={"integrations.github.token_ref": "env://USER_TOKEN"},
+            expected_versions={"integrations.github.token_ref": 1},
+        )
+
+        workspace_reset = await service.reset_override(
+            "integrations.github.token_ref", scope="workspace"
+        )
+        user_after_workspace_reset = await service.effective_value_async(
+            "integrations.github.token_ref", scope="user"
+        )
+        user_reset = await service.reset_override(
+            "integrations.github.token_ref", scope="user"
+        )
+        absent_reset = await service.reset_override(
+            "integrations.github.token_ref", scope="user"
+        )
+
+        with pytest.raises(KeyError):
+            await service.reset_override("settings.unknown_key", scope="workspace")
+        with pytest.raises(ValueError, match="invalid_scope"):
+            await service.reset_override(
+                "workflow.default_publish_mode", scope="user"
+            )
+
+    assert workspace_reset.source in {"config_or_default", "environment", "default"}
+    assert user_after_workspace_reset.value == "env://USER_TOKEN"
+    assert user_after_workspace_reset.source == "user_override"
+    assert user_reset.source in {"config_or_default", "environment", "default"}
+    assert absent_reset.source in {"config_or_default", "environment", "default"}
+
+
+@pytest.mark.asyncio
 async def test_pending_activation_redacts_sensitive_non_reference_values(
     settings_session_maker,
 ):


### PR DESCRIPTION
## Summary

Implements Jira issue MM-654 for sparse user/workspace settings override persistence and reset validation. The change enforces a 16 KiB serialized override value limit, rejects unsafe payload classes before persistence, and preserves the existing sparse inheritance, reset, audit, and optimistic concurrency behavior.

## Jira

- Jira issue key: MM-654

## MoonSpec

- Active MoonSpec feature path: `specs/339-sparse-settings-overrides`
- Verification verdict: `ADDITIONAL_WORK_NEEDED`

## Tests run

- `pytest tests/unit/services/test_settings_catalog.py -q` - PASS (`57 passed`)
- `pytest tests/unit/api_service/api/routers/test_settings_api.py -q` - PASS (`26 passed`)
- `pytest tests/integration/api/test_settings_overrides_contract.py -m integration_ci -q` - PASS (`2 passed`)
- `pytest tests/unit/services/test_settings_catalog.py tests/unit/api_service/api/routers/test_settings_api.py -q` - PASS (`83 passed`)
- `./tools/test_unit.sh` - PASS (Python `4866 passed`; frontend `337 passed`, `227 skipped`)
- `./tools/test_integration.sh` - BLOCKED in the managed runtime by Docker administrative policy (`403 Forbidden`)

## Remaining risks

- Full compose-backed integration verification could not run in this managed environment because Docker access was denied by administrative policy.
- The final MoonSpec verify gate reported an environment projection preflight issue for `.gemini/skills`; implementation and focused tests passed, but the full verification verdict is not `FULLY_IMPLEMENTED` until those environment blockers are cleared and verification is rerun.
