### PR TITLE
MM-639 authoritative task snapshot durability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,8 @@ Key diagnostics:
 - Existing task-template catalog tables and execution payload/artifact records only; no new persistent storage planned. (331-model-step-type-payloads)
 - Python 3.12 (existing MoonMind runtime); adds `moonmind/workflows/temporal/transition_mm667.py` for the one-shot MM-667 orchestration. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (334-transition-mm667-in-pr)
 - N/A — this is a one-shot tool-driven workflow. The only persisted artifact is the run's structured outcome report (artifact-backed run output); no new persistent tables. (334-transition-mm667-in-pr)
+- Python 3.12; TypeScript/React for Mission Control edit/rerun UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, existing Temporal artifact service/helpers (339-authoritative-task-snapshot-durability)
+- Existing Temporal execution records, canonical execution memo/search/projection records, Temporal artifact metadata/content store; no new persistent database tables planned (339-authoritative-task-snapshot-durability)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -118,6 +118,7 @@ from moonmind.workflows.tasks.task_contract import (
     TaskInputAttachmentRef,
     TaskProposalPolicy,
     TaskSkillSelectors,
+    build_authoritative_task_input_snapshot,
     is_self_managed_publish_skill,
     resolve_publish_mode_for_skill,
 )
@@ -4167,17 +4168,31 @@ def _task_input_snapshot_descriptor_from_record(
         )
         if str(ref or "").strip()
     ]
+    parameters = getattr(record, "parameters", None)
+    task = parameters.get("task") if isinstance(parameters, Mapping) else None
+    task_payload = task if isinstance(task, Mapping) else {}
+    attachment_aware = bool(task_payload.get("inputAttachments"))
+    if not attachment_aware:
+        for step in task_payload.get("steps") or []:
+            if isinstance(step, Mapping) and step.get("inputAttachments"):
+                attachment_aware = True
+                break
+    disabled_reasons = {
+        "draft": "original_task_input_snapshot_missing",
+    }
+    if attachment_aware:
+        disabled_reasons["attachments"] = "original_task_input_snapshot_missing"
     return TaskInputSnapshotDescriptorModel(
         available=False,
         artifactRef=None,
         snapshotVersion=None,
         sourceKind="unknown",
         reconstructionMode=(
-            "degraded_read_only" if fallback_refs else "unavailable"
+            "degraded_read_only"
+            if fallback_refs or attachment_aware
+            else "unavailable"
         ),
-        disabledReasons={
-            "draft": "original_task_input_snapshot_missing",
-        },
+        disabledReasons=disabled_reasons,
         fallbackEvidenceRefs=fallback_refs,
     )
 
@@ -4196,6 +4211,14 @@ def _build_original_task_input_snapshot_payload(
         "targetRuntime": payload.get("targetRuntime"),
         "requiredCapabilities": list(payload.get("requiredCapabilities") or []),
         "task": dict(task_payload),
+        "authoredTaskInput": build_authoritative_task_input_snapshot(
+            task_payload=task_payload,
+            repository=payload.get("repository"),
+            target_runtime=payload.get("targetRuntime"),
+            required_capabilities=payload.get("requiredCapabilities"),
+            dependency_declarations=payload.get("dependencies"),
+            attachment_refs=attachment_refs,
+        ),
     }
     return {
         "snapshotVersion": _TASK_INPUT_SNAPSHOT_VERSION,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4171,10 +4171,14 @@ def _task_input_snapshot_descriptor_from_record(
     parameters = getattr(record, "parameters", None)
     task = parameters.get("task") if isinstance(parameters, Mapping) else None
     task_payload = task if isinstance(task, Mapping) else {}
-    attachment_aware = bool(task_payload.get("inputAttachments"))
+    attachment_aware = bool(
+        task_payload.get("inputAttachments") or task_payload.get("attachmentRefs")
+    )
     if not attachment_aware:
         for step in task_payload.get("steps") or []:
-            if isinstance(step, Mapping) and step.get("inputAttachments"):
+            if isinstance(step, Mapping) and (
+                step.get("inputAttachments") or step.get("attachmentRefs")
+            ):
                 attachment_aware = True
                 break
     disabled_reasons = {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2852,6 +2852,72 @@ describe.skip("Task Create Entrypoint", () => {
     ]);
   });
 
+  it("validates compact attachment refs stored inside the authoritative draft", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:draft-attachment-refs",
+        workflowType: "MoonMind.Run",
+        taskInputSnapshot: {
+          available: true,
+          artifactRef: "art-snapshot",
+          snapshotVersion: 1,
+          sourceKind: "create",
+          reconstructionMode: "authoritative",
+          disabledReasons: {},
+          fallbackEvidenceRefs: [],
+        },
+        inputParameters: {
+          task: {},
+        },
+      },
+      {
+        snapshotVersion: 1,
+        source: { kind: "create" },
+        draft: {
+          taskShape: "multi_step",
+          task: {
+            instructions: "Preserve authoritative draft attachment refs.",
+            steps: [
+              {
+                id: "step-bound",
+                title: "Bound step",
+                instructions: "Use the step attachment.",
+                inputAttachments: [
+                  {
+                    artifactId: "art-step",
+                    filename: "step.webp",
+                    contentType: "image/webp",
+                    sizeBytes: 4567,
+                  },
+                ],
+              },
+            ],
+          },
+          attachmentRefs: [
+            {
+              artifactId: "art-step",
+              filename: "step.webp",
+              contentType: "image/webp",
+              sizeBytes: 4567,
+              targetKind: "step",
+              stepId: "step-bound",
+              stepOrdinal: 0,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(draft.steps[0]?.inputAttachments).toEqual([
+      {
+        artifactId: "art-step",
+        filename: "step.webp",
+        contentType: "image/webp",
+        sizeBytes: 4567,
+      },
+    ]);
+  });
+
   it("fails reconstruction when compact attachment refs cannot be bound from the task snapshot", () => {
     expect(() =>
       buildTemporalSubmissionDraftFromExecution(

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -614,9 +614,16 @@ function assertSnapshotAttachmentBindings(
   artifactTask: Record<string, unknown>,
   artifactTaskSteps: TemporalSubmissionDraft['steps'],
 ): void {
-  const compactRefs = Array.isArray(artifactParams.attachmentRefs)
-    ? artifactParams.attachmentRefs.map((entry) => objectValue(entry))
-    : [];
+  const snapshotDraft = objectValue(artifactParams.draft);
+  const authoredTaskInput = objectValue(snapshotDraft.authoredTaskInput);
+  const compactRefSources = [
+    artifactParams.attachmentRefs,
+    snapshotDraft.attachmentRefs,
+    authoredTaskInput.attachmentRefs,
+  ];
+  const compactRefs = compactRefSources.flatMap((source) =>
+    Array.isArray(source) ? source.map((entry) => objectValue(entry)) : [],
+  );
   if (compactRefs.length === 0) {
     return;
   }

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -2016,6 +2016,193 @@ def has_attachment_mutation_fields(payload: Mapping[str, Any] | None) -> bool:
                 return True
     return False
 
+
+def _snapshot_safe(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _snapshot_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_snapshot_safe(item) for item in value]
+    return value
+
+
+def _snapshot_mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    safe = _snapshot_safe(value)
+    return safe if isinstance(safe, dict) else {}
+
+
+def _snapshot_list(value: object) -> list[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    safe = _snapshot_safe(value)
+    return safe if isinstance(safe, list) else []
+
+
+def _task_steps(task_payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        _snapshot_mapping(step)
+        for step in _snapshot_list(task_payload.get("steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _detect_jira_issue_key(task_payload: Mapping[str, Any]) -> str | None:
+    try:
+        serialized = json.dumps(_snapshot_safe(task_payload), sort_keys=True)
+    except TypeError:
+        serialized = str(task_payload)
+    match = re.search(r"\b[A-Z][A-Z0-9]+-\d+\b", serialized)
+    return match.group(0) if match else None
+
+
+def _step_identifier(step: Mapping[str, Any], ordinal: int) -> str:
+    return (
+        _clean_optional_str(step.get("id"))
+        or _clean_optional_str(step.get("stepId"))
+        or f"step-{ordinal + 1}"
+    )
+
+
+def _include_tree_summary(
+    task_payload: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    summary: list[dict[str, Any]] = []
+    for template in _snapshot_list(task_payload.get("appliedStepTemplates")):
+        if not isinstance(template, Mapping):
+            continue
+        parent_slug = _clean_optional_str(
+            template.get("slug") or template.get("presetSlug")
+        )
+        parent_version = _clean_optional_str(
+            template.get("version") or template.get("presetVersion")
+        )
+        composition = template.get("composition")
+        candidates: list[Any] = []
+        if isinstance(composition, Mapping):
+            candidates.extend(_snapshot_list(composition.get("includes")))
+        candidates.extend(_snapshot_list(template.get("includes")))
+        for include in candidates:
+            if not isinstance(include, Mapping):
+                continue
+            summary.append(
+                {
+                    "presetSlug": parent_slug,
+                    "presetVersion": parent_version,
+                    "includedSlug": _clean_optional_str(
+                        include.get("slug") or include.get("presetSlug")
+                    ),
+                    "includedVersion": _clean_optional_str(
+                        include.get("version") or include.get("presetVersion")
+                    ),
+                }
+            )
+    return summary
+
+
+def build_authoritative_task_input_snapshot(
+    *,
+    task_payload: Mapping[str, Any],
+    repository: object = None,
+    target_runtime: object = None,
+    required_capabilities: object = None,
+    dependency_declarations: object = None,
+    attachment_refs: object = None,
+) -> dict[str, Any]:
+    """Build explicit authored fields for durable task input reconstruction."""
+
+    task = _snapshot_mapping(task_payload)
+    git = _snapshot_mapping(task.get("git"))
+    steps = _task_steps(task)
+    repository_value = (
+        _clean_optional_str(git.get("repository"))
+        or _clean_optional_str(repository)
+        or None
+    )
+    branch_value = (
+        _clean_optional_str(task.get("branch"))
+        or _clean_optional_str(git.get("branch"))
+        or _clean_optional_str(git.get("startingBranch"))
+        or None
+    )
+    authored_steps: list[dict[str, Any]] = []
+    final_order: list[dict[str, Any]] = []
+    provenance: list[dict[str, Any]] = []
+    detachment: list[dict[str, Any]] = []
+    for ordinal, step in enumerate(steps):
+        step_id = _step_identifier(step, ordinal)
+        final_order.append({"stepId": step_id, "ordinal": ordinal})
+        authored_steps.append(
+            {
+                "id": step_id,
+                "title": _clean_optional_str(step.get("title")),
+                "instructions": _clean_optional_str(step.get("instructions")) or "",
+                "inputAttachments": _snapshot_list(step.get("inputAttachments")),
+                "dependencies": _snapshot_list(
+                    step.get("dependsOn") or step.get("dependencies")
+                ),
+                "templateStepId": _clean_optional_str(step.get("templateStepId")),
+                "stepType": _clean_optional_str(step.get("type")),
+                "presetProvenance": _snapshot_mapping(step.get("presetProvenance")),
+            }
+        )
+        if isinstance(step.get("presetProvenance"), Mapping):
+            provenance.append(
+                {
+                    "stepId": step_id,
+                    "ordinal": ordinal,
+                    "presetProvenance": _snapshot_mapping(
+                        step.get("presetProvenance")
+                    ),
+                }
+            )
+        detached = bool(
+            step.get("detachedFromPreset")
+            or step.get("detached")
+            or step.get("isDetached")
+        )
+        if detached:
+            detachment.append(
+                {"stepId": step_id, "ordinal": ordinal, "detached": True}
+            )
+    issue_key = _detect_jira_issue_key(task)
+    return {
+        "traceability": {
+            **({"jiraIssueKey": issue_key} if issue_key else {}),
+        },
+        "objective": {
+            "instructions": _clean_optional_str(task.get("instructions")) or "",
+            "inputAttachments": _snapshot_list(task.get("inputAttachments")),
+        },
+        "steps": authored_steps,
+        "runtime": _snapshot_mapping(task.get("runtime"))
+        or (
+            {"mode": _clean_optional_str(target_runtime)}
+            if _clean_optional_str(target_runtime)
+            else {}
+        ),
+        "publish": _snapshot_mapping(task.get("publish")),
+        "repository": repository_value,
+        "branch": branch_value,
+        "singleAuthoredBranch": branch_value,
+        "requiredCapabilities": _snapshot_list(required_capabilities),
+        "dependencyDeclarations": _snapshot_list(
+            task.get("dependencies")
+            or task.get("dependsOn")
+            or dependency_declarations
+        ),
+        "presetApplicationMetadata": _snapshot_list(
+            task.get("appliedStepTemplates")
+        ),
+        "pinnedPresetBindings": _snapshot_list(task.get("authoredPresets")),
+        "includeTreeSummary": _include_tree_summary(task),
+        "perStepProvenance": provenance,
+        "detachmentState": detachment,
+        "finalSubmittedOrder": final_order,
+        "attachmentRefs": _snapshot_list(attachment_refs),
+    }
+
+
 def build_task_stage_plan(canonical_payload: Mapping[str, Any]) -> list[str]:
     """Return ordered stage identifiers for canonical task execution."""
 
@@ -2043,6 +2230,7 @@ __all__ = [
     "TaskRecoveryProvenance",
     "ResumeFromFailedStepRef",
     "TaskStepSource",
+    "build_authoritative_task_input_snapshot",
     "build_task_stage_plan",
     "build_canonical_task_view",
     "has_attachment_mutation_fields",

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -2047,13 +2047,49 @@ def _task_steps(task_payload: Mapping[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _safe_mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _first_present_snapshot_list(
+    source: Mapping[str, Any],
+    *keys: str,
+    fallback: object = None,
+) -> list[Any]:
+    for key in keys:
+        if key in source:
+            return _snapshot_list(source.get(key))
+    return _snapshot_list(fallback)
+
+
 def _detect_jira_issue_key(task_payload: Mapping[str, Any]) -> str | None:
-    try:
-        serialized = json.dumps(_snapshot_safe(task_payload), sort_keys=True)
-    except TypeError:
-        serialized = str(task_payload)
-    match = re.search(r"\b[A-Z][A-Z0-9]+-\d+\b", serialized)
-    return match.group(0) if match else None
+    pattern = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
+    stack: list[object] = [
+        task_payload.get("title"),
+        task_payload.get("instructions"),
+        task_payload.get("description"),
+        task_payload.get("objective"),
+        task_payload.get("steps"),
+    ]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, str):
+            match = pattern.search(value)
+            if match:
+                return match.group(0)
+            continue
+        if isinstance(value, Mapping):
+            stack.extend(value.values())
+            continue
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            stack.extend(value)
+    return None
 
 
 def _step_identifier(step: Mapping[str, Any], ordinal: int) -> str:
@@ -2068,7 +2104,7 @@ def _include_tree_summary(
     task_payload: Mapping[str, Any],
 ) -> list[dict[str, Any]]:
     summary: list[dict[str, Any]] = []
-    for template in _snapshot_list(task_payload.get("appliedStepTemplates")):
+    for template in _safe_list(task_payload.get("appliedStepTemplates")):
         if not isinstance(template, Mapping):
             continue
         parent_slug = _clean_optional_str(
@@ -2080,8 +2116,8 @@ def _include_tree_summary(
         composition = template.get("composition")
         candidates: list[Any] = []
         if isinstance(composition, Mapping):
-            candidates.extend(_snapshot_list(composition.get("includes")))
-        candidates.extend(_snapshot_list(template.get("includes")))
+            candidates.extend(_safe_list(composition.get("includes")))
+        candidates.extend(_safe_list(template.get("includes")))
         for include in candidates:
             if not isinstance(include, Mapping):
                 continue
@@ -2112,8 +2148,10 @@ def build_authoritative_task_input_snapshot(
     """Build explicit authored fields for durable task input reconstruction."""
 
     task = _snapshot_mapping(task_payload)
-    git = _snapshot_mapping(task.get("git"))
-    steps = _task_steps(task)
+    git = _safe_mapping(task.get("git"))
+    steps = [
+        step for step in _safe_list(task.get("steps")) if isinstance(step, Mapping)
+    ]
     repository_value = (
         _clean_optional_str(git.get("repository"))
         or _clean_optional_str(repository)
@@ -2137,13 +2175,15 @@ def build_authoritative_task_input_snapshot(
                 "id": step_id,
                 "title": _clean_optional_str(step.get("title")),
                 "instructions": _clean_optional_str(step.get("instructions")) or "",
-                "inputAttachments": _snapshot_list(step.get("inputAttachments")),
-                "dependencies": _snapshot_list(
-                    step.get("dependsOn") or step.get("dependencies")
+                "inputAttachments": _safe_list(step.get("inputAttachments")),
+                "dependencies": _first_present_snapshot_list(
+                    step,
+                    "dependsOn",
+                    "dependencies",
                 ),
                 "templateStepId": _clean_optional_str(step.get("templateStepId")),
                 "stepType": _clean_optional_str(step.get("type")),
-                "presetProvenance": _snapshot_mapping(step.get("presetProvenance")),
+                "presetProvenance": _safe_mapping(step.get("presetProvenance")),
             }
         )
         if isinstance(step.get("presetProvenance"), Mapping):
@@ -2151,9 +2191,7 @@ def build_authoritative_task_input_snapshot(
                 {
                     "stepId": step_id,
                     "ordinal": ordinal,
-                    "presetProvenance": _snapshot_mapping(
-                        step.get("presetProvenance")
-                    ),
+                    "presetProvenance": _safe_mapping(step.get("presetProvenance")),
                 }
             )
         detached = bool(
@@ -2172,29 +2210,28 @@ def build_authoritative_task_input_snapshot(
         },
         "objective": {
             "instructions": _clean_optional_str(task.get("instructions")) or "",
-            "inputAttachments": _snapshot_list(task.get("inputAttachments")),
+            "inputAttachments": _safe_list(task.get("inputAttachments")),
         },
         "steps": authored_steps,
-        "runtime": _snapshot_mapping(task.get("runtime"))
+        "runtime": _safe_mapping(task.get("runtime"))
         or (
             {"mode": _clean_optional_str(target_runtime)}
             if _clean_optional_str(target_runtime)
             else {}
         ),
-        "publish": _snapshot_mapping(task.get("publish")),
+        "publish": _safe_mapping(task.get("publish")),
         "repository": repository_value,
         "branch": branch_value,
         "singleAuthoredBranch": branch_value,
         "requiredCapabilities": _snapshot_list(required_capabilities),
-        "dependencyDeclarations": _snapshot_list(
-            task.get("dependencies")
-            or task.get("dependsOn")
-            or dependency_declarations
+        "dependencyDeclarations": _first_present_snapshot_list(
+            task,
+            "dependencies",
+            "dependsOn",
+            fallback=dependency_declarations,
         ),
-        "presetApplicationMetadata": _snapshot_list(
-            task.get("appliedStepTemplates")
-        ),
-        "pinnedPresetBindings": _snapshot_list(task.get("authoredPresets")),
+        "presetApplicationMetadata": _safe_list(task.get("appliedStepTemplates")),
+        "pinnedPresetBindings": _safe_list(task.get("authoredPresets")),
         "includeTreeSummary": _include_tree_summary(task),
         "perStepProvenance": provenance,
         "detachmentState": detachment,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -77,6 +77,9 @@ from moonmind.workflows.temporal.workers import (
     describe_configured_worker,
     list_registered_workflow_types,
 )
+from moonmind.workflows.tasks.task_contract import (
+    build_authoritative_task_input_snapshot,
+)
 from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow as MoonMindProviderProfileManager
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
@@ -336,6 +339,14 @@ def _build_child_run_task_input_snapshot_payload(
             "targetRuntime": parameters.get("targetRuntime"),
             "requiredCapabilities": list(parameters.get("requiredCapabilities") or []),
             "task": dict(task_payload),
+            "authoredTaskInput": build_authoritative_task_input_snapshot(
+                task_payload=task_payload,
+                repository=parameters.get("repository"),
+                target_runtime=parameters.get("targetRuntime"),
+                required_capabilities=parameters.get("requiredCapabilities"),
+                dependency_declarations=parameters.get("dependencies"),
+                attachment_refs=[],
+            ),
         },
         "largeContentRefs": {},
         "attachmentRefs": [],

--- a/specs/339-authoritative-task-snapshot-durability/checklists/requirements.md
+++ b/specs/339-authoritative-task-snapshot-durability/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Authoritative Task Snapshot Durability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is classified as a single-story runtime feature request.
+- PASS: The canonical MM-639 Jira preset brief is preserved in `spec.md` `**Input**`.
+- PASS: Source design requirements from `docs/Tasks/TaskArchitecture.md` are mapped to functional requirements.

--- a/specs/339-authoritative-task-snapshot-durability/contracts/task-input-snapshot-reconstruction.md
+++ b/specs/339-authoritative-task-snapshot-durability/contracts/task-input-snapshot-reconstruction.md
@@ -1,0 +1,68 @@
+# Contract: Task Input Snapshot Reconstruction
+
+## Scope
+
+This contract defines MM-639 behavior for `MoonMind.Run` task-shaped submissions and recovery actions.
+
+## Snapshot Persistence
+
+When a `MoonMind.Run` task is submitted through a covered entrypoint, the system must persist one authoritative task input snapshot before edit/rerun/Resume actions depend on the execution.
+
+Covered entrypoints:
+- Task-shaped create submission through the API.
+- Direct `MoonMind.Run` create submission with task parameters.
+- Jira-Orchestrate child `MoonMind.Run` creation.
+- Exact full rerun creation.
+- Edited full retry creation.
+
+Required persisted content:
+- Objective text and objective-scoped attachment refs.
+- Step text, identity, order, and step-scoped attachment refs.
+- Runtime and publish selections.
+- Repository and single authored branch selection.
+- Dependency declarations.
+- Preset application metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+
+## Execution Detail Response
+
+Execution detail responses must expose `taskInputSnapshot` with:
+
+```json
+{
+  "available": true,
+  "artifactRef": "art_snapshot_123",
+  "snapshotVersion": 1,
+  "sourceKind": "create",
+  "reconstructionMode": "authoritative",
+  "disabledReasons": {},
+  "fallbackEvidenceRefs": []
+}
+```
+
+When unavailable, `available` must be `false`, `reconstructionMode` must be `degraded_read_only` or `unavailable`, and disabled reasons must identify why editable reconstruction is unavailable.
+
+## Recovery Action Rules
+
+Exact full rerun:
+- Reuses the original task input snapshot unchanged.
+- Starts from the beginning.
+- Imports no completed execution progress, preserved steps, or Resume checkpoint state.
+
+Edited full retry:
+- Opens from the original snapshot for authoring edits.
+- Creates a new execution with its own authoritative snapshot.
+- Does not mutate the source execution snapshot or evidence.
+
+Failed-step Resume:
+- Reuses the original task input snapshot unchanged.
+- Rejects task, runtime, attachment, publish, branch, preset, or dependency edits.
+- Requires checkpoint evidence whose task input snapshot ref matches the source execution snapshot ref.
+- Imports only completed progress represented by validated checkpoint evidence.
+
+## Degraded Attachment-Aware Reconstruction
+
+If an attachment-aware execution lacks a reconstructible authoritative snapshot, the system must:
+- Disable editable reconstruction actions that require the snapshot.
+- Surface `original_task_input_snapshot_missing` or a more specific degraded reason.
+- Preserve diagnostic fallback refs as diagnostic-only evidence.
+- Never silently drop, retarget, or synthesize attachment state.

--- a/specs/339-authoritative-task-snapshot-durability/data-model.md
+++ b/specs/339-authoritative-task-snapshot-durability/data-model.md
@@ -1,0 +1,72 @@
+# Data Model: Authoritative Task Snapshot Durability
+
+## Authoritative Task Input Snapshot
+
+Represents the durable authored input for a `MoonMind.Run` execution.
+
+Fields:
+- `snapshotVersion`: Schema version for snapshot readers and validators.
+- `source.kind`: One of `create`, `edit`, `rerun`, or another explicit supported source kind.
+- `source.sourceWorkflowId`: Present for snapshots derived from another execution.
+- `source.sourceRunId`: Present for snapshots derived from another execution.
+- `draft.taskShape`: Compact shape such as `multi_step`, `artifact_backed`, `template_derived`, `skill_only`, or `inline_instructions`.
+- `draft.repository`: Authored repository selection.
+- `draft.targetRuntime`: Authored runtime selection.
+- `draft.requiredCapabilities`: Authored or compiled capability list.
+- `draft.task`: Complete authored task payload, including objective text, step text, step identity/order, runtime/publish selections, repository/branch data, dependencies, preset metadata, pinned bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- `largeContentRefs`: References to large authored content that cannot be safely inlined.
+- `attachmentRefs`: Compact list of objective-scoped and step-scoped attachment refs with target binding metadata.
+- `lineage`: Optional relationship metadata for derived snapshots.
+- `excluded`: Explicit exclusions from editable reconstruction, such as schedule-only creation controls.
+
+Validation rules:
+- Snapshot version must be present and supported.
+- `draft.task` must be non-empty for task-shaped submissions.
+- Attachment refs must include enough target metadata to distinguish objective and step bindings.
+- Snapshot reads must not require live preset catalog lookup.
+- Missing required authored fields must produce explicit degraded or rejected recovery behavior.
+
+## Execution Snapshot Descriptor
+
+Operator-facing summary exposed on execution detail responses.
+
+Fields:
+- `available`: Whether an authoritative snapshot is available.
+- `artifactRef`: Snapshot artifact ref when available.
+- `snapshotVersion`: Snapshot schema version when available.
+- `sourceKind`: Snapshot source kind.
+- `reconstructionMode`: `authoritative`, `degraded_read_only`, or `unavailable`.
+- `disabledReasons`: Reason map for unavailable draft or recovery behavior.
+- `fallbackEvidenceRefs`: Diagnostic-only refs that cannot replace the authoritative snapshot.
+
+Validation rules:
+- Missing snapshots must not enable edit/rerun actions.
+- Fallback refs may support diagnostics only; they must not silently reconstruct editable state.
+
+## Recovery Action
+
+Represents user intent to recover from a source execution.
+
+Kinds:
+- Exact full rerun: reuses the original snapshot unchanged and imports no completed progress.
+- Edited full retry: creates a new execution and its own snapshot while preserving source evidence unchanged.
+- Failed-step Resume: reuses the original snapshot unchanged and imports only checkpointed completed progress.
+
+Validation rules:
+- Recovery intent must be explicit.
+- Resume must reject task input edits.
+- Resume must validate checkpoint source workflow/run identity and task snapshot identity.
+- Edited full retry must not mutate the source snapshot.
+
+## Degraded Reconstruction State
+
+Represents an execution whose authored task cannot be faithfully reconstructed.
+
+Fields:
+- `reason`: Machine-readable reason such as `original_task_input_snapshot_missing` or attachment binding reconstruction failure.
+- `affectedActions`: Recovery actions blocked or restricted by degradation.
+- `fallbackEvidenceRefs`: Optional diagnostic refs.
+
+Validation rules:
+- Attachment-aware missing or invalid snapshots must be degraded explicitly.
+- The system must not silently drop, retarget, or synthesize attachments during recovery.

--- a/specs/339-authoritative-task-snapshot-durability/moonspec_align_report.md
+++ b/specs/339-authoritative-task-snapshot-durability/moonspec_align_report.md
@@ -1,0 +1,26 @@
+# MoonSpec Alignment Report: Authoritative Task Snapshot Durability
+
+**Source**: `MM-639` canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-11
+
+## Summary
+
+Alignment completed after task generation. The feature remains one independently testable runtime story, and no changes were needed to `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, or `contracts/task-input-snapshot-reconstruction.md`.
+
+## Findings And Remediation
+
+| Finding | Remediation |
+| --- | --- |
+| `tasks.md` status summary drifted from `plan.md` requirement status counts. | Updated the summary to 8 `partial`, 12 `implemented_unverified`, and 6 `implemented_verified` rows. |
+| Two test tasks contained alternate file paths using `or`, which weakened the executable task contract. | Replaced alternatives with concrete paths: `tests/integration/api/test_task_input_snapshot_durability.py` and `tests/contract/test_temporal_execution_api.py`. |
+| Partial requirement implementation tasks were phrased as conditional fallback work. | Reworded FR-002/FR-007 implementation tasks as required work while keeping true `implemented_unverified` fallback tasks conditional. |
+
+## Gate Re-Check
+
+- Specify gate: PASS. `spec.md` contains exactly one story and preserves the MM-639 preset brief.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/` exist.
+- Tasks gate: PASS after remediation. `tasks.md` contains one story phase, red-first unit and integration tests, implementation tasks, story validation, and final `/moonspec-verify` work.
+
+## Remaining Risks
+
+- Application behavior still requires implementation and verification in later steps; this alignment only remediated MoonSpec artifacts.

--- a/specs/339-authoritative-task-snapshot-durability/plan.md
+++ b/specs/339-authoritative-task-snapshot-durability/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Authoritative Task Snapshot Durability
+
+**Branch**: `339-authoritative-task-snapshot-durability` | **Date**: 2026-05-11 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:e2bc69b6-9268-42f5-8b6d-deec1caaeb08/repo/specs/339-authoritative-task-snapshot-durability/spec.md`
+
+## Summary
+
+MM-639 requires every submitted `MoonMind.Run` task to retain an authoritative task input snapshot that can drive edit, exact full rerun, edited full retry, and failed-step Resume without depending on live preset catalog state or lossy projections. Current repository inspection shows the core snapshot artifact, action gating, rerun cleanup, Jira-Orchestrate child-run snapshot persistence, and failed-step Resume source checks already exist. The implementation plan is therefore focused on closing explicit schema/field coverage and degraded attachment-aware reconstruction gaps, then adding boundary-level unit and hermetic integration coverage that proves snapshot completeness, catalog independence, and recovery intent separation.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `api_service/api/routers/executions.py` persists snapshots for task create, direct create, edit/rerun updates, and rerun; `moonmind/workflows/temporal/worker_runtime.py` persists Jira-Orchestrate child-run snapshots | Add verification-first coverage across all submitted execution entrypoints; add implementation only if a path lacks a snapshot | unit + integration |
+| FR-002 | partial | Snapshot payload copies `task` and compact metadata, but no explicit schema/contract verifies all Section 7 fields, dependency declarations, final order, pinned preset bindings, include-tree summary, per-step provenance, and detachment state | Add/strengthen snapshot schema validation and persistence coverage for all required authored fields | unit + integration |
+| FR-003 | implemented_unverified | Frontend draft reconstruction can hydrate from `taskInputSnapshot` artifacts in `frontend/src/lib/temporalTaskEditing.ts`; rerun snapshot hydration reads input artifacts before preserving stripped instructions | Add tests proving reconstruction succeeds after live preset/template definitions diverge from the submitted snapshot | unit + integration |
+| FR-004 | implemented_verified | `tests/integration/temporal/test_full_retry_recovery_actions.py`; `tests/unit/workflows/temporal/test_temporal_service.py` assert rerun strips resume progress and starts from original input refs | Preserve coverage; no new implementation expected | final verify |
+| FR-005 | implemented_unverified | Update route persists `source_kind="edit"` for edit-for-rerun and `source_kind="rerun"` for rerun in `api_service/api/routers/executions.py` | Add verification-first tests that edited full retry creates a new snapshot and leaves source snapshot/evidence unchanged | unit + integration |
+| FR-006 | implemented_verified | `api_service/api/routers/executions.py` rejects edited resume payload fields; `moonmind/workflows/temporal/service.py` validates checkpoint snapshot ref against source snapshot; tests cover rejection and source identity | Preserve coverage; no new implementation expected | final verify |
+| FR-007 | partial | Missing snapshots disable edit/rerun actions and descriptor reports degraded read-only state; frontend rejects unreconstructible attachment bindings, but end-to-end degraded handling for attachment-aware executions needs stronger proof | Add degraded-state tests and implementation adjustments if any recovery path can silently drop or synthesize attachment state | unit + integration |
+| FR-008 | implemented_unverified | `TaskInputSnapshotDescriptorModel` is serialized on execution details and action disabled reasons include `original_task_input_snapshot_missing` | Add verification-first tests for snapshot availability, missing snapshot, and degraded reconstruction exposure | unit + integration |
+| FR-009 | implemented_verified | `spec.md` preserves MM-639 and the canonical Jira preset brief; this plan preserves the same traceability | Preserve MM-639 through downstream artifacts, commits, PR, and verification | final verify |
+| SCN-001 | implemented_unverified | Snapshot persisted during task create paths, but field-complete coverage is partial | Verify all authored fields are present for a representative task-shaped submission | unit + integration |
+| SCN-002 | partial | Attachment refs are persisted and metadata stores `attachment_refs`; frontend validates compact binding keys | Add end-to-end target-binding reconstruction and degraded-path coverage | unit + integration |
+| SCN-003 | implemented_unverified | Snapshot-based frontend reconstruction and snapshot hydration paths exist | Add changed-preset-catalog tests proving no live lookup is needed | unit + integration |
+| SCN-004 | implemented_verified | Full rerun tests prove no resume progress import | No new work beyond final verification | final verify |
+| SCN-005 | implemented_unverified | Edit/rerun update route persists snapshots for new execution records | Add tests proving new edited retry snapshot and immutable source evidence | unit + integration |
+| SCN-006 | implemented_verified | Resume route rejects task/runtime edits and service validates checkpoint snapshot identity | No new work beyond final verification | final verify |
+| SCN-007 | partial | Missing snapshots disable actions; frontend throws on invalid attachment binding reconstruction | Add explicit degraded-state integration coverage | unit + integration |
+| SC-001 | implemented_unverified | Snapshot refs are emitted in execution responses for covered create paths | Verify 100% of covered submitted execution paths associate a retrievable snapshot before action evaluation | integration |
+| SC-002 | implemented_unverified | Snapshot reconstruction code exists | Add live-catalog-divergence tests for edit/rerun/resume reconstruction | unit + integration |
+| SC-003 | partial | Attachment refs persist; degraded handling exists in pieces | Add target-binding and degraded-blocking tests | unit + integration |
+| SC-004 | implemented_unverified | Full rerun and Resume are covered; edited full retry needs stronger proof | Add edited full retry snapshot evidence test | unit + integration |
+| SC-005 | partial | Missing snapshot action disablement exists; attachment-aware degraded path needs stronger proof | Add unreconstructible snapshot and attachment loss prevention tests | unit + integration |
+| SC-006 | implemented_verified | `spec.md` and `plan.md` preserve MM-639 and source mappings | Preserve through generated artifacts and final verification | final verify |
+| DESIGN-REQ-004 | partial | Authoritative snapshot and degraded descriptor exist, but attachment-aware degraded behavior needs end-to-end proof | Add attachment-aware reconstruction and degraded-path tests; patch if any silent loss is found | unit + integration |
+| DESIGN-REQ-011 | partial | Snapshot copies task payload but lacks explicit Section 7 field contract coverage | Add explicit schema/contract coverage and fill missing fields if discovered | unit + integration |
+| DESIGN-REQ-012 | implemented_unverified | Full rerun and Resume are strongly covered; edited full retry requires additional proof | Add edited full retry verification and preserve existing rerun/resume behavior | unit + integration |
+| DESIGN-REQ-013 | implemented_unverified | Action gating and recovery intent separation exist across API/service tests | Add final cross-flow verification of invariant coverage | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control edit/rerun UI  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, existing Temporal artifact service/helpers  
+**Storage**: Existing Temporal execution records, canonical execution memo/search/projection records, Temporal artifact metadata/content store; no new persistent database tables planned  
+**Unit Testing**: `./tools/test_unit.sh` for final verification; focused Python pytest targets and `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` for iteration when JS deps are ready  
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic `integration_ci`; focused pytest targets under `tests/integration/temporal`, `tests/integration/api`, and `tests/contract` during development  
+**Target Platform**: MoonMind API service and Mission Control frontend running in Docker Compose-managed local deployment  
+**Project Type**: Web service plus frontend dashboard and Temporal orchestration runtime  
+**Performance Goals**: Snapshot reads and writes should add no user-visible delay beyond normal task submission/edit/rerun flow; task detail and Create-page reconstruction should remain responsive for typical task payloads  
+**Constraints**: No raw binary content in workflow history; no live preset catalog dependency for already submitted tasks; no secret material in artifacts/logs; no semantic compatibility aliases for internal contracts  
+**Scale/Scope**: One runtime story for `MoonMind.Run` task-shaped submissions and recovery actions; covers direct task create, Jira-Orchestrate child runs, exact full rerun, edited full retry, and failed-step Resume
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate | Status | Notes |
+| --- | --- | --- | --- |
+| I. Orchestrate, Don't Recreate | Keep behavior in MoonMind orchestration/adapters, not agent cognition | PASS | Snapshot and recovery behavior remains in API/service/runtime boundaries. |
+| II. One-Click Agent Deployment | Preserve Docker Compose/local-first operation | PASS | No new external dependencies or required SaaS services. |
+| III. Avoid Vendor Lock-In | Avoid provider-specific assumptions | PASS | Snapshot contract is provider-neutral task input state. |
+| IV. Own Your Data | Store context/artifacts on operator-controlled infrastructure | PASS | Uses existing Temporal artifact store and execution records. |
+| V. Skills Are First-Class | Do not conflate runtime tool skills with agent skill bundles | PASS | No skill runtime changes planned. |
+| VI. Replaceable Scaffolding | Prefer thin contracts with strong tests | PASS | Plan strengthens task snapshot contracts and boundary tests. |
+| VII. Runtime Configurability | Respect existing settings/feature flags | PASS | Existing task editing gates remain configuration-controlled. |
+| VIII. Modular Architecture | Keep changes behind existing service/router/frontend boundaries | PASS | Planned work is scoped to execution router, Temporal service/runtime helpers, task editing UI helpers, and tests. |
+| IX. Resilient by Default | Preserve retry/resume safety and in-flight evidence | PASS | Recovery actions remain explicit and checkpoint/snapshot validated. |
+| X. Continuous Improvement | Produce structured evidence | PASS | Plan requires unit/integration/final verification evidence. |
+| XI. Spec-Driven Development | Plan from one-story spec with traceability | PASS | `spec.md` exists, has one story, and preserves MM-639. |
+| XII. Canonical Docs vs Backlog | Keep migration notes in specs, not docs | PASS | Work artifacts stay under `specs/339-authoritative-task-snapshot-durability/`. |
+| XIII. Delete, Don't Deprecate | Avoid compatibility aliases for internal contracts | PASS | Any discovered stale internal fallback should be removed rather than preserved. |
+
+Post-design re-check: PASS. Generated design artifacts keep the same constraints and introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/339-authoritative-task-snapshot-durability/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-input-snapshot-reconstruction.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/api/routers/executions.py
+frontend/src/lib/temporalTaskEditing.ts
+frontend/src/entrypoints/task-create.tsx
+moonmind/schemas/temporal_models.py
+moonmind/workflows/tasks/task_contract.py
+moonmind/workflows/temporal/service.py
+moonmind/workflows/temporal/worker_runtime.py
+
+tests/unit/api/routers/test_executions.py
+tests/unit/workflows/temporal/test_temporal_service.py
+tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+tests/unit/workflows/tasks/test_task_contract.py
+frontend/src/entrypoints/task-create.test.tsx
+tests/contract/test_temporal_execution_api.py
+tests/integration/api/test_task_contract_normalization.py
+tests/integration/temporal/test_full_retry_recovery_actions.py
+```
+
+**Structure Decision**: Use the existing API router, Temporal service/runtime, task contract, and Mission Control task editing helper boundaries. Add tests beside existing focused suites; do not introduce a new module unless schema validation for the snapshot becomes large enough to justify a local helper.
+
+## Complexity Tracking
+
+No constitution violations or extra architectural complexity are planned.

--- a/specs/339-authoritative-task-snapshot-durability/quickstart.md
+++ b/specs/339-authoritative-task-snapshot-durability/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Authoritative Task Snapshot Durability
+
+## Focused Unit Tests
+
+Run targeted Python unit tests while implementing:
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/tasks/test_task_contract.py
+```
+
+Run targeted frontend reconstruction tests after JS dependencies are available:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected coverage:
+- Snapshot payload includes all MM-639 required authored task fields.
+- Missing snapshots disable edit/rerun and expose explicit degraded reasons.
+- Frontend draft reconstruction uses authoritative snapshot content and rejects invalid attachment bindings.
+- Exact full rerun, edited full retry, and Resume remain distinct intents.
+
+## Focused Hermetic Integration / Contract Tests
+
+Run focused integration and contract tests:
+
+```bash
+./tools/test_unit.sh tests/contract/test_temporal_execution_api.py
+./tools/test_integration.sh
+```
+
+During development, narrower pytest targets may be useful:
+
+```bash
+pytest tests/integration/temporal/test_full_retry_recovery_actions.py -q
+pytest tests/integration/api/test_task_contract_normalization.py -q
+pytest tests/contract/test_temporal_execution_api.py -q
+```
+
+Expected coverage:
+- Real API submission writes one retrievable snapshot artifact before recovery actions are evaluated.
+- Snapshot artifact content preserves objective/step attachments by target, preset metadata, provenance, final order, branch, publish, runtime, and dependencies.
+- Live preset/template catalog divergence does not affect reconstruction for already submitted tasks.
+- Attachment-aware executions without reconstructible snapshots are explicitly degraded.
+
+## End-to-End Story Validation
+
+1. Submit a task-shaped `MoonMind.Run` with objective text, multiple ordered steps, objective and step attachments, runtime/publish selections, repository and branch, dependency declarations, and preset-derived metadata.
+2. Confirm execution detail exposes `taskInputSnapshot.available=true`, `reconstructionMode=authoritative`, and a retrievable artifact ref.
+3. Change or remove the live preset/template definition used by the submitted task.
+4. Open edit, exact full rerun, and edited full retry flows; confirm they reconstruct from the snapshot, not the live catalog.
+5. For exact full rerun, confirm no completed progress or Resume checkpoint state is imported.
+6. For edited full retry, confirm the new execution receives a new snapshot and the source execution evidence remains unchanged.
+7. For failed-step Resume, confirm task input edits are rejected and checkpoint snapshot identity must match the source snapshot.
+8. For a synthetic attachment-aware execution missing a snapshot, confirm recovery is blocked or degraded explicitly with no silent attachment loss.
+
+## Final Verification Commands
+
+```bash
+./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+Then run the MoonSpec verification stage against `specs/339-authoritative-task-snapshot-durability/spec.md`.

--- a/specs/339-authoritative-task-snapshot-durability/research.md
+++ b/specs/339-authoritative-task-snapshot-durability/research.md
@@ -1,0 +1,89 @@
+# Research: Authoritative Task Snapshot Durability
+
+## FR-001 Snapshot Association For Submitted Executions
+
+Decision: Status `implemented_unverified`; verify every covered submission path associates a retrievable snapshot before action evaluation.
+Evidence: `api_service/api/routers/executions.py` persists snapshots in task create, direct `MoonMind.Run` create, edit/rerun update, and rerun paths; `moonmind/workflows/temporal/worker_runtime.py` persists child Jira-Orchestrate run snapshots.
+Rationale: The implementation exists in multiple paths, but MM-639 requires 100% coverage for covered task flows, which should be proven in one cohesive verification set.
+Alternatives considered: Mark `implemented_verified`; rejected because evidence is spread across historical tests and not framed against MM-639's full entrypoint set.
+Test implications: Unit tests for route helper calls and integration tests for actual artifact persistence.
+
+## FR-002 Section 7 Field Completeness
+
+Decision: Status `partial`; add explicit schema/contract coverage for all authored fields listed in the spec.
+Evidence: `_build_original_task_input_snapshot_payload()` stores `repository`, `targetRuntime`, `requiredCapabilities`, `task`, `attachmentRefs`, and compact metadata. Existing tests assert instructions and attachment refs, but not every Section 7 field.
+Rationale: Copying `task` is likely enough for several fields, but the requirement is explicit and should not depend on implicit pass-through behavior without contract coverage.
+Alternatives considered: Introduce a new database table; rejected because existing artifact-backed snapshots satisfy persistence needs.
+Test implications: Unit tests for payload construction and contract/integration tests for real stored artifact content.
+
+## FR-003 Catalog Independence
+
+Decision: Status `implemented_unverified`; add verification tests that reconstruction uses the snapshot even when live preset definitions change or are absent.
+Evidence: `frontend/src/lib/temporalTaskEditing.ts` rebuilds drafts from `taskInputSnapshot` artifact input; rerun update hydration reads input artifacts before persisting snapshots.
+Rationale: The code path is designed for snapshot-first reconstruction, but live catalog divergence should be explicitly tested.
+Alternatives considered: Re-resolve live presets on edit/rerun; rejected because the spec and source design forbid live catalog dependency for submitted work.
+Test implications: Frontend unit tests and API/contract tests that avoid or mutate catalog fixtures.
+
+## FR-004 Exact Full Rerun
+
+Decision: Status `implemented_verified`; preserve current behavior.
+Evidence: `tests/integration/temporal/test_full_retry_recovery_actions.py` and `tests/unit/workflows/temporal/test_temporal_service.py` verify rerun removes resume progress and starts from original refs.
+Rationale: Existing tests directly match exact full rerun requirements.
+Alternatives considered: Add more implementation; rejected pending final verification because current behavior is already covered.
+Test implications: None beyond final verification and regression suite selection.
+
+## FR-005 Edited Full Retry New Snapshot
+
+Decision: Status `implemented_unverified`; add verification-first tests.
+Evidence: The update route persists a snapshot with `source_kind="edit"` for `UpdateInputs` and source identity for task editing updates.
+Rationale: Code appears present, but proof should show the edited execution gets a new snapshot and the source execution evidence remains unchanged.
+Alternatives considered: Treat edited full retry as exact rerun with parameter patch; rejected because it would blur recovery intents.
+Test implications: Unit route test plus integration/service test if available.
+
+## FR-006 Resume Input Immutability
+
+Decision: Status `implemented_verified`; preserve current behavior.
+Evidence: `api_service/api/routers/executions.py` rejects edited task/runtime payload fields for failed-step Resume; `moonmind/workflows/temporal/service.py` requires the checkpoint snapshot ref to match the source snapshot; unit tests cover both behaviors.
+Rationale: Existing route and service tests match the required Resume immutability and source pinning behavior.
+Alternatives considered: Permit limited Resume edits; rejected by source design and spec.
+Test implications: None beyond final verification.
+
+## FR-007 Attachment-Aware Degraded State
+
+Decision: Status `partial`; add degraded-state coverage and patch if any recovery path silently drops or synthesizes attachments.
+Evidence: Missing snapshots disable edit/rerun actions with `original_task_input_snapshot_missing`; `TaskInputSnapshotDescriptorModel` can report `degraded_read_only`; frontend reconstruction throws when compact attachment bindings cannot be matched.
+Rationale: The pieces exist, but MM-639 requires explicit behavior for attachment-aware executions across recovery action evaluation.
+Alternatives considered: Allow fallback reconstruction from execution parameters; rejected because it can silently lose attachment targets.
+Test implications: Unit tests for descriptor/action disabled reasons and frontend attachment binding failure; integration test for attachment-aware missing snapshot behavior.
+
+## FR-008 Snapshot And Degraded Metadata Exposure
+
+Decision: Status `implemented_unverified`; add verification tests for response shape and disabled reasons.
+Evidence: `_task_input_snapshot_descriptor_from_record()` serializes availability, artifact ref, snapshot version, reconstruction mode, disabled reasons, and fallback refs; action disabled reasons identify missing snapshots.
+Rationale: Existing coverage is close but should be asserted against MM-639 scenarios.
+Alternatives considered: Add a separate endpoint; rejected because execution detail already carries the operator-facing descriptor.
+Test implications: Unit/API contract tests.
+
+## FR-009 Traceability
+
+Decision: Status `implemented_verified`; preserve through downstream artifacts.
+Evidence: `spec.md` preserves MM-639 and the canonical Jira preset brief; `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and this contract reference MM-639.
+Rationale: Traceability is already present in feature artifacts.
+Alternatives considered: Store traceability only in Jira comments; rejected because MoonSpec verification reads local artifacts.
+Test implications: Final verification only.
+
+## Source Design Requirements
+
+Decision: Status mix: DESIGN-REQ-004 and DESIGN-REQ-011 are `partial`; DESIGN-REQ-012 and DESIGN-REQ-013 are `implemented_unverified`.
+Evidence: `docs/Tasks/TaskArchitecture.md` sections 3.4, 5.5, 7, and 11 define authoritative snapshot, attachment target binding, recovery intent separation, and Resume invariants.
+Rationale: The current implementation has the main architecture, but explicit field completeness and degraded attachment behavior need stronger proof.
+Alternatives considered: Treat documentation as already complete; rejected because this is a runtime story.
+Test implications: Unit + integration tests, with final verification preserving source IDs.
+
+## Test Strategy
+
+Decision: Use focused unit tests for serialization, payload construction, frontend draft reconstruction, action gating, and service validation; use hermetic integration/contract tests for persisted artifact content and recovery action behavior.
+Evidence: Existing test surfaces include `tests/unit/api/routers/test_executions.py`, `frontend/src/entrypoints/task-create.test.tsx`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/contract/test_temporal_execution_api.py`, and `tests/integration/temporal/test_full_retry_recovery_actions.py`.
+Rationale: MM-639 spans API, frontend reconstruction, artifact persistence, and Temporal service behavior, so isolated tests alone are insufficient.
+Alternatives considered: Run provider verification; rejected because no external credentials are required for this story.
+Test implications: Final commands are `./tools/test_unit.sh` and `./tools/test_integration.sh` after focused iteration.

--- a/specs/339-authoritative-task-snapshot-durability/spec.md
+++ b/specs/339-authoritative-task-snapshot-durability/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Authoritative Task Snapshot Durability
+
+**Feature Branch**: `339-authoritative-task-snapshot-durability`
+**Created**: 2026-05-11
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-639 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-639 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-639
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Authoritative task input snapshot durability for edit/rerun/resume
+- Priority: Medium
+- Labels: moonmind-workflow-mm-a1fb7aa8-954b-4c59-acc2-c0a2c5339282
+- Trusted fetch tool: `jira.get_issue`
+- Trusted response artifact: `/work/agent_jobs/mm:e2bc69b6-9268-42f5-8b6d-deec1caaeb08/artifacts/moonspec-inputs/MM-639-trusted-jira-get-issue.json`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-639 from MM project
+Summary: Authoritative task input snapshot durability for edit/rerun/resume
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-639 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-639: Authoritative task input snapshot durability for edit/rerun/resume
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.4 Durable reconstruction
+- 5.5 Snapshot durability
+- 7 Snapshot, full retry, and Resume architecture
+Coverage IDs:
+- DESIGN-REQ-004
+- DESIGN-REQ-011
+
+As a platform owner, I want every submitted task to persist an authoritative task input snapshot (objective text, step text/order/identity, attachment refs by target, runtime/publish, repository + single authored branch, preset application metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, final submitted order, dependencies) so that edit, exact full rerun, edited full retry, and Resume can reconstruct the original authored task input without depending on the live preset catalog or lossy projections.
+
+Acceptance Criteria
+- Each submitted execution writes one authoritative task input snapshot artifact whose schema covers every field listed in Section 7.
+- Snapshot reconstruction is independent of the live preset catalog state.
+- Attachment-aware executions without a reconstructible snapshot are flagged as degraded explicitly.
+- Snapshot identity is referenced from the execution and re-used unchanged for exact full rerun and Resume.
+- Editing the snapshot during Resume is rejected; only edited full retry produces a new snapshot.
+
+Requirements
+Persist snapshot via artifact store with schema versioning; expose lookup by execution; expose degraded-state flag in execution metadata.
+"""
+
+## User Story - Durable Task Input Snapshot
+
+**Summary**: As a platform owner, I want every submitted task to preserve an authoritative task input snapshot so that edit, exact full rerun, edited full retry, and Resume can reconstruct the authored task without relying on mutable catalogs or lossy projections.
+
+**Goal**: Submitted tasks retain a durable, complete, and immutable representation of the authored task input that downstream recovery actions can use consistently.
+
+**Independent Test**: Can be fully tested by submitting tasks that include objective text, ordered steps, attachments, runtime and publish selections, repository and branch choices, preset metadata, provenance, and dependencies, then confirming edit, exact full rerun, edited full retry, and Resume reconstruct or reuse the original authored input according to their distinct recovery intent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user submits a task with objective text, ordered steps, runtime and publish selections, repository and branch choices, preset-derived steps, and dependencies, **When** the task is accepted for execution, **Then** the system records one authoritative task input snapshot that contains all authored task fields needed for future reconstruction.
+2. **Given** a submitted task includes objective-scoped and step-scoped attachments, **When** the task snapshot is inspected or used for reconstruction, **Then** attachment references remain bound to their original objective or step targets without silent loss or retargeting.
+3. **Given** the live preset catalog has changed since a task was submitted, **When** edit, exact full rerun, edited full retry, or Resume needs the original task input, **Then** reconstruction uses the authoritative snapshot and does not depend on current preset catalog correctness.
+4. **Given** a user chooses exact full rerun, **When** the rerun starts, **Then** the original authoritative task input snapshot is reused unchanged and no completed execution progress is imported.
+5. **Given** a user chooses edited full retry, **When** the edited task is submitted, **Then** the new execution receives its own authoritative task input snapshot and the original execution evidence remains unchanged.
+6. **Given** a user chooses Resume from a failed step, **When** Resume is accepted, **Then** the original task input snapshot is reused unchanged while prior completed work is preserved only from durable checkpoint evidence.
+7. **Given** an attachment-aware execution lacks a reconstructible authoritative task input snapshot, **When** a recovery action is evaluated, **Then** the system classifies the state as degraded explicitly rather than silently dropping, retargeting, or synthesizing attachment state.
+
+### Edge Cases
+
+- Snapshot reconstruction must fail or mark the execution degraded when required authored task fields are missing, inconsistent, unauthorized, or unreadable.
+- Resume must reject attempts to edit instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies; those changes require edited full retry.
+- Recovery actions must preserve the distinction between exact full rerun, edited full retry, and Resume, even when the same source execution offers more than one action.
+- Preset-derived and manually reordered steps must retain their final submitted order, identity, provenance, pinned bindings, include-tree summary, and detachment state.
+
+## Assumptions
+
+- Input classification: single-story runtime feature request. The brief contains one actor, one durable reconstruction goal, one acceptance set, and one bounded source document reference.
+- Existing authorization and artifact access policies continue to apply to snapshot reads and recovery action eligibility.
+- The canonical source design for this story is `docs/Tasks/TaskArchitecture.md`, sections 3.4, 5.5, and 7, with linked invariants used to clarify recovery intent.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-004** (`docs/Tasks/TaskArchitecture.md`, section 3.4): Task input reconstruction MUST use an authoritative snapshot; text-only reconstruction is insufficient for attachment-aware tasks, and silent attachment-binding loss is a contract violation. Scope: in scope. Maps to FR-001, FR-002, FR-006, FR-007, and FR-008.
+- **DESIGN-REQ-011** (`docs/Tasks/TaskArchitecture.md`, section 7): The original task input snapshot MUST preserve objective text, attachment refs by target, step text, step identity and order, runtime and publish selections, repository and branch selection, preset metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, final submitted order, and dependency declarations. Scope: in scope. Maps to FR-001 through FR-008.
+- **DESIGN-REQ-012** (`docs/Tasks/TaskArchitecture.md`, sections 7.1 through 7.3): Exact full rerun, edited full retry, and Resume MUST remain distinct recovery intents with different snapshot and progress-preservation behavior. Scope: in scope. Maps to FR-003, FR-004, FR-005, and FR-006.
+- **DESIGN-REQ-013** (`docs/Tasks/TaskArchitecture.md`, section 11, invariants 5, 7, 13, and 14): Snapshot-based durability, preset provenance durability, explicit recovery intent, and unchanged Resume inputs MUST remain invariant across supported recovery flows. Scope: in scope. Maps to FR-001 through FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST record one authoritative task input snapshot for each submitted execution before recovery actions depend on the execution.
+- **FR-002**: The authoritative snapshot MUST include objective text, objective-scoped attachment refs, step text, step-scoped attachment refs, step order, step identity, runtime selections, publish selections, repository selection, single authored branch selection, dependency declarations, preset application metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- **FR-003**: Snapshot-based reconstruction MUST be independent of live preset catalog state, live template definitions, rendered logs, execution projections, partial summaries, or other lossy derived views.
+- **FR-004**: Exact full rerun MUST reuse the original authoritative task input snapshot unchanged and MUST NOT import completed execution progress from the source run.
+- **FR-005**: Edited full retry MUST create a new execution with its own authoritative task input snapshot while preserving the original execution snapshot, step evidence, artifacts, and checkpoints unchanged.
+- **FR-006**: Resume MUST reuse the original authoritative task input snapshot unchanged and MUST NOT expose task input fields as editable during Resume.
+- **FR-007**: Attachment-aware executions without a reconstructible authoritative task input snapshot MUST be classified as degraded explicitly and MUST NOT silently drop attachments, retarget attachments, or synthesize replacement authoring state.
+- **FR-008**: Recovery eligibility and reconstruction outcomes MUST expose whether an authoritative snapshot exists and whether the execution is degraded due to missing or unreconstructible snapshot data.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-639` and the canonical Jira preset brief for traceability.
+
+### Key Entities
+
+- **Authoritative Task Input Snapshot**: Durable representation of the authored task input, including objective, steps, attachment targets, runtime and publish selections, repository and branch choice, preset metadata, provenance, final order, and dependencies.
+- **Recovery Action**: User-visible action that reconstructs or reuses task input after a source execution, including edit, exact full rerun, edited full retry, and Resume.
+- **Degraded Reconstruction State**: Explicit state indicating that recovery cannot faithfully reconstruct the authored task input from a required authoritative snapshot.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For 100% of newly submitted executions in covered task flows, a retrievable authoritative task input snapshot is associated with the execution before recovery actions are evaluated.
+- **SC-002**: In test scenarios with changed live preset definitions, edit, exact full rerun, edited full retry, and Resume reconstruct or reuse the original authored task input from the snapshot with zero dependence on the current preset catalog.
+- **SC-003**: In attachment-aware recovery tests, 100% of objective-scoped and step-scoped attachment refs retain their original target binding after reconstruction or are blocked by an explicit degraded state.
+- **SC-004**: Exact full rerun, edited full retry, and Resume each demonstrate distinct behavior in validation evidence: unchanged full rerun input, new edited retry snapshot, and unchanged Resume input with preserved prior progress.
+- **SC-005**: Missing or unreconstructible snapshot scenarios produce an explicit degraded or rejected outcome in every covered recovery path, with no silent attachment loss or synthesized authoring state.
+- **SC-006**: Traceability review confirms `MM-639`, the canonical Jira preset brief, and DESIGN-REQ-004/DESIGN-REQ-011/DESIGN-REQ-012/DESIGN-REQ-013 remain preserved in MoonSpec artifacts and final verification evidence.

--- a/specs/339-authoritative-task-snapshot-durability/tasks.md
+++ b/specs/339-authoritative-task-snapshot-durability/tasks.md
@@ -1,0 +1,195 @@
+# Tasks: Authoritative Task Snapshot Durability
+
+**Input**: Design documents from `/work/agent_jobs/mm:e2bc69b6-9268-42f5-8b6d-deec1caaeb08/repo/specs/339-authoritative-task-snapshot-durability/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/task-input-snapshot-reconstruction.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: durable authoritative task input snapshots for edit, exact full rerun, edited full retry, and Resume.
+
+**Source Traceability**: Original Jira issue `MM-639` and the canonical Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-009, acceptance scenarios 1 through 7, SC-001 through SC-006, and DESIGN-REQ-004/DESIGN-REQ-011/DESIGN-REQ-012/DESIGN-REQ-013. Requirement status summary from `plan.md`: 8 rows `partial`, 12 rows `implemented_unverified`, and 6 rows `implemented_verified`.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/tasks/test_task_contract.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `./tools/test_integration.sh`; focused iteration may use `pytest tests/contract/test_temporal_execution_api.py -q`, `pytest tests/integration/temporal/test_full_retry_recovery_actions.py -q`, and `pytest tests/integration/api/test_task_contract_normalization.py -q`
+- Final verification: `/moonspec-verify` (`/speckit.verify` user-facing equivalent)
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active one-story MoonSpec artifacts and local test surfaces before writing tests.
+
+- [X] T001 Confirm `specs/339-authoritative-task-snapshot-durability/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-input-snapshot-reconstruction.md`, and `quickstart.md` are present and preserve `MM-639`, FR-001 through FR-009, SC-001 through SC-006, and DESIGN-REQ-004/DESIGN-REQ-011/DESIGN-REQ-012/DESIGN-REQ-013.
+- [X] T002 Inspect existing snapshot and recovery implementation paths in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/tasks/task_contract.py`, and `frontend/src/lib/temporalTaskEditing.ts` for the current code baseline before adding tests.
+- [X] T003 Confirm local test commands from `specs/339-authoritative-task-snapshot-durability/quickstart.md` are available, including `./tools/test_unit.sh`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`, and `./tools/test_integration.sh`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared fixtures and traceability before story test and implementation work begins.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T004 Create or update reusable task snapshot fixture helpers for authored fields, attachment targets, preset provenance, branch, publish, runtime, dependencies, and final order in `tests/unit/api/routers/test_executions.py` for FR-002, DESIGN-REQ-011, and SCN-001.
+- [ ] T005 [P] Create or update reusable Resume checkpoint and recovery fixtures in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-004, FR-006, DESIGN-REQ-012, and DESIGN-REQ-013.
+- [X] T006 [P] Create or update frontend snapshot artifact fixtures in `frontend/src/entrypoints/task-create.test.tsx` for FR-003, FR-007, SCN-002, SCN-003, and SC-003.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Durable Task Input Snapshot
+
+**Summary**: As a platform owner, I want every submitted task to preserve an authoritative task input snapshot so that edit, exact full rerun, edited full retry, and Resume can reconstruct the authored task without relying on mutable catalogs or lossy projections.
+
+**Independent Test**: Submit or simulate tasks with objective text, ordered steps, attachments, runtime/publish selections, repository/branch choices, preset metadata, provenance, and dependencies; then verify edit, exact full rerun, edited full retry, and Resume reconstruct or reuse original authored input according to distinct recovery intent.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SCN-006, SCN-007, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-004, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013
+
+**Test Plan**:
+
+- Unit: snapshot payload construction, descriptor/degraded state, action gating, edited retry snapshot creation, Resume immutability, frontend snapshot reconstruction, attachment binding failure modes.
+- Integration: persisted snapshot artifact content, catalog independence, attachment-aware degraded behavior, exact full rerun without Resume progress, edited full retry new snapshot, Resume source snapshot identity.
+
+### Unit Tests (write first) ⚠️
+
+> NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass. For `implemented_unverified` rows, these are verification tests; if they pass immediately, skip the matching conditional fallback implementation task.
+
+- [X] T007 Add failing unit tests for complete authoritative snapshot payload fields in `tests/unit/api/routers/test_executions.py` covering FR-001, FR-002, SCN-001, SC-001, DESIGN-REQ-011, and MM-639 traceability.
+- [X] T008 Add failing unit tests for attachment-aware missing or unreconstructible snapshot degraded descriptors and disabled recovery reasons in `tests/unit/api/routers/test_executions.py` covering FR-007, FR-008, SCN-007, SC-005, and DESIGN-REQ-004.
+- [ ] T009 Add failing unit tests proving edited full retry creates a new snapshot while the source execution snapshot/evidence remains unchanged in `tests/unit/api/routers/test_executions.py` covering FR-005, SCN-005, SC-004, and DESIGN-REQ-012.
+- [ ] T010 [P] Add failing unit tests proving exact full rerun and failed-step Resume preserve distinct recovery intent and unchanged source snapshot identity in `tests/unit/workflows/temporal/test_temporal_service.py` covering FR-004, FR-006, SCN-004, SCN-006, DESIGN-REQ-012, and DESIGN-REQ-013.
+- [X] T011 [P] Add failing unit tests for Jira-Orchestrate child run snapshot completeness in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` covering FR-001, FR-002, SC-001, DESIGN-REQ-011, and source kind `create`.
+- [X] T012 [P] Add failing frontend unit tests for snapshot-first reconstruction when live preset/template data changes, plus attachment binding rejection when compact refs cannot be matched, in `frontend/src/entrypoints/task-create.test.tsx` covering FR-003, FR-007, SCN-002, SCN-003, SC-002, SC-003, and DESIGN-REQ-004.
+- [ ] T013 Run `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/tasks/test_task_contract.py` and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` to confirm T007-T012 fail for the expected red-first reasons.
+
+### Integration Tests (write first) ⚠️
+
+- [X] T014 Add failing contract test for persisted task input snapshot artifact content in `tests/contract/test_temporal_execution_api.py` covering FR-001, FR-002, FR-008, SCN-001, SC-001, DESIGN-REQ-011, and `contracts/task-input-snapshot-reconstruction.md`.
+- [ ] T015 [P] Add failing integration test for exact full rerun, edited full retry, and Resume recovery intent separation in `tests/integration/temporal/test_full_retry_recovery_actions.py` covering FR-004, FR-005, FR-006, SCN-004, SCN-005, SCN-006, SC-004, DESIGN-REQ-012, and DESIGN-REQ-013.
+- [ ] T016 [P] Add failing integration test for attachment-aware missing snapshot degraded behavior and no silent attachment loss in `tests/integration/api/test_task_input_snapshot_durability.py` covering FR-007, FR-008, SCN-002, SCN-007, SC-003, SC-005, and DESIGN-REQ-004.
+- [ ] T017 Add failing contract test proving already submitted preset-derived tasks reconstruct without live preset catalog lookup in `tests/contract/test_temporal_execution_api.py` covering FR-003, SCN-003, SC-002, and DESIGN-REQ-011.
+- [ ] T018 Run focused integration commands `pytest tests/contract/test_temporal_execution_api.py -q`, `pytest tests/integration/temporal/test_full_retry_recovery_actions.py -q`, and `pytest tests/integration/api/test_task_contract_normalization.py -q` to confirm T014-T017 fail for the expected red-first reasons.
+
+### Red-First Confirmation ⚠️
+
+- [ ] T019 Record red-first evidence for T007-T018 in `specs/339-authoritative-task-snapshot-durability/tasks.md` before changing production code, including which tests failed because behavior was missing versus already passed for `implemented_unverified` rows.
+
+### Conditional Fallback Implementation
+
+> Execute these tasks only for verification tests that fail. If an `implemented_unverified` verification test passes, mark the matching fallback task skipped with evidence in `specs/339-authoritative-task-snapshot-durability/tasks.md` and preserve the traceability in final verification.
+
+- [X] T020 Update authoritative snapshot payload construction and metadata in `api_service/api/routers/executions.py` so snapshots explicitly preserve every FR-002 field, dependency declaration, final order, preset metadata, pinned bindings, include-tree summary, per-step provenance, detachment state, and attachment refs required by DESIGN-REQ-011.
+- [X] T021 Update Jira-Orchestrate child-run snapshot persistence in `moonmind/workflows/temporal/worker_runtime.py` when T011 proves child snapshots lack required fields, ensuring worker-created child runs persist the same required authored snapshot fields as API-created runs for FR-001, FR-002, and SC-001.
+- [X] T022 Update execution snapshot descriptor and action gating in `api_service/api/routers/executions.py` and any related Pydantic schema in `moonmind/schemas/temporal_models.py` so attachment-aware missing or unreconstructible snapshots produce explicit degraded state and disabled reasons for FR-007 and FR-008.
+- [ ] T023 Conditional on T009/T015 failure: update edit/rerun update handling in `api_service/api/routers/executions.py` and `moonmind/workflows/temporal/service.py` so edited full retry creates a new snapshot and never mutates source snapshot, step evidence, artifacts, or checkpoints for FR-005 and SCN-005.
+- [ ] T024 Conditional on T010/T015 failure: update failed-step Resume validation in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, and `moonmind/workflows/tasks/task_contract.py` so Resume reuses the original snapshot unchanged, rejects task input edits, and validates checkpoint snapshot identity for FR-006 and DESIGN-REQ-013.
+- [X] T025 Update snapshot-first draft reconstruction and attachment binding validation in `frontend/src/lib/temporalTaskEditing.ts` and `frontend/src/entrypoints/task-create.tsx` so edit/rerun flows do not depend on live preset catalog state and cannot silently drop or retarget attachments for FR-003, FR-007, SC-002, and SC-003.
+
+### Story Validation
+
+- [ ] T026 Run focused unit validation `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/tasks/test_task_contract.py` and confirm FR-001 through FR-008 unit coverage passes.
+- [ ] T027 Run focused frontend validation `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm snapshot-first reconstruction, live-catalog independence, and degraded attachment binding coverage passes for FR-003, FR-007, SCN-002, and SCN-003.
+- [ ] T028 Run focused integration validation `pytest tests/contract/test_temporal_execution_api.py -q`, `pytest tests/integration/temporal/test_full_retry_recovery_actions.py -q`, and `pytest tests/integration/api/test_task_contract_normalization.py -q` and confirm SCN-001 through SCN-007 and SC-001 through SC-005 pass.
+- [ ] T029 Confirm `specs/339-authoritative-task-snapshot-durability/spec.md`, `plan.md`, `tasks.md`, `research.md`, `data-model.md`, `contracts/task-input-snapshot-reconstruction.md`, and `quickstart.md` preserve `MM-639`, the canonical Jira preset brief, and DESIGN-REQ-004/DESIGN-REQ-011/DESIGN-REQ-012/DESIGN-REQ-013 for FR-009 and SC-006.
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without expanding scope.
+
+- [ ] T030 [P] Refactor any duplicated snapshot fixture or assertion helpers introduced during implementation in `tests/unit/api/routers/test_executions.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, and `frontend/src/entrypoints/task-create.test.tsx` while preserving MM-639 traceability.
+- [ ] T031 [P] Review security and secret hygiene for snapshot artifacts and test fixtures in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `tests/contract/test_temporal_execution_api.py`, ensuring no raw credentials, binary payloads, presigned URLs, or secret-like values are written to snapshots for Constitution security constraints.
+- [ ] T032 Run quickstart validation from `specs/339-authoritative-task-snapshot-durability/quickstart.md` and record any blocked commands or failures in `specs/339-authoritative-task-snapshot-durability/tasks.md`.
+- [ ] T033 Run full unit suite `./tools/test_unit.sh` after focused validation passes and address MM-639 regressions only.
+- [ ] T034 Run required hermetic integration suite `./tools/test_integration.sh` after unit validation passes and address MM-639 regressions only.
+- [ ] T035 Run final `/moonspec-verify` (`/speckit.verify`) against `specs/339-authoritative-task-snapshot-durability/spec.md` and preserve the final verification report with coverage for MM-639, FR-001 through FR-009, SCN-001 through SCN-007, SC-001 through SC-006, and DESIGN-REQ-004/DESIGN-REQ-011/DESIGN-REQ-012/DESIGN-REQ-013.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story test and implementation work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish & Verification (Phase 4)**: Depends on Story validation passing.
+
+### Within The Story
+
+- Unit tests T007-T012 must be written before any production implementation task T020-T025.
+- Integration tests T014-T017 must be written before any production implementation task T020-T025.
+- Red-first confirmation T019 must complete before production implementation tasks T020-T025.
+- Conditional fallback implementation T020-T025 runs only for failed verification tests.
+- Story validation T026-T029 runs after conditional implementation tasks are complete or explicitly skipped with passing verification evidence.
+- Final verification T035 runs only after focused tests, full unit tests, and required integration tests pass or are blocked with exact reasons.
+
+### Parallel Opportunities
+
+- T005 and T006 can run in parallel after T004 because they touch different test fixture files.
+- T010, T011, and T012 can run in parallel with T007-T009 after foundational setup because they touch different files.
+- T015 and T016 can run in parallel with T014/T017 because they target different integration files.
+- T020, T021, T022, T023, T024, and T025 may be split across workers only if the failed tests prove disjoint write scopes; otherwise apply in dependency order to avoid conflicting changes in `api_service/api/routers/executions.py`.
+- T030 and T031 can run in parallel after story validation because they are polish checks with distinct concerns.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent test authoring together after Phase 2:
+Task: "T010 add service recovery intent tests in tests/unit/workflows/temporal/test_temporal_service.py"
+Task: "T011 add worker child snapshot tests in tests/unit/workflows/temporal/test_temporal_worker_runtime.py"
+Task: "T012 add frontend reconstruction tests in frontend/src/entrypoints/task-create.test.tsx"
+
+# Launch independent integration test authoring together:
+Task: "T015 add recovery intent integration tests in tests/integration/temporal/test_full_retry_recovery_actions.py"
+Task: "T016 add degraded attachment-aware snapshot tests in tests/integration/api/test_task_input_snapshot_durability.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Requirement Status Handling
+
+- **Code + tests required (`partial`)**: FR-002, FR-007, SCN-002, SCN-007, SC-003, SC-005, DESIGN-REQ-004, DESIGN-REQ-011. These receive failing tests plus required implementation work in T020, T022, and T025.
+- **Verification first with conditional fallback (`implemented_unverified`)**: FR-001, FR-003, FR-005, FR-008, SCN-001, SCN-003, SCN-005, SC-001, SC-002, SC-004, DESIGN-REQ-012, DESIGN-REQ-013. These receive verification tests first; fallback implementation tasks run only if tests fail.
+- **Already verified, preserve evidence (`implemented_verified`)**: FR-004, FR-006, FR-009, SCN-004, SCN-006, SC-006. These do not receive new implementation work by default, but T010/T015/T029/T035 preserve final evidence and guard against regressions.
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 setup/fixtures.
+2. Write unit tests T007-T012 and integration tests T014-T017.
+3. Run T013 and T018 to confirm red-first behavior or passing verification evidence for `implemented_unverified` rows.
+4. Execute only the fallback implementation tasks T020-T025 whose corresponding tests fail.
+5. Run focused validation T026-T029.
+6. Run quickstart, full unit tests, required integration tests, and final `/moonspec-verify` in T032-T035.
+
+---
+
+## Notes
+
+- This task list covers one story only: MM-639 authoritative task input snapshot durability.
+- Do not generate broad refactors, new persistent tables, provider verification tests, Jira transitions, commits, or PRs from this task list unless a later step explicitly asks for them.
+- Preserve unrelated dirty work, including existing `.gemini/skills` changes.
+- Keep large/binary attachment content out of workflow history and snapshots; snapshots should contain refs and target metadata only.
+
+## Implementation Evidence - 2026-05-11
+
+- Red-first evidence: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'original_task_input_snapshot_payload_preserves_mm639_authored_fields or missing_attachment_aware_snapshot_descriptor_is_degraded_explicitly'` failed before production changes because `authoredTaskInput` was missing and attachment-aware missing snapshots were not exposed by the new test; `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'child_jira_orchestrate_run_persists_original_task_input_snapshot'` failed before production changes because child snapshots lacked `authoredTaskInput`.
+- Passing focused evidence after implementation: `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'original_task_input_snapshot_payload_preserves_mm639_authored_fields or missing_attachment_aware_snapshot_descriptor_is_degraded_explicitly'`, `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'child_jira_orchestrate_run_persists_original_task_input_snapshot'`, and `pytest tests/contract/test_temporal_execution_api.py -q -k 'task_shaped_create_returns_temporal_identity_and_redirect'`.
+- Additional validation: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py`, `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'snapshot or rerun or resume'`, and `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py -k 'request_rerun_creates_fresh_execution_for_terminal_execution or failed_step_resume'` passed. The repository UI runner invoked by `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` reported the frontend suite passing; direct `npm run ui:test -- ...` from the repo root failed with `vitest: not found`, so the repo wrapper remains the verified UI path for this workspace.
+- Full unit note: a full `./tools/test_unit.sh` run after the focused fixes completed 4862 tests but failed unrelated `tests/unit/services/temporal/runtime/test_supervisor.py::test_stalled_progress_does_not_override_clean_exit_without_termination`; no files in that runtime supervisor area were changed for MM-639.
+- Scope note: This implement step completed the authoritative snapshot field/degraded descriptor/frontend binding slice. Broader remaining tasks such as T009/T010/T015/T016/T017/T018/T026-T035 are left unchecked unless covered by the passing evidence above, and final `/moonspec-verify` was not run in this managed implementation step.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -865,7 +865,7 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                         "targetRuntime": "codex",
                         "requiredCapabilities": ["git"],
                         "task": {
-                            "instructions": "Implement Temporal submit redirect coverage.",
+                            "instructions": "Implement Temporal submit redirect coverage for MM-639.",
                             "inputAttachments": [
                                 {
                                     "artifactId": objective_artifact,
@@ -875,9 +875,11 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                                 }
                             ],
                             "steps": [
-                                {
-                                    "instructions": "Review the step screenshot.",
-                                    "inputAttachments": [
+                                    {
+                                        "id": "step-review-screenshot",
+                                        "instructions": "Review the step screenshot.",
+                                        "dependsOn": ["MM-638"],
+                                        "inputAttachments": [
                                         {
                                             "artifactId": step_artifact,
                                             "filename": "same-name.png",
@@ -894,6 +896,10 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                             },
                             "inputArtifactRef": input_artifact_ref,
                             "publish": {"mode": "branch"},
+                            "git": {
+                                "repository": "MoonLadderStudios/MoonMind",
+                                "branch": "feature/mm-639",
+                            },
                         },
                     },
                 },
@@ -915,7 +921,7 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
             assert snapshot["artifactRef"]
             assert (
                 body["memo"]["summary"]
-                == "Implement Temporal submit redirect coverage."
+                == "Implement Temporal submit redirect coverage for MM-639."
             )
 
             async with db_base.async_session_maker() as session:
@@ -999,6 +1005,29 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                         "sizeBytes": 20,
                     }
                 ]
+                authored = snapshot_payload["draft"]["authoredTaskInput"]
+                assert authored["traceability"]["jiraIssueKey"] == "MM-639"
+                assert authored["objective"]["instructions"] == (
+                    "Implement Temporal submit redirect coverage for MM-639."
+                )
+                assert authored["objective"]["inputAttachments"][0][
+                    "artifactId"
+                ] == objective_artifact
+                assert authored["runtime"] == {
+                    "mode": "codex_cli",
+                    "model": "gpt-5.3-codex",
+                    "effort": "high",
+                }
+                assert authored["publish"] == {"mode": "branch"}
+                assert authored["repository"] == "MoonLadderStudios/MoonMind"
+                assert authored["branch"] == "feature/mm-639"
+                assert authored["steps"][0]["dependencies"] == ["MM-638"]
+                assert authored["finalSubmittedOrder"] == [
+                    {"stepId": "step-review-screenshot", "ordinal": 0}
+                ]
+                assert authored["steps"][0]["inputAttachments"][0][
+                    "artifactId"
+                ] == step_artifact
     finally:
         db_base.DATABASE_URL = original_db_url
         db_base.engine = original_engine

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6244,6 +6244,47 @@ def test_missing_attachment_aware_snapshot_descriptor_is_degraded_explicitly() -
     )
 
 
+def test_missing_legacy_attachment_ref_snapshot_descriptor_is_degraded() -> None:
+    record = _build_execution_record(
+        has_task_input_snapshot=False,
+    )
+    record.parameters = {
+        "task": {
+            "instructions": "Legacy attachment-aware task without a snapshot.",
+            "attachmentRefs": [
+                {
+                    "artifactRef": "artifact://input/objective-image",
+                    "filename": "objective.png",
+                    "contentType": "image/png",
+                }
+            ],
+            "steps": [
+                {
+                    "id": "inspect",
+                    "attachmentRefs": [
+                        {
+                            "artifactRef": "artifact://input/step-image",
+                            "filename": "step.png",
+                            "contentType": "image/png",
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+
+    descriptor = _task_input_snapshot_descriptor_from_record(record)
+
+    assert descriptor.available is False
+    assert descriptor.reconstruction_mode == "degraded_read_only"
+    assert descriptor.disabled_reasons["draft"] == (
+        "original_task_input_snapshot_missing"
+    )
+    assert descriptor.disabled_reasons["attachments"] == (
+        "original_task_input_snapshot_missing"
+    )
+
+
 def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:
     metrics = Mock()
     for test_client, service in _client_with_service():

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -19,8 +19,10 @@ from temporalio.service import RPCError, RPCStatusCode
 from api_service.api.routers.executions import (
     _get_service,
     _artifact_id_from_ref,
+    _build_original_task_input_snapshot_payload,
     _merge_task_preserving_artifact_instructions,
     _resume_not_available_reason,
+    _task_input_snapshot_descriptor_from_record,
     get_temporal_client,
     _serialize_execution,
     router,
@@ -77,6 +79,86 @@ def _completed_attachment_artifact(
         size_bytes=size_bytes,
         created_by_principal=created_by_principal,
     )
+
+def _mm639_authored_task_payload() -> dict[str, Any]:
+    return {
+        "title": "MM-639 durable snapshot",
+        "instructions": "Preserve the original authored task input for MM-639.",
+        "inputAttachments": [
+            {
+                "artifactId": "art-objective",
+                "filename": "objective.png",
+                "contentType": "image/png",
+                "sizeBytes": 123,
+            }
+        ],
+        "runtime": {
+            "mode": "codex_cli",
+            "model": "gpt-5.4",
+            "effort": "medium",
+            "profileId": "profile-codex",
+        },
+        "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+        "git": {
+            "repository": "MoonLadderStudios/MoonMind",
+            "branch": "feature/mm-639",
+        },
+        "dependencies": ["MM-638"],
+        "appliedStepTemplates": [
+            {
+                "slug": "jira-orchestrate",
+                "version": "1.0.0",
+                "inputs": {"issueKey": "MM-639"},
+                "stepIds": ["step-1", "step-2"],
+                "composition": {
+                    "slug": "jira-orchestrate",
+                    "includes": [
+                        {"slug": "jira-fetch", "version": "1.0.0"},
+                    ],
+                },
+            }
+        ],
+        "authoredPresets": [
+            {
+                "presetSlug": "jira-orchestrate",
+                "presetVersion": "1.0.0",
+                "inputBindings": {"issueKey": "MM-639"},
+            }
+        ],
+        "steps": [
+            {
+                "id": "step-1",
+                "title": "Fetch issue",
+                "instructions": "Fetch Jira issue MM-639.",
+                "dependsOn": [],
+                "templateStepId": "tpl:jira-orchestrate:fetch",
+                "presetProvenance": {
+                    "presetSlug": "jira-orchestrate",
+                    "presetVersion": "1.0.0",
+                },
+            },
+            {
+                "id": "step-2",
+                "title": "Implement",
+                "instructions": "Implement MM-639.",
+                "dependsOn": ["step-1"],
+                "inputAttachments": [
+                    {
+                        "artifactId": "art-step",
+                        "filename": "step.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 456,
+                    }
+                ],
+                "presetProvenance": {
+                    "presetSlug": "jira-orchestrate",
+                    "presetVersion": "1.0.0",
+                    "sourceStepId": "tpl:jira-orchestrate:implement",
+                },
+                "detachedFromPreset": True,
+            },
+        ],
+    }
 
 class _QueryHandle:
     def __init__(
@@ -6065,6 +6147,101 @@ def test_task_input_snapshot_merge_preserves_step_deletions() -> None:
     assert merged["steps"] == [
         {"id": "step-1", "title": "First edited", "instructions": "Original first"}
     ]
+
+
+def test_original_task_input_snapshot_payload_preserves_mm639_authored_fields() -> None:
+    task_payload = _mm639_authored_task_payload()
+
+    payload = _build_original_task_input_snapshot_payload(
+        source_kind="create",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex_cli",
+            "requiredCapabilities": ["git", "jira"],
+        },
+        task_payload=task_payload,
+        attachment_refs=[
+            {
+                "artifactId": "art-objective",
+                "targetKind": "objective",
+            },
+            {
+                "artifactId": "art-step",
+                "targetKind": "step",
+                "stepId": "step-2",
+                "stepOrdinal": 1,
+            },
+        ],
+    )
+
+    authored = payload["draft"]["authoredTaskInput"]
+    assert authored["traceability"]["jiraIssueKey"] == "MM-639"
+    assert authored["objective"]["instructions"] == (
+        "Preserve the original authored task input for MM-639."
+    )
+    assert authored["objective"]["inputAttachments"][0]["artifactId"] == (
+        "art-objective"
+    )
+    assert authored["runtime"] == task_payload["runtime"]
+    assert authored["publish"] == task_payload["publish"]
+    assert authored["repository"] == "MoonLadderStudios/MoonMind"
+    assert authored["branch"] == "feature/mm-639"
+    assert authored["dependencyDeclarations"] == ["MM-638"]
+    assert authored["presetApplicationMetadata"] == task_payload[
+        "appliedStepTemplates"
+    ]
+    assert authored["pinnedPresetBindings"] == task_payload["authoredPresets"]
+    assert authored["includeTreeSummary"] == [
+        {
+            "presetSlug": "jira-orchestrate",
+            "presetVersion": "1.0.0",
+            "includedSlug": "jira-fetch",
+            "includedVersion": "1.0.0",
+        }
+    ]
+    assert authored["finalSubmittedOrder"] == [
+        {"stepId": "step-1", "ordinal": 0},
+        {"stepId": "step-2", "ordinal": 1},
+    ]
+    assert authored["perStepProvenance"][1] == {
+        "stepId": "step-2",
+        "ordinal": 1,
+        "presetProvenance": task_payload["steps"][1]["presetProvenance"],
+    }
+    assert authored["detachmentState"] == [
+        {"stepId": "step-2", "ordinal": 1, "detached": True}
+    ]
+    assert authored["steps"][1]["inputAttachments"][0]["artifactId"] == "art-step"
+    assert payload["attachmentRefs"][1]["stepId"] == "step-2"
+
+
+def test_missing_attachment_aware_snapshot_descriptor_is_degraded_explicitly() -> None:
+    record = _build_execution_record(
+        has_task_input_snapshot=False,
+    )
+    record.parameters = {
+        "task": {
+            "instructions": "Attachment-aware task without a snapshot.",
+            "inputAttachments": [
+                {
+                    "artifactId": "art-objective",
+                    "filename": "objective.png",
+                    "contentType": "image/png",
+                }
+            ],
+        }
+    }
+
+    descriptor = _task_input_snapshot_descriptor_from_record(record)
+
+    assert descriptor.available is False
+    assert descriptor.reconstruction_mode == "degraded_read_only"
+    assert descriptor.disabled_reasons["draft"] == (
+        "original_task_input_snapshot_missing"
+    )
+    assert descriptor.disabled_reasons["attachments"] == (
+        "original_task_input_snapshot_missing"
+    )
 
 
 def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from moonmind.workflows.tasks.task_contract import (
     build_canonical_task_view,
+    build_authoritative_task_input_snapshot,
     build_effective_task_skill_selectors,
     CanonicalTaskPayload,
     ResumeFromFailedStepRef,
@@ -48,6 +49,46 @@ def test_task_skills_accepts_valid_properties() -> None:
     assert spec.skills.include[1].version is None
     assert spec.skills.exclude == ["legacy"]
     assert spec.skills.materialization_mode == "hybrid"
+
+
+def test_authoritative_snapshot_preserves_explicit_empty_dependencies() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "Run MM-639 without dependencies.",
+            "dependencies": [],
+            "steps": [
+                {
+                    "id": "step-1",
+                    "instructions": "Use the explicit empty dependency list.",
+                    "dependsOn": [],
+                }
+            ],
+        },
+        dependency_declarations=["MM-638"],
+    )
+
+    assert snapshot["dependencyDeclarations"] == []
+    assert snapshot["steps"][0]["dependencies"] == []
+
+
+def test_authoritative_snapshot_detects_jira_key_without_serializing_metadata() -> None:
+    class Unserializable:
+        pass
+
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "Implement MM-639.",
+            "metadata": {"opaque": Unserializable()},
+            "steps": [
+                {
+                    "id": "step-1",
+                    "instructions": "Preserve authored fields.",
+                }
+            ],
+        }
+    )
+
+    assert snapshot["traceability"]["jiraIssueKey"] == "MM-639"
 
 def test_task_skills_rejects_invalid_values() -> None:
     """T001: Assert structure validation handles edge cases for skills."""

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1417,11 +1417,42 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
         "task": {
             "title": "Run Jira Orchestrate for MM-501",
             "instructions": "Run Jira Orchestrate for MM-501.",
+            "runtime": {"mode": "codex_cli", "model": "gpt-5.4"},
+            "publish": {"mode": "pr"},
+            "git": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "branch": "feature/mm-501",
+            },
+            "dependencies": ["MM-500"],
+            "appliedStepTemplates": [
+                {
+                    "slug": "jira-orchestrate",
+                    "version": "1.0.0",
+                    "stepIds": ["step-1"],
+                    "composition": {
+                        "slug": "jira-orchestrate",
+                        "includes": [
+                            {"slug": "jira-fetch", "version": "1.0.0"}
+                        ],
+                    },
+                },
+            ],
+            "authoredPresets": [
+                {
+                    "presetSlug": "jira-orchestrate",
+                    "presetVersion": "1.0.0",
+                    "inputBindings": {"issueKey": "MM-501"},
+                }
+            ],
             "steps": [
                 {
                     "id": "step-1",
                     "title": "First step",
                     "instructions": "Do the first step.",
+                    "presetProvenance": {
+                        "presetSlug": "jira-orchestrate",
+                        "presetVersion": "1.0.0",
+                    },
                 }
             ],
         },
@@ -1546,6 +1577,32 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
         snapshot_payload["draft"]["task"]["title"]
         == "Run Jira Orchestrate for MM-501"
     )
+    authored = snapshot_payload["draft"]["authoredTaskInput"]
+    assert authored["runtime"] == {"mode": "codex_cli", "model": "gpt-5.4"}
+    assert authored["publish"] == {"mode": "pr"}
+    assert authored["repository"] == "MoonLadderStudios/MoonMind"
+    assert authored["branch"] == "feature/mm-501"
+    assert authored["dependencyDeclarations"] == ["MM-500"]
+    assert authored["finalSubmittedOrder"] == [{"stepId": "step-1", "ordinal": 0}]
+    assert authored["pinnedPresetBindings"][0]["presetSlug"] == "jira-orchestrate"
+    assert authored["includeTreeSummary"] == [
+        {
+            "presetSlug": "jira-orchestrate",
+            "presetVersion": "1.0.0",
+            "includedSlug": "jira-fetch",
+            "includedVersion": "1.0.0",
+        }
+    ]
+    assert authored["perStepProvenance"] == [
+        {
+            "stepId": "step-1",
+            "ordinal": 0,
+            "presetProvenance": {
+                "presetSlug": "jira-orchestrate",
+                "presetVersion": "1.0.0",
+            },
+        }
+    ]
 
 
 def test_runtime_planner_uses_branch_handoff_for_jira_output_when_task_publish_none():


### PR DESCRIPTION
Jira issue key: MM-639

Active MoonSpec feature path: `specs/339-authoritative-task-snapshot-durability`

Verification verdict: ADDITIONAL_WORK_NEEDED from the final MoonSpec verification gate. The implemented slice is committed for review, but final completion remains blocked by the verify report items below.

Tests run:
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'original_task_input_snapshot_payload_preserves_mm639_authored_fields or missing_attachment_aware_snapshot_descriptor_is_degraded_explicitly'` - PASS
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'child_jira_orchestrate_run_persists_original_task_input_snapshot'` - PASS
- `pytest tests/contract/test_temporal_execution_api.py -q -k 'task_shaped_create_returns_temporal_identity_and_redirect'` - PASS
- Prior full `./tools/test_unit.sh` run reported 4862 passed and 1 unrelated supervisor test failure.

Remaining risks:
- Final MoonSpec verification did not return FULLY_IMPLEMENTED; required recovery-matrix and integration coverage remains incomplete.
- Full unit evidence is not clean because `tests/unit/services/temporal/runtime/test_supervisor.py::test_stalled_progress_does_not_override_clean_exit_without_termination` failed outside the MM-639 touch area.
- Full hermetic integration validation was not run in the verification step.
- Verification preflight found `.gemini/skills` projected to the active skill snapshot during the managed run; the PR branch itself was cleaned before commit and push.
