### PR TITLE
MM-642 Compile-time preset composition MoonSpec

### DIFF
--- a/specs/341-compile-time-preset-composition/checklists/requirements.md
+++ b/specs/341-compile-time-preset-composition/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Compile-Time Preset Composition With Provenance Preservation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details beyond required source contract field names from the Jira brief
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders where possible while preserving required source terms
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification beyond required contract field names
+
+## Notes
+
+- PASS: `spec.md` preserves the canonical `MM-642` Jira preset brief and classifies the request as one runtime story.

--- a/specs/341-compile-time-preset-composition/contracts/task-preset-composition-contract.md
+++ b/specs/341-compile-time-preset-composition/contracts/task-preset-composition-contract.md
@@ -1,0 +1,41 @@
+# Contract: Task Preset Composition
+
+## Boundary
+
+The control plane compiles task presets before execution submission is finalized. Workers consume the resolved task payload and do not expand presets or read the live preset catalog for already submitted work.
+
+## Inputs
+
+A task-shaped submission may contain:
+- Manual task steps.
+- Selected preset or task template metadata.
+- Recursive include metadata.
+- Existing runtime, publish, Jira, and attachment fields.
+
+## Outputs
+
+A successful submitted task payload contains:
+- A deterministic final `steps` array containing executable work.
+- `steps[].source` for preset-derived, included, or detached steps when reliable origin data exists.
+- `authoredPresets` bindings for selected and recursively included presets.
+- `appliedStepTemplates` entries with compact composition metadata.
+- Existing non-preset submission fields preserved.
+
+## Failure Behavior
+
+Submission finalization is blocked before execution work is created when preset compilation detects:
+- Cycles.
+- Missing preset references.
+- Disabled or unauthorized presets.
+- Version mismatches.
+- Conflicting aliases.
+- Incompatible input mappings.
+- Unsupported unresolved preset include work in worker-facing steps.
+
+## Invariants
+
+- Preset composition is compile-time control-plane behavior.
+- Submitted execution payloads do not require live preset lookup.
+- Task snapshots preserve pinned bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- Manual-only submissions do not fabricate preset provenance.
+- Compact provenance is stored instead of full template content.

--- a/specs/341-compile-time-preset-composition/data-model.md
+++ b/specs/341-compile-time-preset-composition/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Compile-Time Preset Composition With Provenance Preservation
+
+## Task Draft
+
+Authoring-state task before submission.
+
+Key fields:
+- Manual steps authored directly by the user.
+- Selected preset bindings and nested include metadata.
+- Runtime, publish intent, Jira provenance, and attachment references.
+
+Validation rules:
+- Preset include references must resolve before execution finalization.
+- Manual-only drafts must not gain preset metadata.
+
+## Preset Include Tree
+
+Nested preset composition graph selected during task authoring.
+
+Key fields:
+- Preset identifier or slug.
+- Version.
+- Alias.
+- Include path.
+- Input mapping.
+- Original step identifiers.
+
+Validation rules:
+- Reject cycles, missing references, disabled or unauthorized presets, version mismatches, conflicting aliases, and incompatible mappings.
+- The tree resolves to bounded, deterministic flattened steps.
+
+## Compiled Task Snapshot
+
+Submitted task representation used for execution, audit, rerun, and reconstruction.
+
+Key fields:
+- Final ordered executable steps.
+- `authoredPresets` bindings.
+- `appliedStepTemplates` composition summary.
+- Per-step `source` provenance.
+- Existing runtime, publish, Jira, and attachment metadata.
+
+Validation rules:
+- Must not require live preset catalog lookup to reconstruct submitted work.
+- Must preserve compact provenance rather than full template content.
+
+## Step Source Provenance
+
+Per-step origin metadata.
+
+Key fields:
+- `kind`.
+- `presetId` or `presetSlug`.
+- `version`.
+- `includePath`.
+- `originalStepId`.
+- `inputMapping`.
+- Detachment state when present.
+
+Validation rules:
+- Present only when reliable source data exists.
+- Detached steps preserve enough source data for audit while reflecting detachment.
+
+## Worker-Facing Payload
+
+Execution payload consumed by managed workers.
+
+Key fields:
+- Resolved executable steps.
+- Compact task and preset provenance metadata.
+
+Validation rules:
+- Must not contain unresolved preset include work as executable steps.
+- Must not require worker-side preset expansion.

--- a/specs/341-compile-time-preset-composition/moonspec_align_report.md
+++ b/specs/341-compile-time-preset-composition/moonspec_align_report.md
@@ -10,11 +10,12 @@
 | --- | --- | --- | --- |
 | Source preservation | PASS | `spec.md` preserves `MM-642`, the canonical Jira preset brief, and source coverage IDs `DESIGN-REQ-010` and `DESIGN-REQ-011`. | None |
 | Single-story gate | PASS | `spec.md` contains exactly one `## User Story - Compile-Time Preset Composition`. | None |
-| Plan coverage | PASS | `plan.md` maps FR-001 through FR-008, acceptance scenarios, and DESIGN-REQ-010/011 to code and test evidence. | None |
-| Task coverage | PASS | `tasks.md` covers setup, verification-first evidence, fallback implementation, focused validation, full unit validation, integration blocker recording, and final verification. | None |
+| Requirement coverage | PASS | `plan.md` maps FR-001 through FR-008, SC-001 through SC-007, and DESIGN-REQ-010/011 to code and test evidence. | Added explicit SC-001 through SC-007 rows to `plan.md`. |
+| Research traceability | PASS | `research.md` explains the verification-first status for functional requirements and source design requirements. | Added a success-criteria coverage section mapping SC-001 through SC-007 to existing evidence. |
+| Task coverage | PASS | `tasks.md` covers setup, verification-first evidence, fallback implementation, focused validation, full unit validation, integration blocker recording, and final verification. | Expanded success-criteria references from ranges into explicit IDs for downstream checks. |
+| Quickstart consistency | PASS | `quickstart.md` lists focused and required validation commands. | Added an explicit SC-001 through SC-007 traceability check. |
 | Constitution alignment | PASS | `plan.md` records PASS for all constitution principles and no complexity exceptions. | None |
-| Test command alignment | PASS | `quickstart.md`, `plan.md`, and `tasks.md` reference the same focused and required test commands. | None |
 
 ## Decision
 
-No artifact remediation was required after alignment. The MM-642 artifact set is intentionally separate from `specs/324-compile-recursive-presets` because that earlier feature preserves Jira key `MM-630`, while this run must preserve `MM-642` for downstream traceability.
+Alignment chose conservative artifact-only remediation: preserve the existing single-story MM-642 scope and add explicit success-criteria traceability rows/references. No production code, tests, or downstream artifact regeneration was required because the underlying plan status and task strategy did not change.

--- a/specs/341-compile-time-preset-composition/moonspec_align_report.md
+++ b/specs/341-compile-time-preset-composition/moonspec_align_report.md
@@ -1,0 +1,20 @@
+# MoonSpec Alignment Report: Compile-Time Preset Composition With Provenance Preservation
+
+**Feature**: `specs/341-compile-time-preset-composition`
+**Source**: `MM-642` canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-12
+
+## Findings
+
+| Area | Result | Evidence | Remediation |
+| --- | --- | --- | --- |
+| Source preservation | PASS | `spec.md` preserves `MM-642`, the canonical Jira preset brief, and source coverage IDs `DESIGN-REQ-010` and `DESIGN-REQ-011`. | None |
+| Single-story gate | PASS | `spec.md` contains exactly one `## User Story - Compile-Time Preset Composition`. | None |
+| Plan coverage | PASS | `plan.md` maps FR-001 through FR-008, acceptance scenarios, and DESIGN-REQ-010/011 to code and test evidence. | None |
+| Task coverage | PASS | `tasks.md` covers setup, verification-first evidence, fallback implementation, focused validation, full unit validation, integration blocker recording, and final verification. | None |
+| Constitution alignment | PASS | `plan.md` records PASS for all constitution principles and no complexity exceptions. | None |
+| Test command alignment | PASS | `quickstart.md`, `plan.md`, and `tasks.md` reference the same focused and required test commands. | None |
+
+## Decision
+
+No artifact remediation was required after alignment. The MM-642 artifact set is intentionally separate from `specs/324-compile-recursive-presets` because that earlier feature preserves Jira key `MM-630`, while this run must preserve `MM-642` for downstream traceability.

--- a/specs/341-compile-time-preset-composition/plan.md
+++ b/specs/341-compile-time-preset-composition/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Compile-Time Preset Composition With Provenance Preservation
+
+**Branch**: `341-compile-time-preset-composition` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story runtime spec from the `MM-642` Jira preset brief.
+
+## Summary
+
+MM-642 requires task preset composition to be finalized in the control plane before execution submission: recursive preset includes are validated, flattened with manual steps into deterministic executable order, and preserved with compact authored-preset and per-step provenance. Current repository evidence from the related recursive preset compilation implementation indicates the production behavior and focused test coverage already exist; this orchestration therefore treats implementation as verification-first and only plans fallback edits if current tests expose drift.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `api_service/services/task_templates/catalog.py` emits recursive composition metadata; `tests/unit/api/test_task_step_templates_service.py` covers expansion | no new implementation; rerun focused tests | unit |
+| FR-002 | implemented_verified | catalog validation tests cover missing/unavailable targets, cycles, conflicting aliases, mappings, and scope failures | no new implementation; rerun focused tests | unit |
+| FR-003 | implemented_verified | catalog, API route, frontend, and integration tests assert flattened deterministic step order | no new implementation; rerun focused tests | unit + integration_ci |
+| FR-004 | implemented_verified | `moonmind/workflows/tasks/task_contract.py`, route tests, and frontend tests preserve `authoredPresets` and `steps[].source` | no new implementation; rerun focused tests | unit + integration_ci |
+| FR-005 | implemented_verified | task contract and worker runtime tests prevent unresolved preset include work from reaching worker-facing payloads | no new implementation; rerun focused tests | unit + integration_ci |
+| FR-006 | implemented_verified | task-shaped submission integration coverage preserves snapshot metadata after catalog-independent submission | no new implementation; rerun focused tests | integration_ci |
+| FR-007 | implemented_verified | API route and integration regressions assert manual-only submissions do not fabricate preset metadata | no new implementation; rerun focused tests | unit + integration_ci |
+| FR-008 | implemented_unverified | `spec.md` preserves `MM-642`; downstream artifacts need final traceability check | preserve `MM-642` in all generated artifacts and final verification evidence | final verify |
+| SCN-001 | implemented_verified | recursive preset route and catalog tests exercise compile-before-finalization behavior | no new implementation | unit + integration_ci |
+| SCN-002 | implemented_verified | catalog validation tests cover explicit include-tree failures | no new implementation | unit |
+| SCN-003 | implemented_verified | deterministic order tests exist across catalog/API/integration coverage | no new implementation | unit + integration_ci |
+| SCN-004 | implemented_verified | task contract, API, frontend, and integration assertions cover provenance preservation | no new implementation | unit + integration_ci |
+| SCN-005 | implemented_verified | worker runtime and task-shaped submission tests cover resolved worker payloads | no new implementation | unit + integration_ci |
+| SCN-006 | implemented_verified | integration and snapshot metadata assertions cover catalog-independent reconstruction semantics | no new implementation | integration_ci |
+| DESIGN-REQ-010 | implemented_verified | source invariant is represented by catalog compilation, task contract validation, worker runtime behavior, and tests | no new implementation | unit + integration_ci |
+| DESIGN-REQ-011 | implemented_verified | source invariant is represented by snapshot/provenance tests and contract helpers | no new implementation | unit + integration_ci |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control Create page payload behavior.  
+**Primary Dependencies**: FastAPI route/service layer, SQLAlchemy async task template catalog, Pydantic v2 task contract models, Temporal Python SDK worker/runtime boundaries, React Create page.  
+**Storage**: Existing task template tables, Temporal execution records, artifact-backed original task input snapshots, and task payload metadata only; no new persistent storage.  
+**Unit Testing**: `./tools/test_unit.sh`; focused pytest and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` for Create page behavior.  
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration; focused iteration with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci`.  
+**Target Platform**: MoonMind API service, Mission Control Create page, and Temporal managed task execution on Linux.  
+**Project Type**: Python backend workflow/control plane with React frontend entrypoint.  
+**Performance Goals**: Recursive compilation remains bounded by existing flattened step limits and requires no live preset catalog lookup after submission.  
+**Constraints**: Preserve Temporal payload compatibility, keep large template content out of workflow history, fail explicitly for invalid include trees, and do not add compatibility aliases for internal contracts.  
+**Scale/Scope**: One task preset composition slice spanning catalog expansion, create/API normalization, task snapshots, and worker-facing payloads.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The plan strengthens MoonMind control-plane orchestration and does not recreate agent cognition.
+- II. One-Click Agent Deployment: PASS. No new service, dependency, or deployment prerequisite.
+- III. Avoid Vendor Lock-In: PASS. Uses MoonMind task contracts and preset metadata, not provider-specific behavior.
+- IV. Own Your Data: PASS. Submitted snapshots and provenance remain MoonMind-owned data.
+- V. Skills Are First-Class: PASS. Presets remain composable authoring inputs that compile to runtime-neutral task steps.
+- VI. Replaceable Scaffolding / Thick Contracts: PASS. Work centers on explicit task and preset compilation contracts.
+- VII. Runtime Configurability: PASS. Existing template catalog/runtime settings remain the control points.
+- VIII. Modular Architecture: PASS. Boundaries remain catalog, create/API normalization, snapshot, and worker runtime modules.
+- IX. Resilient by Default: PASS. Invalid preset trees fail before execution, and submitted work is reconstructable without live catalog drift.
+- X. Continuous Improvement: PASS. Planning, tests, and verification artifacts preserve evidence for MM-642.
+- XI. Spec-Driven Development: PASS. Spec, plan, tasks, implementation evidence, and verification remain traceable to MM-642.
+- XII. Canonical Docs vs Tmp: PASS. Runtime rollout notes live under `specs/341-compile-time-preset-composition/`; canonical docs are source references only.
+- XIII. Pre-release Compatibility: PASS. The plan avoids new compatibility aliases and relies on a single canonical compiled task contract.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/341-compile-time-preset-composition/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-preset-composition-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/executions.py
+└── services/task_templates/catalog.py
+
+moonmind/
+└── workflows/
+    ├── tasks/task_contract.py
+    └── temporal/worker_runtime.py
+
+frontend/
+└── src/entrypoints/task-create.tsx
+
+tests/
+├── unit/api/test_task_step_templates_service.py
+├── unit/api/routers/test_executions.py
+├── unit/workflows/tasks/test_task_contract.py
+├── unit/workflows/temporal/test_temporal_worker_runtime.py
+├── integration/temporal/test_task_shaped_submission_normalization.py
+└── frontend/src/entrypoints/task-create.test.tsx
+```
+
+**Structure Decision**: Use the existing backend, workflow, frontend, and test locations that already own task preset compilation and submission behavior.
+
+## Complexity Tracking
+
+No constitution violations or extra complexity accepted.

--- a/specs/341-compile-time-preset-composition/plan.md
+++ b/specs/341-compile-time-preset-composition/plan.md
@@ -27,6 +27,13 @@ MM-642 requires task preset composition to be finalized in the control plane bef
 | SCN-006 | implemented_verified | integration and snapshot metadata assertions cover catalog-independent reconstruction semantics | no new implementation | integration_ci |
 | DESIGN-REQ-010 | implemented_verified | source invariant is represented by catalog compilation, task contract validation, worker runtime behavior, and tests | no new implementation | unit + integration_ci |
 | DESIGN-REQ-011 | implemented_verified | source invariant is represented by snapshot/provenance tests and contract helpers | no new implementation | unit + integration_ci |
+| SC-001 | implemented_verified | focused integration and catalog validation cover submitted tasks with recursive preset includes being validated before execution finalization | no new implementation | integration_ci |
+| SC-002 | implemented_verified | catalog/API/frontend/integration evidence covers deterministic final order for equivalent valid draft inputs | no new implementation | unit + integration_ci |
+| SC-003 | implemented_verified | task contract, API, frontend, and integration tests preserve source provenance for preset-derived and detached steps | no new implementation | unit + integration_ci |
+| SC-004 | implemented_verified | worker runtime, task contract, and focused integration evidence show compiled tasks execute without live catalog lookup | no new implementation | unit + integration_ci |
+| SC-005 | implemented_verified | task-shaped submission integration and snapshot metadata evidence cover reconstruction after live catalog changes | no new implementation | integration_ci |
+| SC-006 | implemented_verified | API route and integration manual-only regressions preserve zero-preset behavior | no new implementation | unit + integration_ci |
+| SC-007 | implemented_verified | `spec.md`, generated design artifacts, `tasks.md`, alignment report, and verification report preserve `MM-642`, the canonical brief, DESIGN-REQ-010, and DESIGN-REQ-011 | no new implementation | final verify |
 
 ## Technical Context
 

--- a/specs/341-compile-time-preset-composition/quickstart.md
+++ b/specs/341-compile-time-preset-composition/quickstart.md
@@ -33,3 +33,5 @@ Run required final suites when available:
 2. Confirm `plan.md`, `research.md`, `data-model.md`, this quickstart, contract, tasks, and verification evidence reference `MM-642`.
 3. Confirm source coverage IDs `DESIGN-REQ-010` and `DESIGN-REQ-011` map to compile-time composition and provenance durability.
 4. Confirm manual-only submission tests still show no fabricated preset metadata.
+
+5. Confirm SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, and SC-007 remain covered by the focused unit, frontend, integration, and final verification evidence.

--- a/specs/341-compile-time-preset-composition/quickstart.md
+++ b/specs/341-compile-time-preset-composition/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Compile-Time Preset Composition With Provenance Preservation
+
+## Focused Validation
+
+Run backend catalog, contract, worker, and API coverage:
+
+```bash
+python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q
+```
+
+Run focused Create page coverage:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Run focused hermetic integration coverage:
+
+```bash
+python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci
+```
+
+Run required final suites when available:
+
+```bash
+./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+## Manual Traceability Check
+
+1. Confirm `spec.md` preserves `MM-642` and the canonical Jira preset brief.
+2. Confirm `plan.md`, `research.md`, `data-model.md`, this quickstart, contract, tasks, and verification evidence reference `MM-642`.
+3. Confirm source coverage IDs `DESIGN-REQ-010` and `DESIGN-REQ-011` map to compile-time composition and provenance durability.
+4. Confirm manual-only submission tests still show no fabricated preset metadata.

--- a/specs/341-compile-time-preset-composition/research.md
+++ b/specs/341-compile-time-preset-composition/research.md
@@ -55,3 +55,19 @@ Evidence: `spec.md` preserves the full orchestration input, and this plan refere
 Rationale: Final verification and PR metadata need a durable source trace independent of later Jira or catalog changes.
 Alternatives considered: Reuse the related MM-630 artifacts. Rejected because they preserve a different Jira source key and cannot serve as MM-642 traceability evidence.
 Test implications: Final MoonSpec verification must inspect artifacts for `MM-642`, DESIGN-REQ-010, and DESIGN-REQ-011.
+
+## Success Criteria Coverage
+
+Decision: Treat SC-001 through SC-007 as implemented and verified by the same focused evidence that verifies FR-001 through FR-008 and DESIGN-REQ-010 through DESIGN-REQ-011.
+Evidence: `tests/unit/api/test_task_step_templates_service.py`, `tests/unit/workflows/tasks/test_task_contract.py`, `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`, `tests/unit/api/routers/test_executions.py`, `frontend/src/entrypoints/task-create.test.tsx`, `tests/integration/temporal/test_task_shaped_submission_normalization.py`, and the preserved MM-642 artifact set.
+Rationale: The success criteria are measurable expressions of the same compile-time composition, provenance durability, worker independence, manual-only regression, and traceability behavior mapped in the functional requirements.
+Alternatives considered: Create separate success-criteria-only tests. Rejected because existing unit and integration tests already exercise the observable outcomes directly.
+Test implications: Rerun focused unit, frontend, and integration checks plus final MoonSpec verification when validating the story.
+
+- SC-001 maps to FR-001 and FR-002 validation-before-finalization evidence.
+- SC-002 maps to FR-003 deterministic order evidence.
+- SC-003 maps to FR-004 provenance preservation evidence.
+- SC-004 maps to FR-005 worker-facing payload independence evidence.
+- SC-005 maps to FR-006 reconstruction metadata evidence.
+- SC-006 maps to FR-007 manual-only regression evidence.
+- SC-007 maps to FR-008 traceability preservation evidence.

--- a/specs/341-compile-time-preset-composition/research.md
+++ b/specs/341-compile-time-preset-composition/research.md
@@ -1,0 +1,57 @@
+# Research: Compile-Time Preset Composition With Provenance Preservation
+
+## FR-001 / DESIGN-REQ-010
+
+Decision: Treat compile-time recursive composition as implemented and verified by existing catalog expansion behavior.
+Evidence: `api_service/services/task_templates/catalog.py` builds recursive composition and authored preset metadata; `tests/unit/api/test_task_step_templates_service.py` asserts expansion output, composition metadata, and authored presets.
+Rationale: The Jira brief requires control-plane resolution before execution submission, which is already represented by catalog expansion and submission normalization paths.
+Alternatives considered: Add a new compiler service. Rejected because existing catalog expansion is the established control-plane boundary and is already covered by focused tests.
+Test implications: Rerun catalog unit tests and focused task-shaped integration coverage.
+
+## FR-002
+
+Decision: Treat include-tree validation as implemented and verified by current unit coverage.
+Evidence: `tests/unit/api/test_task_step_templates_service.py` includes cases for missing targets, unavailable presets, cycles, duplicate aliases, incompatible input mappings, and scope/authorization failures.
+Rationale: The story needs explicit failure before execution finalization; catalog validation is the earliest boundary that can stop invalid compositions.
+Alternatives considered: Validate only in the API route. Rejected because worker and frontend paths also rely on catalog compilation semantics.
+Test implications: Rerun catalog unit tests.
+
+## FR-003 / DESIGN-REQ-011
+
+Decision: Treat deterministic flattened order and stable submitted identity as implemented and verified.
+Evidence: `tests/unit/api/test_task_step_templates_service.py`, `tests/unit/api/routers/test_executions.py`, `frontend/src/entrypoints/task-create.test.tsx`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py` assert final order and source metadata.
+Rationale: Deterministic order is a submitted contract invariant and is covered across catalog, Create page, API, and integration boundaries.
+Alternatives considered: Add a separate ordering manifest. Rejected because final submitted step order plus compact provenance is sufficient.
+Test implications: Rerun focused backend, frontend, and integration tests.
+
+## FR-004 / FR-006 / DESIGN-REQ-011
+
+Decision: Treat provenance durability as implemented and verified by task contract, route, frontend, and integration tests.
+Evidence: `moonmind/workflows/tasks/task_contract.py` models `authoredPresets` and `steps[].source`; tests assert include path, input mapping, preset slug/version, original step ID, and detached state preservation.
+Rationale: The submitted task snapshot is the durable source for audit, reconstruction, rerun, and diagnostics after catalog drift.
+Alternatives considered: Store full preset templates in workflow history. Rejected because large content must stay out of workflow histories and compact provenance is enough.
+Test implications: Rerun contract, route, frontend, and integration tests.
+
+## FR-005
+
+Decision: Treat worker-facing no-live-catalog behavior as implemented and verified.
+Evidence: `moonmind/workflows/temporal/worker_runtime.py` preserves expanded payload metadata; task contract tests reject unresolved preset include work; integration tests assert worker-facing payload contains resolved steps.
+Rationale: Workers should consume the resolved execution payload, not authoring-time preset definitions.
+Alternatives considered: Worker-side expansion at execution time. Rejected because it violates the MM-642 source invariant and makes already submitted work sensitive to live catalog changes.
+Test implications: Rerun worker runtime/task contract tests and integration coverage.
+
+## FR-007
+
+Decision: Treat manual-only regression behavior as implemented and verified.
+Evidence: API route and integration tests assert manual-only task submissions do not receive `authoredPresets` or `appliedStepTemplates`.
+Rationale: Preset provenance must not be fabricated for tasks that do not use presets.
+Alternatives considered: Always include empty preset arrays. Rejected because it changes submitted payload shape and weakens provenance semantics.
+Test implications: Rerun route and integration tests.
+
+## FR-008
+
+Decision: Preserve `MM-642` and the canonical Jira preset brief in this artifact set and final verification.
+Evidence: `spec.md` preserves the full orchestration input, and this plan references the Jira key explicitly.
+Rationale: Final verification and PR metadata need a durable source trace independent of later Jira or catalog changes.
+Alternatives considered: Reuse the related MM-630 artifacts. Rejected because they preserve a different Jira source key and cannot serve as MM-642 traceability evidence.
+Test implications: Final MoonSpec verification must inspect artifacts for `MM-642`, DESIGN-REQ-010, and DESIGN-REQ-011.

--- a/specs/341-compile-time-preset-composition/spec.md
+++ b/specs/341-compile-time-preset-composition/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Compile-Time Preset Composition With Provenance Preservation
+
+**Feature Branch**: `341-compile-time-preset-composition`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-642 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-642 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-642
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Compile-time preset composition with provenance preservation
+- Priority: Medium
+- Labels: moonmind-workflow-mm-a1fb7aa8-954b-4c59-acc2-c0a2c5339282
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+- Trusted response artifact: `/work/agent_jobs/mm:0e8a2988-d5ec-40c0-abd6-ca28183deeb5/artifacts/moonspec-inputs/MM-642-trusted-jira-get-issue.json`
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-642 from MM project
+Summary: Compile-time preset composition with provenance preservation
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-642 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-642: Compile-time preset composition with provenance preservation
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 5.4 Preset compilation
+- Invariant 6
+- Invariant 7
+Coverage IDs:
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+As a control-plane engineer, I want a control-plane preset compiler that resolves recursive preset composition before execution submission, validates the include tree, flattens manual + preset-derived steps into the final submitted order with provenance, and produces a resolved execution payload that does not require live preset catalog lookup at execution time.
+Acceptance Criteria
+- Recursive preset composition is fully resolved before submission.
+- Compiler validates the include tree (cycles, missing references, version mismatch) and surfaces explicit errors.
+- Manual and preset-derived steps are flattened in their final submitted order with stable identity.
+- authoredPresets bindings and steps[].source provenance (kind, presetId/slug, version, includePath, originalStepId) are preserved on the submitted contract.
+- Resolved execution payload runs without reading the live preset catalog.
+- Detached templates are represented in step source provenance.
+Requirements
+Implement preset compiler that produces both the resolved worker-facing payload and the authored binding metadata used by snapshot reconstruction.
+"""
+
+**Implementation Intent**: Runtime. The Jira preset brief selects control-plane behavior for task submission and execution boundaries; the referenced task architecture invariants are treated as runtime source requirements.
+
+## User Story - Compile-Time Preset Composition
+
+**Summary**: As a control-plane engineer, I want recursive preset composition resolved before execution submission so that submitted worker payloads are deterministic, self-contained, and auditable without live preset catalog lookup.
+
+**Goal**: Ensure a submitted task that combines manual and preset-derived steps has one final executable order with durable authored-preset and per-step provenance.
+
+**Independent Test**: Submit a task draft containing manual steps plus recursive preset-derived steps, then verify before execution starts that the submitted task has deterministic flattened steps, preserved `authoredPresets` bindings, preserved `steps[].source` provenance, and a worker-facing payload that does not require the live preset catalog.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task draft references a preset include tree, **When** the draft is submitted, **Then** the include tree is fully resolved before execution finalization.
+2. **Given** the include tree contains a cycle, missing reference, version mismatch, disabled preset, unauthorized preset, or invalid mapping, **When** submission attempts compilation, **Then** the system blocks execution finalization with an explicit validation error.
+3. **Given** manual steps and preset-derived steps appear in one draft, **When** compilation succeeds, **Then** submitted steps are flattened into the final deterministic order with stable step identity.
+4. **Given** preset-derived or detached steps carry origin data, **When** the submitted task snapshot is recorded, **Then** `authoredPresets` and `steps[].source` preserve kind, preset identifier or slug, version, include path, original step identifier, input mapping, and detachment state where those values exist.
+5. **Given** a worker starts an already submitted task, **When** it reads the worker-facing execution payload, **Then** the payload contains resolved executable steps and does not require worker-side preset expansion or live preset catalog lookup.
+6. **Given** the live preset catalog changes after submission, **When** the submitted task is reconstructed, audited, rerun, or diagnosed, **Then** the submitted snapshot and provenance preserve the original final order and source bindings.
+
+### Edge Cases
+
+- Recursive include trees contain cycles or unsupported include shapes.
+- Nested presets reference missing, disabled, unauthorized, or mismatched-version definitions.
+- Included presets provide conflicting aliases or incompatible input mappings.
+- Preset-derived steps are detached or edited before submission.
+- A task contains no presets and must remain a manual-only flat submission without fabricated preset metadata.
+- A preset definition is modified or deleted after a task has already been submitted.
+
+## Assumptions
+
+- Preset composition is a control-plane submission concern, not a worker concern.
+- Existing task snapshots are the durable reconstruction source for submitted work.
+- MM-642 is a single-story runtime feature request because it describes one independently testable submission and execution-boundary behavior.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-010**: Source `docs/Tasks/TaskArchitecture.md` section `11. Invariants`, invariant 6. Preset composition must be compile-time control-plane behavior, and submitted execution payloads must not require live preset lookup. Scope: in scope. Mapped to FR-001, FR-002, FR-003, and FR-005.
+- **DESIGN-REQ-011**: Source `docs/Tasks/TaskArchitecture.md` section `11. Invariants`, invariant 7. Task snapshots must preserve pinned bindings, include-tree summary, per-step provenance, detachment state, and final submitted order. Scope: in scope. Mapped to FR-003, FR-004, FR-006, and FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST resolve recursive preset composition before execution submission is finalized.
+- **FR-002**: The system MUST validate preset include trees and block execution finalization for cycles, missing references, version mismatches, disabled or unauthorized presets, conflicting aliases, or incompatible mappings.
+- **FR-003**: The system MUST flatten manual and preset-derived steps into the final deterministic submitted order with stable step identity.
+- **FR-004**: Submitted task snapshots MUST preserve `authoredPresets` bindings and `steps[].source` provenance, including kind, preset identifier or slug, version, include path, original step identifier, input mapping, and detachment state where present.
+- **FR-005**: Worker-facing execution payloads MUST contain resolved executable steps and MUST NOT require worker-side preset expansion or live preset catalog lookup.
+- **FR-006**: Already submitted work MUST be reconstructable from submitted snapshot metadata after live preset catalog changes without changing original step order or provenance.
+- **FR-007**: Manual-only task submissions MUST remain unchanged and MUST NOT receive fabricated preset binding or source metadata.
+- **FR-008**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-642` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Task Draft**: Authoring-state task containing manual steps, optional preset selections, runtime settings, publish intent, Jira provenance, and attachments before submission.
+- **Preset Include Tree**: Nested preset composition structure that must be validated and resolved before execution finalization.
+- **Compiled Task Snapshot**: Authoritative submitted representation containing final ordered steps, authored preset bindings, include-tree summary, and provenance needed for audit, rerun, and reconstruction.
+- **Step Source Provenance**: Per-step source metadata describing manual, preset-derived, included, or detached origin information.
+- **Worker-Facing Payload**: Resolved execution contract consumed by workers after preset compilation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of submitted tasks with recursive preset includes are validated before execution finalization.
+- **SC-002**: Re-submitting equivalent valid draft inputs produces the same final step order and stable identity in repeated submissions.
+- **SC-003**: 100% of preset-derived or detached submitted steps with reliable origin data preserve source provenance in the submitted snapshot.
+- **SC-004**: Workers can execute a compiled preset-derived task after submission without consulting the live preset catalog.
+- **SC-005**: A submitted task can be reconstructed after live preset catalog changes without changing original final order, authored preset bindings, or step provenance.
+- **SC-006**: Manual-only task submission behavior remains unchanged for tasks with zero presets.
+- **SC-007**: Traceability review confirms `MM-642`, the canonical Jira preset brief, DESIGN-REQ-010, and DESIGN-REQ-011 remain preserved across MoonSpec artifacts and final verification evidence.

--- a/specs/341-compile-time-preset-composition/tasks.md
+++ b/specs/341-compile-time-preset-composition/tasks.md
@@ -1,0 +1,92 @@
+# Tasks: Compile-Time Preset Composition With Provenance Preservation
+
+**Input**: `specs/341-compile-time-preset-composition/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-composition-contract.md`, `quickstart.md`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-composition-contract.md`, and `quickstart.md` exist for one story.
+**Unit Test Command**: `./tools/test_unit.sh`
+**Integration Test Command**: `./tools/test_integration.sh`
+
+## Source Traceability
+
+MM-642 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers exactly one story: Compile-Time Preset Composition. Traceability spans FR-001 through FR-008, acceptance scenarios 1-6, edge cases, SC-001 through SC-007, DESIGN-REQ-010, and DESIGN-REQ-011.
+
+Requirement status from `plan.md`: FR-001 through FR-007, DESIGN-REQ-010, and DESIGN-REQ-011 are implemented_verified by existing production code and focused tests. FR-008 is implemented_unverified until this artifact set and final verification preserve MM-642 end to end. No production code changes are planned unless verification exposes drift.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature locator points to `specs/341-compile-time-preset-composition` in `.specify/feature.json`
+- [X] T002 Confirm `specs/341-compile-time-preset-composition/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-composition-contract.md`, and `quickstart.md` exist before implementation
+- [X] T003 Review current task preset catalog, task contract, Create page, execution router, worker runtime, and focused test fixtures in `api_service/services/task_templates/catalog.py`, `moonmind/workflows/tasks/task_contract.py`, `frontend/src/entrypoints/task-create.tsx`, `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/worker_runtime.py`, and `tests/integration/temporal/test_task_shaped_submission_normalization.py`
+
+## Phase 2: Foundational
+
+- [X] T004 Confirm no database migration or new persistent table is required because existing snapshots and task payload metadata carry compact composition provenance (FR-004, FR-006, DESIGN-REQ-011)
+- [X] T005 Confirm existing unit and integration test files already target catalog validation, task contract validation, API normalization, Create page payload preservation, worker runtime preparation, and task-shaped submission boundaries (FR-001 through FR-007)
+- [X] T006 Confirm the related implemented recursive-preset work cannot be reused as the MM-642 source artifact because it preserves Jira key MM-630 rather than MM-642 (FR-008)
+
+## Phase 3: Story - Compile-Time Preset Composition
+
+**Story Summary**: Control-plane preset composition resolves recursive presets before execution submission and preserves final order plus provenance for workers, audit, rerun, and reconstruction.
+
+**Independent Test**: Submit a task draft containing manual steps plus recursive preset-derived steps, then verify before execution starts that the submitted task has deterministic flattened steps, preserved `authoredPresets`, preserved `steps[].source`, and a worker-facing payload that does not require the live preset catalog.
+
+**Traceability IDs**: FR-001 through FR-008; acceptance scenarios 1-6; SC-001 through SC-007; DESIGN-REQ-010; DESIGN-REQ-011.
+
+**Unit Test Plan**: Verify catalog expansion and validation, task contract provenance validation, worker runtime resolved payload handling, API task-shaped normalization, manual-only regression, and Create page submission provenance.
+
+**Integration Test Plan**: Verify task-shaped submission preserves final flattened order, compact provenance, no unresolved worker payload, reconstruction metadata, and manual-only behavior.
+
+### Verification Tests First
+
+- [X] T007 [P] Verify catalog unit coverage for recursive composition metadata, authored presets, validation failures, deterministic order, and stable source provenance in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-002, FR-003, FR-004, DESIGN-REQ-010, DESIGN-REQ-011)
+- [X] T008 [P] Verify task contract unit coverage for recursive `authoredPresets`, `steps[].source`, detached provenance, and rejection of unresolved preset include work in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, FR-005, DESIGN-REQ-011)
+- [X] T009 [P] Verify worker runtime unit coverage for resolved template expansion metadata and worker-facing task payload behavior in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` (FR-005, DESIGN-REQ-010)
+- [X] T010 [P] Verify API route unit coverage for preserving recursive `authoredPresets`, `appliedStepTemplates` composition, final order, runtime, publish, Jira provenance, attachments, and manual-only regression in `tests/unit/api/routers/test_executions.py` (FR-003, FR-004, FR-006, FR-007)
+- [X] T011 [P] Verify Create page unit coverage for recursive preset expansion submission and non-mutating auto-expansion in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
+- [X] T012 [P] Verify hermetic integration coverage for task-shaped submission preserving flattened order, compiled provenance, no unresolved worker payload, catalog-independent reconstruction metadata, and manual-only regression in `tests/integration/temporal/test_task_shaped_submission_normalization.py` (FR-001 through FR-007)
+
+### Red-First Confirmation Status
+
+- [X] T013 Record that new red-first test authoring is not needed for MM-642 because the same behavior was already driven by prior recursive-preset tests and the current plan is verification-first against existing implementation evidence (FR-001 through FR-007)
+- [X] T014 If any verification test fails, reclassify the affected requirement from implemented_verified to partial in `specs/341-compile-time-preset-composition/plan.md` before editing production code (FR-001 through FR-007)
+
+### Conditional Fallback Implementation
+
+- [X] T015 If T007 exposes catalog validation or composition drift, update `api_service/services/task_templates/catalog.py` and rerun catalog tests (FR-001, FR-002, FR-003, DESIGN-REQ-010)
+- [X] T016 If T008 exposes task contract provenance drift, update `moonmind/workflows/tasks/task_contract.py` and rerun task contract tests (FR-004, FR-005, DESIGN-REQ-011)
+- [X] T017 If T009 exposes worker live-catalog dependency drift, update `moonmind/workflows/temporal/worker_runtime.py` and rerun worker runtime tests (FR-005)
+- [X] T018 If T010 or T012 exposes snapshot or normalization drift, update `api_service/api/routers/executions.py` and rerun API/integration tests (FR-004, FR-006, FR-007)
+- [X] T019 If T011 exposes Create page submission drift, update `frontend/src/entrypoints/task-create.tsx` and rerun focused UI tests (FR-003, FR-004)
+
+### Story Validation
+
+- [X] T020 Run focused backend unit tests with `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` (FR-001 through FR-007)
+- [X] T021 Run focused Create page validation with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
+- [X] T022 Run focused hermetic integration validation with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007, SC-001 through SC-006)
+- [X] T023 Verify the task preset composition contract remains satisfied by comparing implementation behavior against `specs/341-compile-time-preset-composition/contracts/task-preset-composition-contract.md` (FR-001 through FR-007)
+- [X] T024 Verify `MM-642`, DESIGN-REQ-010, DESIGN-REQ-011, and the canonical Jira preset brief remain preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-composition-contract.md`, `quickstart.md`, and `tasks.md` (FR-008, SC-007)
+
+## Final Phase: Polish And Verification
+
+- [X] T025 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
+- [X] T026 Run the required hermetic integration suite with `./tools/test_integration.sh` or record the exact environmental blocker if Docker is unavailable: Docker returned `403 Forbidden` after the buildx warning in this managed environment (SC-001 through SC-006)
+- [X] T027 Confirm no provider verification or credentialed tests are required for MM-642 and document skipped provider checks in `specs/341-compile-time-preset-composition/verification.md`
+- [X] T028 Run `/moonspec-verify` after implementation and tests pass or are blocked with exact reasons, ensuring verification covers MM-642, the preserved Jira preset brief, FR-001 through FR-008, SC-001 through SC-007, DESIGN-REQ-010, DESIGN-REQ-011, commands run, and remaining risks
+
+## Dependencies And Execution Order
+
+1. Phase 1 setup tasks T001-T003 must complete first.
+2. Phase 2 foundational tasks T004-T006 confirm existing boundaries and evidence.
+3. Verification tasks T007-T012 are evaluated before any production edits.
+4. Conditional fallback tasks T015-T019 are only executed if verification exposes drift.
+5. Story validation tasks T020-T024 prove MM-642 against current code and artifacts.
+6. Final verification tasks T025-T028 close the feature.
+
+## Parallel Examples
+
+- T007, T008, T009, T010, T011, and T012 can be evaluated in parallel because they inspect different test files or boundaries.
+- T015 through T019 must not be run unless the corresponding verification test fails.
+- T020, T021, and T022 should run after artifact generation and before final verification.
+
+## Implementation Strategy
+
+This MM-642 run is verification-first because the same compile-time preset composition behavior is already present in the repository from prior recursive-preset implementation. Preserve the new Jira source trace in this artifact set, rerun focused and required tests, edit production code only if current evidence fails, and finish with MoonSpec verification against the `MM-642` brief.

--- a/specs/341-compile-time-preset-composition/tasks.md
+++ b/specs/341-compile-time-preset-composition/tasks.md
@@ -7,7 +7,7 @@
 
 ## Source Traceability
 
-MM-642 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers exactly one story: Compile-Time Preset Composition. Traceability spans FR-001 through FR-008, acceptance scenarios 1-6, edge cases, SC-001 through SC-007, DESIGN-REQ-010, and DESIGN-REQ-011.
+MM-642 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers exactly one story: Compile-Time Preset Composition. Traceability spans FR-001 through FR-008, acceptance scenarios 1-6, edge cases, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, DESIGN-REQ-010, and DESIGN-REQ-011.
 
 Requirement status from `plan.md`: FR-001 through FR-007, DESIGN-REQ-010, and DESIGN-REQ-011 are implemented_verified by existing production code and focused tests. FR-008 is implemented_unverified until this artifact set and final verification preserve MM-642 end to end. No production code changes are planned unless verification exposes drift.
 
@@ -29,7 +29,7 @@ Requirement status from `plan.md`: FR-001 through FR-007, DESIGN-REQ-010, and DE
 
 **Independent Test**: Submit a task draft containing manual steps plus recursive preset-derived steps, then verify before execution starts that the submitted task has deterministic flattened steps, preserved `authoredPresets`, preserved `steps[].source`, and a worker-facing payload that does not require the live preset catalog.
 
-**Traceability IDs**: FR-001 through FR-008; acceptance scenarios 1-6; SC-001 through SC-007; DESIGN-REQ-010; DESIGN-REQ-011.
+**Traceability IDs**: FR-001 through FR-008; acceptance scenarios 1-6; SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007; DESIGN-REQ-010; DESIGN-REQ-011.
 
 **Unit Test Plan**: Verify catalog expansion and validation, task contract provenance validation, worker runtime resolved payload handling, API task-shaped normalization, manual-only regression, and Create page submission provenance.
 
@@ -61,16 +61,16 @@ Requirement status from `plan.md`: FR-001 through FR-007, DESIGN-REQ-010, and DE
 
 - [X] T020 Run focused backend unit tests with `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` (FR-001 through FR-007)
 - [X] T021 Run focused Create page validation with `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-004)
-- [X] T022 Run focused hermetic integration validation with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007, SC-001 through SC-006)
+- [X] T022 Run focused hermetic integration validation with `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` (FR-001 through FR-007, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006)
 - [X] T023 Verify the task preset composition contract remains satisfied by comparing implementation behavior against `specs/341-compile-time-preset-composition/contracts/task-preset-composition-contract.md` (FR-001 through FR-007)
 - [X] T024 Verify `MM-642`, DESIGN-REQ-010, DESIGN-REQ-011, and the canonical Jira preset brief remain preserved in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/task-preset-composition-contract.md`, `quickstart.md`, and `tasks.md` (FR-008, SC-007)
 
 ## Final Phase: Polish And Verification
 
 - [X] T025 Run the full required unit suite with `./tools/test_unit.sh` (FR-001 through FR-008)
-- [X] T026 Run the required hermetic integration suite with `./tools/test_integration.sh` or record the exact environmental blocker if Docker is unavailable: Docker returned `403 Forbidden` after the buildx warning in this managed environment (SC-001 through SC-006)
+- [X] T026 Run the required hermetic integration suite with `./tools/test_integration.sh` or record the exact environmental blocker if Docker is unavailable: Docker returned `403 Forbidden` after the buildx warning in this managed environment (SC-001, SC-002, SC-003, SC-004, SC-005, SC-006)
 - [X] T027 Confirm no provider verification or credentialed tests are required for MM-642 and document skipped provider checks in `specs/341-compile-time-preset-composition/verification.md`
-- [X] T028 Run `/moonspec-verify` after implementation and tests pass or are blocked with exact reasons, ensuring verification covers MM-642, the preserved Jira preset brief, FR-001 through FR-008, SC-001 through SC-007, DESIGN-REQ-010, DESIGN-REQ-011, commands run, and remaining risks
+- [X] T028 Run `/moonspec-verify` after implementation and tests pass or are blocked with exact reasons, ensuring verification covers MM-642, the preserved Jira preset brief, FR-001 through FR-008, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, DESIGN-REQ-010, DESIGN-REQ-011, commands run, and remaining risks
 
 ## Dependencies And Execution Order
 

--- a/specs/341-compile-time-preset-composition/verification.md
+++ b/specs/341-compile-time-preset-composition/verification.md
@@ -1,0 +1,69 @@
+# MoonSpec Verification Report
+
+**Feature**: Compile-Time Preset Composition With Provenance Preservation
+**Spec**: `/work/agent_jobs/mm:0e8a2988-d5ec-40c0-abd6-ca28183deeb5/repo/specs/341-compile-time-preset-composition/spec.md`
+**Original Request Source**: `spec.md` `Input`, canonical Jira preset brief for `MM-642`
+**Verdict**: FULLY_IMPLEMENTED
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Focused backend unit | `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` | PASS | 371 passed; covers catalog composition, task contract, worker runtime, and API normalization boundaries. |
+| Focused Create page | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` | PASS | 38 passed, 228 skipped; direct invocation used after installing JS dependencies because `npm run ui:test -- ...` could not resolve `vitest` in this environment. |
+| Focused hermetic integration | `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` | PASS | 9 passed; covers task-shaped submission boundary and snapshot/provenance behavior. |
+| Required unit | `./tools/test_unit.sh` | PASS | Rerun passed: 4,883 Python tests, 1 xpassed, 16 subtests, and 20 frontend files / 341 tests passed. An earlier run had one unrelated supervisor test failure; the same test passed in isolation and the full rerun passed. |
+| Required integration | `./tools/test_integration.sh` | NOT RUN | Blocked by environment: Docker returned `403 Forbidden` after the buildx plugin warning while building `repo-pytest`. |
+| Provider verification | N/A | NOT RUN | Not required; MM-642 covers local control-plane preset compilation and task submission/execution boundaries, not credentialed providers. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `api_service/services/task_templates/catalog.py`; `tests/unit/api/test_task_step_templates_service.py`; focused integration | VERIFIED | Recursive composition resolves before execution submission. |
+| FR-002 | `tests/unit/api/test_task_step_templates_service.py` | VERIFIED | Invalid include trees fail explicitly before finalization. |
+| FR-003 | catalog, API route, frontend, and integration tests | VERIFIED | Manual and preset-derived steps flatten into deterministic final order. |
+| FR-004 | `moonmind/workflows/tasks/task_contract.py`; route/frontend/integration tests | VERIFIED | `authoredPresets` and `steps[].source` provenance are preserved. |
+| FR-005 | `moonmind/workflows/temporal/worker_runtime.py`; task contract and integration tests | VERIFIED | Worker-facing payloads contain resolved executable steps and reject unresolved preset include work. |
+| FR-006 | task-shaped integration and snapshot metadata tests | VERIFIED | Submitted work is reconstructable from snapshot/provenance without live catalog dependency. |
+| FR-007 | API route and integration manual-only regressions | VERIFIED | Manual-only submissions do not gain fabricated preset metadata. |
+| FR-008 | `spec.md`, `plan.md`, `research.md`, `data-model.md`, contract, quickstart, tasks, alignment report, and this verification report | VERIFIED | `MM-642` and the canonical Jira preset brief are preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Scenario 1 | catalog and integration tests | VERIFIED | Preset include trees resolve before execution finalization. |
+| Scenario 2 | catalog validation tests | VERIFIED | Invalid includes block execution finalization. |
+| Scenario 3 | catalog/API/frontend/integration tests | VERIFIED | Final submitted order is deterministic. |
+| Scenario 4 | task contract, API, frontend, and integration tests | VERIFIED | Provenance fields are preserved where reliable origin data exists. |
+| Scenario 5 | worker runtime, task contract, and integration tests | VERIFIED | Worker payload is resolved and catalog-independent. |
+| Scenario 6 | integration and snapshot metadata tests | VERIFIED | Submitted snapshot preserves original order and provenance after catalog changes. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-010 | catalog compilation, worker payload tests, focused integration | VERIFIED | Preset composition is compile-time control-plane behavior and submitted payloads do not require live lookup. |
+| DESIGN-REQ-011 | task contract, snapshot/provenance tests, focused integration | VERIFIED | Snapshots preserve pinned bindings, include-tree summary, per-step provenance, detachment state, and final order. |
+| Constitution | `plan.md` constitution check; no source code drift introduced in this run | VERIFIED | No new service, storage, provider coupling, or compatibility alias introduced. |
+
+## Original Request Alignment
+
+- PASS: The MM-642 Jira preset brief is preserved as the canonical orchestration input.
+- PASS: The input is classified as a single-story runtime feature request.
+- PASS: Existing artifacts were inspected; no prior `MM-642` spec existed, and the related `MM-630` feature could not serve as MM-642 traceability evidence.
+- PASS: Existing implementation and tests satisfy the requested compile-time preset composition and provenance preservation behavior.
+
+## Gaps
+
+- Full required integration suite could not be executed in this managed environment because Docker access is administratively blocked with `403 Forbidden`. Focused `integration_ci` coverage for this story passed locally without Docker compose.
+
+## Remaining Work
+
+- None for MM-642 implementation. Re-run `./tools/test_integration.sh` in an environment with permitted Docker compose access before merge if required by the repository gate.
+
+## Decision
+
+MM-642 is fully implemented against the preserved Jira preset brief and one-story MoonSpec artifacts. The only remaining operational risk is the environment-level Docker policy blocking the full integration runner.


### PR DESCRIPTION
## Summary

- Jira issue key: MM-642
- Active MoonSpec feature path: `specs/341-compile-time-preset-composition`
- Adds MoonSpec artifacts for compile-time preset composition with provenance preservation.
- Preserves the canonical MM-642 Jira preset brief, source design mappings, task plan, alignment report, and verification report.

## Verification Verdict

- Implementation verification report: `FULLY_IMPLEMENTED`
- Latest managed read-only verification gate: `ADDITIONAL_WORK_NEEDED` due environment-only workspace projection preflight (`.gemini/skills`) and Docker policy blocking full integration in this runtime. No MM-642 implementation gaps were found.

## Tests Run

- `python -m pytest tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py -q` -> PASS, 371 passed
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` -> PASS, 38 passed, 228 skipped
- `python -m pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q -m integration_ci` -> PASS, 9 passed
- `./tools/test_unit.sh` -> PASS, 4,883 Python tests plus 20 frontend files passed
- `./tools/test_integration.sh` -> NOT RUN in this runtime; Docker returned `403 Forbidden`

## Remaining Risks

- Full compose-backed integration must be rerun in an environment with permitted Docker access.
- This managed workspace has an unrelated `.gemini/skills` projection change that was not included in the PR.
