### PR TITLE
[codex] Fix Claude publish lease conflict recovery

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
 
 from pydantic import BaseModel, ValidationError
 from temporalio import exceptions as temporal_exceptions
@@ -118,6 +118,11 @@ from moonmind.schemas.managed_session_models import (
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.plan_validation import validate_plan_payload
+
+if TYPE_CHECKING:
+    from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+    from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 from moonmind.workflows.skills.skill_dispatcher import execute_skill_activity
 from moonmind.workflows.skills.skill_plan_contracts import (
     ActivityExecutionContext,
@@ -6604,6 +6609,72 @@ class TemporalAgentRuntimeActivities:
                     env=command_env,
                 )
 
+            async def _finalize_push_success(
+                *,
+                extra: Mapping[str, Any] | None = None,
+                precomputed_commit_count: int | None = commit_count,
+            ) -> dict[str, Any]:
+                head_sha = await self._resolve_workspace_head_sha(
+                    workspace=workspace,
+                    run_id=run_id,
+                    env=command_env,
+                )
+
+                final_commit_count = precomputed_commit_count
+                # Verify the branch actually has commits over the publish base.
+                # git push succeeds as a no-op when the branch is already
+                # up-to-date, which would cause repo.create_pr to fail
+                # with HTTP 422 ("No commits between main and <branch>").
+                if final_commit_count is None:
+                    final_commit_count = await self._count_branch_commits_ahead(
+                        workspace=workspace,
+                        base_ref=base_ref,
+                        branch=current_branch,
+                        run_id=run_id,
+                        env=command_env,
+                    )
+
+                if final_commit_count == 0:
+                    logger.warning(
+                        "Post-agent git push completed for run %s but branch "
+                        "'%s' has no commits over %s",
+                        run_id,
+                        current_branch,
+                        base_ref,
+                    )
+                    result: dict[str, Any] = {
+                        "push_status": "no_commits",
+                        "push_branch": current_branch,
+                        "push_base_branch": base_branch_name,
+                        "push_base_ref": base_ref,
+                        "push_commit_count": 0,
+                    }
+                    if head_sha:
+                        result["push_head_sha"] = head_sha
+                    if extra:
+                        result.update(extra)
+                    return result
+
+                logger.info(
+                    "Post-agent git push completed for run %s (branch=%s)",
+                    run_id,
+                    current_branch,
+                )
+                result = {
+                    "push_status": "pushed",
+                    "push_branch": current_branch,
+                    "push_base_branch": base_branch_name,
+                    "push_base_ref": base_ref,
+                }
+                result.update(commit_info)
+                if extra:
+                    result.update(extra)
+                if head_sha:
+                    result["push_head_sha"] = head_sha
+                if final_commit_count >= 0:
+                    result["push_commit_count"] = final_commit_count
+                return result
+
             remote_sha: str | None = None
             remote_sha_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
@@ -6668,6 +6739,7 @@ class TemporalAgentRuntimeActivities:
                     base_branch=base_branch_name,
                 )
                 if classified.get("push_status") == "lease_conflict":
+                    retry_metadata: dict[str, Any] = {"push_retry_count": 1}
                     fetch_proc = await asyncio.create_subprocess_exec(
                         *self._workspace_git_command(
                             workspace, "fetch", "origin", current_branch,
@@ -6687,6 +6759,7 @@ class TemporalAgentRuntimeActivities:
                     classified["fetch_status"] = (
                         "fetched" if fetch_proc.returncode == 0 else "failed"
                     )
+                    retry_metadata["fetch_status"] = classified["fetch_status"]
                     if fetch_proc.returncode != 0:
                         classified["fetch_error"] = (
                             fetch_stderr.decode(
@@ -6696,63 +6769,129 @@ class TemporalAgentRuntimeActivities:
                                 "utf-8", errors="replace"
                             ).strip()
                         )
+                    else:
+                        remote_tracking_ref = f"refs/remotes/origin/{current_branch}"
+                        local_head_after_fetch = await self._resolve_workspace_head_sha(
+                            workspace=workspace,
+                            run_id=run_id,
+                            env=command_env,
+                        )
+                        remote_sha_after_fetch = await self._resolve_workspace_ref_sha(
+                            workspace=workspace,
+                            ref=remote_tracking_ref,
+                            run_id=run_id,
+                            env=command_env,
+                        )
+                        if (
+                            local_head_after_fetch
+                            and remote_sha_after_fetch
+                            and local_head_after_fetch == remote_sha_after_fetch
+                        ):
+                            retry_metadata["rebase_status"] = "not_needed"
+                            return await _finalize_push_success(
+                                extra=retry_metadata,
+                                precomputed_commit_count=None,
+                            )
+
+                        rebase_proc = await asyncio.create_subprocess_exec(
+                            *self._workspace_git_command(
+                                workspace, "rebase", remote_tracking_ref,
+                            ),
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE,
+                            env=command_env,
+                        )
+                        try:
+                            rebase_stdout, rebase_stderr = await asyncio.wait_for(
+                                rebase_proc.communicate(), timeout=120,
+                            )
+                        except asyncio.TimeoutError:
+                            rebase_proc.kill()
+                            await rebase_proc.wait()
+                            raise
+                        if rebase_proc.returncode != 0:
+                            rebase_detail = (
+                                rebase_stderr.decode(
+                                    "utf-8", errors="replace"
+                                ).strip()
+                                or rebase_stdout.decode(
+                                    "utf-8", errors="replace"
+                                ).strip()
+                                or "(no stderr)"
+                            )
+                            classified["rebase_status"] = "failed"
+                            classified["retryable"] = False
+                            classified["push_error"] = (
+                                f"{classified['push_error']}; automatic rebase "
+                                f"onto {remote_tracking_ref} failed: {rebase_detail}"
+                            )
+                            abort_proc = await asyncio.create_subprocess_exec(
+                                *self._workspace_git_command(
+                                    workspace, "rebase", "--abort",
+                                ),
+                                stdout=asyncio.subprocess.PIPE,
+                                stderr=asyncio.subprocess.PIPE,
+                                env=command_env,
+                            )
+                            try:
+                                await asyncio.wait_for(
+                                    abort_proc.communicate(), timeout=30,
+                                )
+                            except asyncio.TimeoutError:
+                                abort_proc.kill()
+                                await abort_proc.wait()
+                            return classified
+
+                        retry_metadata["rebase_status"] = "rebased"
+                        retry_remote_sha = remote_sha_after_fetch
+                        if retry_remote_sha is None:
+                            retry_remote_sha = await self._resolve_workspace_ref_sha(
+                                workspace=workspace,
+                                ref=remote_tracking_ref,
+                                run_id=run_id,
+                                env=command_env,
+                            )
+                        retry_push_proc = await asyncio.create_subprocess_exec(
+                            *self._workspace_git_command(
+                                workspace,
+                                *build_git_push_with_lease_args(
+                                    branch=current_branch,
+                                    recorded_remote_sha=retry_remote_sha,
+                                ),
+                            ),
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE,
+                            env=command_env,
+                        )
+                        try:
+                            _, retry_push_stderr = await asyncio.wait_for(
+                                retry_push_proc.communicate(), timeout=120,
+                            )
+                        except asyncio.TimeoutError:
+                            retry_push_proc.kill()
+                            await retry_push_proc.wait()
+                            raise
+                        if retry_push_proc.returncode == 0:
+                            return await _finalize_push_success(
+                                extra=retry_metadata,
+                                precomputed_commit_count=None,
+                            )
+                        retry_error_detail = (
+                            retry_push_stderr.decode(
+                                "utf-8", errors="replace"
+                            ).strip()
+                            or "(no stderr)"
+                        )
+                        retry_classified = classify_git_push_failure(
+                            stderr=retry_error_detail,
+                            branch=current_branch,
+                            base_branch=base_branch_name,
+                        )
+                        retry_classified.update(retry_metadata)
+                        return retry_classified
                 return classified
 
-            head_sha = await self._resolve_workspace_head_sha(
-                workspace=workspace,
-                run_id=run_id,
-                env=command_env,
-            )
-
-            # Verify the branch actually has commits over the publish base.
-            # git push succeeds as a no-op when the branch is already
-            # up-to-date, which would cause repo.create_pr to fail
-            # with HTTP 422 ("No commits between main and <branch>").
-            if commit_count is None:
-                commit_count = await self._count_branch_commits_ahead(
-                    workspace=workspace,
-                    base_ref=base_ref,
-                    branch=current_branch,
-                    run_id=run_id,
-                    env=command_env,
-                )
-
-            if commit_count == 0:
-                logger.warning(
-                    "Post-agent git push completed for run %s but branch "
-                    "'%s' has no commits over %s",
-                    run_id,
-                    current_branch,
-                    base_ref,
-                )
-                result = {
-                    "push_status": "no_commits",
-                    "push_branch": current_branch,
-                    "push_base_branch": base_branch_name,
-                    "push_base_ref": base_ref,
-                    "push_commit_count": 0,
-                }
-                if head_sha:
-                    result["push_head_sha"] = head_sha
-                return result
-
-            logger.info(
-                "Post-agent git push completed for run %s (branch=%s)",
-                run_id,
-                current_branch,
-            )
-            result: dict[str, Any] = {
-                "push_status": "pushed",
-                "push_branch": current_branch,
-                "push_base_branch": base_branch_name,
-                "push_base_ref": base_ref,
-            }
-            result.update(commit_info)
-            if head_sha:
-                result["push_head_sha"] = head_sha
-            if commit_count >= 0:
-                result["push_commit_count"] = commit_count
-            return result
+            return await _finalize_push_success()
         except Exception as exc:
             logger.warning(
                 "Post-agent git push failed for run %s",
@@ -6763,6 +6902,41 @@ class TemporalAgentRuntimeActivities:
                 "push_status": "failed",
                 "push_error": str(exc),
             }
+
+    async def _resolve_workspace_ref_sha(
+        self,
+        *,
+        workspace: str,
+        ref: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> str | None:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(workspace, "rev-parse", "--verify", ref),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            try:
+                stdout_bytes, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=10,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return None
+            if proc.returncode != 0:
+                return None
+            return stdout_bytes.decode("utf-8", errors="replace").strip() or None
+        except Exception:
+            logger.debug(
+                "Failed to resolve workspace ref sha for run %s (ref=%s)",
+                run_id,
+                ref,
+                exc_info=True,
+            )
+            return None
 
     async def _resolve_workspace_head_sha(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
+from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
 
 from pydantic import BaseModel, ValidationError
 from temporalio import exceptions as temporal_exceptions
@@ -119,10 +119,6 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.plan_validation import validate_plan_payload
 
-if TYPE_CHECKING:
-    from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
-    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
-    from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 from moonmind.workflows.skills.skill_dispatcher import execute_skill_activity
 from moonmind.workflows.skills.skill_plan_contracts import (
     ActivityExecutionContext,
@@ -6844,13 +6840,6 @@ class TemporalAgentRuntimeActivities:
 
                         retry_metadata["rebase_status"] = "rebased"
                         retry_remote_sha = remote_sha_after_fetch
-                        if retry_remote_sha is None:
-                            retry_remote_sha = await self._resolve_workspace_ref_sha(
-                                workspace=workspace,
-                                ref=remote_tracking_ref,
-                                run_id=run_id,
-                                env=command_env,
-                            )
                         retry_push_proc = await asyncio.create_subprocess_exec(
                             *self._workspace_git_command(
                                 workspace,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -85,7 +85,6 @@ from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
 )
 from moonmind.workflows.temporal.activity_catalog import (
-    ARTIFACTS_TASK_QUEUE,
     INTEGRATIONS_TASK_QUEUE,
     WORKFLOW_TASK_QUEUE,
     TemporalActivityRoute,
@@ -203,6 +202,7 @@ DEPENDENCY_WAIT_THROUGH_RERUN_PATCH = "dependency-wait-through-rerun-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
 NATIVE_PR_BRANCH_DEFAULTS_PATCH = "native-pr-branch-defaults-v1"
 NATIVE_PR_PUSH_STATUS_GATE_PATCH = "native-pr-push-status-gate-v1"
+NATIVE_PR_LEASE_CONFLICT_GATE_PATCH = "native-pr-lease-conflict-gate-v1"
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
@@ -3675,6 +3675,8 @@ class MoonMindRunWorkflow:
         status = self._coerce_text(push_status)
         if status in {"failed", "skipped"}:
             return True
+        if status == "lease_conflict":
+            return workflow.patched(NATIVE_PR_LEASE_CONFLICT_GATE_PATCH)
         if status == "protected_branch":
             return workflow.patched(NATIVE_PR_PUSH_STATUS_GATE_PATCH)
         return False
@@ -3741,6 +3743,28 @@ class MoonMindRunWorkflow:
             push_error = self._coerce_text(outputs.get("push_error"), max_chars=200)
             self._publish_status = "failed"
             self._publish_reason = push_error or "publish skipped"
+            return
+
+        if push_status == "lease_conflict":
+            if not workflow.patched(NATIVE_PR_LEASE_CONFLICT_GATE_PATCH):
+                return
+            push_error = self._coerce_text(outputs.get("push_error"), max_chars=200)
+            push_branch = self._coerce_text(outputs.get("push_branch"), max_chars=120)
+            self._publish_status = "failed"
+            if push_branch and push_error:
+                self._publish_reason = (
+                    f"publish failed: remote branch '{push_branch}' changed "
+                    f"before publish completed: {push_error}"
+                )
+            elif push_branch:
+                self._publish_reason = (
+                    f"publish failed: remote branch '{push_branch}' changed "
+                    "before publish completed"
+                )
+            else:
+                self._publish_reason = (
+                    "publish failed: remote branch changed before publish completed"
+                )
             return
 
         if push_status == "protected_branch":

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -596,6 +596,89 @@ class TestPushWorkspaceBranch:
         assert "Permission denied" in result["push_error"]
 
     @pytest.mark.asyncio
+    async def test_push_rebases_and_retries_once_after_lease_conflict(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse --abbrev-ref HEAD
+                proc.communicate = AsyncMock(return_value=(b"feature/retry-push\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # remote branch sha before first push
+                proc.communicate = AsyncMock(return_value=(b"old-remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # first push loses its lease
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"",
+                        b"! [rejected] feature/retry-push -> feature/retry-push (stale info)",
+                    )
+                )
+                proc.returncode = 1
+            elif call_count == 6:  # fetch updated remote branch
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # local HEAD after fetch
+                proc.communicate = AsyncMock(return_value=(b"local-head-before-rebase\n", b""))
+                proc.returncode = 0
+            elif call_count == 8:  # updated remote tracking sha
+                proc.communicate = AsyncMock(return_value=(b"new-remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 9:  # rebase onto updated remote branch
+                proc.communicate = AsyncMock(return_value=(b"Successfully rebased\n", b""))
+                proc.returncode = 0
+            elif call_count == 10:  # retry push with updated lease
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 11:  # final HEAD
+                proc.communicate = AsyncMock(return_value=(b"rebased-head-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 12:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"2\n", b""))
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/retry-push"
+        assert result["push_retry_count"] == 1
+        assert result["fetch_status"] == "fetched"
+        assert result["rebase_status"] == "rebased"
+        assert result["push_commit_count"] == 2
+        assert result["push_head_sha"] == "rebased-head-sha"
+
+        push_calls = [call for call in recorded_calls if "push" in call]
+        assert len(push_calls) == 2
+        assert any(
+            "--force-with-lease=refs/heads/feature/retry-push:old-remote-sha" in call
+            for call in push_calls
+        )
+        assert any(
+            "--force-with-lease=refs/heads/feature/retry-push:new-remote-sha" in call
+            for call in push_calls
+        )
+        assert any(
+            list(call[-2:]) == ["rebase", "refs/remotes/origin/feature/retry-push"]
+            for call in recorded_calls
+        )
+
+    @pytest.mark.asyncio
     async def test_push_branch_detection_failure(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -10,6 +10,7 @@ from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.run import (
     INTEGRATION_POLL_LOOP_PATCH,
     NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+    NATIVE_PR_LEASE_CONFLICT_GATE_PATCH,
     NATIVE_PR_PUSH_STATUS_GATE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
@@ -1134,6 +1135,34 @@ def test_native_pr_push_status_gate_blocks_protected_branch_when_patched(
     ) is True
     assert mock_run_workflow._publish_status == "failed"
     assert "feature/existing" in (mock_run_workflow._publish_reason or "")
+
+def test_native_pr_push_status_gate_blocks_unrecovered_lease_conflict(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_LEASE_CONFLICT_GATE_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={
+            "outputs": {
+                "push_status": "lease_conflict",
+                "push_branch": "feature/existing",
+                "push_error": "! [rejected] feature/existing (stale info)",
+            }
+        },
+    )
+
+    assert mock_run_workflow._native_pr_push_status_blocks_creation(
+        "lease_conflict"
+    ) is True
+    assert mock_run_workflow._publish_status == "failed"
+    assert "remote branch 'feature/existing' changed" in (
+        mock_run_workflow._publish_reason or ""
+    )
 
 def test_record_execution_context_resets_last_step_fields_when_current_node_has_no_summary(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
## Summary

Fixes Claude Code managed publishing when GitHub rejects the post-agent push because the remote branch changed before `--force-with-lease` completed.

## Root Cause

The publish activity already classified GitHub stale-lease push failures as retryable `lease_conflict`, but it only fetched the updated branch and returned that status. The parent workflow did not treat `lease_conflict` as a blocking publish failure, so later PR creation/finalization could continue in a fresh workspace and fail with a misleading no-publishable-diff error.

## Changes

- Fetches the updated remote branch after a lease conflict, rebases the local task branch onto the updated tracking ref, and retries the push once with the refreshed lease SHA.
- Preserves publish metadata for the retry path, including fetch/rebase status, retry count, head SHA, and commit count.
- Adds a replay-gated workflow guard so unrecovered lease conflicts block native PR creation and surface as publish failures instead of no-diff PR failures.
- Adds regression tests for activity-level retry recovery and workflow-level lease-conflict blocking.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/workflows/test_run_integration.py::test_native_pr_push_status_gate_blocks_unrecovered_lease_conflict tests/integration/temporal/test_publish_reconciliation.py`
- `ruff check moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/workflows/run.py tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `git diff --check`