### PR TITLE
[codex] fix deployment compose output tail helper

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -292,6 +292,8 @@ def _remap_host_compose_path(
 
 def _tail_text(payload: bytes, *, max_chars: int = 512) -> str:
     text = payload.decode("utf-8", errors="replace")
+    if max_chars <= 0:
+        return ""
     return text[-max_chars:]
 
 

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -290,6 +290,11 @@ def _remap_host_compose_path(
     return local_dir / compose_file.name
 
 
+def _tail_text(payload: bytes, *, max_chars: int = 512) -> str:
+    text = payload.decode("utf-8", errors="replace")
+    return text[-max_chars:]
+
+
 @dataclass(frozen=True, slots=True)
 class HostDockerComposeRunner:
     """Docker Compose runner for a trusted deployment-control worker.

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, Mapping
 
@@ -818,3 +819,47 @@ def test_compose_base_command_accepts_windows_host_paths(tmp_path):
     command = runner._compose_base_command()
     assert command[5] == "C:\\Users\\dev\\MoonMind"
     assert command[-1] == str(compose)
+
+
+@pytest.mark.asyncio
+async def test_host_compose_runner_returns_bounded_command_output_tails(
+    tmp_path, monkeypatch
+):
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"0123456789abcdefTAIL", b"compose stderr tail"
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        cwd: str,
+        env: Mapping[str, str],
+        stdout: Any,
+        stderr: Any,
+    ):
+        captured["args"] = args
+        captured["cwd"] = cwd
+        captured["env"] = env
+        captured["stdout"] = stdout
+        captured["stderr"] = stderr
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    runner = HostDockerComposeRunner(project_dir=str(tmp_path))
+
+    result = await runner._run_compose_command(
+        ("docker", "compose", "ps"), max_output_chars=8
+    )
+
+    assert result["exitCode"] == 0
+    assert result["stdout"] == "cdefTAIL"
+    assert result["stderr"] == "err tail"
+    assert result["command"][-1] == "ps"
+    assert captured["cwd"] == str(tmp_path)

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -15,6 +15,7 @@ from moonmind.workflows.skills.deployment_execution import (
     _ensure_command_succeeded,
     _is_host_absolute_path,
     _remap_host_compose_path,
+    _tail_text,
     build_compose_command_plan,
     build_deployment_update_handler,
 )
@@ -537,6 +538,13 @@ def test_compose_config_validation_failure_has_normalized_class() -> None:
 
     assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
     assert exc_info.value.details["failureClass"] == "compose_config_validation_failure"
+
+
+def test_tail_text_returns_empty_for_non_positive_limit() -> None:
+    payload = b"abcdef"
+
+    assert _tail_text(payload, max_chars=0) == ""
+    assert _tail_text(payload, max_chars=-3) == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix the deployment update runner crash that caused `deployment.update_compose_stack` tasks to fail during before-state capture with `NameError: name '_tail_text' is not defined`.

## Root Cause

`HostDockerComposeRunner._run_compose_command()` and image inspection error handling referenced `_tail_text()`, but that helper was only present in the Temporal activity runtime module and not in the deployment skill execution module where the compose runner executes.

## Changes

- Added a local `_tail_text()` helper to the deployment execution module.
- Added a unit regression test for `HostDockerComposeRunner._run_compose_command()` that verifies bounded stdout/stderr tails are returned from the real runner boundary.

## Validation

- `python3.12 -m pytest tests/unit/workflows/skills/test_deployment_update_execution.py tests/unit/workflows/skills/test_deployment_tool_contracts.py -q` passed: 43 passed.
- `python3.12 -m pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q` passed: 4 passed.
- `git diff --check -- moonmind/workflows/skills/deployment_execution.py tests/unit/workflows/skills/test_deployment_update_execution.py` passed.

## Notes

Full `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` was attempted but this checkout's `.venv` uses Python 3.11, while the repo has Python 3.12-only test syntax in `tests/unit/services/temporal/runtime/test_managed_session_controller.py:2191`; collection failed before reaching this change.
