### PR TITLE
Add Jira Orchestrate verify remediation loop

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -178,9 +178,35 @@ steps:
   - title: Verify completion
     instructions: |-
       Run moonspec-verify as the final read-only gate unless an up-to-date verification report already covers the current code and artifacts.
-      If the verdict is ADDITIONAL_WORK_NEEDED, use the report as the remaining-work list and run at most two bounded implementation and verification cycles.
+      If the verdict is ADDITIONAL_WORK_NEEDED, preserve the report as the mandatory remediation input for the next step.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context.
-      Continue to pull request creation only when the verdict is FULLY_IMPLEMENTED.
+      Do not create a pull request from this step. Pull request creation is allowed only after the post-remediation verification step reports FULLY_IMPLEMENTED.
+    skill:
+      id: moonspec-verify
+      args: {}
+  - title: Remediate verification gaps
+    instructions: |-
+      Inspect the latest moonspec-verify result for {{ inputs.jira_issue_key }} before doing any work.
+
+      If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation is skipped because verification already passed.
+
+      If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
+
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+
+      Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
+    skill:
+      id: moonspec-implement
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Verify remediation
+    instructions: |-
+      Run moonspec-verify after remediation, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
+
+      This is the controlling verification gate for Jira Orchestrate publication. If the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop the orchestration, report the gaps or missing evidence, and do not continue to pull request creation.
+
+      Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
       args: {}
@@ -189,6 +215,8 @@ steps:
       jiraOrchestrateRole: pull-request-handoff
     instructions: |-
       Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
+
+      Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop without committing, pushing, creating a pull request, or changing Jira.
 
       This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Code Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -923,7 +923,7 @@ def _is_jira_orchestrate_pr_handoff_node(
         role = str(annotations.get("jiraOrchestrateRole") or "").strip().lower()
         if role == "pull-request-handoff":
             return True
-    return _template_step_id_matches(node, slug="jira-orchestrate", step_index=12)
+    return _template_step_id_matches(node, slug="jira-orchestrate", step_index=14)
 
 
 def _append_story_breakdown_instructions(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -923,7 +923,14 @@ def _is_jira_orchestrate_pr_handoff_node(
         role = str(annotations.get("jiraOrchestrateRole") or "").strip().lower()
         if role == "pull-request-handoff":
             return True
-    return _template_step_id_matches(node, slug="jira-orchestrate", step_index=14)
+    return any(
+        _template_step_id_matches(
+            node,
+            slug="jira-orchestrate",
+            step_index=step_index,
+        )
+        for step_index in (12, 13)
+    )
 
 
 def _append_story_breakdown_instructions(

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -123,7 +123,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
-        assert len(jira_orchestrate_steps) == 13
+        assert len(jira_orchestrate_steps) == 15
+        assert jira_orchestrate_steps.count("moonspec-implement") == 2
+        assert jira_orchestrate_steps.count("moonspec-verify") == 2
         blocker_step = jira_orchestrate_template.latest_version.steps[1]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
         assert blocker_step["type"] == "tool"
@@ -135,12 +137,28 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]
         assert "stop the orchestration immediately" in blocker_step["instructions"]
+        remediation_step = next(
+            step
+            for step in jira_orchestrate_template.latest_version.steps
+            if step["title"] == "Remediate verification gaps"
+        )
+        assert remediation_step["skill"]["id"] == "moonspec-implement"
+        assert "ADDITIONAL_WORK_NEEDED" in remediation_step["instructions"]
+        assert "verification report's gaps" in remediation_step["instructions"]
+        remediation_verify_step = next(
+            step
+            for step in jira_orchestrate_template.latest_version.steps
+            if step["title"] == "Verify remediation"
+        )
+        assert remediation_verify_step["skill"]["id"] == "moonspec-verify"
+        assert "controlling verification gate" in remediation_verify_step["instructions"]
         pr_step = next(
             step
             for step in jira_orchestrate_template.latest_version.steps
             if step["title"] == "Create pull request"
         )
         assert "pull request" in pr_step["instructions"]
+        assert "post-remediation moonspec-verify" in pr_step["instructions"]
         assert "parent workflow must use the pull request URL" in pr_step["instructions"]
         assert "explicit PR-publication step" in pr_step["instructions"]
         assert "controlling instruction for this step only" in pr_step["instructions"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1862,6 +1862,8 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "moonspec-align",
                 "moonspec-implement",
                 "moonspec-verify",
+                "moonspec-implement",
+                "moonspec-verify",
                 "auto",
                 "jira-issue-updater",
             ]
@@ -1881,7 +1883,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 context={},
             )
 
-            assert len(expanded["steps"]) == 13
+            assert len(expanded["steps"]) == 15
             assert expanded["steps"][0]["skill"]["id"] == "jira-issue-updater"
             assert "MM-328" in expanded["steps"][0]["instructions"]
             assert "In Progress" in expanded["steps"][0]["instructions"]
@@ -1918,35 +1920,47 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             ]
             assert "Jira preset brief" in expanded["steps"][2]["instructions"]
             assert "Keep the scope narrow." in expanded["steps"][3]["instructions"]
-            assert expanded["steps"][11]["title"] == "Create pull request"
-            assert expanded["steps"][11]["annotations"] == {
+            assert expanded["steps"][11]["title"] == "Remediate verification gaps"
+            assert expanded["steps"][11]["skill"]["id"] == "moonspec-implement"
+            assert "ADDITIONAL_WORK_NEEDED" in expanded["steps"][11]["instructions"]
+            assert "verification report's gaps" in expanded["steps"][11]["instructions"]
+            assert expanded["steps"][12]["title"] == "Verify remediation"
+            assert expanded["steps"][12]["skill"]["id"] == "moonspec-verify"
+            assert "controlling verification gate" in expanded["steps"][12][
+                "instructions"
+            ]
+            assert expanded["steps"][13]["title"] == "Create pull request"
+            assert expanded["steps"][13]["annotations"] == {
                 "jiraOrchestrateRole": "pull-request-handoff"
             }
-            assert "pull request title must include MM-328" in expanded["steps"][11][
+            assert "post-remediation moonspec-verify" in expanded["steps"][13][
                 "instructions"
             ]
-            assert "parent workflow must use the pull request URL" in expanded["steps"][11][
+            assert "pull request title must include MM-328" in expanded["steps"][13][
                 "instructions"
             ]
-            assert "explicit PR-publication step" in expanded["steps"][11][
+            assert "parent workflow must use the pull request URL" in expanded["steps"][13][
                 "instructions"
             ]
-            assert "controlling instruction for this step only" in expanded["steps"][11][
+            assert "explicit PR-publication step" in expanded["steps"][13][
                 "instructions"
             ]
-            assert "merge automation" in expanded["steps"][11]["instructions"]
-            assert "non-draft pull request" in expanded["steps"][11]["instructions"]
-            assert "isDraft value is false" in expanded["steps"][11]["instructions"]
-            assert "confirmed non-draft" in expanded["steps"][11]["instructions"]
-            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][11][
+            assert "controlling instruction for this step only" in expanded["steps"][13][
                 "instructions"
             ]
-            assert expanded["steps"][12]["skill"]["id"] == "jira-issue-updater"
-            assert "pull_request_url" in expanded["steps"][12]["instructions"]
-            assert "stop without changing Jira" in expanded["steps"][12][
+            assert "merge automation" in expanded["steps"][13]["instructions"]
+            assert "non-draft pull request" in expanded["steps"][13]["instructions"]
+            assert "isDraft value is false" in expanded["steps"][13]["instructions"]
+            assert "confirmed non-draft" in expanded["steps"][13]["instructions"]
+            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][13][
                 "instructions"
             ]
-            assert "Code Review" in expanded["steps"][12]["instructions"]
+            assert expanded["steps"][14]["skill"]["id"] == "jira-issue-updater"
+            assert "pull_request_url" in expanded["steps"][14]["instructions"]
+            assert "stop without changing Jira" in expanded["steps"][14][
+                "instructions"
+            ]
+            assert "Code Review" in expanded["steps"][14]["instructions"]
             assert all(
                 step["title"] != "Return Jira orchestration report"
                 for step in expanded["steps"]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1387,17 +1387,21 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
             )
 
     task = expanded_parameters["task"]
-    assert expanded_parameters["stepCount"] == 13
-    assert len(task["steps"]) == 13
+    assert expanded_parameters["stepCount"] == 15
+    assert len(task["steps"]) == 15
     assert task["steps"][0]["title"] == "Move Jira issue to In Progress"
     assert task["steps"][0]["skill"]["id"] == "jira-issue-updater"
     assert "MM-501" in task["steps"][0]["instructions"]
     assert task["steps"][7]["skill"]["id"] == "moonspec-tasks"
     assert task["steps"][9]["skill"]["id"] == "moonspec-implement"
-    assert task["steps"][11]["title"] == "Create pull request"
-    assert task["steps"][12]["title"] == "Move Jira issue to Code Review"
+    assert task["steps"][11]["title"] == "Remediate verification gaps"
+    assert task["steps"][11]["skill"]["id"] == "moonspec-implement"
+    assert task["steps"][12]["title"] == "Verify remediation"
+    assert task["steps"][12]["skill"]["id"] == "moonspec-verify"
+    assert task["steps"][13]["title"] == "Create pull request"
+    assert task["steps"][14]["title"] == "Move Jira issue to Code Review"
     assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
-    assert len(task["appliedStepTemplates"][0]["stepIds"]) == 13
+    assert len(task["appliedStepTemplates"][0]["stepIds"]) == 15
     assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
     assert task["authoredPresets"][0]["presetVersion"] == "1.0.0"
     assert "authoredPresets" not in task["appliedStepTemplates"][0]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2270,6 +2270,58 @@ def test_runtime_planner_preserves_jira_orchestrate_pr_handoff_instructions():
     )
     assert "commit your work" not in pr_node["inputs"]["instructions"]
 
+
+@pytest.mark.parametrize("step_index", [12, 13])
+def test_runtime_planner_preserves_jira_orchestrate_pr_handoff_step_id_fallback(
+    step_index,
+):
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run Jira Orchestrate for THOR-352.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "appliedStepTemplates": [{"slug": "jira-orchestrate"}],
+                "steps": [
+                    {
+                        "id": "tpl:jira-orchestrate:1.0.0:11:verify",
+                        "title": "Verify completion",
+                        "tool": {"type": "skill", "name": "moonspec-verify"},
+                        "instructions": "Verify the Jira issue.",
+                    },
+                    {
+                        "id": f"tpl:jira-orchestrate:1.0.0:{step_index:02d}:create-pr",
+                        "title": "Create pull request",
+                        "instructions": (
+                            "Create a pull request and record pull_request_url."
+                        ),
+                    },
+                    {
+                        "id": "tpl:jira-orchestrate:1.0.0:14:code-review",
+                        "title": "Move Jira issue to Code Review",
+                        "tool": {"type": "skill", "name": "jira-issue-updater"},
+                        "instructions": "Move the Jira issue to Code Review.",
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    pr_node = plan["nodes"][1]
+    assert pr_node["inputs"]["title"] == "Create pull request"
+    assert "Create a pull request" in pr_node["inputs"]["instructions"]
+    assert (
+        "Do NOT push or create a pull request"
+        not in pr_node["inputs"]["instructions"]
+    )
+    assert "commit your work" not in pr_node["inputs"]["instructions"]
+
+
 def test_runtime_planner_publish_pr_skips_gh_suffix_for_jules():
     """Jules uses API automationMode AUTO_CREATE_PR; do not inject gh CLI text."""
     planner = _build_runtime_planner()


### PR DESCRIPTION
## Summary

- Adds a Jira Orchestrate remediation step that runs `moonspec-implement` when the first verify result reports `ADDITIONAL_WORK_NEEDED`.
- Adds a post-remediation `moonspec-verify` gate before PR creation.
- Updates seeded-template, task expansion, and runtime-shaping tests for the new 15-step Jira Orchestrate flow.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/integration/test_startup_task_template_seeding.py`