### PR TITLE
The floating bar on the create task page used to contain the GitHub repository dropdown, the branch dropdown, and the publish mode dropdown. These hav

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -8298,7 +8298,7 @@ describe.skip("Task Create Entrypoint", () => {
     );
   });
 
-  it("keeps step authoring and branch controls inside Steps with one Submit floating bar", async () => {
+  it("keeps step authoring controls in Steps and branch controls in the Submit floating bar", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const primaryStepLabel = await screen.findByText("Step 1");
@@ -8327,12 +8327,10 @@ describe.skip("Task Create Entrypoint", () => {
     const stepExtension = addStepButton.closest(".queue-step-extension");
     const floatingBar = createButton.closest(".queue-floating-bar");
     const floatingBarRow = createButton.closest(".queue-floating-bar-row");
-    const authoringControlsRow = repoInput.closest(".queue-authoring-controls-row");
 
     expect(stepExtension).not.toBeNull();
     expect(floatingBar).not.toBeNull();
     expect(floatingBarRow).not.toBeNull();
-    expect(authoringControlsRow).not.toBeNull();
     expect(addStepButton.closest('[data-canonical-create-section="Steps"]')).toBe(
       stepsSection,
     );
@@ -8342,18 +8340,11 @@ describe.skip("Task Create Entrypoint", () => {
     expect(floatingBar?.classList.contains("queue-step-submit-actions")).toBe(
       true,
     );
-    expect(repoInput.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
+    expect(repoInput.closest(".queue-floating-bar-row")).toBe(floatingBarRow);
+    expect(branchSelect.closest(".queue-floating-bar-row")).toBe(floatingBarRow);
+    expect(publishModeSelect.closest(".queue-floating-bar-row")).toBe(
+      floatingBarRow,
     );
-    expect(branchSelect.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
-    );
-    expect(publishModeSelect.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
-    );
-    expect(repoInput.closest(".queue-floating-bar-row")).toBeNull();
-    expect(branchSelect.closest(".queue-floating-bar-row")).toBeNull();
-    expect(publishModeSelect.closest(".queue-floating-bar-row")).toBeNull();
     expect(reportToggle.closest(".queue-floating-bar")).toBeNull();
     expect(createButton.closest('[data-canonical-create-section="Submit"]')).toBe(
       submitSection,
@@ -8361,11 +8352,15 @@ describe.skip("Task Create Entrypoint", () => {
     expect(
       reportToggle.closest('[data-canonical-create-section="Execution controls"]'),
     ).not.toBeNull();
-    expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBeNull();
-    expect(branchSelect.closest('[data-canonical-create-section="Submit"]')).toBeNull();
+    expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
+    );
+    expect(branchSelect.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
+    );
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Submit"]'),
-    ).toBeNull();
+    ).toBe(submitSection);
     expect(createButton.classList.contains("queue-submit-primary--icon")).toBe(
       true,
     );
@@ -8373,13 +8368,13 @@ describe.skip("Task Create Entrypoint", () => {
     expect(createButton.getAttribute("title")).toBe("Create this task");
     expect(
       repoInput.closest('[data-canonical-create-section="Steps"]'),
-    ).toBe(stepsSection);
+    ).toBeNull();
     expect(
       branchSelect.closest('[data-canonical-create-section="Steps"]'),
-    ).toBe(stepsSection);
+    ).toBeNull();
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Steps"]'),
-    ).toBe(stepsSection);
+    ).toBeNull();
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Execution context"]'),
     ).toBeNull();
@@ -12788,7 +12783,7 @@ describe("Task Create MM-641 authoring validation", () => {
     fetchSpy.mockRestore();
   });
 
-  it("renders repository branch and publish mode inside the Steps card", async () => {
+  it("renders repository branch and publish mode inside the floating Submit bar", async () => {
     renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
 
     const stepsSection = await waitFor(() => {
@@ -12807,41 +12802,33 @@ describe("Task Create MM-641 authoring validation", () => {
     const publishModeSelect = screen.getByLabelText("Publish Mode");
     const floatingBar = createButton.closest(".queue-floating-bar");
     const floatingBarRow = createButton.closest(".queue-floating-bar-row");
-    const authoringControls = repoInput.closest(".queue-step-authoring-controls");
-    const authoringControlsRow = repoInput.closest(".queue-authoring-controls-row");
 
     expect(floatingBar).not.toBeNull();
     expect(floatingBarRow).not.toBeNull();
-    expect(authoringControls).not.toBeNull();
-    expect(authoringControlsRow).not.toBeNull();
-    expect(repoInput.closest(".queue-floating-bar")).toBeNull();
-    expect(branchInput.closest(".queue-floating-bar")).toBeNull();
-    expect(publishModeSelect.closest(".queue-floating-bar")).toBeNull();
-    expect(repoInput.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
-    );
-    expect(branchInput.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
-    );
-    expect(publishModeSelect.closest(".queue-authoring-controls-row")).toBe(
-      authoringControlsRow,
+    expect(repoInput.closest(".queue-floating-bar")).toBe(floatingBar);
+    expect(branchInput.closest(".queue-floating-bar")).toBe(floatingBar);
+    expect(publishModeSelect.closest(".queue-floating-bar")).toBe(floatingBar);
+    expect(repoInput.closest(".queue-floating-bar-row")).toBe(floatingBarRow);
+    expect(branchInput.closest(".queue-floating-bar-row")).toBe(floatingBarRow);
+    expect(publishModeSelect.closest(".queue-floating-bar-row")).toBe(
+      floatingBarRow,
     );
     expect(createButton.closest(".queue-floating-bar")).toBe(floatingBar);
     expect(createButton.closest(".queue-floating-bar-row")).toBe(floatingBarRow);
-    expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBeNull();
-    expect(branchInput.closest('[data-canonical-create-section="Submit"]')).toBeNull();
+    expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
+    );
+    expect(branchInput.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
+    );
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Submit"]'),
-    ).toBeNull();
-    expect(repoInput.closest('[data-canonical-create-section="Steps"]')).toBe(
-      stepsSection,
-    );
-    expect(branchInput.closest('[data-canonical-create-section="Steps"]')).toBe(
-      stepsSection,
-    );
+    ).toBe(submitSection);
+    expect(repoInput.closest('[data-canonical-create-section="Steps"]')).toBeNull();
+    expect(branchInput.closest('[data-canonical-create-section="Steps"]')).toBeNull();
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Steps"]'),
-    ).toBe(stepsSection);
+    ).toBeNull();
     expect(createButton.closest('[data-canonical-create-section="Submit"]')).toBe(
       submitSection,
     );
@@ -12877,21 +12864,21 @@ describe("Task Create MM-641 authoring validation", () => {
   it("submits a combined valid MM-641 draft without targetBranch", async () => {
     renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
 
-    const stepsSection = document.querySelector<HTMLElement>(
-      '[data-canonical-create-section="Steps"]',
+    const submitSection = document.querySelector<HTMLElement>(
+      '[data-canonical-create-section="Submit"]',
     );
     const repoInput = await screen.findByLabelText("GitHub Repo");
     const branchInput = screen.getByLabelText("Branch");
     const publishModeSelect = screen.getByLabelText("Publish Mode");
-    expect(repoInput.closest('[data-canonical-create-section="Steps"]')).toBe(
-      stepsSection,
+    expect(repoInput.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
     );
-    expect(branchInput.closest('[data-canonical-create-section="Steps"]')).toBe(
-      stepsSection,
+    expect(branchInput.closest('[data-canonical-create-section="Submit"]')).toBe(
+      submitSection,
     );
     expect(
-      publishModeSelect.closest('[data-canonical-create-section="Steps"]'),
-    ).toBe(stepsSection);
+      publishModeSelect.closest('[data-canonical-create-section="Submit"]'),
+    ).toBe(submitSection);
 
     fireEvent.change(screen.getByLabelText("Instructions"), {
       target: { value: "Implement MM-641 from the Jira preset brief." },

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -8853,90 +8853,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               </button>
             </div>
 
-            <div
-              className="queue-step-authoring-controls"
-              role="group"
-              aria-label="Repository, branch, and publish mode"
-            >
-              {branchStatusMessage ? (
-                <p
-                  className={
-                    branchOptionsQuery.isError || selectedBranchIsStale
-                      ? "queue-authoring-controls-status notice error"
-                      : "queue-authoring-controls-status small"
-                  }
-                >
-                  {branchStatusMessage}
-                </p>
-              ) : null}
-              <div className="queue-authoring-controls-row">
-                <div
-                  className="queue-inline-selector queue-inline-selector--repo"
-                  title={repositoryTooltip}
-                >
-                  <RepoIcon />
-                  <input
-                    name="repository"
-                    aria-label="GitHub Repo"
-                    title={repositoryTooltip}
-                    list={REPOSITORY_OPTIONS_DATALIST_ID}
-                    value={repository}
-                    placeholder="owner/repo"
-                    onChange={(event) =>
-                      handleRepositoryChange(event.target.value)
-                    }
-                  />
-                </div>
-                <div
-                  className="queue-inline-selector queue-inline-selector--branch"
-                  title={branchTooltip}
-                >
-                  <BranchIcon />
-                  <input
-                    name="branch"
-                    aria-label="Branch"
-                    title={branchTooltip}
-                    list={BRANCH_OPTIONS_DATALIST_ID}
-                    value={branch}
-                    placeholder={
-                      branchOptionsQuery.isLoading
-                        ? "Loading branches..."
-                        : "Branch"
-                    }
-                    disabled={branchControlDisabled}
-                    onChange={(event) => {
-                      setBranchTouched(true);
-                      setBranch(event.target.value);
-                    }}
-                  />
-                </div>
-                <div
-                  className="queue-inline-selector queue-inline-selector--publish"
-                  title={publishModeTooltip}
-                >
-                  <PublishIcon />
-                  <select
-                    name="publishMode"
-                    aria-label="Publish Mode"
-                    title={publishModeTooltip}
-                    value={publishMode}
-                    onChange={(event) => setPublishMode(event.target.value)}
-                    disabled={!mergeAutomationAvailable}
-                  >
-                    <option value="none">None</option>
-                    <option value="branch">Branch</option>
-                    <option value="pr">PR</option>
-                    <option
-                      value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}
-                      disabled={!mergeAutomationAvailable}
-                    >
-                      PR with Merge Automation
-                    </option>
-                  </select>
-                </div>
-              </div>
-            </div>
-
           </div>
         </section>
 
@@ -9358,7 +9274,82 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           role="group"
           aria-label="Task submission controls"
         >
+          {branchStatusMessage ? (
+            <p
+              className={
+                branchOptionsQuery.isError || selectedBranchIsStale
+                  ? "queue-authoring-controls-status notice error"
+                  : "queue-authoring-controls-status small"
+              }
+            >
+              {branchStatusMessage}
+            </p>
+          ) : null}
           <div className="queue-floating-bar-row">
+            <div
+              className="queue-inline-selector queue-inline-selector--repo"
+              title={repositoryTooltip}
+            >
+              <RepoIcon />
+              <input
+                name="repository"
+                aria-label="GitHub Repo"
+                title={repositoryTooltip}
+                list={REPOSITORY_OPTIONS_DATALIST_ID}
+                value={repository}
+                placeholder="owner/repo"
+                onChange={(event) =>
+                  handleRepositoryChange(event.target.value)
+                }
+              />
+            </div>
+            <div
+              className="queue-inline-selector queue-inline-selector--branch"
+              title={branchTooltip}
+            >
+              <BranchIcon />
+              <input
+                name="branch"
+                aria-label="Branch"
+                title={branchTooltip}
+                list={BRANCH_OPTIONS_DATALIST_ID}
+                value={branch}
+                placeholder={
+                  branchOptionsQuery.isLoading
+                    ? "Loading branches..."
+                    : "Branch"
+                }
+                disabled={branchControlDisabled}
+                onChange={(event) => {
+                  setBranchTouched(true);
+                  setBranch(event.target.value);
+                }}
+              />
+            </div>
+            <div
+              className="queue-inline-selector queue-inline-selector--publish"
+              title={publishModeTooltip}
+            >
+              <PublishIcon />
+              <select
+                name="publishMode"
+                aria-label="Publish Mode"
+                title={publishModeTooltip}
+                value={publishMode}
+                onChange={(event) => setPublishMode(event.target.value)}
+                disabled={!mergeAutomationAvailable}
+              >
+                <option value="none">None</option>
+                <option value="branch">Branch</option>
+                <option value="pr">PR</option>
+                <option
+                  value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}
+                  disabled={!mergeAutomationAvailable}
+                >
+                  PR with Merge Automation
+                </option>
+              </select>
+            </div>
             <button
               type="submit"
               ref={submitButtonRef}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3571,10 +3571,14 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: grid;
   width: 100%;
   justify-self: stretch;
-  grid-template-columns: auto;
+  grid-template-columns:
+    minmax(12rem, 1.65fr)
+    minmax(10rem, 1.45fr)
+    minmax(8rem, 1fr)
+    auto;
   gap: 0.5rem;
   align-items: center;
-  justify-content: end;
+  justify-content: stretch;
 }
 
 .queue-floating-bar-status {
@@ -3762,7 +3766,15 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .queue-floating-bar-row {
+    grid-template-columns:
+      minmax(0, 1fr)
+      minmax(9.5rem, 0.8fr)
+      auto;
     justify-content: stretch;
+  }
+
+  .queue-floating-bar-row .queue-inline-selector--repo {
+    grid-column: 1 / -1;
   }
 
   .queue-floating-bar-row .queue-submit-primary {


### PR DESCRIPTION
The floating bar on the create task page used to contain the GitHub repository dropdown, the branch dropdown, and the publish mode dropdown. These have moved to the bottom of the steps section, but it would be preferred for them to remain part of the floating bar. Fix this issue.