### PR TITLE
[codex] Fix publish lease for missing branch tracking refs

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -228,7 +228,7 @@ def build_git_push_with_lease_args(
     lease = (
         f"--force-with-lease=refs/heads/{branch_name}:{remote_sha}"
         if remote_sha
-        else f"--force-with-lease=refs/heads/{branch_name}"
+        else f"--force-with-lease=refs/heads/{branch_name}:"
     )
     return ["push", "-u", lease, "origin", branch_name]
 
@@ -6696,30 +6696,12 @@ class TemporalAgentRuntimeActivities:
                     result["push_commit_count"] = final_commit_count
                 return result
 
-            remote_sha: str | None = None
-            remote_sha_proc = await asyncio.create_subprocess_exec(
-                *self._workspace_git_command(
-                    workspace,
-                    "rev-parse",
-                    "--verify",
-                    f"refs/remotes/origin/{current_branch}",
-                ),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            remote_sha = await self._resolve_workspace_remote_branch_sha(
+                workspace=workspace,
+                branch=current_branch,
+                run_id=run_id,
                 env=command_env,
             )
-            try:
-                remote_sha_stdout, _ = await asyncio.wait_for(
-                    remote_sha_proc.communicate(), timeout=10,
-                )
-            except asyncio.TimeoutError:
-                remote_sha_proc.kill()
-                await remote_sha_proc.wait()
-                raise
-            if remote_sha_proc.returncode == 0:
-                remote_sha = remote_sha_stdout.decode(
-                    "utf-8", errors="replace"
-                ).strip() or None
 
             push_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
@@ -6761,9 +6743,16 @@ class TemporalAgentRuntimeActivities:
                 )
                 if classified.get("push_status") == "lease_conflict":
                     retry_metadata: dict[str, Any] = {"push_retry_count": 1}
+                    remote_tracking_ref = f"refs/remotes/origin/{current_branch}"
                     fetch_proc = await asyncio.create_subprocess_exec(
                         *self._workspace_git_command(
-                            workspace, "fetch", "origin", current_branch,
+                            workspace,
+                            "fetch",
+                            "origin",
+                            (
+                                f"refs/heads/{current_branch}:"
+                                f"{remote_tracking_ref}"
+                            ),
                         ),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
@@ -6791,7 +6780,6 @@ class TemporalAgentRuntimeActivities:
                             ).strip()
                         )
                     else:
-                        remote_tracking_ref = f"refs/remotes/origin/{current_branch}"
                         local_head_after_fetch = await self._resolve_workspace_head_sha(
                             workspace=workspace,
                             run_id=run_id,
@@ -6803,6 +6791,15 @@ class TemporalAgentRuntimeActivities:
                             run_id=run_id,
                             env=command_env,
                         )
+                        if not remote_sha_after_fetch:
+                            remote_sha_after_fetch = (
+                                await self._resolve_workspace_remote_branch_sha(
+                                    workspace=workspace,
+                                    branch=current_branch,
+                                    run_id=run_id,
+                                    env=command_env,
+                                )
+                            )
                         if (
                             local_head_after_fetch
                             and remote_sha_after_fetch
@@ -6916,6 +6913,78 @@ class TemporalAgentRuntimeActivities:
                 "push_status": "failed",
                 "push_error": str(exc),
             }
+
+    async def _resolve_workspace_remote_branch_sha(
+        self,
+        *,
+        workspace: str,
+        branch: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> str | None:
+        """Resolve a remote branch SHA without requiring a tracking ref.
+
+        Managed workspaces may not fetch every task branch into
+        ``refs/remotes/origin``. A force-with-lease push must still pin the
+        current remote value when the branch exists, otherwise Git reports
+        ``stale info`` even though the operation is safe to retry.
+        """
+
+        branch_name = str(branch or "").strip()
+        if not branch_name:
+            return None
+        remote_ref = f"refs/remotes/origin/{branch_name}"
+        remote_sha = await self._resolve_workspace_ref_sha(
+            workspace=workspace,
+            ref=remote_ref,
+            run_id=run_id,
+            env=env,
+        )
+        if remote_sha:
+            return remote_sha
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(
+                    workspace,
+                    "ls-remote",
+                    "origin",
+                    f"refs/heads/{branch_name}",
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=30,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return None
+            if proc.returncode != 0:
+                logger.debug(
+                    "Could not resolve remote branch SHA for run %s: %s",
+                    run_id,
+                    stderr_bytes.decode("utf-8", errors="replace").strip(),
+                )
+                return None
+            first_line = (
+                stdout_bytes.decode("utf-8", errors="replace").splitlines() or [""]
+            )[0].strip()
+            if not first_line:
+                return None
+            remote_sha = first_line.split(maxsplit=1)[0].strip()
+            return remote_sha or None
+        except Exception:
+            logger.debug(
+                "Failed to resolve remote branch SHA for run %s (branch=%s)",
+                run_id,
+                branch_name,
+                exc_info=True,
+            )
+            return None
 
     async def _resolve_workspace_ref_sha(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6750,7 +6750,7 @@ class TemporalAgentRuntimeActivities:
                             "fetch",
                             "origin",
                             (
-                                f"refs/heads/{current_branch}:"
+                                f"+refs/heads/{current_branch}:"
                                 f"{remote_tracking_ref}"
                             ),
                         ),

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -569,6 +569,69 @@ class TestPushWorkspaceBranch:
             ]
 
     @pytest.mark.asyncio
+    async def test_push_uses_ls_remote_when_tracking_ref_is_missing(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse --abbrev-ref HEAD
+                proc.communicate = AsyncMock(return_value=(b"feature/no-tracking\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # missing local tracking ref
+                proc.communicate = AsyncMock(
+                    return_value=(b"", b"fatal: Needed a single revision")
+                )
+                proc.returncode = 128
+            elif call_count == 5:  # remote branch exists
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"remote-branch-sha\trefs/heads/feature/no-tracking\n",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif call_count == 6:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # final HEAD
+                proc.communicate = AsyncMock(return_value=(b"local-head-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 8:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/no-tracking"
+        assert any(
+            list(call[-3:]) == ["ls-remote", "origin", "refs/heads/feature/no-tracking"]
+            for call in recorded_calls
+        )
+        assert any(
+            "--force-with-lease=refs/heads/feature/no-tracking:remote-branch-sha"
+            in call
+            for call in recorded_calls
+            if "push" in call
+        )
+
+    @pytest.mark.asyncio
     async def test_push_failure(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -737,6 +737,14 @@ class TestPushWorkspaceBranch:
             for call in push_calls
         )
         assert any(
+            list(call[-3:]) == [
+                "fetch",
+                "origin",
+                "+refs/heads/feature/retry-push:refs/remotes/origin/feature/retry-push",
+            ]
+            for call in recorded_calls
+        )
+        assert any(
             list(call[-2:]) == ["rebase", "refs/remotes/origin/feature/retry-push"]
             for call in recorded_calls
         )

--- a/tests/unit/workflows/temporal/test_publish_branch_lease.py
+++ b/tests/unit/workflows/temporal/test_publish_branch_lease.py
@@ -23,6 +23,18 @@ def test_build_git_push_with_lease_args_pins_recorded_remote_sha() -> None:
     ]
 
 
+def test_build_git_push_with_lease_args_uses_empty_expect_for_new_branch() -> None:
+    args = build_git_push_with_lease_args(branch="feature/new")
+
+    assert args == [
+        "push",
+        "-u",
+        "--force-with-lease=refs/heads/feature/new:",
+        "origin",
+        "feature/new",
+    ]
+
+
 def test_classify_git_push_failure_returns_retryable_lease_conflict() -> None:
     result = classify_git_push_failure(
         stderr="! [rejected] feature -> feature (stale info)",


### PR DESCRIPTION
## Summary
- Resolve remote task branch SHAs with `git ls-remote` when a managed workspace lacks an `origin/<branch>` tracking ref.
- Use an explicit empty `--force-with-lease=<ref>:` expectation only for true new branch creation.
- Fetch conflicted task branches with an explicit refspec before rebase/retry.

## Root Cause
A MoonMind task failed during final PR publishing because the remote task branch existed, but the managed workspace had no local remote-tracking ref for it. The publish helper built an unpinned `--force-with-lease`, which Git rejected with `stale info`.

## Validation
- `pytest tests/unit/workflows/temporal/test_publish_branch_lease.py tests/unit/services/temporal/test_fetch_result_push.py -q`
- `python3.12 -m pytest tests/unit/workflows/temporal/test_publish_branch_lease.py tests/unit/services/temporal/test_fetch_result_push.py -q`
- `git diff --check`

## Notes
`./tools/test_unit.sh` is blocked in this checkout because the repo-local `.venv` uses Python 3.11.13 and cannot collect an unrelated Python 3.12-style f-string in `tests/unit/services/temporal/runtime/test_managed_session_controller.py`. The focused publish tests pass under Python 3.12.