### PR TITLE
The default Jira Breakdown and Orchestrate project key that's shown in the UI inputs should be MM and not TOOL.

### DIFF
--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -23,7 +23,7 @@ inputs:
     label: Jira Project Key
     type: text
     required: true
-    default: TOOL
+    default: MM
   - name: jira_issue_type
     label: Jira Issue Type
     type: text

--- a/api_service/data/task_step_templates/jira-breakdown.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown.yaml
@@ -22,7 +22,7 @@ inputs:
     label: Jira Project Key
     type: text
     required: true
-    default: TOOL
+    default: MM
   - name: jira_issue_type
     label: Jira Issue Type
     type: text

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -71,6 +71,7 @@ _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS = frozenset(
     {_JIRA_BREAKDOWN_SLUG, _JIRA_BREAKDOWN_ORCHESTRATE_SLUG}
 )
 _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
+_JIRA_BREAKDOWN_REPLACEABLE_PROJECT_DEFAULTS = frozenset({"TOOL", "MM"})
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
 _NATIVE_BOOLEAN_TEMPLATE_PATTERN = re.compile(r"^\{\{.*\}\}$", re.DOTALL)
@@ -766,7 +767,7 @@ def _apply_contextual_input_overrides(
         if (
             not submitted_project
             or submitted_project == schema_project
-            or submitted_project == "TOOL"
+            or submitted_project in _JIRA_BREAKDOWN_REPLACEABLE_PROJECT_DEFAULTS
         ):
             adjusted[_JIRA_BREAKDOWN_PROJECT_INPUT] = project_key
     return adjusted

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1887,7 +1887,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
-                    "jira_project_key": "TOOL",
+                    "jira_project_key": "MM",
                     "jira_issue_type": "Story",
                 },
                 context={},
@@ -1897,14 +1897,14 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
             assert "docs/Designs/RuntimeTypes.md" in expanded["steps"][0]["instructions"]
             assert expanded["steps"][1]["skill"]["id"] == "story.create_jira_issues"
-            assert "Jira Story issue in project TOOL" in expanded["steps"][1]["instructions"]
+            assert "Jira Story issue in project MM" in expanded["steps"][1]["instructions"]
             assert "linear_blocker_chain" in expanded["steps"][1]["instructions"]
             assert "ordered blocker chain" in expanded["steps"][1]["instructions"]
             assert "Source Document path" in expanded["steps"][1]["instructions"]
             assert expanded["steps"][1]["storyOutput"] == {
                 "mode": "jira",
                 "jira": {
-                    "projectKey": "TOOL",
+                    "projectKey": "MM",
                     "issueTypeName": "Story",
                     "boardId": "",
                     "dependencyMode": "linear_blocker_chain",
@@ -2005,7 +2005,7 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 for item in template["inputs"]
                 if item["name"] == "jira_project_key"
             )
-            assert project_input["default"] is None
+            assert project_input["default"] == "MM"
 
             expanded = await service.expand_template(
                 slug="jira-breakdown-orchestrate",
@@ -2147,7 +2147,7 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
                 {"mode": "claude_code"}
             )
 
-async def test_jira_breakdown_requires_project_when_multiple_allowed_without_repo_policy(
+async def test_jira_breakdown_uses_seeded_default_when_multiple_allowed_without_repo_policy(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2178,21 +2178,22 @@ async def test_jira_breakdown_requires_project_when_multiple_allowed_without_rep
                 for item in template["inputs"]
                 if item["name"] == "jira_project_key"
             )
-            assert project_input["default"] is None
+            assert project_input["default"] == "MM"
 
-            with pytest.raises(TaskTemplateValidationError):
-                await service.expand_template(
-                    slug="jira-breakdown",
-                    scope="global",
-                    scope_ref=None,
-                    version="1.0.0",
-                    inputs={
-                        "feature_request": "docs/Designs/RuntimeTypes.md",
-                        "jira_issue_type": "Story",
-                        "jira_dependency_mode": "none",
-                    },
-                    context={},
-                )
+            expanded = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_issue_type": "Story",
+                    "jira_dependency_mode": "none",
+                },
+                context={},
+            )
+
+            assert expanded["steps"][1]["storyOutput"]["jira"]["projectKey"] == "MM"
 
 async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
     seed_dir = (

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2014,7 +2014,7 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
-                    "jira_project_key": "TOOL",
+                    "jira_project_key": "MM",
                     "jira_issue_type": "Story",
                     "jira_dependency_mode": "linear_blocker_chain",
                     "publish_mode": "pr",


### PR DESCRIPTION
The default Jira Breakdown and Orchestrate project key that's shown in the UI inputs should be MM and not TOOL.