### PR TITLE
[codex] Recover Codex quota failures from logs

### DIFF
--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -17,6 +17,7 @@ _RATE_LIMIT_MARKERS = (
     "rate-limit",
     "too many requests",
     "usage limit",
+    "usage_limit_reached",
     "hit your limit",
     "send a request to your admin",
 )
@@ -107,6 +108,19 @@ def provider_error_requires_cooldown(
         PROVIDER_CAPACITY_ERROR_CODE,
     } or normalized_retry == RETRY_AFTER_COOLDOWN_RECOMMENDATION
 
+def provider_failure_search_markers() -> tuple[str, ...]:
+    """Return the provider-failure markers suitable for coarse log searches."""
+
+    return tuple(
+        dict.fromkeys(
+            (
+                *_AUTH_FAILURE_MARKERS,
+                *_RATE_LIMIT_MARKERS,
+                *_CAPACITY_MARKERS,
+            )
+        )
+    )
+
 __all__ = [
     "PROVIDER_AUTH_ERROR_CODE",
     "PROVIDER_CAPACITY_ERROR_CODE",
@@ -115,5 +129,6 @@ __all__ = [
     "RETRY_AFTER_COOLDOWN_RECOMMENDATION",
     "ProviderFailureClassification",
     "classify_provider_failure",
+    "provider_failure_search_markers",
     "provider_error_requires_cooldown",
 ]

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -40,6 +40,7 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
+from moonmind.workflows.provider_failures import classify_provider_failure
 
 _STATE_FILENAME = ".moonmind-codex-session-state.json"
 _READY_LOOP_SECONDS = 3600.0
@@ -52,7 +53,22 @@ _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
 _LOG_RECOVERY_MAX_ROWS = 200
+_LOG_RECOVERY_PROVIDER_MAX_ROWS = 1000
 _LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
+_LOG_RECOVERY_PROVIDER_MARKERS: tuple[str, ...] = (
+    "429",
+    "rate limit",
+    "too many requests",
+    "usage limit",
+    "usage_limit_reached",
+    "hit your limit",
+    "send a request to your admin",
+    "high demand",
+    "overloaded",
+    "temporarily unavailable",
+    "service unavailable",
+    "gateway timeout",
+)
 
 @dataclass(frozen=True)
 class _RolloutTurnScan:
@@ -1128,7 +1144,55 @@ class CodexManagedSessionRuntime:
         recovered = "".join(characters).strip()
         return recovered or None
 
-    def _extract_turn_error_from_logs(self, vendor_turn_id: str) -> str | None:
+    @classmethod
+    def _extract_log_error_text(cls, text: str) -> str | None:
+        marker = "Turn error:"
+        marker_index = text.find(marker)
+        if marker_index >= 0:
+            recovered = text[marker_index + len(marker) :].strip()
+            if recovered:
+                return recovered
+        recovered = cls._extract_quoted_log_field(text, "error.message")
+        if recovered:
+            return recovered
+        received_marker = "Received message "
+        received_index = text.find(received_marker)
+        if received_index >= 0:
+            raw_json = text[received_index + len(received_marker) :].strip()
+            try:
+                payload = json.loads(raw_json)
+            except json.JSONDecodeError:
+                payload = None
+            if isinstance(payload, Mapping):
+                error_payload = payload.get("error")
+                recovered = cls._error_text_from_value(error_payload)
+                if recovered:
+                    status_code = payload.get("status_code")
+                    status_suffix = (
+                        f" (status {status_code})" if status_code is not None else ""
+                    )
+                    return recovered + status_suffix
+        return None
+
+    @staticmethod
+    def _sqlite_timestamp_cutoff(turn_started_at: float | None) -> int | None:
+        if turn_started_at is None:
+            return None
+        try:
+            return max(
+                0,
+                int(float(turn_started_at) - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS),
+            )
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def _extract_turn_error_from_logs(
+        self,
+        vendor_turn_id: str,
+        *,
+        turn_started_at: float | None = None,
+    ) -> str | None:
+        timestamp_cutoff = self._sqlite_timestamp_cutoff(turn_started_at)
         for log_path in sorted(
             self._codex_home_path.glob("logs_*.sqlite"),
             key=self._log_shard_sort_key,
@@ -1164,18 +1228,40 @@ class CodexManagedSessionRuntime:
                         ),
                         (f"%{vendor_turn_id}%", _LOG_RECOVERY_MAX_ROWS),
                     ).fetchall()
+                    provider_rows: list[tuple[Any, ...]] = []
+                    if timestamp_cutoff is not None and "ts" in available_columns:
+                        quoted_ts_column = self._quoted_sqlite_identifier("ts")
+                        marker_clauses = " OR ".join(
+                            f"{quoted_text_column} LIKE ?"
+                            for _marker in _LOG_RECOVERY_PROVIDER_MARKERS
+                        )
+                        provider_rows = connection.execute(
+                            (
+                                f"SELECT {quoted_text_column} FROM \"logs\" "
+                                f"WHERE {quoted_ts_column} >= ? "
+                                f"AND ({marker_clauses}) "
+                                f"ORDER BY \"id\" DESC LIMIT ?"
+                            ),
+                            (
+                                timestamp_cutoff,
+                                *(
+                                    f"%{marker}%"
+                                    for marker in _LOG_RECOVERY_PROVIDER_MARKERS
+                                ),
+                                _LOG_RECOVERY_PROVIDER_MAX_ROWS,
+                            ),
+                        ).fetchall()
             except (ValueError, sqlite3.Error):
                 continue
             for (raw_text,) in rows:
                 text = str(raw_text or "").strip()
-                marker = "Turn error:"
-                marker_index = text.find(marker)
-                if marker_index >= 0:
-                    recovered = text[marker_index + len(marker) :].strip()
-                    if recovered:
-                        return recovered
-                recovered = self._extract_quoted_log_field(text, "error.message")
+                recovered = self._extract_log_error_text(text)
                 if recovered:
+                    return recovered
+            for (raw_text,) in provider_rows:
+                text = str(raw_text or "").strip()
+                recovered = self._extract_log_error_text(text)
+                if recovered and classify_provider_failure(recovered) is not None:
                     return recovered
         return None
 
@@ -1259,7 +1345,10 @@ class CodexManagedSessionRuntime:
         if scan.saw_task_complete:
             if scan.assistant_text:
                 return _TurnTerminalOutcome(status="completed")
-            recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
+            recovered_error = self._extract_turn_error_from_logs(
+                vendor_turn_id,
+                turn_started_at=turn_started_at,
+            )
             if recovered_error:
                 return _TurnTerminalOutcome(
                     status="failed",
@@ -1307,7 +1396,10 @@ class CodexManagedSessionRuntime:
                 failure_class="permanent",
             )
         if rollout_scan.saw_task_complete:
-            recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
+            recovered_error = self._extract_turn_error_from_logs(
+                vendor_turn_id,
+                turn_started_at=state.last_control_at,
+            )
             if recovered_error:
                 return _TurnTerminalOutcome(
                     status="failed",

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -40,7 +40,10 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
-from moonmind.workflows.provider_failures import classify_provider_failure
+from moonmind.workflows.provider_failures import (
+    classify_provider_failure,
+    provider_failure_search_markers,
+)
 
 _STATE_FILENAME = ".moonmind-codex-session-state.json"
 _READY_LOOP_SECONDS = 3600.0
@@ -53,22 +56,9 @@ _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
 _LOG_RECOVERY_MAX_ROWS = 200
-_LOG_RECOVERY_PROVIDER_MAX_ROWS = 1000
+_LOG_RECOVERY_PROVIDER_MAX_ROWS = 200
 _LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
-_LOG_RECOVERY_PROVIDER_MARKERS: tuple[str, ...] = (
-    "429",
-    "rate limit",
-    "too many requests",
-    "usage limit",
-    "usage_limit_reached",
-    "hit your limit",
-    "send a request to your admin",
-    "high demand",
-    "overloaded",
-    "temporarily unavailable",
-    "service unavailable",
-    "gateway timeout",
-)
+_LOG_RECOVERY_PROVIDER_MARKERS: tuple[str, ...] = provider_failure_search_markers()
 
 @dataclass(frozen=True)
 class _RolloutTurnScan:
@@ -1175,14 +1165,11 @@ class CodexManagedSessionRuntime:
         return None
 
     @staticmethod
-    def _sqlite_timestamp_cutoff(turn_started_at: float | None) -> int | None:
+    def _sqlite_provider_timestamp_cutoff(turn_started_at: float | None) -> int | None:
         if turn_started_at is None:
             return None
         try:
-            return max(
-                0,
-                int(float(turn_started_at) - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS),
-            )
+            return max(0, int(float(turn_started_at)))
         except (TypeError, ValueError, OverflowError):
             return None
 
@@ -1192,7 +1179,10 @@ class CodexManagedSessionRuntime:
         *,
         turn_started_at: float | None = None,
     ) -> str | None:
-        timestamp_cutoff = self._sqlite_timestamp_cutoff(turn_started_at)
+        provider_timestamp_cutoff = self._sqlite_provider_timestamp_cutoff(
+            turn_started_at
+        )
+        provider_rows_remaining = _LOG_RECOVERY_PROVIDER_MAX_ROWS
         for log_path in sorted(
             self._codex_home_path.glob("logs_*.sqlite"),
             key=self._log_shard_sort_key,
@@ -1229,7 +1219,11 @@ class CodexManagedSessionRuntime:
                         (f"%{vendor_turn_id}%", _LOG_RECOVERY_MAX_ROWS),
                     ).fetchall()
                     provider_rows: list[tuple[Any, ...]] = []
-                    if timestamp_cutoff is not None and "ts" in available_columns:
+                    if (
+                        provider_timestamp_cutoff is not None
+                        and provider_rows_remaining > 0
+                        and "ts" in available_columns
+                    ):
                         quoted_ts_column = self._quoted_sqlite_identifier("ts")
                         marker_clauses = " OR ".join(
                             f"{quoted_text_column} LIKE ?"
@@ -1243,14 +1237,15 @@ class CodexManagedSessionRuntime:
                                 f"ORDER BY \"id\" DESC LIMIT ?"
                             ),
                             (
-                                timestamp_cutoff,
+                                provider_timestamp_cutoff,
                                 *(
                                     f"%{marker}%"
                                     for marker in _LOG_RECOVERY_PROVIDER_MARKERS
                                 ),
-                                _LOG_RECOVERY_PROVIDER_MAX_ROWS,
+                                provider_rows_remaining,
                             ),
                         ).fetchall()
+                        provider_rows_remaining -= len(provider_rows)
             except (ValueError, sqlite3.Error):
                 continue
             for (raw_text,) in rows:
@@ -1263,6 +1258,8 @@ class CodexManagedSessionRuntime:
                 recovered = self._extract_log_error_text(text)
                 if recovered and classify_provider_failure(recovered) is not None:
                     return recovered
+            if provider_rows_remaining <= 0:
+                break
         return None
 
     def _reset_skill_outcome(self) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from datetime import UTC, datetime, timedelta
 import sqlite3
 from pathlib import Path
@@ -49,6 +50,32 @@ def _write_fake_codex_logs(
             connection.execute(
                 "INSERT INTO logs (feedback_log_body) VALUES (?)",
                 (entry,),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+    return log_path
+
+def _write_fake_codex_logs_with_timestamps(
+    codex_home_path: str | Path,
+    *,
+    entries: list[tuple[int, str]],
+    filename: str = "logs_1.sqlite",
+) -> Path:
+    log_path = Path(codex_home_path) / filename
+    connection = sqlite3.connect(log_path)
+    try:
+        connection.execute(
+            "CREATE TABLE logs ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "ts INTEGER, "
+            "feedback_log_body TEXT"
+            ")"
+        )
+        for timestamp, entry in entries:
+            connection.execute(
+                "INSERT INTO logs (ts, feedback_log_body) VALUES (?, ?)",
+                (timestamp, entry),
             )
         connection.commit()
     finally:
@@ -759,6 +786,77 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
         == "codex app-server task_complete produced no assistant output"
     )
     assert "lastAssistantText" not in handle.metadata
+
+def test_runtime_send_turn_recovers_usage_limit_from_recent_log_for_empty_task_complete(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-04-10T17:57:55.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    quota_summary = (
+        "You've hit your usage limit. To get more access now, send a request "
+        "to your admin or try again at May 13th, 2026 1:35 AM."
+    )
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        entries=[
+            (
+                int(time.time()) + 1,
+                "session_loop{thread_id=vendor-thread-1}:run_turn: "
+                f"Turn error: {quota_summary}",
+            )
+        ],
+    )
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata == {
+        "failureClass": "permanent",
+        "reason": quota_summary,
+    }
 
 def _spool_skill_outcome_path(request: LaunchCodexManagedSessionRequest) -> Path:
     return Path(request.artifact_spool_path) / "skill_outcome.json"
@@ -2030,6 +2128,46 @@ def test_runtime_extract_turn_error_from_logs_recovers_provider_error_message(
     )
 
     assert runtime._extract_turn_error_from_logs("vendor-turn-1") == "http 404"
+
+def test_runtime_extract_turn_error_from_logs_recovers_recent_provider_error_without_turn_id(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "raise SystemExit(0)"),
+    )
+    turn_started_at = int(time.time())
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        entries=[
+            (
+                turn_started_at - 60,
+                "Turn error: You've hit your usage limit from an older turn.",
+            ),
+            (
+                turn_started_at,
+                "Received message "
+                '{"type":"error","error":{"type":"usage_limit_reached",'
+                '"message":"The usage limit has been reached"},'
+                '"status_code":429}',
+            ),
+        ],
+    )
+
+    assert (
+        runtime._extract_turn_error_from_logs(
+            "vendor-turn-without-log-row",
+            turn_started_at=turn_started_at,
+        )
+        == "The usage limit has been reached (status 429)"
+    )
 
 @pytest.mark.parametrize(
     ("thread_status_type", "thread_status_reason", "expected_status", "expected_reason"),

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2169,6 +2169,81 @@ def test_runtime_extract_turn_error_from_logs_recovers_recent_provider_error_wit
         == "The usage limit has been reached (status 429)"
     )
 
+def test_runtime_extract_turn_error_from_logs_ignores_provider_error_before_turn_start(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "raise SystemExit(0)"),
+    )
+    turn_started_at = int(time.time())
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        entries=[
+            (
+                turn_started_at - 1,
+                "Turn error: You've hit your usage limit from a previous turn.",
+            ),
+        ],
+    )
+
+    assert (
+        runtime._extract_turn_error_from_logs(
+            "vendor-turn-without-log-row",
+            turn_started_at=turn_started_at,
+        )
+        is None
+    )
+
+def test_runtime_extract_turn_error_from_logs_applies_global_provider_row_limit(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "raise SystemExit(0)"),
+    )
+    turn_started_at = int(time.time())
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        filename="logs_10.sqlite",
+        entries=[
+            (turn_started_at, "provider marker 429 without parseable error")
+            for _ in range(200)
+        ],
+    )
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        filename="logs_9.sqlite",
+        entries=[
+            (
+                turn_started_at,
+                "Turn error: You've hit your usage limit in an older shard.",
+            ),
+        ],
+    )
+
+    assert (
+        runtime._extract_turn_error_from_logs(
+            "vendor-turn-without-log-row",
+            turn_started_at=turn_started_at,
+        )
+        is None
+    )
+
 @pytest.mark.parametrize(
     ("thread_status_type", "thread_status_reason", "expected_status", "expected_reason"),
     [

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from moonmind.workflows.provider_failures import (
     classify_provider_failure,
     provider_error_requires_cooldown,
+    provider_failure_search_markers,
 )
 
 def test_classifies_high_demand_as_provider_capacity() -> None:
@@ -37,6 +38,28 @@ def test_classifies_codex_usage_limit_as_429() -> None:
     assert result.failure_class == "integration_error"
     assert result.provider_error_code == "429"
     assert result.retry_recommendation == "retry_after_cooldown"
+
+def test_classifies_codex_structured_usage_limit_as_429() -> None:
+    result = classify_provider_failure("provider error type=usage_limit_reached")
+
+    assert result is not None
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "429"
+    assert result.retry_recommendation == "retry_after_cooldown"
+
+def test_provider_failure_search_markers_cover_classification_markers() -> None:
+    markers = provider_failure_search_markers()
+
+    for expected in (
+        "rate-limit",
+        "http 503",
+        "status 503",
+        "temporary errors",
+        "try again later",
+        "usage_limit_reached",
+        "http 401",
+    ):
+        assert expected in markers
 
 def test_classifies_claude_code_short_limit_as_429() -> None:
     """Claude Code's shorter wording omits 'usage' — markers must still match."""


### PR DESCRIPTION
## Summary
- recover recent Codex provider quota/capacity failures from runtime SQLite logs when an empty task_complete would otherwise be treated as generic output loss
- parse Codex Turn error, error.message, and Received message log shapes so provider classification can set cooldown metadata
- add regression coverage for recent usage-limit recovery without a matching turn-id log row and for empty task_complete recovery

## Root Cause
Codex recorded the real 429 usage-limit failure in its internal logs, but later task_complete events carried no assistant output and no provider error. MoonMind only searched log rows containing the current turn id, so the session response collapsed to `codex app-server task_complete produced no assistant output` with no providerErrorCode or retryRecommendation. The AgentRun cooldown path therefore never signaled the provider profile manager and the parent workflow exhausted step retries.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `./tools/test_unit.sh`