### PR TITLE
Change Jira issue MM-645 to status In Progress before implementation starts.

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4761,6 +4761,43 @@ async def _persist_original_task_input_snapshot_from_parameters(
         source_run_id=source_run_id,
     )
 
+async def _reuse_original_task_input_snapshot_from_source(
+    *,
+    session: AsyncSession,
+    source_record,
+    target_record,
+) -> str:
+    source_memo = dict(getattr(source_record, "memo", None) or {})
+    snapshot_ref = _task_input_snapshot_ref_from_memo(source_memo)
+    if not snapshot_ref:
+        return ""
+    snapshot_version = int(
+        source_memo.get("task_input_snapshot_version")
+        or source_memo.get("taskInputSnapshotVersion")
+        or _TASK_INPUT_SNAPSHOT_VERSION
+    )
+    records_to_update = []
+    if isinstance(target_record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)):
+        records_to_update.append(target_record)
+        if not isinstance(target_record, TemporalExecutionCanonicalRecord):
+            canonical_record = await session.get(
+                TemporalExecutionCanonicalRecord,
+                target_record.workflow_id,
+            )
+            if canonical_record is not None:
+                records_to_update.append(canonical_record)
+    for target in records_to_update:
+        memo = dict(target.memo or {})
+        memo["task_input_snapshot_ref"] = snapshot_ref
+        memo["task_input_snapshot_version"] = snapshot_version
+        memo["task_input_snapshot_source_kind"] = "rerun"
+        target.memo = memo
+        refs = list(target.artifact_refs or [])
+        if snapshot_ref not in refs:
+            refs.append(snapshot_ref)
+            target.artifact_refs = refs
+    return snapshot_ref
+
 async def _attach_input_attachment_artifacts_to_execution(
     *,
     session: AsyncSession | None,
@@ -6573,18 +6610,31 @@ async def update_execution(
     refreshed_record = await service.describe_execution(response_workflow_id)
     snapshot_ref = ""
     if is_task_editing_update:
-        snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
-            session=session,
-            record=refreshed_record,
-            user=user,
-            parameters=dict(getattr(refreshed_record, "parameters", None) or {}),
-            source_kind=(
-                "rerun" if payload.update_name == "RequestRerun" else "edit"
-            ),
-            source_workflow_id=record.workflow_id,
-            source_run_id=getattr(record, "run_id", None),
-            input_artifact_ref=payload.input_artifact_ref,
+        exact_rerun = (
+            payload.update_name == "RequestRerun"
+            and payload.input_artifact_ref is None
+            and payload.plan_artifact_ref is None
+            and payload.parameters_patch is None
         )
+        if exact_rerun:
+            snapshot_ref = await _reuse_original_task_input_snapshot_from_source(
+                session=session,
+                source_record=record,
+                target_record=refreshed_record,
+            )
+        else:
+            snapshot_ref = await _persist_original_task_input_snapshot_from_parameters(
+                session=session,
+                record=refreshed_record,
+                user=user,
+                parameters=dict(getattr(refreshed_record, "parameters", None) or {}),
+                source_kind=(
+                    "rerun" if payload.update_name == "RequestRerun" else "edit"
+                ),
+                source_workflow_id=record.workflow_id,
+                source_run_id=getattr(record, "run_id", None),
+                input_artifact_ref=payload.input_artifact_ref,
+            )
     if is_task_editing_update:
         accepted = bool(update_result.get("accepted", True))
         applied = str(update_result.get("applied") or "").strip() or None

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4764,20 +4764,31 @@ async def _persist_original_task_input_snapshot_from_parameters(
 async def _reuse_original_task_input_snapshot_from_source(
     *,
     session: AsyncSession,
-    source_record,
-    target_record,
+    source_record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
+    target_record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
 ) -> str:
     source_memo = dict(getattr(source_record, "memo", None) or {})
     snapshot_ref = _task_input_snapshot_ref_from_memo(source_memo)
     if not snapshot_ref:
         return ""
-    snapshot_version = int(
-        source_memo.get("task_input_snapshot_version")
-        or source_memo.get("taskInputSnapshotVersion")
-        or _TASK_INPUT_SNAPSHOT_VERSION
-    )
-    records_to_update = []
-    if isinstance(target_record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)):
+    raw_version = source_memo.get("task_input_snapshot_version")
+    if raw_version is None:
+        raw_version = source_memo.get("taskInputSnapshotVersion")
+    try:
+        snapshot_version = (
+            int(raw_version)
+            if raw_version is not None
+            else _TASK_INPUT_SNAPSHOT_VERSION
+        )
+    except (TypeError, ValueError):
+        snapshot_version = _TASK_INPUT_SNAPSHOT_VERSION
+    records_to_update: list[
+        TemporalExecutionRecord | TemporalExecutionCanonicalRecord
+    ] = []
+    if isinstance(
+        target_record,
+        (TemporalExecutionRecord, TemporalExecutionCanonicalRecord),
+    ):
         records_to_update.append(target_record)
         if not isinstance(target_record, TemporalExecutionCanonicalRecord):
             canonical_record = await session.get(
@@ -4786,6 +4797,7 @@ async def _reuse_original_task_input_snapshot_from_source(
             )
             if canonical_record is not None:
                 records_to_update.append(canonical_record)
+    linked_execution_keys: set[tuple[str, str, str]] = set()
     for target in records_to_update:
         memo = dict(target.memo or {})
         memo["task_input_snapshot_ref"] = snapshot_ref
@@ -4796,6 +4808,31 @@ async def _reuse_original_task_input_snapshot_from_source(
         if snapshot_ref not in refs:
             refs.append(snapshot_ref)
             target.artifact_refs = refs
+        execution_key = (target.namespace, target.workflow_id, target.run_id)
+        if execution_key in linked_execution_keys:
+            continue
+        linked_execution_keys.add(execution_key)
+        exists = await session.execute(
+            select(TemporalArtifactLink.id).where(
+                TemporalArtifactLink.artifact_id == snapshot_ref,
+                TemporalArtifactLink.namespace == target.namespace,
+                TemporalArtifactLink.workflow_id == target.workflow_id,
+                TemporalArtifactLink.run_id == target.run_id,
+                TemporalArtifactLink.link_type == _TASK_INPUT_SNAPSHOT_LINK_TYPE,
+            ).limit(1)
+        )
+        if exists.scalar_one_or_none() is None:
+            session.add(
+                TemporalArtifactLink(
+                    id=uuid4(),
+                    artifact_id=snapshot_ref,
+                    namespace=target.namespace,
+                    workflow_id=target.workflow_id,
+                    run_id=target.run_id,
+                    link_type=_TASK_INPUT_SNAPSHOT_LINK_TYPE,
+                    label="Original task input snapshot",
+                )
+            )
     return snapshot_ref
 
 async def _attach_input_attachment_artifacts_to_execution(

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -12,8 +12,8 @@ import {
 import {
   taskEditForRerunHref,
   taskEditHref,
-  taskRerunHref,
 } from '../lib/temporalTaskEditing';
+import { navigateTo } from '../lib/navigation';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
@@ -41,6 +41,10 @@ vi.mock('react-virtuoso', () => ({
       </div>
     );
   },
+}));
+
+vi.mock('../lib/navigation', () => ({
+  navigateTo: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -311,6 +315,7 @@ describe('Task Detail Entrypoint', () => {
     window.sessionStorage.clear();
     fetchSpy = vi.spyOn(window, 'fetch');
     fetchSpy.mockClear();
+    vi.mocked(navigateTo).mockReset();
   });
 
   it('returns null for route templates with missing parameters', () => {
@@ -1164,7 +1169,6 @@ describe('Task Detail Entrypoint', () => {
     expect(taskEditForRerunHref('mm:wf 1')).toBe(
       '/tasks/new?rerunExecutionId=mm%3Awf%201&mode=edit',
     );
-    expect(taskRerunHref('mm:wf 1')).toBe('/tasks/new?rerunExecutionId=mm%3Awf%201');
   });
 
   it('shows Edit and Rerun entry points only when Temporal task editing is flagged on and capabilities allow them', async () => {
@@ -1225,15 +1229,20 @@ describe('Task Detail Entrypoint', () => {
     expect(screen.getByRole('link', { name: 'Edit task' }).getAttribute('href')).toBe(
       '/tasks/new?editExecutionId=test-123',
     );
-    expect(screen.getByRole('link', { name: 'Rerun' }).getAttribute('href')).toBe(
-      '/tasks/new?rerunExecutionId=test-123',
-    );
     const editLink = screen.getByRole('link', { name: 'Edit task' });
-    const rerunLink = screen.getByRole('link', { name: 'Rerun' });
+    const rerunButton = screen.getByRole('button', { name: 'Rerun' });
     editLink.addEventListener('click', (event) => event.preventDefault());
-    rerunLink.addEventListener('click', (event) => event.preventDefault());
     fireEvent.click(editLink);
-    fireEvent.click(rerunLink);
+    fireEvent.click(rerunButton);
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/executions/test-123/update',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ updateName: 'RequestRerun' }),
+        }),
+      );
+    });
     expect(telemetryEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1347,19 +1356,19 @@ describe('Task Detail Entrypoint', () => {
     renderWithClient(<TaskDetailPage payload={actionPayload} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'Rerun' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Rerun' })).toBeTruthy();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'Rerun' }).getAttribute('aria-disabled')).toBe('true');
+      expect((screen.getByRole('button', { name: 'Rerun' }) as HTMLButtonElement).disabled).toBe(
+        true,
+      );
     });
 
-    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
-    const allowed = screen.getByRole('link', { name: 'Rerun' }).dispatchEvent(clickEvent);
-
-    expect(allowed).toBe(false);
-    expect(clickEvent.defaultPrevented).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Rerun' }));
+    const updateCalls = fetchSpy.mock.calls.filter(([input]) => String(input).includes('/update'));
+    expect(updateCalls).toHaveLength(1);
     promptSpy.mockRestore();
   });
 
@@ -1412,9 +1421,8 @@ describe('Task Detail Entrypoint', () => {
     expect(screen.getByRole('link', { name: 'Edit task' }).getAttribute('href')).toBe(
       '/tasks/new?rerunExecutionId=test-123&mode=edit',
     );
-    expect(screen.getByRole('link', { name: 'Rerun' }).getAttribute('href')).toBe(
-      '/tasks/new?rerunExecutionId=test-123',
-    );
+    expect(screen.getByRole('button', { name: 'Rerun' })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Rerun' })).toBeNull();
   });
 
   it('does not show edit unavailable text while another edit path is enabled', async () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -12,8 +12,8 @@ import {
   recordTemporalTaskEditingClientEvent,
   taskEditForRerunHref,
   taskEditHref,
-  taskRerunHref,
 } from '../lib/temporalTaskEditing';
+import { navigateTo } from '../lib/navigation';
 
 type DashboardConfig = {
   pollIntervalsMs?: { list?: number; detail?: number; events?: number };
@@ -4237,10 +4237,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       ? taskEditForRerunHref(workflowId)
       : taskEditHref(workflowId)
     : '';
-  const rerunHref = workflowId ? taskRerunHref(workflowId) : '';
   const onTaskEditingNavigation = (
     event: MouseEvent<HTMLAnchorElement>,
-    telemetryEvent: 'detail_edit_click' | 'detail_rerun_click',
+    telemetryEvent: 'detail_edit_click',
   ) => {
     if (busy) {
       event.preventDefault();
@@ -4251,6 +4250,39 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       mode: 'detail',
       workflowId,
     });
+  };
+  const onRerun = () => {
+    setActionError(null);
+    if (busy || !workflowId) return;
+    recordTemporalTaskEditingClientEvent({
+      event: 'detail_rerun_click',
+      mode: 'detail',
+      workflowId,
+    });
+    updateMutation.mutate(
+      { updateName: 'RequestRerun' },
+      {
+        onSuccess: (result: unknown) => {
+          const payloadResult = result as {
+            execution?: { workflowId?: string | null };
+            workflow_id?: string | null;
+          };
+          const redirectWorkflowId =
+            String(payloadResult.execution?.workflowId || '').trim() ||
+            String(payloadResult.workflow_id || '').trim() ||
+            workflowId;
+          try {
+            window.sessionStorage.setItem(
+              'moonmind.temporalTaskEditing.notice',
+              'Rerun was requested and the latest execution view is ready.',
+            );
+          } catch {
+            // Navigation should not depend on session storage availability.
+          }
+          navigateTo(`/tasks/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
+        },
+      },
+    );
   };
   const isTerminalExecution = TERMINAL_STATES.has(execution?.rawState || execution?.state || '');
   const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
@@ -4818,15 +4850,15 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                     Edit task
                   </a>
                 ) : null}
-                {taskEditingOn && actions.canRerun && rerunHref ? (
-                  <a
-                    className="button secondary"
-                    href={rerunHref}
-                    aria-disabled={busy}
-                    onClick={(event) => onTaskEditingNavigation(event, 'detail_rerun_click')}
+                {taskEditingOn && actions.canRerun ? (
+                  <button
+                    type="button"
+                    className="secondary"
+                    disabled={busy}
+                    onClick={onRerun}
                   >
                     Rerun
-                  </a>
+                  </button>
                 ) : null}
                 {taskEditingOn && actions.canResumeFromFailedStep ? (
                   <button

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -229,10 +229,6 @@ export function taskEditForRerunHref(workflowId: string): string {
   return `${taskCreateHref()}?rerunExecutionId=${encodeURIComponent(workflowId)}&mode=edit`;
 }
 
-export function taskRerunHref(workflowId: string): string {
-  return `${taskCreateHref()}?rerunExecutionId=${encodeURIComponent(workflowId)}`;
-}
-
 export function resolveTaskSubmitPageMode(
   search: string | URLSearchParams,
 ): TaskSubmitPageModeResolution {

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2533,7 +2533,16 @@ class TemporalExecutionService:
                 ),
             )
         else:
-            record.parameters = self._full_rerun_parameters(record.parameters)
+            recovery_provenance = None
+            if not input_artifact_ref and not plan_artifact_ref:
+                recovery_provenance = self._exact_full_rerun_recovery(
+                    source_workflow_id=record.workflow_id,
+                    source_run_id=record.run_id,
+                )
+            record.parameters = self._full_rerun_parameters(
+                record.parameters,
+                recovery_provenance=recovery_provenance,
+            )
         self._continue_as_new(
             record,
             summary="Rerun requested via Continue-As-New.",
@@ -2558,13 +2567,21 @@ class TemporalExecutionService:
         params = dict(record.parameters or {})
         if parameters_patch:
             params.update(parameters_patch)
-        params = self._full_rerun_parameters(
-            params,
-            recovery_provenance=self._full_retry_recovery_from_patch(
+            recovery_provenance = self._full_retry_recovery_from_patch(
                 parameters_patch,
                 source_workflow_id=record.workflow_id,
                 source_run_id=record.run_id,
-            ),
+            )
+        elif not input_artifact_ref and not plan_artifact_ref:
+            recovery_provenance = self._exact_full_rerun_recovery(
+                source_workflow_id=record.workflow_id,
+                source_run_id=record.run_id,
+            )
+        else:
+            recovery_provenance = None
+        params = self._full_rerun_parameters(
+            params,
+            recovery_provenance=recovery_provenance,
         )
 
         rerun_source = {
@@ -2650,6 +2667,24 @@ class TemporalExecutionService:
             task_params["recovery"] = dict(recovery_provenance)
             params["task"] = task_params
         return params
+
+    @staticmethod
+    def _exact_full_rerun_recovery(
+        *,
+        source_workflow_id: str,
+        source_run_id: str,
+    ) -> dict[str, Any]:
+        canonical_workflow_id = source_workflow_id.strip()
+        canonical_run_id = source_run_id.strip()
+        if not canonical_workflow_id or not canonical_run_id:
+            raise TemporalExecutionValidationError(
+                "Rerun source workflowId and runId are required."
+            )
+        return {
+            "kind": "exact_full_rerun",
+            "sourceWorkflowId": canonical_workflow_id,
+            "sourceRunId": canonical_run_id,
+        }
 
     @staticmethod
     def _full_retry_recovery_from_patch(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2534,7 +2534,7 @@ class TemporalExecutionService:
             )
         else:
             recovery_provenance = None
-            if not input_artifact_ref and not plan_artifact_ref:
+            if input_artifact_ref is None and plan_artifact_ref is None:
                 recovery_provenance = self._exact_full_rerun_recovery(
                     source_workflow_id=record.workflow_id,
                     source_run_id=record.run_id,
@@ -2572,7 +2572,7 @@ class TemporalExecutionService:
                 source_workflow_id=record.workflow_id,
                 source_run_id=record.run_id,
             )
-        elif not input_artifact_ref and not plan_artifact_ref:
+        elif input_artifact_ref is None and plan_artifact_ref is None:
             recovery_provenance = self._exact_full_rerun_recovery(
                 source_workflow_id=record.workflow_id,
                 source_run_id=record.run_id,
@@ -2671,11 +2671,11 @@ class TemporalExecutionService:
     @staticmethod
     def _exact_full_rerun_recovery(
         *,
-        source_workflow_id: str,
-        source_run_id: str,
+        source_workflow_id: str | None,
+        source_run_id: str | None,
     ) -> dict[str, Any]:
-        canonical_workflow_id = source_workflow_id.strip()
-        canonical_run_id = source_run_id.strip()
+        canonical_workflow_id = (source_workflow_id or "").strip()
+        canonical_run_id = (source_run_id or "").strip()
         if not canonical_workflow_id or not canonical_run_id:
             raise TemporalExecutionValidationError(
                 "Rerun source workflowId and runId are required."

--- a/specs/344-exact-full-rerun-workflow/checklists/requirements.md
+++ b/specs/344-exact-full-rerun-workflow/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Exact Full Rerun Workflow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist validation completed on 2026-05-13.
+- The spec defines one runtime user story for MM-645 exact full rerun behavior.
+- The original Jira preset brief is preserved verbatim in the `**Input**` field for final verification.
+- All in-scope source design requirements map to functional requirements.

--- a/specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md
+++ b/specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md
@@ -1,0 +1,66 @@
+# Contract: Exact Full Rerun
+
+## Mission Control Interaction
+
+User-visible action:
+
+- Label: `Rerun`
+- Available when execution actions expose `canRerun = true`.
+- Unavailable reason should remain visible when `canRerun = false`.
+- Selecting `Rerun` for exact full rerun MUST submit the rerun request directly from the task detail surface and MUST NOT navigate to or render task authoring.
+
+Out of scope:
+
+- `Edit task` and edit-for-rerun remain the editable retry path.
+- Failed-step `Resume` remains the progress-preserving retry path.
+
+## Request Shape
+
+Exact full rerun request:
+
+```json
+{
+  "updateName": "RequestRerun"
+}
+```
+
+Allowed metadata:
+
+- Idempotency metadata may be included when supported by the existing update route.
+
+Forbidden exact-rerun mutation fields:
+
+- `parametersPatch`
+- `inputArtifactRef`
+- `planArtifactRef`
+- Any submitted task body edits
+- Any resume checkpoint or preserved-progress payload
+
+## Created Execution Semantics
+
+The created execution MUST include recovery provenance equivalent to:
+
+```json
+{
+  "task": {
+    "recovery": {
+      "kind": "exact_full_rerun",
+      "sourceWorkflowId": "<source workflow id>",
+      "sourceRunId": "<source run id>"
+    }
+  }
+}
+```
+
+The created execution MUST:
+
+- Reuse the original task input snapshot unchanged.
+- Start from the beginning.
+- Run the normal full execution path.
+- Exclude completed progress, preserved step outputs, resume source metadata, and resume checkpoint refs.
+
+## Error Semantics
+
+If exact rerun cannot safely reuse the original task input snapshot, the system MUST fail closed with an explicit unavailable/degraded reason. The existing `original_task_input_snapshot_missing` reason remains valid for missing source snapshots.
+
+If source workflow/run identity is missing, the system MUST reject exact rerun rather than creating unpinned provenance.

--- a/specs/344-exact-full-rerun-workflow/data-model.md
+++ b/specs/344-exact-full-rerun-workflow/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: Exact Full Rerun Workflow
+
+## Failed Execution
+
+Represents the source execution selected for exact full rerun.
+
+Fields:
+
+- `workflowId`: Stable workflow identifier for the source execution.
+- `runId`: Concrete run identifier for the failed source run.
+- `state`: Must be an eligible terminal state for Rerun.
+- `taskInputSnapshotRef`: Reference to the authoritative original task input snapshot.
+- `inputArtifactRef`: Existing input artifact reference, when present.
+- `planArtifactRef`: Existing plan artifact reference, when present.
+- `resumeCheckpointRef`: Existing failed-step resume checkpoint reference, if any; must not carry into exact rerun.
+- `completedProgress`: Any completed stages or preserved outputs on the source; must not carry into exact rerun.
+
+Validation rules:
+
+- Exact rerun is unavailable when `taskInputSnapshotRef` is missing or unauthorized.
+- Exact rerun provenance must use the source `workflowId` and `runId`.
+- Existing resume/checkpoint state is source evidence only and is not exact rerun input.
+
+## Original Task Input Snapshot
+
+Represents the authoritative authored task input for recovery actions.
+
+Fields:
+
+- Objective/task instructions.
+- Objective-scoped attachment refs.
+- Step text, order, identity, and step-scoped attachment refs.
+- Runtime and publish selections.
+- Repository and single authored branch selection.
+- Preset application metadata, pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+- Dependency declarations.
+
+Validation rules:
+
+- Exact full rerun reuses this snapshot unchanged.
+- Snapshot reconstruction must not depend on current live preset catalog state.
+- Attachment-aware executions without a reconstructible snapshot are degraded/blocked.
+
+## Exact Full Rerun Execution
+
+Represents the new execution created by the direct Rerun action.
+
+Fields:
+
+- `workflowId`: New execution workflow identifier.
+- `runId`: New execution run identifier once available.
+- `taskInputSnapshotRef`: The unchanged source snapshot reference or a verified equivalent artifact whose content and lineage are unchanged.
+- `recovery.kind`: `exact_full_rerun`.
+- `recovery.sourceWorkflowId`: Source failed execution workflow identifier.
+- `recovery.sourceRunId`: Source failed execution run identifier.
+- `rerunSource`: Existing source linkage metadata where applicable.
+
+Validation rules:
+
+- Must start from the beginning.
+- Must not include `resume`, `resumeSource`, `resumeCheckpointRef`, `preservedSteps`, `completedSteps`, or equivalent progress-import fields.
+- Must not accept editable task mutation fields on the exact direct action path.
+
+## State Transitions
+
+```text
+Failed Execution with authoritative snapshot
+  └── user chooses Rerun
+      └── validate eligibility and source identity
+          └── create Exact Full Rerun Execution
+              ├── recovery.kind = exact_full_rerun
+              ├── source workflow/run IDs pinned
+              ├── original task input snapshot reused unchanged
+              └── full execution starts from beginning
+```
+
+Blocked transition:
+
+```text
+Failed Execution without authoritative snapshot
+  └── user chooses Rerun
+      └── explicit unavailable/degraded outcome
+```

--- a/specs/344-exact-full-rerun-workflow/moonspec_align_report.md
+++ b/specs/344-exact-full-rerun-workflow/moonspec_align_report.md
@@ -1,0 +1,22 @@
+# MoonSpec Align Report
+
+**Feature**: `344-exact-full-rerun-workflow`
+**Date**: 2026-05-13
+**Source**: MM-645 Jira preset brief preserved in `spec.md`
+
+## Findings And Remediation
+
+| Artifact | Finding | Severity | Remediation |
+| --- | --- | --- | --- |
+| `tasks.md` | Requirement status summary counted `plan.md` rows incorrectly. The plan has 10 partial, 5 missing, 8 implemented_unverified, and 1 implemented_verified rows across FR/SCN/SC/DESIGN entries. | Low | Updated the `Source Traceability` summary in `tasks.md` to match `plan.md`. |
+
+## Checks
+
+- Specify gate: PASS. `spec.md` contains exactly one user story and preserves `MM-645` plus the original Jira preset brief.
+- Plan gate: PASS. `plan.md` contains explicit unit and integration strategies, requirement status rows, constitution checks, and required design artifacts.
+- Tasks gate: PASS after remediation. `tasks.md` has sequential task IDs, exactly one story phase, red-first unit and integration tests before implementation, conditional fallback tasks for implemented-unverified rows, and final `/moonspec-verify` work.
+- Downstream regeneration: Not required. The edit corrected a summary count only and did not change source requirements, architecture, contracts, or task coverage.
+
+## Remaining Risks
+
+- None found in MoonSpec artifacts. Application behavior remains unimplemented until the generated `tasks.md` is executed.

--- a/specs/344-exact-full-rerun-workflow/plan.md
+++ b/specs/344-exact-full-rerun-workflow/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Exact Full Rerun Workflow
+
+**Branch**: `344-exact-full-rerun-workflow` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:5918c7c6-d387-42cb-b505-bee2d80f5a2e/repo/specs/344-exact-full-rerun-workflow/spec.md`
+
+## Summary
+
+MM-645 requires Rerun on an eligible failed execution to be an exact full rerun: no authoring form, unchanged reuse of the original task input snapshot, explicit `exact_full_rerun` recovery provenance with pinned source workflow/run IDs, full from-beginning execution, and no imported Resume progress. Repo inspection found related foundations already present: terminal action capability gating, task input snapshot descriptors, `RequestRerun`, full-rerun parameter sanitization, snapshot persistence, and UI tests for exact no-mutation payloads. The remaining delivery work is to remove the authoring-form detour for exact Rerun, ensure the backend creates the new execution from the authoritative snapshot with `exact_full_rerun` provenance, and add verification-first unit and hermetic integration coverage proving unchanged snapshot reuse and no progress import.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `frontend/src/entrypoints/task-detail.tsx` links Rerun to `/tasks/new?rerunExecutionId=...`; `frontend/src/entrypoints/task-create.tsx` renders a Rerun Task form | Route exact Rerun through a direct recovery action that does not open task authoring | unit + integration |
+| FR-002 | partial | `moonmind/workflows/temporal/service.py` builds rerun parameters from canonical parameters; `api_service/api/routers/executions.py` persists a new rerun snapshot | Reuse the source authoritative task input snapshot unchanged for exact rerun input and prove no mutation payload is required | unit + integration |
+| FR-003 | missing | No-mutation `RequestRerun` path calls `_full_rerun_parameters(record.parameters)` without recovery provenance | Add `exact_full_rerun` recovery provenance to exact rerun submissions | unit + integration |
+| FR-004 | missing | `_full_retry_recovery_from_patch()` validates source IDs only when a patch provides recovery; exact no-mutation rerun sends no patch | Derive and pin source workflow/run IDs for exact rerun provenance server-side | unit + integration |
+| FR-005 | implemented_unverified | `_full_rerun_parameters()` strips task run IDs and rerun creation creates a new execution; no MM-645 end-to-end proof found | Add verification tests first; implementation contingency if full execution path is not clearly from-beginning | integration |
+| FR-006 | partial | Current exact Rerun still opens `/tasks/new` Rerun Task form before submit | Replace exact Rerun authoring navigation with direct request flow while keeping editable retry separate | unit + integration |
+| FR-007 | implemented_unverified | `_strip_resume_reference_parameters()` removes resume/progress fields; related tests cover resume cleanup in update paths | Add exact rerun verification tests proving no preserved progress, resume refs, or checkpoints are imported | unit + integration |
+| FR-008 | partial | Snapshot build/persistence preserves rich authored fields, but exact rerun does not yet prove unchanged source snapshot reuse | Ensure exact rerun uses source authoritative snapshot as the input source and preserves authored details unchanged | unit + integration |
+| FR-009 | implemented_verified | `api_service/api/routers/executions.py` disables edit/rerun when `task_input_snapshot_ref` is missing; tests cover `original_task_input_snapshot_missing` | No new implementation; preserve behavior while changing Rerun route | final verify |
+| FR-010 | implemented_unverified | `spec.md` preserves MM-645 and original preset brief; downstream artifacts not yet generated | Preserve MM-645 through plan, tasks, implementation notes, verification, commit, and PR metadata | final verify |
+| SCN-001 | partial | Rerun action exists but opens authoring form | Direct action test from failed execution creates new execution without authoring route | integration |
+| SCN-002 | partial | Snapshot descriptors exist; unchanged reuse not proven | Verify exact rerun input identity/content equals source snapshot | integration |
+| SCN-003 | missing | Exact no-mutation path lacks explicit recovery provenance | Verify `exact_full_rerun` with source workflow/run IDs | unit + integration |
+| SCN-004 | implemented_unverified | Parameter stripping suggests from-beginning execution; no focused scenario proof | Verify full from-beginning execution parameters omit task run/progress carryover | unit + integration |
+| SCN-005 | implemented_unverified | Resume cleanup helpers exist; exact rerun scenario coverage missing | Verify no completed progress, preserved outputs, or resume checkpoint refs in exact rerun | unit + integration |
+| SC-001 | partial | Rerun creates a request but currently through authoring page | Add UI/API evidence for 100% direct exact rerun action in validation scenarios | integration |
+| SC-002 | partial | Snapshot creation exists; unchanged source snapshot reuse not proven | Add exact snapshot identity/content validation | integration |
+| SC-003 | missing | Exact provenance absent | Add provenance validation | unit + integration |
+| SC-004 | implemented_unverified | Sanitization exists but no focused MM-645 test | Add no-progress-import validation | unit + integration |
+| SC-005 | implemented_unverified | `spec.md` preserves MM-645 | Continue traceability through remaining artifacts | final verify |
+| DESIGN-REQ-001 | missing | Exact no-mutation rerun lacks recovery provenance | Add exact provenance contract and server-side derivation | unit + integration |
+| DESIGN-REQ-002 | implemented_unverified | `_strip_resume_reference_parameters()` removes resume fields | Add exact rerun no-progress verification | unit + integration |
+| DESIGN-REQ-003 | partial | Authoritative snapshot model exists; exact source snapshot reuse remains unproven | Reuse/preserve source snapshot for exact rerun and test rich authored input | unit + integration |
+| DESIGN-REQ-004 | partial | Existing RequestRerun can rerun, but authoring form and provenance gaps remain | Implement exact full rerun contract end to end | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control UI  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Temporal Python SDK service boundaries, Pydantic v2, React, TanStack Query, Zod, generated OpenAPI types  
+**Storage**: Existing Temporal execution records, canonical execution parameters/memo/search attributes, and Temporal artifact metadata/content store; no new persistent database tables planned  
+**Unit Testing**: `./tools/test_unit.sh` for final unit verification; focused Python pytest and Vitest commands during iteration  
+**Integration Testing**: `./tools/test_integration.sh` for hermetic integration_ci; targeted `pytest tests/integration/temporal ... -m integration_ci` equivalents during iteration when available  
+**Target Platform**: MoonMind local/server deployment with Mission Control web UI and Temporal-backed workflow execution  
+**Project Type**: Full-stack web control plane with Temporal workflow orchestration  
+**Performance Goals**: Exact rerun action should complete normal request validation without additional user-edit round trips; no new long-running synchronous work beyond existing execution creation and artifact lookup  
+**Constraints**: Do not create new persistence; keep recovery intents distinct; preserve in-flight Temporal payload compatibility for existing update names; do not import resume progress into exact rerun; keep Jira issue MM-645 traceable  
+**Scale/Scope**: One runtime story covering eligible failed-execution Rerun from Mission Control through API/service execution creation and verification evidence
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Result | Notes |
+| --- | --- | --- |
+| I. Orchestrate, Don't Recreate | PASS | Uses existing Temporal/Mission Control orchestration surfaces; no new agent cognition layer. |
+| II. One-Click Agent Deployment | PASS | No new required external services or secrets. |
+| III. Avoid Vendor Lock-In | PASS | Recovery semantics are internal workflow contracts, not vendor-specific agent behavior. |
+| IV. Own Your Data | PASS | Reuses operator-controlled task input snapshot artifacts and execution records. |
+| V. Skills Are First-Class | PASS | Planning artifacts preserve MoonSpec workflow expectations without changing skill runtime. |
+| VI. Replaceable Scaffolding | PASS | Keeps recovery behavior behind existing request/update contracts and tests. |
+| VII. Runtime Configurability | PASS | No new hardcoded deployment config planned. |
+| VIII. Modular Architecture | PASS | Work stays within task detail/create UI, execution router, and Temporal execution service boundaries. |
+| IX. Resilient by Default | PASS | Requires retry-safe exact rerun creation and no ambiguous progress carryover. |
+| X. Continuous Improvement | PASS | Verification evidence and traceability are explicit. |
+| XI. Spec-Driven Development | PASS | Work proceeds from `spec.md`; tests are planned before implementation. |
+| XII. Canonical Docs vs Migration Backlog | PASS | Planning artifacts live under `specs/344-exact-full-rerun-workflow`; canonical docs remain source requirements only. |
+| XIII. Pre-Release Compatibility Policy | PASS | No compatibility aliases planned; existing `RequestRerun` contract remains, with stricter exact-rerun semantics. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/344-exact-full-rerun-workflow/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── exact-full-rerun-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output, not created by this plan step
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── api/routers/executions.py
+└── db/models.py
+
+moonmind/
+├── schemas/temporal_models.py
+├── workflows/tasks/task_contract.py
+└── workflows/temporal/service.py
+
+frontend/src/
+├── entrypoints/task-detail.tsx
+├── entrypoints/task-detail.test.tsx
+├── entrypoints/task-create.tsx
+├── entrypoints/task-create.test.tsx
+└── lib/temporalTaskEditing.ts
+
+tests/
+├── unit/api/routers/test_executions.py
+├── unit/workflows/temporal/test_temporal_service.py
+├── unit/workflows/tasks/test_task_contract.py
+└── integration/temporal/
+```
+
+**Structure Decision**: Use the existing full-stack MoonMind control-plane layout. The story crosses Mission Control UI, API route serialization/update handling, Temporal execution service rerun creation, task recovery contracts, and unit/hermetic integration tests.
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/344-exact-full-rerun-workflow/quickstart.md
+++ b/specs/344-exact-full-rerun-workflow/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Exact Full Rerun Workflow
+
+## Purpose
+
+Validate MM-645 against the preserved Jira preset brief in `spec.md`: Rerun on a failed execution starts a new execution from the beginning using the original task input snapshot unchanged, records `exact_full_rerun` provenance, and imports no completed progress.
+
+## Test-First Plan
+
+1. Add failing frontend tests in `frontend/src/entrypoints/task-detail.test.tsx` proving the Rerun action submits directly and does not link to `/tasks/new`.
+2. Add failing frontend tests or update existing `frontend/src/entrypoints/task-create.test.tsx` to confirm exact Rerun no longer depends on the authoring form path.
+3. Add failing unit tests in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact no-mutation rerun creates `task.recovery.kind = exact_full_rerun`, pins source workflow/run IDs, and strips resume/progress fields.
+4. Add failing unit tests in `tests/unit/api/routers/test_executions.py` proving the update route persists/returns exact rerun snapshot lineage and rejects missing source identity or missing snapshot.
+5. Add or update hermetic integration tests under `tests/integration/temporal/` proving the full API/service path creates a fresh exact rerun execution without completed progress import.
+6. Implement the smallest changes needed to pass those tests.
+
+## Focused Commands
+
+Frontend iteration after dependencies are prepared:
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+```
+
+Python unit iteration:
+
+```bash
+pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q
+```
+
+Hermetic integration iteration:
+
+```bash
+pytest tests/integration/temporal -m 'integration_ci' -q --tb=short
+```
+
+Final required unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+Final required hermetic integration verification:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-to-End Validation Scenario
+
+1. Prepare or fixture a failed `MoonMind.Run` execution with:
+   - source workflow ID,
+   - source run ID,
+   - authoritative original task input snapshot,
+   - some completed source progress or resume checkpoint evidence.
+2. Confirm task detail exposes `Rerun` when `canRerun = true`.
+3. Trigger `Rerun` directly from task detail.
+4. Confirm no task authoring page opens.
+5. Confirm the request uses exact rerun shape with no mutation fields.
+6. Confirm the created execution has `exact_full_rerun` provenance pinned to the source workflow/run IDs.
+7. Confirm the original task input snapshot is reused unchanged.
+8. Confirm no completed progress, preserved outputs, resume source, or resume checkpoint refs are present in the new execution.
+9. Confirm `MM-645` remains present in spec, plan, tasks, verification, commit, and PR metadata.
+
+## Expected Blocked Scenario
+
+1. Prepare or fixture a failed execution without an authoritative task input snapshot.
+2. Confirm `Rerun` is unavailable or blocked with `original_task_input_snapshot_missing` or an equivalent explicit degraded reason.
+3. Confirm no new execution is created.

--- a/specs/344-exact-full-rerun-workflow/research.md
+++ b/specs/344-exact-full-rerun-workflow/research.md
@@ -1,0 +1,109 @@
+# Research: Exact Full Rerun Workflow
+
+## FR-001 / FR-006 / SCN-001 / SC-001
+
+Decision: Partial; exact Rerun needs a direct action path that does not open the task authoring form.
+
+Evidence: `frontend/src/entrypoints/task-detail.tsx` builds Rerun links with `taskRerunHref()`, which points to `/tasks/new?rerunExecutionId=...`. `frontend/src/entrypoints/task-create.tsx` renders and submits a Rerun Task page for that mode. Existing tests in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` assert those links and form submissions.
+
+Rationale: MM-645 explicitly says Rerun never opens an authoring form. Current behavior supports exact no-mutation submission only after entering the create/rerun page, so it does not satisfy the operator flow.
+
+Alternatives considered: Keeping the form and disabling editing was rejected because the acceptance criterion says Rerun never opens an authoring form; editable retry is a separate flow.
+
+Test implications: Add frontend unit tests for a direct Rerun action from detail and backend integration/API tests proving the request creates a new execution.
+
+## FR-002 / FR-008 / SCN-002 / SC-002 / DESIGN-REQ-003
+
+Decision: Partial; authoritative snapshot infrastructure exists, but exact rerun must prove unchanged source snapshot reuse.
+
+Evidence: `api_service/api/routers/executions.py` exposes task input snapshot descriptors, persists original task input snapshots, and disables task editing actions when the snapshot is missing. `moonmind/workflows/tasks/task_contract.py` builds authoritative task input snapshots. Tests in `tests/unit/api/routers/test_executions.py` cover snapshot persistence and authored field preservation.
+
+Rationale: Current rerun paths derive parameters from canonical parameters and persist a new rerun snapshot. MM-645 requires exact rerun to reuse the original task input snapshot unchanged as execution input; planning should verify and tighten source snapshot identity/content.
+
+Alternatives considered: Treating newly persisted rerun snapshots as sufficient was rejected because the story requires unchanged source snapshot reuse, not reconstruction from mutable projections.
+
+Test implications: Unit and integration tests should compare the exact rerun input source to the original authoritative snapshot and cover attachments/preset metadata where available.
+
+## FR-003 / FR-004 / SCN-003 / SC-003 / DESIGN-REQ-001
+
+Decision: Missing for exact no-mutation rerun; add server-derived `exact_full_rerun` provenance with pinned source workflow/run IDs.
+
+Evidence: `frontend/src/entrypoints/task-create.tsx` sends an exact `RequestRerun` with no `parametersPatch` when the form is unchanged. `moonmind/workflows/temporal/service.py` only carries recovery provenance when `_full_retry_recovery_from_patch()` finds a recovery object in a patch. With no patch, `_apply_request_rerun()` calls `_full_rerun_parameters(record.parameters)` without recovery provenance.
+
+Rationale: Exact rerun cannot rely on the client to submit provenance if MM-645 removes the authoring-form path. The backend already has the source record and should pin source workflow/run identity.
+
+Alternatives considered: Making the UI send a patch containing `exact_full_rerun` was rejected as the primary mechanism because exact rerun should not send mutable task payload fields and because source identity must be authoritative server-side.
+
+Test implications: Add service and route tests for exact rerun provenance, including rejection or blocked behavior when source run identity is missing.
+
+## FR-005 / SCN-004
+
+Decision: Implemented unverified; from-beginning execution behavior appears present but needs focused MM-645 proof.
+
+Evidence: `moonmind/workflows/temporal/service.py` creates a fresh rerun execution and `_full_rerun_parameters()` removes task run IDs and dependency carryover. `api_service/api/routers/executions.py` also exposes a legacy rerun endpoint that creates a new execution.
+
+Rationale: New execution creation suggests from-beginning behavior, but MM-645 requires explicit validation that preparation, prompt composition, planning or plan hydration, and all steps are not skipped or treated as preserved progress.
+
+Alternatives considered: Marking verified from existing rerun tests was rejected because current tests are split across adjacent features and do not prove the complete exact-rerun path.
+
+Test implications: Add hermetic integration coverage that inspects new execution parameters/projections for a fresh full pipeline run.
+
+## FR-007 / SCN-005 / SC-004 / DESIGN-REQ-002
+
+Decision: Implemented unverified; resume/progress cleanup exists but exact rerun needs focused coverage.
+
+Evidence: `_strip_resume_reference_parameters()` in `moonmind/workflows/temporal/service.py` removes resume-related top-level fields and task resume/recovery blocks. Existing service tests cover resume cleanup in update and resume contexts.
+
+Rationale: The helper likely prevents resume progress import, but exact full rerun should have dedicated proof that completed steps, preserved outputs, resume checkpoint refs, and resume source are absent.
+
+Alternatives considered: Relying on helper-level coverage only was rejected because MM-645 is a user-facing recovery workflow and needs boundary-level evidence.
+
+Test implications: Add unit tests for `_full_rerun_parameters()` and integration tests through the API/update path.
+
+## FR-009
+
+Decision: Implemented verified; preserve existing degraded/blocked behavior for missing snapshots.
+
+Evidence: `api_service/api/routers/executions.py` disables edit/rerun actions when `task_input_snapshot_ref` is absent and reports `original_task_input_snapshot_missing`. Tests in `tests/unit/api/routers/test_executions.py` cover this behavior, including `test_temporal_task_editing_actions_require_original_snapshot` and related terminal fallback rejection tests.
+
+Rationale: The missing-snapshot guard already matches the fail-closed behavior requested by MM-645. Direct Rerun should reuse the same action eligibility.
+
+Alternatives considered: Creating exact rerun from canonical parameters when a snapshot is missing was rejected because it can silently lose authored fields.
+
+Test implications: Final verify plus regression coverage around the new direct Rerun route.
+
+## FR-010 / SC-005
+
+Decision: Implemented unverified; traceability starts in `spec.md` and must continue through later artifacts.
+
+Evidence: `specs/344-exact-full-rerun-workflow/spec.md` preserves Jira issue `MM-645` and the original preset brief verbatim in the input field.
+
+Rationale: This plan step continues traceability, but tasks, implementation notes, verification, commit text, and pull request metadata do not exist yet.
+
+Alternatives considered: Treating spec preservation alone as complete was rejected because FR-010 explicitly names downstream artifacts.
+
+Test implications: Final MoonSpec verification should audit all artifacts for `MM-645`.
+
+## Technical Approach
+
+Decision: Implement exact Rerun as a direct recovery action using existing task editing/update and execution service boundaries.
+
+Evidence: Existing contracts include `canRerun`, `RequestRerun`, task input snapshot descriptors, recovery provenance models, and rerun execution creation.
+
+Rationale: This keeps the change within current Mission Control and Temporal execution boundaries while separating exact rerun from editable retry.
+
+Alternatives considered: Adding a new workflow type or new persistence table was rejected because existing update/route/service contracts are sufficient.
+
+Test implications: Unit tests for payload/provenance helpers, frontend action behavior, and API route serialization; hermetic integration tests for the end-to-end exact rerun creation path.
+
+## Test Tooling
+
+Decision: Use `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration_ci verification.
+
+Evidence: Repo instructions define those as required verification runners. Existing frontend tests use Vitest through the unit runner, and Python tests use pytest.
+
+Rationale: MM-645 crosses frontend, API, and Temporal service boundaries, so both unit and hermetic integration coverage are required.
+
+Alternatives considered: Provider verification was rejected because this story uses local execution contracts and no third-party provider credentials.
+
+Test implications: During iteration, focused `pytest` and `npm run ui:test -- <path>` may be used, but final verification should run the required wrappers.

--- a/specs/344-exact-full-rerun-workflow/spec.md
+++ b/specs/344-exact-full-rerun-workflow/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Exact Full Rerun Workflow
+
+**Feature Branch**: `344-exact-full-rerun-workflow`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-645 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-645 MoonSpec Orchestration Input
+
+Use the Jira preset brief for MM-645 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): docs/Tasks/TaskArchitecture.md.
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+## Source
+
+- Jira issue: MM-645
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Exact full rerun workflow
+- Priority: Medium
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-645 from MM project
+Summary: Exact full rerun workflow
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-645 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-645: Exact full rerun workflow
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 7.2 Exact full rerun
+
+Coverage IDs:
+- DESIGN-REQ-017
+
+As a Mission Control user, I want to choose Rerun on a failed execution to start a new execution from the beginning that reuses the original task input snapshot unchanged so that I can re-execute the exact same task without editing anything and without importing prior progress.
+
+Acceptance Criteria:
+- Rerun never opens an authoring form.
+- Submission reuses the original snapshot reference unchanged.
+- Submission carries TaskRecoveryProvenance kind=exact_full_rerun with pinned source workflow/run ids.
+- New execution runs the full pipeline (prepare, prompt composition, planning/plan hydration, all steps).
+- No completed progress from the source run is imported.
+
+Requirements:
+- Implement exact full rerun submission path and ensure snapshot reuse without mutation.
+
+Relevant implementation notes from docs/Tasks/TaskArchitecture.md:
+- `TaskRecoveryKind` includes `exact_full_rerun`, `edited_full_retry`, and `resume_from_failed_step`.
+- `TaskRecoveryProvenance` includes `kind`, `sourceWorkflowId`, `sourceRunId`, and optional requester/timestamp fields.
+- `task.recovery.kind === "exact_full_rerun"` means the new execution starts from the beginning.
+- The original task input snapshot is the authoritative representation of the authored draft.
+- Edit, exact full rerun, edited full retry, and Resume all depend on the original snapshot for the authored task input.
+- For exact full rerun, the original task input snapshot is reused as the execution input, the task starts from the beginning, prepare/prompt composition/planning or plan hydration/all steps run again, and no completed execution progress is imported from the failed source run.
+"""
+
+## User Story - Exact Failed Task Rerun
+
+**Summary**: As a Mission Control user, I want Rerun on a failed execution to start the whole task again from the original task input so that I can repeat the exact same work without editing the task or carrying over partial progress.
+
+**Goal**: Failed-task recovery clearly separates exact full rerun from editing or resume flows, and a user can restart the full workflow with the original authored input unchanged.
+
+**Independent Test**: Can be fully tested by starting from a failed execution with a known original task input snapshot, choosing Rerun, and confirming the new execution uses the unchanged snapshot, records exact-rerun provenance, starts from the beginning, and imports zero completed progress from the source execution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a failed execution with an available original task input snapshot, **When** the user chooses Rerun, **Then** the system starts a new execution without opening an authoring form.
+2. **Given** the original task input snapshot contains the authored task details, **When** the exact full rerun is submitted, **Then** the new execution reuses that snapshot unchanged as its input.
+3. **Given** the failed source execution has a workflow identity and run identity, **When** the exact full rerun is created, **Then** the new execution records recovery provenance identifying the rerun as `exact_full_rerun` and pins both source identifiers.
+4. **Given** the source execution completed one or more stages before failing, **When** the exact full rerun starts, **Then** preparation, prompt composition, planning or plan hydration, and every task step run from the beginning.
+5. **Given** completed work exists on the failed source execution, **When** the exact full rerun executes, **Then** no completed progress, preserved step output, or resume checkpoint is imported into the new execution.
+
+### Edge Cases
+
+- The source execution has no reconstructible original task input snapshot when the user attempts Rerun.
+- The source execution contains attachments, preset-derived steps, or dependency metadata that must remain unchanged in the reused snapshot.
+- The source execution has completed stages or step outputs that could be mistaken for resume progress.
+- The user needs to change the task before retrying, which belongs to an editable retry flow rather than exact full rerun.
+- The same failed execution offers both Rerun and Resume, but each action must preserve its distinct recovery intent.
+
+## Assumptions
+
+- Mission Control already has a failed execution detail surface where Rerun is presented as a recovery action.
+- The original task input snapshot is the authoritative source for the authored task details when exact full rerun is available.
+- If the original task input snapshot cannot be recovered or authorized, the system should fail closed with an operator-visible degraded outcome instead of silently creating a partial rerun.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Tasks/TaskArchitecture.md` lines 296-304): Recovery provenance must distinguish `exact_full_rerun` from other recovery intents and include pinned source workflow and run identifiers. Scope: in scope. Maps to FR-003 and FR-004.
+- **DESIGN-REQ-002** (`docs/Tasks/TaskArchitecture.md` lines 338-341): Full-rerun recovery starts from the beginning, while resume is the only recovery path that restores completed progress. Scope: in scope. Maps to FR-005 and FR-007.
+- **DESIGN-REQ-003** (`docs/Tasks/TaskArchitecture.md` lines 347-371): The original task input snapshot is authoritative for recovery actions and must preserve authored task content, attachment refs, step ordering, runtime and publish selections, repository and branch choice, preset metadata, provenance, detachment state, final order, and dependencies. Scope: in scope. Maps to FR-002 and FR-008.
+- **DESIGN-REQ-004** (`docs/Tasks/TaskArchitecture.md` lines 386-395): Exact full rerun reuses the original task input snapshot, starts from the beginning, reruns the normal execution path, and imports no completed progress from the failed source run. Scope: in scope. Maps to FR-001, FR-002, FR-005, FR-006, and FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow a user to choose Rerun on an eligible failed execution to start a new execution from the beginning without opening an authoring form.
+- **FR-002**: The system MUST reuse the source execution's original task input snapshot unchanged as the exact full rerun input.
+- **FR-003**: The system MUST record the new execution's recovery intent as `exact_full_rerun`.
+- **FR-004**: The system MUST preserve the source workflow identifier and source run identifier in the exact full rerun's recovery provenance.
+- **FR-005**: The system MUST run the full execution path for an exact full rerun, including preparation, prompt composition, planning or plan hydration, and all task steps.
+- **FR-006**: The system MUST NOT open or depend on editable task authoring state for exact full rerun submission.
+- **FR-007**: The system MUST NOT import completed progress, preserved step outputs, or resume checkpoints from the source execution into an exact full rerun.
+- **FR-008**: The system MUST preserve all authored input details already present in the original task input snapshot, including attachments, step order, runtime and publish selections, repository and branch choice, preset metadata, provenance, detachment state, final order, and dependencies.
+- **FR-009**: The system MUST present an explicit degraded or blocked outcome when exact full rerun cannot safely reuse the original task input snapshot.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-645` and the original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Failed Execution**: The source task run selected by the user for recovery, including its workflow identity, run identity, terminal failure state, prior progress, and original task input snapshot reference.
+- **Original Task Input Snapshot**: The authoritative authored task input that exact full rerun reuses unchanged, including task text, attachments, step structure, selections, preset metadata, and dependencies.
+- **Exact Full Rerun Execution**: The new execution created from the failed source execution, with recovery intent `exact_full_rerun` and pinned source identifiers.
+- **Recovery Provenance**: The traceability record that distinguishes exact full rerun from editable retry and resume and links the new execution back to the exact source workflow/run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In validation scenarios with an eligible failed execution, 100% of Rerun actions create a new execution without opening an authoring form.
+- **SC-002**: 100% of exact full rerun validation cases reuse the original task input snapshot unchanged.
+- **SC-003**: 100% of exact full rerun validation cases record `exact_full_rerun` provenance with non-empty source workflow and run identifiers.
+- **SC-004**: 100% of exact full rerun validation cases execute from the beginning with no imported completed progress or resume checkpoint state.
+- **SC-005**: Traceability review confirms `MM-645` and the original Jira preset brief are preserved in the active MoonSpec artifacts and downstream delivery metadata.

--- a/specs/344-exact-full-rerun-workflow/tasks.md
+++ b/specs/344-exact-full-rerun-workflow/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Exact Full Rerun Workflow
+
+**Input**: Design documents from `/work/agent_jobs/mm:5918c7c6-d387-42cb-b505-bee2d80f5a2e/repo/specs/344-exact-full-rerun-workflow/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/exact-full-rerun-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks cover exactly one story: exact full rerun from a failed execution using the original task input snapshot unchanged.
+
+**Source Traceability**: Preserves Jira issue `MM-645` and the original Jira preset brief from `spec.md`. Requirement status from `plan.md`: 5 partial, 4 missing, 9 implemented_unverified, 1 implemented_verified across FR/SCN/SC/DESIGN rows.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh`
+- Integration tests: `./tools/test_integration.sh`
+- Focused frontend tests: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
+- Focused Python unit tests: `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q`
+- Focused hermetic integration tests: `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, success criterion, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the existing test surfaces and feature artifacts are ready for MM-645 work.
+
+- [ ] T001 Verify `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, and `specs/344-exact-full-rerun-workflow/quickstart.md` exist and preserve `MM-645` traceability for FR-010 and SC-005
+- [ ] T002 Confirm frontend unit test tooling is available for `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` using `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
+- [ ] T003 Confirm Python unit test tooling is available for `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/api/routers/test_executions.py` using `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q`
+- [ ] T004 Confirm hermetic integration test tooling is available for `tests/integration/temporal` using `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish blocking fixtures and shared contract expectations before story test work begins.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T005 [P] Identify and document the existing exact-rerun fixture shapes in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, SCN-001, and the Mission Control contract
+- [ ] T006 [P] Identify and document existing source execution fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-003, FR-004, FR-005, FR-007, DESIGN-REQ-001, and DESIGN-REQ-002
+- [ ] T007 [P] Identify and document existing execution router fixture builders in `tests/unit/api/routers/test_executions.py` for FR-002, FR-008, FR-009, SCN-002, and DESIGN-REQ-003
+- [ ] T008 [P] Identify an existing hermetic integration test location or create a placeholder test module path under `tests/integration/temporal/test_exact_full_rerun_workflow.py` for SCN-001 through SCN-005
+- [ ] T009 Confirm no new persistent database table or migration is needed by reviewing `specs/344-exact-full-rerun-workflow/data-model.md` and existing execution record fields in `api_service/db/models.py` for the storage constraint
+
+**Checkpoint**: Foundation ready; story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Exact Failed Task Rerun
+
+**Summary**: As a Mission Control user, I want Rerun on a failed execution to start the whole task again from the original task input so that I can repeat the exact same work without editing the task or carrying over partial progress.
+
+**Independent Test**: Start from a failed execution with a known original task input snapshot, choose Rerun, and confirm the new execution uses the unchanged snapshot, records exact-rerun provenance, starts from the beginning, and imports zero completed progress from the source execution.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004
+
+**Unit Test Plan**:
+
+- Frontend: direct Rerun action from task detail does not navigate to `/tasks/new`, editable retry remains separate, unavailable reason remains visible.
+- Service: exact no-mutation rerun derives `exact_full_rerun` provenance, pins source workflow/run IDs, strips resume/progress fields, and rejects missing source identity.
+- Router: exact rerun snapshot lineage and missing snapshot/source identity behavior remain explicit.
+
+**Integration Test Plan**:
+
+- Mission Control/API path creates a new exact rerun execution without authoring.
+- Created execution reuses original snapshot unchanged, records provenance, starts from the beginning, and imports no completed progress or resume checkpoint state.
+
+### Unit Tests (write first)
+
+- [ ] T010 [P] Add failing frontend unit test proving the Rerun action submits directly from `frontend/src/entrypoints/task-detail.test.tsx` without linking to `/tasks/new` for FR-001, FR-006, SCN-001, SC-001, and the exact-rerun contract
+- [ ] T011 [P] Add failing frontend unit test preserving Edit task as the editable retry path while Rerun remains exact in `frontend/src/entrypoints/task-detail.test.tsx` for FR-006 and the contract non-goal
+- [ ] T012 [P] Add failing frontend unit test removing or guarding exact Rerun authoring-form dependency in `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, and SCN-001
+- [ ] T013 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact no-mutation `RequestRerun` creates `task.recovery.kind = exact_full_rerun` with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [ ] T014 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact full rerun strips `resume`, `resumeSource`, `resumeCheckpointRef`, `preservedSteps`, and `completedSteps` for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [ ] T015 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact rerun rejects or blocks missing source run identity rather than creating unpinned provenance for FR-004 and DESIGN-REQ-001
+- [ ] T016 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving exact rerun persists/returns source snapshot lineage without mutable task patch fields for FR-002, FR-008, SCN-002, SC-002, and DESIGN-REQ-003
+- [ ] T017 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving missing original task input snapshot keeps exact Rerun unavailable with `original_task_input_snapshot_missing` for FR-009
+- [ ] T018 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and confirm T010-T012 fail for the expected MM-645 reasons before implementation
+- [ ] T019 Run `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q` and confirm T013-T017 fail for the expected MM-645 reasons before implementation
+
+### Integration Tests (write first)
+
+- [ ] T020 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving a failed execution direct Rerun creates a new execution without task authoring for FR-001, FR-006, SCN-001, and SC-001
+- [ ] T021 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun reuses the original task input snapshot unchanged for FR-002, FR-008, SCN-002, SC-002, DESIGN-REQ-003, and DESIGN-REQ-004
+- [ ] T022 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving created exact rerun execution contains `exact_full_rerun` provenance with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [ ] T023 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun starts from the beginning and excludes preserved progress/checkpoint state for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [ ] T024 Run `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short` and confirm T020-T023 fail for the expected MM-645 reasons before implementation
+
+### Conditional Verification For Implemented-Unverified Rows
+
+- [ ] T025 Run the focused tests from T013-T014 and T020-T023 after writing them to determine whether FR-005, FR-007, SCN-004, SCN-005, SC-004, DESIGN-REQ-002, and existing full-rerun sanitization already pass or require fallback implementation in `moonmind/workflows/temporal/service.py`
+- [ ] T026 If T025 passes for from-beginning/no-progress behavior, record the existing evidence in `specs/344-exact-full-rerun-workflow/tasks.md` task notes or implementation handoff without changing production code for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+
+### Implementation
+
+- [ ] T027 Implement server-side exact rerun provenance derivation in `moonmind/workflows/temporal/service.py` for no-mutation `RequestRerun`, covering FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [ ] T028 Implement or adjust exact full rerun parameter/snapshot reuse behavior in `moonmind/workflows/temporal/service.py` so the original task input snapshot is reused unchanged and no resume/progress fields carry over, covering FR-002, FR-005, FR-007, FR-008, SCN-002, SCN-004, SCN-005, SC-002, SC-004, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-004
+- [ ] T029 Update exact rerun update-route handling in `api_service/api/routers/executions.py` to persist/return correct source snapshot lineage, reject unsafe missing source identity, and preserve `original_task_input_snapshot_missing` behavior for FR-002, FR-004, FR-008, and FR-009
+- [ ] T030 Update Mission Control task detail Rerun behavior in `frontend/src/entrypoints/task-detail.tsx` to submit direct exact rerun without navigating to task authoring, covering FR-001, FR-006, SCN-001, SC-001, and the contract
+- [ ] T031 Update shared task editing helpers in `frontend/src/lib/temporalTaskEditing.ts` only if needed to separate direct exact Rerun from edit-for-rerun navigation, covering FR-001 and FR-006
+- [ ] T032 Remove or guard obsolete exact Rerun authoring-form assumptions in `frontend/src/entrypoints/task-create.tsx` while preserving edit-for-rerun behavior, covering FR-006 and the contract non-goal
+- [ ] T033 Apply fallback implementation in `moonmind/workflows/temporal/service.py` only if T025 shows existing sanitization does not fully prevent completed progress, preserved step output, or checkpoint import for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [ ] T034 Regenerate or adjust generated API/type fixtures only if the implementation changes public response shape in `frontend/src/generated/openapi.ts`, covering contract consistency for FR-001 through FR-009
+
+### Story Validation
+
+- [ ] T035 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/task-create.tsx`, and `frontend/src/lib/temporalTaskEditing.ts`
+- [ ] T036 Run `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q` and fix failures in `moonmind/workflows/temporal/service.py` and `api_service/api/routers/executions.py`
+- [ ] T037 Run `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short` and fix failures in the exact rerun workflow path
+- [ ] T038 Validate the independent story end to end against `specs/344-exact-full-rerun-workflow/quickstart.md`, confirming no authoring form, unchanged snapshot reuse, `exact_full_rerun` provenance, full from-beginning execution, and no progress import for FR-001 through FR-009 and SCN-001 through SCN-005
+
+**Checkpoint**: The exact failed task Rerun story is fully functional, covered by unit and integration tests, and testable independently.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding scope.
+
+- [ ] T039 [P] Review `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, `specs/344-exact-full-rerun-workflow/quickstart.md`, and `specs/344-exact-full-rerun-workflow/tasks.md` to ensure `MM-645` and the original Jira preset brief remain traceable for FR-010 and SC-005
+- [ ] T040 [P] Add any missing edge-case coverage discovered during implementation to `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py` for missing source identity, missing snapshot, and progress carryover guardrails
+- [ ] T041 Run `./tools/test_unit.sh` for final unit verification across Python and frontend suites
+- [ ] T042 Run `./tools/test_integration.sh` for final hermetic integration_ci verification
+- [ ] T043 Run `/moonspec-verify` for `specs/344-exact-full-rerun-workflow/spec.md` after implementation and tests pass, comparing final evidence against the preserved MM-645 Jira preset brief
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish And Verification (Phase 4)**: Depends on story implementation and focused tests passing.
+
+### Within The Story
+
+- Unit tests T010-T017 must be written before implementation tasks T027-T034.
+- Integration tests T020-T023 must be written before implementation tasks T027-T034.
+- Red-first confirmation T018, T019, and T024 must complete before production code tasks.
+- Conditional verification T025 decides whether fallback implementation T033 is needed for implemented-unverified cleanup behavior.
+- Service implementation T027-T028 should precede API route wiring T029.
+- API route wiring T029 should precede frontend direct-action implementation T030-T032 when frontend depends on response semantics.
+- Story validation T035-T038 follows implementation tasks.
+- Final verification T043 follows final unit and integration runs T041-T042.
+
+### Parallel Opportunities
+
+- T005, T006, T007, and T008 can run in parallel because they inspect different fixture/test surfaces.
+- T010, T013, T016, and T017 can be authored in parallel because they touch different test files.
+- T020-T023 can be authored together in one integration module, but coordinate edits because they share `tests/integration/temporal/test_exact_full_rerun_workflow.py`.
+- T027 and T030 can begin in parallel only after red-first confirmation if API contract assumptions are stable; T029 should reconcile backend response behavior before final frontend validation.
+- T039 and T040 can run in parallel after story validation.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent red-first unit test authoring:
+Task: "T010 Add direct Rerun frontend unit test in frontend/src/entrypoints/task-detail.test.tsx"
+Task: "T013 Add exact provenance service unit test in tests/unit/workflows/temporal/test_temporal_service.py"
+Task: "T016 Add source snapshot router unit test in tests/unit/api/routers/test_executions.py"
+
+# Launch independent implementation after red-first confirmation:
+Task: "T027 Implement exact rerun provenance in moonmind/workflows/temporal/service.py"
+Task: "T030 Implement direct Rerun action in frontend/src/entrypoints/task-detail.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 setup/foundation checks.
+2. Write frontend, service, router, and integration tests first.
+3. Run T018, T019, and T024 to confirm the tests fail for the intended MM-645 gaps.
+4. Implement server-side exact rerun provenance and unchanged snapshot/no-progress semantics.
+5. Wire API route behavior and then frontend direct Rerun behavior.
+6. Re-run focused frontend, unit, and integration tests.
+7. Run final `./tools/test_unit.sh` and `./tools/test_integration.sh`.
+8. Run `/moonspec-verify` against the preserved MM-645 Jira preset brief.
+
+### Requirement Status Handling
+
+- Code-and-test work: FR-001, FR-002, FR-003, FR-004, FR-006, FR-008, SCN-001, SCN-002, SCN-003, SC-001, SC-002, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-004.
+- Verification-first with conditional fallback: FR-005, FR-007, FR-010, SCN-004, SCN-005, SC-004, SC-005, DESIGN-REQ-002.
+- Already verified, preserve with regression/final validation: FR-009.
+
+---
+
+## Notes
+
+- This task list covers one story only: MM-645 exact full rerun workflow.
+- Unit and integration tests are required before implementation.
+- Exact Rerun must remain distinct from Edit task/edit-for-rerun and failed-step Resume.
+- Do not introduce new persistent storage.
+- Preserve `MM-645` in downstream implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/344-exact-full-rerun-workflow/tasks.md
+++ b/specs/344-exact-full-rerun-workflow/tasks.md
@@ -28,10 +28,10 @@
 
 **Purpose**: Confirm the existing test surfaces and feature artifacts are ready for MM-645 work.
 
-- [ ] T001 Verify `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, and `specs/344-exact-full-rerun-workflow/quickstart.md` exist and preserve `MM-645` traceability for FR-010 and SC-005
-- [ ] T002 Confirm frontend unit test tooling is available for `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` using `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
-- [ ] T003 Confirm Python unit test tooling is available for `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/api/routers/test_executions.py` using `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q`
-- [ ] T004 Confirm hermetic integration test tooling is available for `tests/integration/temporal` using `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short`
+- [X] T001 Verify `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, and `specs/344-exact-full-rerun-workflow/quickstart.md` exist and preserve `MM-645` traceability for FR-010 and SC-005
+- [X] T002 Confirm frontend unit test tooling is available for `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` using `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
+- [X] T003 Confirm Python unit test tooling is available for `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/api/routers/test_executions.py` using `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q`
+- [X] T004 Confirm hermetic integration test tooling is available for `tests/integration/temporal` using `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short`
 
 ---
 
@@ -41,11 +41,11 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T005 [P] Identify and document the existing exact-rerun fixture shapes in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, SCN-001, and the Mission Control contract
-- [ ] T006 [P] Identify and document existing source execution fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-003, FR-004, FR-005, FR-007, DESIGN-REQ-001, and DESIGN-REQ-002
-- [ ] T007 [P] Identify and document existing execution router fixture builders in `tests/unit/api/routers/test_executions.py` for FR-002, FR-008, FR-009, SCN-002, and DESIGN-REQ-003
-- [ ] T008 [P] Identify an existing hermetic integration test location or create a placeholder test module path under `tests/integration/temporal/test_exact_full_rerun_workflow.py` for SCN-001 through SCN-005
-- [ ] T009 Confirm no new persistent database table or migration is needed by reviewing `specs/344-exact-full-rerun-workflow/data-model.md` and existing execution record fields in `api_service/db/models.py` for the storage constraint
+- [X] T005 [P] Identify and document the existing exact-rerun fixture shapes in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, SCN-001, and the Mission Control contract
+- [X] T006 [P] Identify and document existing source execution fixture builders in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-003, FR-004, FR-005, FR-007, DESIGN-REQ-001, and DESIGN-REQ-002
+- [X] T007 [P] Identify and document existing execution router fixture builders in `tests/unit/api/routers/test_executions.py` for FR-002, FR-008, FR-009, SCN-002, and DESIGN-REQ-003
+- [X] T008 [P] Identify an existing hermetic integration test location or create a placeholder test module path under `tests/integration/temporal/test_exact_full_rerun_workflow.py` for SCN-001 through SCN-005
+- [X] T009 Confirm no new persistent database table or migration is needed by reviewing `specs/344-exact-full-rerun-workflow/data-model.md` and existing execution record fields in `api_service/db/models.py` for the storage constraint
 
 **Checkpoint**: Foundation ready; story test and implementation work can now begin.
 
@@ -72,47 +72,47 @@
 
 ### Unit Tests (write first)
 
-- [ ] T010 [P] Add failing frontend unit test proving the Rerun action submits directly from `frontend/src/entrypoints/task-detail.test.tsx` without linking to `/tasks/new` for FR-001, FR-006, SCN-001, SC-001, and the exact-rerun contract
-- [ ] T011 [P] Add failing frontend unit test preserving Edit task as the editable retry path while Rerun remains exact in `frontend/src/entrypoints/task-detail.test.tsx` for FR-006 and the contract non-goal
-- [ ] T012 [P] Add failing frontend unit test removing or guarding exact Rerun authoring-form dependency in `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, and SCN-001
-- [ ] T013 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact no-mutation `RequestRerun` creates `task.recovery.kind = exact_full_rerun` with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
-- [ ] T014 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact full rerun strips `resume`, `resumeSource`, `resumeCheckpointRef`, `preservedSteps`, and `completedSteps` for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
-- [ ] T015 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact rerun rejects or blocks missing source run identity rather than creating unpinned provenance for FR-004 and DESIGN-REQ-001
-- [ ] T016 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving exact rerun persists/returns source snapshot lineage without mutable task patch fields for FR-002, FR-008, SCN-002, SC-002, and DESIGN-REQ-003
-- [ ] T017 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving missing original task input snapshot keeps exact Rerun unavailable with `original_task_input_snapshot_missing` for FR-009
+- [X] T010 [P] Add failing frontend unit test proving the Rerun action submits directly from `frontend/src/entrypoints/task-detail.test.tsx` without linking to `/tasks/new` for FR-001, FR-006, SCN-001, SC-001, and the exact-rerun contract
+- [X] T011 [P] Add failing frontend unit test preserving Edit task as the editable retry path while Rerun remains exact in `frontend/src/entrypoints/task-detail.test.tsx` for FR-006 and the contract non-goal
+- [X] T012 [P] Add failing frontend unit test removing or guarding exact Rerun authoring-form dependency in `frontend/src/entrypoints/task-create.test.tsx` for FR-001, FR-006, and SCN-001
+- [X] T013 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact no-mutation `RequestRerun` creates `task.recovery.kind = exact_full_rerun` with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [X] T014 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact full rerun strips `resume`, `resumeSource`, `resumeCheckpointRef`, `preservedSteps`, and `completedSteps` for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [X] T015 [P] Add failing service unit test in `tests/unit/workflows/temporal/test_temporal_service.py` proving exact rerun rejects or blocks missing source run identity rather than creating unpinned provenance for FR-004 and DESIGN-REQ-001
+- [X] T016 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving exact rerun persists/returns source snapshot lineage without mutable task patch fields for FR-002, FR-008, SCN-002, SC-002, and DESIGN-REQ-003
+- [X] T017 [P] Add failing router unit test in `tests/unit/api/routers/test_executions.py` proving missing original task input snapshot keeps exact Rerun unavailable with `original_task_input_snapshot_missing` for FR-009
 - [ ] T018 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and confirm T010-T012 fail for the expected MM-645 reasons before implementation
 - [ ] T019 Run `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q` and confirm T013-T017 fail for the expected MM-645 reasons before implementation
 
 ### Integration Tests (write first)
 
-- [ ] T020 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving a failed execution direct Rerun creates a new execution without task authoring for FR-001, FR-006, SCN-001, and SC-001
-- [ ] T021 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun reuses the original task input snapshot unchanged for FR-002, FR-008, SCN-002, SC-002, DESIGN-REQ-003, and DESIGN-REQ-004
-- [ ] T022 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving created exact rerun execution contains `exact_full_rerun` provenance with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
-- [ ] T023 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun starts from the beginning and excludes preserved progress/checkpoint state for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [X] T020 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving a failed execution direct Rerun creates a new execution without task authoring for FR-001, FR-006, SCN-001, and SC-001
+- [X] T021 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun reuses the original task input snapshot unchanged for FR-002, FR-008, SCN-002, SC-002, DESIGN-REQ-003, and DESIGN-REQ-004
+- [X] T022 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving created exact rerun execution contains `exact_full_rerun` provenance with source workflow/run IDs for FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [X] T023 [P] Add failing hermetic integration test in `tests/integration/temporal/test_exact_full_rerun_workflow.py` proving exact rerun starts from the beginning and excludes preserved progress/checkpoint state for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
 - [ ] T024 Run `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short` and confirm T020-T023 fail for the expected MM-645 reasons before implementation
 
 ### Conditional Verification For Implemented-Unverified Rows
 
-- [ ] T025 Run the focused tests from T013-T014 and T020-T023 after writing them to determine whether FR-005, FR-007, SCN-004, SCN-005, SC-004, DESIGN-REQ-002, and existing full-rerun sanitization already pass or require fallback implementation in `moonmind/workflows/temporal/service.py`
-- [ ] T026 If T025 passes for from-beginning/no-progress behavior, record the existing evidence in `specs/344-exact-full-rerun-workflow/tasks.md` task notes or implementation handoff without changing production code for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [X] T025 Run the focused tests from T013-T014 and T020-T023 after writing them to determine whether FR-005, FR-007, SCN-004, SCN-005, SC-004, DESIGN-REQ-002, and existing full-rerun sanitization already pass or require fallback implementation in `moonmind/workflows/temporal/service.py`
+- [X] T026 If T025 passes for from-beginning/no-progress behavior, record the existing evidence in `specs/344-exact-full-rerun-workflow/tasks.md` task notes or implementation handoff without changing production code for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
 
 ### Implementation
 
-- [ ] T027 Implement server-side exact rerun provenance derivation in `moonmind/workflows/temporal/service.py` for no-mutation `RequestRerun`, covering FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
-- [ ] T028 Implement or adjust exact full rerun parameter/snapshot reuse behavior in `moonmind/workflows/temporal/service.py` so the original task input snapshot is reused unchanged and no resume/progress fields carry over, covering FR-002, FR-005, FR-007, FR-008, SCN-002, SCN-004, SCN-005, SC-002, SC-004, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-004
-- [ ] T029 Update exact rerun update-route handling in `api_service/api/routers/executions.py` to persist/return correct source snapshot lineage, reject unsafe missing source identity, and preserve `original_task_input_snapshot_missing` behavior for FR-002, FR-004, FR-008, and FR-009
-- [ ] T030 Update Mission Control task detail Rerun behavior in `frontend/src/entrypoints/task-detail.tsx` to submit direct exact rerun without navigating to task authoring, covering FR-001, FR-006, SCN-001, SC-001, and the contract
-- [ ] T031 Update shared task editing helpers in `frontend/src/lib/temporalTaskEditing.ts` only if needed to separate direct exact Rerun from edit-for-rerun navigation, covering FR-001 and FR-006
-- [ ] T032 Remove or guard obsolete exact Rerun authoring-form assumptions in `frontend/src/entrypoints/task-create.tsx` while preserving edit-for-rerun behavior, covering FR-006 and the contract non-goal
-- [ ] T033 Apply fallback implementation in `moonmind/workflows/temporal/service.py` only if T025 shows existing sanitization does not fully prevent completed progress, preserved step output, or checkpoint import for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
-- [ ] T034 Regenerate or adjust generated API/type fixtures only if the implementation changes public response shape in `frontend/src/generated/openapi.ts`, covering contract consistency for FR-001 through FR-009
+- [X] T027 Implement server-side exact rerun provenance derivation in `moonmind/workflows/temporal/service.py` for no-mutation `RequestRerun`, covering FR-003, FR-004, SCN-003, SC-003, and DESIGN-REQ-001
+- [X] T028 Implement or adjust exact full rerun parameter/snapshot reuse behavior in `moonmind/workflows/temporal/service.py` so the original task input snapshot is reused unchanged and no resume/progress fields carry over, covering FR-002, FR-005, FR-007, FR-008, SCN-002, SCN-004, SCN-005, SC-002, SC-004, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-004
+- [X] T029 Update exact rerun update-route handling in `api_service/api/routers/executions.py` to persist/return correct source snapshot lineage, reject unsafe missing source identity, and preserve `original_task_input_snapshot_missing` behavior for FR-002, FR-004, FR-008, and FR-009
+- [X] T030 Update Mission Control task detail Rerun behavior in `frontend/src/entrypoints/task-detail.tsx` to submit direct exact rerun without navigating to task authoring, covering FR-001, FR-006, SCN-001, SC-001, and the contract
+- [X] T031 Update shared task editing helpers in `frontend/src/lib/temporalTaskEditing.ts` only if needed to separate direct exact Rerun from edit-for-rerun navigation, covering FR-001 and FR-006
+- [X] T032 Remove or guard obsolete exact Rerun authoring-form assumptions in `frontend/src/entrypoints/task-create.tsx` while preserving edit-for-rerun behavior, covering FR-006 and the contract non-goal
+- [X] T033 Apply fallback implementation in `moonmind/workflows/temporal/service.py` only if T025 shows existing sanitization does not fully prevent completed progress, preserved step output, or checkpoint import for FR-005, FR-007, SCN-004, SCN-005, SC-004, and DESIGN-REQ-002
+- [X] T034 Regenerate or adjust generated API/type fixtures only if the implementation changes public response shape in `frontend/src/generated/openapi.ts`, covering contract consistency for FR-001 through FR-009
 
 ### Story Validation
 
-- [ ] T035 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/task-create.tsx`, and `frontend/src/lib/temporalTaskEditing.ts`
-- [ ] T036 Run `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q` and fix failures in `moonmind/workflows/temporal/service.py` and `api_service/api/routers/executions.py`
-- [ ] T037 Run `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short` and fix failures in the exact rerun workflow path
-- [ ] T038 Validate the independent story end to end against `specs/344-exact-full-rerun-workflow/quickstart.md`, confirming no authoring form, unchanged snapshot reuse, `exact_full_rerun` provenance, full from-beginning execution, and no progress import for FR-001 through FR-009 and SCN-001 through SCN-005
+- [X] T035 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix failures in `frontend/src/entrypoints/task-detail.tsx`, `frontend/src/entrypoints/task-create.tsx`, and `frontend/src/lib/temporalTaskEditing.ts`
+- [X] T036 Run `pytest tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -q` and fix failures in `moonmind/workflows/temporal/service.py` and `api_service/api/routers/executions.py`
+- [X] T037 Run `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short` and fix failures in the exact rerun workflow path
+- [X] T038 Validate the independent story end to end against `specs/344-exact-full-rerun-workflow/quickstart.md`, confirming no authoring form, unchanged snapshot reuse, `exact_full_rerun` provenance, full from-beginning execution, and no progress import for FR-001 through FR-009 and SCN-001 through SCN-005
 
 **Checkpoint**: The exact failed task Rerun story is fully functional, covered by unit and integration tests, and testable independently.
 
@@ -122,9 +122,9 @@
 
 **Purpose**: Strengthen the completed story without adding scope.
 
-- [ ] T039 [P] Review `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, `specs/344-exact-full-rerun-workflow/quickstart.md`, and `specs/344-exact-full-rerun-workflow/tasks.md` to ensure `MM-645` and the original Jira preset brief remain traceable for FR-010 and SC-005
-- [ ] T040 [P] Add any missing edge-case coverage discovered during implementation to `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py` for missing source identity, missing snapshot, and progress carryover guardrails
-- [ ] T041 Run `./tools/test_unit.sh` for final unit verification across Python and frontend suites
+- [X] T039 [P] Review `specs/344-exact-full-rerun-workflow/spec.md`, `specs/344-exact-full-rerun-workflow/plan.md`, `specs/344-exact-full-rerun-workflow/research.md`, `specs/344-exact-full-rerun-workflow/data-model.md`, `specs/344-exact-full-rerun-workflow/contracts/exact-full-rerun-contract.md`, `specs/344-exact-full-rerun-workflow/quickstart.md`, and `specs/344-exact-full-rerun-workflow/tasks.md` to ensure `MM-645` and the original Jira preset brief remain traceable for FR-010 and SC-005
+- [X] T040 [P] Add any missing edge-case coverage discovered during implementation to `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py` for missing source identity, missing snapshot, and progress carryover guardrails
+- [X] T041 Run `./tools/test_unit.sh` for final unit verification across Python and frontend suites
 - [ ] T042 Run `./tools/test_integration.sh` for final hermetic integration_ci verification
 - [ ] T043 Run `/moonspec-verify` for `specs/344-exact-full-rerun-workflow/spec.md` after implementation and tests pass, comparing final evidence against the preserved MM-645 Jira preset brief
 
@@ -203,3 +203,7 @@ Task: "T030 Implement direct Rerun action in frontend/src/entrypoints/task-detai
 - Exact Rerun must remain distinct from Edit task/edit-for-rerun and failed-step Resume.
 - Do not introduce new persistent storage.
 - Preserve `MM-645` in downstream implementation notes, verification output, commit text, and pull request metadata.
+- T005-T007 fixture notes: frontend coverage uses `task-detail.test.tsx` task action payloads and `task-create.test.tsx` edit-for-rerun coverage; service coverage uses `temporal_db` source execution fixtures in `test_temporal_service.py`; router coverage uses `_build_execution_record()` and task input snapshot action serialization fixtures in `test_executions.py`.
+- T026/T038 evidence: focused service and integration assertions prove `_full_rerun_parameters()` strips task run IDs, resume source/checkpoint, preserved steps, completed steps, and task resume data while adding exact provenance from the source workflow/run.
+- TDD red evidence: service exact-rerun unit expectations failed before production changes because `task.recovery` was missing; the new MM-645 integration test failed against an unmodified temporary worktree because `exact_full_rerun` provenance was absent.
+- T042 blocked in this managed container: `./tools/test_integration.sh` reached Docker Compose image build and failed with Docker daemon `403 Forbidden` administrative rules. Direct hermetic pytest verification passed with `pytest tests/integration/temporal -m 'integration_ci' -q --tb=short`.

--- a/specs/344-exact-full-rerun-workflow/tasks.md
+++ b/specs/344-exact-full-rerun-workflow/tasks.md
@@ -7,7 +7,7 @@
 
 **Organization**: Tasks cover exactly one story: exact full rerun from a failed execution using the original task input snapshot unchanged.
 
-**Source Traceability**: Preserves Jira issue `MM-645` and the original Jira preset brief from `spec.md`. Requirement status from `plan.md`: 5 partial, 4 missing, 9 implemented_unverified, 1 implemented_verified across FR/SCN/SC/DESIGN rows.
+**Source Traceability**: Preserves Jira issue `MM-645` and the original Jira preset brief from `spec.md`. Requirement status from `plan.md`: 10 partial, 5 missing, 8 implemented_unverified, 1 implemented_verified across FR/SCN/SC/DESIGN rows.
 
 **Test Commands**:
 

--- a/tests/integration/temporal/test_backend_resume_eligibility.py
+++ b/tests/integration/temporal/test_backend_resume_eligibility.py
@@ -166,6 +166,8 @@ async def test_generic_rerun_does_not_carry_resume_reference_fields(
             created.state = MoonMindWorkflowState.FAILED
             created.close_status = TemporalExecutionCloseStatus.FAILED
             await session.commit()
+            source_workflow_id = created.workflow_id
+            source_run_id = created.run_id
 
             result = await service.update_execution(
                 workflow_id=created.workflow_id,
@@ -190,6 +192,11 @@ async def test_generic_rerun_does_not_carry_resume_reference_fields(
     assert rerun.parameters["task"] == {
         "title": "Resume source",
         "instructions": "Original",
+        "recovery": {
+            "kind": "exact_full_rerun",
+            "sourceWorkflowId": source_workflow_id,
+            "sourceRunId": source_run_id,
+        },
     }
 
 

--- a/tests/integration/temporal/test_exact_full_rerun_workflow.py
+++ b/tests/integration/temporal/test_exact_full_rerun_workflow.py
@@ -1,0 +1,139 @@
+"""Hermetic integration coverage for MM-645 exact full rerun workflow."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    MoonMindWorkflowState,
+    TemporalExecutionCloseStatus,
+)
+from moonmind.workflows.temporal.service import TemporalExecutionService
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+@asynccontextmanager
+async def _db(tmp_path: Path):
+    url = f"sqlite+aiosqlite:///{tmp_path}/exact_full_rerun_workflow.db"
+    engine = create_async_engine(url, future=True)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def test_failed_execution_direct_rerun_creates_exact_full_rerun_from_original_inputs(
+    tmp_path: Path,
+) -> None:
+    async with _db(tmp_path) as maker:
+        async with maker() as session:
+            service = TemporalExecutionService(session, client_adapter=AsyncMock())
+            source = await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=uuid4(),
+                title="MM-645 failed source",
+                input_artifact_ref="artifact://input/source",
+                plan_artifact_ref="artifact://plan/source",
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "taskRunId": "old-task-run",
+                    "resumeSource": {"workflowId": "mm:old", "runId": "run-old"},
+                    "resumeCheckpointRef": "artifact://checkpoint/old",
+                    "preservedSteps": [{"logicalStepId": "plan"}],
+                    "completedSteps": [{"logicalStepId": "plan"}],
+                    "task": {
+                        "title": "Original task",
+                        "instructions": "Run the original task input unchanged.",
+                        "recovery": {
+                            "kind": "resume_from_failed_step",
+                            "sourceWorkflowId": "mm:old",
+                            "sourceRunId": "run-old",
+                        },
+                        "resume": {
+                            "kind": "resume_from_failed_step",
+                            "sourceWorkflowId": "mm:old",
+                            "sourceRunId": "run-old",
+                            "failedStepId": "implement",
+                            "resumeCheckpointRef": "artifact://checkpoint/old",
+                            "taskInputSnapshotRef": "artifact://snapshot/old",
+                        },
+                    },
+                },
+                idempotency_key=None,
+            )
+            source = await service.record_terminal_state(
+                workflow_id=source.workflow_id,
+                state="failed",
+                close_status="failed",
+                summary="failed before exact rerun",
+            )
+            source.memo = {
+                **dict(source.memo or {}),
+                "task_input_snapshot_ref": "artifact://snapshot/source",
+                "task_input_snapshot_version": "2026-05-13T00:00:00Z",
+            }
+            source.artifact_refs = [
+                "artifact://input/source",
+                "artifact://plan/source",
+                "artifact://snapshot/source",
+            ]
+            await session.commit()
+            await session.refresh(source)
+
+            response = await service.update_execution(
+                workflow_id=source.workflow_id,
+                update_name="RequestRerun",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                parameters_patch=None,
+                title=None,
+                new_manifest_artifact_ref=None,
+                mode=None,
+                max_concurrency=None,
+                node_ids=None,
+                idempotency_key="exact-full-rerun-mm-645",
+            )
+            source_after_rerun = await service.describe_execution(source.workflow_id)
+            rerun = await service.describe_execution(response["workflow_id"])
+
+    assert response["continue_as_new_cause"] == "manual_rerun"
+    assert rerun.workflow_id != source_after_rerun.workflow_id
+    assert source_after_rerun.state is MoonMindWorkflowState.FAILED
+    assert source_after_rerun.close_status is TemporalExecutionCloseStatus.FAILED
+
+    assert rerun.input_ref == "artifact://input/source"
+    assert rerun.plan_ref == "artifact://plan/source"
+    assert rerun.parameters["repository"] == "MoonLadderStudios/MoonMind"
+    assert rerun.parameters["rerunSource"] == {
+        "workflowId": source_after_rerun.workflow_id,
+        "runId": source_after_rerun.run_id,
+    }
+    assert rerun.parameters["task"] == {
+        "title": "Original task",
+        "instructions": "Run the original task input unchanged.",
+        "recovery": {
+            "kind": "exact_full_rerun",
+            "sourceWorkflowId": source_after_rerun.workflow_id,
+            "sourceRunId": source_after_rerun.run_id,
+        },
+    }
+    assert "taskRunId" not in rerun.parameters
+    assert "resumeSource" not in rerun.parameters
+    assert "resumeCheckpointRef" not in rerun.parameters
+    assert "preservedSteps" not in rerun.parameters
+    assert "completedSteps" not in rerun.parameters
+    assert "resume" not in rerun.parameters["task"]

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -33,6 +33,7 @@ from api_service.db.base import get_async_session
 from api_service.db.models import (
     MoonMindWorkflowState,
     TemporalArtifactEncryption,
+    TemporalArtifactLink,
     TemporalArtifactStatus,
     TemporalExecutionCanonicalRecord,
     TemporalExecutionRecord,
@@ -51,22 +52,48 @@ from moonmind.schemas.temporal_models import (
     StepLedgerSnapshotModel,
 )
 
+
 class _ScalarRows:
-    def __init__(self, rows: list[SimpleNamespace]) -> None:
+    def __init__(self, rows: list[object]) -> None:
         self._rows = rows
 
-    def all(self) -> list[SimpleNamespace]:
+    def all(self) -> list[object]:
         return self._rows
 
+
 class _ExecuteResult:
-    def __init__(self, rows: list[SimpleNamespace]) -> None:
+    def __init__(self, rows: list[object]) -> None:
         self._rows = rows
 
     def scalars(self) -> _ScalarRows:
         return _ScalarRows(self._rows)
 
+    def scalar_one_or_none(self) -> object | None:
+        return self._rows[0] if self._rows else None
+
+
 def _artifact_session(rows: list[SimpleNamespace]) -> SimpleNamespace:
     return SimpleNamespace(execute=AsyncMock(return_value=_ExecuteResult(rows)))
+
+
+class _SnapshotReuseSession:
+    def __init__(
+        self,
+        *,
+        canonical: TemporalExecutionCanonicalRecord | None = None,
+        existing_link: object | None = None,
+    ) -> None:
+        self._canonical = canonical
+        self._existing_link = existing_link
+        self.added: list[object] = []
+        self.get = AsyncMock(return_value=canonical)
+
+    async def execute(self, _statement: object) -> _ExecuteResult:
+        rows = [self._existing_link] if self._existing_link is not None else []
+        return _ExecuteResult(rows)
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
 
 def _completed_attachment_artifact(
     artifact_id: str,
@@ -7597,8 +7624,7 @@ async def test_exact_rerun_reuses_source_task_input_snapshot_lineage() -> None:
         memo={},
         artifact_refs=[],
     )
-    session = AsyncMock()
-    session.get.return_value = canonical
+    session = _SnapshotReuseSession(canonical=canonical)
 
     snapshot_ref = await _reuse_original_task_input_snapshot_from_source(
         session=session,
@@ -7616,6 +7642,44 @@ async def test_exact_rerun_reuses_source_task_input_snapshot_lineage() -> None:
         TemporalExecutionCanonicalRecord,
         "mm:rerun",
     )
+    assert len(session.added) == 1
+    link = session.added[0]
+    assert isinstance(link, TemporalArtifactLink)
+    assert link.artifact_id == "artifact://snapshot/source"
+    assert link.namespace == "moonmind"
+    assert link.workflow_id == "mm:rerun"
+    assert link.run_id == "run-rerun"
+    assert link.link_type == "input.original_snapshot"
+
+
+@pytest.mark.asyncio
+async def test_exact_rerun_reuses_snapshot_defaults_invalid_version() -> None:
+    source = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    source.memo = {
+        **source.memo,
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+        "task_input_snapshot_version": "2026-05-13T00:00:00Z",
+        "task_input_snapshot_source_kind": "create",
+    }
+    target = TemporalExecutionCanonicalRecord(
+        workflow_id="mm:rerun",
+        run_id="run-rerun",
+        namespace="moonmind",
+        workflow_type=TemporalWorkflowType.RUN,
+        memo={},
+        artifact_refs=[],
+    )
+    session = _SnapshotReuseSession()
+
+    snapshot_ref = await _reuse_original_task_input_snapshot_from_source(
+        session=session,
+        source_record=source,
+        target_record=target,
+    )
+
+    assert snapshot_ref == "artifact://snapshot/source"
+    assert target.memo["task_input_snapshot_version"] == 1
+    assert len(session.added) == 1
 
 
 def test_terminal_task_editing_actions_reject_parameter_fallback_without_snapshot(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -22,6 +22,7 @@ from api_service.api.routers.executions import (
     _build_original_task_input_snapshot_payload,
     _merge_task_preserving_artifact_instructions,
     _resume_not_available_reason,
+    _reuse_original_task_input_snapshot_from_source,
     _task_input_snapshot_descriptor_from_record,
     get_temporal_client,
     _serialize_execution,
@@ -33,6 +34,8 @@ from api_service.db.models import (
     MoonMindWorkflowState,
     TemporalArtifactEncryption,
     TemporalArtifactStatus,
+    TemporalExecutionCanonicalRecord,
+    TemporalExecutionRecord,
     TemporalWorkflowType,
 )
 from moonmind.config.settings import settings
@@ -7567,6 +7570,52 @@ def test_mm644_rerun_snapshot_payload_records_source_lineage() -> None:
         "sourceRunId": "run-source",
     }
     assert payload["draft"]["task"]["recovery"]["kind"] == "edited_full_retry"
+
+
+@pytest.mark.asyncio
+async def test_exact_rerun_reuses_source_task_input_snapshot_lineage() -> None:
+    source = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    source.memo = {
+        **source.memo,
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+        "task_input_snapshot_version": 1,
+        "task_input_snapshot_source_kind": "create",
+    }
+    target = TemporalExecutionRecord(
+        workflow_id="mm:rerun",
+        run_id="run-rerun",
+        namespace="moonmind",
+        workflow_type=TemporalWorkflowType.RUN,
+        memo={},
+        artifact_refs=[],
+    )
+    canonical = TemporalExecutionCanonicalRecord(
+        workflow_id="mm:rerun",
+        run_id="run-rerun",
+        namespace="moonmind",
+        workflow_type=TemporalWorkflowType.RUN,
+        memo={},
+        artifact_refs=[],
+    )
+    session = AsyncMock()
+    session.get.return_value = canonical
+
+    snapshot_ref = await _reuse_original_task_input_snapshot_from_source(
+        session=session,
+        source_record=source,
+        target_record=target,
+    )
+
+    assert snapshot_ref == "artifact://snapshot/source"
+    for record in (target, canonical):
+        assert record.memo["task_input_snapshot_ref"] == "artifact://snapshot/source"
+        assert record.memo["task_input_snapshot_version"] == 1
+        assert record.memo["task_input_snapshot_source_kind"] == "rerun"
+        assert record.artifact_refs == ["artifact://snapshot/source"]
+    session.get.assert_awaited_once_with(
+        TemporalExecutionCanonicalRecord,
+        "mm:rerun",
+    )
 
 
 def test_terminal_task_editing_actions_reject_parameter_fallback_without_snapshot(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1961,7 +1961,14 @@ async def test_request_rerun_uses_continue_as_new_same_workflow_id(
         assert "resumeCheckpointRef" not in refreshed.parameters
         assert "preservedSteps" not in refreshed.parameters
         assert "completedSteps" not in refreshed.parameters
-        assert refreshed.parameters["task"] == {"instructions": "Original task"}
+        assert refreshed.parameters["task"] == {
+            "instructions": "Original task",
+            "recovery": {
+                "kind": "exact_full_rerun",
+                "sourceWorkflowId": workflow_id,
+                "sourceRunId": original_run_id,
+            },
+        }
         assert refreshed.search_attributes["mm_continue_as_new_cause"] == "manual_rerun"
 
 @pytest.mark.asyncio
@@ -2049,7 +2056,14 @@ async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
         assert "resumeCheckpointRef" not in rerun.parameters
         assert "preservedSteps" not in rerun.parameters
         assert "completedSteps" not in rerun.parameters
-        assert rerun.parameters["task"] == {"instructions": "Original task"}
+        assert rerun.parameters["task"] == {
+            "instructions": "Original task",
+            "recovery": {
+                "kind": "exact_full_rerun",
+                "sourceWorkflowId": source_workflow_id,
+                "sourceRunId": source_run_id,
+            },
+        }
         assert service._client_adapter.update_workflow.await_count == 0
 
 
@@ -2145,6 +2159,24 @@ def test_full_retry_recovery_from_patch_rejects_forged_source_ids():
             },
             source_workflow_id="mm:source",
             source_run_id="run-source",
+        )
+
+
+@pytest.mark.parametrize(
+    ("source_workflow_id", "source_run_id"),
+    [("", "run-source"), ("mm:source", " ")],
+)
+def test_exact_full_rerun_recovery_rejects_missing_source_identity(
+    source_workflow_id: str,
+    source_run_id: str,
+) -> None:
+    with pytest.raises(
+        TemporalExecutionValidationError,
+        match="Rerun source workflowId and runId are required",
+    ):
+        TemporalExecutionService._exact_full_rerun_recovery(
+            source_workflow_id=source_workflow_id,
+            source_run_id=source_run_id,
         )
 
 

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2164,11 +2164,11 @@ def test_full_retry_recovery_from_patch_rejects_forged_source_ids():
 
 @pytest.mark.parametrize(
     ("source_workflow_id", "source_run_id"),
-    [("", "run-source"), ("mm:source", " ")],
+    [("", "run-source"), ("mm:source", " "), (None, "run-source")],
 )
 def test_exact_full_rerun_recovery_rejects_missing_source_identity(
-    source_workflow_id: str,
-    source_run_id: str,
+    source_workflow_id: str | None,
+    source_run_id: str | None,
 ) -> None:
     with pytest.raises(
         TemporalExecutionValidationError,


### PR DESCRIPTION
Change Jira issue MM-645 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.