### PR TITLE
I want to make the provider login terminal page look nicer. The box to paste in an authentication code should go below the terminal window, since it h

### DIFF
--- a/frontend/src/entrypoints/oauth-terminal.test.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.test.tsx
@@ -238,14 +238,8 @@ describe('OAuthTerminalPage clipboard behavior', () => {
     renderPage();
     await waitForSocket();
 
-    expect(await screen.findByText('codex-oauth')).toBeTruthy();
-    expect(screen.getByText('codex cli')).toBeTruthy();
-    expect(screen.getByText('OpenAI')).toBeTruthy();
-    expect(screen.getByText('2026-05-05T22:00:00Z')).toBeTruthy();
+    fireEvent.click(await screen.findByRole('button', { name: 'Finalize Provider Profile' }));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Finalize Provider Profile' }));
-
-    expect(await screen.findByText('Codex Team')).toBeTruthy();
     expect((await screen.findAllByText('Succeeded')).length).toBeGreaterThan(0);
     expect(await screen.findByText('Provider profile registered successfully.')).toBeTruthy();
     expect(storageSetItem).toHaveBeenCalledWith(

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -591,6 +591,9 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
           <span className="oauth-terminal-status">{formatStatusLabel(status)}</span>
         </div>
       </header>
+      <section className="oauth-terminal-surface" aria-label="OAuth terminal output">
+        <div ref={terminalElementRef} className="oauth-terminal-xterm" />
+      </section>
       <section className="oauth-terminal-paste-box">
         <label className="oauth-terminal-paste-label" htmlFor="oauth-terminal-paste-input">
           Paste authentication code
@@ -616,56 +619,8 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
           </button>
         </div>
       </section>
-      <section className="oauth-terminal-surface" aria-label="OAuth terminal output">
-        <div ref={terminalElementRef} className="oauth-terminal-xterm" />
-      </section>
       {session ? (
-        <section className="oauth-terminal-session-panel" aria-label="OAuth session details">
-          <dl>
-            <div>
-              <dt>Profile</dt>
-              <dd>{session.profile_summary?.profile_id ?? session.profile_id ?? 'Unknown profile'}</dd>
-            </div>
-            <div>
-              <dt>Runtime</dt>
-              <dd>{formatStatusLabel(session.runtime_id ?? 'unknown')}</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>{oauthStatusLabel(session.status)}</dd>
-            </div>
-            {session.profile_summary ? (
-              <div>
-                <dt>Provider</dt>
-                <dd>
-                  {session.profile_summary.provider_label ??
-                    session.profile_summary.provider_id}
-                </dd>
-              </div>
-            ) : null}
-            {session.expires_at ? (
-              <div>
-                <dt>Expiry</dt>
-                <dd>{session.expires_at}</dd>
-              </div>
-            ) : null}
-            {session.profile_summary ? (
-              <div>
-                <dt>Account</dt>
-                <dd>
-                  {session.profile_summary.account_label ??
-                    session.profile_summary.provider_label ??
-                    session.profile_summary.provider_id}
-                </dd>
-              </div>
-            ) : null}
-            {session.failure_reason ? (
-              <div>
-                <dt>Failure</dt>
-                <dd>{safeDisplayText(session.failure_reason)}</dd>
-              </div>
-            ) : null}
-          </dl>
+        <section className="oauth-terminal-session-panel" aria-label="OAuth session actions">
           <div className="oauth-terminal-session-actions">
             {TERMINAL_FINALIZE_STATUSES.includes(session.status) ? (
               <button
@@ -700,6 +655,11 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
               </button>
             ) : null}
           </div>
+          {session.failure_reason ? (
+            <p role="alert" className="oauth-terminal-finalize-result oauth-terminal-finalize-result--error">
+              {safeDisplayText(session.failure_reason)}
+            </p>
+          ) : null}
           {session.status === 'succeeded' ? (
             <p role="status" className="oauth-terminal-finalize-result oauth-terminal-finalize-result--success">
               Provider profile registered successfully.

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -620,7 +620,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
         </div>
       </section>
       {session ? (
-        <section className="oauth-terminal-session-panel" aria-label="OAuth session actions">
+        <section className="oauth-terminal-session-panel" aria-label="OAuth session status and actions">
           <div className="oauth-terminal-session-actions">
             {TERMINAL_FINALIZE_STATUSES.includes(session.status) ? (
               <button

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3832,32 +3832,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .oauth-terminal-session-panel {
-  background: rgb(var(--mm-panel, 255 255 255));
-  border: 1px solid rgb(var(--mm-border, 203 213 225));
-  border-radius: 8px;
   display: grid;
   gap: 12px;
-  padding: 16px;
-}
-
-.oauth-terminal-session-panel dl {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  margin: 0;
-}
-
-.oauth-terminal-session-panel dt {
-  color: rgb(var(--mm-muted, 100 116 139));
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.oauth-terminal-session-panel dd {
-  color: rgb(var(--mm-text, 15 23 42));
-  margin: 2px 0 0;
-  overflow-wrap: anywhere;
 }
 
 .oauth-terminal-session-actions {
@@ -3886,23 +3862,21 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .oauth-terminal-paste-box {
-  background: rgb(var(--mm-panel, 255 255 255));
-  border: 1px solid rgb(var(--mm-border, 203 213 225));
-  border-radius: 12px;
   display: grid;
-  gap: 12px;
-  padding: 16px;
+  gap: 8px;
 }
 
 .oauth-terminal-paste-label {
-  color: rgb(var(--mm-text, 15 23 42));
-  font-size: 0.95rem;
+  color: rgb(var(--mm-muted, 100 116 139));
+  font-size: 0.75rem;
   font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .oauth-terminal-paste-controls {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .oauth-terminal-paste-input {
@@ -3910,6 +3884,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   min-height: 5.5rem;
   resize: vertical;
+}
+
+.oauth-terminal-paste-controls > .primary {
+  justify-self: start;
 }
 
 .oauth-terminal-surface {


### PR DESCRIPTION
I want to make the provider login terminal page look nicer. The box to paste in an authentication code should go below the terminal window, since it happens after. Additionally, it does not need the outer box border around the div containing the send to terminal button. It also does not need the box around finalize provider profile along with all of the column headers present there - profile, runtime, status, etc. I'm not sure why they were added to this page. Just make it look clean, logical, and fitting for the overall aesthetic of the app.