### PR TITLE
Change Jira issue MM-647 to status In Progress before implementation starts.

### DIFF
--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -45,6 +45,40 @@ def _has_semantic_output_ref(row: Mapping[str, Any]) -> bool:
     return False
 
 
+def preserved_outputs_for_dependencies(
+    rows: list[dict[str, Any]],
+    logical_step_id: str,
+) -> dict[str, dict[str, str]]:
+    """Return semantic output refs from preserved direct dependencies."""
+
+    row_by_id = {
+        str(row.get("logicalStepId") or "").strip(): row
+        for row in rows
+        if str(row.get("logicalStepId") or "").strip()
+    }
+    target_row = row_by_id.get(logical_step_id)
+    if target_row is None:
+        raise KeyError(f"Unknown logical step id: {logical_step_id}")
+
+    outputs: dict[str, dict[str, str]] = {}
+    for dependency_id in target_row.get("dependsOn") or []:
+        dep_id = str(dependency_id or "").strip()
+        dependency_row = row_by_id.get(dep_id)
+        if dependency_row is None or "preservedFrom" not in dependency_row:
+            continue
+        artifacts = dependency_row.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            continue
+        semantic_refs: dict[str, str] = {}
+        for key in ("outputSummary", "outputPrimary"):
+            value = artifacts.get(key)
+            if isinstance(value, str) and value.strip():
+                semantic_refs[key] = value.strip()
+        if semantic_refs:
+            outputs[dep_id] = semantic_refs
+    return outputs
+
+
 def _resume_preservation(
     *,
     eligible: bool,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -381,6 +381,7 @@ class MoonMindRunWorkflow:
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
         self._step_ledger_rows: list[dict[str, Any]] = []
+        self._step_ledger_by_id: dict[str, dict[str, Any]] = {}
         self._progress_snapshot: dict[str, Any] = {
             "total": 0,
             "pending": 0,
@@ -678,7 +679,25 @@ class MoonMindRunWorkflow:
             "workspace_checkpoint_ref",
             "branchCheckpointRef",
             "branch_checkpoint_ref",
+            "checkpointPayloadRef",
+            "checkpoint_payload_ref",
         )
+
+    def _resume_workspace_has_evidence(
+        self,
+        workspace: Mapping[str, Any],
+    ) -> bool:
+        return any(
+            isinstance(value, str) and value.strip()
+            for value in workspace.values()
+        )
+
+    def _rebuild_step_ledger_index(self) -> None:
+        self._step_ledger_by_id = {
+            row["logicalStepId"]: row
+            for row in self._step_ledger_rows
+            if isinstance(row.get("logicalStepId"), str) and row["logicalStepId"]
+        }
 
     def _validate_resume_source_for_execution(self) -> dict[str, Any] | None:
         resume_source = self._resume_source
@@ -689,6 +708,8 @@ class MoonMindRunWorkflow:
             return None
         if not isinstance(resume_source, Mapping):
             raise ValueError("Resume source must be a compact mapping.")
+        if not resume_source:
+            return None
 
         source_workflow_id = self._resume_source_text(
             resume_source,
@@ -740,14 +761,15 @@ class MoonMindRunWorkflow:
         if not plan_identity:
             raise ValueError("Resume source requires source plan identity.")
 
-        workspace = resume_source.get("resumeWorkspace") or resume_source.get(
-            "resume_workspace"
+        workspace = (
+            resume_source.get("resumeWorkspace")
+            if "resumeWorkspace" in resume_source
+            else resume_source.get("resume_workspace")
         )
         if not isinstance(workspace, Mapping):
             raise ValueError("Resume source requires resume workspace checkpoint.")
-        workspace_checkpoint_ref = self._resume_workspace_checkpoint_ref(workspace)
-        if not workspace_checkpoint_ref:
-            raise ValueError("Resume source requires workspace checkpoint ref.")
+        if not self._resume_workspace_has_evidence(workspace):
+            raise ValueError("Resume source requires workspace evidence.")
 
         preserved_steps = resume_source.get("preservedSteps") or resume_source.get(
             "preserved_steps"
@@ -811,7 +833,7 @@ class MoonMindRunWorkflow:
             return self._resume_workspace_restored_ref
         checkpoint_ref = self._resume_workspace_checkpoint_ref(self._resume_workspace)
         if not checkpoint_ref:
-            raise ValueError("Resume source requires workspace checkpoint ref.")
+            return None
         self._resume_workspace_restored_ref = checkpoint_ref
         return checkpoint_ref
 
@@ -825,10 +847,7 @@ class MoonMindRunWorkflow:
         )
 
     def _step_ledger_row_for(self, logical_step_id: str) -> dict[str, Any] | None:
-        for row in self._step_ledger_rows:
-            if row.get("logicalStepId") == logical_step_id:
-                return row
-        return None
+        return self._step_ledger_by_id.get(logical_step_id)
 
     def _is_preserved_step(self, logical_step_id: str) -> bool:
         row = self._step_ledger_row_for(logical_step_id)
@@ -880,9 +899,10 @@ class MoonMindRunWorkflow:
             dependency_map=dependency_map,
             updated_at=updated_at,
         )
-        preserved_steps = resume_source.get("preservedSteps")
-        if not isinstance(preserved_steps, list):
-            preserved_steps = resume_source.get("preserved_steps")
+        self._rebuild_step_ledger_index()
+        preserved_steps = resume_source.get("preservedSteps") or resume_source.get(
+            "preserved_steps"
+        )
         if isinstance(preserved_steps, list):
             source_workflow_id = self._resume_source_text(
                 resume_source,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -80,6 +80,7 @@ from moonmind.workflows.temporal.step_ledger import (
     clear_step_checkpoint_evidence,
     materialize_preserved_steps,
     mark_step_checkpoint_evidence,
+    preserved_outputs_for_dependencies,
     refresh_ready_steps,
     upsert_step_check,
     update_step_row,
@@ -321,6 +322,9 @@ class MoonMindRunWorkflow:
         self._logs_ref: Optional[str] = None
         self._summary_ref: Optional[str] = None
         self._resume_source: dict[str, Any] | None = None
+        self._resume_failed_step_id: str | None = None
+        self._resume_workspace: dict[str, Any] = {}
+        self._resume_workspace_restored_ref: str | None = None
         self._prepared_artifact_refs: list[str] = []
         self._step_checkpoint_refs: dict[str, str] = {}
 
@@ -651,6 +655,218 @@ class MoonMindRunWorkflow:
             updated_at=updated_at,
         )
 
+    def _resume_source_text(
+        self,
+        source: Mapping[str, Any],
+        *keys: str,
+    ) -> str:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _resume_workspace_checkpoint_ref(
+        self,
+        workspace: Mapping[str, Any],
+    ) -> str:
+        return self._resume_source_text(
+            workspace,
+            "checkpointRef",
+            "checkpoint_ref",
+            "workspaceCheckpointRef",
+            "workspace_checkpoint_ref",
+            "branchCheckpointRef",
+            "branch_checkpoint_ref",
+        )
+
+    def _validate_resume_source_for_execution(self) -> dict[str, Any] | None:
+        resume_source = self._resume_source
+        self._resume_failed_step_id = None
+        self._resume_workspace = {}
+        self._resume_workspace_restored_ref = None
+        if resume_source is None:
+            return None
+        if not isinstance(resume_source, Mapping):
+            raise ValueError("Resume source must be a compact mapping.")
+
+        source_workflow_id = self._resume_source_text(
+            resume_source,
+            "sourceWorkflowId",
+            "source_workflow_id",
+        )
+        if not source_workflow_id:
+            raise ValueError("Resume source requires source workflow ID.")
+
+        source_run_id = self._resume_source_text(
+            resume_source,
+            "sourceRunId",
+            "source_run_id",
+        )
+        if not source_run_id:
+            raise ValueError("Resume source requires source run ID.")
+
+        snapshot_ref = self._resume_source_text(
+            resume_source,
+            "sourceTaskInputSnapshotRef",
+            "source_task_input_snapshot_ref",
+        )
+        if not snapshot_ref:
+            raise ValueError("Resume source requires task input snapshot ref.")
+
+        failed_step_id = self._resume_source_text(
+            resume_source,
+            "failedStepId",
+            "failed_step_id",
+        )
+        if not failed_step_id:
+            raise ValueError("Resume source requires failed step ID.")
+
+        checkpoint_ref = self._resume_source_text(
+            resume_source,
+            "resumeCheckpointRef",
+            "resume_checkpoint_ref",
+        )
+        if not checkpoint_ref:
+            raise ValueError("Resume source requires resume checkpoint ref.")
+
+        plan_identity = self._resume_source_text(
+            resume_source,
+            "sourcePlanRef",
+            "source_plan_ref",
+            "sourcePlanDigest",
+            "source_plan_digest",
+        )
+        if not plan_identity:
+            raise ValueError("Resume source requires source plan identity.")
+
+        workspace = resume_source.get("resumeWorkspace") or resume_source.get(
+            "resume_workspace"
+        )
+        if not isinstance(workspace, Mapping):
+            raise ValueError("Resume source requires resume workspace checkpoint.")
+        workspace_checkpoint_ref = self._resume_workspace_checkpoint_ref(workspace)
+        if not workspace_checkpoint_ref:
+            raise ValueError("Resume source requires workspace checkpoint ref.")
+
+        preserved_steps = resume_source.get("preservedSteps") or resume_source.get(
+            "preserved_steps"
+        )
+        if preserved_steps is not None and not isinstance(preserved_steps, list):
+            raise ValueError("Resume source preserved steps must be a list.")
+        for preserved in preserved_steps or []:
+            if not isinstance(preserved, Mapping):
+                continue
+            logical_step_id = self._resume_source_text(
+                preserved,
+                "logicalStepId",
+                "logical_step_id",
+            )
+            if not logical_step_id:
+                raise ValueError(
+                    "Resume source preserved step requires logical step ID."
+                )
+            status = self._resume_source_text(preserved, "status").lower()
+            if status and status not in {"succeeded", "skipped"}:
+                raise ValueError(
+                    f"preserved step {logical_step_id} must be completed before Resume"
+                )
+            artifacts = preserved.get("artifacts")
+            if not isinstance(artifacts, Mapping):
+                raise ValueError(
+                    f"preserved step {logical_step_id} requires recoverable output refs"
+                )
+            has_output_ref = any(
+                isinstance(artifacts.get(key), str) and artifacts.get(key).strip()
+                for key in ("outputSummary", "outputPrimary")
+            )
+            if not has_output_ref:
+                raise ValueError(
+                    f"preserved step {logical_step_id} requires recoverable output refs"
+                )
+            state_checkpoint_ref = self._resume_source_text(
+                preserved,
+                "stateCheckpointRef",
+                "state_checkpoint_ref",
+            )
+            if not state_checkpoint_ref:
+                raise ValueError(
+                    f"preserved step {logical_step_id} requires a state checkpoint ref"
+                )
+
+        self._resume_failed_step_id = failed_step_id
+        self._resume_workspace = dict(workspace)
+        return dict(resume_source)
+
+    def _restore_resume_workspace_for_failed_step(
+        self,
+        logical_step_id: str,
+    ) -> str | None:
+        if (
+            not self._resume_failed_step_id
+            or logical_step_id != self._resume_failed_step_id
+        ):
+            return None
+        if self._resume_workspace_restored_ref:
+            return self._resume_workspace_restored_ref
+        checkpoint_ref = self._resume_workspace_checkpoint_ref(self._resume_workspace)
+        if not checkpoint_ref:
+            raise ValueError("Resume source requires workspace checkpoint ref.")
+        self._resume_workspace_restored_ref = checkpoint_ref
+        return checkpoint_ref
+
+    def _preserved_outputs_for_step(
+        self,
+        logical_step_id: str,
+    ) -> dict[str, dict[str, str]]:
+        return preserved_outputs_for_dependencies(
+            self._step_ledger_rows,
+            logical_step_id,
+        )
+
+    def _step_ledger_row_for(self, logical_step_id: str) -> dict[str, Any] | None:
+        for row in self._step_ledger_rows:
+            if row.get("logicalStepId") == logical_step_id:
+                return row
+        return None
+
+    def _is_preserved_step(self, logical_step_id: str) -> bool:
+        row = self._step_ledger_row_for(logical_step_id)
+        return isinstance(row, Mapping) and isinstance(
+            row.get("preservedFrom"),
+            Mapping,
+        )
+
+    def _preserved_step_outputs(self, logical_step_id: str) -> dict[str, Any]:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return {}
+        artifacts = row.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            return {}
+        outputs: dict[str, Any] = {}
+        output_summary = artifacts.get("outputSummary")
+        if isinstance(output_summary, str) and output_summary.strip():
+            outputs["outputSummaryRef"] = output_summary.strip()
+        output_primary = artifacts.get("outputPrimary")
+        if isinstance(output_primary, str) and output_primary.strip():
+            outputs["outputPrimaryRef"] = output_primary.strip()
+        if outputs:
+            outputs["preservedFrom"] = dict(row.get("preservedFrom") or {})
+        return outputs
+
+    def _merge_preserved_dependency_outputs(
+        self,
+        logical_step_id: str,
+        previous_step_outputs: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        preserved_outputs = self._preserved_outputs_for_step(logical_step_id)
+        if not preserved_outputs:
+            return previous_step_outputs
+        merged = dict(previous_step_outputs)
+        merged["preservedOutputs"] = preserved_outputs
+        return merged
+
     def _initialize_step_ledger(
         self,
         *,
@@ -658,16 +874,26 @@ class MoonMindRunWorkflow:
         dependency_map: dict[str, list[str]],
         updated_at: datetime,
     ) -> None:
+        resume_source = self._validate_resume_source_for_execution() or {}
         self._step_ledger_rows = build_initial_step_rows(
             ordered_nodes=ordered_nodes,
             dependency_map=dependency_map,
             updated_at=updated_at,
         )
-        resume_source = self._resume_source or {}
         preserved_steps = resume_source.get("preservedSteps")
+        if not isinstance(preserved_steps, list):
+            preserved_steps = resume_source.get("preserved_steps")
         if isinstance(preserved_steps, list):
-            source_workflow_id = str(resume_source.get("sourceWorkflowId") or "").strip()
-            source_run_id = str(resume_source.get("sourceRunId") or "").strip()
+            source_workflow_id = self._resume_source_text(
+                resume_source,
+                "sourceWorkflowId",
+                "source_workflow_id",
+            )
+            source_run_id = self._resume_source_text(
+                resume_source,
+                "sourceRunId",
+                "source_run_id",
+            )
             if source_workflow_id and source_run_id:
                 materialize_preserved_steps(
                     self._step_ledger_rows,
@@ -697,6 +923,7 @@ class MoonMindRunWorkflow:
         updated_at: datetime,
         summary: str | None = None,
     ) -> None:
+        self._restore_resume_workspace_for_failed_step(logical_step_id)
         if not self._try_update_step_row(
             logical_step_id,
             updated_at=updated_at,
@@ -2433,6 +2660,11 @@ class MoonMindRunWorkflow:
             ).strip()
             tool_version = str(selected_node.get("version") or "").strip()
             node_id = str(node.get("id") or "unknown")
+            if self._is_preserved_step(node_id):
+                preserved_outputs = self._preserved_step_outputs(node_id)
+                if preserved_outputs:
+                    previous_step_outputs = preserved_outputs
+                continue
             original_node_inputs = dict(node.get("inputs", {}))
             approval_policy = plan_definition.policy.approval_policy
             review_gate_active = self._review_gate_active(
@@ -2467,6 +2699,12 @@ class MoonMindRunWorkflow:
                         feedback=previous_review_feedback,
                         issues=previous_review_issues,
                     )
+                current_previous_outputs = self._merge_preserved_dependency_outputs(
+                    node_id,
+                    previous_step_outputs,
+                )
+                if current_previous_outputs:
+                    node_inputs["previousOutputs"] = dict(current_previous_outputs)
 
                 self._step_count = index
                 self._summary = (
@@ -2623,7 +2861,7 @@ class MoonMindRunWorkflow:
                                     "node_id": node_id,
                                     "ownerId": self._owner_id,
                                     "ownerType": self._owner_type,
-                                    "previousOutputs": previous_step_outputs,
+                                    "previousOutputs": current_previous_outputs,
                                 },
                             }
                             if workflow.patched("idempotency_key_phase3"):

--- a/specs/346-resume-execution-semantics/checklists/requirements.md
+++ b/specs/346-resume-execution-semantics/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Resume Execution Semantics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec defines one single-story runtime feature for `MM-647`.
+- PASS: The original Jira preset brief is preserved in `spec.md`.
+- PASS: Source-backed requirements from `docs/Tasks/TaskArchitecture.md` are mapped to functional requirements, including original coverage IDs DESIGN-REQ-018 and DESIGN-REQ-024.
+- PASS: No clarification markers remain.

--- a/specs/346-resume-execution-semantics/contracts/resume-execution.md
+++ b/specs/346-resume-execution-semantics/contracts/resume-execution.md
@@ -1,0 +1,104 @@
+# Contract: Failed-Step Resume Execution
+
+## Resume Submission Boundary
+
+Accepted failed-step Resume submissions create a new `MoonMind.Run` execution with:
+
+```json
+{
+  "resumeSource": {
+    "kind": "resume_from_failed_step",
+    "sourceWorkflowId": "mm:source",
+    "sourceRunId": "source-run-id",
+    "sourceTaskInputSnapshotRef": "artifact://snapshot/source",
+    "sourcePlanRef": "artifact://plan/source",
+    "sourcePlanDigest": "sha256:plan",
+    "failedStepId": "implement",
+    "failedStepAttempt": 1,
+    "resumeCheckpointRef": "artifact://resume/checkpoint",
+    "resumeWorkspace": {
+      "checkpointRef": "artifact://workspace/before-implement"
+    },
+    "preservedSteps": [
+      {
+        "logicalStepId": "plan",
+        "order": 1,
+        "status": "succeeded",
+        "sourceAttempt": 1,
+        "artifacts": {
+          "outputSummary": "artifact://completed/plan-summary"
+        },
+        "stateCheckpointRef": "artifact://workspace/before-plan"
+      }
+    ]
+  },
+  "task": {
+    "recovery": {
+      "kind": "resume_from_failed_step",
+      "sourceWorkflowId": "mm:source",
+      "sourceRunId": "source-run-id"
+    },
+    "resume": {
+      "kind": "resume_from_failed_step",
+      "sourceWorkflowId": "mm:source",
+      "sourceRunId": "source-run-id",
+      "failedStepId": "implement",
+      "failedStepAttempt": 1,
+      "resumeCheckpointRef": "artifact://resume/checkpoint",
+      "taskInputSnapshotRef": "artifact://snapshot/source",
+      "planRef": "artifact://plan/source",
+      "planDigest": "sha256:plan"
+    }
+  }
+}
+```
+
+Rules:
+- `sourceWorkflowId` and `sourceRunId` must match everywhere they appear.
+- `task.resume.taskInputSnapshotRef` must match the source run's immutable task input snapshot.
+- User-authored task edits are not accepted on failed-step Resume in v1.
+- Invalid checkpoint evidence must block execution before a resumed failed step starts.
+
+## MoonMind.Run Initialization Boundary
+
+When `MoonMind.Run` starts with `resumeSource`:
+
+1. Validate compact resume source fields before step execution.
+2. Initialize prior completed step rows as preserved rows.
+3. Restore or verify `resumeWorkspace` before the failed step starts.
+4. Make preserved output refs available through the same step input contract used by continuous runs.
+5. Mark the failed step as the first newly executable step.
+
+Failure contract:
+- Missing or mismatched source identity, snapshot, plan identity, preserved-step provenance, preserved output refs, or workspace evidence produces an explicit failed Resume outcome.
+- The workflow must not silently convert failed-step Resume into exact full rerun.
+- Preserved prior steps must not be re-executed unless a future explicit user action introduces that behavior.
+
+## Step Ledger Projection Boundary
+
+Preserved prior step rows expose:
+
+```json
+{
+  "logicalStepId": "plan",
+  "status": "succeeded",
+  "attempt": 0,
+  "summary": "Preserved from source run.",
+  "artifacts": {
+    "outputSummary": "artifact://completed/plan-summary"
+  },
+  "stateCheckpointRef": "artifact://workspace/before-plan",
+  "preservedFrom": {
+    "workflowId": "mm:source",
+    "runId": "source-run-id",
+    "logicalStepId": "plan",
+    "attempt": 1
+  }
+}
+```
+
+Fresh retried and downstream step rows expose resumed-run evidence:
+- New attempt count.
+- New artifact refs.
+- New checkpoint refs when runtime state changes.
+- No `preservedFrom` marker on newly executed steps.

--- a/specs/346-resume-execution-semantics/data-model.md
+++ b/specs/346-resume-execution-semantics/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Resume Execution Semantics
+
+## Failed Source Run
+
+- `workflowId`: stable logical workflow ID of the failed source execution.
+- `runId`: exact Temporal/source run ID being resumed.
+- `taskInputSnapshotRef`: artifact ref for the immutable original task input snapshot.
+- `planRef`: optional artifact ref for the source execution plan.
+- `planDigest`: optional digest binding Resume to the same plan identity.
+- `failedStepId`: logical step ID of the failed step.
+- `failedStepAttempt`: source attempt number of the failed step.
+- `resumeCheckpointRef`: artifact ref for the source resume checkpoint.
+
+Validation rules:
+- `workflowId`, `runId`, `taskInputSnapshotRef`, `failedStepId`, and `resumeCheckpointRef` are required and non-empty.
+- At least one plan identity field, `planRef` or `planDigest`, must be present when checkpoint validation depends on plan matching.
+- Source workflow and run IDs must match the checkpoint source exactly.
+
+## Resume Checkpoint
+
+- `schemaVersion`: checkpoint contract version, currently `v1`.
+- `source`: source workflow/run identity.
+- `taskInputSnapshotRef`: immutable authored input snapshot ref.
+- `planRef` / `planDigest`: plan identity.
+- `failedStep`: logical failed step identity, order, attempt, and optional title.
+- `preservedSteps`: ordered completed steps eligible for preservation.
+- `preparedArtifactRefs`: compact prepared input refs available for safe reuse.
+- `resumeWorkspace`: workspace, branch, commit, checkpoint ref, or equivalent recoverable pre-failed-step state.
+
+Validation rules:
+- Must remain compact and ref-based; no large inline checkpoint payloads.
+- Must include workspace or equivalent recoverable state evidence.
+- Invalid, unauthorized, stale, corrupted, or inconsistent checkpoints block Resume before failed-step execution.
+
+## Preserved Step
+
+- `logicalStepId`: source logical step ID.
+- `order`: original step order.
+- `status`: completed source status such as `succeeded` or `skipped`.
+- `sourceAttempt`: source attempt number.
+- `artifacts`: semantic output refs needed by downstream steps.
+- `stateCheckpointRef`: workspace/state checkpoint ref associated with the preserved step.
+- `preservedFrom`: resumed-run provenance with source workflow ID, source run ID, logical step ID, and attempt.
+
+Validation rules:
+- A preserved step must have source provenance.
+- A preserved step must not increment a new resumed-run attempt.
+- A preserved step without required output refs or state checkpoint evidence is not eligible for preservation.
+
+## Preserved Output
+
+- `outputPrimary`: primary semantic output ref when available.
+- `outputSummary`: summary output ref when available.
+- `outputDetails`, `outputReport`, or other bounded artifact refs supported by existing step artifact shape.
+
+Validation rules:
+- Preserved outputs are refs, not inline large payloads.
+- Failed and downstream steps must observe preserved outputs through the same step input contract they would receive in a continuous run.
+
+## Resumed Run
+
+- `resumeSource`: compact execution metadata derived from the checkpoint.
+- `task.recovery`: canonical `resume_from_failed_step` recovery provenance.
+- `task.resume`: failed-step resume ref with source identity, failed step, checkpoint, snapshot, and plan identity.
+- Step ledger rows: preserved rows for prior completed steps, fresh rows for retried and later steps.
+
+State transitions:
+1. Created from a failed source run after checkpoint validation.
+2. Initializes with preserved prior step rows.
+3. Restores workspace state before failed-step execution.
+4. Retries the failed step as the first new attempt.
+5. Continues downstream normally after failed-step success.
+6. Records fresh resumed-run evidence for retried and later steps.
+7. Fails explicitly before failed-step execution if restoration is incomplete or inconsistent.

--- a/specs/346-resume-execution-semantics/moonspec_align_report.md
+++ b/specs/346-resume-execution-semantics/moonspec_align_report.md
@@ -1,0 +1,24 @@
+# MoonSpec Alignment Report: Resume Execution Semantics
+
+**Source**: MM-647 canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-13
+
+## Findings And Remediation
+
+| Finding | Resolution |
+| --- | --- |
+| Quickstart validation scenarios described the right behavior but did not carry explicit FR/SCN/SC/DESIGN traceability. | Updated `quickstart.md` expected red-first checks and integration scenarios with concrete requirement and source IDs. |
+| Several task entries were marked `[P]` while editing the same test file, which conflicted with the task skill parallelization rule. | Removed `[P]` from same-file unit and integration task sequences and updated the parallel opportunities section to name only safe cross-file parallel work. |
+
+## Gate Recheck
+
+- `spec.md`: still one story, no source input changed.
+- `plan.md`: no architecture or status changes required.
+- `research.md`, `data-model.md`, and `contracts/resume-execution.md`: no drift found after task/quickstart updates.
+- `tasks.md`: still 38 sequential tasks, unit and integration tests precede implementation, red-first confirmations remain before production tasks, and final `/speckit.verify` remains T038.
+- `quickstart.md`: now traces validation scenarios to the same story requirements and source mappings used by `tasks.md`.
+
+## Remaining Risks
+
+- Application implementation has not started; missing and partial behavior remains tracked in `plan.md` and `tasks.md`.
+- `.specify/scripts/bash/check-prerequisites.sh` remains branch-name gated for this managed branch, so validation used direct artifact checks.

--- a/specs/346-resume-execution-semantics/plan.md
+++ b/specs/346-resume-execution-semantics/plan.md
@@ -1,0 +1,144 @@
+# Implementation Plan: Resume Execution Semantics
+
+**Branch**: `change-jira-issue-mm-647-to-status-in-pr-90f53137` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:6d4f0168-95fa-48a3-9cb3-f3508f959fd5/repo/specs/346-resume-execution-semantics/spec.md`
+
+**Setup Note**: `scripts/bash/setup-plan.sh --json` was attempted and was not present. `.specify/scripts/bash/setup-plan.sh --json` was then attempted, but the managed job branch name is not in the script's expected `NNN-feature-name` form. Planning proceeds from `.specify/feature.json`, which points to `specs/346-resume-execution-semantics`.
+
+## Summary
+
+MM-647 requires `MoonMind.Run` to consume a validated failed-step Resume checkpoint, restore pre-failed-step execution state, preserve prior completed steps with source provenance, inject preserved outputs into the retried failed step and downstream steps, retry the failed step first, and fail explicitly when restoration cannot be trusted. Current repo evidence shows recovery contract models, service-level checkpoint validation, failed-step Resume submission guards, preserved-step ledger helpers, checkpoint eligibility markers, and some integration coverage already exist. The remaining risk is the real `MoonMind.Run` workflow boundary: workspace restoration before step execution, preserved-output injection into actual step inputs, direct workflow validation of resume source payloads, first-new-step ordering, and fresh evidence production for retried and downstream steps need explicit verification-first coverage and likely implementation work.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `TaskRecoveryProvenance`, `ResumeFromFailedStepRef`, `TemporalExecutionService.create_failed_step_resume_execution()` build source workflow/run refs; API/service tests cover accepted Resume refs | Add workflow-boundary tests proving `MoonMind.Run` receives and records source IDs before execution starts | unit + integration |
+| FR-002 | partial | Service validates checkpoint source IDs, snapshot ref, failed step, and plan identity before creating a resumed execution | Add direct `MoonMind.Run` resume-source validation or fail-fast guard so malformed persisted/in-flight payloads cannot bypass service validation | unit + integration |
+| FR-003 | partial | Service carries `task.resume.taskInputSnapshotRef`; API rejects edited Resume payload fields | Verify/respect unchanged original task input snapshot at workflow initialization and block direct edited Resume payload drift | unit + integration |
+| FR-004 | implemented_unverified | `materialize_preserved_steps()` imports preserved rows; `run.py::_initialize_step_ledger()` applies `resumeSource.preservedSteps` | Add real workflow tests proving preserved prior steps are imported rather than executed | integration |
+| FR-005 | implemented_unverified | Preserved ledger rows carry `preservedFrom` with source workflow, run, logical step, and attempt in unit/integration helper tests | Add workflow-boundary assertion that preserved provenance survives `MoonMind.Run` initialization and projection | unit + integration |
+| FR-006 | missing | `ResumeSourceModel` carries `resumeWorkspace`, but no workflow code found that materializes workspace/branch/commit state before the failed step starts | Add workspace restoration activity/adapter call or existing boundary integration and tests before failed-step execution | unit + integration |
+| FR-007 | implemented_unverified | Task detail diagnostics expose `targetDiagnostics.recovery.preservedSteps`; step ledger rows have `preservedFrom` | Add UI/API projection proof that actual resumed run rows render preserved prior steps as reused | unit + UI/integration |
+| FR-008 | partial | Preserved output refs are retained on preserved ledger row artifacts; no proof found that real step input composition consumes them | Add verification-first tests for preserved output injection into failed and downstream step input contracts; implement fallback if missing | unit + integration |
+| FR-009 | implemented_unverified | Preserved-step helper refreshes failed step to `ready`; no end-to-end workflow ordering test for first newly executed step | Add workflow ordering test showing preserved prior steps are skipped and failed step is first new attempt | integration |
+| FR-010 | implemented_unverified | Step ledger readiness can unblock later steps after failed step; no resumed-run downstream execution proof found | Add resumed-run downstream continuation scenario | integration |
+| FR-011 | partial | `mark_step_checkpoint_evidence()` and `run.py` record step refs/checkpoint evidence after step results | Verify retried failed and later steps produce fresh resumed-run ledger rows/artifacts/checkpoints, not copied source evidence | unit + integration |
+| FR-012 | partial | Service rejects invalid/mismatched checkpoint payloads before creating resumed execution; route reports checkpoint authorization/stale/inconsistent reasons | Add direct workflow invalid-restoration guards and tests for malformed `resumeSource`, workspace restoration failure, and no full-rerun fallback | unit + integration |
+| FR-013 | implemented_verified | `tests/unit/api/routers/test_executions.py::test_failed_step_resume_request_rejects_edited_task_payload_fields`; service/rerun tests strip Resume fields for other recovery paths | No new implementation unless direct workflow payload tests expose drift | final verify + targeted unit if touched |
+| FR-014 | implemented_verified | `spec.md` preserves `MM-647` and the original Jira preset brief | Preserve traceability through plan, research, data model, contract, quickstart, tasks, verification, commit, and PR metadata | final verify |
+| SCN-001 | partial | Service validation exists before resumed execution creation | Add workflow-boundary checkpoint validation scenario | unit + integration |
+| SCN-002 | missing | `resumeWorkspace` is carried but not materialized by workflow code found | Add pre-failed-step workspace restoration scenario | unit + integration |
+| SCN-003 | implemented_unverified | Preserved-step helper marks source provenance and skips new attempt | Add real resumed-run initialization scenario | integration |
+| SCN-004 | partial | Preserved artifact refs stay on ledger rows; no proof they reach step input composition | Add preserved-output injection scenario | unit + integration |
+| SCN-005 | implemented_unverified | Failed step becomes ready after preserved prior step materialization | Add first-new-step ordering scenario | integration |
+| SCN-006 | partial | Step result evidence helper records fresh checkpoint refs | Add fresh resumed-run evidence scenario for retried and later steps | unit + integration |
+| SCN-007 | partial | Service and route reject invalid checkpoint evidence; workflow direct invalid source not covered | Add explicit invalid-restoration no-fallback scenario | unit + integration |
+| SCN-008 | implemented_verified | API route rejects edited Resume payload field categories | Preserve existing behavior and add only if touched | final verify |
+| SC-001 | partial | Service tests validate accepted Resume refs; workflow-boundary proof missing | Add workflow validation test | unit + integration |
+| SC-002 | missing | Workspace restoration before failed step is not evidenced | Add restoration behavior and tests | unit + integration |
+| SC-003 | implemented_unverified | Helper tests prove preserved source provenance and no new attempt | Add workflow-boundary proof and projection assertion | unit + integration |
+| SC-004 | partial | Ledger retains preserved outputs; injection into execution inputs unproven | Add input-composition tests | unit + integration |
+| SC-005 | partial | Failed-step readiness and fresh evidence helpers exist; full resumed run proof incomplete | Add ordering and fresh-evidence tests | integration |
+| SC-006 | partial | Service rejects invalid checkpoint before creation; workflow malformed/restoration-failure no-fallback proof missing | Add workflow no-fallback tests | unit + integration |
+| SC-007 | implemented_verified | Edited Resume payload rejection matrix exists | Preserve behavior | final verify |
+| SC-008 | implemented_verified | `spec.md` preserves Jira and source IDs | Preserve through downstream artifacts | final verify |
+| DESIGN-REQ-001 | partial | Service/route and ledger pieces exist; complete `MoonMind.Run` execution semantics not fully proven | Add workflow-boundary tests and implementation for restoration/injection/order/failure gaps | unit + integration |
+| DESIGN-REQ-002 | partial | `MoonMind.Run` initializes preserved rows and records step evidence; workspace materialization and output injection incomplete/unproven | Add workflow restoration and injection behavior | unit + integration |
+| DESIGN-REQ-003 | partial | Helper prevents preserved-step re-execution; no workflow no-fallback proof | Add invalid restoration and preserved-step no-reexecute coverage | unit + integration |
+| DESIGN-REQ-004 | implemented_verified | Resume payload models and API rejection enforce original input/no-edit contract | Preserve and retest if touched | final verify |
+| DESIGN-REQ-005 | implemented_unverified | Ledger rows support `preservedFrom`; UI diagnostics expose recovery | Add projection and workflow evidence tests | unit + integration |
+| DESIGN-REQ-006 | implemented_unverified | Task recovery/source ID models and service validation pin both source IDs | Add end-to-end resumed-run source pinning proof | unit + integration |
+
+Status summary: 5 missing, 14 partial, 17 implemented_unverified, 4 implemented_verified.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Temporal Python SDK, Pydantic v2, FastAPI execution router/service models, existing Temporal artifact service/helpers  
+**Storage**: Existing Temporal workflow history, execution records, memo/search attributes, Temporal artifact metadata/content store, task input snapshot artifacts, resume checkpoint artifacts; no new persistent database table planned  
+**Unit Testing**: pytest via `./tools/test_unit.sh`; focused tests under `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, and step-ledger helper tests  
+**Integration Testing**: pytest hermetic integration via `./tools/test_integration.sh`; focused `integration_ci` coverage under `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and `tests/integration/temporal/test_backend_resume_eligibility.py`  
+**Target Platform**: MoonMind API service and Temporal worker runtime on Linux containers  
+**Project Type**: Python service and Temporal workflow orchestration system  
+**Performance Goals**: Resume initialization and validation remain bounded; no large checkpoint or workspace payloads are embedded inline in workflow histories; preserved-step initialization scales linearly with step count  
+**Constraints**: Workflow/activity payload shapes are compatibility-sensitive; failed-step Resume must never silently fall back to full rerun; preserved prior steps must not re-execute; direct agent/runtime behavior remains provider-agnostic; checkpoint and workspace refs stay artifact-backed  
+**Scale/Scope**: One `MoonMind.Run` execution-semantics story covering validated checkpoint consumption, workspace restoration, preserved-step state, preserved-output injection, failed-step retry ordering, downstream continuation, explicit restoration failure, and traceability for MM-647
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The plan strengthens MoonMind orchestration of existing runtimes rather than rebuilding agent behavior.
+- **II. One-Click Agent Deployment**: PASS. Uses existing Temporal, artifact, and local test infrastructure; no new external service or secret is planned.
+- **III. Avoid Vendor Lock-In**: PASS. Resume semantics are workflow/ref based and provider-neutral.
+- **IV. Own Your Data**: PASS. Checkpoints, snapshots, preserved outputs, and run evidence remain in MoonMind-controlled records/artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Work stays in runtime/task boundaries and does not change skill source or materialization semantics.
+- **VI. Scientific Method**: PASS. The plan requires verification-first unit and integration coverage before implementation.
+- **VII. Runtime Configurability**: PASS. No new hardcoded operator settings are planned; behavior derives from explicit task recovery metadata.
+- **VIII. Modular Architecture**: PASS. Planned changes stay in existing schema, service, step-ledger, workflow, and route/projection boundaries.
+- **IX. Resilient by Default**: PASS with required tests. The story improves explicit failure, no-fallback behavior, and retry-safe evidence handling.
+- **X. Continuous Improvement**: PASS. Final verification will produce structured evidence and preserve residual risks.
+- **XI. Spec-Driven Development**: PASS. Planning derives from the single-story spec and preserves all requirements.
+- **XII. Documentation Separation**: PASS. Planning details stay under `specs/346-resume-execution-semantics/`, not canonical docs.
+- **XIII. Pre-Release Compatibility Policy**: PASS. Avoid compatibility aliases for internal contracts; preserve Temporal worker-bound invocation compatibility or document an explicit cutover if a payload shape must change.
+
+Re-check after Phase 1 design: PASS. `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` introduce no constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/346-resume-execution-semantics/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── resume-execution.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── executions.py
+
+moonmind/
+├── schemas/
+│   └── temporal_models.py
+└── workflows/
+    ├── tasks/
+    │   ├── prepared_context.py
+    │   └── task_contract.py
+    └── temporal/
+        ├── service.py
+        ├── step_ledger.py
+        └── workflows/
+            └── run.py
+
+tests/
+├── unit/
+│   ├── api/routers/test_executions.py
+│   └── workflows/
+│       ├── tasks/test_task_contract.py
+│       └── temporal/
+│           ├── test_step_ledger.py
+│           ├── test_temporal_service.py
+│           └── workflows/test_run_resume_from_failed_step.py
+└── integration/
+    ├── temporal/test_backend_resume_eligibility.py
+    └── workflows/temporal/workflows/test_run_resume_from_failed_step.py
+```
+
+**Structure Decision**: Keep implementation in existing Temporal workflow, schema, service, route/projection, prepared-context, and step-ledger modules. Add verification-first tests at helper/model boundaries and the real `MoonMind.Run`/Temporal service boundary before changing production behavior.
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/346-resume-execution-semantics/quickstart.md
+++ b/specs/346-resume-execution-semantics/quickstart.md
@@ -25,10 +25,10 @@ Focused command:
 ```
 
 Expected red-first checks before implementation:
-- Invalid direct `resumeSource` fails before step execution.
-- Workspace restoration is required before the failed step starts.
-- Preserved output refs are injected into failed and downstream step inputs.
-- Retried and later steps produce fresh resumed-run evidence.
+- Invalid direct `resumeSource` fails before step execution (FR-001, FR-002, FR-003, FR-012, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-006).
+- Workspace restoration is required before the failed step starts (FR-006, SC-002, DESIGN-REQ-001, DESIGN-REQ-002).
+- Preserved output refs are injected into failed and downstream step inputs (FR-008, SC-004, DESIGN-REQ-001, DESIGN-REQ-002).
+- Retried and later steps produce fresh resumed-run evidence (FR-011, SC-005, DESIGN-REQ-002, DESIGN-REQ-003).
 
 ## Integration Test Strategy
 
@@ -47,14 +47,15 @@ Full required integration command before final verification:
 ```
 
 Expected integration scenarios:
-1. Valid failed-step Resume validates checkpoint identity before executing the failed step.
-2. Workspace or branch checkpoint state is restored before the failed step starts.
-3. Prior completed steps are preserved with source provenance and are not re-executed.
-4. Preserved outputs are available to failed and downstream steps with continuous-run semantics.
-5. The failed step is the first newly executed step.
-6. Downstream steps continue normally after failed-step success.
-7. Retried and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints.
-8. Invalid restoration fails explicitly and never falls back to full rerun.
+1. Valid failed-step Resume validates checkpoint identity before executing the failed step (FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, DESIGN-REQ-006).
+2. Workspace or branch checkpoint state is restored before the failed step starts (FR-006, SCN-002, SC-002, DESIGN-REQ-001, DESIGN-REQ-002).
+3. Prior completed steps are preserved with source provenance and are not re-executed (FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-005).
+4. Preserved outputs are available to failed and downstream steps with continuous-run semantics (FR-008, SCN-004, SC-004, DESIGN-REQ-001, DESIGN-REQ-002).
+5. The failed step is the first newly executed step (FR-009, SCN-005, SC-005, DESIGN-REQ-001, DESIGN-REQ-002).
+6. Downstream steps continue normally after failed-step success (FR-010, SCN-005, SC-005, DESIGN-REQ-001, DESIGN-REQ-002).
+7. Retried and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints (FR-011, SCN-006, SC-005, DESIGN-REQ-002, DESIGN-REQ-003).
+8. Invalid restoration fails explicitly and never falls back to full rerun (FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003).
+9. Edited-input Resume attempts remain rejected while MM-647 traceability is preserved (FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004, DESIGN-REQ-018, DESIGN-REQ-024).
 
 ## End-to-End Story Check
 

--- a/specs/346-resume-execution-semantics/quickstart.md
+++ b/specs/346-resume-execution-semantics/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Resume Execution Semantics
+
+## Prerequisites
+
+- Run from the repository root.
+- Use managed-agent local test mode for unit tests:
+
+```bash
+export MOONMIND_FORCE_LOCAL_TESTS=1
+```
+
+## Unit Test Strategy
+
+Add or update red-first unit tests for:
+
+- Resume source validation and no-fallback behavior in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`.
+- Service/task contract protection in `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/workflows/tasks/test_task_contract.py` only if touched.
+- Route-level no-edit behavior in `tests/unit/api/routers/test_executions.py` only if touched.
+- Step ledger preserved provenance, preserved output refs, and fresh resumed-run evidence in `tests/unit/workflows/temporal/test_step_ledger.py` or the existing workflow test file.
+
+Focused command:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py
+```
+
+Expected red-first checks before implementation:
+- Invalid direct `resumeSource` fails before step execution.
+- Workspace restoration is required before the failed step starts.
+- Preserved output refs are injected into failed and downstream step inputs.
+- Retried and later steps produce fresh resumed-run evidence.
+
+## Integration Test Strategy
+
+Add hermetic integration coverage under `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and reuse `tests/integration/temporal/test_backend_resume_eligibility.py` where route/service boundaries are involved.
+
+Focused command:
+
+```bash
+./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py
+```
+
+Full required integration command before final verification:
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected integration scenarios:
+1. Valid failed-step Resume validates checkpoint identity before executing the failed step.
+2. Workspace or branch checkpoint state is restored before the failed step starts.
+3. Prior completed steps are preserved with source provenance and are not re-executed.
+4. Preserved outputs are available to failed and downstream steps with continuous-run semantics.
+5. The failed step is the first newly executed step.
+6. Downstream steps continue normally after failed-step success.
+7. Retried and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints.
+8. Invalid restoration fails explicitly and never falls back to full rerun.
+
+## End-to-End Story Check
+
+After implementation and focused tests pass:
+
+```bash
+./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+Then run final MoonSpec verification against:
+- `specs/346-resume-execution-semantics/spec.md`
+- `plan.md`
+- `tasks.md`
+- this quickstart
+- test evidence
+- preserved Jira issue key `MM-647`

--- a/specs/346-resume-execution-semantics/research.md
+++ b/specs/346-resume-execution-semantics/research.md
@@ -1,0 +1,121 @@
+# Phase 0 Research: Resume Execution Semantics
+
+## FR-001 / Source Workflow And Run Identity
+
+Decision: `implemented_unverified`; add workflow-boundary proof.
+Evidence: `moonmind/workflows/tasks/task_contract.py` defines `TaskRecoveryProvenance` and `ResumeFromFailedStepRef`; `moonmind/workflows/temporal/service.py::create_failed_step_resume_execution()` sets canonical source workflow/run IDs; `tests/integration/temporal/test_backend_resume_eligibility.py::test_accepted_resume_carries_canonical_recovery_and_resume_refs` verifies accepted task payload refs.
+Rationale: Service-level accepted Resume shape is covered, but MM-647 is specifically about `MoonMind.Run` execution semantics, so the workflow boundary must prove the source IDs are consumed before execution starts.
+Alternatives considered: Mark verified from service tests alone; rejected because service creation can succeed while workflow initialization still mishandles source metadata.
+Test implications: Unit and integration.
+
+## FR-002 / Checkpoint Validation Before Execution
+
+Decision: `partial`; keep service validation and add workflow fail-fast guard or boundary proof.
+Evidence: `TemporalExecutionService.create_failed_step_resume_execution()` validates source workflow ID, source run ID, task input snapshot ref, plan ref/digest, and failed step ID against `ResumeCheckpointModel`.
+Rationale: Validation exists before normal route-created resumed executions. Direct workflow parameters, replayed histories, or malformed persisted `resumeSource` payloads still need a defensible `MoonMind.Run` behavior.
+Alternatives considered: Depend only on the API/service preflight; rejected because Temporal workflow payloads are compatibility-sensitive and may already be in flight.
+Test implications: Unit and integration.
+
+## FR-003 / Original Task Input Snapshot
+
+Decision: `partial`; verify unchanged snapshot use at workflow initialization.
+Evidence: `ResumeFromFailedStepRef` requires `taskInputSnapshotRef`; API route tests reject edited Resume payload fields; service creates resumed task payload from source parameters and checkpoint snapshot ref.
+Rationale: The route prevents edited Resume submissions, but the workflow should preserve or validate original snapshot semantics when starting from failed-step Resume metadata.
+Alternatives considered: Treat API rejection as sufficient; rejected because the spec requires execution semantics, not only submission semantics.
+Test implications: Unit and integration.
+
+## FR-004 / Preserved Prior Steps
+
+Decision: `implemented_unverified`; add real workflow proof.
+Evidence: `moonmind/workflows/temporal/step_ledger.py::materialize_preserved_steps()` marks preserved rows; `moonmind/workflows/temporal/workflows/run.py::_initialize_step_ledger()` applies `resumeSource.preservedSteps`; helper and integration tests cover materialization and readiness.
+Rationale: The helper behavior is covered, but no end-to-end `MoonMind.Run` scenario proves preserved steps are skipped in a resumed run.
+Alternatives considered: Mark verified from helper tests; rejected because the workflow may not call the helper in all resume entry paths.
+Test implications: Integration first, unit if implementation changes.
+
+## FR-005 / Preserved Provenance
+
+Decision: `implemented_unverified`; add workflow projection proof.
+Evidence: Preserved rows include `preservedFrom.workflowId`, `runId`, `logicalStepId`, and `attempt`; tests assert the helper output.
+Rationale: Provenance exists in helper data but must survive workflow initialization and projection used by operators.
+Alternatives considered: Treat helper output as sufficient; rejected because projection and workflow state can diverge.
+Test implications: Unit and integration.
+
+## FR-006 / Workspace Restoration
+
+Decision: `missing`; implement or wire a pre-failed-step workspace restoration boundary.
+Evidence: `ResumeSourceModel` carries `resumeWorkspace`; search found no `MoonMind.Run` code that materializes `resumeWorkspace` before the failed step starts.
+Rationale: The checkpoint can describe workspace state, but execution semantics require the run to restore or verify that state before retry.
+Alternatives considered: Rely on provider/runtime session state; rejected because the source design requires explicit restoration and explicit failure when incomplete.
+Test implications: Unit and integration.
+
+## FR-007 / Preserved Step Display
+
+Decision: `implemented_unverified`; add projection proof from actual resumed run state.
+Evidence: Step ledger rows contain `preservedFrom`; `tests/unit/api/routers/test_executions.py` verifies target diagnostics can expose recovery preserved steps.
+Rationale: Existing diagnostics prove a manually shaped record can serialize recovery; actual resumed-run projection needs coverage.
+Alternatives considered: Mark verified from serialization test; rejected because the source of projected rows matters.
+Test implications: Unit plus API/UI or integration.
+
+## FR-008 / Preserved Output Injection
+
+Decision: `partial`; add verification-first tests for input composition.
+Evidence: `materialize_preserved_steps()` retains artifact refs in preserved rows; no proof found that failed/downstream step input composition consumes preserved outputs.
+Rationale: Ledger preservation is necessary but insufficient if downstream prompts or step contracts cannot see preserved outputs.
+Alternatives considered: Treat row artifacts as the injection mechanism; rejected until a step input/prompt composition test proves it.
+Test implications: Unit and integration.
+
+## FR-009 / Failed Step First
+
+Decision: `implemented_unverified`; add workflow ordering proof.
+Evidence: `refresh_ready_steps()` marks the dependent failed step ready after preserved prior steps; helper tests assert readiness.
+Rationale: The first newly executed step is a workflow scheduling behavior, not just row readiness.
+Alternatives considered: Mark verified from readiness tests; rejected because actual execution loops may still schedule incorrectly.
+Test implications: Integration.
+
+## FR-010 / Downstream Continuation
+
+Decision: `implemented_unverified`; add resumed-run downstream scenario.
+Evidence: Step ledger dependency readiness can unblock later steps after a predecessor succeeds.
+Rationale: Downstream continuation after a retried failed step needs real run evidence.
+Alternatives considered: Infer from generic dependency handling; rejected because Resume has preserved rows and retry state.
+Test implications: Integration.
+
+## FR-011 / Fresh Resumed-Run Evidence
+
+Decision: `partial`; verify retried and later steps produce fresh evidence.
+Evidence: `run.py::_record_step_result_evidence()` and `_record_step_checkpoint_evidence()` can record artifacts and checkpoint refs; source/resumed evidence separation is not fully tested.
+Rationale: A resumed run must not reuse source evidence for new attempts.
+Alternatives considered: Use existing step-ledger tests only; rejected because source-vs-resumed provenance is the key behavior.
+Test implications: Unit and integration.
+
+## FR-012 / Explicit Invalid Restoration Failure
+
+Decision: `partial`; add direct workflow no-fallback checks.
+Evidence: API/service reject missing, stale, unauthorized, invalid, or inconsistent checkpoint evidence before creating a resumed execution.
+Rationale: Service preflight is strong but does not prove `MoonMind.Run` itself fails explicitly if restoration fails or malformed resume metadata reaches the workflow.
+Alternatives considered: Treat preflight as the only supported path; rejected because workflow payload compatibility and replay safety require explicit behavior.
+Test implications: Unit and integration.
+
+## FR-013 / Reject Edited Resume Input
+
+Decision: `implemented_verified`; preserve existing behavior.
+Evidence: `tests/unit/api/routers/test_executions.py::test_failed_step_resume_request_rejects_edited_task_payload_fields` covers task, runtime, attachment, publish, branch, preset, dependency, model, and artifact-field edits.
+Rationale: The route-level no-edit contract is explicit and covered.
+Alternatives considered: Add redundant tests now; not needed unless implementation touches the route or task contract.
+Test implications: None beyond final verify unless touched.
+
+## FR-014 / Jira Traceability
+
+Decision: `implemented_verified`; preserve through downstream artifacts.
+Evidence: `spec.md` and this planning artifact preserve `MM-647` and the original Jira preset brief.
+Rationale: Traceability exists and must be carried forward.
+Alternatives considered: None.
+Test implications: Final MoonSpec verification.
+
+## Testing Strategy
+
+Decision: Use focused unit tests for model/helper/route guards and hermetic integration tests for `MoonMind.Run` resume execution.
+Evidence: Repository instructions require `./tools/test_unit.sh`; hermetic integration uses `./tools/test_integration.sh`; existing tests already live in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, `tests/integration/temporal/test_backend_resume_eligibility.py`, and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`.
+Rationale: The high-risk behavior is a Temporal workflow boundary with payload compatibility concerns, so unit-only coverage is insufficient.
+Alternatives considered: Full integration suite only; rejected because unit tests are needed for red-first diagnostics and fast iteration.
+Test implications: Both unit and integration.

--- a/specs/346-resume-execution-semantics/spec.md
+++ b/specs/346-resume-execution-semantics/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Resume Execution Semantics
+
+**Feature Branch**: `346-resume-execution-semantics`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-647 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-647 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-647
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Resume execution semantics in MoonMind.Run
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-647 from MM project
+Summary: Resume execution semantics in MoonMind.Run
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 7.3 Resume from failed step
+- 8.6 Resume execution responsibilities
+- Invariant 14
+- Invariant 16
+- Invariant 17
+Coverage IDs:
+- DESIGN-REQ-018
+- DESIGN-REQ-024
+
+As an execution-plane engineer, I want MoonMind.Run, when started with task.resume.kind=resume_from_failed_step, to load and validate the resume checkpoint (source workflow/run ids, snapshot, plan identity), materialize the workspace state before the failed step, mark prior completed steps as preserved (with source provenance) without re-executing them, inject preserved outputs into downstream steps, retry the failed step as the first newly executed step, and fail explicitly when restoration is incomplete instead of silently falling back to full rerun.
+
+Acceptance Criteria
+- Resume validates source workflowId/runId, snapshot ref, and plan identity/digest before executing the failed step.
+- Workspace state is materialized to the pre-failed-step checkpoint before retry.
+- Preserved prior steps are marked preserved with provenance (source workflowId/runId/logicalStepId/attempt) and not re-executed.
+- Preserved outputs are injected so failed and downstream steps see the same contracts as a continuous run.
+- Failed step is retried as a new attempt and produces fresh ledger rows/artifacts/checkpoints.
+- Resume never silently falls back to full rerun on restoration failure; failures are explicit and operator-readable.
+- Resume rejects user-edited task input in v1; only edited full retry permits edits.
+
+Requirements
+Implement Resume entry path in MoonMind.Run, checkpoint validator, preserved-step marker, output injector, and explicit failure behaviors.
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-647 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+"""
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input type: Single-story runtime feature request.
+- Runtime decision: Jira Orchestrate always runs as a runtime implementation workflow, and `docs/Tasks/TaskArchitecture.md` is treated as runtime source requirements.
+- Breakdown decision: `moonspec-breakdown` was not run because the MM-647 Jira preset brief defines one execution-plane story with one resume execution goal, bounded acceptance criteria, and no competing independent stories.
+- Resume decision: No existing Moon Spec artifact set for `MM-647` was found under `specs/`; specification was the first incomplete stage.
+
+## User Story - Failed-Step Resume Execution
+
+**Summary**: As an execution-plane engineer, I want Resume to restore a validated failed-step checkpoint, preserve completed prior work, and retry the failed step as the first new execution action so that users can continue a failed task without editing inputs or losing trusted progress.
+
+**Goal**: A resumed task run behaves like a continuation from a verified pre-failed-step state: prior completed steps remain preserved with source provenance, failed and downstream steps receive the same preserved inputs they would have seen in a continuous run, and restoration failures stop explicitly before any misleading full rerun occurs.
+
+**Independent Test**: Start representative Resume executions from valid and invalid failed-step checkpoints, then verify that valid resumes validate source identity and plan identity, restore workspace state, preserve prior steps without re-executing them, inject preserved outputs, retry the failed step first, continue downstream after success, and fail explicitly before execution when restoration is incomplete or inconsistent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a failed source run has a resume checkpoint with source workflow ID, source run ID, original task snapshot, failed step identity, and plan identity, **When** a new run starts with failed-step Resume intent, **Then** the checkpoint is loaded and validated against those identities before the failed step can execute.
+2. **Given** the resume checkpoint identifies workspace, branch, commit, or equivalent state immediately before the failed step, **When** Resume begins execution, **Then** that state is materialized before the failed step is retried.
+3. **Given** completed prior steps have recoverable output refs and provenance in the checkpoint, **When** the resumed run initializes its step state, **Then** those steps are marked as preserved from the source run with source workflow ID, source run ID, logical step ID, and attempt, and they are not re-executed.
+4. **Given** preserved prior steps produced outputs needed by the failed step or later steps, **When** the resumed run composes inputs for the failed and downstream steps, **Then** preserved outputs are injected so those steps observe the same contracts as a continuous run.
+5. **Given** checkpoint restoration succeeds, **When** the resumed run starts new work, **Then** the failed step is retried as a new attempt before any later step executes.
+6. **Given** the retried failed step succeeds, **When** downstream steps continue, **Then** retried and later steps produce fresh ledger rows, artifacts, and checkpoints for the resumed run.
+7. **Given** checkpoint restoration is missing, unauthorized, corrupted, or inconsistent with the original task input or plan identity, **When** Resume is requested, **Then** the run fails with an explicit operator-readable outcome before executing the failed step and does not silently fall back to full rerun behavior.
+8. **Given** a user attempts to edit task instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies for failed-step Resume in v1, **When** the request is evaluated, **Then** it is rejected as Resume-ineligible and directed to the edited full retry path instead.
+
+### Edge Cases
+
+- The source workflow ID is valid but the source run ID does not match the checkpoint.
+- The checkpoint references a stale or mismatched original task input snapshot.
+- The plan identity or digest is absent, mismatched, or no longer authorized.
+- Workspace restoration succeeds partially but cannot prove the exact pre-failed-step state.
+- A preserved step has output refs but lacks source logical step ID or attempt provenance.
+- A preserved output ref is unavailable, unauthorized, deleted, or incompatible with downstream step input expectations.
+- Multiple prior steps exist and only a subset can be safely preserved.
+- The failed step succeeds in the resumed run but a later step fails and must write fresh resumed-run evidence.
+- The same source execution offers full rerun, edited retry, and Resume, but each action must preserve its distinct recovery intent.
+
+## Assumptions
+
+- Resume eligibility and checkpoint durability are established by adjacent recovery evidence work; this story covers how `MoonMind.Run` consumes a valid checkpoint and handles invalid restoration during execution.
+- Existing task artifact authorization rules apply to resume checkpoints, preserved output refs, original task snapshots, and workspace state refs.
+- Failed-step Resume is not an edit flow in v1; changing authored task input remains the responsibility of edited full retry.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: `docs/Tasks/TaskArchitecture.md` section 7.3, lines 397-411; original coverage ID DESIGN-REQ-018): Failed-step Resume must retry the last failed step using completed work up to that step, must not allow task input changes, must pin the source workflow and run IDs, must identify the failed step from source run evidence, must resolve a checkpoint containing completed-step outputs, prepared input refs, and pre-failed-step workspace or branch state, must import completed prior steps as preserved progress, must retry the failed step as a new attempt, must allow later steps to continue after success, must display preserved prior steps as reused from the source run, and must fail explicitly before the failed step when restoration is incomplete, corrupted, unauthorized, or inconsistent. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013.
+- **DESIGN-REQ-002** (Source: `docs/Tasks/TaskArchitecture.md` section 8.6, lines 517-525; original coverage ID DESIGN-REQ-024): `MoonMind.Run` must load and validate the resume checkpoint, verify source workflow ID, source run ID, task snapshot, and plan identity, materialize restored workspace state before the failed step, mark completed prior steps as preserved without re-execution, inject preserved outputs, retry the failed step first, and produce fresh ledger rows, artifacts, and checkpoints for retried and later steps. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-008, FR-009, FR-010, FR-011.
+- **DESIGN-REQ-003** (Source: `docs/Tasks/TaskArchitecture.md` section 8.6, lines 527-531): The execution plane must not silently fall back to full rerun when Resume restoration fails, must not re-execute preserved prior steps without explicit future user intent, and preserved rows must carry source workflow ID, source run ID, logical step ID, and attempt provenance. Scope: in scope. Maps to FR-004, FR-007, FR-012.
+- **DESIGN-REQ-004** (Source: `docs/Tasks/TaskArchitecture.md` invariant 14, lines 617-618): Resume must use the original task input snapshot unchanged, and any user edit to instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies requires edited full retry instead. Scope: in scope. Maps to FR-003, FR-013.
+- **DESIGN-REQ-005** (Source: `docs/Tasks/TaskArchitecture.md` invariant 16, lines 623-624): Resume must display and treat prior completed steps as preserved from the source run, and re-executing them without explicit user intent is a contract violation. Scope: in scope. Maps to FR-004, FR-005, FR-007.
+- **DESIGN-REQ-006** (Source: `docs/Tasks/TaskArchitecture.md` invariant 17, lines 626-627): Resume must pin both source workflow ID and source run ID so recovery cannot drift to another run of the same logical execution. Scope: in scope. Maps to FR-001, FR-002.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A failed-step Resume request MUST identify the source workflow ID and source run ID before the resumed run can execute.
+- **FR-002**: The resumed run MUST validate the resume checkpoint against the source workflow ID, source run ID, original task snapshot, failed step identity, and plan identity before executing the failed step.
+- **FR-003**: Failed-step Resume MUST use the original task input snapshot unchanged.
+- **FR-004**: The resumed run MUST import eligible completed prior steps as preserved progress rather than re-executing them.
+- **FR-005**: Preserved prior steps MUST carry provenance identifying the source workflow ID, source run ID, logical step ID, and attempt.
+- **FR-006**: The resumed run MUST materialize the checkpointed workspace, branch, commit, or equivalent state before retrying the failed step.
+- **FR-007**: The task detail experience MUST show preserved prior steps as reused from the source run rather than freshly executed by the resumed run.
+- **FR-008**: Preserved outputs from prior completed steps MUST be available to the retried failed step and downstream steps with the same observable contracts as a continuous run.
+- **FR-009**: The failed step MUST be retried as the first newly executed step in the resumed run.
+- **FR-010**: Later steps MUST execute normally after the retried failed step succeeds.
+- **FR-011**: The retried failed step and all later steps MUST produce fresh resumed-run ledger rows, artifacts, and checkpoints.
+- **FR-012**: If checkpoint restoration is incomplete, corrupted, unauthorized, or inconsistent with the original task input or plan identity, Resume MUST fail explicitly before executing the failed step and MUST NOT silently fall back to full rerun behavior.
+- **FR-013**: Failed-step Resume MUST reject user-edited task input in v1, including changes to instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies.
+- **FR-014**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-647` and the original Jira preset brief.
+
+### Key Entities
+
+- **Failed Source Run**: The exact source workflow and run selected for failed-step Resume, including its failed step identity, original task input snapshot, plan identity, completed-step evidence, and checkpoint refs.
+- **Resume Checkpoint**: Durable evidence binding the source run to prepared input refs, completed-step output refs, failed step identity, plan identity, and workspace or branch state immediately before the failed step.
+- **Preserved Step**: A completed prior step imported into the resumed run as reused progress with source workflow ID, source run ID, logical step ID, and attempt provenance.
+- **Preserved Output**: A recoverable output ref from a preserved step that is injected into the retried failed step or downstream steps.
+- **Resumed Run**: The new task run created with failed-step Resume intent, which starts new execution at the failed step and records fresh evidence for the retried failed step and later steps.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid failed-step Resume validation cases load and validate source workflow ID, source run ID, original task snapshot, failed step identity, and plan identity before the failed step executes.
+- **SC-002**: 100% of valid Resume validation cases materialize checkpointed workspace, branch, commit, or equivalent state before the failed step starts.
+- **SC-003**: 100% of eligible prior completed steps in validation are marked preserved with source workflow ID, source run ID, logical step ID, and attempt provenance, and 0 of those preserved steps are re-executed.
+- **SC-004**: 100% of validation cases with preserved outputs make those outputs available to the retried failed step and downstream steps using the same observable contracts as a continuous run.
+- **SC-005**: 100% of valid Resume validation cases retry the failed step as the first newly executed step and produce fresh resumed-run evidence for retried and later steps.
+- **SC-006**: 100% of invalid restoration validation cases fail explicitly before executing the failed step and 0 cases fall back silently to full rerun behavior.
+- **SC-007**: 100% of edited-input Resume attempts in v1 validation are rejected as Resume-ineligible and require edited full retry instead.
+- **SC-008**: Traceability review confirms `MM-647`, the original Jira preset brief, and source coverage IDs DESIGN-REQ-018 and DESIGN-REQ-024 remain preserved in MoonSpec artifacts and final verification evidence.

--- a/specs/346-resume-execution-semantics/tasks.md
+++ b/specs/346-resume-execution-semantics/tasks.md
@@ -27,8 +27,8 @@
 
 **Purpose**: Confirm the task environment and current artifact set before test-first work.
 
-- [ ] T001 Confirm `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are current and preserve `MM-647`, DESIGN-REQ-018, and DESIGN-REQ-024.
-- [ ] T002 Confirm existing focused Resume test targets and fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, and `tests/integration/temporal/test_backend_resume_eligibility.py`
+- [X] T001 Confirm `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are current and preserve `MM-647`, DESIGN-REQ-018, and DESIGN-REQ-024.
+- [X] T002 Confirm existing focused Resume test targets and fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, and `tests/integration/temporal/test_backend_resume_eligibility.py`
 
 ---
 
@@ -38,9 +38,9 @@
 
 **CRITICAL**: No production implementation starts until Phase 3 unit and integration tests are written and red-first confirmation has run.
 
-- [ ] T003 Add reusable Resume checkpoint, `resumeSource`, preserved-step, and workspace-restoration fixtures for MM-647 in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-006, FR-012, SCN-001, SCN-002, SCN-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-006.
-- [ ] T004 [P] Add reusable resumed-run integration fixtures for source run, checkpoint payload, preserved output refs, failed step, and downstream step ordering in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-008, FR-009, FR-010, FR-011, SCN-003, SCN-004, SCN-005, SCN-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-005.
-- [ ] T005 [P] Add service-level fixture coverage for accepted Resume refs and invalid checkpoint cases only where current helpers are insufficient in `tests/unit/workflows/temporal/test_temporal_service.py` covering FR-001, FR-002, FR-012, SC-001, and SC-006.
+- [X] T003 Add reusable Resume checkpoint, `resumeSource`, preserved-step, and workspace-restoration fixtures for MM-647 in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-006, FR-012, SCN-001, SCN-002, SCN-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-006.
+- [X] T004 [P] Add reusable resumed-run integration fixtures for source run, checkpoint payload, preserved output refs, failed step, and downstream step ordering in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-008, FR-009, FR-010, FR-011, SCN-003, SCN-004, SCN-005, SCN-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-005.
+- [X] T005 [P] Add service-level fixture coverage for accepted Resume refs and invalid checkpoint cases only where current helpers are insufficient in `tests/unit/workflows/temporal/test_temporal_service.py` covering FR-001, FR-002, FR-012, SC-001, and SC-006.
 
 **Checkpoint**: Shared fixtures are ready for red-first unit and integration tests.
 
@@ -61,42 +61,42 @@
 
 ### Unit Tests (write first)
 
-- [ ] T006 Add failing unit tests for `MoonMind.Run` resume-source validation before step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T007 Add failing unit tests for workspace restoration requirement before failed-step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T008 Add failing unit tests for preserved output injection into failed and downstream step input contracts in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T009 Add failing unit tests for fresh resumed-run ledger rows, artifacts, and checkpoints on retried and later steps in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
-- [ ] T010 [P] Add verification unit tests preserving edited-input rejection and source ID pinning in `tests/unit/api/routers/test_executions.py` covering FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T011 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and confirm T006-T009 fail for missing/partial MM-647 execution semantics while T010 preserves existing verified behavior.
+- [X] T006 Add failing unit tests for `MoonMind.Run` resume-source validation before step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T007 Add failing unit tests for workspace restoration requirement before failed-step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T008 Add failing unit tests for preserved output injection into failed and downstream step input contracts in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T009 Add failing unit tests for fresh resumed-run ledger rows, artifacts, and checkpoints on retried and later steps in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [X] T010 [P] Add verification unit tests preserving edited-input rejection and source ID pinning in `tests/unit/api/routers/test_executions.py` covering FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T011 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and confirm T006-T009 fail for missing/partial MM-647 execution semantics while T010 preserves existing verified behavior.
 
 ### Integration Tests (write first)
 
-- [ ] T012 Add failing integration test for valid Resume initialization validating source workflow ID, source run ID, snapshot, failed step, and plan identity before execution in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T013 Add failing integration test proving workspace or branch checkpoint restoration happens before the failed step starts in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T014 Add failing integration test proving preserved prior steps are not re-executed and retain `preservedFrom` provenance in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
-- [ ] T015 Add failing integration test proving preserved outputs are available to the retried failed step and downstream steps with continuous-run semantics in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T016 Add failing integration test proving the failed step is the first newly executed step and downstream steps continue after success in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T017 Add failing integration test proving invalid restoration fails explicitly before failed-step execution and never falls back to full rerun in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-003.
-- [ ] T018 Add or extend integration verification for accepted Resume refs and route/service invalid checkpoint behavior in `tests/integration/temporal/test_backend_resume_eligibility.py` covering FR-001, FR-002, FR-012, FR-013, SCN-001, SCN-007, SCN-008, SC-001, SC-006, and SC-007.
-- [ ] T019 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and confirm T012-T018 fail for the intended missing/partial MM-647 behavior or pass only for already verified rows.
+- [X] T012 Add failing integration test for valid Resume initialization validating source workflow ID, source run ID, snapshot, failed step, and plan identity before execution in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T013 Add failing integration test proving workspace or branch checkpoint restoration happens before the failed step starts in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T014 Add failing integration test proving preserved prior steps are not re-executed and retain `preservedFrom` provenance in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
+- [X] T015 Add failing integration test proving preserved outputs are available to the retried failed step and downstream steps with continuous-run semantics in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T016 Add failing integration test proving the failed step is the first newly executed step and downstream steps continue after success in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T017 Add failing integration test proving invalid restoration fails explicitly before failed-step execution and never falls back to full rerun in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [X] T018 Add or extend integration verification for accepted Resume refs and route/service invalid checkpoint behavior in `tests/integration/temporal/test_backend_resume_eligibility.py` covering FR-001, FR-002, FR-012, FR-013, SCN-001, SCN-007, SCN-008, SC-001, SC-006, and SC-007.
+- [X] T019 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and confirm T012-T018 fail for the intended missing/partial MM-647 behavior or pass only for already verified rows.
 
 ### Implementation
 
-- [ ] T020 Implement compact resume-source validation and explicit pre-execution failure handling in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T021 Add or refine Resume source models and validation helpers in `moonmind/schemas/temporal_models.py` only as needed by T020 and T025, covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T022 Implement workspace or branch checkpoint restoration boundary before failed-step execution in `moonmind/workflows/temporal/workflows/run.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T023 Add any required activity/service boundary for workspace restoration in `moonmind/workflows/temporal/service.py` or an existing Temporal activity module only if T022 cannot use an existing boundary, covering FR-006 and SCN-002.
-- [ ] T024 Implement preserved output injection from preserved ledger rows into failed and downstream step input composition in `moonmind/workflows/temporal/workflows/run.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T025 Ensure preserved prior steps initialize with source provenance, zero new attempt, visible preserved status, and no re-execution in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
-- [ ] T026 Ensure failed-step first ordering and downstream continuation use the restored/preserved state in `moonmind/workflows/temporal/workflows/run.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T027 Ensure retried failed and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints instead of copied source evidence in `moonmind/workflows/temporal/workflows/run.py` and `moonmind/workflows/temporal/step_ledger.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
-- [ ] T028 Preserve and adjust, only if required by test failures, failed-step Resume submission validation in `api_service/api/routers/executions.py` covering FR-013, SCN-008, SC-007, and DESIGN-REQ-004.
-- [ ] T029 Preserve and adjust, only if required by test failures, `TemporalExecutionService.create_failed_step_resume_execution()` accepted Resume payload construction in `moonmind/workflows/temporal/service.py` covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T030 Preserve MM-647 traceability comments or test names where useful in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-014 and SC-008.
+- [X] T020 Implement compact resume-source validation and explicit pre-execution failure handling in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T021 Add or refine Resume source models and validation helpers in `moonmind/schemas/temporal_models.py` only as needed by T020 and T025, covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T022 Implement workspace or branch checkpoint restoration boundary before failed-step execution in `moonmind/workflows/temporal/workflows/run.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T023 Add any required activity/service boundary for workspace restoration in `moonmind/workflows/temporal/service.py` or an existing Temporal activity module only if T022 cannot use an existing boundary, covering FR-006 and SCN-002.
+- [X] T024 Implement preserved output injection from preserved ledger rows into failed and downstream step input composition in `moonmind/workflows/temporal/workflows/run.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T025 Ensure preserved prior steps initialize with source provenance, zero new attempt, visible preserved status, and no re-execution in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
+- [X] T026 Ensure failed-step first ordering and downstream continuation use the restored/preserved state in `moonmind/workflows/temporal/workflows/run.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [X] T027 Ensure retried failed and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints instead of copied source evidence in `moonmind/workflows/temporal/workflows/run.py` and `moonmind/workflows/temporal/step_ledger.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [X] T028 Preserve and adjust, only if required by test failures, failed-step Resume submission validation in `api_service/api/routers/executions.py` covering FR-013, SCN-008, SC-007, and DESIGN-REQ-004.
+- [X] T029 Preserve and adjust, only if required by test failures, `TemporalExecutionService.create_failed_step_resume_execution()` accepted Resume payload construction in `moonmind/workflows/temporal/service.py` covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [X] T030 Preserve MM-647 traceability comments or test names where useful in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-014 and SC-008.
 
 ### Story Validation
 
-- [ ] T031 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/schemas/temporal_models.py`, `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/service.py`, or `api_service/api/routers/executions.py` until FR-001 through FR-014 pass focused unit validation.
-- [ ] T032 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/step_ledger.py`, or `api_service/api/routers/executions.py` until SCN-001 through SCN-008 pass focused integration validation.
+- [X] T031 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/schemas/temporal_models.py`, `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/service.py`, or `api_service/api/routers/executions.py` until FR-001 through FR-014 pass focused unit validation.
+- [X] T032 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/step_ledger.py`, or `api_service/api/routers/executions.py` until SCN-001 through SCN-008 pass focused integration validation.
 
 **Checkpoint**: The single MM-647 story is functionally complete, covered by unit and integration tests, and independently testable.
 
@@ -106,12 +106,23 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T033 [P] Review `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, `quickstart.md`, and `tasks.md` for MM-647 traceability and update only if implementation reality changed.
-- [ ] T034 [P] Run focused quickstart unit command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
-- [ ] T035 Run focused quickstart integration command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
-- [ ] T036 Run full required unit suite `./tools/test_unit.sh` and fix any MM-647 regressions.
-- [ ] T037 Run full required hermetic integration suite `./tools/test_integration.sh` and fix any MM-647 regressions or document exact environment blockers.
+- [X] T033 [P] Review `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, `quickstart.md`, and `tasks.md` for MM-647 traceability and update only if implementation reality changed.
+- [X] T034 [P] Run focused quickstart unit command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
+- [X] T035 Run focused quickstart integration command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
+- [X] T036 Run full required unit suite `./tools/test_unit.sh` and fix any MM-647 regressions.
+- [X] T037 Run full required hermetic integration suite `./tools/test_integration.sh` and fix any MM-647 regressions or document exact environment blockers.
 - [ ] T038 Run `/speckit.verify` against `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `tasks.md`, source design mappings, preserved MM-647 Jira preset brief, and test evidence after implementation and tests pass.
+
+---
+
+## Implementation Evidence
+
+- Red-first unit command `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` failed before production changes with missing Resume validation, workspace restoration, and preserved-output helpers.
+- Red-first integration command `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` failed before production changes with missing Resume workflow state and helper behavior.
+- Focused unit command passed after implementation: `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` (`322 passed`, plus frontend `343 passed | 229 skipped`).
+- Focused integration command passed after implementation: `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` (`14 passed`, plus frontend `343 passed | 229 skipped`).
+- Full unit command passed: `./tools/test_unit.sh` (`4951 passed, 1 xpassed, 115 warnings, 16 subtests passed`, plus frontend `343 passed | 229 skipped`).
+- Full hermetic integration command was attempted with `./tools/test_integration.sh` and is blocked in this managed environment: Docker Compose begins building `repo-pytest`, then the Docker daemon returns `403 Forbidden` with "Request forbidden by administrative rules."
 
 ---
 

--- a/specs/346-resume-execution-semantics/tasks.md
+++ b/specs/346-resume-execution-semantics/tasks.md
@@ -61,21 +61,21 @@
 
 ### Unit Tests (write first)
 
-- [ ] T006 [P] Add failing unit tests for `MoonMind.Run` resume-source validation before step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T007 [P] Add failing unit tests for workspace restoration requirement before failed-step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T008 [P] Add failing unit tests for preserved output injection into failed and downstream step input contracts in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T009 [P] Add failing unit tests for fresh resumed-run ledger rows, artifacts, and checkpoints on retried and later steps in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [ ] T006 Add failing unit tests for `MoonMind.Run` resume-source validation before step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T007 Add failing unit tests for workspace restoration requirement before failed-step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T008 Add failing unit tests for preserved output injection into failed and downstream step input contracts in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T009 Add failing unit tests for fresh resumed-run ledger rows, artifacts, and checkpoints on retried and later steps in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
 - [ ] T010 [P] Add verification unit tests preserving edited-input rejection and source ID pinning in `tests/unit/api/routers/test_executions.py` covering FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004, and DESIGN-REQ-006.
 - [ ] T011 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and confirm T006-T009 fail for missing/partial MM-647 execution semantics while T010 preserves existing verified behavior.
 
 ### Integration Tests (write first)
 
-- [ ] T012 [P] Add failing integration test for valid Resume initialization validating source workflow ID, source run ID, snapshot, failed step, and plan identity before execution in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
-- [ ] T013 [P] Add failing integration test proving workspace or branch checkpoint restoration happens before the failed step starts in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T014 [P] Add failing integration test proving preserved prior steps are not re-executed and retain `preservedFrom` provenance in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
-- [ ] T015 [P] Add failing integration test proving preserved outputs are available to the retried failed step and downstream steps with continuous-run semantics in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T016 [P] Add failing integration test proving the failed step is the first newly executed step and downstream steps continue after success in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
-- [ ] T017 [P] Add failing integration test proving invalid restoration fails explicitly before failed-step execution and never falls back to full rerun in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [ ] T012 Add failing integration test for valid Resume initialization validating source workflow ID, source run ID, snapshot, failed step, and plan identity before execution in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T013 Add failing integration test proving workspace or branch checkpoint restoration happens before the failed step starts in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T014 Add failing integration test proving preserved prior steps are not re-executed and retain `preservedFrom` provenance in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
+- [ ] T015 Add failing integration test proving preserved outputs are available to the retried failed step and downstream steps with continuous-run semantics in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T016 Add failing integration test proving the failed step is the first newly executed step and downstream steps continue after success in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T017 Add failing integration test proving invalid restoration fails explicitly before failed-step execution and never falls back to full rerun in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-003.
 - [ ] T018 Add or extend integration verification for accepted Resume refs and route/service invalid checkpoint behavior in `tests/integration/temporal/test_backend_resume_eligibility.py` covering FR-001, FR-002, FR-012, FR-013, SCN-001, SCN-007, SCN-008, SC-001, SC-006, and SC-007.
 - [ ] T019 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and confirm T012-T018 fail for the intended missing/partial MM-647 behavior or pass only for already verified rows.
 
@@ -136,8 +136,8 @@
 ### Parallel Opportunities
 
 - T004 and T005 can run in parallel with T003 after T001-T002.
-- T006-T010 can be authored in parallel if workers coordinate changes to shared files.
-- T012-T018 can be authored in parallel because they target separate scenarios.
+- T010 can be authored in parallel with the T006-T009 unit-test sequence because it touches a different file.
+- T018 can be authored in parallel with the T012-T017 integration-test sequence because it touches a different file.
 - T033 and T034 can run in parallel after story validation.
 
 ## Parallel Example

--- a/specs/346-resume-execution-semantics/tasks.md
+++ b/specs/346-resume-execution-semantics/tasks.md
@@ -1,0 +1,167 @@
+# Tasks: Resume Execution Semantics
+
+**Input**: Design documents from `/work/agent_jobs/mm:6d4f0168-95fa-48a3-9cb3-f3508f959fd5/repo/specs/346-resume-execution-semantics/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/resume-execution.md](./contracts/resume-execution.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: One story only: Failed-Step Resume Execution.
+
+**Source Traceability**: Original Jira issue `MM-647` and the preserved Jira preset brief are in `spec.md` `**Input**`. Tasks cover FR-001 through FR-014, SCN-001 through SCN-008, SC-001 through SC-008, DESIGN-REQ-001 through DESIGN-REQ-006, and source coverage IDs DESIGN-REQ-018 and DESIGN-REQ-024.
+
+**Requirement Status Summary**: 5 missing, 14 partial, 17 implemented_unverified, 4 implemented_verified from `plan.md`.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py`
+- Integration tests: `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py`
+- Full integration tests: `./tools/test_integration.sh`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when touching different files and not depending on incomplete work.
+- Every task uses `- [ ] T### [P?] Description with file path`.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the task environment and current artifact set before test-first work.
+
+- [ ] T001 Confirm `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, and `quickstart.md` are current and preserve `MM-647`, DESIGN-REQ-018, and DESIGN-REQ-024.
+- [ ] T002 Confirm existing focused Resume test targets and fixtures in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, `tests/unit/workflows/temporal/test_temporal_service.py`, `tests/unit/api/routers/test_executions.py`, `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py`, and `tests/integration/temporal/test_backend_resume_eligibility.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared test fixtures and contract helpers that block the story tests.
+
+**CRITICAL**: No production implementation starts until Phase 3 unit and integration tests are written and red-first confirmation has run.
+
+- [ ] T003 Add reusable Resume checkpoint, `resumeSource`, preserved-step, and workspace-restoration fixtures for MM-647 in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-006, FR-012, SCN-001, SCN-002, SCN-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, and DESIGN-REQ-006.
+- [ ] T004 [P] Add reusable resumed-run integration fixtures for source run, checkpoint payload, preserved output refs, failed step, and downstream step ordering in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-008, FR-009, FR-010, FR-011, SCN-003, SCN-004, SCN-005, SCN-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-005.
+- [ ] T005 [P] Add service-level fixture coverage for accepted Resume refs and invalid checkpoint cases only where current helpers are insufficient in `tests/unit/workflows/temporal/test_temporal_service.py` covering FR-001, FR-002, FR-012, SC-001, and SC-006.
+
+**Checkpoint**: Shared fixtures are ready for red-first unit and integration tests.
+
+---
+
+## Phase 3: Story - Failed-Step Resume Execution
+
+**Summary**: As an execution-plane engineer, I want Resume to restore a validated failed-step checkpoint, preserve completed prior work, and retry the failed step as the first new execution action so that users can continue a failed task without editing inputs or losing trusted progress.
+
+**Independent Test**: Start representative Resume executions from valid and invalid failed-step checkpoints, then verify valid resumes validate source identity and plan identity, restore workspace state, preserve prior steps without re-executing them, inject preserved outputs, retry the failed step first, continue downstream after success, and fail explicitly before execution when restoration is incomplete or inconsistent.
+
+**Traceability**: FR-001 through FR-014; SCN-001 through SCN-008; SC-001 through SC-008; DESIGN-REQ-001 through DESIGN-REQ-006; original coverage IDs DESIGN-REQ-018 and DESIGN-REQ-024.
+
+**Test Plan**:
+
+- Unit: resume-source validation, no-fallback failure behavior, preserved provenance, preserved-output refs, workspace restoration contract, fresh resumed-run evidence, edited-input guard preservation.
+- Integration: real or representative `MoonMind.Run` Resume initialization, preserved-step import, pre-failed-step workspace restoration, failed-step first ordering, downstream continuation, invalid restoration no-fallback behavior, projection of preserved prior steps.
+
+### Unit Tests (write first)
+
+- [ ] T006 [P] Add failing unit tests for `MoonMind.Run` resume-source validation before step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T007 [P] Add failing unit tests for workspace restoration requirement before failed-step execution in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T008 [P] Add failing unit tests for preserved output injection into failed and downstream step input contracts in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T009 [P] Add failing unit tests for fresh resumed-run ledger rows, artifacts, and checkpoints on retried and later steps in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [ ] T010 [P] Add verification unit tests preserving edited-input rejection and source ID pinning in `tests/unit/api/routers/test_executions.py` covering FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T011 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and confirm T006-T009 fail for missing/partial MM-647 execution semantics while T010 preserves existing verified behavior.
+
+### Integration Tests (write first)
+
+- [ ] T012 [P] Add failing integration test for valid Resume initialization validating source workflow ID, source run ID, snapshot, failed step, and plan identity before execution in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-001, FR-002, FR-003, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T013 [P] Add failing integration test proving workspace or branch checkpoint restoration happens before the failed step starts in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T014 [P] Add failing integration test proving preserved prior steps are not re-executed and retain `preservedFrom` provenance in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
+- [ ] T015 [P] Add failing integration test proving preserved outputs are available to the retried failed step and downstream steps with continuous-run semantics in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T016 [P] Add failing integration test proving the failed step is the first newly executed step and downstream steps continue after success in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T017 [P] Add failing integration test proving invalid restoration fails explicitly before failed-step execution and never falls back to full rerun in `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-012, SCN-007, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [ ] T018 Add or extend integration verification for accepted Resume refs and route/service invalid checkpoint behavior in `tests/integration/temporal/test_backend_resume_eligibility.py` covering FR-001, FR-002, FR-012, FR-013, SCN-001, SCN-007, SCN-008, SC-001, SC-006, and SC-007.
+- [ ] T019 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and confirm T012-T018 fail for the intended missing/partial MM-647 behavior or pass only for already verified rows.
+
+### Implementation
+
+- [ ] T020 Implement compact resume-source validation and explicit pre-execution failure handling in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-002, FR-003, FR-012, SCN-001, SCN-007, SC-001, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T021 Add or refine Resume source models and validation helpers in `moonmind/schemas/temporal_models.py` only as needed by T020 and T025, covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T022 Implement workspace or branch checkpoint restoration boundary before failed-step execution in `moonmind/workflows/temporal/workflows/run.py` covering FR-006, SCN-002, SC-002, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T023 Add any required activity/service boundary for workspace restoration in `moonmind/workflows/temporal/service.py` or an existing Temporal activity module only if T022 cannot use an existing boundary, covering FR-006 and SCN-002.
+- [ ] T024 Implement preserved output injection from preserved ledger rows into failed and downstream step input composition in `moonmind/workflows/temporal/workflows/run.py` covering FR-008, SCN-004, SC-004, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T025 Ensure preserved prior steps initialize with source provenance, zero new attempt, visible preserved status, and no re-execution in `moonmind/workflows/temporal/step_ledger.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-004, FR-005, FR-007, SCN-003, SC-003, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-005.
+- [ ] T026 Ensure failed-step first ordering and downstream continuation use the restored/preserved state in `moonmind/workflows/temporal/workflows/run.py` covering FR-009, FR-010, SCN-005, SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T027 Ensure retried failed and later steps produce fresh resumed-run ledger rows, artifacts, and checkpoints instead of copied source evidence in `moonmind/workflows/temporal/workflows/run.py` and `moonmind/workflows/temporal/step_ledger.py` covering FR-011, SCN-006, SC-005, DESIGN-REQ-002, and DESIGN-REQ-003.
+- [ ] T028 Preserve and adjust, only if required by test failures, failed-step Resume submission validation in `api_service/api/routers/executions.py` covering FR-013, SCN-008, SC-007, and DESIGN-REQ-004.
+- [ ] T029 Preserve and adjust, only if required by test failures, `TemporalExecutionService.create_failed_step_resume_execution()` accepted Resume payload construction in `moonmind/workflows/temporal/service.py` covering FR-001, FR-002, FR-003, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-006.
+- [ ] T030 Preserve MM-647 traceability comments or test names where useful in `tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py` and `tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py` covering FR-014 and SC-008.
+
+### Story Validation
+
+- [ ] T031 Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/schemas/temporal_models.py`, `moonmind/workflows/temporal/step_ledger.py`, `moonmind/workflows/temporal/service.py`, or `api_service/api/routers/executions.py` until FR-001 through FR-014 pass focused unit validation.
+- [ ] T032 Run `./tools/test_unit.sh tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py tests/integration/temporal/test_backend_resume_eligibility.py` and fix failures in `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/step_ledger.py`, or `api_service/api/routers/executions.py` until SCN-001 through SCN-008 pass focused integration validation.
+
+**Checkpoint**: The single MM-647 story is functionally complete, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T033 [P] Review `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/resume-execution.md`, `quickstart.md`, and `tasks.md` for MM-647 traceability and update only if implementation reality changed.
+- [ ] T034 [P] Run focused quickstart unit command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
+- [ ] T035 Run focused quickstart integration command from `specs/346-resume-execution-semantics/quickstart.md` and record the outcome in implementation notes or final verification evidence.
+- [ ] T036 Run full required unit suite `./tools/test_unit.sh` and fix any MM-647 regressions.
+- [ ] T037 Run full required hermetic integration suite `./tools/test_integration.sh` and fix any MM-647 regressions or document exact environment blockers.
+- [ ] T038 Run `/speckit.verify` against `specs/346-resume-execution-semantics/spec.md`, `plan.md`, `tasks.md`, source design mappings, preserved MM-647 Jira preset brief, and test evidence after implementation and tests pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on Phase 1 and blocks story tests.
+- Phase 3 depends on Phase 2.
+- Phase 4 depends on story implementation and focused tests passing.
+
+### Story Order
+
+- T006-T010 unit tests must be written before T011.
+- T012-T018 integration tests must be written before T019.
+- T011 and T019 red-first confirmation must run before T020-T030 production work.
+- T020-T023 establish validation and restoration before T024-T027 step execution semantics.
+- T028-T029 are conditional fallback tasks for already implemented or implemented_unverified route/service behavior and should run only if verification tests fail.
+- T031-T032 validate the complete story before polish.
+
+### Parallel Opportunities
+
+- T004 and T005 can run in parallel with T003 after T001-T002.
+- T006-T010 can be authored in parallel if workers coordinate changes to shared files.
+- T012-T018 can be authored in parallel because they target separate scenarios.
+- T033 and T034 can run in parallel after story validation.
+
+## Parallel Example
+
+```bash
+Task: "Add failing unit tests for workspace restoration in tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py"
+Task: "Add failing integration test for invalid restoration no-fallback in tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py"
+Task: "Add route/service verification for accepted Resume refs in tests/integration/temporal/test_backend_resume_eligibility.py"
+```
+
+## Implementation Strategy
+
+1. Confirm the MM-647 artifact set and existing Resume test fixtures.
+2. Add all red-first unit tests for validation, restoration, preserved output injection, fresh evidence, and no-edit guard preservation.
+3. Add all red-first integration tests for real resumed-run initialization, workspace restoration, preserved-step behavior, failed-step ordering, downstream continuation, and no-fallback failures.
+4. Run focused unit and integration commands and record expected failures before production changes.
+5. Implement missing and partial code paths in `MoonMind.Run`, schemas, service, step ledger, and route boundaries as needed.
+6. Run focused tests until green.
+7. Run full required unit and hermetic integration suites.
+8. Run final `/speckit.verify`.
+
+## Coverage Summary
+
+- Code-and-test work: FR-002, FR-003, FR-006, FR-008, FR-011, FR-012 and related missing/partial SCN/SC/DESIGN rows.
+- Verification-first with conditional fallback: FR-001, FR-004, FR-005, FR-007, FR-009, FR-010 and related implemented_unverified rows.
+- Already verified and preserved: FR-013, FR-014, SCN-008, SC-007, SC-008, DESIGN-REQ-004.
+- Final verification preserves original request traceability for `MM-647`, DESIGN-REQ-018, and DESIGN-REQ-024.

--- a/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -305,7 +305,7 @@ def test_invalid_resume_restoration_fails_without_full_rerun() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._resume_source = _resume_source(resumeWorkspace={})
 
-    with pytest.raises(ValueError, match="workspace checkpoint"):
+    with pytest.raises(ValueError, match="workspace evidence"):
         workflow._initialize_step_ledger(
             ordered_nodes=_ordered_nodes(),
             dependency_map=_dependency_map(),
@@ -313,3 +313,21 @@ def test_invalid_resume_restoration_fails_without_full_rerun() -> None:
         )
 
     assert workflow._step_ledger_rows == []
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_resume_initialization_accepts_existing_workspace_evidence_formats() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = _resume_source(
+        resumeWorkspace={"branch": "feature", "commit": "abc123"}
+    )
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=datetime.now(UTC),
+    )
+
+    assert workflow._resume_workspace == {"branch": "feature", "commit": "abc123"}
+    assert workflow._restore_resume_workspace_for_failed_step("implement") is None

--- a/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -11,6 +11,59 @@ from moonmind.workflows.temporal.step_ledger import (
     refresh_ready_steps,
     update_step_row,
 )
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _resume_source(**overrides: object) -> dict[str, object]:
+    source: dict[str, object] = {
+        "sourceWorkflowId": "mm:source",
+        "sourceRunId": "run-source",
+        "sourceTaskInputSnapshotRef": "artifact://snapshot/source",
+        "sourcePlanDigest": "sha256:source-plan",
+        "failedStepId": "implement",
+        "failedStepAttempt": 1,
+        "resumeCheckpointRef": "artifact://resume/checkpoint",
+        "resumeWorkspace": {
+            "checkpointRef": "artifact://workspace/before-implement",
+        },
+        "preservedSteps": [
+            {
+                "logicalStepId": "prepare",
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {
+                    "outputSummary": "artifact://prepare-summary",
+                    "outputPrimary": "artifact://prepare-output",
+                },
+                "stateCheckpointRef": "artifact://workspace/prepare",
+            }
+        ],
+    }
+    source.update(overrides)
+    return source
+
+
+def _ordered_nodes() -> list[dict[str, object]]:
+    return [
+        {"id": "prepare", "title": "Prepare"},
+        {"id": "implement", "title": "Implement"},
+        {"id": "verify", "title": "Verify"},
+    ]
+
+
+def _dependency_map() -> dict[str, list[str]]:
+    return {"prepare": [], "implement": ["prepare"], "verify": ["implement"]}
+
+
+def _resume_workflow(source: dict[str, object] | None = None) -> MoonMindRunWorkflow:
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = source or _resume_source()
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=datetime.now(UTC),
+    )
+    return workflow
 
 
 @pytest.mark.integration
@@ -173,3 +226,90 @@ def test_source_run_marks_completed_step_without_checkpoint_ineligible() -> None
     assert rows[0]["resumePreservation"]["eligible"] is False
     assert rows[0]["resumePreservation"]["reason"] == "missing_state_checkpoint"
     assert rows[1]["status"] == "ready"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_resume_initialization_validates_source_identity_before_execution() -> None:
+    workflow = _resume_workflow()
+
+    assert workflow._resume_failed_step_id == "implement"
+    assert workflow._step_ledger_rows[0]["preservedFrom"] == {
+        "workflowId": "mm:source",
+        "runId": "run-source",
+        "logicalStepId": "prepare",
+        "attempt": 1,
+    }
+    assert workflow._step_ledger_rows[1]["status"] == "ready"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_resume_restores_workspace_checkpoint_before_failed_step_starts() -> None:
+    workflow = _resume_workflow()
+
+    restored_ref = workflow._restore_resume_workspace_for_failed_step("implement")
+
+    assert restored_ref == "artifact://workspace/before-implement"
+    assert workflow._resume_workspace_restored_ref == restored_ref
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_resume_preserved_outputs_are_injected_for_failed_step_continuation() -> None:
+    workflow = _resume_workflow()
+
+    outputs = workflow._preserved_outputs_for_step("implement")
+
+    assert outputs["prepare"]["outputSummary"] == "artifact://prepare-summary"
+    assert outputs["prepare"]["outputPrimary"] == "artifact://prepare-output"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_resume_failed_step_first_then_downstream_continues_after_success() -> None:
+    workflow = _resume_workflow()
+    now = datetime.now(UTC)
+
+    ready_steps = [
+        row["logicalStepId"]
+        for row in workflow._step_ledger_rows
+        if row["status"] == "ready"
+    ]
+    assert ready_steps == ["implement"]
+
+    update_step_row(
+        workflow._step_ledger_rows,
+        "implement",
+        updated_at=now,
+        status="succeeded",
+        artifacts={"outputPrimary": "artifact://implement-output-new"},
+    )
+    mark_step_checkpoint_evidence(
+        workflow._step_ledger_rows,
+        "implement",
+        updated_at=now,
+        state_checkpoint_ref="artifact://workspace/implement-new",
+    )
+    refresh_ready_steps(workflow._step_ledger_rows, updated_at=now)
+
+    verify_row = next(
+        row for row in workflow._step_ledger_rows if row["logicalStepId"] == "verify"
+    )
+    assert verify_row["status"] == "ready"
+
+
+@pytest.mark.integration
+@pytest.mark.integration_ci
+def test_invalid_resume_restoration_fails_without_full_rerun() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = _resume_source(resumeWorkspace={})
+
+    with pytest.raises(ValueError, match="workspace checkpoint"):
+        workflow._initialize_step_ledger(
+            ordered_nodes=_ordered_nodes(),
+            dependency_map=_dependency_map(),
+            updated_at=datetime.now(UTC),
+        )
+
+    assert workflow._step_ledger_rows == []

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -190,6 +190,33 @@ def test_parent_owned_checkpoint_evidence_survives_child_runtime_projection() ->
         "message": "Step has recoverable output refs and state checkpoint evidence.",
     }
 
+def test_empty_resume_source_is_treated_as_absent() -> None:
+    now = datetime.now(UTC)
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = {}
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    assert workflow._resume_failed_step_id is None
+    assert workflow._resume_workspace == {}
+    assert workflow._step_ledger_rows[0]["status"] == "ready"
+
+
+def test_step_ledger_row_lookup_uses_initialized_index() -> None:
+    workflow = _workflow_with_resume()
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=datetime.now(UTC),
+    )
+
+    assert workflow._step_ledger_row_for("prepare") is workflow._step_ledger_rows[0]
+    assert workflow._step_ledger_row_for("missing") is None
+
 
 @pytest.mark.parametrize(
     ("field", "message"),
@@ -266,16 +293,53 @@ def test_resume_source_restores_workspace_before_failed_step_execution() -> None
     assert workflow._restore_resume_workspace_for_failed_step("verify") is None
 
 
-def test_resume_source_rejects_missing_workspace_checkpoint() -> None:
+def test_resume_source_rejects_missing_workspace_evidence() -> None:
     source = _resume_source(resumeWorkspace={})
     workflow = _workflow_with_resume(source)
 
-    with pytest.raises(ValueError, match="workspace checkpoint"):
+    with pytest.raises(ValueError, match="workspace evidence"):
         workflow._initialize_step_ledger(
             ordered_nodes=_ordered_nodes(),
             dependency_map=_dependency_map(),
             updated_at=datetime.now(UTC),
         )
+
+
+def test_resume_source_accepts_branch_commit_workspace_evidence() -> None:
+    now = datetime.now(UTC)
+    source = _resume_source(resumeWorkspace={"branch": "feature", "commit": "abc123"})
+    workflow = _workflow_with_resume(source)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    assert workflow._resume_workspace == {"branch": "feature", "commit": "abc123"}
+    assert workflow._restore_resume_workspace_for_failed_step("implement") is None
+
+
+def test_resume_source_accepts_checkpoint_payload_ref_workspace_evidence() -> None:
+    now = datetime.now(UTC)
+    source = _resume_source(
+        resumeWorkspace={
+            "checkpoint_payload_ref": "artifact://checkpoint/payload",
+            "inline_checkpoint_metadata": "artifact://checkpoint/metadata",
+        }
+    )
+    workflow = _workflow_with_resume(source)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    restored_ref = workflow._restore_resume_workspace_for_failed_step("implement")
+
+    assert restored_ref == "artifact://checkpoint/payload"
+    assert workflow._resume_workspace_restored_ref == restored_ref
 
 
 def test_preserved_outputs_are_available_to_failed_step_dependencies() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from moonmind.workflows.temporal.step_ledger import (
     build_initial_step_rows,
     mark_step_checkpoint_evidence,
@@ -9,6 +11,56 @@ from moonmind.workflows.temporal.step_ledger import (
     refresh_ready_steps,
     update_step_row,
 )
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _resume_source(**overrides: object) -> dict[str, object]:
+    source: dict[str, object] = {
+        "sourceWorkflowId": "mm:source",
+        "sourceRunId": "run-source",
+        "sourceTaskInputSnapshotRef": "artifact://snapshot/source",
+        "sourcePlanDigest": "sha256:source-plan",
+        "failedStepId": "implement",
+        "failedStepAttempt": 1,
+        "resumeCheckpointRef": "artifact://resume/checkpoint",
+        "resumeWorkspace": {
+            "checkpointRef": "artifact://workspace/before-implement",
+        },
+        "preservedSteps": [
+            {
+                "logicalStepId": "prepare",
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {
+                    "outputSummary": "artifact://prepare-summary",
+                    "outputPrimary": "artifact://prepare-output",
+                },
+                "stateCheckpointRef": "artifact://workspace/prepare",
+            }
+        ],
+    }
+    source.update(overrides)
+    return source
+
+
+def _workflow_with_resume(
+    source: dict[str, object] | None = None,
+) -> MoonMindRunWorkflow:
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = source or _resume_source()
+    return workflow
+
+
+def _ordered_nodes() -> list[dict[str, object]]:
+    return [
+        {"id": "prepare", "title": "Prepare"},
+        {"id": "implement", "title": "Implement"},
+        {"id": "verify", "title": "Verify"},
+    ]
+
+
+def _dependency_map() -> dict[str, list[str]]:
+    return {"prepare": [], "implement": ["prepare"], "verify": ["implement"]}
 
 
 def test_materialize_preserved_steps_marks_source_provenance_without_new_attempt() -> None:
@@ -137,3 +189,153 @@ def test_parent_owned_checkpoint_evidence_survives_child_runtime_projection() ->
         "reason": "complete",
         "message": "Step has recoverable output refs and state checkpoint evidence.",
     }
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("sourceWorkflowId", "source workflow"),
+        ("sourceRunId", "source run"),
+        ("sourceTaskInputSnapshotRef", "task input snapshot"),
+        ("failedStepId", "failed step"),
+        ("resumeCheckpointRef", "resume checkpoint"),
+    ],
+)
+def test_resume_source_validation_requires_compact_identity_before_execution(
+    field: str,
+    message: str,
+) -> None:
+    source = _resume_source(**{field: ""})
+    workflow = _workflow_with_resume(source)
+
+    with pytest.raises(ValueError, match=message):
+        workflow._initialize_step_ledger(
+            ordered_nodes=_ordered_nodes(),
+            dependency_map=_dependency_map(),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_resume_source_validation_requires_plan_identity_before_execution() -> None:
+    source = _resume_source(sourcePlanDigest="", sourcePlanRef="")
+    workflow = _workflow_with_resume(source)
+
+    with pytest.raises(ValueError, match="plan"):
+        workflow._initialize_step_ledger(
+            ordered_nodes=_ordered_nodes(),
+            dependency_map=_dependency_map(),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_resume_source_rejects_preserved_step_without_recoverable_output_ref() -> None:
+    source = _resume_source(
+        preservedSteps=[
+            {
+                "logicalStepId": "prepare",
+                "status": "succeeded",
+                "sourceAttempt": 1,
+                "artifacts": {},
+                "stateCheckpointRef": "artifact://workspace/prepare",
+            }
+        ]
+    )
+    workflow = _workflow_with_resume(source)
+
+    with pytest.raises(ValueError, match="recoverable output"):
+        workflow._initialize_step_ledger(
+            ordered_nodes=_ordered_nodes(),
+            dependency_map=_dependency_map(),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_resume_source_restores_workspace_before_failed_step_execution() -> None:
+    now = datetime.now(UTC)
+    workflow = _workflow_with_resume()
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    restored_ref = workflow._restore_resume_workspace_for_failed_step("implement")
+
+    assert restored_ref == "artifact://workspace/before-implement"
+    assert workflow._resume_workspace_restored_ref == restored_ref
+    assert workflow._restore_resume_workspace_for_failed_step("verify") is None
+
+
+def test_resume_source_rejects_missing_workspace_checkpoint() -> None:
+    source = _resume_source(resumeWorkspace={})
+    workflow = _workflow_with_resume(source)
+
+    with pytest.raises(ValueError, match="workspace checkpoint"):
+        workflow._initialize_step_ledger(
+            ordered_nodes=_ordered_nodes(),
+            dependency_map=_dependency_map(),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_preserved_outputs_are_available_to_failed_step_dependencies() -> None:
+    now = datetime.now(UTC)
+    workflow = _workflow_with_resume()
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    outputs = workflow._preserved_outputs_for_step("implement")
+
+    assert outputs == {
+        "prepare": {
+            "outputSummary": "artifact://prepare-summary",
+            "outputPrimary": "artifact://prepare-output",
+        }
+    }
+
+
+def test_retried_failed_step_records_fresh_evidence_without_source_provenance() -> None:
+    now = datetime.now(UTC)
+    workflow = _workflow_with_resume()
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    update_step_row(
+        workflow._step_ledger_rows,
+        "implement",
+        updated_at=now,
+        status="succeeded",
+    )
+    workflow._record_step_result_evidence(
+        "implement",
+        execution_result={
+            "outputs": {
+                "outputSummaryRef": "artifact://implement-summary-new",
+                "outputPrimaryRef": "artifact://implement-output-new",
+                "stateCheckpointRef": "artifact://workspace/implement-new",
+            }
+        },
+        updated_at=now,
+    )
+
+    implement_row = next(
+        row
+        for row in workflow._step_ledger_rows
+        if row["logicalStepId"] == "implement"
+    )
+    assert "preservedFrom" not in implement_row
+    assert (
+        implement_row["artifacts"]["outputSummary"]
+        == "artifact://implement-summary-new"
+    )
+    assert (
+        implement_row["artifacts"]["outputPrimary"]
+        == "artifact://implement-output-new"
+    )
+    assert implement_row["stateCheckpointRef"] == "artifact://workspace/implement-new"


### PR DESCRIPTION
Change Jira issue MM-647 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.