### PR TITLE
Change Jira issue MM-648 to status In Progress before implementation starts.

### DIFF
--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -4557,12 +4557,17 @@ class CodexWorker:
 
     @classmethod
     def _attachment_step_ref(cls, step: Mapping[str, Any], index: int) -> str:
-        explicit = str(step.get("id") or "").strip()
+        explicit = str(
+            step.get("id") or step.get("stepRef") or step.get("ref") or ""
+        ).strip()
         if explicit:
             return cls._sanitize_attachment_workspace_segment(
                 explicit, fallback=f"step-{index + 1}"
             )
-        return f"step-{index + 1}"
+        raise ValueError(
+            "stable stepRef is required for step inputAttachments; "
+            f"task.steps[{index}] must include id, stepRef, or ref"
+        )
 
     @staticmethod
     def _require_attachment_ref_field(
@@ -4694,6 +4699,7 @@ class CodexWorker:
             "contentType": target.content_type,
             "sizeBytes": target.size_bytes,
             "targetKind": target.target_kind,
+            "status": "prepared",
             "workspacePath": workspace_path.as_posix(),
         }
         if target.step_ref is not None:

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -40,6 +41,8 @@ class PreparedInputEntry(BaseModel):
     target_kind: TargetKind = Field(alias="targetKind")
     raw_input_ref: str = Field(alias="rawInputRef")
     derived_context_ref: str | None = Field(default=None, alias="derivedContextRef")
+    workspace_path: str | None = Field(default=None, alias="workspacePath")
+    status: str = "prepared"
     step_ref: str | None = Field(default=None, alias="stepRef")
     step_ordinal: int | None = Field(default=None, alias="stepOrdinal")
 
@@ -253,10 +256,25 @@ def _entry_from_attachment(
     raw_input_ref = _artifact_ref(artifact_id)
     if target_kind == "objective":
         derived_context_ref = f"prepared-context://objective/{safe_artifact_id}"
+        workspace_path = _workspace_path(
+            artifact_id=artifact_id,
+            filename=_optional_text(
+                attachment.get("filename") or attachment.get("name")
+            ),
+            target_kind=target_kind,
+        )
     else:
         safe_step_ref = _safe_segment(step_ref or "")
         derived_context_ref = (
             f"prepared-context://steps/{safe_step_ref}/{safe_artifact_id}"
+        )
+        workspace_path = _workspace_path(
+            artifact_id=artifact_id,
+            filename=_optional_text(
+                attachment.get("filename") or attachment.get("name")
+            ),
+            target_kind=target_kind,
+            step_ref=step_ref,
         )
     return PreparedInputEntry(
         artifactId=artifact_id,
@@ -272,6 +290,7 @@ def _entry_from_attachment(
         targetKind=target_kind,
         rawInputRef=raw_input_ref,
         derivedContextRef=derived_context_ref,
+        workspacePath=workspace_path,
         stepRef=step_ref,
         stepOrdinal=step_ordinal,
     )
@@ -301,9 +320,13 @@ def _step_ref(step: Mapping[str, Any], index: int) -> str:
         step.get("id")
         or step.get("stepRef")
         or step.get("ref")
-        or step.get("name")
     )
-    return candidate or f"step-{index}"
+    if not candidate:
+        raise ValueError(
+            "stable stepRef is required for step inputAttachments; "
+            f"task.steps[{index - 1}] must include id, stepRef, or ref"
+        )
+    return candidate
 
 
 def _artifact_id(attachment: Mapping[str, Any]) -> str:
@@ -362,6 +385,37 @@ def _optional_int(value: Any) -> int | None:
 def _safe_segment(value: str) -> str:
     cleaned = _SAFE_SEGMENT_RE.sub("-", value.strip()).strip("-")
     return cleaned or "input"
+
+
+def _workspace_path(
+    *,
+    artifact_id: str,
+    filename: str | None,
+    target_kind: TargetKind,
+    step_ref: str | None = None,
+) -> str:
+    output_name = (
+        f"{_workspace_segment(artifact_id, fallback='artifact')}-"
+        f"{_workspace_segment(filename, fallback='attachment')}"
+    )
+    if target_kind == "objective":
+        return (Path(".moonmind") / "inputs" / "objective" / output_name).as_posix()
+    if target_kind == "step" and step_ref:
+        return (
+            Path(".moonmind")
+            / "inputs"
+            / "steps"
+            / _workspace_segment(step_ref, fallback="step")
+            / output_name
+        ).as_posix()
+    raise ValueError("stable stepRef is required for step inputAttachments")
+
+
+def _workspace_segment(value: Any, *, fallback: str) -> str:
+    text = str(value or "").replace("\\", "/").strip()
+    basename = Path(text).name
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "_", basename).strip("._")
+    return sanitized or fallback
 
 
 def _dedupe_refs(refs: Sequence[str]) -> list[str]:

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -152,8 +152,11 @@ def build_prepared_input_manifest(
         )
 
     for index, step in enumerate(_step_sequence(task_payload.get("steps")), start=1):
+        step_attachments = _attachment_sequence(step.get("inputAttachments"))
+        if not step_attachments:
+            continue
         step_ref = _step_ref(step, index)
-        for attachment in _attachment_sequence(step.get("inputAttachments")):
+        for attachment in step_attachments:
             entries.append(
                 _entry_from_attachment(
                     attachment,
@@ -259,13 +262,12 @@ def _entry_from_attachment(
         ) from exc
     safe_artifact_id = _safe_segment(artifact_id)
     raw_input_ref = _artifact_ref(artifact_id)
+    filename = _optional_text(attachment.get("filename") or attachment.get("name"))
     if target_kind == "objective":
         derived_context_ref = f"prepared-context://objective/{safe_artifact_id}"
         workspace_path = _workspace_path(
             artifact_id=artifact_id,
-            filename=_optional_text(
-                attachment.get("filename") or attachment.get("name")
-            ),
+            filename=filename,
             target_kind=target_kind,
         )
     else:
@@ -275,15 +277,13 @@ def _entry_from_attachment(
         )
         workspace_path = _workspace_path(
             artifact_id=artifact_id,
-            filename=_optional_text(
-                attachment.get("filename") or attachment.get("name")
-            ),
+            filename=filename,
             target_kind=target_kind,
             step_ref=step_ref,
         )
     return PreparedInputEntry(
         artifactId=artifact_id,
-        filename=_optional_text(attachment.get("filename") or attachment.get("name")),
+        filename=filename,
         contentType=_optional_text(
             attachment.get("contentType") or attachment.get("mimeType")
         ),

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -250,8 +250,13 @@ def _entry_from_attachment(
     step_ref: str | None = None,
     step_ordinal: int | None = None,
 ) -> PreparedInputEntry:
-    _reject_inline_attachment_content(attachment)
-    artifact_id = _artifact_id(attachment)
+    try:
+        _reject_inline_attachment_content(attachment)
+        artifact_id = _artifact_id(attachment)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_attachment_target_label(target_kind, step_ref)}: {exc}"
+        ) from exc
     safe_artifact_id = _safe_segment(artifact_id)
     raw_input_ref = _artifact_ref(artifact_id)
     if target_kind == "objective":
@@ -294,6 +299,16 @@ def _entry_from_attachment(
         stepRef=step_ref,
         stepOrdinal=step_ordinal,
     )
+
+
+def _attachment_target_label(
+    target_kind: TargetKind,
+    step_ref: str | None,
+) -> str:
+    label = f"input attachment targetKind={target_kind}"
+    if target_kind == "step" and step_ref:
+        label = f"{label} stepRef={step_ref}"
+    return label
 
 
 def _task_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/specs/347-prepare-target-aware-attachments/checklists/requirements.md
+++ b/specs/347-prepare-target-aware-attachments/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Prepare-Time Target-Aware Attachment Materialization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves `MM-648`, defines one runtime story, and maps DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 to functional requirements.

--- a/specs/347-prepare-target-aware-attachments/contracts/prepared-attachment-manifest.md
+++ b/specs/347-prepare-target-aware-attachments/contracts/prepared-attachment-manifest.md
@@ -1,0 +1,48 @@
+# Prepared Attachment Manifest Contract
+
+## Purpose
+
+`MM-648` requires preparation to produce target-aware attachment evidence without silent retargeting and without binary payloads in workflow-visible data.
+
+## Compact Workflow Manifest
+
+```json
+{
+  "manifestRef": "prepared-context-manifest://task-inputs",
+  "entries": [
+    {
+      "artifactId": "objective-image",
+      "filename": "objective.png",
+      "contentType": "image/png",
+      "sizeBytes": 42,
+      "targetKind": "objective",
+      "rawInputRef": "artifact://objective-image",
+      "derivedContextRef": "prepared-context://objective/objective-image",
+      "workspacePath": ".moonmind/inputs/objective/objective-image-objective.png",
+      "status": "prepared"
+    },
+    {
+      "artifactId": "step-image",
+      "filename": "screen.png",
+      "contentType": "image/png",
+      "sizeBytes": 17,
+      "targetKind": "step",
+      "stepRef": "review-step",
+      "stepOrdinal": 1,
+      "rawInputRef": "artifact://step-image",
+      "derivedContextRef": "prepared-context://steps/review-step/step-image",
+      "workspacePath": ".moonmind/inputs/steps/review-step/step-image-screen.png",
+      "status": "prepared"
+    }
+  ]
+}
+```
+
+## Rules
+
+- `stepRef` is required for every `targetKind: step` entry.
+- `stepOrdinal` is diagnostic only and must never be used as the binding authority.
+- `workspacePath` is a stable workspace-relative path and must not contain binary bytes.
+- `status` is required for materialized manifest entries and should be `prepared` after successful materialization.
+- Invalid, missing, unauthorized, incomplete, or inline-content attachment inputs fail preparation before affected step execution.
+- Reorder, preset apply, and text edits must preserve `stepRef`-based binding; an attachment must not bind to a new step because its array index changed.

--- a/specs/347-prepare-target-aware-attachments/data-model.md
+++ b/specs/347-prepare-target-aware-attachments/data-model.md
@@ -1,0 +1,48 @@
+# Data Model: Prepare-Time Target-Aware Attachment Materialization
+
+## Attachment Target
+
+- `targetKind`: `objective` or `step`.
+- `targetRef`: implicit task objective for objective targets; stable `stepRef` for step targets.
+- `stepOrdinal`: optional diagnostic order only; never the authoritative binding.
+
+Validation:
+- Step targets require a non-empty stable `stepRef`.
+- Objective targets must not carry `stepRef`.
+
+## Prepared Attachment
+
+- `artifactId`: source artifact identifier.
+- `filename`: sanitized original filename metadata.
+- `contentType`: MIME type metadata when known.
+- `sizeBytes`: source size metadata when known.
+- `targetKind`: objective or step.
+- `stepRef`: required for step targets.
+- `rawInputRef`: lightweight source artifact ref.
+- `derivedContextRef`: lightweight target-aware context ref.
+- `workspacePath`: stable workspace-relative materialized path when materialized by the worker.
+- `status`: preparation status such as `prepared` for successful manifest entries.
+
+Validation:
+- Prepared attachment metadata must not contain inline binary data, data URLs, or generated markdown payloads.
+- Workspace paths are metadata refs, not binary payloads.
+
+## Attachments Manifest
+
+- `manifestRef`: compact workflow-visible manifest ref.
+- `entries`: every prepared attachment entry for objective and step targets.
+
+Validation:
+- Every authored attachment must appear exactly once per authored target binding.
+- Duplicate artifact IDs across different targets remain separate entries.
+- Manifest data remains bounded metadata suitable for workflow/activity boundaries.
+
+## Target-Aware Image Context
+
+- `targetKind`: objective or step.
+- `stepRef`: required for step targets.
+- `attachmentRefs`: artifact IDs included for that target.
+- `contextPath` or `derivedContextRef`: lightweight ref to generated context artifact.
+
+Validation:
+- Context artifacts are grouped by target and must not collapse unrelated step attachments into a shared bucket.

--- a/specs/347-prepare-target-aware-attachments/plan.md
+++ b/specs/347-prepare-target-aware-attachments/plan.md
@@ -23,7 +23,7 @@ Deliver `MM-648` by tightening existing target-aware attachment preparation so s
 | FR-010 | implemented_verified | `spec.md`, this plan, `tasks.md`, and `verification.md` preserve `MM-648` and the original preset brief | Keep traceability through final delivery metadata | final verification |
 | SC-001 | implemented_verified | Worker manifest tests assert one entry per authored objective/step attachment | No additional implementation | unit |
 | SC-002 | implemented_verified | Prepared-context tests cover reorder and text edit binding stability | No additional implementation | unit |
-| SC-003 | implemented_unverified | Unit worker failure tests identify failed target; no integration test currently proves target-specific preparation failure | add integration verification first; repair preparation boundary only if verification fails | integration + conditional implementation |
+| SC-003 | implemented_verified | Integration coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` proves invalid step attachment preparation fails with target-specific diagnostics; unit worker failure tests identify failed targets | No additional implementation | integration + unit |
 | SC-004 | implemented_verified | Existing vision/target-aware workflow evidence plus focused integration confirms per-target refs | No additional implementation | integration |
 | SC-005 | implemented_verified | Verification report maps `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 | No additional implementation | final verification |
 | DESIGN-REQ-002 | implemented_verified | Binary inputs remain artifact/workspace refs and are not embedded in workflow-visible payloads | No additional implementation | unit + final verification |

--- a/specs/347-prepare-target-aware-attachments/plan.md
+++ b/specs/347-prepare-target-aware-attachments/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Prepare-Time Target-Aware Attachment Materialization
+
+**Branch**: `[347-prepare-target-aware-attachments]` | **Date**: 2026-05-13 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/347-prepare-target-aware-attachments/spec.md`
+
+## Summary
+
+Deliver `MM-648` by tightening existing target-aware attachment preparation so step-scoped attachments require stable step identity, prepared manifests expose stable materialization/status metadata, and regression coverage proves reorder, preset apply, and text edits cannot silently retarget attachments. The implementation builds on `moonmind/workflows/tasks/prepared_context.py`, `moonmind/agents/codex_worker/worker.py`, and existing workflow boundary tests from prior target-aware input work.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing artifact/vision/prepared-context helpers  
+**Storage**: Existing artifact store and workspace-local `.moonmind/` prepared files only; no new persistent storage  
+**Unit Testing**: pytest through `./tools/test_unit.sh`  
+**Integration Testing**: pytest hermetic integration through `./tools/test_integration.sh` where needed  
+**Target Platform**: MoonMind worker/runtime execution on Linux containers  
+**Project Type**: Backend workflow/runtime library  
+**Performance Goals**: Manifest generation remains linear in attachment count and avoids loading binary bytes into workflow-visible payloads  
+**Constraints**: No binary bytes in workflow history; target binding must be explicit; fail fast on invalid preparation; no compatibility aliases for internal contracts  
+**Scale/Scope**: One task with objective attachments and multiple step attachments across normalized/preset-derived step payloads
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS - uses existing workflow/runtime boundaries and provider adapters.
+- II. One-Click Agent Deployment: PASS - no new mandatory external service or secret.
+- III. Avoid Vendor Lock-In: PASS - target-aware refs are provider-neutral.
+- IV. Own Your Data: PASS - prepared files and context refs stay in operator-controlled artifact/workspace paths.
+- V. Skills Are First-Class and Easy to Add: PASS - no skill source mutation or runtime skill contract changes.
+- VI. Scientific Method / Tests Anchor: PASS - unit and workflow-boundary tests validate the contract.
+- VII. Runtime Configurability: PASS - no hardcoded operator settings added.
+- VIII. Modular Architecture: PASS - changes remain in prepared-context and worker preparation boundaries.
+- IX. Resilient by Default: PASS - invalid attachments fail explicitly before step execution.
+- X. Continuous Improvement: PASS - final evidence preserves `MM-648` traceability.
+- XI. Spec-Driven Development: PASS - this plan follows `spec.md` and leads to `tasks.md`.
+- XII. Canonical Documentation Separation: PASS - implementation notes stay in feature artifacts, not canonical docs.
+- XIII. Pre-Release Velocity: PASS - unsupported ambiguous step attachment payloads fail fast rather than receiving compatibility fallback retargeting.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/347-prepare-target-aware-attachments/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/
+│   └── prepared-attachment-manifest.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/tasks/prepared_context.py
+tests/unit/workflows/tasks/test_prepared_context.py
+moonmind/agents/codex_worker/worker.py
+tests/unit/agents/codex_worker/test_attachment_materialization.py
+tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
+```
+
+**Structure Decision**: Keep pure target-binding and compact workflow metadata in `moonmind/workflows/tasks/prepared_context.py`; keep actual file materialization and `.moonmind/attachments_manifest.json` writing in the Codex worker preparation boundary.
+
+## Complexity Tracking
+
+No constitution violations or additional complexity exceptions.

--- a/specs/347-prepare-target-aware-attachments/plan.md
+++ b/specs/347-prepare-target-aware-attachments/plan.md
@@ -23,7 +23,7 @@ Deliver `MM-648` by tightening existing target-aware attachment preparation so s
 | FR-010 | implemented_verified | `spec.md`, this plan, `tasks.md`, and `verification.md` preserve `MM-648` and the original preset brief | Keep traceability through final delivery metadata | final verification |
 | SC-001 | implemented_verified | Worker manifest tests assert one entry per authored objective/step attachment | No additional implementation | unit |
 | SC-002 | implemented_verified | Prepared-context tests cover reorder and text edit binding stability | No additional implementation | unit |
-| SC-003 | implemented_verified | Worker failure tests identify failed target; focused integration passed target-aware workflow boundary | No additional implementation | unit + integration |
+| SC-003 | implemented_unverified | Unit worker failure tests identify failed target; no integration test currently proves target-specific preparation failure | add integration verification first; repair preparation boundary only if verification fails | integration + conditional implementation |
 | SC-004 | implemented_verified | Existing vision/target-aware workflow evidence plus focused integration confirms per-target refs | No additional implementation | integration |
 | SC-005 | implemented_verified | Verification report maps `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 | No additional implementation | final verification |
 | DESIGN-REQ-002 | implemented_verified | Binary inputs remain artifact/workspace refs and are not embedded in workflow-visible payloads | No additional implementation | unit + final verification |

--- a/specs/347-prepare-target-aware-attachments/plan.md
+++ b/specs/347-prepare-target-aware-attachments/plan.md
@@ -7,6 +7,29 @@
 
 Deliver `MM-648` by tightening existing target-aware attachment preparation so step-scoped attachments require stable step identity, prepared manifests expose stable materialization/status metadata, and regression coverage proves reorder, preset apply, and text edits cannot silently retarget attachments. The implementation builds on `moonmind/workflows/tasks/prepared_context.py`, `moonmind/agents/codex_worker/worker.py`, and existing workflow boundary tests from prior target-aware input work.
 
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+|----|--------|----------|--------------|----------------|
+| FR-001 | implemented_verified | `moonmind/workflows/tasks/prepared_context.py` rejects inline content; full unit verification passed | Keep refs/metadata-only behavior traceable | unit + final verification |
+| FR-002 | implemented_verified | `moonmind/agents/codex_worker/worker.py` materializes objective and step attachments into target-specific `.moonmind/inputs/...` paths; worker tests passed | No additional implementation | unit |
+| FR-003 | implemented_verified | Prepared-context and worker manifests are generated and asserted in tests | No additional implementation | unit |
+| FR-004 | implemented_verified | Manifest entries include artifact metadata, target kind/ref, workspace path, content type, size, and status | No additional implementation | unit |
+| FR-005 | implemented_verified | Existing target-aware workflow and vision context tests cover per-target context grouping; focused integration passed | No additional implementation | integration + final verification |
+| FR-006 | implemented_verified | Reorder/text edit regression tests prove bindings remain keyed by stable step refs | No additional implementation | unit |
+| FR-007 | implemented_verified | Worker download failure tests and stable-ref validation fail explicitly with target diagnostics | No additional implementation | unit |
+| FR-008 | implemented_verified | Prepared metadata assertions exclude data URLs/base64; workflow payloads carry refs | No additional implementation | unit + final verification |
+| FR-009 | implemented_verified | `prepared_context.py` and `worker.py` reject step attachments without `id`, `stepRef`, or `ref` | No additional implementation | unit |
+| FR-010 | implemented_verified | `spec.md`, this plan, `tasks.md`, and `verification.md` preserve `MM-648` and the original preset brief | Keep traceability through final delivery metadata | final verification |
+| SC-001 | implemented_verified | Worker manifest tests assert one entry per authored objective/step attachment | No additional implementation | unit |
+| SC-002 | implemented_verified | Prepared-context tests cover reorder and text edit binding stability | No additional implementation | unit |
+| SC-003 | implemented_verified | Worker failure tests identify failed target; focused integration passed target-aware workflow boundary | No additional implementation | unit + integration |
+| SC-004 | implemented_verified | Existing vision/target-aware workflow evidence plus focused integration confirms per-target refs | No additional implementation | integration |
+| SC-005 | implemented_verified | Verification report maps `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 | No additional implementation | final verification |
+| DESIGN-REQ-002 | implemented_verified | Binary inputs remain artifact/workspace refs and are not embedded in workflow-visible payloads | No additional implementation | unit + final verification |
+| DESIGN-REQ-020 | implemented_verified | Preparation materialization, manifest metadata, target-aware context refs, and explicit failures are covered | No additional implementation | unit + integration |
+| DESIGN-REQ-029 | implemented_verified | Stable step-ref enforcement removes array-index retargeting fallback | No additional implementation | unit |
+
 ## Technical Context
 
 **Language/Version**: Python 3.12  

--- a/specs/347-prepare-target-aware-attachments/quickstart.md
+++ b/specs/347-prepare-target-aware-attachments/quickstart.md
@@ -9,5 +9,6 @@
    `./tools/test_integration.sh`
 5. If Docker is unavailable, run the focused local workflow boundary fallback and document the Docker blocker:
    `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`
-6. Add or run integration-level coverage proving missing or invalid attachment preparation fails with the affected target before final `/moonspec-verify` closes SC-003.
+6. Run integration-level coverage proving missing or invalid attachment preparation fails with the affected target before final `/moonspec-verify` closes SC-003:
+   `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`
 7. Inspect generated or fixture manifests and verify each attachment entry preserves `targetKind`, stable `stepRef` for step targets, `workspacePath`, and `status`, with no binary bytes.

--- a/specs/347-prepare-target-aware-attachments/quickstart.md
+++ b/specs/347-prepare-target-aware-attachments/quickstart.md
@@ -5,6 +5,9 @@
    `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py`
 3. Run focused worker materialization tests:
    `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
-4. Run existing target-aware workflow integration coverage when Docker/compose is available:
+4. Run target-aware workflow integration coverage when Docker/compose is available:
    `./tools/test_integration.sh`
-5. Inspect generated or fixture manifests and verify each attachment entry preserves `targetKind`, stable `stepRef` for step targets, `workspacePath`, and `status`, with no binary bytes.
+5. If Docker is unavailable, run the focused local workflow boundary fallback and document the Docker blocker:
+   `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`
+6. Add or run integration-level coverage proving missing or invalid attachment preparation fails with the affected target before final `/moonspec-verify` closes SC-003.
+7. Inspect generated or fixture manifests and verify each attachment entry preserves `targetKind`, stable `stepRef` for step targets, `workspacePath`, and `status`, with no binary bytes.

--- a/specs/347-prepare-target-aware-attachments/quickstart.md
+++ b/specs/347-prepare-target-aware-attachments/quickstart.md
@@ -1,0 +1,10 @@
+# Quickstart: Prepare-Time Target-Aware Attachment Materialization
+
+1. Confirm `specs/347-prepare-target-aware-attachments/spec.md` preserves `MM-648` and the canonical Jira preset brief.
+2. Run focused prepared-context unit tests:
+   `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py`
+3. Run focused worker materialization tests:
+   `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
+4. Run existing target-aware workflow integration coverage when Docker/compose is available:
+   `./tools/test_integration.sh`
+5. Inspect generated or fixture manifests and verify each attachment entry preserves `targetKind`, stable `stepRef` for step targets, `workspacePath`, and `status`, with no binary bytes.

--- a/specs/347-prepare-target-aware-attachments/research.md
+++ b/specs/347-prepare-target-aware-attachments/research.md
@@ -58,11 +58,11 @@ Test implications: Unit tests directly cover the normalization/contract risk.
 
 ## FR-007 and SC-003 Explicit Preparation Failure
 
-Decision: implemented_verified.
-Evidence: Worker tests cover failed artifact download diagnostics and stable-ref validation; focused integration validates target-aware workflow dispatch boundaries.
-Rationale: Preparation must stop before downstream execution sees incomplete target state.
-Alternatives considered: Allowing partial manifests was rejected because downstream steps could mistake partial preparation for complete state.
-Test implications: Unit tests cover deterministic failure paths; integration runner should be rerun in Docker-enabled CI.
+Decision: FR-007 is implemented_verified; SC-003 is implemented_unverified pending integration-level failure coverage.
+Evidence: Worker tests cover failed artifact download diagnostics and stable-ref validation. Repository search found unit coverage for target-specific preparation failure, but no integration test that proves preparation failure surfaces target-specific diagnostics.
+Rationale: Preparation must stop before downstream execution sees incomplete target state, and SC-003 specifically requires integration evidence.
+Alternatives considered: Treating unit worker failure coverage as sufficient for SC-003 was rejected because the success criterion explicitly names integration coverage.
+Test implications: Add or run integration verification for target-specific preparation failure first; repair the preparation boundary only if that integration evidence exposes a real behavior gap.
 
 ## FR-010 and SC-005 Traceability
 

--- a/specs/347-prepare-target-aware-attachments/research.md
+++ b/specs/347-prepare-target-aware-attachments/research.md
@@ -58,11 +58,11 @@ Test implications: Unit tests directly cover the normalization/contract risk.
 
 ## FR-007 and SC-003 Explicit Preparation Failure
 
-Decision: FR-007 is implemented_verified; SC-003 is implemented_unverified pending integration-level failure coverage.
-Evidence: Worker tests cover failed artifact download diagnostics and stable-ref validation. Repository search found unit coverage for target-specific preparation failure, but no integration test that proves preparation failure surfaces target-specific diagnostics.
+Decision: FR-007 and SC-003 are implemented_verified.
+Evidence: Worker tests cover failed artifact download diagnostics and stable-ref validation. Integration coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` proves invalid step attachment preparation returns an explicit target-specific failure containing the logical step, target kind, stable step ref, and reason.
 Rationale: Preparation must stop before downstream execution sees incomplete target state, and SC-003 specifically requires integration evidence.
 Alternatives considered: Treating unit worker failure coverage as sufficient for SC-003 was rejected because the success criterion explicitly names integration coverage.
-Test implications: Add or run integration verification for target-specific preparation failure first; repair the preparation boundary only if that integration evidence exposes a real behavior gap.
+Test implications: Keep both the integration boundary test and worker unit failure diagnostics in the required evidence set.
 
 ## FR-010 and SC-005 Traceability
 

--- a/specs/347-prepare-target-aware-attachments/research.md
+++ b/specs/347-prepare-target-aware-attachments/research.md
@@ -1,0 +1,25 @@
+# Research: Prepare-Time Target-Aware Attachment Materialization
+
+## Decision: Build on existing prepared context contracts
+
+Rationale: `moonmind/workflows/tasks/prepared_context.py` already models objective and step prepared refs, workflow metadata, bounded failure payloads, and no-inline-content guardrails from prior target-aware input work. Extending that contract with stable materialization metadata and stricter step identity checks is smaller and safer than introducing a parallel attachment model.
+
+Alternatives considered: A new preparation contract was rejected because it would duplicate target-binding semantics and increase risk of inconsistent workflow metadata.
+
+## Decision: Fail fast when step attachments lack stable step identity
+
+Rationale: `MM-648` specifically forbids silent retargeting after reorder, preset apply, or text edits. Falling back to `step-<index>` for step attachments can change meaning when order changes. Step-scoped attachments must have a stable authored or normalized step reference.
+
+Alternatives considered: Preserving index fallback was rejected because it encodes the silent retargeting risk identified by DESIGN-REQ-029.
+
+## Decision: Keep materialized files workspace-local and referenced by metadata
+
+Rationale: Existing Codex worker preparation writes `.moonmind/inputs/...` files and `.moonmind/attachments_manifest.json`. The workflow-visible contract should carry refs and metadata only, while the worker-local manifest records stable workspace paths and status.
+
+Alternatives considered: Storing binary bytes or full file content in workflow history was rejected by DESIGN-REQ-002 and Constitution secret/data hygiene rules.
+
+## Decision: Validate retargeting through pure unit tests plus worker materialization tests
+
+Rationale: Reorder, preset apply, and text edit risks are normalization/contract risks. Unit tests can deterministically show attachments remain bound by stable step IDs rather than array positions; worker tests can show final materialized paths and manifest entries preserve the same target refs.
+
+Alternatives considered: A full Temporal integration test for every edit/preset path was rejected as unnecessary for this narrow contract when the target-binding function is pure and existing workflow-boundary tests already cover dispatch filtering.

--- a/specs/347-prepare-target-aware-attachments/research.md
+++ b/specs/347-prepare-target-aware-attachments/research.md
@@ -23,3 +23,51 @@ Alternatives considered: Storing binary bytes or full file content in workflow h
 Rationale: Reorder, preset apply, and text edit risks are normalization/contract risks. Unit tests can deterministically show attachments remain bound by stable step IDs rather than array positions; worker tests can show final materialized paths and manifest entries preserve the same target refs.
 
 Alternatives considered: A full Temporal integration test for every edit/preset path was rejected as unnecessary for this narrow contract when the target-binding function is pure and existing workflow-boundary tests already cover dispatch filtering.
+
+## Requirement Gap Analysis
+
+Decision: All in-scope `MM-648` requirements are implemented and verified by current code plus focused tests; no additional production work is planned from this planning pass.
+Evidence: `moonmind/workflows/tasks/prepared_context.py`, `moonmind/agents/codex_worker/worker.py`, `tests/unit/workflows/tasks/test_prepared_context.py`, `tests/unit/agents/codex_worker/test_attachment_materialization.py`, `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py`, and `specs/347-prepare-target-aware-attachments/verification.md`.
+Rationale: The previous implementation removed step-index fallback, added stable `workspacePath` and `status` manifest metadata, preserved refs-only workflow payloads, and verified the target-aware workflow boundary. The full unit suite passed; the compose-backed integration runner was blocked by Docker administrative policy, with the focused target-aware integration test passing locally.
+Alternatives considered: Regenerating tasks or broadening implementation was rejected because the current evidence already satisfies the single `MM-648` story and additional scope would duplicate previous target-aware input work.
+Test implications: Keep unit and focused integration evidence as the primary verification path; rerun `./tools/test_integration.sh` in a Docker-enabled environment before merge if required by CI policy.
+
+## FR-001 through FR-004 Prepared Manifest Metadata
+
+Decision: implemented_verified.
+Evidence: `PreparedInputEntry` carries refs, `workspacePath`, and `status`; worker materialization writes `.moonmind/attachments_manifest.json`; unit tests assert manifest metadata and no inline binary content.
+Rationale: These requirements concern bounded metadata shape and stable materialization paths, which are directly covered by pure unit tests and worker materialization tests.
+Alternatives considered: Adding a new manifest model was rejected because existing prepared-context and worker manifest surfaces already own this contract.
+Test implications: Unit tests are sufficient for the metadata contract; final verification checks traceability.
+
+## FR-005 and SC-004 Target-Aware Image Context
+
+Decision: implemented_verified.
+Evidence: Existing vision/target-aware workflow tests plus focused integration test `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` passed locally.
+Rationale: `MM-648` depends on preserving per-target context refs rather than changing the vision provider implementation.
+Alternatives considered: New end-to-end provider tests were rejected because provider credentials are outside hermetic CI and the target-aware boundary is covered locally.
+Test implications: Focused integration and existing vision tests cover the contract; provider verification is not required.
+
+## FR-006, FR-009, and DESIGN-REQ-029 No Silent Retargeting
+
+Decision: implemented_verified.
+Evidence: `prepared_context.py` and `worker.py` now require stable `id`, `stepRef`, or `ref` for step-scoped attachments; unit tests cover missing stable refs and binding stability across reorder/text edits.
+Rationale: Step index fallback was the remaining retargeting hazard. Failing fast on ambiguous step attachments matches the pre-release compatibility policy and the source invariant.
+Alternatives considered: Keeping `step-<index>` fallback was rejected because it can silently retarget attachments after step reorder.
+Test implications: Unit tests directly cover the normalization/contract risk.
+
+## FR-007 and SC-003 Explicit Preparation Failure
+
+Decision: implemented_verified.
+Evidence: Worker tests cover failed artifact download diagnostics and stable-ref validation; focused integration validates target-aware workflow dispatch boundaries.
+Rationale: Preparation must stop before downstream execution sees incomplete target state.
+Alternatives considered: Allowing partial manifests was rejected because downstream steps could mistake partial preparation for complete state.
+Test implications: Unit tests cover deterministic failure paths; integration runner should be rerun in Docker-enabled CI.
+
+## FR-010 and SC-005 Traceability
+
+Decision: implemented_verified.
+Evidence: `spec.md`, `plan.md`, `tasks.md`, and `verification.md` preserve `MM-648`, the canonical Jira preset brief, and source mappings for DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029.
+Rationale: Final verification needs a durable source trail from Jira brief to implementation evidence.
+Alternatives considered: Relying only on local handoff artifacts was rejected because MoonSpec verification uses committed feature artifacts as the alignment source.
+Test implications: Final verification is the relevant validation path.

--- a/specs/347-prepare-target-aware-attachments/spec.md
+++ b/specs/347-prepare-target-aware-attachments/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: Prepare-Time Target-Aware Attachment Materialization
+
+**Feature Branch**: `[347-prepare-target-aware-attachments]`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: "# MM-648 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-648
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Prepare-time target-aware attachment materialization without retargeting
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`, and preset-adjacent custom fields were empty or unrelated.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-648 from MM project
+Summary: Prepare-time target-aware attachment materialization without retargeting
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-648 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-648: Prepare-time target-aware attachment materialization without retargeting
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 3.2 Artifact-first binary handling
+- 8.2 Prepare responsibilities
+- Invariant 1
+- Invariant 3
+- Invariant 11
+Coverage IDs:
+- DESIGN-REQ-002
+- DESIGN-REQ-020
+- DESIGN-REQ-029
+
+As an execution-plane engineer, I want the prepare activity to download objective-scoped and step-scoped attachments, write a canonical attachments manifest, materialize raw files into stable workspace locations, produce target-aware image context artifacts, fail explicitly on incomplete/invalid preparation, and never silently retarget an attachment when steps are reordered, presets applied, or text edited.
+
+Acceptance Criteria
+- Objective and step attachments download to distinct, stable workspace locations.
+- A canonical attachments manifest is written that names target kind and step reference for every attachment.
+- Target-aware image context artifacts are produced per target.
+- Prepare fails explicitly on missing/invalid attachments rather than silently dropping them.
+- Step reorder, preset apply, and text edits never silently retarget an existing attachment.
+- No binary attachment bytes appear in workflow history.
+
+Requirements
+Implement prepare activity behaviors, manifest writer, target-aware context generation, and contract-level guards against retargeting at the snapshot/normalizer boundary.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+## User Story - Target-Aware Attachment Preparation
+
+**Summary**: As an execution-plane engineer, I want preparation to materialize objective-scoped and step-scoped attachments with explicit target metadata so that execution never loses, mixes, or silently retargets attachments.
+
+**Goal**: Attachment-aware task execution prepares every authored attachment into stable workspace files and target-aware context artifacts while preserving the original objective or step binding across preparation, prompt composition, and diagnostic evidence.
+
+**Independent Test**: Submit or exercise a prepared task payload containing objective and step attachments, then verify the prepared outputs include distinct workspace files, a canonical manifest naming each attachment target, per-target image context artifacts, explicit failures for invalid attachment refs, and no inline binary payloads in workflow-visible data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task with objective-scoped and step-scoped attachments, **When** preparation runs, **Then** each attachment is downloaded to a stable workspace location scoped to its original target and no target receives another target's file.
+2. **Given** prepared attachment outputs, **When** diagnostics or downstream prompt composition reads the attachments manifest, **Then** every manifest entry names the attachment artifact, target kind, step reference when applicable, stable file path, and derived context refs.
+3. **Given** image attachments on both the objective and individual steps, **When** image context generation completes, **Then** the system produces target-aware context artifacts per objective or step target instead of one ambiguous attachment bucket.
+4. **Given** an attachment ref is missing, unauthorized, incomplete, or invalid, **When** preparation runs, **Then** preparation fails explicitly with the affected target and reason rather than dropping the attachment or continuing with partial state.
+5. **Given** task steps are reordered, presets are applied, or text is edited before submission, **When** normalization and preparation process existing attachment refs, **Then** the attachment remains bound to its explicit target identity and is never silently retargeted by list position or text content.
+6. **Given** prepared attachment evidence is stored in workflow-visible payloads, **When** those payloads are inspected, **Then** they contain only lightweight refs and metadata, never binary attachment bytes.
+
+### Edge Cases
+
+- Objective-scoped attachments and step-scoped attachments may reference files with the same original filename; prepared paths must remain distinct and deterministic.
+- A step attachment without a stable step reference must fail validation instead of binding by array index.
+- Duplicate artifact refs across targets must be represented as separate target bindings without overwriting target metadata.
+- Non-image attachments must still be materialized and listed in the manifest even when no image context artifact is produced.
+- Partial preparation failures must not leave outputs that downstream steps can mistake for complete preparation.
+
+## Assumptions
+
+- Existing artifact storage remains the binary source of truth; this story does not add new persistent storage.
+- The existing task-shaped contract already carries objective-level and step-level attachment refs; this story strengthens preparation and boundary validation for those refs.
+- Stable step references can use existing authored step IDs or normalized logical step identifiers already available in task payloads.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-002**: Source `docs/Tasks/TaskArchitecture.md` section 3.2 and Invariant 1 require binary inputs to be stored as artifacts and referenced by lightweight refs, with no binary payloads in workflow history. Scope: in scope. Mapped requirements: FR-001, FR-008.
+- **DESIGN-REQ-020**: Source `docs/Tasks/TaskArchitecture.md` section 8.2 requires prepare to download objective-scoped and step-scoped attachments, write a canonical attachments manifest, materialize raw files into stable workspace locations, produce target-aware image context artifacts, and fail explicitly when preparation is incomplete or invalid. Scope: in scope. Mapped requirements: FR-002, FR-003, FR-004, FR-005, FR-006, FR-007.
+- **DESIGN-REQ-029**: Source `docs/Tasks/TaskArchitecture.md` Invariant 11 requires step reordering, preset application, and text edits to never silently retarget an existing attachment to another step. Scope: in scope. Mapped requirements: FR-004, FR-006, FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST consume task attachment inputs as artifact refs and metadata only, never inline binary bytes in workflow-visible payloads.
+- **FR-002**: System MUST download objective-scoped attachments and step-scoped attachments during preparation into stable, target-distinct workspace locations.
+- **FR-003**: System MUST write a canonical attachments manifest for preparation outputs.
+- **FR-004**: Each manifest entry MUST identify the source artifact, original filename, target kind, target reference, stable workspace path, content type, and preparation status.
+- **FR-005**: System MUST produce image context artifacts grouped by explicit target so objective context and each step context remain distinguishable.
+- **FR-006**: System MUST preserve existing attachment target identity across step reorder, preset apply, and text edit normalization paths without rebinding by array index or text position.
+- **FR-007**: System MUST fail preparation explicitly when an attachment is missing, unauthorized, incomplete, invalid, or cannot be materialized, and the failure MUST identify the affected target.
+- **FR-008**: System MUST expose only lightweight refs to prepared files, manifests, and context artifacts across workflow/activity boundaries.
+- **FR-009**: System MUST reject or fail task normalization when a step-scoped attachment cannot be associated with a stable step reference.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-648` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Attachment Target**: The authored destination for an attachment, either the task objective or a specific task step, identified by target kind and stable target reference.
+- **Prepared Attachment**: A materialized attachment file associated with one attachment target, source artifact metadata, workspace path, status, and optional context refs.
+- **Attachments Manifest**: The canonical preparation output that records every prepared attachment and target-aware context ref for downstream execution and diagnostics.
+- **Target-Aware Image Context**: A derived context artifact generated for one explicit attachment target rather than a global attachment bucket.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A mixed objective-and-step attachment task produces one manifest entry for every authored attachment with correct target kind and target reference.
+- **SC-002**: Unit coverage proves step reorder, preset application, and text edit normalization do not change existing attachment target bindings.
+- **SC-003**: Integration coverage proves preparation fails with an explicit target-specific error for missing or invalid attachment refs.
+- **SC-004**: Integration coverage proves image context outputs are grouped per target and downstream payloads carry refs rather than binary bytes.
+- **SC-005**: Final verification can trace `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 through spec, plan, tasks, tests, and implementation evidence.

--- a/specs/347-prepare-target-aware-attachments/tasks.md
+++ b/specs/347-prepare-target-aware-attachments/tasks.md
@@ -7,7 +7,7 @@
 
 **Organization**: Tasks cover exactly one story: `Target-Aware Attachment Preparation`.
 
-**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029. `plan.md` classifies most rows as `implemented_verified`; SC-003 is `implemented_unverified` and therefore requires integration verification before final `/moonspec-verify`.
+**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029. `plan.md` classifies all rows as `implemented_verified`; final `/moonspec-verify` remains the last dedicated workflow step.
 
 **Test Commands**:
 
@@ -20,17 +20,17 @@
 
 **Purpose**: Confirm active artifacts and requirement status before validation work.
 
-- [ ] T001 Confirm `.specify/feature.json` points to `specs/347-prepare-target-aware-attachments` and that `specs/347-prepare-target-aware-attachments/spec.md` contains exactly one `## User Story -` section. (FR-010, SC-005)
-- [ ] T002 Confirm `specs/347-prepare-target-aware-attachments/plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` exist and preserve `MM-648`. (FR-010, SC-005)
-- [ ] T003 Inspect `specs/347-prepare-target-aware-attachments/plan.md` `## Requirement Status` and confirm FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 are present, with SC-003 marked `implemented_unverified`. (FR-010, SC-005, SC-003)
+- [X] T001 Confirm `.specify/feature.json` points to `specs/347-prepare-target-aware-attachments` and that `specs/347-prepare-target-aware-attachments/spec.md` contains exactly one `## User Story -` section. (FR-010, SC-005)
+- [X] T002 Confirm `specs/347-prepare-target-aware-attachments/plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` exist and preserve `MM-648`. (FR-010, SC-005)
+- [X] T003 Inspect `specs/347-prepare-target-aware-attachments/plan.md` `## Requirement Status` and confirm FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 are present, with SC-003 marked `implemented_verified`. (FR-010, SC-005, SC-003)
 
 ## Phase 2: Foundational
 
 **Purpose**: Confirm the existing test and implementation surfaces used by the single story.
 
-- [ ] T004 [P] Inspect unit test surfaces in `tests/unit/workflows/tasks/test_prepared_context.py` and `tests/unit/agents/codex_worker/test_attachment_materialization.py` for manifest metadata, stable step-ref, no-inline-content, and materialization coverage. (FR-001, FR-002, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T005 [P] Inspect integration boundary coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for objective/current-step context isolation and identify where target-specific preparation failure coverage belongs. (FR-005, SC-003, SC-004, DESIGN-REQ-020)
-- [ ] T006 [P] Inspect implementation surfaces in `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for stable step identity enforcement, `workspacePath`, `status`, and explicit failure behavior. (FR-001 through FR-009)
+- [X] T004 [P] Inspect unit test surfaces in `tests/unit/workflows/tasks/test_prepared_context.py` and `tests/unit/agents/codex_worker/test_attachment_materialization.py` for manifest metadata, stable step-ref, no-inline-content, and materialization coverage. (FR-001, FR-002, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
+- [X] T005 [P] Inspect integration boundary coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for objective/current-step context isolation and identify where target-specific preparation failure coverage belongs. (FR-005, SC-003, SC-004, DESIGN-REQ-020)
+- [X] T006 [P] Inspect implementation surfaces in `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for stable step identity enforcement, `workspacePath`, `status`, and explicit failure behavior. (FR-001 through FR-009)
 
 **Checkpoint**: Existing evidence surfaces are identified; story validation can begin.
 
@@ -58,30 +58,30 @@
 
 ### Unit Tests (red-first / verification-first)
 
-- [ ] T007 [P] Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py` and confirm prepared context unit coverage passes or fails for the intended missing behavior. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-029)
-- [ ] T008 [P] Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm worker materialization unit coverage passes or fails for the intended missing behavior. (FR-002, FR-004, FR-007, FR-009, SC-001, DESIGN-REQ-020, DESIGN-REQ-029)
+- [X] T007 [P] Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py` and confirm prepared context unit coverage passes or fails for the intended missing behavior. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-029)
+- [X] T008 [P] Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm worker materialization unit coverage passes or fails for the intended missing behavior. (FR-002, FR-004, FR-007, FR-009, SC-001, DESIGN-REQ-020, DESIGN-REQ-029)
 
 ### Integration Tests (verification-first)
 
-- [ ] T009 Run `./tools/test_integration.sh` for hermetic integration coverage, or if Docker is unavailable, record the exact blocker and run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`. (FR-005, SC-004, DESIGN-REQ-020)
-- [ ] T010 Add or run an integration-level target-specific preparation failure check in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` or the nearest existing integration boundary, proving missing/invalid attachment preparation fails with the affected target. (SC-003, FR-007, DESIGN-REQ-020)
+- [X] T009 Run `./tools/test_integration.sh` for hermetic integration coverage, or if Docker is unavailable, record the exact blocker and run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`. (FR-005, SC-004, DESIGN-REQ-020)
+- [X] T010 Add or run an integration-level target-specific preparation failure check in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` or the nearest existing integration boundary, proving missing/invalid attachment preparation fails with the affected target. (SC-003, FR-007, DESIGN-REQ-020)
 
 ### Red-First Confirmation
 
-- [ ] T011 If T007 or T008 fails, confirm the failure is due to missing or regressed `MM-648` behavior before editing production code; otherwise record the tests as implemented-verified evidence. (FR-001 through FR-009)
-- [ ] T012 If T009 or T010 fails, confirm whether the failure is a real target-aware workflow/preparation regression or an environment blocker before editing production code; otherwise record the integration evidence. (FR-005, FR-007, SC-003, SC-004)
+- [X] T011 If T007 or T008 fails, confirm the failure is due to missing or regressed `MM-648` behavior before editing production code; otherwise record the tests as implemented-verified evidence. (FR-001 through FR-009)
+- [X] T012 If T009 or T010 fails, confirm whether the failure is a real target-aware workflow/preparation regression or an environment blocker before editing production code; otherwise record the integration evidence. (FR-005, FR-007, SC-003, SC-004)
 
 ### Conditional Implementation Repairs
 
-- [ ] T013 If T007 fails for prepared-context behavior, repair `moonmind/workflows/tasks/prepared_context.py` to enforce stable step refs, preserve refs-only metadata, and emit `workspacePath`/`status` fields. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-029)
-- [ ] T014 If T008 fails for worker materialization behavior, repair `moonmind/agents/codex_worker/worker.py` to reject ambiguous step attachments, materialize target-distinct paths, mark manifest entries prepared, and preserve target-specific failure diagnostics. (FR-002, FR-004, FR-007, FR-009, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T015 If T009 or T010 exposes a real workflow/preparation boundary regression, repair `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/tasks/prepared_context.py`, or related target-aware wiring so steps receive objective plus only current-step context and preparation failures expose affected targets. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
+- [X] T013 If T007 fails for prepared-context behavior, repair `moonmind/workflows/tasks/prepared_context.py` to enforce stable step refs, preserve refs-only metadata, and emit `workspacePath`/`status` fields. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-029)
+- [X] T014 If T008 fails for worker materialization behavior, repair `moonmind/agents/codex_worker/worker.py` to reject ambiguous step attachments, materialize target-distinct paths, mark manifest entries prepared, and preserve target-specific failure diagnostics. (FR-002, FR-004, FR-007, FR-009, DESIGN-REQ-020, DESIGN-REQ-029)
+- [X] T015 If T009 or T010 exposes a real workflow/preparation boundary regression, repair `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/tasks/prepared_context.py`, or related target-aware wiring so steps receive objective plus only current-step context and preparation failures expose affected targets. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
 
 ### Story Validation
 
-- [ ] T016 Run focused unit verification with `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` after any repairs, and confirm all `MM-648` unit coverage passes. (FR-001 through FR-009, SC-001 through SC-003, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T017 Run full unit verification with `./tools/test_unit.sh` after any repairs, and capture the result in final verification evidence. (FR-001 through FR-010)
-- [ ] T018 Run integration verification using `./tools/test_integration.sh` or focused fallback commands with documented Docker blocker, and capture the result in final verification evidence. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
+- [X] T016 Run focused unit verification with `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` after any repairs, and confirm all `MM-648` unit coverage passes. (FR-001 through FR-009, SC-001 through SC-003, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
+- [X] T017 Run full unit verification with `./tools/test_unit.sh` after any repairs, and capture the result in final verification evidence. (FR-001 through FR-010)
+- [X] T018 Run integration verification using `./tools/test_integration.sh` or focused fallback commands with documented Docker blocker, and capture the result in final verification evidence. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
 
 **Checkpoint**: The story is validated against implemented-verified evidence and SC-003 integration evidence, or conditional repair tasks have restored the expected behavior.
 
@@ -89,8 +89,8 @@
 
 **Purpose**: Preserve traceability and final evidence without adding hidden scope.
 
-- [ ] T019 [P] Review `specs/347-prepare-target-aware-attachments/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` for `MM-648` traceability drift. (FR-010, SC-005)
-- [ ] T020 [P] Review `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for secret hygiene and binary-content guardrails in attachment metadata. (FR-001, FR-008, DESIGN-REQ-002)
+- [X] T019 [P] Review `specs/347-prepare-target-aware-attachments/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` for `MM-648` traceability drift. (FR-010, SC-005)
+- [X] T020 [P] Review `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for secret hygiene and binary-content guardrails in attachment metadata. (FR-001, FR-008, DESIGN-REQ-002)
 - [ ] T021 Run `/moonspec-verify` against `MM-648`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-010, SC-005)
 
 ## Dependencies & Execution Order
@@ -127,8 +127,8 @@ Task: "T006 Inspect implementation surfaces in moonmind/workflows/tasks/prepared
 ## Implementation Strategy
 
 1. Preserve the single-story `MM-648` scope and do not generate future stories.
-2. Treat FR-001 through FR-010, SC-001, SC-002, SC-004, SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 as implemented-verified per `plan.md`.
-3. Treat SC-003 as implemented-unverified until integration-level preparation failure evidence exists.
+2. Treat FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 as implemented-verified per `plan.md`.
+3. Preserve the integration-level preparation failure evidence for SC-003 in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py`.
 4. If focused unit or integration tests fail for real behavior gaps, run only the corresponding conditional repair tasks.
 5. Keep binary content out of workflow-visible payloads and preserve stable step-ref binding.
 6. Run final unit/integration validation or document environment blockers.
@@ -146,5 +146,5 @@ Task: "T006 Inspect implementation surfaces in moonmind/workflows/tasks/prepared
 
 ## Notes
 
-- The task list intentionally distinguishes implemented-verified evidence from SC-003 integration verification work.
+- The task list intentionally preserves the red-first SC-003 integration evidence added during implementation.
 - Compose-backed integration remains the preferred hermetic integration command; focused pytest fallbacks are valid only when Docker is unavailable in the managed environment.

--- a/specs/347-prepare-target-aware-attachments/tasks.md
+++ b/specs/347-prepare-target-aware-attachments/tasks.md
@@ -7,7 +7,7 @@
 
 **Organization**: Tasks cover exactly one story: `Target-Aware Attachment Preparation`.
 
-**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029. `plan.md` classifies all rows as `implemented_verified`; this task list therefore preserves validation-first work plus conditional implementation repairs if any verification regresses.
+**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029. `plan.md` classifies most rows as `implemented_verified`; SC-003 is `implemented_unverified` and therefore requires integration verification before final `/moonspec-verify`.
 
 **Test Commands**:
 
@@ -22,14 +22,14 @@
 
 - [ ] T001 Confirm `.specify/feature.json` points to `specs/347-prepare-target-aware-attachments` and that `specs/347-prepare-target-aware-attachments/spec.md` contains exactly one `## User Story -` section. (FR-010, SC-005)
 - [ ] T002 Confirm `specs/347-prepare-target-aware-attachments/plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` exist and preserve `MM-648`. (FR-010, SC-005)
-- [ ] T003 Inspect `specs/347-prepare-target-aware-attachments/plan.md` `## Requirement Status` and confirm FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 are present. (FR-010, SC-005)
+- [ ] T003 Inspect `specs/347-prepare-target-aware-attachments/plan.md` `## Requirement Status` and confirm FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 are present, with SC-003 marked `implemented_unverified`. (FR-010, SC-005, SC-003)
 
 ## Phase 2: Foundational
 
 **Purpose**: Confirm the existing test and implementation surfaces used by the single story.
 
 - [ ] T004 [P] Inspect unit test surfaces in `tests/unit/workflows/tasks/test_prepared_context.py` and `tests/unit/agents/codex_worker/test_attachment_materialization.py` for manifest metadata, stable step-ref, no-inline-content, and materialization coverage. (FR-001, FR-002, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T005 [P] Inspect integration boundary coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for objective/current-step context isolation. (FR-005, SC-004, DESIGN-REQ-020)
+- [ ] T005 [P] Inspect integration boundary coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for objective/current-step context isolation and identify where target-specific preparation failure coverage belongs. (FR-005, SC-003, SC-004, DESIGN-REQ-020)
 - [ ] T006 [P] Inspect implementation surfaces in `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for stable step identity enforcement, `workspacePath`, `status`, and explicit failure behavior. (FR-001 through FR-009)
 
 **Checkpoint**: Existing evidence surfaces are identified; story validation can begin.
@@ -38,7 +38,7 @@
 
 **Summary**: Preparation materializes objective and step attachments while preserving explicit target identity and rejecting ambiguous retargeting inputs.
 
-**Independent Test**: Build mixed objective/step attachment payloads and verify manifest entries, materialized paths, status metadata, no inline payloads, fail-fast behavior for step attachments without stable refs, and per-target workflow context isolation.
+**Independent Test**: Build mixed objective/step attachment payloads and verify manifest entries, materialized paths, status metadata, no inline payloads, fail-fast behavior for step attachments without stable refs, per-target workflow context isolation, and target-specific preparation failure diagnostics.
 
 **Traceability**: FR-001 through FR-010; SC-001 through SC-005; DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029; MM-648.
 
@@ -53,43 +53,45 @@
 **Integration Test Plan**:
 
 - Confirm `MoonMind.Run` target-aware workflow boundary provides objective context plus only current-step context.
-- Run the compose-backed `./tools/test_integration.sh` when Docker is available; otherwise run the focused local integration fallback and document Docker policy blockage.
+- Add or run an integration-level target-specific preparation failure check for SC-003.
+- Run the compose-backed `./tools/test_integration.sh` when Docker is available; otherwise run focused local integration checks and document Docker policy blockage.
 
 ### Unit Tests (red-first / verification-first)
 
 - [ ] T007 [P] Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py` and confirm prepared context unit coverage passes or fails for the intended missing behavior. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-029)
-- [ ] T008 [P] Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm worker materialization unit coverage passes or fails for the intended missing behavior. (FR-002, FR-004, FR-007, FR-009, SC-001, SC-003, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T008 [P] Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm worker materialization unit coverage passes or fails for the intended missing behavior. (FR-002, FR-004, FR-007, FR-009, SC-001, DESIGN-REQ-020, DESIGN-REQ-029)
 
 ### Integration Tests (verification-first)
 
 - [ ] T009 Run `./tools/test_integration.sh` for hermetic integration coverage, or if Docker is unavailable, record the exact blocker and run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`. (FR-005, SC-004, DESIGN-REQ-020)
+- [ ] T010 Add or run an integration-level target-specific preparation failure check in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` or the nearest existing integration boundary, proving missing/invalid attachment preparation fails with the affected target. (SC-003, FR-007, DESIGN-REQ-020)
 
 ### Red-First Confirmation
 
-- [ ] T010 If T007 or T008 fails, confirm the failure is due to missing or regressed `MM-648` behavior before editing production code; otherwise record the tests as implemented-verified evidence. (FR-001 through FR-009)
-- [ ] T011 If T009 fails, confirm whether the failure is a real target-aware workflow regression or an environment blocker before editing production code; otherwise record the integration evidence. (FR-005, SC-004)
+- [ ] T011 If T007 or T008 fails, confirm the failure is due to missing or regressed `MM-648` behavior before editing production code; otherwise record the tests as implemented-verified evidence. (FR-001 through FR-009)
+- [ ] T012 If T009 or T010 fails, confirm whether the failure is a real target-aware workflow/preparation regression or an environment blocker before editing production code; otherwise record the integration evidence. (FR-005, FR-007, SC-003, SC-004)
 
 ### Conditional Implementation Repairs
 
-- [ ] T012 If T007 fails for prepared-context behavior, repair `moonmind/workflows/tasks/prepared_context.py` to enforce stable step refs, preserve refs-only metadata, and emit `workspacePath`/`status` fields. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-029)
-- [ ] T013 If T008 fails for worker materialization behavior, repair `moonmind/agents/codex_worker/worker.py` to reject ambiguous step attachments, materialize target-distinct paths, mark manifest entries prepared, and preserve target-specific failure diagnostics. (FR-002, FR-004, FR-007, FR-009, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T014 If T009 exposes a real workflow boundary regression, repair `moonmind/workflows/temporal/workflows/run.py` or related target-aware context wiring so steps receive objective plus only current-step context. (FR-005, SC-004, DESIGN-REQ-020)
+- [ ] T013 If T007 fails for prepared-context behavior, repair `moonmind/workflows/tasks/prepared_context.py` to enforce stable step refs, preserve refs-only metadata, and emit `workspacePath`/`status` fields. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-029)
+- [ ] T014 If T008 fails for worker materialization behavior, repair `moonmind/agents/codex_worker/worker.py` to reject ambiguous step attachments, materialize target-distinct paths, mark manifest entries prepared, and preserve target-specific failure diagnostics. (FR-002, FR-004, FR-007, FR-009, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T015 If T009 or T010 exposes a real workflow/preparation boundary regression, repair `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/tasks/prepared_context.py`, or related target-aware wiring so steps receive objective plus only current-step context and preparation failures expose affected targets. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
 
 ### Story Validation
 
-- [ ] T015 Run focused unit verification with `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` after any repairs, and confirm all `MM-648` unit coverage passes. (FR-001 through FR-009, SC-001 through SC-003, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
-- [ ] T016 Run full unit verification with `./tools/test_unit.sh` after any repairs, and capture the result in final verification evidence. (FR-001 through FR-010)
-- [ ] T017 Run integration verification using `./tools/test_integration.sh` or the focused fallback command with documented Docker blocker, and capture the result in final verification evidence. (FR-005, SC-004, DESIGN-REQ-020)
+- [ ] T016 Run focused unit verification with `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` after any repairs, and confirm all `MM-648` unit coverage passes. (FR-001 through FR-009, SC-001 through SC-003, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T017 Run full unit verification with `./tools/test_unit.sh` after any repairs, and capture the result in final verification evidence. (FR-001 through FR-010)
+- [ ] T018 Run integration verification using `./tools/test_integration.sh` or focused fallback commands with documented Docker blocker, and capture the result in final verification evidence. (FR-005, FR-007, SC-003, SC-004, DESIGN-REQ-020)
 
-**Checkpoint**: The story is validated against the implemented-verified evidence, or conditional repair tasks have restored the expected behavior.
+**Checkpoint**: The story is validated against implemented-verified evidence and SC-003 integration evidence, or conditional repair tasks have restored the expected behavior.
 
 ## Phase 4: Polish And Verification
 
 **Purpose**: Preserve traceability and final evidence without adding hidden scope.
 
-- [ ] T018 [P] Review `specs/347-prepare-target-aware-attachments/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` for `MM-648` traceability drift. (FR-010, SC-005)
-- [ ] T019 [P] Review `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for secret hygiene and binary-content guardrails in attachment metadata. (FR-001, FR-008, DESIGN-REQ-002)
-- [ ] T020 Run `/moonspec-verify` against `MM-648`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-010, SC-005)
+- [ ] T019 [P] Review `specs/347-prepare-target-aware-attachments/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` for `MM-648` traceability drift. (FR-010, SC-005)
+- [ ] T020 [P] Review `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for secret hygiene and binary-content guardrails in attachment metadata. (FR-001, FR-008, DESIGN-REQ-002)
+- [ ] T021 Run `/moonspec-verify` against `MM-648`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-010, SC-005)
 
 ## Dependencies & Execution Order
 
@@ -102,16 +104,16 @@
 
 ### Within The Story
 
-- T007-T009 run before T010-T011.
-- T012-T014 are conditional and run only if verification exposes a real behavior gap.
-- T015-T017 run after conditional repairs, or immediately after T010-T011 when existing evidence passes.
-- T020 runs only after unit and integration evidence is captured or blockers are documented.
+- T007-T010 run before T011-T012.
+- T013-T015 are conditional and run only if verification exposes a real behavior gap.
+- T016-T018 run after conditional repairs, or immediately after T011-T012 when existing evidence passes.
+- T021 runs only after unit and integration evidence is captured or blockers are documented.
 
 ### Parallel Opportunities
 
 - T004, T005, and T006 can run in parallel because they inspect different surfaces.
 - T007 and T008 can run independently when test runner resources permit.
-- T018 and T019 can run in parallel because they cover artifact review and code guardrail review separately.
+- T019 and T020 can run in parallel because they cover artifact review and code guardrail review separately.
 
 ## Parallel Example
 
@@ -125,22 +127,24 @@ Task: "T006 Inspect implementation surfaces in moonmind/workflows/tasks/prepared
 ## Implementation Strategy
 
 1. Preserve the single-story `MM-648` scope and do not generate future stories.
-2. Treat all rows from `plan.md` as `implemented_verified`, so start with verification-first tasks rather than immediate implementation.
-3. If focused unit or integration tests fail for real behavior gaps, run only the corresponding conditional repair tasks.
-4. Keep binary content out of workflow-visible payloads and preserve stable step-ref binding.
-5. Run final unit/integration validation or document environment blockers.
-6. Run `/moonspec-verify` and preserve `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 in final evidence.
+2. Treat FR-001 through FR-010, SC-001, SC-002, SC-004, SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 as implemented-verified per `plan.md`.
+3. Treat SC-003 as implemented-unverified until integration-level preparation failure evidence exists.
+4. If focused unit or integration tests fail for real behavior gaps, run only the corresponding conditional repair tasks.
+5. Keep binary content out of workflow-visible payloads and preserve stable step-ref binding.
+6. Run final unit/integration validation or document environment blockers.
+7. Run `/moonspec-verify` and preserve `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 in final evidence.
 
 ## Coverage Inventory
 
-- FR-001, FR-008, DESIGN-REQ-002: T004, T006, T007, T012, T015, T016, T019, T020.
-- FR-002, FR-003, FR-004, FR-007, DESIGN-REQ-020: T004, T006, T008, T013, T015, T016, T020.
-- FR-005, SC-004: T005, T009, T014, T017, T020.
-- FR-006, FR-009, SC-002, DESIGN-REQ-029: T004, T006, T007, T008, T012, T013, T015, T020.
-- FR-010, SC-005: T001, T002, T003, T018, T020.
-- SC-001, SC-003: T007, T008, T010, T015, T020.
+- FR-001, FR-008, DESIGN-REQ-002: T004, T006, T007, T013, T016, T017, T020, T021.
+- FR-002, FR-003, FR-004, DESIGN-REQ-020: T004, T006, T008, T014, T016, T017, T021.
+- FR-005, SC-004: T005, T009, T015, T018, T021.
+- FR-007, SC-003: T004, T006, T008, T010, T012, T014, T015, T016, T018, T021.
+- FR-006, FR-009, SC-002, DESIGN-REQ-029: T004, T006, T007, T008, T013, T014, T016, T021.
+- FR-010, SC-005: T001, T002, T003, T019, T021.
+- SC-001: T007, T008, T011, T016, T021.
 
 ## Notes
 
-- The task list intentionally distinguishes implemented-verified evidence from conditional implementation repair work.
-- Compose-backed integration remains the preferred hermetic integration command; the focused pytest fallback is valid only when Docker is unavailable in the managed environment.
+- The task list intentionally distinguishes implemented-verified evidence from SC-003 integration verification work.
+- Compose-backed integration remains the preferred hermetic integration command; focused pytest fallbacks are valid only when Docker is unavailable in the managed environment.

--- a/specs/347-prepare-target-aware-attachments/tasks.md
+++ b/specs/347-prepare-target-aware-attachments/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: Prepare-Time Target-Aware Attachment Materialization
+
+**Input**: Design documents from `specs/347-prepare-target-aware-attachments/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/prepared-attachment-manifest.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Organization**: One story: `Target-Aware Attachment Preparation`.
+
+**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
+
+## Phase 1: Setup
+
+- [X] T001 Confirm no existing `MM-648` feature artifacts and create `specs/347-prepare-target-aware-attachments/`. (FR-010, SC-005)
+- [X] T002 Preserve the full `MM-648` Jira preset brief in `spec.md` and `.specify/feature.json`. (FR-010, SC-005)
+- [X] T003 Inspect existing prepared context and worker materialization surfaces. (FR-001 through FR-009)
+
+## Phase 2: Design
+
+- [X] T004 Create `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md`. (FR-001 through FR-010)
+- [X] T005 Confirm the plan uses no new persistent storage and keeps binary bytes out of workflow-visible payloads. (FR-001, FR-008, DESIGN-REQ-002)
+
+## Phase 3: Story - Target-Aware Attachment Preparation
+
+**Summary**: Preparation materializes objective and step attachments while preserving explicit target identity and rejecting ambiguous retargeting inputs.
+
+**Independent Test**: Build mixed objective/step attachment payloads and verify manifest entries, materialized paths, status metadata, no inline payloads, and fail-fast behavior for step attachments without stable step refs.
+
+### Unit Tests (write first)
+
+- [X] T006 Add failing unit tests in `tests/unit/workflows/tasks/test_prepared_context.py` proving step attachments without stable `stepRef` fail and reorder/text edits preserve `stepRef` bindings. (FR-006, FR-009, SC-002, DESIGN-REQ-029)
+- [X] T007 Add failing unit tests in `tests/unit/workflows/tasks/test_prepared_context.py` proving prepared manifest entries expose `workspacePath` and `status` metadata without binary content. (FR-003, FR-004, FR-008, DESIGN-REQ-020)
+- [X] T008 Add failing worker tests in `tests/unit/agents/codex_worker/test_attachment_materialization.py` proving step attachment fallback by index is rejected and materialized entries include `status`. (FR-002, FR-004, FR-007, FR-009)
+
+### Red-First Confirmation
+
+- [X] T009 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm new tests fail for missing behavior. (T006-T008)
+
+### Implementation
+
+- [X] T010 Update `moonmind/workflows/tasks/prepared_context.py` to require stable step refs for step attachments and include bounded `workspacePath`/`status` metadata in prepared entries. (FR-003, FR-004, FR-006, FR-008, FR-009)
+- [X] T011 Update `moonmind/agents/codex_worker/worker.py` to reject step-scoped attachment materialization when the step lacks a stable reference and mark successful manifest entries as prepared. (FR-002, FR-004, FR-007, FR-009)
+
+### Story Validation
+
+- [X] T012 Run focused unit tests and fix failures. (FR-001 through FR-009)
+- [X] T013 Run `./tools/test_unit.sh` for full unit verification. (FR-001 through FR-010)
+- [X] T014 Run `./tools/test_integration.sh` or document exact blocker if unavailable. (SC-001, SC-003, SC-004)
+  - Evidence: `./tools/test_integration.sh` was blocked by Docker administrative policy (`403 Forbidden`) while Compose tried to build the pytest image. Supplemental local focused integration check passed: `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`.
+
+## Phase 4: Verification
+
+- [X] T015 Run `/moonspec-verify` against `MM-648`, the preserved brief, source mappings, tests, and implementation evidence. (FR-010, SC-005)
+
+## Coverage Inventory
+
+- FR-001, FR-008, DESIGN-REQ-002: T005, T007, T010, T012-T015.
+- FR-002, FR-003, FR-004, FR-005, FR-007, DESIGN-REQ-020: T007, T008, T010-T014.
+- FR-006, FR-009, DESIGN-REQ-029: T006, T008, T010-T014.
+- FR-010, SC-005: T001, T002, T015.

--- a/specs/347-prepare-target-aware-attachments/tasks.md
+++ b/specs/347-prepare-target-aware-attachments/tasks.md
@@ -1,66 +1,146 @@
 # Tasks: Prepare-Time Target-Aware Attachment Materialization
 
 **Input**: Design documents from `specs/347-prepare-target-aware-attachments/`
-**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/prepared-attachment-manifest.md, quickstart.md
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, `quickstart.md`
 
-**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+**Tests**: Unit tests and integration tests are REQUIRED. Write or confirm tests first, confirm missing or regressed behavior before implementation, then implement or repair production code until tests pass.
 
-**Organization**: One story: `Target-Aware Attachment Preparation`.
+**Organization**: Tasks cover exactly one story: `Target-Aware Attachment Preparation`.
 
-**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029.
+**Source Traceability**: Preserves Jira issue `MM-648`, the canonical Jira preset brief, FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029. `plan.md` classifies all rows as `implemented_verified`; this task list therefore preserves validation-first work plus conditional implementation repairs if any verification regresses.
 
 **Test Commands**:
 
 - Unit tests: `./tools/test_unit.sh`
 - Integration tests: `./tools/test_integration.sh`
+- Focused integration fallback when Docker is unavailable: `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`
 - Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
 
 ## Phase 1: Setup
 
-- [X] T001 Confirm no existing `MM-648` feature artifacts and create `specs/347-prepare-target-aware-attachments/`. (FR-010, SC-005)
-- [X] T002 Preserve the full `MM-648` Jira preset brief in `spec.md` and `.specify/feature.json`. (FR-010, SC-005)
-- [X] T003 Inspect existing prepared context and worker materialization surfaces. (FR-001 through FR-009)
+**Purpose**: Confirm active artifacts and requirement status before validation work.
 
-## Phase 2: Design
+- [ ] T001 Confirm `.specify/feature.json` points to `specs/347-prepare-target-aware-attachments` and that `specs/347-prepare-target-aware-attachments/spec.md` contains exactly one `## User Story -` section. (FR-010, SC-005)
+- [ ] T002 Confirm `specs/347-prepare-target-aware-attachments/plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` exist and preserve `MM-648`. (FR-010, SC-005)
+- [ ] T003 Inspect `specs/347-prepare-target-aware-attachments/plan.md` `## Requirement Status` and confirm FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 are present. (FR-010, SC-005)
 
-- [X] T004 Create `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md`. (FR-001 through FR-010)
-- [X] T005 Confirm the plan uses no new persistent storage and keeps binary bytes out of workflow-visible payloads. (FR-001, FR-008, DESIGN-REQ-002)
+## Phase 2: Foundational
+
+**Purpose**: Confirm the existing test and implementation surfaces used by the single story.
+
+- [ ] T004 [P] Inspect unit test surfaces in `tests/unit/workflows/tasks/test_prepared_context.py` and `tests/unit/agents/codex_worker/test_attachment_materialization.py` for manifest metadata, stable step-ref, no-inline-content, and materialization coverage. (FR-001, FR-002, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T005 [P] Inspect integration boundary coverage in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for objective/current-step context isolation. (FR-005, SC-004, DESIGN-REQ-020)
+- [ ] T006 [P] Inspect implementation surfaces in `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for stable step identity enforcement, `workspacePath`, `status`, and explicit failure behavior. (FR-001 through FR-009)
+
+**Checkpoint**: Existing evidence surfaces are identified; story validation can begin.
 
 ## Phase 3: Story - Target-Aware Attachment Preparation
 
 **Summary**: Preparation materializes objective and step attachments while preserving explicit target identity and rejecting ambiguous retargeting inputs.
 
-**Independent Test**: Build mixed objective/step attachment payloads and verify manifest entries, materialized paths, status metadata, no inline payloads, and fail-fast behavior for step attachments without stable step refs.
+**Independent Test**: Build mixed objective/step attachment payloads and verify manifest entries, materialized paths, status metadata, no inline payloads, fail-fast behavior for step attachments without stable refs, and per-target workflow context isolation.
 
-### Unit Tests (write first)
+**Traceability**: FR-001 through FR-010; SC-001 through SC-005; DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029; MM-648.
 
-- [X] T006 Add failing unit tests in `tests/unit/workflows/tasks/test_prepared_context.py` proving step attachments without stable `stepRef` fail and reorder/text edits preserve `stepRef` bindings. (FR-006, FR-009, SC-002, DESIGN-REQ-029)
-- [X] T007 Add failing unit tests in `tests/unit/workflows/tasks/test_prepared_context.py` proving prepared manifest entries expose `workspacePath` and `status` metadata without binary content. (FR-003, FR-004, FR-008, DESIGN-REQ-020)
-- [X] T008 Add failing worker tests in `tests/unit/agents/codex_worker/test_attachment_materialization.py` proving step attachment fallback by index is rejected and materialized entries include `status`. (FR-002, FR-004, FR-007, FR-009)
+**Unit Test Plan**:
+
+- Confirm prepared context entries reject inline binary/generated content and include bounded refs/metadata.
+- Confirm objective and step attachments produce stable target-aware workspace paths and manifest metadata.
+- Confirm step-scoped attachments without stable `id`, `stepRef`, or `ref` fail fast.
+- Confirm reorder/text edits do not retarget existing attachment bindings.
+- Confirm worker materialization failure diagnostics identify the affected target.
+
+**Integration Test Plan**:
+
+- Confirm `MoonMind.Run` target-aware workflow boundary provides objective context plus only current-step context.
+- Run the compose-backed `./tools/test_integration.sh` when Docker is available; otherwise run the focused local integration fallback and document Docker policy blockage.
+
+### Unit Tests (red-first / verification-first)
+
+- [ ] T007 [P] Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py` and confirm prepared context unit coverage passes or fails for the intended missing behavior. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, SC-001, SC-002, DESIGN-REQ-002, DESIGN-REQ-029)
+- [ ] T008 [P] Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm worker materialization unit coverage passes or fails for the intended missing behavior. (FR-002, FR-004, FR-007, FR-009, SC-001, SC-003, DESIGN-REQ-020, DESIGN-REQ-029)
+
+### Integration Tests (verification-first)
+
+- [ ] T009 Run `./tools/test_integration.sh` for hermetic integration coverage, or if Docker is unavailable, record the exact blocker and run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`. (FR-005, SC-004, DESIGN-REQ-020)
 
 ### Red-First Confirmation
 
-- [X] T009 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm new tests fail for missing behavior. (T006-T008)
+- [ ] T010 If T007 or T008 fails, confirm the failure is due to missing or regressed `MM-648` behavior before editing production code; otherwise record the tests as implemented-verified evidence. (FR-001 through FR-009)
+- [ ] T011 If T009 fails, confirm whether the failure is a real target-aware workflow regression or an environment blocker before editing production code; otherwise record the integration evidence. (FR-005, SC-004)
 
-### Implementation
+### Conditional Implementation Repairs
 
-- [X] T010 Update `moonmind/workflows/tasks/prepared_context.py` to require stable step refs for step attachments and include bounded `workspacePath`/`status` metadata in prepared entries. (FR-003, FR-004, FR-006, FR-008, FR-009)
-- [X] T011 Update `moonmind/agents/codex_worker/worker.py` to reject step-scoped attachment materialization when the step lacks a stable reference and mark successful manifest entries as prepared. (FR-002, FR-004, FR-007, FR-009)
+- [ ] T012 If T007 fails for prepared-context behavior, repair `moonmind/workflows/tasks/prepared_context.py` to enforce stable step refs, preserve refs-only metadata, and emit `workspacePath`/`status` fields. (FR-001, FR-003, FR-004, FR-006, FR-008, FR-009, DESIGN-REQ-002, DESIGN-REQ-029)
+- [ ] T013 If T008 fails for worker materialization behavior, repair `moonmind/agents/codex_worker/worker.py` to reject ambiguous step attachments, materialize target-distinct paths, mark manifest entries prepared, and preserve target-specific failure diagnostics. (FR-002, FR-004, FR-007, FR-009, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T014 If T009 exposes a real workflow boundary regression, repair `moonmind/workflows/temporal/workflows/run.py` or related target-aware context wiring so steps receive objective plus only current-step context. (FR-005, SC-004, DESIGN-REQ-020)
 
 ### Story Validation
 
-- [X] T012 Run focused unit tests and fix failures. (FR-001 through FR-009)
-- [X] T013 Run `./tools/test_unit.sh` for full unit verification. (FR-001 through FR-010)
-- [X] T014 Run `./tools/test_integration.sh` or document exact blocker if unavailable. (SC-001, SC-003, SC-004)
-  - Evidence: `./tools/test_integration.sh` was blocked by Docker administrative policy (`403 Forbidden`) while Compose tried to build the pytest image. Supplemental local focused integration check passed: `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short`.
+- [ ] T015 Run focused unit verification with `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` after any repairs, and confirm all `MM-648` unit coverage passes. (FR-001 through FR-009, SC-001 through SC-003, DESIGN-REQ-002, DESIGN-REQ-020, DESIGN-REQ-029)
+- [ ] T016 Run full unit verification with `./tools/test_unit.sh` after any repairs, and capture the result in final verification evidence. (FR-001 through FR-010)
+- [ ] T017 Run integration verification using `./tools/test_integration.sh` or the focused fallback command with documented Docker blocker, and capture the result in final verification evidence. (FR-005, SC-004, DESIGN-REQ-020)
 
-## Phase 4: Verification
+**Checkpoint**: The story is validated against the implemented-verified evidence, or conditional repair tasks have restored the expected behavior.
 
-- [X] T015 Run `/moonspec-verify` against `MM-648`, the preserved brief, source mappings, tests, and implementation evidence. (FR-010, SC-005)
+## Phase 4: Polish And Verification
+
+**Purpose**: Preserve traceability and final evidence without adding hidden scope.
+
+- [ ] T018 [P] Review `specs/347-prepare-target-aware-attachments/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/prepared-attachment-manifest.md`, and `quickstart.md` for `MM-648` traceability drift. (FR-010, SC-005)
+- [ ] T019 [P] Review `moonmind/workflows/tasks/prepared_context.py` and `moonmind/agents/codex_worker/worker.py` for secret hygiene and binary-content guardrails in attachment metadata. (FR-001, FR-008, DESIGN-REQ-002)
+- [ ] T020 Run `/moonspec-verify` against `MM-648`, the original Jira preset brief, `spec.md`, `plan.md`, `tasks.md`, source design mappings, and test evidence. (FR-010, SC-005)
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on setup artifact confirmation and identifies validation surfaces.
+- **Story (Phase 3)**: Depends on foundational inspection. Verification tasks run before any conditional implementation repairs.
+- **Polish And Verification (Phase 4)**: Depends on story validation evidence.
+
+### Within The Story
+
+- T007-T009 run before T010-T011.
+- T012-T014 are conditional and run only if verification exposes a real behavior gap.
+- T015-T017 run after conditional repairs, or immediately after T010-T011 when existing evidence passes.
+- T020 runs only after unit and integration evidence is captured or blockers are documented.
+
+### Parallel Opportunities
+
+- T004, T005, and T006 can run in parallel because they inspect different surfaces.
+- T007 and T008 can run independently when test runner resources permit.
+- T018 and T019 can run in parallel because they cover artifact review and code guardrail review separately.
+
+## Parallel Example
+
+```bash
+# Inspect independent evidence surfaces:
+Task: "T004 Inspect unit tests in tests/unit/workflows/tasks/test_prepared_context.py and tests/unit/agents/codex_worker/test_attachment_materialization.py"
+Task: "T005 Inspect integration coverage in tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py"
+Task: "T006 Inspect implementation surfaces in moonmind/workflows/tasks/prepared_context.py and moonmind/agents/codex_worker/worker.py"
+```
+
+## Implementation Strategy
+
+1. Preserve the single-story `MM-648` scope and do not generate future stories.
+2. Treat all rows from `plan.md` as `implemented_verified`, so start with verification-first tasks rather than immediate implementation.
+3. If focused unit or integration tests fail for real behavior gaps, run only the corresponding conditional repair tasks.
+4. Keep binary content out of workflow-visible payloads and preserve stable step-ref binding.
+5. Run final unit/integration validation or document environment blockers.
+6. Run `/moonspec-verify` and preserve `MM-648`, DESIGN-REQ-002, DESIGN-REQ-020, and DESIGN-REQ-029 in final evidence.
 
 ## Coverage Inventory
 
-- FR-001, FR-008, DESIGN-REQ-002: T005, T007, T010, T012-T015.
-- FR-002, FR-003, FR-004, FR-005, FR-007, DESIGN-REQ-020: T007, T008, T010-T014.
-- FR-006, FR-009, DESIGN-REQ-029: T006, T008, T010-T014.
-- FR-010, SC-005: T001, T002, T015.
+- FR-001, FR-008, DESIGN-REQ-002: T004, T006, T007, T012, T015, T016, T019, T020.
+- FR-002, FR-003, FR-004, FR-007, DESIGN-REQ-020: T004, T006, T008, T013, T015, T016, T020.
+- FR-005, SC-004: T005, T009, T014, T017, T020.
+- FR-006, FR-009, SC-002, DESIGN-REQ-029: T004, T006, T007, T008, T012, T013, T015, T020.
+- FR-010, SC-005: T001, T002, T003, T018, T020.
+- SC-001, SC-003: T007, T008, T010, T015, T020.
+
+## Notes
+
+- The task list intentionally distinguishes implemented-verified evidence from conditional implementation repair work.
+- Compose-backed integration remains the preferred hermetic integration command; the focused pytest fallback is valid only when Docker is unavailable in the managed environment.

--- a/specs/347-prepare-target-aware-attachments/verification.md
+++ b/specs/347-prepare-target-aware-attachments/verification.md
@@ -1,0 +1,43 @@
+# MoonSpec Verification Report
+
+**Feature**: Prepare-Time Target-Aware Attachment Materialization  
+**Spec**: `/work/agent_jobs/mm:582f6f4c-2a08-4fdd-9e41-0b3b02e8f097/repo/specs/347-prepare-target-aware-attachments/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving `MM-648` Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: MEDIUM
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Focused unit red/green | `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` | PASS | 23 passed plus frontend suite passed through the unit runner. |
+| Full unit | `./tools/test_unit.sh` | PASS | 4965 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest: 20 files passed, 343 tests passed, 229 skipped. |
+| Hermetic integration runner | `./tools/test_integration.sh` | NOT RUN | Blocked by Docker administrative policy: Compose build failed with `403 Forbidden`. |
+| Focused integration fallback | `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short` | PASS | 1 passed; validates existing target-aware workflow boundary behavior locally. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `prepared_context.py` rejects inline content; existing tests plus full unit run | VERIFIED | Workflow-visible payloads remain refs/metadata only. |
+| FR-002 | `worker.py` materializes objective and step attachments; worker tests | VERIFIED | Stable target-distinct workspace paths are asserted. |
+| FR-003 | `prepared_context.py` and worker manifest writer; unit tests | VERIFIED | Canonical manifests include every prepared entry. |
+| FR-004 | `PreparedInputEntry.workspacePath/status`; worker manifest `status` | VERIFIED | Entries identify artifact, target, path, and status. |
+| FR-005 | Existing vision/target-aware workflow tests and focused integration | VERIFIED | Per-target context delivery remains covered. |
+| FR-006 | Stable `stepRef` tests for reorder/text edits | VERIFIED | Bindings are keyed by stable step identity, not list position. |
+| FR-007 | Worker download failure tests and stable-ref validation | VERIFIED | Invalid prep fails explicitly before materialization completes. |
+| FR-008 | Unit tests assert no data URLs/base64 in prepared metadata | VERIFIED | Only refs and bounded metadata cross boundaries. |
+| FR-009 | `prepared_context.py` and `worker.py` reject step attachments without `id`, `stepRef`, or `ref` | VERIFIED | Removes index fallback retargeting risk. |
+| FR-010 | `spec.md`, `plan.md`, `tasks.md`, this report | VERIFIED | `MM-648` preserved throughout artifacts. |
+
+## Source Design Coverage
+
+| Source Requirement | Status | Evidence |
+|--------------------|--------|----------|
+| DESIGN-REQ-002 | VERIFIED | No binary payloads; artifact refs, workspace paths, and context refs only. |
+| DESIGN-REQ-020 | VERIFIED | Preparation manifest, materialized paths, status metadata, explicit failures. |
+| DESIGN-REQ-029 | VERIFIED | Stable step-ref enforcement and reorder/text-edit tests prevent silent retargeting. |
+
+## Remaining Risks
+
+- The full compose-backed integration suite could not run in this managed environment because Docker access was denied by administrative policy. Focused local integration coverage passed for the target-aware workflow boundary.

--- a/specs/347-prepare-target-aware-attachments/verification.md
+++ b/specs/347-prepare-target-aware-attachments/verification.md
@@ -3,7 +3,7 @@
 **Feature**: Prepare-Time Target-Aware Attachment Materialization  
 **Spec**: `/work/agent_jobs/mm:582f6f4c-2a08-4fdd-9e41-0b3b02e8f097/repo/specs/347-prepare-target-aware-attachments/spec.md`  
 **Original Request Source**: `spec.md` `Input` preserving `MM-648` Jira preset brief  
-**Verdict**: FULLY_IMPLEMENTED  
+**Verdict**: ADDITIONAL_WORK_NEEDED
 **Confidence**: MEDIUM
 
 ## Test Results
@@ -25,7 +25,7 @@
 | FR-004 | `PreparedInputEntry.workspacePath/status`; worker manifest `status` | VERIFIED | Entries identify artifact, target, path, and status. |
 | FR-005 | Existing vision/target-aware workflow tests and focused integration | VERIFIED | Per-target context delivery remains covered. |
 | FR-006 | Stable `stepRef` tests for reorder/text edits | VERIFIED | Bindings are keyed by stable step identity, not list position. |
-| FR-007 | Worker download failure tests and stable-ref validation | VERIFIED | Invalid prep fails explicitly before materialization completes. |
+| FR-007 | Worker download failure tests and stable-ref validation | VERIFIED | Unit evidence verifies explicit failure behavior. |
 | FR-008 | Unit tests assert no data URLs/base64 in prepared metadata | VERIFIED | Only refs and bounded metadata cross boundaries. |
 | FR-009 | `prepared_context.py` and `worker.py` reject step attachments without `id`, `stepRef`, or `ref` | VERIFIED | Removes index fallback retargeting risk. |
 | FR-010 | `spec.md`, `plan.md`, `tasks.md`, this report | VERIFIED | `MM-648` preserved throughout artifacts. |
@@ -35,9 +35,9 @@
 | Source Requirement | Status | Evidence |
 |--------------------|--------|----------|
 | DESIGN-REQ-002 | VERIFIED | No binary payloads; artifact refs, workspace paths, and context refs only. |
-| DESIGN-REQ-020 | VERIFIED | Preparation manifest, materialized paths, status metadata, explicit failures. |
+| DESIGN-REQ-020 | PARTIAL | Preparation manifest, materialized paths, status metadata, and unit failure behavior are covered; SC-003 still needs integration-level failure evidence. |
 | DESIGN-REQ-029 | VERIFIED | Stable step-ref enforcement and reorder/text-edit tests prevent silent retargeting. |
 
 ## Remaining Risks
 
-- The full compose-backed integration suite could not run in this managed environment because Docker access was denied by administrative policy. Focused local integration coverage passed for the target-aware workflow boundary.
+- The full compose-backed integration suite could not run in this managed environment because Docker access was denied by administrative policy. Focused local integration coverage passed for the target-aware workflow boundary. Alignment found SC-003 still needs integration-level evidence for target-specific preparation failure before the story should be closed as fully implemented.

--- a/specs/347-prepare-target-aware-attachments/verification.md
+++ b/specs/347-prepare-target-aware-attachments/verification.md
@@ -3,7 +3,7 @@
 **Feature**: Prepare-Time Target-Aware Attachment Materialization  
 **Spec**: `/work/agent_jobs/mm:582f6f4c-2a08-4fdd-9e41-0b3b02e8f097/repo/specs/347-prepare-target-aware-attachments/spec.md`  
 **Original Request Source**: `spec.md` `Input` preserving `MM-648` Jira preset brief  
-**Verdict**: ADDITIONAL_WORK_NEEDED
+**Verdict**: READY_FOR_MOONSPEC_VERIFY
 **Confidence**: MEDIUM
 
 ## Test Results
@@ -12,8 +12,8 @@
 |-------|---------|--------|-------|
 | Focused unit red/green | `./tools/test_unit.sh tests/unit/workflows/tasks/test_prepared_context.py tests/unit/agents/codex_worker/test_attachment_materialization.py` | PASS | 23 passed plus frontend suite passed through the unit runner. |
 | Full unit | `./tools/test_unit.sh` | PASS | 4965 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest: 20 files passed, 343 tests passed, 229 skipped. |
-| Hermetic integration runner | `./tools/test_integration.sh` | NOT RUN | Blocked by Docker administrative policy: Compose build failed with `403 Forbidden`. |
-| Focused integration fallback | `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short` | PASS | 1 passed; validates existing target-aware workflow boundary behavior locally. |
+| Hermetic integration runner | `./tools/test_integration.sh` | BLOCKED | Blocked by Docker administrative policy: Compose build failed with `403 Forbidden`. |
+| Focused integration fallback | `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short` | PASS | 2 passed; validates target-aware workflow boundary behavior and target-specific preparation failure locally. |
 
 ## Requirement Coverage
 
@@ -25,7 +25,7 @@
 | FR-004 | `PreparedInputEntry.workspacePath/status`; worker manifest `status` | VERIFIED | Entries identify artifact, target, path, and status. |
 | FR-005 | Existing vision/target-aware workflow tests and focused integration | VERIFIED | Per-target context delivery remains covered. |
 | FR-006 | Stable `stepRef` tests for reorder/text edits | VERIFIED | Bindings are keyed by stable step identity, not list position. |
-| FR-007 | Worker download failure tests and stable-ref validation | VERIFIED | Unit evidence verifies explicit failure behavior. |
+| FR-007 | Worker download failure tests, stable-ref validation, and focused integration failure payload test | VERIFIED | Unit and integration evidence verify explicit target-specific failure behavior. |
 | FR-008 | Unit tests assert no data URLs/base64 in prepared metadata | VERIFIED | Only refs and bounded metadata cross boundaries. |
 | FR-009 | `prepared_context.py` and `worker.py` reject step attachments without `id`, `stepRef`, or `ref` | VERIFIED | Removes index fallback retargeting risk. |
 | FR-010 | `spec.md`, `plan.md`, `tasks.md`, this report | VERIFIED | `MM-648` preserved throughout artifacts. |
@@ -35,9 +35,9 @@
 | Source Requirement | Status | Evidence |
 |--------------------|--------|----------|
 | DESIGN-REQ-002 | VERIFIED | No binary payloads; artifact refs, workspace paths, and context refs only. |
-| DESIGN-REQ-020 | PARTIAL | Preparation manifest, materialized paths, status metadata, and unit failure behavior are covered; SC-003 still needs integration-level failure evidence. |
+| DESIGN-REQ-020 | VERIFIED | Preparation manifest, materialized paths, status metadata, unit failure behavior, and integration-level target-specific failure diagnostics are covered. |
 | DESIGN-REQ-029 | VERIFIED | Stable step-ref enforcement and reorder/text-edit tests prevent silent retargeting. |
 
 ## Remaining Risks
 
-- The full compose-backed integration suite could not run in this managed environment because Docker access was denied by administrative policy. Focused local integration coverage passed for the target-aware workflow boundary. Alignment found SC-003 still needs integration-level evidence for target-specific preparation failure before the story should be closed as fully implemented.
+- The full compose-backed integration suite could not run in this managed environment because Docker access was denied by administrative policy. Focused local integration coverage passed for the target-aware workflow boundary and target-specific preparation failure. Final `/moonspec-verify` remains pending for the dedicated verification step.

--- a/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -10,6 +10,9 @@ pytest.importorskip("temporalio")
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.activity_runtime import (
+    build_target_aware_prepared_context_payload,
+)
 
 
 def test_run_boundary_prepares_objective_and_current_step_context_only() -> None:
@@ -55,3 +58,25 @@ def test_run_boundary_prepares_objective_and_current_step_context_only() -> None
     assert dumped["parameters"]["metadata"]["moonmind"]["preparedContext"][
         "targetCounts"
     ] == {"objective": 1, "step": 1}
+
+
+def test_prepare_boundary_reports_target_for_invalid_step_attachment() -> None:
+    payload = build_target_aware_prepared_context_payload(
+        {
+            "steps": [
+                {
+                    "id": "first-step",
+                    "inputAttachments": [{"filename": "missing-ref.png"}],
+                }
+            ]
+        },
+        logical_step_id="first-step",
+    )
+
+    assert payload["ok"] is False
+    failure = payload["failure"]
+    assert failure["logicalStepId"] == "first-step"
+    assert failure["reason"] == "ValueError"
+    assert "targetKind=step" in failure["message"]
+    assert "stepRef=first-step" in failure["message"]
+    assert "missing artifactId" in failure["message"]

--- a/tests/unit/agents/codex_worker/test_attachment_materialization.py
+++ b/tests/unit/agents/codex_worker/test_attachment_materialization.py
@@ -98,7 +98,8 @@ def _canonical_payload() -> dict[str, object]:
                     ],
                 },
                 {
-                    "instructions": "No id",
+                    "id": "summarize-step",
+                    "instructions": "Stable id",
                     "inputAttachments": [
                         {
                             "artifactId": "art_no_id",
@@ -124,7 +125,7 @@ def test_collect_attachment_targets_preserves_canonical_target_fields(
     assert targets[0].step_ref is None
     assert targets[1].step_ref == "review-step"
     assert targets[1].step_ordinal == 0
-    assert targets[2].step_ref == "step-2"
+    assert targets[2].step_ref == "summarize-step"
     assert targets[2].step_ordinal == 1
 
 def test_attachment_workspace_paths_are_target_aware_and_sanitized(
@@ -141,7 +142,7 @@ def test_attachment_workspace_paths_are_target_aware_and_sanitized(
     assert paths == [
         ".moonmind/inputs/objective/art_objective-Objective_Diagram.png",
         ".moonmind/inputs/steps/review-step/art_step-shot.png",
-        ".moonmind/inputs/steps/step-2/art_no_id-same.png",
+        ".moonmind/inputs/steps/summarize-step/art_no_id-same.png",
     ]
 
 def test_attachment_workspace_paths_do_not_depend_on_unrelated_target_order(
@@ -187,6 +188,22 @@ def test_collect_attachment_targets_rejects_malformed_refs(tmp_path: Path) -> No
     task["inputAttachments"] = [{"artifactId": "art_missing_filename"}]
 
     with pytest.raises(ValueError, match="filename is required"):
+        worker._collect_input_attachment_targets(payload)
+
+
+def test_collect_attachment_targets_rejects_step_attachments_without_stable_ref(
+    tmp_path: Path,
+) -> None:
+    worker = _worker(tmp_path)
+    payload = _canonical_payload()
+    task = payload["task"]
+    assert isinstance(task, dict)
+    steps = task["steps"]
+    assert isinstance(steps, list)
+    assert isinstance(steps[1], dict)
+    steps[1].pop("id")
+
+    with pytest.raises(ValueError, match="stable stepRef"):
         worker._collect_input_attachment_targets(payload)
 
 @pytest.mark.asyncio
@@ -330,7 +347,7 @@ async def test_materialize_input_attachments_writes_files_and_manifest(
         repo_dir / ".moonmind/inputs/steps/review-step/art_step-shot.png"
     ).read_bytes() == b"step"
     assert (
-        repo_dir / ".moonmind/inputs/steps/step-2/art_no_id-same.png"
+        repo_dir / ".moonmind/inputs/steps/summarize-step/art_no_id-same.png"
     ).read_bytes() == b"no-id"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["version"] == 1
@@ -341,6 +358,7 @@ async def test_materialize_input_attachments_writes_files_and_manifest(
             "contentType": "image/png",
             "sizeBytes": 3,
             "targetKind": "objective",
+            "status": "prepared",
             "workspacePath": (
                 ".moonmind/inputs/objective/"
                 "art_objective-Objective_Diagram.png"
@@ -354,6 +372,7 @@ async def test_materialize_input_attachments_writes_files_and_manifest(
             "targetKind": "step",
             "stepRef": "review-step",
             "stepOrdinal": 0,
+            "status": "prepared",
             "workspacePath": ".moonmind/inputs/steps/review-step/art_step-shot.png",
         },
         {
@@ -362,9 +381,12 @@ async def test_materialize_input_attachments_writes_files_and_manifest(
             "contentType": "image/png",
             "sizeBytes": 5,
             "targetKind": "step",
-            "stepRef": "step-2",
+            "stepRef": "summarize-step",
             "stepOrdinal": 1,
-            "workspacePath": ".moonmind/inputs/steps/step-2/art_no_id-same.png",
+            "status": "prepared",
+            "workspacePath": (
+                ".moonmind/inputs/steps/summarize-step/art_no_id-same.png"
+            ),
         },
     ]
 
@@ -451,7 +473,7 @@ async def test_prepare_stage_materializes_attachments_before_return(
             "contentType": "image/png",
             "sizeBytes": 5,
             "targetKind": "step",
-            "stepRef": "step-2",
+            "stepRef": "summarize-step",
             "stepOrdinal": 1,
         },
     ]

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -84,6 +84,80 @@ def test_prepared_manifest_preserves_zero_byte_size() -> None:
     assert manifest.entries[0].size_bytes == 0
 
 
+def test_prepared_manifest_rejects_step_attachment_without_stable_step_ref() -> None:
+    with pytest.raises(ValueError, match="stable stepRef"):
+        build_prepared_input_manifest(
+            {
+                "steps": [
+                    {
+                        "instructions": "No stable step identity",
+                        "inputAttachments": [{"artifactId": "artifact-step"}],
+                    }
+                ]
+            }
+        )
+
+
+def test_prepared_manifest_bindings_survive_reorder_and_text_edits() -> None:
+    original = {
+        "steps": [
+            {
+                "id": "first-step",
+                "instructions": "Original text",
+                "inputAttachments": [{"artifactId": "first-artifact"}],
+            },
+            {
+                "id": "second-step",
+                "instructions": "Original text",
+                "inputAttachments": [{"artifactId": "second-artifact"}],
+            },
+        ]
+    }
+    reordered = {
+        "steps": [
+            {
+                "id": "second-step",
+                "instructions": "Edited text",
+                "inputAttachments": [{"artifactId": "second-artifact"}],
+            },
+            {
+                "id": "first-step",
+                "instructions": "Edited text",
+                "inputAttachments": [{"artifactId": "first-artifact"}],
+            },
+        ]
+    }
+
+    original_manifest = build_prepared_input_manifest(original)
+    reordered_manifest = build_prepared_input_manifest(reordered)
+
+    original_bindings = {
+        entry.artifact_id: entry.step_ref for entry in original_manifest.entries
+    }
+    reordered_bindings = {
+        entry.artifact_id: entry.step_ref for entry in reordered_manifest.entries
+    }
+
+    assert reordered_bindings == original_bindings
+
+
+def test_prepared_manifest_entries_include_stable_workspace_status_metadata() -> None:
+    manifest = build_prepared_input_manifest(_task_payload())
+
+    dumped = manifest.model_dump(by_alias=True)
+
+    assert dumped["entries"][0]["workspacePath"] == (
+        ".moonmind/inputs/objective/artifact-objective-objective.png"
+    )
+    assert dumped["entries"][0]["status"] == "prepared"
+    assert dumped["entries"][1]["workspacePath"] == (
+        ".moonmind/inputs/steps/collect-evidence/artifact-step-1-evidence.txt"
+    )
+    assert dumped["entries"][1]["status"] == "prepared"
+    assert "data:image" not in str(dumped)
+    assert "base64" not in str(dumped)
+
+
 def test_prepared_models_reject_missing_step_binding_and_embedded_content() -> None:
     with pytest.raises(ValidationError, match="stepRef"):
         PreparedInputEntry.model_validate(

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -98,6 +98,26 @@ def test_prepared_manifest_rejects_step_attachment_without_stable_step_ref() -> 
         )
 
 
+def test_prepared_manifest_allows_anonymous_steps_without_attachments() -> None:
+    manifest = build_prepared_input_manifest(
+        {
+            "inputAttachments": [{"artifactId": "objective-artifact"}],
+            "steps": [
+                {"instructions": "No attachments on this anonymous step"},
+                {
+                    "id": "attached-step",
+                    "inputAttachments": [{"artifactId": "step-artifact"}],
+                },
+            ],
+        }
+    )
+
+    assert [(entry.artifact_id, entry.step_ref) for entry in manifest.entries] == [
+        ("objective-artifact", None),
+        ("step-artifact", "attached-step"),
+    ]
+
+
 def test_prepared_manifest_bindings_survive_reorder_and_text_edits() -> None:
     original = {
         "steps": [


### PR DESCRIPTION
Change Jira issue MM-648 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.