### PR TITLE
Change Jira issue MM-649 to status In Progress before implementation starts.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,8 @@ Key diagnostics:
 - Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, authoritative task input snapshot artifacts; no new persistent database table planned (343-editable-full-retry-workflow)
 - Python 3.12 + Temporal Python SDK, Pydantic v2, FastAPI execution service models, existing Temporal artifact service/helpers (345-step-ledger-checkpoint-durability)
 - Existing Temporal workflow state/history, Temporal artifact metadata/content store, execution source records; no new persistent database table planned (345-step-ledger-checkpoint-durability)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind workflow/task contract helpers (348-target-aware-step-scope)
+- Existing workflow history and artifact refs only; no new persistent storage planned (348-target-aware-step-scope)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -245,6 +245,8 @@ Key diagnostics:
 - Existing execution records and artifact metadata/content stores only; no new persistent storage (340-create-page-authoring-validation)
 - Python 3.12; TypeScript/React for Mission Control UI behavior + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, React, TanStack Query, Zod, Vitest, pytest (343-editable-full-retry-workflow)
 - Existing Temporal execution records, memo/search attributes, Temporal artifact metadata/content store, authoritative task input snapshot artifacts; no new persistent database table planned (343-editable-full-retry-workflow)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind workflow/task contract helpers (348-target-aware-step-scope)
+- Existing workflow history and artifact refs only; no new persistent storage planned (348-target-aware-step-scope)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -530,6 +530,32 @@ class MoonMindAgentRun:
         if task_run_id:
             metadata.setdefault("taskRunId", task_run_id)
 
+        request_metadata = (
+            request.parameters.get("metadata")
+            if isinstance(request.parameters, Mapping)
+            else None
+        )
+        request_moonmind = (
+            request_metadata.get("moonmind")
+            if isinstance(request_metadata, Mapping)
+            and isinstance(request_metadata.get("moonmind"), Mapping)
+            else None
+        )
+        parent_prepared_context = (
+            request_moonmind.get("preparedContext")
+            if isinstance(request_moonmind, Mapping)
+            and isinstance(request_moonmind.get("preparedContext"), Mapping)
+            else None
+        )
+        if parent_prepared_context is not None:
+            moonmind_payload = (
+                metadata.get("moonmind")
+                if isinstance(metadata.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload["preparedContext"] = dict(parent_prepared_context)
+            metadata["moonmind"] = moonmind_payload
+
         step_ledger_context = _request_step_ledger_context(request)
         report_output_context = (
             request.parameters.get("reportOutput")

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -530,15 +530,13 @@ class MoonMindAgentRun:
         if task_run_id:
             metadata.setdefault("taskRunId", task_run_id)
 
-        request_metadata = (
-            request.parameters.get("metadata")
-            if isinstance(request.parameters, Mapping)
-            else None
+        request_params = (
+            request.parameters if isinstance(request.parameters, Mapping) else {}
         )
+        request_metadata = request_params.get("metadata")
         request_moonmind = (
             request_metadata.get("moonmind")
             if isinstance(request_metadata, Mapping)
-            and isinstance(request_metadata.get("moonmind"), Mapping)
             else None
         )
         parent_prepared_context = (

--- a/specs/348-target-aware-step-scope/checklists/requirements.md
+++ b/specs/348-target-aware-step-scope/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Target-Aware Step Execution Scope
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves the MM-649 canonical Jira preset brief verbatim in `**Input**`.
+- PASS: The request is classified as a single-story runtime feature.
+- PASS: In-scope source design requirements from `docs/Tasks/TaskArchitecture.md` sections 8.3 and 8.4 are mapped to functional requirements.

--- a/specs/348-target-aware-step-scope/contracts/step-context-scope.md
+++ b/specs/348-target-aware-step-scope/contracts/step-context-scope.md
@@ -1,0 +1,78 @@
+# Contract: Step Context Scope and AgentRun Child Input
+
+## Scope
+
+This contract covers the parent workflow boundary that selects target-aware prepared context for one runtime step and passes that bounded context into `MoonMind.AgentRun` child workflows or external runtime adapters.
+
+## Parent Selection Contract
+
+Input:
+
+```json
+{
+  "task": {
+    "inputAttachments": [{"artifactId": "objective-image"}],
+    "steps": [
+      {"id": "collect-evidence", "inputAttachments": [{"artifactId": "collect-notes"}]},
+      {"id": "write-report", "inputAttachments": [{"artifactId": "report-notes"}]}
+    ]
+  },
+  "logicalStepId": "collect-evidence"
+}
+```
+
+Required output metadata:
+
+```json
+{
+  "manifestRef": "prepared-context-manifest://task-inputs",
+  "logicalStepId": "collect-evidence",
+  "objectiveContextRefs": ["prepared-context://objective/objective-image"],
+  "stepContextRefs": ["prepared-context://steps/collect-evidence/collect-notes"],
+  "rawInputRefs": ["artifact://objective-image", "artifact://collect-notes"],
+  "inputRefs": [
+    "prepared-context://objective/objective-image",
+    "prepared-context://steps/collect-evidence/collect-notes",
+    "artifact://objective-image",
+    "artifact://collect-notes"
+  ],
+  "targetCounts": {"objective": 1, "step": 1}
+}
+```
+
+Forbidden:
+- `prepared-context://steps/write-report/report-notes`
+- `artifact://report-notes`
+- inline binary bytes, data URLs, or generated markdown bodies
+- any target binding computed from filename, array index, path position, or instruction text
+
+## AgentRun Child Input Contract
+
+For a child workflow representing `collect-evidence`, the parent request MUST include:
+
+- `AgentExecutionRequest.parameters.metadata.moonmind.preparedContext.logicalStepId = "collect-evidence"`
+- objective context refs relevant to the task
+- step context refs only for `collect-evidence`
+- no prepared refs for sibling steps
+
+For managed runtimes, prepared refs MAY stay in `parameters.metadata.moonmind.preparedContext.inputRefs` rather than `AgentExecutionRequest.inputRefs`, but the same exclusion rule applies.
+
+## Diagnostic Contract
+
+Child workflow logs, result metadata, or diagnostics MAY report:
+
+- parent workflow/run identifiers
+- represented `logicalStepId`
+- bounded prepared context refs and target counts
+- explicit rejection/failure reason for invalid prepared context
+
+Child workflow logs, result metadata, or diagnostics MUST NOT:
+
+- redefine which target owns an attachment
+- broaden step context to sibling-step refs
+- override parent-provided `preparedContext.logicalStepId`
+- embed unrelated attachment contents
+
+## Compatibility
+
+Prepared-context metadata is a workflow boundary payload. Any shape change must either preserve worker-bound invocation compatibility for in-flight runs or use an explicit versioned cutover plan with boundary tests.

--- a/specs/348-target-aware-step-scope/data-model.md
+++ b/specs/348-target-aware-step-scope/data-model.md
@@ -1,0 +1,59 @@
+# Data Model: Target-Aware Step Execution Scope
+
+## Prepared Context Item
+
+- `artifactId`: Stable artifact identifier for the original input.
+- `targetKind`: `objective` or `step`.
+- `stepRef`: Required when `targetKind` is `step`; forbidden for `objective`.
+- `rawInputRef`: Lightweight artifact ref for the prepared raw input.
+- `derivedContextRef`: Optional lightweight ref for generated context derived from the input.
+- `workspacePath`: Optional stable materialization path for diagnostics and runtime adapters.
+- `status`: Preparation status, expected to be `prepared` before step dispatch.
+
+Validation:
+- Step items without `stepRef` are invalid.
+- Objective items with `stepRef` are invalid.
+- Inline binary data, data URLs, generated markdown bodies, and secret-like values are invalid for workflow-visible metadata.
+
+## Prepared Input Manifest
+
+- `manifestRef`: Lightweight ref identifying the prepared-input manifest.
+- `entries`: Ordered collection of Prepared Context Items.
+
+Relationships:
+- One task execution has zero or one active prepared-input manifest.
+- A manifest may contain objective entries and entries for multiple steps.
+- Runtime context selection reads the manifest but never mutates target binding.
+
+## Step Runtime Context
+
+- `logicalStepId`: Stable logical step identifier for the current runtime step.
+- `manifestRef`: Ref to the manifest used for selection.
+- `objectiveContextRefs`: Prepared refs visible to the step because they are task-level objective context.
+- `stepContextRefs`: Prepared refs visible to the step because they are explicitly bound to `logicalStepId`.
+- `rawInputRefs`: Raw artifact refs for the objective and current-step items only.
+- `inputRefs`: Deduplicated effective refs delivered to non-managed runtime adapters or metadata for managed runtimes.
+
+Validation:
+- `stepContextRefs` must contain only entries whose `stepRef` equals `logicalStepId`.
+- Refs for unrelated steps must be absent.
+- Large or binary content must never be embedded.
+
+## AgentRun Child Input
+
+- `AgentExecutionRequest.inputRefs`: Effective compact refs for external/coordinated runtimes, excluding unrelated step refs.
+- `AgentExecutionRequest.parameters.metadata.moonmind.preparedContext`: Parent-owned prepared-context metadata for managed and external child runs.
+- `AgentExecutionRequest.parameters.metadata.moonmind.stepLedger`: Optional step ledger context for the represented step.
+
+Validation:
+- Parent MoonMind.Run is the only authority that selects prepared context for the represented step.
+- Child workflows may consume and report the parent-provided prepared context but must not redefine target binding.
+- Child diagnostics may include bounded refs/counts, not unrelated attachment content.
+
+## State Transitions
+
+1. Task payload contains objective and step-scoped attachment refs.
+2. Prepare produces a manifest with explicit target metadata.
+3. Parent workflow selects one Step Runtime Context for a logical step.
+4. Parent workflow dispatches runtime or AgentRun child input with only objective plus current-step context.
+5. Child result and diagnostics preserve parent-owned target-binding metadata without broadening scope.

--- a/specs/348-target-aware-step-scope/moonspec_align_report.md
+++ b/specs/348-target-aware-step-scope/moonspec_align_report.md
@@ -2,6 +2,7 @@
 
 **Created**: 2026-05-13
 **Feature**: `specs/348-target-aware-step-scope`
+**Source**: MM-649 canonical Jira preset brief
 
 ## Findings
 

--- a/specs/348-target-aware-step-scope/moonspec_align_report.md
+++ b/specs/348-target-aware-step-scope/moonspec_align_report.md
@@ -1,0 +1,25 @@
+# MoonSpec Alignment Report: Target-Aware Step Execution Scope
+
+**Created**: 2026-05-13
+**Feature**: `specs/348-target-aware-step-scope`
+
+## Findings
+
+| Finding | Status | Evidence | Remediation |
+| --- | --- | --- | --- |
+| Original Jira coverage IDs were preserved in `spec.md` but not carried forward in downstream traceability artifacts. | FIXED | `spec.md` maps local `DESIGN-REQ-001` to original Jira `DESIGN-REQ-021` and local `DESIGN-REQ-002` to original Jira `DESIGN-REQ-022`. | Added downstream traceability notes in `plan.md`, `research.md`, `quickstart.md`, and `tasks.md`. |
+| Specify gate alignment | PASS | `spec.md` has exactly one user story and no unresolved clarification markers. | None. |
+| Plan/design gate alignment | PASS | `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, and `quickstart.md` exist with explicit unit and integration strategies. | None. |
+| Tasks gate alignment | PASS | `tasks.md` has one story phase, sequential task IDs, unit tests before implementation, integration tests before implementation, red-first confirmation, conditional fallback implementation, story validation, and final `/moonspec-verify`. | None. |
+
+## Key Decisions
+
+- Preserve local MoonSpec IDs (`DESIGN-REQ-001`, `DESIGN-REQ-002`) for internal spec coherence and also carry original Jira coverage IDs (`DESIGN-REQ-021`, `DESIGN-REQ-022`) into downstream verification evidence.
+- Keep implementation tasks conditional because current repo evidence already implements most behavior and the remaining work is verification-first.
+- Treat FR-009 and SC-005 as traceability gates that remain open until implementation notes, final verification output, commit text, and pull request metadata exist.
+
+## Validation
+
+- Prerequisites: `SPECIFY_FEATURE=348-target-aware-step-scope .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` passed.
+- Task format: 27 tasks, sequential IDs, exactly one story phase, final `/moonspec-verify` present.
+- Traceability: MM-649, FR-009, SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 and DESIGN-REQ-022 are preserved for downstream verification.

--- a/specs/348-target-aware-step-scope/plan.md
+++ b/specs/348-target-aware-step-scope/plan.md
@@ -11,6 +11,8 @@ MM-649 requires step execution and delegated MoonMind.AgentRun child workflows t
 
 ## Requirement Status
 
+Traceability note: `DESIGN-REQ-001` maps the original Jira coverage ID `DESIGN-REQ-021`, and `DESIGN-REQ-002` maps the original Jira coverage ID `DESIGN-REQ-022`.
+
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
 | FR-001 | implemented_verified | `moonmind/workflows/temporal/workflows/run.py` builds prepared context before dispatch; `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` asserts objective + current step refs | Preserve behavior | unit + integration final verify |

--- a/specs/348-target-aware-step-scope/plan.md
+++ b/specs/348-target-aware-step-scope/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Target-Aware Step Execution Scope
+
+**Branch**: `change-jira-issue-mm-649-to-status-in-pr-179b6dcb` | **Date**: 2026-05-13 | **Spec**: `specs/348-target-aware-step-scope/spec.md`
+**Input**: Single-story feature specification from `specs/348-target-aware-step-scope/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` was attempted, but it stopped because the current branch name does not match the numeric MoonSpec feature prefix. Planning continues manually against the active feature directory recorded in `.specify/feature.json`.
+
+## Summary
+
+MM-649 requires step execution and delegated MoonMind.AgentRun child workflows to consume objective context plus only the current step's prepared context. Current repo evidence shows compact prepared-context models, target filtering, parent workflow request assembly, and unit/integration coverage already exist for the main runtime boundary. Planned work is primarily verification-first: strengthen child-workflow authority/diagnostic evidence where current tests are thinner, then patch the parent request metadata or child diagnostic handling only if those verification tests expose a gap.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/workflows/temporal/workflows/run.py` builds prepared context before dispatch; `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` asserts objective + current step refs | Preserve behavior | unit + integration final verify |
+| FR-002 | implemented_verified | `moonmind/workflows/tasks/prepared_context.py` selects only matching `stepRef`; unit tests exclude `artifact-step-2` / `report-notes` | Preserve behavior | unit + integration final verify |
+| FR-003 | implemented_unverified | Prepared refs include target-specific workspace paths, but same-workspace exclusion evidence should be made explicit | Add verification test first; patch context selection only if it fails | unit + integration |
+| FR-004 | implemented_verified | `select_step_prepared_context()` matches explicit `step_ref`; reorder/text edit unit coverage exists in `test_prepared_context.py` | Preserve behavior | unit final verify |
+| FR-005 | implemented_verified | Parent `_build_agent_execution_request()` injects prepared context into the request used for `MoonMind.AgentRun`; unit test covers represented-step child request | Preserve behavior | unit + integration final verify |
+| FR-006 | implemented_unverified | Parent workflow constructs child request and metadata, but authority semantics need a focused assertion | Add verification test for parent-owned target binding metadata; patch metadata only if missing | unit + integration |
+| FR-007 | implemented_unverified | Child diagnostics currently preserve `moonmind.preparedContext` metadata, but no test proves diagnostics cannot redefine target semantics | Add verification test for diagnostic metadata shape; patch child result enrichment only if needed | unit |
+| FR-008 | implemented_verified | Unit and integration tests assert unrelated step refs are absent from request payloads | Preserve behavior | unit + integration final verify |
+| FR-009 | missing | Spec preserves MM-649; downstream implementation notes, tasks, verification, commit, and PR metadata do not exist yet | Preserve traceability through all later artifacts | final verify |
+| SCN-001 | implemented_verified | First-step request includes objective and first-step refs only | Preserve behavior | unit final verify |
+| SCN-002 | implemented_unverified | Filtering works with a single manifest, but same-workspace materialization should be asserted by contract | Add explicit same-workspace/materialized-path verification | unit + integration |
+| SCN-003 | implemented_verified | `test_child_agent_run_request_receives_only_represented_step_context` covers child request scoping | Preserve behavior | unit + integration final verify |
+| SCN-004 | implemented_unverified | Diagnostics metadata exists but target-binding non-redefinition needs focused proof | Add diagnostic authority verification | unit |
+| SCN-005 | implemented_unverified | Invalid context is rejected in unit and integration tests; current-step/objective association should remain covered in final verification | Preserve and verify | unit + integration final verify |
+| SC-001 | implemented_verified | Unit tests inspect runtime contexts and exclude other step refs | Preserve behavior | unit final verify |
+| SC-002 | implemented_unverified | Unit child-request proof exists; add integration/boundary evidence for child workflow input path | Add verification test first | integration |
+| SC-003 | implemented_unverified | Current tests imply shared manifest filtering; explicit same-workspace case still planned | Add same-workspace verification | unit + integration |
+| SC-004 | implemented_unverified | Parent metadata exists; diagnostic authority proof planned | Add diagnostic verification | unit |
+| SC-005 | missing | Final verification does not exist yet | Preserve traceability and run final verify later | final verify |
+| DESIGN-REQ-001 | implemented_verified | Step execution filtering code and tests cover objective + current step only | Preserve behavior | unit + integration final verify |
+| DESIGN-REQ-002 | implemented_unverified | AgentRun request scoping exists; child logs/diagnostics authority proof still needs targeted evidence | Add verification tests before any patch | unit + integration |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, pytest, existing MoonMind workflow/task contract helpers  
+**Storage**: Existing workflow history and artifact refs only; no new persistent storage planned  
+**Unit Testing**: `./tools/test_unit.sh`, with focused iteration through pytest targets under `tests/unit/workflows/tasks/` and `tests/unit/workflows/temporal/workflows/`  
+**Integration Testing**: `./tools/test_integration.sh`, with focused `integration_ci` coverage under `tests/integration/workflows/temporal/workflows/`  
+**Target Platform**: MoonMind Temporal worker/runtime environment on Linux containers  
+**Project Type**: Python orchestration service with Temporal workflows and managed/external agent adapters  
+**Performance Goals**: Prepared context selection remains bounded to compact refs and metadata; no binary or large generated context enters workflow-visible payloads  
+**Constraints**: Maintain Temporal workflow payload compatibility, preserve parent-owned target binding semantics, avoid raw credentials or binary payloads in metadata, keep workflow code deterministic  
+**Scale/Scope**: One runtime story covering step request assembly, AgentRun child input scoping, and diagnostic evidence for target-aware prepared context
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Plan keeps provider agents behind existing AgentRun request contracts.
+- II. One-Click Agent Deployment: PASS. No new mandatory services, secrets, or deployment dependencies.
+- III. Avoid Vendor Lock-In: PASS. Context scoping remains runtime-neutral metadata and refs.
+- IV. Own Your Data: PASS. Prepared context uses MoonMind-owned artifact refs and step-level injection.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill contract changes are planned.
+- VI. Replaceable Scaffolding, Thick Contracts: PASS. Contract tests anchor workflow/request behavior without adding cognitive scaffolding.
+- VII. Powerful Runtime Configurability: PASS. No hardcoded provider behavior or new runtime settings.
+- VIII. Modular and Extensible Architecture: PASS. Planned work stays in task prepared-context and workflow boundary modules.
+- IX. Resilient by Default: PASS. Any workflow/activity payload changes require boundary coverage; current plan is verification-first.
+- X. Facilitate Continuous Improvement: PASS. Later verification must produce structured evidence.
+- XI. Spec-Driven Development: PASS. `spec.md` exists and this plan preserves requirement traceability.
+- XII. Canonical Documentation Separation: PASS. Planning remains in `specs/348-target-aware-step-scope/`.
+- XIII. Pre-Release Velocity: PASS. If verification reveals stale aliases or obsolete paths, tasks must remove them rather than preserving wrappers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/348-target-aware-step-scope/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── step-context-scope.md
+└── tasks.md             # Created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── workflows/
+│   ├── tasks/
+│   │   └── prepared_context.py
+│   └── temporal/
+│       ├── activity_runtime.py
+│       └── workflows/
+│           ├── run.py
+│           └── agent_run.py
+└── schemas/
+    └── agent_runtime_models.py
+
+tests/
+├── unit/
+│   └── workflows/
+│       ├── tasks/test_prepared_context.py
+│       └── temporal/workflows/test_run_target_aware_inputs.py
+└── integration/
+    └── workflows/temporal/workflows/test_run_target_aware_inputs.py
+```
+
+**Structure Decision**: This is a Python Temporal workflow/runtime contract change. Planning targets existing workflow, task-contract, and test directories rather than creating new services or storage layers.
+
+## Complexity Tracking
+
+No constitution violations requiring complexity tracking.

--- a/specs/348-target-aware-step-scope/plan.md
+++ b/specs/348-target-aware-step-scope/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-MM-649 requires step execution and delegated MoonMind.AgentRun child workflows to consume objective context plus only the current step's prepared context. Current repo evidence shows compact prepared-context models, target filtering, parent workflow request assembly, and unit/integration coverage already exist for the main runtime boundary. Planned work is primarily verification-first: strengthen child-workflow authority/diagnostic evidence where current tests are thinner, then patch the parent request metadata or child diagnostic handling only if those verification tests expose a gap.
+MM-649 requires step execution and delegated MoonMind.AgentRun child workflows to consume objective context plus only the current step's prepared context. The canonical Jira preset brief is preserved for final traceability. Current repo evidence shows compact prepared-context models, target filtering, parent workflow request assembly, and unit/integration coverage already exist for the main runtime boundary. Planned work is primarily verification-first: strengthen child-workflow authority/diagnostic evidence where current tests are thinner, then patch the parent request metadata or child diagnostic handling only if those verification tests expose a gap.
 
 ## Requirement Status
 

--- a/specs/348-target-aware-step-scope/quickstart.md
+++ b/specs/348-target-aware-step-scope/quickstart.md
@@ -72,5 +72,6 @@ Final verification must preserve:
 - Jira issue `MM-649`
 - the canonical Jira preset brief in `spec.md`
 - DESIGN-REQ-001 and DESIGN-REQ-002
+- original Jira coverage IDs DESIGN-REQ-021 and DESIGN-REQ-022
 - FR-001 through FR-009
 - SC-001 through SC-005

--- a/specs/348-target-aware-step-scope/quickstart.md
+++ b/specs/348-target-aware-step-scope/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: Target-Aware Step Execution Scope
+
+## Prerequisites
+
+- Python 3.12 environment for MoonMind tests.
+- Local repository dependencies installed by the standard test runner.
+- No external provider credentials are required.
+
+## Focused Unit Verification
+
+Run prepared-context contract tests:
+
+```bash
+pytest tests/unit/workflows/tasks/test_prepared_context.py -q --tb=short
+```
+
+Run parent workflow request-scoping tests:
+
+```bash
+pytest tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py -q --tb=short
+```
+
+Expected evidence:
+- Objective refs are included.
+- Current-step refs are included.
+- Sibling-step refs are absent.
+- Invalid inline or missing attachment refs fail explicitly.
+- Parent-owned prepared context metadata is preserved for AgentRun child inputs.
+
+## Focused Integration Verification
+
+Run the hermetic workflow boundary target-aware tests:
+
+```bash
+pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short
+```
+
+Expected evidence:
+- The run boundary prepares objective plus current-step context only.
+- Invalid step attachment preparation reports the affected target.
+- Add or update integration coverage for AgentRun child input scoping if current evidence is insufficient for SC-002.
+
+## Full Required Verification
+
+Before closing implementation, run:
+
+```bash
+./tools/test_unit.sh
+```
+
+Then run hermetic integration tests:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Story Validation
+
+Validate a task with one objective attachment and at least two step-scoped attachments:
+
+1. Select context for the first step.
+2. Confirm the first step receives objective refs and first-step refs only.
+3. Select context for the second step.
+4. Confirm the second step receives objective refs and second-step refs only.
+5. Dispatch or inspect the AgentRun child input for each represented step.
+6. Confirm diagnostics identify parent-owned target binding and do not redefine target scope.
+
+## Traceability
+
+Final verification must preserve:
+
+- Jira issue `MM-649`
+- the canonical Jira preset brief in `spec.md`
+- DESIGN-REQ-001 and DESIGN-REQ-002
+- FR-001 through FR-009
+- SC-001 through SC-005

--- a/specs/348-target-aware-step-scope/research.md
+++ b/specs/348-target-aware-step-scope/research.md
@@ -63,3 +63,11 @@ Evidence: Constitution principle IX requires boundary regression coverage for wo
 Rationale: Prepared-context metadata crosses the parent-child workflow boundary and may be present in in-flight histories.
 Alternatives considered: Hidden fallback translation for alternate target fields. Rejected because fallback transforms could hide target-binding errors.
 Test implications: Add boundary-level regression coverage for request metadata shape and degraded/invalid prepared context inputs.
+
+## Source Coverage ID Preservation
+
+Decision: Preserve both local MoonSpec source IDs and original Jira coverage IDs in downstream evidence.
+Evidence: `spec.md` maps `DESIGN-REQ-001` to original Jira coverage ID `DESIGN-REQ-021` and `DESIGN-REQ-002` to original Jira coverage ID `DESIGN-REQ-022`.
+Rationale: Local IDs keep this one-story spec internally coherent, while original Jira IDs let final verification compare against the canonical preset brief without ambiguity.
+Alternatives considered: Use only local MoonSpec IDs after specification. Rejected because MM-649's preserved Jira brief explicitly includes the original coverage IDs.
+Test implications: Traceability tasks and final `/moonspec-verify` evidence must mention `DESIGN-REQ-021` and `DESIGN-REQ-022` alongside `DESIGN-REQ-001` and `DESIGN-REQ-002`.

--- a/specs/348-target-aware-step-scope/research.md
+++ b/specs/348-target-aware-step-scope/research.md
@@ -1,0 +1,65 @@
+# Research: Target-Aware Step Execution Scope
+
+## FR-001 / FR-002 / FR-004 / FR-008 / DESIGN-REQ-001
+
+Decision: Treat step prepared-context selection as already implemented and verified for the core current-step-only behavior.
+Evidence: `moonmind/workflows/tasks/prepared_context.py` defines `PreparedInputManifest`, `StepPreparedContext`, and `select_step_prepared_context()`. `tests/unit/workflows/tasks/test_prepared_context.py` verifies objective and current-step refs are included while unrelated step refs are absent. `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` verifies parent request assembly excludes `report-notes`/other-step refs.
+Rationale: The implementation matches explicit target metadata rather than filename, path position, step order, or instruction text. Existing tests cover reorder/text edit stability and unrelated-step exclusion.
+Alternatives considered: Rewriting context selection in workflow code. Rejected because the task helper already centralizes the contract and is easier to test deterministically.
+Test implications: Preserve existing unit coverage and rerun focused unit/integration tests during implementation and final verification.
+
+## FR-003 / SCN-002 / SC-003
+
+Decision: Classify same-workspace materialization as implemented_unverified.
+Evidence: `PreparedInputEntry.workspace_path` records target-specific paths, and `tests/unit/workflows/tasks/test_prepared_context.py` checks stable objective and step workspace paths. Current integration coverage verifies unrelated step refs are excluded from workflow request payloads.
+Rationale: The behavior is strongly implied, but MM-649 specifically calls out no leakage even when preparation materialized all attachments in one workspace. A focused verification test should make that scenario explicit.
+Alternatives considered: Mark implemented_verified based on existing path and request filtering tests. Rejected because the requirement names a concrete failure mode that deserves direct evidence.
+Test implications: Add unit and integration verification for a manifest/request with multiple prepared attachments available in the same task preparation set; patch only if the test exposes leakage.
+
+## FR-005 / SCN-003
+
+Decision: Treat AgentRun represented-step request scoping as implemented_verified for unit-level request construction.
+Evidence: `moonmind/workflows/temporal/workflows/run.py` builds an `AgentExecutionRequest` containing selected prepared context before invoking `"MoonMind.AgentRun"`. `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py::test_child_agent_run_request_receives_only_represented_step_context` verifies a request for `write-report` includes `report-notes` and excludes `collect-notes`.
+Rationale: The parent request object is the child workflow input shape used by `workflow.execute_child_workflow("MoonMind.AgentRun", request, ...)`.
+Alternatives considered: Add a new child workflow schema. Rejected because `AgentExecutionRequest` is already the boundary contract.
+Test implications: Keep existing unit coverage and add integration/boundary evidence for the child workflow input path if tasks require stronger SC-002 proof.
+
+## FR-006 / DESIGN-REQ-002 Parent Authority
+
+Decision: Classify parent target-binding authority as implemented_unverified.
+Evidence: Parent `MoonMind.Run` builds prepared context from task payload and injects `metadata.moonmind.preparedContext` before child dispatch. `MoonMind.AgentRun` preserves metadata and enriches results without building a new target-binding model.
+Rationale: The design is correct, but the tests should explicitly assert that the parent-provided metadata is the authority and no child-side input can broaden it.
+Alternatives considered: Introduce a separate authority marker model. Rejected for planning because existing `moonmind.preparedContext` metadata can carry the authority semantics if verified.
+Test implications: Add a focused unit or integration boundary test for parent-owned target binding metadata. Patch metadata naming or child enrichment only if the test fails.
+
+## FR-007 / SCN-004 / SC-004 Diagnostics
+
+Decision: Classify diagnostic non-redefinition as implemented_unverified.
+Evidence: `moonmind/workflows/temporal/workflows/agent_run.py` preserves `metadata["moonmind"]` and adds step ledger/report output context, but current tests do not directly assert that child logs/diagnostics cannot redefine target binding semantics.
+Rationale: This is an operator-evidence requirement, not only a request filtering requirement. It needs explicit proof that diagnostics report consumed context or parent-provided refs without introducing alternate target rules.
+Alternatives considered: Treat absence of child-side target parsing as sufficient. Rejected because the spec asks for logs/diagnostics behavior.
+Test implications: Add a unit test around AgentRun result enrichment or request metadata preservation. If diagnostics can overwrite target semantics, patch child result metadata to preserve parent authority and reject or ignore child-side redefinitions.
+
+## FR-009 / SC-005 Traceability
+
+Decision: Traceability is missing until downstream tasks, implementation notes, verification output, commit text, and PR metadata exist.
+Evidence: `specs/348-target-aware-step-scope/spec.md` preserves MM-649 and the canonical Jira preset brief. No tasks or verification artifacts exist yet.
+Rationale: Planning can preserve traceability, but completion depends on later MoonSpec stages.
+Alternatives considered: Mark verified because spec preservation exists. Rejected because FR-009 includes later artifacts not created in this step.
+Test implications: `tasks.md` and final verification must include traceability checks for MM-649 and the canonical brief.
+
+## Test Tooling
+
+Decision: Use `./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration verification. Use focused pytest/Vitest commands only for iteration when needed.
+Evidence: Repo instructions require `./tools/test_unit.sh` and `./tools/test_integration.sh`; existing tests are pytest-based Python workflow tests.
+Rationale: The story touches workflow and activity boundaries, so both unit and hermetic integration checks are required.
+Alternatives considered: Provider verification tests. Rejected because this story does not require live external provider credentials.
+Test implications: Tasks should add or update pytest tests first, confirm failures where behavior is missing, then run focused tests and final suite scripts.
+
+## Constitution And Compatibility Constraints
+
+Decision: Treat workflow/activity payload shapes as compatibility-sensitive and avoid adding compatibility aliases.
+Evidence: Constitution principle IX requires boundary regression coverage for workflow/activity contracts; principle XIII requires deleting superseded internal contracts rather than preserving aliases.
+Rationale: Prepared-context metadata crosses the parent-child workflow boundary and may be present in in-flight histories.
+Alternatives considered: Hidden fallback translation for alternate target fields. Rejected because fallback transforms could hide target-binding errors.
+Test implications: Add boundary-level regression coverage for request metadata shape and degraded/invalid prepared context inputs.

--- a/specs/348-target-aware-step-scope/spec.md
+++ b/specs/348-target-aware-step-scope/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Target-Aware Step Execution Scope
+
+**Feature Branch**: `348-target-aware-step-scope`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: """
+Use the Jira preset brief for MM-649 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-649 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-649
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Target-aware step execution & AgentRun child-workflow scope inheritance
+- Priority: Medium
+- Labels: moonmind-workflow-mm-a1fb7aa8-954b-4c59-acc2-c0a2c5339282
+- Linked issues: None
+- Trusted fetch tool: `jira.get_issue`
+- Trusted response artifact: `/work/agent_jobs/mm:9776de74-4361-4351-8716-2fcc1af2ca51/artifacts/moonspec-inputs/MM-649-trusted-jira-get-issue-summary.json`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-649 from MM project
+Summary: Target-aware step execution & AgentRun child-workflow scope inheritance
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-649 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-649: Target-aware step execution & AgentRun child-workflow scope inheritance
+
+Source Reference
+Source Document: docs/Tasks/TaskArchitecture.md
+Source Title: Task Architecture (Control Plane)
+Source Sections:
+- 8.3 Step execution responsibilities
+- 8.4 Child workflow responsibilities
+- 12.2 MoonMind.AgentRun
+- Invariant 10
+Coverage IDs:
+- DESIGN-REQ-021
+- DESIGN-REQ-022
+
+As an execution-plane engineer, I want each step to consume task-level objective context plus only its own step-scoped image context (no cross-step leakage) and want MoonMind.AgentRun child workflows to receive only the prepared context for the step they execute, never redefining or broadening attachment scope or target-binding semantics.
+
+Acceptance Criteria
+- Step execution receives only objective context plus its own step-scoped attachment context by default.
+- No cross-step attachment leakage occurs even when prepare materialized all attachments in one workspace.
+- MoonMind.AgentRun children receive only prepared context relevant to the assigned step.
+- Parent MoonMind.Run remains the source of truth for attachment target binding.
+- Child workflow logs/diagnostics do not redefine target binding semantics.
+
+Requirements
+Implement step-context dispatcher in workflow code that filters prepared context by target, and AgentRun child-input scoping.
+"""
+
+## User Story - Step-Scoped Execution Context
+
+**Summary**: As an execution-plane engineer, I want each step and delegated AgentRun child to receive only the prepared context relevant to that step so that attachments cannot leak across step boundaries.
+
+**Goal**: Step execution preserves target-aware attachment semantics by combining task-level objective context with only the current step's own prepared step-scoped context, including when execution is delegated to a child agent run.
+
+**Independent Test**: Run or simulate a task with objective context and at least two steps that each have distinct prepared attachments, then verify each step runtime and AgentRun child receives the objective context plus only its own step-scoped prepared context, with diagnostics preserving the parent workflow as the target-binding authority.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task has objective context and distinct step-scoped prepared attachments for multiple steps, **When** the first step begins execution, **Then** it receives the objective context plus only attachments targeted to that first step.
+2. **Given** all attachments were materialized in one preparation workspace, **When** any individual step runtime context is assembled, **Then** unrelated step attachments remain excluded from that step's context.
+3. **Given** a step is executed through a MoonMind.AgentRun child workflow, **When** the child input is prepared, **Then** the child receives only prepared context relevant to the represented step.
+4. **Given** child workflow logs or diagnostics are emitted, **When** an operator reviews them, **Then** they describe consumed context without redefining or broadening attachment target-binding semantics.
+5. **Given** a prepared context item cannot be associated with the current step or the task objective, **When** step execution context is assembled, **Then** the system rejects or omits it with explicit evidence rather than leaking it into the step.
+
+### Edge Cases
+
+- A step with no scoped attachments still receives relevant task-level objective context and no unrelated step context.
+- Two steps may use attachments with the same filename or storage location pattern; filtering remains based on target binding, not filename.
+- A child run may be started after prior steps completed; it still receives only context for the represented child step.
+- Diagnostic artifacts may summarize excluded context counts but must not expose unrelated attachment contents to the child step.
+
+## Assumptions
+
+- Objective context is relevant to each step unless a later policy explicitly narrows objective visibility.
+- Prepare-time materialization and manifest generation are handled by existing or preceding target-aware preparation work; this story focuses on execution-time dispatch and child-input scoping.
+- Parent MoonMind.Run has access to prepared target metadata before step runtime or child workflow dispatch.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tasks/TaskArchitecture.md` section 8.3 requires step execution to consume task-level objective context when relevant, consume only the current step's step-scoped image context by default, and avoid leaking unrelated step attachments into the wrong step. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, and FR-008. Original Jira coverage ID: DESIGN-REQ-021.
+- **DESIGN-REQ-002**: Source `docs/Tasks/TaskArchitecture.md` section 8.4 requires MoonMind.AgentRun parent-child boundaries to preserve target-aware prepared context, keep the parent workflow as the source of truth for attachment target binding, send children only context relevant to their step, and prevent child logs or diagnostics from redefining target semantics. Scope: in scope. Maps to FR-005, FR-006, FR-007, and FR-008. Original Jira coverage ID: DESIGN-REQ-022.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST assemble step runtime context from task-level objective context plus only prepared context explicitly targeted to the current step.
+- **FR-002**: System MUST exclude prepared context targeted to other steps from the current step runtime context by default.
+- **FR-003**: System MUST preserve target-aware filtering even when preparation materialized objective and step attachments in the same workspace.
+- **FR-004**: System MUST use explicit target metadata, not filename, path position, step order, or text content, to decide which prepared context belongs to a step.
+- **FR-005**: System MUST pass MoonMind.AgentRun child workflows only the prepared context relevant to the child workflow's represented step.
+- **FR-006**: Parent MoonMind.Run MUST remain the authoritative source of attachment target binding for child workflow dispatch.
+- **FR-007**: Child workflow logs and diagnostics MUST NOT redefine, broaden, or override attachment target-binding semantics.
+- **FR-008**: System MUST produce verification evidence showing unrelated step-scoped context is absent from step runtime inputs and AgentRun child inputs.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key `MM-649` and the canonical Jira preset brief.
+
+### Key Entities
+
+- **Prepared Context Item**: A lightweight reference or derived context artifact with target metadata identifying whether it belongs to the task objective or a specific step.
+- **Step Runtime Context**: The bounded context delivered to a step, composed from relevant objective context and the current step's prepared context.
+- **AgentRun Child Input**: The prepared execution payload sent from MoonMind.Run to a child workflow for one represented step.
+- **Target Binding Authority**: The parent MoonMind.Run state and prepared metadata that define which attachments belong to each objective or step target.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a task with at least two step-scoped attachment sets, 100% of inspected step runtime contexts exclude attachments targeted to other steps.
+- **SC-002**: AgentRun child workflow input verification confirms 100% of child runs receive only the represented step's prepared context plus relevant objective context.
+- **SC-003**: Boundary tests cover at least one same-workspace materialization case where unrelated prepared attachments are present but excluded from a step.
+- **SC-004**: Diagnostic evidence identifies the parent workflow as the target-binding authority and contains no child-side target redefinition.
+- **SC-005**: Traceability review confirms `MM-649`, the canonical Jira preset brief, DESIGN-REQ-001, and DESIGN-REQ-002 remain preserved in MoonSpec artifacts and final verification evidence.

--- a/specs/348-target-aware-step-scope/tasks.md
+++ b/specs/348-target-aware-step-scope/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: Target-Aware Step Execution Scope
+
+**Input**: Design documents from `specs/348-target-aware-step-scope/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write verification tests first, run them before fallback implementation work, and implement only the conditional code changes exposed by failing verification.
+
+**Organization**: Tasks cover exactly one user story: Step-Scoped Execution Context.
+
+**Source Traceability**: MM-649 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-009, acceptance scenarios 1-5, edge cases, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh`
+- Focused unit iteration: `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short`
+- Integration tests: `./tools/test_integration.sh`
+- Focused integration iteration: `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when tasks touch different files and have no dependency on incomplete work.
+- Every task includes exact file paths and the relevant requirement, scenario, success criterion, or source-design IDs.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature artifact set and existing test surfaces before story work.
+
+- [ ] T001 Confirm active feature artifacts exist at `specs/348-target-aware-step-scope/spec.md`, `specs/348-target-aware-step-scope/plan.md`, `specs/348-target-aware-step-scope/research.md`, `specs/348-target-aware-step-scope/data-model.md`, `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, and `specs/348-target-aware-step-scope/quickstart.md` for FR-009 and SC-005.
+- [ ] T002 Review existing prepared-context and workflow boundary tests in `tests/unit/workflows/tasks/test_prepared_context.py`, `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, and `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for FR-001, FR-002, FR-004, FR-005, FR-008, and DESIGN-REQ-001.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish traceability and boundary assumptions before adding story verification tests.
+
+**CRITICAL**: No story implementation or fallback code changes can begin until this phase is complete.
+
+- [ ] T003 Verify `specs/348-target-aware-step-scope/spec.md` contains exactly one `## User Story -` section and no `[NEEDS CLARIFICATION]` markers for the single-story gate.
+- [ ] T004 Build a requirement coverage checklist from `specs/348-target-aware-step-scope/plan.md` covering all `implemented_verified`, `implemented_unverified`, and `missing` rows for FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T005 Confirm no new persistent storage or new external provider dependency is needed by reviewing `specs/348-target-aware-step-scope/data-model.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md` for Constitution principles II, III, IV, IX, and XIII.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Step-Scoped Execution Context
+
+**Summary**: As an execution-plane engineer, I want each step and delegated AgentRun child to receive only the prepared context relevant to that step so attachments cannot leak across step boundaries.
+
+**Independent Test**: Run or simulate a task with objective context and at least two steps that each have distinct prepared attachments, then verify each step runtime and AgentRun child receives objective context plus only its own step-scoped prepared context, with diagnostics preserving the parent workflow as the target-binding authority.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, DESIGN-REQ-001, DESIGN-REQ-002.
+
+**Unit Test Plan**:
+
+- Preserve existing verified unit coverage for current-step-only context selection.
+- Add verification-first unit coverage for same-workspace exclusion, parent authority metadata, child diagnostic non-redefinition, and MM-649 traceability.
+
+**Integration Test Plan**:
+
+- Preserve existing run-boundary integration coverage for objective plus current-step refs.
+- Add verification-first integration coverage for AgentRun child input scoping and same-workspace prepared attachments.
+
+### Unit Tests (write first)
+
+- [ ] T006 [P] Add verification-first unit test for same-workspace prepared attachments excluding sibling-step refs in `tests/unit/workflows/tasks/test_prepared_context.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [ ] T007 [P] Add verification-first unit test for parent-owned prepared context metadata on AgentRun child requests in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-006, SCN-003, SC-002, and DESIGN-REQ-002.
+- [ ] T008 [P] Add verification-first unit test proving child workflow result metadata or diagnostics do not redefine parent target binding in `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py` covering FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
+- [ ] T009 [P] Add MM-649 traceability unit test in `tests/unit/specs/test_mm649_traceability.py` covering FR-009 and SC-005 across `specs/348-target-aware-step-scope/spec.md`, `plan.md`, and `tasks.md`.
+- [ ] T010 Run `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-006, FR-007, FR-009, SC-003, SC-004, SC-005, and DESIGN-REQ-002.
+
+### Integration Tests (write first)
+
+- [ ] T011 [P] Add verification-first integration test for AgentRun child input scoping in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-005, FR-006, SC-002, SCN-003, and DESIGN-REQ-002.
+- [ ] T012 [P] Add verification-first integration test for same-workspace prepared attachment materialization excluding sibling-step refs in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [ ] T013 Run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-005, FR-006, SC-002, SC-003, and DESIGN-REQ-002.
+
+### Red-First Confirmation
+
+- [ ] T014 Confirm T006-T013 were executed before production code changes; for `implemented_unverified` rows, mark passing verification tasks as no-code-needed and failing verification tasks as requiring the conditional fallback implementation in `specs/348-target-aware-step-scope/tasks.md`.
+- [ ] T015 Confirm existing verified behavior remains covered by current tests before fallback changes by reviewing T010 and T013 output for FR-001, FR-002, FR-004, FR-005, FR-008, SCN-001, SCN-003, SC-001, and DESIGN-REQ-001.
+
+### Conditional Fallback Implementation
+
+- [ ] T016 If T006 or T012 fails, update prepared-context selection or metadata handling in `moonmind/workflows/tasks/prepared_context.py` so same-workspace manifests still expose only objective plus current-step refs for FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [ ] T017 If T007 or T011 fails, update parent workflow request assembly in `moonmind/workflows/temporal/workflows/run.py` so `parameters.metadata.moonmind.preparedContext` remains parent-owned and scoped to the represented step for FR-006, SC-002, and DESIGN-REQ-002.
+- [ ] T018 If T008 fails, update child workflow result or diagnostic metadata handling in `moonmind/workflows/temporal/workflows/agent_run.py` so child diagnostics preserve parent target binding without redefining or broadening scope for FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
+- [ ] T019 If T016-T018 change workflow boundary payloads, update or add compatibility-sensitive regression coverage in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py`, or `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for Constitution principle IX and DESIGN-REQ-002.
+
+### Story Validation
+
+- [ ] T020 Run focused unit command `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` after any fallback implementation and confirm FR-001 through FR-009 coverage.
+- [ ] T021 Run focused integration command `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` after any fallback implementation and confirm SCN-001 through SCN-005 and SC-001 through SC-004 coverage.
+- [ ] T022 Validate the story against `specs/348-target-aware-step-scope/quickstart.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, confirming objective refs, current-step refs, AgentRun child inputs, diagnostics, and sibling-step exclusions for FR-001 through FR-008 and DESIGN-REQ-001 through DESIGN-REQ-002.
+
+**Checkpoint**: The single story is verified, covered by unit and integration tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T023 [P] Update implementation notes or verification notes in `specs/348-target-aware-step-scope/research.md` only if fallback implementation changes alter the plan assumptions for FR-003, FR-006, FR-007, or DESIGN-REQ-002.
+- [ ] T024 [P] Confirm `MM-649`, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002 remain present in `specs/348-target-aware-step-scope/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`, and `tasks.md`.
+- [ ] T025 Run `./tools/test_unit.sh` for final unit verification covering FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-002.
+- [ ] T026 Run `./tools/test_integration.sh` for final hermetic integration verification covering SCN-001 through SCN-005 and SC-001 through SC-004.
+- [ ] T027 Run `/moonspec-verify` for `specs/348-target-aware-step-scope/spec.md` after implementation and tests pass, preserving MM-649, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002 in final verification evidence.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish & Verification (Phase 4)**: Depends on story validation and passing focused tests.
+
+### Within The Story
+
+- Unit verification tasks T006-T010 must run before fallback implementation tasks T016-T019.
+- Integration verification tasks T011-T013 must run before fallback implementation tasks T016-T019.
+- Red-first confirmation tasks T014-T015 must complete before production code fallback changes.
+- Conditional fallback implementation tasks T016-T019 are skipped when verification tests pass.
+- Story validation tasks T020-T022 run after tests and any fallback implementation.
+- Final verification tasks T025-T027 run after focused story validation passes.
+
+### Parallel Opportunities
+
+- T006, T007, T008, and T009 can run in parallel because they target distinct unit test files.
+- T011 and T012 can be authored together only if coordinated carefully in the same integration test file.
+- T023 and T024 can run in parallel after story validation because they touch documentation/traceability surfaces.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent unit test authoring together:
+Task: "Add same-workspace prepared-context unit coverage in tests/unit/workflows/tasks/test_prepared_context.py"
+Task: "Add parent authority request metadata unit coverage in tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py"
+Task: "Add child diagnostic non-redefinition unit coverage in tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py"
+Task: "Add MM-649 traceability unit coverage in tests/unit/specs/test_mm649_traceability.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Verification-First Story Delivery
+
+1. Complete Phase 1 and Phase 2 artifact/traceability checks.
+2. Add unit verification tests for all `implemented_unverified` and `missing` rows.
+3. Add integration verification tests for workflow and AgentRun child boundary scenarios.
+4. Run focused tests before production code changes.
+5. If verification passes, skip conditional fallback implementation tasks and preserve evidence.
+6. If verification fails, complete only the matching fallback implementation tasks.
+7. Re-run focused unit and integration commands.
+8. Run full `./tools/test_unit.sh` and `./tools/test_integration.sh`.
+9. Run final `/moonspec-verify`.
+
+### Requirement Status Handling
+
+- Already verified: FR-001, FR-002, FR-004, FR-005, FR-008, SCN-001, SCN-003, SC-001, DESIGN-REQ-001; preserve with final validation only.
+- Verification-only first: FR-003, FR-006, FR-007, SCN-002, SCN-004, SCN-005, SC-002, SC-003, SC-004, DESIGN-REQ-002.
+- Missing traceability/final evidence: FR-009 and SC-005; cover through T009, T024, and T027.
+- Conditional fallback code changes: T016-T019 only run if verification tests fail.
+
+---
+
+## Notes
+
+- This task list covers exactly one story.
+- Do not add new persistent storage, provider credentials, or broad runtime refactors.
+- Preserve workflow payload compatibility for parent-child AgentRun boundaries.
+- Do not introduce compatibility aliases or fallback transforms that silently change target semantics.
+- Keep large or binary attachment content out of workflow-visible payloads.

--- a/specs/348-target-aware-step-scope/tasks.md
+++ b/specs/348-target-aware-step-scope/tasks.md
@@ -7,7 +7,7 @@
 
 **Organization**: Tasks cover exactly one user story: Step-Scoped Execution Context.
 
-**Source Traceability**: MM-649 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-009, acceptance scenarios 1-5, edge cases, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+**Source Traceability**: MM-649 and the canonical Jira preset brief are preserved in `spec.md`. This task list covers FR-001 through FR-009, acceptance scenarios 1-5, edge cases, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002. Original Jira coverage IDs DESIGN-REQ-021 and DESIGN-REQ-022 are preserved through the DESIGN-REQ-001 and DESIGN-REQ-002 source mappings.
 
 **Test Commands**:
 
@@ -38,7 +38,7 @@
 **CRITICAL**: No story implementation or fallback code changes can begin until this phase is complete.
 
 - [ ] T003 Verify `specs/348-target-aware-step-scope/spec.md` contains exactly one `## User Story -` section and no `[NEEDS CLARIFICATION]` markers for the single-story gate.
-- [ ] T004 Build a requirement coverage checklist from `specs/348-target-aware-step-scope/plan.md` covering all `implemented_verified`, `implemented_unverified`, and `missing` rows for FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002.
+- [ ] T004 Build a requirement coverage checklist from `specs/348-target-aware-step-scope/plan.md` covering all `implemented_verified`, `implemented_unverified`, and `missing` rows for FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022.
 - [ ] T005 Confirm no new persistent storage or new external provider dependency is needed by reviewing `specs/348-target-aware-step-scope/data-model.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md` for Constitution principles II, III, IV, IX, and XIII.
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
@@ -104,10 +104,10 @@
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
 - [ ] T023 [P] Update implementation notes or verification notes in `specs/348-target-aware-step-scope/research.md` only if fallback implementation changes alter the plan assumptions for FR-003, FR-006, FR-007, or DESIGN-REQ-002.
-- [ ] T024 [P] Confirm `MM-649`, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002 remain present in `specs/348-target-aware-step-scope/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`, and `tasks.md`.
+- [ ] T024 [P] Confirm `MM-649`, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022 remain present in `specs/348-target-aware-step-scope/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`, and `tasks.md`.
 - [ ] T025 Run `./tools/test_unit.sh` for final unit verification covering FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-002.
 - [ ] T026 Run `./tools/test_integration.sh` for final hermetic integration verification covering SCN-001 through SCN-005 and SC-001 through SC-004.
-- [ ] T027 Run `/moonspec-verify` for `specs/348-target-aware-step-scope/spec.md` after implementation and tests pass, preserving MM-649, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, and DESIGN-REQ-002 in final verification evidence.
+- [ ] T027 Run `/moonspec-verify` for `specs/348-target-aware-step-scope/spec.md` after implementation and tests pass, preserving MM-649, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022 in final verification evidence.
 
 ---
 
@@ -167,7 +167,7 @@ Task: "Add MM-649 traceability unit coverage in tests/unit/specs/test_mm649_trac
 
 - Already verified: FR-001, FR-002, FR-004, FR-005, FR-008, SCN-001, SCN-003, SC-001, DESIGN-REQ-001; preserve with final validation only.
 - Verification-only first: FR-003, FR-006, FR-007, SCN-002, SCN-004, SCN-005, SC-002, SC-003, SC-004, DESIGN-REQ-002.
-- Missing traceability/final evidence: FR-009 and SC-005; cover through T009, T024, and T027.
+- Missing traceability/final evidence: FR-009, SC-005, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022; cover through T009, T024, and T027.
 - Conditional fallback code changes: T016-T019 only run if verification tests fail.
 
 ---

--- a/specs/348-target-aware-step-scope/tasks.md
+++ b/specs/348-target-aware-step-scope/tasks.md
@@ -26,8 +26,8 @@
 
 **Purpose**: Confirm the feature artifact set and existing test surfaces before story work.
 
-- [ ] T001 Confirm active feature artifacts exist at `specs/348-target-aware-step-scope/spec.md`, `specs/348-target-aware-step-scope/plan.md`, `specs/348-target-aware-step-scope/research.md`, `specs/348-target-aware-step-scope/data-model.md`, `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, and `specs/348-target-aware-step-scope/quickstart.md` for FR-009 and SC-005.
-- [ ] T002 Review existing prepared-context and workflow boundary tests in `tests/unit/workflows/tasks/test_prepared_context.py`, `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, and `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for FR-001, FR-002, FR-004, FR-005, FR-008, and DESIGN-REQ-001.
+- [X] T001 Confirm active feature artifacts exist at `specs/348-target-aware-step-scope/spec.md`, `specs/348-target-aware-step-scope/plan.md`, `specs/348-target-aware-step-scope/research.md`, `specs/348-target-aware-step-scope/data-model.md`, `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, and `specs/348-target-aware-step-scope/quickstart.md` for FR-009 and SC-005.
+- [X] T002 Review existing prepared-context and workflow boundary tests in `tests/unit/workflows/tasks/test_prepared_context.py`, `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, and `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for FR-001, FR-002, FR-004, FR-005, FR-008, and DESIGN-REQ-001.
 
 ---
 
@@ -37,9 +37,9 @@
 
 **CRITICAL**: No story implementation or fallback code changes can begin until this phase is complete.
 
-- [ ] T003 Verify `specs/348-target-aware-step-scope/spec.md` contains exactly one `## User Story -` section and no `[NEEDS CLARIFICATION]` markers for the single-story gate.
-- [ ] T004 Build a requirement coverage checklist from `specs/348-target-aware-step-scope/plan.md` covering all `implemented_verified`, `implemented_unverified`, and `missing` rows for FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022.
-- [ ] T005 Confirm no new persistent storage or new external provider dependency is needed by reviewing `specs/348-target-aware-step-scope/data-model.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md` for Constitution principles II, III, IV, IX, and XIII.
+- [X] T003 Verify `specs/348-target-aware-step-scope/spec.md` contains exactly one `## User Story -` section and no `[NEEDS CLARIFICATION]` markers for the single-story gate.
+- [X] T004 Build a requirement coverage checklist from `specs/348-target-aware-step-scope/plan.md` covering all `implemented_verified`, `implemented_unverified`, and `missing` rows for FR-001 through FR-009, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022.
+- [X] T005 Confirm no new persistent storage or new external provider dependency is needed by reviewing `specs/348-target-aware-step-scope/data-model.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md` for Constitution principles II, III, IV, IX, and XIII.
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -65,35 +65,35 @@
 
 ### Unit Tests (write first)
 
-- [ ] T006 [P] Add verification-first unit test for same-workspace prepared attachments excluding sibling-step refs in `tests/unit/workflows/tasks/test_prepared_context.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
-- [ ] T007 [P] Add verification-first unit test for parent-owned prepared context metadata on AgentRun child requests in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-006, SCN-003, SC-002, and DESIGN-REQ-002.
-- [ ] T008 [P] Add verification-first unit test proving child workflow result metadata or diagnostics do not redefine parent target binding in `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py` covering FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
-- [ ] T009 [P] Add MM-649 traceability unit test in `tests/unit/specs/test_mm649_traceability.py` covering FR-009 and SC-005 across `specs/348-target-aware-step-scope/spec.md`, `plan.md`, and `tasks.md`.
-- [ ] T010 Run `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-006, FR-007, FR-009, SC-003, SC-004, SC-005, and DESIGN-REQ-002.
+- [X] T006 [P] Add verification-first unit test for same-workspace prepared attachments excluding sibling-step refs in `tests/unit/workflows/tasks/test_prepared_context.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [X] T007 [P] Add verification-first unit test for parent-owned prepared context metadata on AgentRun child requests in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-006, SCN-003, SC-002, and DESIGN-REQ-002.
+- [X] T008 [P] Add verification-first unit test proving child workflow result metadata or diagnostics do not redefine parent target binding in `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py` covering FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
+- [X] T009 [P] Add MM-649 traceability unit test in `tests/unit/specs/test_mm649_traceability.py` covering FR-009 and SC-005 across `specs/348-target-aware-step-scope/spec.md`, `plan.md`, and `tasks.md`.
+- [X] T010 Run `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-006, FR-007, FR-009, SC-003, SC-004, SC-005, and DESIGN-REQ-002.
 
 ### Integration Tests (write first)
 
-- [ ] T011 [P] Add verification-first integration test for AgentRun child input scoping in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-005, FR-006, SC-002, SCN-003, and DESIGN-REQ-002.
-- [ ] T012 [P] Add verification-first integration test for same-workspace prepared attachment materialization excluding sibling-step refs in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
-- [ ] T013 Run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-005, FR-006, SC-002, SC-003, and DESIGN-REQ-002.
+- [X] T011 [P] Add verification-first integration test for AgentRun child input scoping in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-005, FR-006, SC-002, SCN-003, and DESIGN-REQ-002.
+- [X] T012 [P] Add verification-first integration test for same-workspace prepared attachment materialization excluding sibling-step refs in `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` covering FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [X] T013 Run `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` and record which verification tests pass, fail, or require fallback implementation for FR-003, FR-005, FR-006, SC-002, SC-003, and DESIGN-REQ-002.
 
 ### Red-First Confirmation
 
-- [ ] T014 Confirm T006-T013 were executed before production code changes; for `implemented_unverified` rows, mark passing verification tasks as no-code-needed and failing verification tasks as requiring the conditional fallback implementation in `specs/348-target-aware-step-scope/tasks.md`.
-- [ ] T015 Confirm existing verified behavior remains covered by current tests before fallback changes by reviewing T010 and T013 output for FR-001, FR-002, FR-004, FR-005, FR-008, SCN-001, SCN-003, SC-001, and DESIGN-REQ-001.
+- [X] T014 Confirm T006-T013 were executed before production code changes; for `implemented_unverified` rows, mark passing verification tasks as no-code-needed and failing verification tasks as requiring the conditional fallback implementation in `specs/348-target-aware-step-scope/tasks.md`.
+- [X] T015 Confirm existing verified behavior remains covered by current tests before fallback changes by reviewing T010 and T013 output for FR-001, FR-002, FR-004, FR-005, FR-008, SCN-001, SCN-003, SC-001, and DESIGN-REQ-001.
 
 ### Conditional Fallback Implementation
 
-- [ ] T016 If T006 or T012 fails, update prepared-context selection or metadata handling in `moonmind/workflows/tasks/prepared_context.py` so same-workspace manifests still expose only objective plus current-step refs for FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
-- [ ] T017 If T007 or T011 fails, update parent workflow request assembly in `moonmind/workflows/temporal/workflows/run.py` so `parameters.metadata.moonmind.preparedContext` remains parent-owned and scoped to the represented step for FR-006, SC-002, and DESIGN-REQ-002.
-- [ ] T018 If T008 fails, update child workflow result or diagnostic metadata handling in `moonmind/workflows/temporal/workflows/agent_run.py` so child diagnostics preserve parent target binding without redefining or broadening scope for FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
-- [ ] T019 If T016-T018 change workflow boundary payloads, update or add compatibility-sensitive regression coverage in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py`, or `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for Constitution principle IX and DESIGN-REQ-002.
+- [X] T016 If T006 or T012 fails, update prepared-context selection or metadata handling in `moonmind/workflows/tasks/prepared_context.py` so same-workspace manifests still expose only objective plus current-step refs for FR-003, SCN-002, SC-003, and DESIGN-REQ-001.
+- [X] T017 If T007 or T011 fails, update parent workflow request assembly in `moonmind/workflows/temporal/workflows/run.py` so `parameters.metadata.moonmind.preparedContext` remains parent-owned and scoped to the represented step for FR-006, SC-002, and DESIGN-REQ-002.
+- [X] T018 If T008 fails, update child workflow result or diagnostic metadata handling in `moonmind/workflows/temporal/workflows/agent_run.py` so child diagnostics preserve parent target binding without redefining or broadening scope for FR-007, SCN-004, SC-004, and DESIGN-REQ-002.
+- [X] T019 If T016-T018 change workflow boundary payloads, update or add compatibility-sensitive regression coverage in `tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`, `tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py`, or `tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py` for Constitution principle IX and DESIGN-REQ-002.
 
 ### Story Validation
 
-- [ ] T020 Run focused unit command `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` after any fallback implementation and confirm FR-001 through FR-009 coverage.
-- [ ] T021 Run focused integration command `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` after any fallback implementation and confirm SCN-001 through SCN-005 and SC-001 through SC-004 coverage.
-- [ ] T022 Validate the story against `specs/348-target-aware-step-scope/quickstart.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, confirming objective refs, current-step refs, AgentRun child inputs, diagnostics, and sibling-step exclusions for FR-001 through FR-008 and DESIGN-REQ-001 through DESIGN-REQ-002.
+- [X] T020 Run focused unit command `pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py tests/unit/specs/test_mm649_traceability.py -q --tb=short` after any fallback implementation and confirm FR-001 through FR-009 coverage.
+- [X] T021 Run focused integration command `pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -m 'integration_ci' -q --tb=short` after any fallback implementation and confirm SCN-001 through SCN-005 and SC-001 through SC-004 coverage.
+- [X] T022 Validate the story against `specs/348-target-aware-step-scope/quickstart.md` and `specs/348-target-aware-step-scope/contracts/step-context-scope.md`, confirming objective refs, current-step refs, AgentRun child inputs, diagnostics, and sibling-step exclusions for FR-001 through FR-008 and DESIGN-REQ-001 through DESIGN-REQ-002.
 
 **Checkpoint**: The single story is verified, covered by unit and integration tests, and independently testable.
 
@@ -103,9 +103,9 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T023 [P] Update implementation notes or verification notes in `specs/348-target-aware-step-scope/research.md` only if fallback implementation changes alter the plan assumptions for FR-003, FR-006, FR-007, or DESIGN-REQ-002.
-- [ ] T024 [P] Confirm `MM-649`, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022 remain present in `specs/348-target-aware-step-scope/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`, and `tasks.md`.
-- [ ] T025 Run `./tools/test_unit.sh` for final unit verification covering FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-002.
+- [X] T023 [P] Update implementation notes or verification notes in `specs/348-target-aware-step-scope/research.md` only if fallback implementation changes alter the plan assumptions for FR-003, FR-006, FR-007, or DESIGN-REQ-002.
+- [X] T024 [P] Confirm `MM-649`, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022 remain present in `specs/348-target-aware-step-scope/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/step-context-scope.md`, `quickstart.md`, and `tasks.md`.
+- [X] T025 Run `./tools/test_unit.sh` for final unit verification covering FR-001 through FR-009 and DESIGN-REQ-001 through DESIGN-REQ-002.
 - [ ] T026 Run `./tools/test_integration.sh` for final hermetic integration verification covering SCN-001 through SCN-005 and SC-001 through SC-004.
 - [ ] T027 Run `/moonspec-verify` for `specs/348-target-aware-step-scope/spec.md` after implementation and tests pass, preserving MM-649, the canonical Jira preset brief, FR-001 through FR-009, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, and original Jira coverage IDs DESIGN-REQ-021 through DESIGN-REQ-022 in final verification evidence.
 

--- a/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -60,6 +60,96 @@ def test_run_boundary_prepares_objective_and_current_step_context_only() -> None
     ] == {"objective": 1, "step": 1}
 
 
+def test_agent_run_child_input_scope_is_parent_selected() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=SimpleNamespace(
+            workflow_id="run-target-aware-child",
+            run_id="run-id-1",
+            namespace="default",
+        ),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "jules"}},
+            node_id="second-step",
+            tool_name="jules",
+            workflow_parameters={
+                "task": {
+                    "inputAttachments": [{"artifactId": "objective-artifact"}],
+                    "steps": [
+                        {
+                            "id": "first-step",
+                            "inputAttachments": [{"artifactId": "first-step-artifact"}],
+                        },
+                        {
+                            "id": "second-step",
+                            "inputAttachments": [
+                                {"artifactId": "second-step-artifact"}
+                            ],
+                        },
+                    ],
+                }
+            },
+        )
+
+    dumped = request.model_dump(by_alias=True)
+    prepared_context = dumped["parameters"]["metadata"]["moonmind"]["preparedContext"]
+
+    assert dumped["agentKind"] == "external"
+    assert prepared_context["logicalStepId"] == "second-step"
+    assert "objective-artifact" in str(dumped)
+    assert "second-step-artifact" in str(dumped)
+    assert "first-step-artifact" not in str(dumped)
+
+
+def test_same_workspace_materialization_excludes_sibling_step_refs() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=SimpleNamespace(
+            workflow_id="run-target-aware-shared-workspace",
+            run_id="run-id-1",
+            namespace="default",
+        ),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="first-step",
+            tool_name="codex_cli",
+            workflow_parameters={
+                "task": {
+                    "steps": [
+                        {
+                            "id": "first-step",
+                            "inputAttachments": [
+                                {"artifactId": "shared-image", "filename": "image.png"}
+                            ],
+                        },
+                        {
+                            "id": "second-step",
+                            "inputAttachments": [
+                                {
+                                    "artifactId": "shared-image-copy",
+                                    "filename": "image.png",
+                                }
+                            ],
+                        },
+                    ],
+                }
+            },
+        )
+
+    dumped = request.model_dump(by_alias=True)
+    prepared_context = dumped["parameters"]["metadata"]["moonmind"]["preparedContext"]
+
+    assert request.input_refs == []
+    assert prepared_context["logicalStepId"] == "first-step"
+    assert "prepared-context://steps/first-step/shared-image" in str(prepared_context)
+    assert "shared-image-copy" not in str(prepared_context)
+    assert "second-step" not in str(prepared_context)
+
+
 def test_prepare_boundary_reports_target_for_invalid_step_attachment() -> None:
     payload = build_target_aware_prepared_context_payload(
         {

--- a/tests/unit/specs/test_mm649_traceability.py
+++ b/tests/unit/specs/test_mm649_traceability.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FEATURE_DIR = Path("specs/348-target-aware-step-scope")
+
+
+def test_mm649_moonspec_artifacts_preserve_required_traceability() -> None:
+    required = {
+        "MM-649",
+        "canonical Jira preset brief",
+        "DESIGN-REQ-001",
+        "DESIGN-REQ-002",
+        "DESIGN-REQ-021",
+        "DESIGN-REQ-022",
+        "FR-009",
+        "SC-005",
+    }
+    artifact_names = [
+        "spec.md",
+        "plan.md",
+        "research.md",
+        "quickstart.md",
+        "tasks.md",
+        "moonspec_align_report.md",
+    ]
+
+    for artifact_name in artifact_names:
+        text = (FEATURE_DIR / artifact_name).read_text()
+        missing = sorted(item for item in required if item not in text)
+        assert not missing, f"{artifact_name} missing {missing}"

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -255,6 +255,58 @@ def test_select_step_context_includes_objective_and_current_step_only() -> None:
     assert "artifact-step-2" not in str(context.model_dump(by_alias=True))
 
 
+def test_select_step_context_excludes_sibling_refs_from_shared_workspace() -> None:
+    manifest = PreparedInputManifest.model_validate(
+        {
+            "manifestRef": "prepared-context-manifest://task-inputs",
+            "entries": [
+                {
+                    "artifactId": "objective-image",
+                    "targetKind": "objective",
+                    "rawInputRef": "artifact://objective-image",
+                    "derivedContextRef": "prepared-context://objective/objective-image",
+                    "workspacePath": ".moonmind/inputs/shared/objective-image.png",
+                },
+                {
+                    "artifactId": "collect-image",
+                    "targetKind": "step",
+                    "stepRef": "collect-evidence",
+                    "rawInputRef": "artifact://collect-image",
+                    "derivedContextRef": (
+                        "prepared-context://steps/collect-evidence/collect-image"
+                    ),
+                    "workspacePath": ".moonmind/inputs/shared/image.png",
+                },
+                {
+                    "artifactId": "report-image",
+                    "targetKind": "step",
+                    "stepRef": "write-report",
+                    "rawInputRef": "artifact://report-image",
+                    "derivedContextRef": (
+                        "prepared-context://steps/write-report/report-image"
+                    ),
+                    "workspacePath": ".moonmind/inputs/shared/image.png",
+                },
+            ],
+        }
+    )
+
+    context = select_step_prepared_context(
+        manifest,
+        logical_step_id="collect-evidence",
+    )
+    dumped = context.model_dump(by_alias=True)
+
+    assert context.objective_context_refs == [
+        "prepared-context://objective/objective-image"
+    ]
+    assert context.step_context_refs == [
+        "prepared-context://steps/collect-evidence/collect-image"
+    ]
+    assert "report-image" not in str(dumped)
+    assert "write-report" not in str(dumped)
+
+
 def test_step_context_metadata_is_bounded_and_target_aware() -> None:
     manifest = build_prepared_input_manifest(_task_payload())
     context = select_step_prepared_context(manifest, logical_step_id="collect-evidence")

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+def _configure_workflow_runtime(monkeypatch):
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-agent-run-prepared-context",
+            "run_id": "run-prepared-context",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+
+
+def _request() -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="external",
+        agentId="jules",
+        executionProfileRef="jules-default",
+        correlationId="corr-prepared-context",
+        idempotencyKey="idem-prepared-context",
+        parameters={
+            "metadata": {
+                "moonmind": {
+                    "preparedContext": {
+                        "manifestRef": "prepared-context-manifest://task-inputs",
+                        "logicalStepId": "collect-evidence",
+                        "objectiveContextRefs": [
+                            "prepared-context://objective/objective-image"
+                        ],
+                        "stepContextRefs": [
+                            "prepared-context://steps/collect-evidence/collect-notes"
+                        ],
+                        "rawInputRefs": [
+                            "artifact://objective-image",
+                            "artifact://collect-notes",
+                        ],
+                        "inputRefs": [
+                            "prepared-context://objective/objective-image",
+                            "prepared-context://steps/collect-evidence/collect-notes",
+                            "artifact://objective-image",
+                            "artifact://collect-notes",
+                        ],
+                        "targetCounts": {"objective": 1, "step": 1},
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_result_metadata_preserves_parent_prepared_context_authority(monkeypatch):
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+
+    result = run._enrich_result_metadata(
+        request=_request(),
+        result=AgentRunResult(
+            summary="done",
+            metadata={
+                "moonmind": {
+                    "preparedContext": {
+                        "manifestRef": "prepared-context-manifest://child",
+                        "logicalStepId": "write-report",
+                        "stepContextRefs": [
+                            "prepared-context://steps/write-report/report-notes"
+                        ],
+                    }
+                }
+            },
+        ),
+    )
+
+    assert result is not None
+    moonmind_metadata = result.metadata["moonmind"]
+    assert moonmind_metadata["preparedContext"]["logicalStepId"] == "collect-evidence"
+    assert moonmind_metadata["preparedContext"]["stepContextRefs"] == [
+        "prepared-context://steps/collect-evidence/collect-notes"
+    ]
+    assert "write-report" not in str(moonmind_metadata)
+    assert "report-notes" not in str(moonmind_metadata)

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -83,6 +83,24 @@ def test_child_agent_run_request_receives_only_represented_step_context() -> Non
     assert "collect-notes" not in str(request.model_dump(by_alias=True))
 
 
+def test_parent_request_metadata_is_target_binding_authority() -> None:
+    request = _build_request_for_step("collect-evidence")
+
+    moonmind_metadata = request.parameters["metadata"]["moonmind"]
+    prepared_context = moonmind_metadata["preparedContext"]
+
+    assert prepared_context["logicalStepId"] == "collect-evidence"
+    assert prepared_context["manifestRef"].startswith("prepared-context-manifest://")
+    assert prepared_context["objectiveContextRefs"] == [
+        "prepared-context://objective/objective-image"
+    ]
+    assert prepared_context["stepContextRefs"] == [
+        "prepared-context://steps/collect-evidence/collect-notes"
+    ]
+    assert "report-notes" not in str(moonmind_metadata)
+    assert "preparedContext" not in request.workspace_spec
+
+
 def test_managed_codex_request_keeps_prepared_context_out_of_input_refs() -> None:
     wf = MoonMindRunWorkflow()
     with patch(


### PR DESCRIPTION
Change Jira issue MM-649 to status In Progress before implementation starts.

Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.