### PR TITLE
[codex] Stop after publish handoff failures

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -203,6 +203,9 @@ NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
 NATIVE_PR_BRANCH_DEFAULTS_PATCH = "native-pr-branch-defaults-v1"
 NATIVE_PR_PUSH_STATUS_GATE_PATCH = "native-pr-push-status-gate-v1"
 NATIVE_PR_LEASE_CONFLICT_GATE_PATCH = "native-pr-lease-conflict-gate-v1"
+RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH = (
+    "run-stop-on-publish-handoff-failure-v1"
+)
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
@@ -2817,10 +2820,33 @@ class MoonMindRunWorkflow:
                 self._refresh_step_readiness(updated_at=workflow.now())
                 self._update_memo()
                 break
+            publish_status_before = self._publish_status
             self._record_publish_result(
                 parameters=parameters,
                 execution_result=execution_result,
             )
+            if (
+                self._publish_status == "failed"
+                and publish_status_before != "failed"
+                and workflow.patched(RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH)
+            ):
+                publish_failure_summary = self._publish_reason or "Publish failed"
+                self._summary = publish_failure_summary
+                self._mark_step_terminal(
+                    node_id,
+                    status="failed",
+                    updated_at=workflow.now(),
+                    summary=publish_failure_summary,
+                    last_error="publish_failed",
+                )
+                self._mark_remaining_plan_steps_skipped(
+                    ordered_nodes=ordered_nodes,
+                    completed_index=index - 1,
+                    summary=publish_failure_summary,
+                )
+                self._refresh_step_readiness(updated_at=workflow.now())
+                self._update_memo()
+                break
             if (
                 pr_publish_optional
                 and publish_mode == "pr"
@@ -3714,6 +3740,9 @@ class MoonMindRunWorkflow:
         parameters: Mapping[str, Any],
         execution_result: Any,
     ) -> None:
+        if self._publish_status == "failed":
+            return
+
         publish_mode = self._publish_mode(parameters)
         if publish_mode not in {"pr", "branch"}:
             return

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -73,6 +73,7 @@ from moonmind.workflows.skills.approval_policy import (
 )
 from moonmind.workflows.skills.skill_registry import parse_skill_registry
 from moonmind.workflows.temporal.step_ledger import (
+    TERMINAL_STEP_STATUSES,
     build_initial_step_rows,
     build_progress_summary,
     build_step_ledger_snapshot,
@@ -3268,6 +3269,16 @@ class MoonMindRunWorkflow:
             node_id = str(node.get("id") or "").strip()
             if not node_id:
                 continue
+            current_row = next(
+                (
+                    row
+                    for row in self._step_ledger_rows
+                    if row.get("logicalStepId") == node_id
+                ),
+                None,
+            )
+            if str((current_row or {}).get("status") or "") in TERMINAL_STEP_STATUSES:
+                continue
             try:
                 self._mark_step_terminal(
                     node_id,
@@ -3740,7 +3751,10 @@ class MoonMindRunWorkflow:
         parameters: Mapping[str, Any],
         execution_result: Any,
     ) -> None:
-        if self._publish_status == "failed":
+        if (
+            self._publish_status == "failed"
+            and workflow.patched(RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH)
+        ):
             return
 
         publish_mode = self._publish_mode(parameters)

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2271,6 +2271,128 @@ async def test_run_execution_stage_skips_native_pr_after_push_failure(
     assert wf._publish_reason == "publish failed: working branch 'main' is protected"
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_stops_after_publish_lease_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wf = MoonMindRunWorkflow()
+    wf._owner_id = "owner-1"
+    wf._repo = "MoonLadderStudios/MoonMind"
+    child_workflow_ids: list[str] = []
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+
+        if activity_type == "artifact.read":
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Two Step Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "node-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "claude"},
+                                "instructions": "Create spec artifacts",
+                            },
+                            "options": {},
+                        },
+                        {
+                            "id": "node-2",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "claude"},
+                                "instructions": "Implement the spec",
+                            },
+                            "options": {},
+                        },
+                    ],
+                    "edges": [{"from": "node-1", "to": "node-2"}],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **kwargs: object,
+    ) -> object:
+        child_workflow_ids.append(str(kwargs.get("id") or ""))
+        return {
+            "summary": "Completed with status completed",
+            "metadata": {
+                "push_status": "lease_conflict",
+                "push_branch": "feature/stale",
+                "push_error": "! [rejected] feature/stale (stale info)",
+                "diagnostic_kind": "publish_lease_conflict",
+                "retryable": True,
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await wf._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert len(child_workflow_ids) == 1
+    assert child_workflow_ids[0].endswith(":agent:node-1")
+    assert not create_pr_called
+    assert wf._publish_status == "failed"
+    assert "remote branch 'feature/stale' changed" in (wf._publish_reason or "")
+
+@pytest.mark.asyncio
 async def test_run_proposals_stage_global_disable_halts_execution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2391,6 +2391,10 @@ async def test_run_execution_stage_stops_after_publish_lease_conflict(
     assert not create_pr_called
     assert wf._publish_status == "failed"
     assert "remote branch 'feature/stale' changed" in (wf._publish_reason or "")
+    steps = wf.get_step_ledger()["steps"]
+    assert steps[0]["status"] == "failed"
+    assert steps[0]["lastError"] == "publish_failed"
+    assert steps[1]["status"] == "skipped"
 
 @pytest.mark.asyncio
 async def test_run_proposals_stage_global_disable_halts_execution(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1164,6 +1164,38 @@ def test_native_pr_push_status_gate_blocks_unrecovered_lease_conflict(
         mock_run_workflow._publish_reason or ""
     )
 
+def test_publish_failure_preservation_is_patch_gated(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._publish_status = "failed"
+    mock_run_workflow._publish_reason = "first publish failure"
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={"outputs": {"push_status": "no_commits"}},
+    )
+
+    assert mock_run_workflow._publish_status == "skipped"
+
+    mock_run_workflow._publish_status = "failed"
+    mock_run_workflow._publish_reason = "first publish failure"
+
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == run_workflow_module.RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={"outputs": {"push_status": "no_commits"}},
+    )
+
+    assert mock_run_workflow._publish_status == "failed"
+    assert mock_run_workflow._publish_reason == "first publish failure"
+
 def test_record_execution_context_resets_last_step_fields_when_current_node_has_no_summary(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## Summary
- Stop execution-stage plans immediately when a child step records a publish handoff failure, such as an unrecovered force-with-lease conflict.
- Preserve the first publish failure reason so later no-op steps cannot overwrite it.
- Add regression coverage proving a lease conflict prevents later child steps and native PR creation.

## Root Cause
A child AgentRun could complete successfully from the process perspective while its branch publish metadata reported `push_status=lease_conflict`. The parent workflow recorded that failed publish state but still advanced to later plan steps, which could start from a stale checkout and lose prior local commits.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_stops_after_publish_lease_conflict`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_skips_native_pr_after_push_failure tests/unit/workflows/temporal/workflows/test_run_integration.py::test_native_pr_push_status_gate_blocks_unrecovered_lease_conflict tests/unit/workflows/temporal/workflows/test_run_integration.py::test_determine_publish_completion_fails_for_no_commit_pr_publish`
- `./tools/test_unit.sh`