### PR TITLE
[codex] Fix deployment compose JSON parsing

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -290,8 +290,10 @@ def _remap_host_compose_path(
     return local_dir / compose_file.name
 
 
-def _tail_text(payload: bytes, *, max_chars: int = 512) -> str:
+def _tail_text(payload: bytes, *, max_chars: int | None = 512) -> str:
     text = payload.decode("utf-8", errors="replace")
+    if max_chars is None:
+        return text
     if max_chars <= 0:
         return ""
     return text[-max_chars:]
@@ -505,7 +507,7 @@ class HostDockerComposeRunner:
         command: Sequence[str],
         *,
         requested_image: str | None = None,
-        max_output_chars: int = 512,
+        max_output_chars: int | None = 512,
     ) -> Mapping[str, Any]:
         resolved = self._compose_command(command)
         env = os.environ.copy()
@@ -547,15 +549,37 @@ class HostDockerComposeRunner:
     async def _run_compose_json(self, args: Sequence[str]) -> list[Mapping[str, Any]]:
         result = await self._run_compose_command(
             ("docker", "compose", *args),
-            max_output_chars=20000,
+            max_output_chars=None,
         )
         _ensure_command_succeeded("config", result)
-        payload = "\n".join(
-            part
-            for part in (str(result.get("stdout") or ""), str(result.get("stderr") or ""))
-            if part.strip()
+        stdout = str(result.get("stdout") or "")
+        if stdout.strip():
+            try:
+                return _parse_json_records(stdout)
+            except json.JSONDecodeError as exc:
+                raise ToolFailure(
+                    error_code="DEPLOYMENT_COMMAND_FAILED",
+                    message="Deployment compose command returned invalid JSON.",
+                    retryable=False,
+                    details={
+                        "phase": "config",
+                        "command": result.get("command"),
+                        "stdout": _tail_text(stdout.encode("utf-8"), max_chars=2000),
+                        "stderr": result.get("stderr"),
+                        "failureClass": "compose_config_validation_failure",
+                    },
+                ) from exc
+        raise ToolFailure(
+            error_code="DEPLOYMENT_COMMAND_FAILED",
+            message="Deployment compose command returned no JSON output.",
+            retryable=False,
+            details={
+                "phase": "config",
+                "command": result.get("command"),
+                "stderr": result.get("stderr"),
+                "failureClass": "compose_config_validation_failure",
+            },
         )
-        return _parse_json_records(payload)
 
     async def _inspect_image(self, requested_image: str) -> Mapping[str, Any]:
         process = await asyncio.create_subprocess_exec(

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -507,7 +507,8 @@ class HostDockerComposeRunner:
         command: Sequence[str],
         *,
         requested_image: str | None = None,
-        max_output_chars: int | None = 512,
+        max_stdout_chars: int | None = 512,
+        max_stderr_chars: int | None = 512,
     ) -> Mapping[str, Any]:
         resolved = self._compose_command(command)
         env = os.environ.copy()
@@ -542,14 +543,15 @@ class HostDockerComposeRunner:
         return {
             "command": resolved,
             "exitCode": process.returncode,
-            "stdout": _tail_text(stdout, max_chars=max_output_chars),
-            "stderr": _tail_text(stderr, max_chars=max_output_chars),
+            "stdout": _tail_text(stdout, max_chars=max_stdout_chars),
+            "stderr": _tail_text(stderr, max_chars=max_stderr_chars),
         }
 
     async def _run_compose_json(self, args: Sequence[str]) -> list[Mapping[str, Any]]:
         result = await self._run_compose_command(
             ("docker", "compose", *args),
-            max_output_chars=None,
+            max_stdout_chars=None,
+            max_stderr_chars=2000,
         )
         _ensure_command_succeeded("config", result)
         stdout = str(result.get("stdout") or "")

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -863,7 +863,9 @@ async def test_host_compose_runner_returns_bounded_command_output_tails(
     runner = HostDockerComposeRunner(project_dir=str(tmp_path))
 
     result = await runner._run_compose_command(
-        ("docker", "compose", "ps"), max_output_chars=8
+        ("docker", "compose", "ps"),
+        max_stdout_chars=8,
+        max_stderr_chars=8,
     )
 
     assert result["exitCode"] == 0
@@ -969,3 +971,42 @@ async def test_host_compose_runner_invalid_json_stdout_is_tool_failure(
     assert failure.message == "Deployment compose command returned invalid JSON."
     assert failure.details["failureClass"] == "compose_config_validation_failure"
     assert failure.details["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_run_compose_json_failure_bounds_stderr_in_tool_failure(
+    tmp_path, monkeypatch
+):
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    huge_stderr = ("compose diagnostic line\n" * 5000).encode("utf-8")
+
+    class FakeProcess:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", huge_stderr
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        cwd: str,
+        env: Mapping[str, str],
+        stdout: Any,
+        stderr: Any,
+    ):
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    runner = HostDockerComposeRunner(project_dir=str(tmp_path))
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await runner._run_compose_json(("ps", "--format", "json"))
+
+    failure = exc_info.value
+    assert failure.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert failure.details["failureClass"] == "compose_config_validation_failure"
+    embedded_result = failure.details["result"]
+    assert len(embedded_result["stderr"]) <= 2000
+    assert len(embedded_result["stderr"]) < len(huge_stderr)

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -871,3 +871,101 @@ async def test_host_compose_runner_returns_bounded_command_output_tails(
     assert result["stderr"] == "err tail"
     assert result["command"][-1] == "ps"
     assert captured["cwd"] == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_host_compose_runner_parses_full_json_stdout_with_stderr_warning(
+    tmp_path, monkeypatch
+):
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+    large_service_record = {
+        "Service": "api",
+        "State": "running",
+        "Labels": "x" * 22000,
+    }
+    images_record = {
+        "Service": "api",
+        "Repository": "ghcr.io/moonladderstudios/moonmind",
+        "Tag": "latest",
+    }
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, stdout: bytes, stderr: bytes) -> None:
+            self._stdout = stdout
+            self._stderr = stderr
+
+        async def communicate(self):
+            return self._stdout, self._stderr
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        cwd: str,
+        env: Mapping[str, str],
+        stdout: Any,
+        stderr: Any,
+    ):
+        calls.append(args)
+        payload = (
+            json.dumps(images_record)
+            if args[-3:] == ("images", "--format", "json")
+            else json.dumps(large_service_record)
+        )
+        return FakeProcess(
+            f"{payload}\n".encode("utf-8"),
+            b'time="2026-05-13T16:37:34Z" level=warning msg="diagnostic"\n',
+        )
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    runner = HostDockerComposeRunner(project_dir=str(tmp_path))
+
+    state = await runner.capture_state(stack="moonmind", phase="before")
+
+    assert state["services"] == [large_service_record]
+    assert state["images"] == [images_record]
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_host_compose_runner_invalid_json_stdout_is_tool_failure(
+    tmp_path, monkeypatch
+):
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return (
+                b"not json\n",
+                b'time="2026-05-13T16:37:34Z" level=warning msg="diagnostic"\n',
+            )
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        cwd: str,
+        env: Mapping[str, str],
+        stdout: Any,
+        stderr: Any,
+    ):
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    runner = HostDockerComposeRunner(project_dir=str(tmp_path))
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await runner._run_compose_json(("ps", "--format", "json"))
+
+    failure = exc_info.value
+    assert failure.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert failure.message == "Deployment compose command returned invalid JSON."
+    assert failure.details["failureClass"] == "compose_config_validation_failure"
+    assert failure.details["stderr"]


### PR DESCRIPTION
## Summary

Fix the deployment update runner so Docker Compose JSON probes parse the complete stdout stream and do not mix stderr diagnostics into the JSON payload.

## Root Cause

The deployment update task failed while capturing the before-state because `docker compose ps --format json` output was truncated before parsing and stderr diagnostics were appended to stdout. On larger stacks this can start parsing in the middle of a JSON line or try to parse warning text as JSON.

## Changes

- Allow compose JSON probes to capture full stdout while keeping regular command logs bounded.
- Parse only stdout for `docker compose ... --format json` responses.
- Convert invalid or missing JSON output into a structured deployment `ToolFailure` with bounded diagnostics.
- Add regression coverage for oversized JSON-lines output with stderr warnings and for invalid JSON stdout.

## Validation

- `pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q` -> 40 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/skills/test_deployment_update_execution.py` -> targeted Python tests passed; frontend suite passed
- `git diff --check` -> passed

Note: full `./tools/test_unit.sh` is currently blocked before this change by an unrelated Python 3.11 collection error in `tests/unit/services/temporal/runtime/test_managed_session_controller.py:2191`.