### PR TITLE
Tune pr-resolver CI wait defaults

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -18,10 +18,12 @@ The task is not complete until the target PR is merged or is proven already merg
 - inputs.branch (optional)
 - inputs.mergeMethod (merge|squash|rebase)
 - inputs.maxIterations (default 3, full remediation cap per cycle)
-- inputs.finalizeMaxRetries (default 6)
+- inputs.finalizeMaxRetries (default 60)
 - inputs.finalizeBackoffSeconds (default 30)
 - inputs.finalizeMaxSleepSeconds (default 120)
-- inputs.finalizeMaxElapsedSeconds (default 1800)
+- inputs.finalizeMaxElapsedSeconds (default 7200)
+- `ci_running` finalize waits use at least 60 seconds before the next check,
+  even when `finalizeBackoffSeconds` is lower.
 
 ## Primary Command (mandatory first action)
 Run the orchestration entrypoint before making manual changes. **You MUST provide the `--pr` argument** (using either the PR number or the branch name) to ensure the script targets the correct PR, even if you are on a different branch or detached HEAD:
@@ -89,6 +91,10 @@ Repeat this state machine until a terminal success or manual blocker:
   - `comments_unavailable`
   - `ci_signal_degraded`
   - `merge_not_ready` (limited grace retries)
+- `ci_running` should be allowed to consume the long finalize elapsed budget so
+  queued or running checks can reach a terminal state; if they then become
+  `ci_failures`, continue into `run_fix_ci_skill` instead of stopping early.
+- `ci_running` should not poll faster than once per minute.
 - If retries transition from transient CI states into actionable `ci_failures`, continue into `run_fix_ci_skill` instead of stopping at manual review.
 - If `merge_not_ready` resolves into an actionable blocker such as `merge_conflicts`, continue into the matching remediation skill instead of stopping at manual review.
 - Non-retryable stop reasons:

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -305,11 +305,12 @@ def run_orchestration(
             return result, EXIT_CODE_ATTEMPTS_EXHAUSTED
 
         if retry_action == "finalize_only_retry":
-            if reason == "merge_not_ready" and grace_remaining > 0:
+            normalized_reason = normalize_text(reason)
+            if normalized_reason == "merge_not_ready" and grace_remaining > 0:
                 grace_remaining -= 1
             effective_base_sleep_seconds = (
                 max(base_sleep_seconds, 60)
-                if reason == "ci_running"
+                if normalized_reason == "ci_running"
                 else base_sleep_seconds
             )
             sleep_seconds = compute_backoff_seconds(
@@ -317,6 +318,8 @@ def run_orchestration(
                 base_sleep_seconds=effective_base_sleep_seconds,
                 max_sleep_seconds=max_sleep_seconds,
             )
+            if normalized_reason == "ci_running":
+                sleep_seconds = max(sleep_seconds, 60)
             finalize_only_retry_index += 1
             history.append(
                 {

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -307,9 +307,14 @@ def run_orchestration(
         if retry_action == "finalize_only_retry":
             if reason == "merge_not_ready" and grace_remaining > 0:
                 grace_remaining -= 1
+            effective_base_sleep_seconds = (
+                max(base_sleep_seconds, 60)
+                if reason == "ci_running"
+                else base_sleep_seconds
+            )
             sleep_seconds = compute_backoff_seconds(
                 finalize_only_retry_index,
-                base_sleep_seconds=base_sleep_seconds,
+                base_sleep_seconds=effective_base_sleep_seconds,
                 max_sleep_seconds=max_sleep_seconds,
             )
             finalize_only_retry_index += 1
@@ -441,7 +446,7 @@ def main() -> None:
     parser.add_argument(
         "--finalize-max-retries",
         type=int,
-        default=6,
+        default=60,
         help="Number of finalize retries after the initial attempt.",
     )
     parser.add_argument(
@@ -459,7 +464,7 @@ def main() -> None:
     parser.add_argument(
         "--max-elapsed-seconds",
         type=int,
-        default=1800,
+        default=7200,
         help="Hard wall-clock cap for orchestration execution.",
     )
     parser.add_argument(

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -649,7 +649,7 @@ def test_orchestrate_ci_running_uses_finalize_only_retry_path(
     assert result["status"] == "merged"
     assert result["mergeAutomationDisposition"] == "merged"
     assert full_invocations == 0
-    assert sleeps == [15]
+    assert sleeps == [60]
 
 def test_orchestrate_ci_failures_after_transient_ci_states_escalates_fix_ci(
     pr_resolve_orchestrate_module: dict[str, Any],
@@ -706,7 +706,7 @@ def test_orchestrate_ci_failures_after_transient_ci_states_escalates_fix_ci(
     assert exit_code == 0
     assert result["status"] == "merged"
     assert full_calls == [(3, 1, "ci_failures")]
-    assert sleeps == [15, 30]
+    assert sleeps == [15, 60]
 
 def test_orchestrate_merge_conflicts_after_ci_running_escalates_fix_conflicts(
     pr_resolve_orchestrate_module: dict[str, Any],
@@ -758,7 +758,7 @@ def test_orchestrate_merge_conflicts_after_ci_running_escalates_fix_conflicts(
     assert exit_code == 0
     assert result["status"] == "merged"
     assert full_calls == [(2, 1, "merge_conflicts")]
-    assert sleeps == [15]
+    assert sleeps == [60]
 
 def test_orchestrate_merge_conflicts_after_merge_not_ready_escalates_fix_conflicts(
     pr_resolve_orchestrate_module: dict[str, Any],
@@ -865,10 +865,10 @@ def test_orchestrate_main_uses_extended_finalize_wait_defaults(
         main()
 
     assert int(raised.value.code) == 0
-    assert captured["finalize_max_retries"] == 6
+    assert captured["finalize_max_retries"] == 60
     assert captured["base_sleep_seconds"] == 30
     assert captured["max_sleep_seconds"] == 120
-    assert captured["max_elapsed_seconds"] == 1800
+    assert captured["max_elapsed_seconds"] == 7200
 
 def test_contract_snapshot_refresh_failed_is_finalize_only_retry(
     pr_resolve_contract_module: dict[str, Any],

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -651,6 +651,43 @@ def test_orchestrate_ci_running_uses_finalize_only_retry_path(
     assert full_invocations == 0
     assert sleeps == [60]
 
+
+def test_orchestrate_ci_running_sleep_floor_overrides_low_max_sleep(
+    pr_resolve_orchestrate_module: dict[str, Any],
+) -> None:
+    run_orchestration = pr_resolve_orchestrate_module["run_orchestration"]
+
+    finalize_results = iter(
+        [
+            {"status": "blocked", "merge_outcome": "blocked", "reason": "ci_running"},
+            {"status": "merged", "merge_outcome": "merged", "reason": "ci_complete"},
+        ]
+    )
+    sleeps: list[int] = []
+
+    result, exit_code = run_orchestration(
+        finalize_runner=lambda _attempt: next(finalize_results),
+        full_runner=lambda _attempt, _escalation, _reason: {
+            "status": "failed",
+            "merge_outcome": "failed",
+            "reason": "unexpected",
+        },
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=2,
+        fix_max_iterations=3,
+        base_sleep_seconds=15,
+        max_sleep_seconds=30,
+        max_elapsed_seconds=900,
+        merge_not_ready_grace_retries=1,
+    )
+
+    assert exit_code == 0
+    assert result["status"] == "merged"
+    assert result["mergeAutomationDisposition"] == "merged"
+    assert sleeps == [60]
+
+
 def test_orchestrate_ci_failures_after_transient_ci_states_escalates_fix_ci(
     pr_resolve_orchestrate_module: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## Summary
- extend pr-resolver finalize retries to support long-running CI
- enforce a 60-second minimum poll interval while CI is running
- document CI wait behavior and update resolver unit expectations

## Tests
- ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py