### PR TITLE
[codex] Handle ignored artifact publish staging

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6025,6 +6025,12 @@ class TemporalAgentRuntimeActivities:
     @staticmethod
     def _parse_git_status_paths(status_output: bytes) -> tuple[str, ...]:
         """Extract changed paths from `git status --porcelain=v1 -z` output."""
+        records = TemporalAgentRuntimeActivities._parse_git_status_records(status_output)
+        return tuple(path for _status, path in records)
+
+    @staticmethod
+    def _parse_git_status_records(status_output: bytes) -> tuple[tuple[str, str], ...]:
+        """Extract ``(status, path)`` records from `git status --porcelain=v1 -z`."""
 
         def _decode_path(path_bytes: bytes) -> str:
             return os.fsdecode(path_bytes)
@@ -6034,7 +6040,7 @@ class TemporalAgentRuntimeActivities:
             return ()
 
         entries = raw_output.split(b"\0")
-        paths: list[str] = []
+        records: list[tuple[str, str]] = []
         index = 0
         while index < len(entries):
             record = entries[index]
@@ -6048,7 +6054,7 @@ class TemporalAgentRuntimeActivities:
             path_bytes = record[3:]
             if not path_bytes:
                 raise ValueError(f"missing path in git status record: {record!r}")
-            paths.append(_decode_path(path_bytes))
+            records.append((status, _decode_path(path_bytes)))
 
             if "R" in status or "C" in status:
                 index += 1
@@ -6061,11 +6067,14 @@ class TemporalAgentRuntimeActivities:
                     raise ValueError(
                         f"missing original path for git rename/copy record: {record!r}"
                     )
-                paths.append(_decode_path(original_path_bytes))
+                records.append((status, _decode_path(original_path_bytes)))
 
             index += 1
 
-        return tuple(dict.fromkeys(paths))
+        deduped: dict[str, tuple[str, str]] = {}
+        for status, path in records:
+            deduped.setdefault(path, (status, path))
+        return tuple(deduped.values())
 
     @staticmethod
     def _should_exclude_publish_path(
@@ -6362,41 +6371,61 @@ class TemporalAgentRuntimeActivities:
 
         try:
             workspace_path = Path(workspace).expanduser().resolve()
-            changed_paths = tuple(
-                path
-                for path in self._parse_git_status_paths(status_stdout)
-                if not self._should_exclude_publish_path(
+            tracked_paths: list[str] = []
+            untracked_paths: list[str] = []
+            for status, path in self._parse_git_status_records(status_stdout):
+                if self._should_exclude_publish_path(
                     path,
                     workspace=workspace_path,
-                )
-            )
+                ):
+                    continue
+                if status == "??":
+                    untracked_paths.append(path)
+                elif status != "!!":
+                    tracked_paths.append(path)
         except ValueError as exc:
             return {
                 "push_status": "failed",
                 "push_error": f"could not parse workspace changes: {exc}",
             }
-        if not changed_paths:
+        if not tracked_paths and not untracked_paths:
             return {}
 
-        add_proc = await asyncio.create_subprocess_exec(
-            *self._workspace_git_command(
-                workspace, "add", "-A", "--", *changed_paths,
-            ),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=command_env,
-        )
-        add_stdout, add_stderr = await asyncio.wait_for(
-            add_proc.communicate(), timeout=30,
-        )
-        if add_proc.returncode != 0:
-            detail = add_stderr.decode("utf-8", errors="replace").strip() or (
-                add_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+        async def _stage_paths(
+            *,
+            mode: str,
+            paths: Sequence[str],
+        ) -> dict[str, str] | None:
+            if not paths:
+                return None
+            add_proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(
+                    workspace, "add", mode, "--", *paths,
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=command_env,
             )
-            return {
-                "push_status": "failed",
-                "push_error": f"could not stage workspace changes: {detail}",
-            }
+            add_stdout, add_stderr = await asyncio.wait_for(
+                add_proc.communicate(), timeout=30,
+            )
+            if add_proc.returncode != 0:
+                detail = add_stderr.decode("utf-8", errors="replace").strip() or (
+                    add_stdout.decode("utf-8", errors="replace").strip()
+                    or "(no stderr)"
+                )
+                return {
+                    "push_status": "failed",
+                    "push_error": f"could not stage workspace changes: {detail}",
+                }
+            return None
+
+        stage_error = await _stage_paths(mode="-u", paths=tracked_paths)
+        if stage_error is not None:
+            return stage_error
+        stage_error = await _stage_paths(mode="-A", paths=untracked_paths)
+        if stage_error is not None:
+            return stage_error
 
         staged_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(

--- a/specs/351-ignored-artifact-staging-resilience/plan.md
+++ b/specs/351-ignored-artifact-staging-resilience/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: Ignored Artifact Staging Resilience
+
+## Summary
+
+Split publish staging by Git status class. Tracked changes use `git add -u`, which handles tracked files under ignored parents. Untracked paths continue to use `git add -A` so normal new files are included while ignored untracked artifacts remain excluded by Git.
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS - uses Git's status and staging semantics directly.
+- IV Own Your Data: PASS - preserves artifact-backed outputs and target repository changes.
+- IX Resilient by Default: PASS - prevents a post-agent finalization failure after useful work completed.
+- XI Spec-Driven Development: PASS - feature artifacts define the narrow behavior change.
+- XII Canonical Documentation: PASS - rollout details stay in this spec, not canonical docs.
+- XIII Compatibility Policy: PASS - no compatibility alias or hidden semantic transform is introduced.
+
+## Test Strategy
+
+- Add a unit regression covering a tracked modified file under ignored `artifacts/`.
+- Run the focused publish test module, then the repo unit runner if feasible.

--- a/specs/351-ignored-artifact-staging-resilience/spec.md
+++ b/specs/351-ignored-artifact-staging-resilience/spec.md
@@ -1,0 +1,17 @@
+# Feature Specification: Ignored Artifact Staging Resilience
+
+## User Story
+
+As an operator, I want workflow publish finalization to tolerate tracked files that live under gitignored artifact directories, so a completed agent run is not failed only because `git add -A` rejects an ignored parent path.
+
+## Requirements
+
+- **FR-001**: When publishing workspace changes, MoonMind MUST stage tracked modifications and deletions even if their parent directory is ignored by the target repository.
+- **FR-002**: MoonMind MUST NOT force-add ignored untracked artifacts into the target repository.
+- **FR-003**: MoonMind MUST keep runtime scaffolding exclusions, including `CLAUDE.md`, live log spool files, and projected skill directories.
+- **FR-004**: A staging failure for genuine Git errors MUST still surface as a publish failure with an actionable error.
+
+## Acceptance Scenarios
+
+- **SCN-001**: Given a tracked `artifacts/jira-orchestrate-pr.json` is modified under a repository that ignores `artifacts/`, when MoonMind publishes the branch, then the tracked file is staged and committed without requiring a `.gitignore` change.
+- **SCN-002**: Given an untracked ignored artifact file exists, when MoonMind publishes the branch, then the ignored untracked file is not force-added.

--- a/specs/351-ignored-artifact-staging-resilience/tasks.md
+++ b/specs/351-ignored-artifact-staging-resilience/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [X] T001 Add status parsing support that preserves the Git status code for publish staging.
+- [X] T002 Stage tracked publish paths with `git add -u` and untracked publish paths with `git add -A`.
+- [X] T003 Add a regression test for tracked ignored-parent artifact handoff files.
+- [X] T004 Run focused and final unit verification.

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -885,27 +885,30 @@ class TestPushWorkspaceBranch:
                     return_value=(b" M api_service/main.py\0?? tests/new_test.py\0", b"")
                 )
                 proc.returncode = 0
-            elif call_count == 3:  # git add -A with runtime exclusions
+            elif call_count == 3:  # git add -u for tracked changes
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 4:  # staged diff check
+            elif call_count == 4:  # git add -A for untracked changes
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # staged diff check
                 proc.communicate = AsyncMock(
                     return_value=(b"api_service/main.py\ntests/new_test.py\n", b"")
                 )
                 proc.returncode = 0
-            elif call_count == 5:  # commit
+            elif call_count == 6:  # commit
                 proc.communicate = AsyncMock(return_value=(b"[auto-dirty123 abc123] msg\n", b""))
                 proc.returncode = 0
-            elif call_count == 6:  # remote default branch
+            elif call_count == 7:  # remote default branch
                 proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
                 proc.returncode = 0
-            elif call_count == 7:  # remote branch sha before push
+            elif call_count == 8:  # remote branch sha before push
                 proc.communicate = AsyncMock(return_value=(b"dirty-remote-sha\n", b""))
                 proc.returncode = 0
-            elif call_count == 8:  # push
+            elif call_count == 9:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 9:  # rev-parse HEAD
+            elif call_count == 10:  # rev-parse HEAD
                 proc.communicate = AsyncMock(return_value=(b"dirty-head-sha\n", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -924,14 +927,83 @@ class TestPushWorkspaceBranch:
         assert result["push_commit_count"] == 1
         assert result["push_head_sha"] == "dirty-head-sha"
         assert result["push_commit_message"] == "Ship dirty workspace"
-        add_call = recorded_calls[2]
-        assert list(add_call[-3:]) == [
+        tracked_add_call = recorded_calls[2]
+        assert list(tracked_add_call[-3:]) == [
+            "-u",
             "--",
             "api_service/main.py",
+        ]
+        untracked_add_call = recorded_calls[3]
+        assert list(untracked_add_call[-3:]) == [
+            "-A",
+            "--",
             "tests/new_test.py",
         ]
         commit_call = next(call for call in recorded_calls if "commit" in call)
         assert list(commit_call[-3:]) == ["commit", "-m", "Ship dirty workspace"]
+
+    @pytest.mark.asyncio
+    async def test_push_stages_tracked_artifact_under_ignored_parent_with_update(self):
+        """Tracked handoff files under ignored artifact dirs must not fail staging."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-artifact123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(
+                    return_value=(b" M artifacts/jira-orchestrate-pr.json\0", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 3:  # git add -u for tracked ignored-parent file
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # staged diff check
+                proc.communicate = AsyncMock(
+                    return_value=(b"artifacts/jira-orchestrate-pr.json\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 5:  # commit
+                proc.communicate = AsyncMock(
+                    return_value=(b"[auto-artifact123 abc123] msg\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 6:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # remote branch sha before push
+                proc.communicate = AsyncMock(return_value=(b"artifact-remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 8:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 9:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"artifact-head-sha\n", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        add_calls = [call for call in recorded_calls if "add" in call]
+        assert len(add_calls) == 1
+        assert list(add_calls[0][-3:]) == [
+            "-u",
+            "--",
+            "artifacts/jira-orchestrate-pr.json",
+        ]
 
     @pytest.mark.asyncio
     async def test_push_dirty_workspace_commit_failure_returns_failed(self):


### PR DESCRIPTION
## Summary
- split publish staging so tracked workspace changes use `git add -u` while untracked paths still use `git add -A`
- preserve existing runtime scaffolding exclusions during publish finalization
- add MoonSpec artifacts and regression coverage for tracked handoff files under ignored `artifacts/` directories

## Root Cause
A completed workflow could fail during final publish when a tracked artifact handoff file, such as `artifacts/jira-orchestrate-pr.json`, lived under a gitignored parent directory. Git can stage the tracked file with `git add -u`, but `git add -A -- <path>` exits nonzero because the ignored parent path is rejected.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py`
- `./tools/test_unit.sh`
