### PR TITLE
[codex] Reject PR publish for Jira side-effect skills

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -118,6 +118,7 @@ from moonmind.workflows.tasks.task_contract import (
     TaskInputAttachmentRef,
     TaskProposalPolicy,
     TaskSkillSelectors,
+    allows_repository_publish_for_skill_context,
     build_authoritative_task_input_snapshot,
     is_self_managed_publish_skill,
     resolve_publish_mode_for_skill,
@@ -4082,6 +4083,9 @@ def _resolve_task_publish_payload(
         publish_mode = resolve_publish_mode_for_skill(
             skill_id,
             requested_mode,
+            allow_repository_publish=allows_repository_publish_for_skill_context(
+                task_payload
+            ),
         )
     except TaskContractError as exc:
         raise _invalid_task_request(str(exc)) from exc

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -34,6 +34,9 @@ _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
+_NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
+    {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
+)
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
     re.IGNORECASE,
@@ -257,10 +260,17 @@ def resolve_publish_mode_for_skill(skill_id: object, requested_mode: object) -> 
     """Resolve publish mode for a skill while enforcing self-managed constraints."""
 
     publish_mode = _normalize_publish_mode(requested_mode)
-    if is_self_managed_publish_skill(skill_id):
+    normalized_skill_id = _normalize_skill_id(skill_id)
+    if is_self_managed_publish_skill(normalized_skill_id):
         if publish_mode != "none":
             raise TaskContractError(
-                f"task.publish.mode must be 'none' when using skill '{_normalize_skill_id(skill_id)}'"
+                f"task.publish.mode must be 'none' when using skill '{normalized_skill_id}'"
+            )
+        return "none"
+    if normalized_skill_id in _NON_REPOSITORY_SIDE_EFFECT_SKILLS:
+        if publish_mode != "none":
+            raise TaskContractError(
+                f"task.publish.mode must be 'none' when using non-repository skill '{normalized_skill_id}'"
             )
         return "none"
     return publish_mode

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -37,6 +37,7 @@ _SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
 _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
     {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
 )
+_JIRA_ORCHESTRATE_PRESET_SLUGS = frozenset({"jira-orchestrate"})
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
     re.IGNORECASE,
@@ -256,7 +257,37 @@ def is_self_managed_publish_skill(skill_id: object) -> bool:
 
     return _normalize_skill_id(skill_id) in _SELF_MANAGED_PUBLISH_SKILLS
 
-def resolve_publish_mode_for_skill(skill_id: object, requested_mode: object) -> str:
+def _iter_applied_step_templates(value: object) -> list[object]:
+    if isinstance(value, Mapping):
+        return _safe_list(value.get("appliedStepTemplates"))
+    model_extra = getattr(value, "model_extra", None)
+    if isinstance(model_extra, Mapping):
+        return _safe_list(model_extra.get("appliedStepTemplates"))
+    return []
+
+
+def _has_jira_orchestrate_preset_context(value: object) -> bool:
+    for template in _iter_applied_step_templates(value):
+        if not isinstance(template, Mapping):
+            continue
+        slug = _normalize_skill_id(template.get("slug") or template.get("presetSlug"))
+        if slug in _JIRA_ORCHESTRATE_PRESET_SLUGS:
+            return True
+    return False
+
+
+def allows_repository_publish_for_skill_context(value: object) -> bool:
+    """Return True when task provenance represents a repository-publishing workflow."""
+
+    return _has_jira_orchestrate_preset_context(value)
+
+
+def resolve_publish_mode_for_skill(
+    skill_id: object,
+    requested_mode: object,
+    *,
+    allow_repository_publish: bool = False,
+) -> str:
     """Resolve publish mode for a skill while enforcing self-managed constraints."""
 
     publish_mode = _normalize_publish_mode(requested_mode)
@@ -268,6 +299,8 @@ def resolve_publish_mode_for_skill(skill_id: object, requested_mode: object) -> 
             )
         return "none"
     if normalized_skill_id in _NON_REPOSITORY_SIDE_EFFECT_SKILLS:
+        if allow_repository_publish:
+            return publish_mode
         if publish_mode != "none":
             raise TaskContractError(
                 f"task.publish.mode must be 'none' when using non-repository skill '{normalized_skill_id}'"
@@ -1415,6 +1448,7 @@ class TaskExecutionSpec(BaseModel):
 
     @model_validator(mode="after")
     def _validate_skill_publish_compatibility(self) -> "TaskExecutionSpec":
+        allow_repository_publish = allows_repository_publish_for_skill_context(self)
         skill_ids: set[str] = {_normalize_skill_id(self.skill.id)}
         for step in self.steps:
             if step.skill is None:
@@ -1422,7 +1456,11 @@ class TaskExecutionSpec(BaseModel):
             skill_ids.add(_normalize_skill_id(step.skill.id))
 
         for skill_id in skill_ids:
-            resolve_publish_mode_for_skill(skill_id, self.publish.mode)
+            resolve_publish_mode_for_skill(
+                skill_id,
+                self.publish.mode,
+                allow_repository_publish=allow_repository_publish,
+            )
         return self
 
     @model_validator(mode="after")
@@ -1862,7 +1900,11 @@ def build_canonical_task_view(
     skill_node = task.get("skill") or {}
     skill = skill_node if isinstance(skill_node, Mapping) else {}
     skill_id = skill.get("id")
-    publish_mode = resolve_publish_mode_for_skill(skill_id, publish_mode_candidate)
+    publish_mode = resolve_publish_mode_for_skill(
+        skill_id,
+        publish_mode_candidate,
+        allow_repository_publish=allows_repository_publish_for_skill_context(task),
+    )
     canonical["task"]["publish"]["mode"] = publish_mode
     if publish_mode == "pr":
         required.append("gh")
@@ -2280,6 +2322,7 @@ __all__ = [
     "build_authoritative_task_input_snapshot",
     "build_task_stage_plan",
     "build_canonical_task_view",
+    "allows_repository_publish_for_skill_context",
     "has_attachment_mutation_fields",
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1743,6 +1743,53 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_pr_publish(
     assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
 
+def test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "task": {
+                    "title": (
+                        "Change Jira issue MM-657 to status In Progress before "
+                        "implementation starts."
+                    ),
+                    "instructions": (
+                        "Change Jira issue MM-657 to status In Progress before "
+                        "implementation starts."
+                    ),
+                    "tool": {"type": "skill", "name": "jira-issue-updater"},
+                    "runtime": {"mode": "claude_code"},
+                    "publish": {"mode": "pr"},
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "jira-orchestrate",
+                            "version": "1.0.0",
+                            "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "invalid_execution_request",
+        "message": (
+            "task.publish.mode must be 'none' when using non-repository skill "
+            "'jira-issue-updater'"
+        ),
+    }
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_allows_jira_orchestrate_publish_none(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1743,6 +1743,55 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_pr_publish(
     assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
 
+def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_pr_publish(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "task": {
+                    "instructions": "Run Jira Orchestrate for THOR-352.",
+                    "tool": {"type": "skill", "name": "jira-issue-updater"},
+                    "skill": {"id": "jira-issue-updater"},
+                    "runtime": {"mode": "codex"},
+                    "publish": {"mode": "pr"},
+                    "steps": [
+                        {
+                            "id": "tpl:jira-orchestrate:1.0.0:01",
+                            "title": "Move Jira issue",
+                            "instructions": "Transition THOR-352 to In Progress.",
+                            "skill": {"id": "jira-issue-updater", "args": {}},
+                        }
+                    ],
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "jira-orchestrate",
+                            "version": "1.0.0",
+                            "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201, response.json()
+    service.create_execution.assert_awaited_once()
+    initial_parameters = service.create_execution.call_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["publishMode"] == "pr"
+    assert initial_parameters["task"]["publish"]["mode"] == "pr"
+    assert initial_parameters["task"]["skill"]["name"] == "jira-issue-updater"
+
+
 def test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
@@ -1765,15 +1814,9 @@ def test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater(
                         "implementation starts."
                     ),
                     "tool": {"type": "skill", "name": "jira-issue-updater"},
+                    "skill": {"id": "jira-issue-updater"},
                     "runtime": {"mode": "claude_code"},
                     "publish": {"mode": "pr"},
-                    "appliedStepTemplates": [
-                        {
-                            "slug": "jira-orchestrate",
-                            "version": "1.0.0",
-                            "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
-                        }
-                    ],
                 },
             },
         },

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -619,6 +619,38 @@ def test_jira_side_effect_skills_reject_repository_publish_modes(
     assert resolve_publish_mode_for_skill(skill_id, "none") == "none"
 
 
+def test_jira_orchestrate_preset_context_allows_first_step_skill_pr_publish() -> None:
+    result = build_canonical_task_view(
+        job_type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "task": {
+                "instructions": "Run Jira Orchestrate for THOR-352.",
+                "skill": {"id": "jira-issue-updater"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {
+                        "id": "tpl:jira-orchestrate:1.0.0:01",
+                        "title": "Move Jira issue",
+                        "instructions": "Transition THOR-352 to In Progress.",
+                        "skill": {"id": "jira-issue-updater", "args": {}},
+                    }
+                ],
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-orchestrate",
+                        "version": "1.0.0",
+                        "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
+                    }
+                ],
+            },
+        },
+    )
+
+    assert result["task"]["publish"]["mode"] == "pr"
+    assert "gh" in result["requiredCapabilities"]
+
+
 def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> None:
     task_skills = TaskExecutionSpec.model_validate(
         {

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -9,6 +9,7 @@ from moonmind.workflows.tasks.task_contract import (
     build_effective_task_skill_selectors,
     CanonicalTaskPayload,
     ResumeFromFailedStepRef,
+    resolve_publish_mode_for_skill,
     TaskContractError,
     TaskExecutionSpec,
     TaskRecoveryProvenance,
@@ -603,6 +604,20 @@ def test_mm569_tool_validation_error_identifies_required_field_path() -> None:
 
     assert "task.steps[].tool.id" in str(excinfo.value)
     assert "tool.name" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "skill_id",
+    ["jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"],
+)
+def test_jira_side_effect_skills_reject_repository_publish_modes(
+    skill_id: str,
+) -> None:
+    with pytest.raises(TaskContractError, match="non-repository skill"):
+        resolve_publish_mode_for_skill(skill_id, "pr")
+
+    assert resolve_publish_mode_for_skill(skill_id, "none") == "none"
+
 
 def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> None:
     task_skills = TaskExecutionSpec.model_validate(


### PR DESCRIPTION
## Summary

- Reject PR/branch publishing for Jira side-effect skills such as jira-issue-updater.
- Preserve jira-orchestrate PR publishing for full implementation workflows.
- Add API and task-contract regression coverage for the MM-657-shaped failure.

## Root Cause

A standalone Jira status transition was submitted with publishMode=pr and stale jira-orchestrate metadata. The run completed its Jira child work, then failed during final PR creation because the branch had no commits to publish.

## Validation

- pytest tests/unit/workflows/tasks/test_task_contract.py::test_jira_side_effect_skills_reject_repository_publish_modes -q
- pytest tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_allows_jira_orchestrate_pr_publish -q
- ./tools/test_unit.sh --python-only tests/unit/workflows/tasks/test_task_contract.py::test_jira_side_effect_skills_reject_repository_publish_modes tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_allows_jira_orchestrate_pr_publish

Note: full ./tools/test_unit.sh previously failed in unrelated Vitest setup because tailwind.config.cjs was already deleted in the worktree before this change.
