### PR TITLE
[codex] Fix Jira orchestrate brief routing

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -102,15 +102,18 @@ steps:
           targetIssueKey: "{{ inputs.jira_issue_key }}"
           linkType: Blocks
   - title: Load Jira preset brief
+    type: tool
     instructions: |-
-      Fetch Jira issue {{ inputs.jira_issue_key }} through the trusted Jira tool surface.
+      Fetch Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira tool surface.
 
       Build the canonical MoonSpec orchestration input from the issue's Jira preset brief. Prefer a normalized preset brief or recommended preset instructions when the Jira issue response exposes one. If that field is unavailable, synthesize the brief from the issue key, summary, description, acceptance criteria, and relevant implementation notes.
 
       Preserve the issue key in the brief so downstream spec artifacts and the pull request can reference {{ inputs.jira_issue_key }}.
-    skill:
-      id: auto
+    tool:
+      id: jira.load_preset_brief
       args: {}
+      inputs:
+        issueKey: "{{ inputs.jira_issue_key }}"
   - title: Classify request and resume point
     instructions: |-
       Use the Jira preset brief for {{ inputs.jira_issue_key }} as the canonical Moon Spec orchestration input.

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -29,6 +29,7 @@ from moonmind.workflows.skills.tool_plan_contracts import ToolResult
 JIRA_CREATE_ISSUES_TOOL_NAME = "story.create_jira_issues"
 JIRA_ORCHESTRATE_TASKS_TOOL_NAME = "story.create_jira_orchestrate_tasks"
 JIRA_CHECK_BLOCKERS_TOOL_NAME = "jira.check_blockers"
+JIRA_LOAD_PRESET_BRIEF_TOOL_NAME = "jira.load_preset_brief"
 JIRA_STORY_TOOL_NAMES = frozenset(
     {JIRA_CREATE_ISSUES_TOOL_NAME, JIRA_ORCHESTRATE_TASKS_TOOL_NAME}
 )
@@ -38,6 +39,9 @@ JIRA_DEPENDENCY_MODE_NONE = "none"
 JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN = "linear_blocker_chain"
 JIRA_DEPENDENCY_MODES = frozenset(
     {JIRA_DEPENDENCY_MODE_NONE, JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN}
+)
+_ACCEPTANCE_HEADING_RE = re.compile(
+    r"(?im)^\s*(acceptance\s+criteria|acceptance|ac)\s*:?\s*$"
 )
 
 DOCUMENT_DISCOVER_TOOL_NAME = "document.discover"
@@ -67,6 +71,88 @@ def _list(value: Any) -> list[Any]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return list(value)
     return []
+
+def _collapse_jira_text(value: str) -> str:
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in value.splitlines()]
+    collapsed: list[str] = []
+    previous_blank = False
+    for line in lines:
+        if not line:
+            if not previous_blank and collapsed:
+                collapsed.append("")
+            previous_blank = True
+            continue
+        collapsed.append(line)
+        previous_blank = False
+    return "\n".join(collapsed).strip()
+
+def _collect_adf_text(node: Any) -> list[str]:
+    if not isinstance(node, Mapping):
+        return []
+    node_type = node.get("type")
+    if node_type == "text":
+        return [str(node.get("text") or "")]
+    if node_type == "hardBreak":
+        return ["\n"]
+    content = node.get("content")
+    if not isinstance(content, list):
+        return []
+    parts: list[str] = []
+    inline = node_type in {"paragraph", "heading", "listItem"}
+    for child in content:
+        child_parts = _collect_adf_text(child)
+        if inline:
+            parts.extend(child_parts)
+        else:
+            text = _collapse_jira_text("".join(child_parts))
+            if text:
+                parts.append(text)
+    if inline:
+        return [_collapse_jira_text("".join(parts))]
+    return parts
+
+def _normalize_jira_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return _collapse_jira_text(value)
+    if isinstance(value, Mapping):
+        return _collapse_jira_text("\n".join(_collect_adf_text(value)))
+    if isinstance(value, list):
+        parts = [_normalize_jira_text(item) for item in value]
+        return _collapse_jira_text("\n".join(part for part in parts if part))
+    return _collapse_jira_text(str(value))
+
+def _extract_acceptance_criteria(
+    fields: Mapping[str, Any],
+    names: Mapping[str, Any],
+) -> str:
+    for field_key, field_name in names.items():
+        normalized_name = str(field_name or "").lower()
+        if "acceptance" not in normalized_name and "criteria" not in normalized_name:
+            continue
+        text = _normalize_jira_text(fields.get(field_key))
+        if text:
+            return text
+    return ""
+
+def _split_description_acceptance(description_text: str) -> tuple[str, str]:
+    match = _ACCEPTANCE_HEADING_RE.search(description_text)
+    if match is None:
+        return description_text, ""
+    before = description_text[: match.start()].strip()
+    after = description_text[match.end() :].strip()
+    return before, after
+
+def _issue_url(payload: Mapping[str, Any]) -> str | None:
+    browse = _string(payload.get("browseUrl") or payload.get("url"))
+    if browse:
+        return browse
+    self_url = _string(payload.get("self"))
+    marker = "/rest/api/"
+    if marker in self_url:
+        return f"{self_url.split(marker, 1)[0]}/browse/{payload.get('key')}"
+    return None
 
 def _first_string(*values: Any) -> str:
     for value in values:
@@ -1825,6 +1911,95 @@ async def check_jira_blockers(
         },
     )
 
+def _load_preset_brief_issue_key(inputs: Mapping[str, Any]) -> str:
+    nested = _mapping(inputs.get("jira") or inputs.get("issue"))
+    return _string(
+        inputs.get("issueKey")
+        or inputs.get("issue_key")
+        or inputs.get("jiraIssueKey")
+        or inputs.get("jira_issue_key")
+        or nested.get("issueKey")
+        or nested.get("issue_key")
+        or nested.get("key")
+    ).upper()
+
+async def load_jira_preset_brief(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    jira_service_factory: JiraServiceFactory = JiraToolService,
+) -> ToolResult:
+    """Load a compact Jira preset brief through MoonMind's trusted Jira service."""
+
+    issue_key = _load_preset_brief_issue_key(inputs)
+    if not issue_key:
+        raise ValueError("issueKey is required for Jira preset brief loading.")
+
+    service = jira_service_factory()
+    try:
+        issue_payload = await service.get_issue(
+            GetIssueRequest(issueKey=issue_key, expand=["names"])
+        )
+    except Exception as exc:
+        code = _string(getattr(exc, "code", "")) or exc.__class__.__name__
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "error": (
+                    f"Could not load Jira preset brief for {issue_key} through "
+                    f"trusted Jira data ({code})."
+                ),
+                "jiraIssueKey": issue_key,
+            },
+        )
+
+    issue = _mapping(issue_payload)
+    fields = _mapping(issue.get("fields"))
+    names = _mapping(issue.get("names"))
+    summary = _string(fields.get("summary"))
+    description_text = _normalize_jira_text(fields.get("description"))
+    acceptance_text = _extract_acceptance_criteria(fields, names)
+    if not acceptance_text:
+        description_text, acceptance_text = _split_description_acceptance(description_text)
+    status = _mapping(fields.get("status"))
+    issue_type = _mapping(fields.get("issuetype"))
+    assignee = _mapping(fields.get("assignee"))
+    resolved_key = _string(issue.get("key")).upper() or issue_key
+
+    preset_parts = [f"{resolved_key}: {summary}".strip()]
+    if description_text:
+        preset_parts.append(description_text)
+    if acceptance_text:
+        preset_parts.append(f"Acceptance criteria\n{acceptance_text}")
+    preset_brief = "\n\n".join(part for part in preset_parts if part)
+    step_parts = [f"Complete Jira issue {resolved_key}: {summary}".strip()]
+    if description_text:
+        step_parts.append(f"Description\n{description_text}")
+    if acceptance_text:
+        step_parts.append(f"Acceptance criteria\n{acceptance_text}")
+    step_instructions = "\n\n".join(part for part in step_parts if part)
+
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "trustedSource": "moonmind.jira.get_issue",
+            "jiraIssueKey": resolved_key,
+            "jiraPresetBrief": preset_brief,
+            "jiraStepInstructions": step_instructions,
+            "jiraIssue": {
+                "key": resolved_key,
+                "summary": summary,
+                "descriptionText": description_text,
+                "acceptanceCriteriaText": acceptance_text,
+                "status": _string(status.get("name")),
+                "issueType": _string(issue_type.get("name")),
+                "assignee": _string(assignee.get("displayName")),
+                "url": _issue_url(issue),
+            },
+            "summary": f"Loaded Jira preset brief for {resolved_key} from trusted Jira data.",
+        },
+    )
+
 async def discover_documents(
     inputs: Mapping[str, Any],
     _context: Mapping[str, Any] | None = None,
@@ -2222,6 +2397,18 @@ def register_story_output_tool_handlers(
         handler=_check_jira_blockers,
     )
 
+    async def _load_jira_preset_brief(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await load_jira_preset_brief(inputs, context)
+
+    dispatcher.register_skill(
+        skill_name=JIRA_LOAD_PRESET_BRIEF_TOOL_NAME,
+        version="1.0",
+        handler=_load_jira_preset_brief,
+    )
+
     async def _discover_documents(
         inputs: Mapping[str, Any],
         context: Mapping[str, Any] | None = None,
@@ -2252,12 +2439,14 @@ def register_story_output_tool_handlers(
 
 __all__ = [
     "JIRA_CHECK_BLOCKERS_TOOL_NAME",
+    "JIRA_LOAD_PRESET_BRIEF_TOOL_NAME",
     "JIRA_STORY_TOOL_NAMES",
     "check_jira_blockers",
     "create_jira_issues_from_stories",
     "create_jira_orchestrate_tasks_from_issue_mappings",
     "discover_documents",
     "create_document_update_tasks_from_paths",
+    "load_jira_preset_brief",
     "DOCUMENT_DISCOVER_TOOL_NAME",
     "DOCUMENT_UPDATE_TASKS_TOOL_NAME",
     "register_story_output_tool_handlers",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -129,7 +129,7 @@ def _extract_acceptance_criteria(
 ) -> str:
     for field_key, field_name in names.items():
         normalized_name = str(field_name or "").lower()
-        if "acceptance" not in normalized_name and "criteria" not in normalized_name:
+        if "acceptance" not in normalized_name:
             continue
         text = _normalize_jira_text(fields.get(field_key))
         if text:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1345,6 +1345,75 @@ class MoonMindRunWorkflow:
                     break
         return merged_inputs
 
+    @staticmethod
+    def _trusted_previous_outputs_instruction(
+        previous_outputs: object,
+    ) -> str | None:
+        if not isinstance(previous_outputs, Mapping):
+            return None
+        trusted_source = str(previous_outputs.get("trustedSource") or "").strip()
+        if trusted_source != "moonmind.jira.get_issue":
+            return None
+
+        context: dict[str, Any] = {"trustedSource": trusted_source}
+        for key in (
+            "jiraIssueKey",
+            "jiraPresetBrief",
+            "jiraStepInstructions",
+            "jiraIssue",
+            "summary",
+        ):
+            value = previous_outputs.get(key)
+            if value in (None, "", {}, []):
+                continue
+            context[key] = value
+        if len(context) <= 1:
+            return None
+
+        payload = json.dumps(
+            context,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        max_payload_chars = 24000
+        if len(payload) > max_payload_chars:
+            payload = payload[:max_payload_chars] + "...[truncated]"
+        return (
+            "MoonMind trusted previous step context:\n"
+            "The following JSON was produced by MoonMind's trusted Jira tool path. "
+            "Treat it as authoritative for this step. Do not use provider-native "
+            "Jira/Atlassian connectors, web scraping, or guessed issue content to "
+            "replace it.\n"
+            f"```json\n{payload}\n```"
+        )
+
+    def _append_trusted_previous_outputs_to_agent_inputs(
+        self,
+        node_inputs: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        previous_context = self._trusted_previous_outputs_instruction(
+            node_inputs.get("previousOutputs")
+        )
+        if not previous_context:
+            return dict(node_inputs)
+        merged_inputs = dict(node_inputs)
+        for key in (
+            "instructions",
+            "instructionRef",
+            "instruction",
+            "instructionsText",
+            "instructions_text",
+        ):
+            instruction = merged_inputs.get(key)
+            if isinstance(instruction, str) and instruction.strip():
+                if "MoonMind trusted previous step context:" in instruction:
+                    return merged_inputs
+                merged_inputs[key] = instruction.rstrip() + "\n\n" + previous_context
+                return merged_inputs
+        merged_inputs["instructions"] = previous_context
+        return merged_inputs
+
     def _publish_repair_feedback_instruction(
         self,
         *,
@@ -5311,6 +5380,7 @@ class MoonMindRunWorkflow:
         workflow_parameters: Mapping[str, Any] | None = None,
     ) -> "AgentExecutionRequest":
         """Build an ``AgentExecutionRequest`` from plan-node inputs and workflow context."""
+        node_inputs = self._append_trusted_previous_outputs_to_agent_inputs(node_inputs)
         runtime_block_raw = node_inputs.get("runtime")
         runtime_block = (
             runtime_block_raw if isinstance(runtime_block_raw, Mapping) else {}

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -385,6 +385,7 @@ class MoonMindRunWorkflow:
         self._last_publish_repair_node_id: str | None = None
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
+        self._trusted_jira_context: dict[str, Any] | None = None
         self._step_ledger_rows: list[dict[str, Any]] = []
         self._step_ledger_by_id: dict[str, dict[str, Any]] = {}
         self._progress_snapshot: dict[str, Any] = {
@@ -1346,9 +1347,34 @@ class MoonMindRunWorkflow:
         return merged_inputs
 
     @staticmethod
-    def _trusted_previous_outputs_instruction(
+    def _truncate_json_context_value(value: Any, *, max_chars: int) -> Any:
+        suffix = "...[truncated]"
+        if isinstance(value, str):
+            if len(value) <= max_chars:
+                return value
+            return value[: max(0, max_chars - len(suffix))] + suffix
+        if isinstance(value, Mapping):
+            return {
+                str(key): MoonMindRunWorkflow._truncate_json_context_value(
+                    nested,
+                    max_chars=max_chars,
+                )
+                for key, nested in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                MoonMindRunWorkflow._truncate_json_context_value(
+                    nested,
+                    max_chars=max_chars,
+                )
+                for nested in value
+            ]
+        return value
+
+    @staticmethod
+    def _trusted_previous_outputs_context(
         previous_outputs: object,
-    ) -> str | None:
+    ) -> dict[str, Any] | None:
         if not isinstance(previous_outputs, Mapping):
             return None
         trusted_source = str(previous_outputs.get("trustedSource") or "").strip()
@@ -1369,16 +1395,63 @@ class MoonMindRunWorkflow:
             context[key] = value
         if len(context) <= 1:
             return None
+        return context
 
+    @staticmethod
+    def _trusted_context_payload(context: Mapping[str, Any]) -> str:
+        max_payload_chars = 24000
+        compact_context = {
+            key: MoonMindRunWorkflow._truncate_json_context_value(
+                value,
+                max_chars=6000,
+            )
+            for key, value in context.items()
+        }
         payload = json.dumps(
-            context,
+            compact_context,
             ensure_ascii=True,
             sort_keys=True,
             separators=(",", ": "),
         )
-        max_payload_chars = 24000
-        if len(payload) > max_payload_chars:
-            payload = payload[:max_payload_chars] + "...[truncated]"
+        if len(payload) <= max_payload_chars:
+            return payload
+
+        essential_context = {
+            key: compact_context[key]
+            for key in (
+                "trustedSource",
+                "jiraIssueKey",
+                "summary",
+                "jiraPresetBrief",
+                "jiraStepInstructions",
+            )
+            if key in compact_context
+        }
+        essential_context = {
+            key: MoonMindRunWorkflow._truncate_json_context_value(
+                value,
+                max_chars=3000,
+            )
+            for key, value in essential_context.items()
+        }
+        return json.dumps(
+            essential_context,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+
+    @staticmethod
+    def _trusted_previous_outputs_instruction(
+        previous_outputs: object,
+    ) -> str | None:
+        context = MoonMindRunWorkflow._trusted_previous_outputs_context(
+            previous_outputs
+        )
+        if not context:
+            return None
+
+        payload = MoonMindRunWorkflow._trusted_context_payload(context)
         return (
             "MoonMind trusted previous step context:\n"
             "The following JSON was produced by MoonMind's trusted Jira tool path. "
@@ -1401,9 +1474,6 @@ class MoonMindRunWorkflow:
         for key in (
             "instructions",
             "instructionRef",
-            "instruction",
-            "instructionsText",
-            "instructions_text",
         ):
             instruction = merged_inputs.get(key)
             if isinstance(instruction, str) and instruction.strip():
@@ -1413,6 +1483,24 @@ class MoonMindRunWorkflow:
                 return merged_inputs
         merged_inputs["instructions"] = previous_context
         return merged_inputs
+
+    def _record_trusted_jira_context(self, outputs: Mapping[str, Any]) -> None:
+        context = self._trusted_previous_outputs_context(outputs)
+        if context:
+            self._trusted_jira_context = context
+
+    def _merge_trusted_jira_context(
+        self,
+        previous_outputs: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        if not self._trusted_jira_context:
+            return previous_outputs
+        if self._trusted_previous_outputs_context(previous_outputs):
+            return previous_outputs
+        merged = dict(previous_outputs)
+        for key, value in self._trusted_jira_context.items():
+            merged.setdefault(key, value)
+        return merged
 
     def _publish_repair_feedback_instruction(
         self,
@@ -2797,6 +2885,9 @@ class MoonMindRunWorkflow:
                     node_id,
                     previous_step_outputs,
                 )
+                current_previous_outputs = self._merge_trusted_jira_context(
+                    current_previous_outputs
+                )
                 if current_previous_outputs:
                     node_inputs["previousOutputs"] = dict(current_previous_outputs)
 
@@ -3259,6 +3350,7 @@ class MoonMindRunWorkflow:
                 execution_result, "outputs"
             )
             if isinstance(outputs_for_story_output, Mapping):
+                self._record_trusted_jira_context(outputs_for_story_output)
                 previous_step_outputs = outputs_for_story_output
                 story_output_result = outputs_for_story_output.get("storyOutput")
                 if isinstance(story_output_result, Mapping):

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -120,6 +120,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         ]
         assert jira_orchestrate_steps[0] == "jira-issue-updater"
         assert jira_orchestrate_steps[1] == "jira.check_blockers"
+        assert jira_orchestrate_steps[2] == "jira.load_preset_brief"
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
@@ -137,6 +138,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]
         assert "stop the orchestration immediately" in blocker_step["instructions"]
+        brief_step = jira_orchestrate_template.latest_version.steps[2]
+        assert brief_step["title"] == "Load Jira preset brief"
+        assert brief_step["type"] == "tool"
+        assert brief_step["tool"]["id"] == "jira.load_preset_brief"
         remediation_step = next(
             step
             for step in jira_orchestrate_template.latest_version.steps

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2233,7 +2233,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             ] == [
                 "jira-issue-updater",
                 "jira.check_blockers",
-                "auto",
+                "jira.load_preset_brief",
                 "auto",
                 "moonspec-specify",
                 "auto",
@@ -2298,6 +2298,9 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "stop the orchestration immediately" in expanded["steps"][1][
                 "instructions"
             ]
+            assert expanded["steps"][2]["type"] == "tool"
+            assert expanded["steps"][2]["tool"]["id"] == "jira.load_preset_brief"
+            assert expanded["steps"][2]["tool"]["inputs"] == {"issueKey": "MM-328"}
             assert "Jira preset brief" in expanded["steps"][2]["instructions"]
             assert "Keep the scope narrow." in expanded["steps"][3]["instructions"]
             assert expanded["steps"][11]["title"] == "Remediate verification gaps"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -180,6 +180,34 @@ async def test_load_jira_preset_brief_uses_trusted_jira_issue_payload():
     assert "Given an operator" in result.outputs["jiraPresetBrief"]
     assert result.outputs["jiraIssue"]["status"] == "In Progress"
 
+
+@pytest.mark.asyncio
+async def test_load_jira_preset_brief_ignores_criteria_only_custom_fields():
+    service = _FakeJiraService()
+    service.issue_responses["MM-657"] = {
+        "key": "MM-657",
+        "names": {
+            "customfield_10001": "Exit Criteria",
+            "customfield_10042": "Acceptance Criteria",
+        },
+        "fields": {
+            "summary": "Settings HTTP API surface",
+            "description": "Expose catalog and audit endpoints.",
+            "customfield_10001": "Wrong criteria text",
+            "customfield_10042": "Given an operator\nThen settings are auditable",
+        },
+    }
+
+    result = await load_jira_preset_brief(
+        {"issueKey": "MM-657"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert "Given an operator" in result.outputs["jiraPresetBrief"]
+    assert "Wrong criteria text" not in result.outputs["jiraPresetBrief"]
+
+
 @pytest.mark.asyncio
 async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_source():
     service = _FakeJiraService()

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -12,6 +12,7 @@ from moonmind.workflows.temporal.story_output_tools import (
     create_jira_issues_from_stories,
     create_jira_orchestrate_tasks_from_issue_mappings,
     discover_documents,
+    load_jira_preset_brief,
 )
 
 class _FakeJiraService:
@@ -133,6 +134,51 @@ async def test_create_jira_issues_from_inline_story_breakdown():
     assert request.summary == "Create proposal intent records"
     assert request.fields["labels"] == ["moonmind"]
     assert "Intent is visible" in request.description
+
+@pytest.mark.asyncio
+async def test_load_jira_preset_brief_uses_trusted_jira_issue_payload():
+    service = _FakeJiraService()
+    service.issue_responses["MM-657"] = {
+        "key": "MM-657",
+        "self": "https://jira.example/rest/api/3/issue/657",
+        "names": {"customfield_10042": "Acceptance Criteria"},
+        "fields": {
+            "summary": "Settings HTTP API surface",
+            "description": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Expose catalog and audit endpoints.",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "customfield_10042": "Given an operator\nThen settings are auditable",
+            "status": {"name": "In Progress"},
+            "issuetype": {"name": "Story"},
+            "assignee": {"displayName": "Nate"},
+        },
+    }
+
+    result = await load_jira_preset_brief(
+        {"issueKey": "MM-657"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert service.get_issue_requests[0].issue_key == "MM-657"
+    assert service.get_issue_requests[0].expand == ["names"]
+    assert result.outputs["trustedSource"] == "moonmind.jira.get_issue"
+    assert result.outputs["jiraIssueKey"] == "MM-657"
+    assert "MM-657: Settings HTTP API surface" in result.outputs["jiraPresetBrief"]
+    assert "Expose catalog and audit endpoints." in result.outputs["jiraPresetBrief"]
+    assert "Given an operator" in result.outputs["jiraPresetBrief"]
+    assert result.outputs["jiraIssue"]["status"] == "In Progress"
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_source():

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -170,6 +171,58 @@ def test_agent_request_includes_trusted_jira_previous_outputs_in_instruction_ref
     assert "moonmind.jira.get_issue" in request.instruction_ref
     assert "MM-657: Settings HTTP API surface" in request.instruction_ref
     assert "Do not use provider-native Jira/Atlassian connectors" in request.instruction_ref
+
+
+def test_trusted_jira_context_persists_after_intermediate_step_output() -> None:
+    wf = MoonMindRunWorkflow()
+    wf._record_trusted_jira_context(
+        {
+            "trustedSource": "moonmind.jira.get_issue",
+            "jiraIssueKey": "MM-657",
+            "jiraPresetBrief": "MM-657: Settings HTTP API surface",
+        }
+    )
+
+    merged = wf._merge_trusted_jira_context({"storyOutput": {"status": "COMPLETED"}})
+
+    assert merged["storyOutput"] == {"status": "COMPLETED"}
+    assert merged["trustedSource"] == "moonmind.jira.get_issue"
+    assert merged["jiraIssueKey"] == "MM-657"
+    assert merged["jiraPresetBrief"] == "MM-657: Settings HTTP API surface"
+
+
+def test_trusted_jira_context_uses_valid_json_after_truncation() -> None:
+    instruction = MoonMindRunWorkflow._trusted_previous_outputs_instruction(
+        {
+            "trustedSource": "moonmind.jira.get_issue",
+            "jiraIssueKey": "MM-657",
+            "jiraPresetBrief": "A" * 30000,
+        }
+    )
+
+    assert instruction is not None
+    payload = instruction.split("```json\n", 1)[1].split("\n```", 1)[0]
+    parsed = json.loads(payload)
+    assert parsed["trustedSource"] == "moonmind.jira.get_issue"
+    assert parsed["jiraPresetBrief"].endswith("...[truncated]")
+
+
+def test_trusted_jira_context_ignores_unconsumed_instruction_aliases() -> None:
+    wf = MoonMindRunWorkflow()
+    merged = wf._append_trusted_previous_outputs_to_agent_inputs(
+        {
+            "runtime": {"mode": "claude_code"},
+            "instruction": "Unused alias",
+            "previousOutputs": {
+                "trustedSource": "moonmind.jira.get_issue",
+                "jiraIssueKey": "MM-657",
+                "jiraPresetBrief": "MM-657: Settings HTTP API surface",
+            },
+        }
+    )
+
+    assert merged["instruction"] == "Unused alias"
+    assert "MoonMind trusted previous step context:" in merged["instructions"]
 
 
 def test_prepare_failure_prevents_unbounded_context_dispatch() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -142,6 +142,36 @@ def test_managed_codex_request_keeps_prepared_context_out_of_input_refs() -> Non
     ]
 
 
+def test_agent_request_includes_trusted_jira_previous_outputs_in_instruction_ref() -> None:
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={
+                "runtime": {"mode": "claude_code"},
+                "instructions": "Classify request and resume point.",
+                "previousOutputs": {
+                    "trustedSource": "moonmind.jira.get_issue",
+                    "jiraIssueKey": "MM-657",
+                    "jiraPresetBrief": "MM-657: Settings HTTP API surface",
+                    "jiraIssue": {"status": "In Progress"},
+                },
+            },
+            node_id="classify",
+            tool_name="claude_code",
+            workflow_parameters={"task": {}},
+        )
+
+    assert request.instruction_ref is not None
+    assert request.instruction_ref.startswith("Classify request and resume point.")
+    assert "MoonMind trusted previous step context:" in request.instruction_ref
+    assert "moonmind.jira.get_issue" in request.instruction_ref
+    assert "MM-657: Settings HTTP API surface" in request.instruction_ref
+    assert "Do not use provider-native Jira/Atlassian connectors" in request.instruction_ref
+
+
 def test_prepare_failure_prevents_unbounded_context_dispatch() -> None:
     wf = MoonMindRunWorkflow()
     with patch(


### PR DESCRIPTION
## Summary
- Route the Jira orchestrate preset brief load through a deterministic trusted Jira tool step instead of an auto agent step.
- Add `jira.load_preset_brief` output shaping so agents receive the issue brief, description, acceptance criteria, issue URL, and trusted source marker from MoonMind Jira access.
- Append trusted prior Jira tool outputs into downstream agent instructions so later steps do not fall back to provider-native Atlassian/Jira connectors or guessed tenant context.
- Cover the template expansion, trusted Jira tool handler, workflow prompt injection, and startup template seeding paths with tests.

## Root cause
The previous resilience work protected blocker checks and selected Jira skills, but the “Load Jira preset brief” step in the orchestrate preset was still `skill: auto`. That left Claude free to use its own Jira connector path, which selected the wrong tenant even though MoonMind had valid Jira permissions. The workflow also did not explicitly bridge trusted tool output from earlier steps into later agent instructions.

## Validation
- `pytest tests/unit/workflows/temporal/test_story_output_tools.py::test_load_jira_preset_brief_uses_trusted_jira_issue_payload -q`
- `pytest tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py::test_agent_request_includes_trusted_jira_previous_outputs_in_instruction_ref -q`
- `pytest tests/unit/api/test_task_step_templates_service.py::test_seed_catalog_includes_jira_orchestrate_preset -q`
- `pytest tests/unit/workflows/temporal/test_story_output_tools.py -q`
- `pytest tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py -q`
- `pytest tests/integration/test_startup_task_template_seeding.py::test_startup_seeds_default_task_templates -q`
- `python3 -m py_compile moonmind/workflows/temporal/story_output_tools.py moonmind/workflows/temporal/workflows/run.py`
- `git diff --check -- api_service/data/task_step_templates/jira-orchestrate.yaml moonmind/workflows/temporal/story_output_tools.py moonmind/workflows/temporal/workflows/run.py tests/integration/test_startup_task_template_seeding.py tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py`

Full `./tools/test_unit.sh` did not complete in this local checkout because collection hit an existing Python 3.11-only syntax failure in `tests/unit/services/temporal/runtime/test_managed_session_controller.py`. The targeted wrapper run passed its Python phase (`118 passed`) but the frontend phase was blocked by the pre-existing deleted `tailwind.config.cjs` in the dirty worktree.