### PR TITLE
MM-684 Normalize slash command snapshots

### DIFF
--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -374,7 +374,23 @@ def _build_runtime_command_metadata(
         command = match.group(1)
         args = match.group(2) or ""
     else:
-        command = first_line[1:].split(maxsplit=1)[0]
+        command_parts = first_line[1:].split(maxsplit=1)
+        if not command_parts:
+            payload.update(
+                {
+                    "command": "",
+                    "rawCommand": first_line,
+                    "args": "",
+                    "instructionBody": raw_instructions,
+                    "detectionStatus": "malformed",
+                    "hintStatus": "opaque",
+                    "recognitionMode": "escaped_literal",
+                    "requiresRuntimeRecognition": False,
+                    "detectionPhase": "submit",
+                }
+            )
+            return payload
+        command = command_parts[0]
         args = ""
     hint_status = _runtime_command_hint_status(command)
     passthrough = _runtime_supports_slash_passthrough(target_runtime)

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -38,6 +38,15 @@ _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
     {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
 )
 _JIRA_ORCHESTRATE_PRESET_SLUGS = frozenset({"jira-orchestrate"})
+_RUNTIME_COMMAND_CAPABILITY_VERSION = "2026-05-13"
+_RUNTIME_COMMAND_HINT_CATALOG_VERSION = "2026-05-13"
+_SLASH_COMMAND_PASSTHROUGH_RUNTIMES = frozenset(
+    {"codex", "codex_cli", "claude", "gemini_cli", "universal"}
+)
+_KNOWN_RUNTIME_COMMAND_HINTS = frozenset({"review", "simplify"})
+_RUNTIME_COMMAND_TOKEN_PATTERN = re.compile(
+    r"^/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$"
+)
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
     re.IGNORECASE,
@@ -241,6 +250,189 @@ def _normalize_runtime_value(value: object, *, field_name: str) -> str | None:
         supported = ", ".join(sorted(SUPPORTED_RUNTIME_MODES))
         raise TaskContractError(f"{field_name} must be one of: {supported}")
     return lowered
+
+
+def _raw_instruction_string(value: object) -> str:
+    if value is None:
+        return ""
+    return value if isinstance(value, str) else str(value)
+
+
+def _first_line_and_body(raw_instructions: str) -> tuple[str, str]:
+    lines = raw_instructions.splitlines()
+    if not lines:
+        return "", ""
+    return lines[0].rstrip(), "\n".join(lines[1:])
+
+
+def _runtime_mode_from_task(
+    task: Mapping[str, Any], *, target_runtime: object = None
+) -> str | None:
+    runtime = _safe_mapping(task.get("runtime"))
+    candidate = (
+        runtime.get("mode")
+        or task.get("targetRuntime")
+        or task.get("target_runtime")
+        or target_runtime
+    )
+    candidate_str = _clean_optional_str(candidate)
+    return candidate_str.lower() if candidate_str else None
+
+
+def _runtime_supports_slash_passthrough(runtime_mode: str | None) -> bool:
+    return (runtime_mode or DEFAULT_TASK_RUNTIME) in _SLASH_COMMAND_PASSTHROUGH_RUNTIMES
+
+
+def _runtime_command_hint_status(command: str) -> str:
+    return "hinted" if command in _KNOWN_RUNTIME_COMMAND_HINTS else "opaque"
+
+
+def _looks_like_ordinary_path(first_line: str) -> bool:
+    token = first_line.split(maxsplit=1)[0]
+    if not token.startswith("/"):
+        return False
+    without_slash = token[1:]
+    return "/" in without_slash or without_slash.startswith(".")
+
+
+def _base_runtime_command_payload(
+    *,
+    source_path: str,
+    target_runtime: str | None,
+    target_step_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "kind": "slash_command",
+        "source": "leading_slash",
+        "sourcePath": source_path,
+    }
+    if target_runtime:
+        payload["targetRuntime"] = target_runtime
+    if target_step_id:
+        payload["targetStepId"] = target_step_id
+    return payload
+
+
+def _build_runtime_command_metadata(
+    *,
+    raw_instructions_value: object,
+    source_path: str,
+    target_runtime: str | None,
+    target_step_id: str | None = None,
+) -> dict[str, Any] | None:
+    raw_instructions = _raw_instruction_string(raw_instructions_value)
+    if not raw_instructions:
+        return None
+    if raw_instructions.startswith("\\/"):
+        first_line, _body = _first_line_and_body(raw_instructions)
+        payload = _base_runtime_command_payload(
+            source_path=source_path,
+            target_runtime=target_runtime,
+            target_step_id=target_step_id,
+        )
+        payload.update(
+            {
+                "command": "",
+                "rawCommand": first_line,
+                "args": "",
+                "instructionBody": raw_instructions[1:],
+                "detectionStatus": "escaped",
+                "hintStatus": "opaque",
+                "recognitionMode": "escaped_literal",
+                "requiresRuntimeRecognition": False,
+                "detectionPhase": "submit",
+            }
+        )
+        return payload
+    if not raw_instructions.startswith("/"):
+        return None
+
+    first_line, instruction_body = _first_line_and_body(raw_instructions)
+    payload = _base_runtime_command_payload(
+        source_path=source_path,
+        target_runtime=target_runtime,
+        target_step_id=target_step_id,
+    )
+    if _looks_like_ordinary_path(first_line):
+        payload.update(
+            {
+                "command": "",
+                "rawCommand": first_line,
+                "args": "",
+                "instructionBody": raw_instructions,
+                "detectionStatus": "malformed",
+                "hintStatus": "opaque",
+                "recognitionMode": "escaped_literal",
+                "requiresRuntimeRecognition": False,
+                "detectionPhase": "submit",
+            }
+        )
+        return payload
+
+    match = _RUNTIME_COMMAND_TOKEN_PATTERN.fullmatch(first_line)
+    if match:
+        command = match.group(1)
+        args = match.group(2) or ""
+    else:
+        command = first_line[1:].split(maxsplit=1)[0]
+        args = ""
+    hint_status = _runtime_command_hint_status(command)
+    passthrough = _runtime_supports_slash_passthrough(target_runtime)
+    if passthrough:
+        recognition_mode = (
+            "hinted_runtime_passthrough"
+            if hint_status == "hinted"
+            else "runtime_passthrough"
+        )
+    else:
+        recognition_mode = "runtime_does_not_support_slash_commands"
+    payload.update(
+        {
+            "command": command,
+            "rawCommand": first_line,
+            "args": args,
+            "instructionBody": instruction_body,
+            "detectionStatus": "detected",
+            "hintStatus": hint_status,
+            "recognitionMode": recognition_mode,
+            "requiresRuntimeRecognition": passthrough,
+            "runtimeCapabilityVersion": _RUNTIME_COMMAND_CAPABILITY_VERSION,
+            "hintCatalogVersion": _RUNTIME_COMMAND_HINT_CATALOG_VERSION,
+            "detectionPhase": "submit",
+        }
+    )
+    return payload
+
+
+def _validate_supplied_runtime_command(
+    supplied: object,
+    expected: Mapping[str, Any] | None,
+    *,
+    field_name: str,
+) -> None:
+    if supplied is None:
+        return
+    if not isinstance(supplied, Mapping):
+        raise TaskContractError(f"{field_name} must be an object")
+    if expected is None:
+        raise TaskContractError(
+            f"{field_name} conflicts with backend runtime command normalization"
+        )
+    for key in (
+        "kind",
+        "sourcePath",
+        "targetStepId",
+        "command",
+        "rawCommand",
+        "detectionStatus",
+        "recognitionMode",
+    ):
+        if key not in supplied:
+            continue
+        if supplied.get(key) != expected.get(key):
+            raise TaskContractError(
+                f"{field_name} conflicts with backend runtime command normalization"
+            )
 
 def _normalize_publish_mode(value: object) -> str:
     candidate = (_clean_optional_str(value) or _default_publish_mode()).lower()
@@ -2220,6 +2412,7 @@ def build_authoritative_task_input_snapshot(
     steps = [
         step for step in _safe_list(task.get("steps")) if isinstance(step, Mapping)
     ]
+    runtime_mode = _runtime_mode_from_task(task, target_runtime=target_runtime)
     repository_value = (
         _clean_optional_str(git.get("repository"))
         or _clean_optional_str(repository)
@@ -2237,23 +2430,35 @@ def build_authoritative_task_input_snapshot(
     detachment: list[dict[str, Any]] = []
     for ordinal, step in enumerate(steps):
         step_id = _step_identifier(step, ordinal)
-        final_order.append({"stepId": step_id, "ordinal": ordinal})
-        authored_steps.append(
-            {
-                "id": step_id,
-                "title": _clean_optional_str(step.get("title")),
-                "instructions": _clean_optional_str(step.get("instructions")) or "",
-                "inputAttachments": _safe_list(step.get("inputAttachments")),
-                "dependencies": _first_present_snapshot_list(
-                    step,
-                    "dependsOn",
-                    "dependencies",
-                ),
-                "templateStepId": _clean_optional_str(step.get("templateStepId")),
-                "stepType": _clean_optional_str(step.get("type")),
-                "presetProvenance": _safe_mapping(step.get("presetProvenance")),
-            }
+        step_runtime_command = _build_runtime_command_metadata(
+            raw_instructions_value=step.get("instructions"),
+            source_path=f"steps[{ordinal}].instructions",
+            target_runtime=runtime_mode,
+            target_step_id=step_id,
         )
+        _validate_supplied_runtime_command(
+            step.get("runtimeCommand"),
+            step_runtime_command,
+            field_name=f"task.steps[{ordinal}].runtimeCommand",
+        )
+        final_order.append({"stepId": step_id, "ordinal": ordinal})
+        authored_step = {
+            "id": step_id,
+            "title": _clean_optional_str(step.get("title")),
+            "instructions": _clean_optional_str(step.get("instructions")) or "",
+            "inputAttachments": _safe_list(step.get("inputAttachments")),
+            "dependencies": _first_present_snapshot_list(
+                step,
+                "dependsOn",
+                "dependencies",
+            ),
+            "templateStepId": _clean_optional_str(step.get("templateStepId")),
+            "stepType": _clean_optional_str(step.get("type")),
+            "presetProvenance": _safe_mapping(step.get("presetProvenance")),
+        }
+        if step_runtime_command is not None:
+            authored_step["runtimeCommand"] = step_runtime_command
+        authored_steps.append(authored_step)
         if isinstance(step.get("presetProvenance"), Mapping):
             provenance.append(
                 {
@@ -2272,19 +2477,32 @@ def build_authoritative_task_input_snapshot(
                 {"stepId": step_id, "ordinal": ordinal, "detached": True}
             )
     issue_key = _detect_jira_issue_key(task)
+    objective_runtime_command = _build_runtime_command_metadata(
+        raw_instructions_value=task.get("instructions"),
+        source_path="objective.instructions",
+        target_runtime=runtime_mode,
+    )
+    _validate_supplied_runtime_command(
+        task.get("runtimeCommand"),
+        objective_runtime_command,
+        field_name="task.runtimeCommand",
+    )
+    objective = {
+        "instructions": _clean_optional_str(task.get("instructions")) or "",
+        "inputAttachments": _safe_list(task.get("inputAttachments")),
+    }
+    if objective_runtime_command is not None:
+        objective["runtimeCommand"] = objective_runtime_command
     return {
         "traceability": {
             **({"jiraIssueKey": issue_key} if issue_key else {}),
         },
-        "objective": {
-            "instructions": _clean_optional_str(task.get("instructions")) or "",
-            "inputAttachments": _safe_list(task.get("inputAttachments")),
-        },
+        "objective": objective,
         "steps": authored_steps,
         "runtime": _safe_mapping(task.get("runtime"))
         or (
-            {"mode": _clean_optional_str(target_runtime)}
-            if _clean_optional_str(target_runtime)
+            {"mode": runtime_mode}
+            if runtime_mode
             else {}
         ),
         "publish": _safe_mapping(task.get("publish")),

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -2445,7 +2445,7 @@ def build_authoritative_task_input_snapshot(
         authored_step = {
             "id": step_id,
             "title": _clean_optional_str(step.get("title")),
-            "instructions": _clean_optional_str(step.get("instructions")) or "",
+            "instructions": _raw_instruction_string(step.get("instructions")),
             "inputAttachments": _safe_list(step.get("inputAttachments")),
             "dependencies": _first_present_snapshot_list(
                 step,
@@ -2488,7 +2488,7 @@ def build_authoritative_task_input_snapshot(
         field_name="task.runtimeCommand",
     )
     objective = {
-        "instructions": _clean_optional_str(task.get("instructions")) or "",
+        "instructions": _raw_instruction_string(task.get("instructions")),
         "inputAttachments": _safe_list(task.get("inputAttachments")),
     }
     if objective_runtime_command is not None:

--- a/specs/353-normalize-slash-commands/checklists/requirements.md
+++ b/specs/353-normalize-slash-commands/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Normalize Slash-Leading Instructions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The request is classified as a single-story runtime implementation feature for backend authoritative task snapshots.
+- PASS: `MM-684` and the canonical Jira preset brief are preserved in `spec.md` `**Input**`.
+- PASS: Source design requirements from `docs/Steps/SlashCommands.md` are mapped to functional requirements, with provider-neutral Create page previews and runtime-specific rendering kept out of scope except where snapshot contracts require supporting metadata.

--- a/specs/353-normalize-slash-commands/contracts/runtime-command-snapshot.md
+++ b/specs/353-normalize-slash-commands/contracts/runtime-command-snapshot.md
@@ -1,0 +1,87 @@
+# Contract: Runtime Command Snapshot Normalization
+
+Source traceability: MM-684 canonical Jira preset brief.
+
+## Input Surface
+
+The canonical task payload may include authored instructions at:
+
+```json
+{
+  "task": {
+    "instructions": "/review\nCheck the branch.",
+    "runtime": {"mode": "codex"},
+    "steps": [
+      {
+        "id": "step-1",
+        "instructions": "/simplify\nReduce duplication."
+      }
+    ]
+  }
+}
+```
+
+Clients may also send preview metadata in `runtimeCommand`, but backend normalization is authoritative. Conflicting or malformed supplied metadata is invalid.
+
+## Snapshot Output
+
+`build_authoritative_task_input_snapshot()` returns preserved authored instructions plus derived command metadata:
+
+```json
+{
+  "objective": {
+    "instructions": "/review\nCheck the branch.",
+    "runtimeCommand": {
+      "kind": "slash_command",
+      "source": "leading_slash",
+      "sourcePath": "objective.instructions",
+      "command": "review",
+      "rawCommand": "/review",
+      "args": "",
+      "instructionBody": "Check the branch.",
+      "targetRuntime": "codex",
+      "detectionStatus": "detected",
+      "hintStatus": "hinted",
+      "recognitionMode": "hinted_runtime_passthrough",
+      "requiresRuntimeRecognition": true,
+      "runtimeCapabilityVersion": "2026-05-13",
+      "hintCatalogVersion": "2026-05-13",
+      "detectionPhase": "submit"
+    }
+  },
+  "steps": [
+    {
+      "id": "step-1",
+      "instructions": "/simplify\nReduce duplication.",
+      "runtimeCommand": {
+        "kind": "slash_command",
+        "source": "leading_slash",
+        "sourcePath": "steps[0].instructions",
+        "targetStepId": "step-1",
+        "command": "simplify"
+      }
+    }
+  ]
+}
+```
+
+## Parser Contract
+
+- Detect only when the normalized instruction string's first character is `/`.
+- Treat `\/` as an escaped literal.
+- Parse structured commands with:
+
+```regex
+^\/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$
+```
+
+- Preserve opaque slash-leading command lines for pass-through runtimes when they are not ordinary path-like text.
+- Treat ordinary path-like first lines such as `/src/app.ts is broken` as malformed literal input.
+- Do not use known-command hints as an allowlist.
+
+## Validation Contract
+
+- Backend-generated metadata must match authored instructions and source path.
+- Supplied metadata with a command, status, source path, or target step that conflicts with backend parsing is rejected.
+- Supplied metadata with unsupported shape is rejected.
+- Absence of supplied metadata is valid; backend computes metadata.

--- a/specs/353-normalize-slash-commands/data-model.md
+++ b/specs/353-normalize-slash-commands/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: Normalize Slash-Leading Instructions
+
+Source traceability: MM-684 canonical Jira preset brief.
+
+## RuntimeCommandInvocation
+
+Represents command metadata derived from one authored instruction field.
+
+Fields:
+- `kind`: constant `slash_command`.
+- `source`: `leading_slash` for detected slash commands, `explicit_ui` only for future explicit UI command sources.
+- `sourcePath`: canonical path to the instruction field, such as `objective.instructions` or `steps[0].instructions`.
+- `command`: parsed command token without the leading slash; empty for escaped literals or malformed literal handling.
+- `rawCommand`: original first-line command token or escaped marker as authored after existing surrounding-whitespace normalization.
+- `args`: parsed argument text from the first command line, or empty string.
+- `instructionBody`: authored text after the first command line, or literal body for escaped commands.
+- `targetRuntime`: normalized runtime mode when available.
+- `targetStepId`: step id for step-level commands.
+- `detectionStatus`: `detected`, `escaped`, `not_detected`, or `malformed`.
+- `hintStatus`: `hinted` or `opaque`.
+- `recognitionMode`: `runtime_passthrough`, `hinted_runtime_passthrough`, `escaped_literal`, or `runtime_does_not_support_slash_commands`.
+- `requiresRuntimeRecognition`: whether a runtime adapter must preserve command recognition.
+- `runtimeCapabilityVersion`: version marker for the runtime capability catalog used during normalization.
+- `hintCatalogVersion`: version marker when a known-command hint catalog was consulted.
+- `detectionPhase`: `submit`.
+
+Validation rules:
+- `sourcePath` is required for every metadata object.
+- `targetStepId` is required for step-level instruction metadata.
+- Unknown valid commands are allowed and use `hintStatus=opaque`.
+- Escaped literals use `detectionStatus=escaped`, `recognitionMode=escaped_literal`, and `requiresRuntimeRecognition=false`.
+- Unsupported runtimes or malformed ordinary path-like inputs must not produce executable pass-through recognition metadata.
+
+## RuntimeCommandPolicy
+
+Represents default validation outcomes for slash command normalization.
+
+Fields:
+- `slashPassthroughRuntime`: default `pass_through`.
+- `runtimeWithoutSlashPassthrough`: default `warn_literal`.
+- `escapedCommand`: default `allow_plain_text`.
+- `malformedCommand`: default `warn_literal`.
+
+Validation rules:
+- Valid unknown commands are never rejected solely because no hint exists.
+- Unsupported-runtime and malformed command handling may warn or reject according to policy, but accepted snapshots preserve authored text.
+
+## AuthoritativeTaskInputSnapshot
+
+Existing durable snapshot extended with optional runtime command metadata.
+
+Relevant fields:
+- `objective.instructions`: preserved task-level authored instructions.
+- `objective.runtimeCommand`: optional `RuntimeCommandInvocation` for task-level instruction metadata.
+- `steps[].instructions`: preserved step-level authored instructions.
+- `steps[].runtimeCommand`: optional `RuntimeCommandInvocation` for step-level instruction metadata.
+- `runtime.mode`: normalized or supplied target runtime used for capability classification.
+
+State transitions:
+- No leading slash: no runtime command metadata.
+- Leading slash valid and runtime supports pass-through: detected metadata requiring runtime recognition.
+- Leading slash unknown but valid: detected opaque metadata requiring runtime recognition.
+- Escaped slash: escaped literal metadata not requiring runtime recognition.
+- Malformed/path-like or unsupported runtime: non-executable metadata or warning state according to policy.

--- a/specs/353-normalize-slash-commands/moonspec_align_report.md
+++ b/specs/353-normalize-slash-commands/moonspec_align_report.md
@@ -1,0 +1,23 @@
+# MoonSpec Alignment Report: MM-684
+
+## Updated
+
+- `research.md`: Added explicit MM-684 source traceability.
+- `data-model.md`: Added explicit MM-684 source traceability.
+- `contracts/runtime-command-snapshot.md`: Added explicit MM-684 source traceability.
+
+## Key Decisions
+
+- Classified the input as a single-story runtime implementation request because the Jira brief is scoped to backend authoritative task snapshots, while related provider-neutral Create page previews are tracked by MM-685.
+- Chose `moonmind/workflows/tasks/task_contract.py` and `tests/unit/workflows/tasks/test_task_contract.py` as the implementation and verification boundary because existing task input snapshot construction and canonical payload validation already live there.
+- Kept runtime-specific rendering and Create page preview behavior out of scope except for metadata needed by later adapter-owned rendering.
+
+## Validation
+
+- `spec.md`, `plan.md`, `tasks.md`, `research.md`, `data-model.md`, `contracts/runtime-command-snapshot.md`, and `quickstart.md` have no unresolved clarification markers.
+- Every in-scope `FR-*`, `SC-*`, and `DESIGN-REQ-*` has task coverage in `tasks.md`.
+- TDD order is preserved: tests and red-first confirmation precede implementation tasks.
+
+## Remaining Risks
+
+- Final implementation may reveal that API-level submission tests are also needed; `tasks.md` requires `./tools/test_integration.sh` if implementation expands beyond the task contract boundary.

--- a/specs/353-normalize-slash-commands/moonspec_align_report.md
+++ b/specs/353-normalize-slash-commands/moonspec_align_report.md
@@ -5,6 +5,7 @@
 - `research.md`: Added explicit MM-684 source traceability.
 - `data-model.md`: Added explicit MM-684 source traceability.
 - `contracts/runtime-command-snapshot.md`: Added explicit MM-684 source traceability.
+- `quickstart.md`: Aligned final verification command with `tasks.md` as `/moonspec-verify specs/353-normalize-slash-commands`.
 
 ## Key Decisions
 
@@ -17,6 +18,7 @@
 - `spec.md`, `plan.md`, `tasks.md`, `research.md`, `data-model.md`, `contracts/runtime-command-snapshot.md`, and `quickstart.md` have no unresolved clarification markers.
 - Every in-scope `FR-*`, `SC-*`, and `DESIGN-REQ-*` has task coverage in `tasks.md`.
 - TDD order is preserved: tests and red-first confirmation precede implementation tasks.
+- Downstream task gate re-check confirms one story phase, explicit unit/integration test tasks, story validation, implementation tasks, and final `/moonspec-verify` work.
 
 ## Remaining Risks
 

--- a/specs/353-normalize-slash-commands/plan.md
+++ b/specs/353-normalize-slash-commands/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Normalize Slash-Leading Instructions
+
+**Branch**: `run-jira-orchestrate-for-mm-684-normaliz-efb4d989` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/353-normalize-slash-commands/spec.md`
+
+## Summary
+
+Implement MM-684 by extending the canonical task contract normalization path so task-level and step-level slash-leading instructions produce authoritative runtime command metadata without rewriting authored instructions. The current snapshot builder preserves instructions but has no runtime command parser or metadata fields, so the feature requires test-first additions around `moonmind/workflows/tasks/task_contract.py` and the existing task contract tests. Unit tests will cover parser and snapshot semantics; integration-style task contract coverage will verify the real canonical payload/snapshot boundary.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `build_authoritative_task_input_snapshot()` preserves `objective.instructions` and step instructions but has no slash command metadata | add metadata without changing preserved text | unit + integration |
+| FR-002 | missing | no `runtimeCommand` parsing found in task contract models or tests | parse task and step instruction fields | unit + integration |
+| FR-003 | missing | no `RuntimeCommandInvocation` model or snapshot output | add compact model/normalization output | unit + integration |
+| FR-004 | missing | steps currently preserve instructions, ids, attachments, dependencies only | attach per-step command metadata with source path and target step id | unit + integration |
+| FR-005 | missing | no parser grammar exists | add conservative parser covering grammar and opaque/path-like cases | unit |
+| FR-006 | missing | no hint status or unknown command handling exists | accept unknown valid commands as opaque for slash-pass-through runtimes | unit |
+| FR-007 | missing | escaped slash inputs are treated as plain text only | record escaped literal metadata and safe recognition mode | unit |
+| FR-008 | missing | no frontend-supplied metadata validation exists | reject malformed/conflicting supplied metadata in task and step payloads | unit + integration |
+| FR-009 | missing | no runtime command policy metadata exists | apply default policy states for unsupported runtimes and malformed command lines | unit |
+| FR-010 | missing | no hint model exists | include hint status without allowlist rejection | unit |
+| FR-011 | implemented_unverified | `spec.md` preserves MM-684 and canonical brief | carry traceability through tasks/verification | final verify |
+| SC-001 | missing | no `/review` snapshot test | add task-level detected command scenario | unit + integration |
+| SC-002 | missing | no `/simplify` step snapshot test | add step-level detected command scenario | unit + integration |
+| SC-003 | missing | no unknown command pass-through test | add opaque unknown command scenario | unit |
+| SC-004 | missing | no escaped literal test | add escaped slash scenario | unit |
+| SC-005 | missing | no malformed/unsupported runtime policy test | add path-like and unsupported-runtime scenarios | unit |
+| SC-006 | missing | no supplied metadata validation test | add conflicting/malformed metadata tests | unit + integration |
+| SC-007 | partial | source requirement mapping exists in `spec.md` | preserve mapping in tasks and verification | final verify |
+| DESIGN-REQ-001 | partial | authored instructions are preserved today | add detected metadata while preserving text | unit + integration |
+| DESIGN-REQ-002 | partial | `_clean_optional_str()` trims surrounding whitespace today | ensure parser never rewrites command token/body after normalization | unit |
+| DESIGN-REQ-003 | missing | no structured command metadata | add runtime command metadata output | unit + integration |
+| DESIGN-REQ-004 | missing | no runtime command fields | add required fields or documented compact equivalents | unit |
+| DESIGN-REQ-005 | missing | no snapshot `runtimeCommand` fields | add objective and step metadata fields | integration |
+| DESIGN-REQ-006 | missing | no parser | add conservative parser | unit |
+| DESIGN-REQ-007 | missing | no unknown command handling | add opaque pass-through behavior | unit |
+| DESIGN-REQ-008 | missing | no escaped command metadata | add escaped literal behavior | unit |
+| DESIGN-REQ-010 | missing | no backend authority over frontend metadata | add validation/rejection behavior | unit + integration |
+| DESIGN-REQ-019 | missing | no hint status | add non-blocking hint status defaults | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, existing MoonMind task contract helpers  
+**Storage**: Existing artifact-backed task input snapshots; no new persistent storage  
+**Unit Testing**: pytest via `./tools/test_unit.sh`  
+**Integration Testing**: pytest task/workflow boundary tests via `./tools/test_unit.sh`; hermetic integration only if API/workflow submission paths change  
+**Target Platform**: MoonMind managed runtime/task orchestration service  
+**Project Type**: Python backend contract/model layer  
+**Performance Goals**: Runtime command detection must be deterministic and linear in instruction length, with negligible overhead during task submission  
+**Constraints**: Preserve authored text; do not introduce allowlist rejection for unknown valid commands; no compatibility aliases for new internal contract names; keep workflow payloads compact  
+**Scale/Scope**: One independently testable backend normalization story covering task and step instruction fields
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The feature records runtime command metadata for adapters and does not implement provider command behavior.
+- II. One-Click Agent Deployment: PASS. No new external service or deployment dependency.
+- III. Avoid Vendor Lock-In: PASS. Metadata is runtime-neutral and preserves unknown provider commands.
+- IV. Own Your Data: PASS. Authored instructions and metadata remain in MoonMind-owned snapshots.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill-source mutation; this affects task contracts only.
+- VI. Scientific Method: PASS. Unit and integration evidence are planned before implementation.
+- VII. Runtime Configurability: PASS. Runtime policy is modeled as configurable behavior rather than hard-coded provider allowlists.
+- VIII. Modular and Extensible Architecture: PASS. Parser and snapshot normalization stay inside the task contract boundary.
+- IX. Resilient by Default: PASS. Payload compatibility risk is limited to adding compact metadata; tests cover real boundary shapes.
+- X. Facilitate Continuous Improvement: PASS. Verification artifacts will preserve outcome evidence and MM-684 traceability.
+- XI. Spec-Driven Development: PASS. This plan follows `spec.md` and will generate tasks before implementation.
+- XII. Canonical Docs vs Tmp: PASS. Implementation tracking stays in `specs/353-normalize-slash-commands/`.
+- XIII. Pre-Release Velocity: PASS. New internal names will be direct; no legacy aliases are planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/353-normalize-slash-commands/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── runtime-command-snapshot.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/tasks/
+└── task_contract.py
+
+tests/unit/workflows/tasks/
+└── test_task_contract.py
+```
+
+**Structure Decision**: Keep the implementation in the existing canonical task contract module because task input snapshot construction and validation already live there. Add focused tests to the existing task contract test file so coverage runs through the real Pydantic and snapshot boundary used by task submissions.
+
+## Complexity Tracking
+
+No constitution violations or added architectural complexity.

--- a/specs/353-normalize-slash-commands/quickstart.md
+++ b/specs/353-normalize-slash-commands/quickstart.md
@@ -42,7 +42,7 @@ Expected result: full unit suite passes in the managed-agent local test mode.
 Run final verification after implementation and tests:
 
 ```bash
-/speckit.verify specs/353-normalize-slash-commands
+/moonspec-verify specs/353-normalize-slash-commands
 ```
 
 Verification must confirm that `MM-684`, the canonical Jira preset brief, and all in-scope `DESIGN-REQ-*` mappings remain preserved.

--- a/specs/353-normalize-slash-commands/quickstart.md
+++ b/specs/353-normalize-slash-commands/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Normalize Slash-Leading Instructions
+
+## Test-First Validation
+
+1. Run the focused task contract tests before implementation and confirm the new MM-684 cases fail:
+
+```bash
+pytest tests/unit/workflows/tasks/test_task_contract.py -q
+```
+
+Expected before implementation: new MM-684 tests fail because runtime command metadata is not produced or validated.
+
+2. Implement the parser, metadata model, snapshot attachment, and supplied metadata validation in `moonmind/workflows/tasks/task_contract.py`.
+
+3. Re-run the focused tests:
+
+```bash
+pytest tests/unit/workflows/tasks/test_task_contract.py -q
+```
+
+Expected after implementation: all task contract tests pass.
+
+4. Run final unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected result: full unit suite passes in the managed-agent local test mode.
+
+## End-to-End Story Checks
+
+- `/review` task instructions preserve raw instructions and add task-level detected command metadata.
+- `/simplify` step instructions preserve raw instructions and add step-level detected command metadata with target step id.
+- `/future-command` is accepted as opaque for slash-pass-through runtimes.
+- `\/review` records escaped literal metadata and does not require runtime recognition.
+- `/src/app.ts is broken` does not become an executable runtime command.
+- Conflicting frontend-supplied `runtimeCommand` metadata is rejected by backend normalization.
+
+## Final MoonSpec Verification
+
+Run final verification after implementation and tests:
+
+```bash
+/speckit.verify specs/353-normalize-slash-commands
+```
+
+Verification must confirm that `MM-684`, the canonical Jira preset brief, and all in-scope `DESIGN-REQ-*` mappings remain preserved.

--- a/specs/353-normalize-slash-commands/research.md
+++ b/specs/353-normalize-slash-commands/research.md
@@ -1,0 +1,67 @@
+# Research: Normalize Slash-Leading Instructions
+
+Source traceability: MM-684 canonical Jira preset brief and `docs/Steps/SlashCommands.md`.
+
+## FR-001 / DESIGN-REQ-001
+
+Decision: Partial existing behavior. Preserve current instruction fields and add metadata alongside them.
+Evidence: `moonmind/workflows/tasks/task_contract.py` `build_authoritative_task_input_snapshot()` copies `objective.instructions` and step `instructions`; `tests/unit/workflows/tasks/test_task_contract.py` covers snapshot preservation for existing fields.
+Rationale: The feature must not replace or mutate authored instructions. Adding sibling metadata fields keeps audit and edit/rerun behavior intact.
+Alternatives considered: Rewriting instructions into rendered runtime input during task submission was rejected because runtime rendering belongs to adapters and later preparation stages.
+Test implications: Unit and boundary tests must assert exact instruction preservation for detected, escaped, unknown, malformed, and unsupported-runtime cases.
+
+## FR-002 / FR-003 / FR-004 / DESIGN-REQ-003 / DESIGN-REQ-004 / DESIGN-REQ-005
+
+Decision: Missing. Add runtime command parsing and metadata generation at snapshot construction time for objective and step instruction fields.
+Evidence: Repository search found no existing `runtimeCommand` or `RuntimeCommandInvocation` model. `TaskExecutionSpec` and `TaskStepSpec` currently allow extra fields but do not validate command metadata.
+Rationale: The authoritative snapshot is the durable reconstruction boundary for task execution, edit, rerun, and audit. This is the correct backend authority point for command metadata.
+Alternatives considered: Adding metadata only in frontend state was rejected because backend normalization must remain authoritative.
+Test implications: Unit tests must cover objective and step metadata shape, source paths, target runtime, and target step id.
+
+## FR-005 / DESIGN-REQ-006
+
+Decision: Missing. Add a conservative parser for first-character slash-leading instructions.
+Evidence: No parser matching the documented grammar exists in task contract code.
+Rationale: The parser must distinguish valid command tokens, opaque provider command lines, escaped slash text, and ordinary path-like text without rewriting input.
+Alternatives considered: A provider allowlist was rejected because unknown valid commands must pass through for slash-capable runtimes.
+Test implications: Unit tests must cover `/review`, `/review args`, `/future-command now`, `/provider.command now`, leading whitespace, `/src/app.ts is broken`, and empty instructions.
+
+## FR-006 / FR-010 / DESIGN-REQ-007 / DESIGN-REQ-019
+
+Decision: Missing. Use hint status as enrichment metadata only.
+Evidence: No command hint catalog is currently present in the task contract layer.
+Rationale: The story requires unknown valid commands to be accepted as opaque runtime invocations. Known hints can be introduced as a compact built-in seed only for status classification, but absence of a hint cannot reject.
+Alternatives considered: Deferring hint status entirely was rejected because the Jira brief requires deterministic `hintStatus`.
+Test implications: Unit tests must assert unknown valid commands receive opaque hint status and are accepted.
+
+## FR-007 / DESIGN-REQ-008
+
+Decision: Missing. Record escaped literal metadata with non-executable recognition mode.
+Evidence: Current instruction normalization strips surrounding whitespace but does not identify escaped leading slash text.
+Rationale: Escaped text must remain auditable as a deliberate literal and must not later be treated as an executable command by default.
+Alternatives considered: Treat escaped slash text as no metadata was rejected because downstream renderers need an explicit safety signal.
+Test implications: Unit tests must assert `\\/review` creates escaped metadata and `requiresRuntimeRecognition=false`.
+
+## FR-008 / DESIGN-REQ-010
+
+Decision: Missing. Reject malformed or conflicting frontend-supplied command metadata at the backend contract boundary.
+Evidence: `TaskExecutionSpec` and `TaskStepSpec` allow extra fields today, so supplied `runtimeCommand` would currently pass through without validation in model dumps but is not included in the authoritative snapshot.
+Rationale: The backend must be authoritative. Supplied metadata that conflicts with parsed instructions creates audit and execution risk.
+Alternatives considered: Silently dropping supplied metadata was rejected because malformed command metadata should fail fast when clients send inconsistent authoritative-looking fields.
+Test implications: Unit tests must cover conflicting command metadata and malformed metadata for objective and step payloads.
+
+## FR-009
+
+Decision: Missing. Add default policy-derived recognition states for unsupported runtimes and malformed ordinary path-like input without changing accepted authored text.
+Evidence: Runtime modes are normalized in `TaskRuntimeSelection`, but no runtime slash capability or policy exists.
+Rationale: The source design calls for warning/reject policy. For this story, compact deterministic metadata can record warning literal states while preserving text for accepted snapshots.
+Alternatives considered: Rejecting all unsupported runtime slash text was rejected because the recommended default is warning literal handling.
+Test implications: Unit tests must assert malformed path-like and unsupported-runtime inputs do not become executable runtime commands.
+
+## Integration Boundary
+
+Decision: Use existing task contract tests as the primary boundary and add integration-shaped assertions around `CanonicalTaskPayload` plus `build_authoritative_task_input_snapshot()`.
+Evidence: The task contract tests already validate canonical payload parsing and snapshot output for task-shaped submissions.
+Rationale: This catches the real payload shape used before workflow submission without requiring Docker-backed integration for a pure contract change.
+Alternatives considered: Compose-backed integration tests were rejected for this story unless API/workflow submission code changes become necessary.
+Test implications: Run targeted pytest during development and full `./tools/test_unit.sh` before final verification.

--- a/specs/353-normalize-slash-commands/spec.md
+++ b/specs/353-normalize-slash-commands/spec.md
@@ -1,0 +1,182 @@
+# Feature Specification: Normalize Slash-Leading Instructions
+
+**Feature Branch**: `353-normalize-slash-commands`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**: User description: "# MM-684 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-684
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Normalize slash-leading instructions into authoritative runtime command snapshots
+- Trusted fetch tool: `jira.get_issue`
+- Trusted response artifact: `artifacts/moonspec-inputs/MM-684-trusted-jira-get-issue-summary.json`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+- Labels: moonmind-workflow-mm-1c30567c-221e-4dc1-bc74-d1248e750656
+- Related Jira issues: is blocked by: MM-685 (Show provider-neutral slash command previews on the Create page)
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-684 from MM project
+Summary: Normalize slash-leading instructions into authoritative runtime command snapshots
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-684 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-684: Normalize slash-leading instructions into authoritative runtime command snapshots
+
+Source Reference
+Source Document: docs/Steps/SlashCommands.md
+Source Title: Runtime Slash Commands on Create Task
+Source Sections:
+- Purpose
+- Problem
+- Design Principles
+- Goals
+- Terminology
+- Domain Model
+- Task Input Shape
+- Detection Rules
+- Unknown Command Contract
+- Escape Behavior
+- Backend Behavior
+- Validation policy
+- Non-goals
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-003
+- DESIGN-REQ-004
+- DESIGN-REQ-005
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-010
+- DESIGN-REQ-019
+
+As a MoonMind operator submitting a task, I want slash-leading task and step instructions to be preserved as authored text while the backend records structured runtime command metadata, so managed runtimes can later recognize the command without losing audit fidelity.
+
+Acceptance Criteria
+- Submitting instructions beginning with /review stores the raw instructions unchanged and a slash_command RuntimeCommandInvocation with command=review, detectionStatus=detected, and a sourcePath matching the instruction field.
+- Submitting step instructions beginning with /simplify stores targetStepId and a step sourcePath such as steps[0].instructions.
+- Unknown valid commands such as /future-command are accepted as opaque runtime invocations for slash-pass-through runtimes and are never rejected solely because no hint exists.
+- Escaped input such as \\/review is stored as escaped_literal metadata and cannot be rendered later as an executable leading slash command by default.
+- Malformed ordinary path-like inputs and runtimes without slash pass-through follow configured warning/reject policy without rewriting authored instructions.
+- Backend normalization rejects inconsistent or malformed frontend-supplied command metadata and remains authoritative when frontend metadata is missing.
+
+Requirements
+- Implement a conservative parser matching the documented grammar and example table while preserving opaque first-line command forms for pass-through runtimes.
+- Add RuntimeCommandInvocation and related capability/hint/policy fields to the authoritative task input snapshot shape.
+- Compute detectionStatus, hintStatus, recognitionMode, requiresRuntimeRecognition, runtimeCapabilityVersion, hintCatalogVersion, sourcePath, command, args, and instructionBody deterministically.
+- Preserve exact user-authored instruction text according to existing task input snapshot rules.
+- Treat command hints as enrichment metadata and not as a blocking command allowlist.
+
+## Relevant Implementation Notes
+
+- Source design path: `docs/Steps/SlashCommands.md`.
+- Purpose/Problem: preserve user-authored slash-leading task text while deriving structured runtime command metadata, because prepared context can otherwise move `/command` away from the first runtime-visible character.
+- Design Principles: preserve user intent exactly, treat slash commands as structured metadata, keep rendering adapter-owned and late, keep support declarative, and preserve edit/rerun fidelity.
+- Domain Model: add `RuntimeCommandInvocation` metadata with `kind`, `source`, `sourcePath`, `command`, `rawCommand`, `args`, `instructionBody`, runtime targeting, detection/hint/recognition statuses, capability/catalog versions, and detection phase.
+- Task Input Shape: task-level `objective.instructions` and step-level `steps[n].instructions` retain authored text and attach the corresponding `runtimeCommand`; step-level commands include `targetStepId` and source paths such as `steps[0].instructions`.
+- Detection Rules: detect only first-character slash-leading instructions; parse known grammar conservatively; accept unknown valid command tokens as opaque runtime invocations for slash-pass-through runtimes; treat escaped, malformed ordinary path-like, or unsupported-runtime cases according to policy.
+- Unknown Command Contract: unknown valid slash commands are first-class runtime invocations, are not allowlist failures, remain slash-leading in runtime-visible input, and must not become shell/runtime arguments outside adapter-owned rendering.
+- Escape Behavior: `\\/command` records escaped literal metadata and must render as non-executable literal text by default.
+- Backend Behavior: backend submit-time normalization is authoritative over frontend preview metadata, validates/canonicalizes supplied metadata, computes command metadata deterministically, stores the authoritative task input snapshot, and rejects inconsistent or malformed frontend-supplied command metadata.
+- Validation Policy: default behavior should pass through valid slash commands for supporting runtimes, warn or reject only for unsupported runtimes/malformed command lines per configured policy, and never reject unknown valid commands solely because no hint exists.
+
+## MoonSpec Classification Input
+
+Classify this as a single-story runtime feature request for Create Task slash-command handling: normalize slash-leading task and step instructions into authoritative runtime command snapshots while preserving authored instruction text, audit fidelity, and MM-684 traceability.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+"
+
+## User Story - Authoritative Runtime Command Snapshots
+
+**Summary**: As a MoonMind operator submitting a task, I want slash-leading task and step instructions to remain exactly as authored while MoonMind records authoritative structured runtime command metadata, so managed runtimes can recognize commands without losing audit fidelity.
+
+**Goal**: Task submission produces an authoritative task input snapshot that preserves authored instruction text and records deterministic runtime command metadata for task-level and step-level leading slash commands.
+
+**Independent Test**: Submit or normalize task inputs containing slash-leading task instructions, slash-leading step instructions, unknown valid commands, escaped slash text, malformed path-like text, and inconsistent frontend-supplied command metadata; verify the resulting authoritative snapshot contains the expected preserved instructions, command metadata, warnings or rejections, and traceable source paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** task instructions begin with `/review`, **When** the task is submitted for a slash-pass-through runtime, **Then** the authoritative snapshot stores the raw instructions unchanged and records a `slash_command` invocation with `command=review`, `detectionStatus=detected`, and `sourcePath` matching the task instruction field.
+2. **Given** a step's instructions begin with `/simplify`, **When** the task is submitted, **Then** the authoritative snapshot records the command metadata on that step with the step `targetStepId` and a step source path such as `steps[0].instructions`.
+3. **Given** instructions begin with an unknown valid command such as `/future-command`, **When** the selected runtime supports slash-command pass-through, **Then** the command is accepted as an opaque runtime invocation and is not rejected solely because no command hint exists.
+4. **Given** instructions begin with escaped slash text such as `\/review`, **When** the task is submitted, **Then** the snapshot records escaped literal metadata and the command cannot later be rendered as an executable leading slash command by default.
+5. **Given** instructions contain malformed ordinary path-like input or target a runtime without slash pass-through, **When** configured policy permits warning literal handling, **Then** authored instructions are preserved and the snapshot records non-executable metadata or warning state without rewriting user text.
+6. **Given** frontend-supplied command metadata conflicts with backend parsing, **When** the task is submitted, **Then** backend normalization remains authoritative and rejects or replaces the inconsistent metadata according to validation policy.
+
+### Edge Cases
+
+- Leading whitespace before a slash command is treated as ordinary authored text and does not produce a detected command.
+- Slash commands with arguments preserve both the raw first line and the parsed argument string.
+- Unknown provider command forms that are slash-leading but outside the structured grammar remain opaque only when they are not clearly ordinary path text and the runtime supports pass-through.
+- Empty instruction fields do not produce command metadata.
+- Multiple instruction-bearing locations in one task can each carry independent source paths without conflating task-level and step-level commands.
+
+## Assumptions
+
+- The selected story covers backend normalization and authoritative snapshot data only; provider-neutral Create page previews are tracked separately by related issue MM-685.
+- Runtime-specific rendering is not completed by this story, but the snapshot metadata must be sufficient for later adapter-owned rendering.
+- The default validation posture follows the source design: pass through valid slash commands for slash-capable runtimes, allow escaped literals, and warn or reject malformed or unsupported-runtime input according to configured policy.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** *(docs/Steps/SlashCommands.md Purpose, Goals)*: The system must detect leading slash commands from normal task or step instructions while preserving the authored instruction text. Scope: in scope. Maps to FR-001, FR-002, FR-003.
+- **DESIGN-REQ-002** *(Design Principles: Preserve user intent exactly)*: Command detection must not rewrite, alias, or reinterpret the user's authored command token or instruction body. Scope: in scope. Maps to FR-001, FR-008.
+- **DESIGN-REQ-003** *(Design Principles: Treat slash commands as structured task metadata)*: A leading slash command must be represented as structured runtime command metadata rather than only prompt text. Scope: in scope. Maps to FR-002, FR-003, FR-004.
+- **DESIGN-REQ-004** *(Domain Model: RuntimeCommandInvocation)*: Runtime command metadata must include command identity, raw command, arguments, instruction body, source path, target runtime or step when relevant, detection status, hint status, recognition mode, runtime recognition requirement, capability or hint versions, and detection phase. Scope: in scope. Maps to FR-003, FR-004.
+- **DESIGN-REQ-005** *(Task Input Shape)*: The authoritative task input snapshot must support runtime command metadata at task-level and step-level instruction locations. Scope: in scope. Maps to FR-002, FR-004.
+- **DESIGN-REQ-006** *(Detection Rules)*: Detection must be conservative, first-character slash based, support the documented grammar, and handle opaque slash-leading command forms for pass-through runtimes when they are not ordinary path-like text. Scope: in scope. Maps to FR-005, FR-006.
+- **DESIGN-REQ-007** *(Unknown Command Contract)*: Unknown valid commands must remain first-class runtime invocations for slash-pass-through runtimes and must not be rejected solely because MoonMind lacks a hint. Scope: in scope. Maps to FR-006.
+- **DESIGN-REQ-008** *(Escape Behavior)*: Escaped leading slash text must be represented as escaped literal metadata and must not later render as an executable leading slash command by default. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-010** *(Backend Behavior, Validation policy)*: Backend submit-time normalization must be authoritative over frontend preview metadata and must validate runtime capability, command grammar, policy, and supplied metadata before building the snapshot. Scope: in scope. Maps to FR-008, FR-009.
+- **DESIGN-REQ-019** *(Non-goals and command hints)*: Command hints may enrich metadata but must not act as a blocking allowlist; Create-page provider-specific previews and runtime-specific command rendering are out of this story unless needed to preserve snapshot contracts. Scope: in scope for non-blocking hints, out of scope for preview UI/rendering. Maps to FR-006, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST preserve user-authored task-level and step-level instruction text in the authoritative task input snapshot when leading slash detection occurs.
+- **FR-002**: The system MUST detect leading slash command candidates independently for task-level instructions and each step instruction field that participates in task submission.
+- **FR-003**: The system MUST record a structured `RuntimeCommandInvocation` for detected task-level commands with deterministic command, raw command, arguments, instruction body, source path, target runtime, detection status, hint status, recognition mode, runtime recognition requirement, capability or hint version, and detection phase values.
+- **FR-004**: The system MUST record step-level runtime command metadata with a step source path and target step identifier when a step instruction begins with a detected slash command.
+- **FR-005**: The system MUST parse slash-leading command lines with the documented conservative grammar and preserve opaque first-line command forms for pass-through runtimes when they are not ordinary path-like text.
+- **FR-006**: The system MUST accept unknown valid slash commands for slash-pass-through runtimes without requiring a known-command hint.
+- **FR-007**: The system MUST represent escaped leading slash input as escaped literal command metadata that cannot be rendered later as an executable leading slash command by default.
+- **FR-008**: The system MUST make backend normalization authoritative by rejecting or replacing malformed or inconsistent frontend-supplied runtime command metadata instead of trusting it blindly.
+- **FR-009**: The system MUST apply configured validation policy for unsupported runtimes and malformed ordinary path-like input without rewriting authored instruction text.
+- **FR-010**: The system MUST keep command hints as enrichment metadata only and must not treat absent hints as a rejection reason for valid pass-through commands.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-684` and this canonical Jira preset brief.
+
+### Key Entities
+
+- **Runtime Command Invocation**: Structured metadata derived from authored instructions, including command identity, parsed body, source location, runtime target, recognition and validation status, and versioned capability context.
+- **Runtime Command Policy**: Configurable validation posture for slash-capable runtimes, runtimes without slash pass-through, escaped commands, and malformed command lines.
+- **Authoritative Task Input Snapshot**: The preserved task submission payload that stores authored instruction text and derived runtime command metadata for workflow execution, audit, edit, and rerun.
+- **Command Hint**: Optional enrichment metadata for known commands that can improve labels or descriptions without becoming an allowlist.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A submitted task with `/review` as the first task instruction characters produces preserved task instructions and a detected `slash_command` invocation with `command=review` and the task instruction source path.
+- **SC-002**: A submitted task with `/simplify` as the first step instruction characters produces preserved step instructions and step command metadata containing the correct target step identifier and `steps[0].instructions`-style source path.
+- **SC-003**: Unknown valid commands such as `/future-command` are accepted for slash-pass-through runtimes with opaque hint status and no allowlist rejection.
+- **SC-004**: Escaped input such as `\/review` records escaped literal metadata and does not leave an executable leading slash command as the default runtime-visible representation.
+- **SC-005**: Malformed ordinary path-like input and runtimes without slash pass-through follow configured warning or rejection policy while preserving authored instructions in any accepted snapshot.
+- **SC-006**: Inconsistent frontend-supplied command metadata is rejected or normalized by backend authority, with test evidence covering missing metadata, conflicting metadata, and malformed metadata.
+- **SC-007**: Traceability evidence preserves `MM-684`, the canonical Jira preset brief, and DESIGN-REQ-001 through DESIGN-REQ-008, DESIGN-REQ-010, and DESIGN-REQ-019 in MoonSpec artifacts and verification evidence.

--- a/specs/353-normalize-slash-commands/tasks.md
+++ b/specs/353-normalize-slash-commands/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `pytest tests/unit/workflows/tasks/test_task_contract.py -q`
 - Integration tests: `pytest tests/unit/workflows/tasks/test_task_contract.py -q` for the canonical payload plus authoritative snapshot boundary; run `./tools/test_integration.sh` only if implementation expands into API/workflow submission code.
-- Final verification: `/speckit.verify specs/353-normalize-slash-commands`
+- Final verification: `/moonspec-verify specs/353-normalize-slash-commands`
 
 ## Format: `[ID] [P?] Description`
 
@@ -81,7 +81,7 @@
 - [X] T017 Implement runtime command metadata construction for step instructions in `moonmind/workflows/tasks/task_contract.py` covering FR-004, SC-002, DESIGN-REQ-005.
 - [X] T018 Implement backend validation for supplied objective and step `runtimeCommand` metadata in `moonmind/workflows/tasks/task_contract.py` covering FR-008, SC-006, DESIGN-REQ-010.
 - [X] T019 Wire objective and step `runtimeCommand` output into `build_authoritative_task_input_snapshot()` in `moonmind/workflows/tasks/task_contract.py` without rewriting existing `instructions`, `inputAttachments`, dependency, provenance, or traceability fields for FR-001 through FR-010.
-- [X] T020 Run `pytest tests/unit/workflows/tasks/test_task_contract.py -q`, fix failures, and verify all MM-684 task contract tests pass.
+- [X] T020 Run story validation with `pytest tests/unit/workflows/tasks/test_task_contract.py -q`, fix failures, and verify all MM-684 task contract tests pass.
 - [X] T021 Run `./tools/test_unit.sh` for final required unit verification and record the result in `specs/353-normalize-slash-commands/verification.md` or final response.
 
 **Checkpoint**: The story is fully functional, covered by unit and integration-shaped task contract tests, and testable independently.
@@ -95,7 +95,7 @@
 - [X] T022 Review `moonmind/workflows/tasks/task_contract.py` for dead helper names, compatibility aliases, or stale comments introduced during implementation and remove them for Constitution XIII.
 - [X] T023 Review `specs/353-normalize-slash-commands/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-snapshot.md`, and `quickstart.md` for MM-684 traceability and update only if implementation reality changed.
 - [X] T024 Run quickstart validation from `specs/353-normalize-slash-commands/quickstart.md`.
-- [X] T025 Run `/speckit.verify specs/353-normalize-slash-commands` after implementation and tests pass.
+- [X] T025 Run `/moonspec-verify specs/353-normalize-slash-commands` after implementation and tests pass.
 
 ---
 
@@ -135,7 +135,7 @@
 4. Implement parser, metadata construction, supplied metadata validation, and snapshot wiring in `moonmind/workflows/tasks/task_contract.py`.
 5. Run targeted tests until green.
 6. Run `./tools/test_unit.sh`.
-7. Run final `/speckit.verify` and preserve MM-684 traceability in verification evidence.
+7. Run final `/moonspec-verify` and preserve MM-684 traceability in verification evidence.
 
 ## Notes
 

--- a/specs/353-normalize-slash-commands/tasks.md
+++ b/specs/353-normalize-slash-commands/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Normalize Slash-Leading Instructions
+
+**Input**: Design documents from `specs/353-normalize-slash-commands/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/runtime-command-snapshot.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration-shaped task contract tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-684 story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: This task list covers FR-001 through FR-011, SC-001 through SC-007, and DESIGN-REQ-001 through DESIGN-REQ-008, DESIGN-REQ-010, and DESIGN-REQ-019 from `spec.md`.
+
+**Test Commands**:
+
+- Unit tests: `pytest tests/unit/workflows/tasks/test_task_contract.py -q`
+- Integration tests: `pytest tests/unit/workflows/tasks/test_task_contract.py -q` for the canonical payload plus authoritative snapshot boundary; run `./tools/test_integration.sh` only if implementation expands into API/workflow submission code.
+- Final verification: `/speckit.verify specs/353-normalize-slash-commands`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the existing task contract module and tests are the only required implementation surface.
+
+- [X] T001 Inspect current task contract parsing/snapshot helpers in `moonmind/workflows/tasks/task_contract.py` and record any additional touched helpers in `specs/353-normalize-slash-commands/research.md` if scope changes.
+- [X] T002 Inspect existing task contract tests in `tests/unit/workflows/tasks/test_task_contract.py` and place all MM-684 regression tests in that file unless a new fixture file becomes necessary.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the exact contract and red-first test shape before story implementation.
+
+**CRITICAL**: No production implementation work can begin until the failing tests in Phase 3 are written and confirmed.
+
+- [X] T003 Confirm `contracts/runtime-command-snapshot.md` matches the final field names to be asserted by tests for FR-003, FR-004, and DESIGN-REQ-004.
+- [X] T004 Confirm no migration, database table, or external service setup is required for MM-684 in `specs/353-normalize-slash-commands/plan.md`.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Authoritative Runtime Command Snapshots
+
+**Summary**: As a MoonMind operator submitting a task, I want slash-leading task and step instructions to remain exactly as authored while MoonMind records authoritative structured runtime command metadata, so managed runtimes can recognize commands without losing audit fidelity.
+
+**Independent Test**: Submit or normalize task inputs containing slash-leading task instructions, slash-leading step instructions, unknown valid commands, escaped slash text, malformed path-like text, and inconsistent frontend-supplied command metadata; verify the resulting authoritative snapshot contains the expected preserved instructions, command metadata, warnings or rejections, and traceable source paths.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-010, DESIGN-REQ-019
+
+**Test Plan**:
+
+- Unit: parser grammar, escaped literals, opaque unknown commands, path-like malformed inputs, unsupported runtime policy, hint status, supplied metadata validation.
+- Integration: canonical payload parsing plus `build_authoritative_task_input_snapshot()` boundary for objective and step runtime command metadata.
+
+### Unit Tests (write first)
+
+> Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T005 Add failing unit tests for task-level `/review` metadata preserving raw instructions in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-001, FR-002, FR-003, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004.
+- [X] T006 Add failing unit tests for step-level `/simplify` metadata with `targetStepId` and `steps[0].instructions` source path in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-004, SC-002, DESIGN-REQ-005.
+- [X] T007 Add failing unit tests for unknown valid commands and opaque provider command lines in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-005, FR-006, FR-010, SC-003, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-019.
+- [X] T008 Add failing unit tests for escaped slash input and malformed ordinary path-like input in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-007, FR-009, SC-004, SC-005, DESIGN-REQ-008.
+- [X] T009 Add failing unit tests for conflicting and malformed frontend-supplied `runtimeCommand` metadata in objective and step payloads in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-008, SC-006, DESIGN-REQ-010.
+- [X] T010 Run `pytest tests/unit/workflows/tasks/test_task_contract.py -q` and confirm T005-T009 fail for missing runtime command behavior before production changes.
+
+### Integration Tests (write first)
+
+- [X] T011 Add failing canonical payload boundary tests using `CanonicalTaskPayload.model_validate()` plus `build_authoritative_task_input_snapshot()` in `tests/unit/workflows/tasks/test_task_contract.py` covering objective and step acceptance scenarios SC-001 and SC-002.
+- [X] T012 Add failing canonical payload boundary tests for missing frontend metadata, conflicting metadata rejection, unknown command acceptance, and escaped literal metadata in `tests/unit/workflows/tasks/test_task_contract.py` covering SC-003, SC-004, SC-006.
+- [X] T013 Run `pytest tests/unit/workflows/tasks/test_task_contract.py -q` and confirm T011-T012 fail for the expected missing boundary behavior.
+
+### Implementation
+
+- [X] T014 Add runtime command constants, supported slash-capable runtime classification, known hint identifiers, and default policy values in `moonmind/workflows/tasks/task_contract.py` covering FR-006, FR-009, FR-010, DESIGN-REQ-007, DESIGN-REQ-019.
+- [X] T015 Implement an internal runtime command parser in `moonmind/workflows/tasks/task_contract.py` covering grammar parsing, arguments, instruction body, opaque command lines, escaped literals, leading whitespace, empty instructions, and path-like malformed lines for FR-005, FR-007, DESIGN-REQ-006, DESIGN-REQ-008.
+- [X] T016 Implement runtime command metadata construction for objective instructions in `moonmind/workflows/tasks/task_contract.py` covering FR-001, FR-002, FR-003, SC-001, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-004.
+- [X] T017 Implement runtime command metadata construction for step instructions in `moonmind/workflows/tasks/task_contract.py` covering FR-004, SC-002, DESIGN-REQ-005.
+- [X] T018 Implement backend validation for supplied objective and step `runtimeCommand` metadata in `moonmind/workflows/tasks/task_contract.py` covering FR-008, SC-006, DESIGN-REQ-010.
+- [X] T019 Wire objective and step `runtimeCommand` output into `build_authoritative_task_input_snapshot()` in `moonmind/workflows/tasks/task_contract.py` without rewriting existing `instructions`, `inputAttachments`, dependency, provenance, or traceability fields for FR-001 through FR-010.
+- [X] T020 Run `pytest tests/unit/workflows/tasks/test_task_contract.py -q`, fix failures, and verify all MM-684 task contract tests pass.
+- [X] T021 Run `./tools/test_unit.sh` for final required unit verification and record the result in `specs/353-normalize-slash-commands/verification.md` or final response.
+
+**Checkpoint**: The story is fully functional, covered by unit and integration-shaped task contract tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T022 Review `moonmind/workflows/tasks/task_contract.py` for dead helper names, compatibility aliases, or stale comments introduced during implementation and remove them for Constitution XIII.
+- [X] T023 Review `specs/353-normalize-slash-commands/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-snapshot.md`, and `quickstart.md` for MM-684 traceability and update only if implementation reality changed.
+- [X] T024 Run quickstart validation from `specs/353-normalize-slash-commands/quickstart.md`.
+- [X] T025 Run `/speckit.verify specs/353-normalize-slash-commands` after implementation and tests pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish (Phase 4)**: Depends on the story being functionally complete and tests passing.
+
+### Within The Story
+
+- T005-T009 unit tests and T011-T012 boundary tests must be written before implementation.
+- T010 and T013 red-first confirmation must complete before T014-T019.
+- T014-T015 parser/policy work precedes T016-T019 snapshot wiring.
+- T020 targeted tests precede T021 full unit verification.
+- T025 final verification runs only after implementation and tests pass.
+
+### Parallel Opportunities
+
+- T001 and T002 can be done in parallel.
+- T005-T009 can be authored together in the same file only with careful merge ordering; otherwise do them sequentially to avoid conflicts.
+- T014 and T015 are tightly coupled and should be implemented together.
+- T023 documentation review can run after T020 while full unit verification T021 is running.
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and foundational confirmation.
+2. Write failing unit and boundary tests in `tests/unit/workflows/tasks/test_task_contract.py`.
+3. Confirm tests fail for missing runtime command metadata/validation.
+4. Implement parser, metadata construction, supplied metadata validation, and snapshot wiring in `moonmind/workflows/tasks/task_contract.py`.
+5. Run targeted tests until green.
+6. Run `./tools/test_unit.sh`.
+7. Run final `/speckit.verify` and preserve MM-684 traceability in verification evidence.
+
+## Notes
+
+- This task list covers one story only: backend authoritative runtime command snapshots for slash-leading instructions.
+- Provider-neutral Create page previews remain out of scope for MM-684 and are tracked by related issue MM-685.
+- Runtime-specific command rendering remains out of scope except for metadata required by later adapter-owned rendering.

--- a/specs/353-normalize-slash-commands/tasks.md
+++ b/specs/353-normalize-slash-commands/tasks.md
@@ -99,6 +99,15 @@
 
 ---
 
+## Phase 5: Post-Verify Remediation
+
+**Purpose**: Address the bounded `ADDITIONAL_WORK_NEEDED` verification gap for leading-whitespace slash instructions.
+
+- [X] T026 Add red-first regression coverage in `tests/unit/workflows/tasks/test_task_contract.py` proving objective and step instructions that begin with whitespace before `/review` or `/simplify` preserve the leading whitespace and do not produce `runtimeCommand` metadata.
+- [X] T027 Preserve raw objective and step instruction text in `build_authoritative_task_input_snapshot()` while leaving runtime command detection authoritative and rerun `pytest tests/unit/workflows/tasks/test_task_contract.py -q`.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -91,6 +91,194 @@ def test_authoritative_snapshot_detects_jira_key_without_serializing_metadata() 
 
     assert snapshot["traceability"]["jiraIssueKey"] == "MM-639"
 
+
+def test_authoritative_snapshot_records_task_runtime_command_metadata() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "/review\nCheck this branch for regressions.",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    assert snapshot["objective"]["instructions"] == (
+        "/review\nCheck this branch for regressions."
+    )
+    assert snapshot["objective"]["runtimeCommand"] == {
+        "kind": "slash_command",
+        "source": "leading_slash",
+        "sourcePath": "objective.instructions",
+        "command": "review",
+        "rawCommand": "/review",
+        "args": "",
+        "instructionBody": "Check this branch for regressions.",
+        "targetRuntime": "codex",
+        "detectionStatus": "detected",
+        "hintStatus": "hinted",
+        "recognitionMode": "hinted_runtime_passthrough",
+        "requiresRuntimeRecognition": True,
+        "runtimeCapabilityVersion": "2026-05-13",
+        "hintCatalogVersion": "2026-05-13",
+        "detectionPhase": "submit",
+    }
+
+
+def test_authoritative_snapshot_records_step_runtime_command_metadata() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "Run task.",
+            "runtime": {"mode": "claude"},
+            "steps": [
+                {
+                    "id": "simplify-step",
+                    "instructions": "/simplify\nReduce duplication.",
+                }
+            ],
+        }
+    )
+
+    assert snapshot["steps"][0]["instructions"] == "/simplify\nReduce duplication."
+    assert snapshot["steps"][0]["runtimeCommand"]["command"] == "simplify"
+    assert snapshot["steps"][0]["runtimeCommand"]["sourcePath"] == (
+        "steps[0].instructions"
+    )
+    assert snapshot["steps"][0]["runtimeCommand"]["targetStepId"] == "simplify-step"
+    assert snapshot["steps"][0]["runtimeCommand"]["targetRuntime"] == "claude"
+    assert snapshot["steps"][0]["runtimeCommand"]["recognitionMode"] == (
+        "hinted_runtime_passthrough"
+    )
+
+
+def test_runtime_command_unknown_valid_commands_are_opaque_not_rejected() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "/future-command now\nUse the provider command.",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["command"] == "future-command"
+    assert command["args"] == "now"
+    assert command["instructionBody"] == "Use the provider command."
+    assert command["hintStatus"] == "opaque"
+    assert command["recognitionMode"] == "runtime_passthrough"
+    assert command["requiresRuntimeRecognition"] is True
+
+
+def test_runtime_command_preserves_opaque_provider_command_lines() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "/provider.command now\nOpaque provider body.",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["command"] == "provider.command"
+    assert command["rawCommand"] == "/provider.command now"
+    assert command["args"] == ""
+    assert command["instructionBody"] == "Opaque provider body."
+    assert command["hintStatus"] == "opaque"
+
+
+def test_runtime_command_escaped_slash_records_literal_metadata() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "\\/review\nTreat this as ordinary text.",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    assert snapshot["objective"]["instructions"] == (
+        "\\/review\nTreat this as ordinary text."
+    )
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["detectionStatus"] == "escaped"
+    assert command["recognitionMode"] == "escaped_literal"
+    assert command["requiresRuntimeRecognition"] is False
+    assert command["rawCommand"] == "\\/review"
+    assert command["instructionBody"] == "/review\nTreat this as ordinary text."
+
+
+def test_runtime_command_path_like_input_is_malformed_literal() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "/src/app.ts is broken",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["detectionStatus"] == "malformed"
+    assert command["recognitionMode"] == "escaped_literal"
+    assert command["requiresRuntimeRecognition"] is False
+    assert command["command"] == ""
+
+
+def test_runtime_command_unsupported_runtime_does_not_require_recognition() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "/review\nCheck external runtime behavior.",
+            "runtime": {"mode": "jules"},
+        }
+    )
+
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["command"] == "review"
+    assert command["detectionStatus"] == "detected"
+    assert command["recognitionMode"] == "runtime_does_not_support_slash_commands"
+    assert command["requiresRuntimeRecognition"] is False
+
+
+def test_runtime_command_leading_whitespace_is_not_detected() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": " /review\nLeading whitespace keeps this literal.",
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    assert "runtimeCommand" not in snapshot["objective"]
+
+
+def test_runtime_command_rejects_conflicting_objective_metadata() -> None:
+    with pytest.raises(TaskContractError, match="task.runtimeCommand conflicts"):
+        build_authoritative_task_input_snapshot(
+            task_payload={
+                "instructions": "/review\nCheck this branch.",
+                "runtime": {"mode": "codex"},
+                "runtimeCommand": {
+                    "kind": "slash_command",
+                    "sourcePath": "objective.instructions",
+                    "command": "simplify",
+                    "detectionStatus": "detected",
+                },
+            }
+        )
+
+
+def test_runtime_command_rejects_conflicting_step_metadata() -> None:
+    with pytest.raises(TaskContractError, match="task.steps\\[0\\].runtimeCommand conflicts"):
+        build_authoritative_task_input_snapshot(
+            task_payload={
+                "instructions": "Run task.",
+                "runtime": {"mode": "codex"},
+                "steps": [
+                    {
+                        "id": "step-1",
+                        "instructions": "/simplify\nReduce duplication.",
+                        "runtimeCommand": {
+                            "kind": "slash_command",
+                            "sourcePath": "steps[0].instructions",
+                            "targetStepId": "different",
+                            "command": "simplify",
+                            "detectionStatus": "detected",
+                        },
+                    }
+                ],
+            }
+        )
+
 def test_task_skills_rejects_invalid_values() -> None:
     """T001: Assert structure validation handles edge cases for skills."""
     from pydantic import ValidationError

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -238,7 +238,30 @@ def test_runtime_command_leading_whitespace_is_not_detected() -> None:
         }
     )
 
+    assert snapshot["objective"]["instructions"] == (
+        " /review\nLeading whitespace keeps this literal."
+    )
     assert "runtimeCommand" not in snapshot["objective"]
+
+
+def test_runtime_command_step_leading_whitespace_preserves_literal_text() -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": "Run task.",
+            "runtime": {"mode": "codex"},
+            "steps": [
+                {
+                    "id": "step-1",
+                    "instructions": " /simplify\nLeading whitespace keeps this literal.",
+                }
+            ],
+        }
+    )
+
+    assert snapshot["steps"][0]["instructions"] == (
+        " /simplify\nLeading whitespace keeps this literal."
+    )
+    assert "runtimeCommand" not in snapshot["steps"][0]
 
 
 def test_runtime_command_rejects_conflicting_objective_metadata() -> None:

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -215,6 +215,34 @@ def test_runtime_command_path_like_input_is_malformed_literal() -> None:
     assert command["command"] == ""
 
 
+@pytest.mark.parametrize(
+    ("instructions", "raw_command", "instruction_body"),
+    [
+        ("/", "/", "/"),
+        ("/   ", "/", "/   "),
+        ("/\nContinue as literal text.", "/", "/\nContinue as literal text."),
+    ],
+)
+def test_runtime_command_slash_only_input_is_malformed_literal(
+    instructions: str, raw_command: str, instruction_body: str
+) -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": instructions,
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    assert snapshot["objective"]["instructions"] == instructions
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["detectionStatus"] == "malformed"
+    assert command["recognitionMode"] == "escaped_literal"
+    assert command["requiresRuntimeRecognition"] is False
+    assert command["command"] == ""
+    assert command["rawCommand"] == raw_command
+    assert command["instructionBody"] == instruction_body
+
+
 def test_runtime_command_unsupported_runtime_does_not_require_recognition() -> None:
     snapshot = build_authoritative_task_input_snapshot(
         task_payload={


### PR DESCRIPTION
Jira issue key: MM-684

Active MoonSpec feature path: specs/353-normalize-slash-commands

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- pytest tests/unit/workflows/tasks/test_task_contract.py -q => 83 passed in 0.11s
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh => Python 5024 passed, 1 xpassed; frontend 20 files passed, 345 passed / 229 skipped

Remaining risks: None identified by post-remediation moonspec-verify.
