### PR TITLE
Run Jira Orchestrate for MM-685: Show provider-neutral slash command previews on the Create page

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -24,6 +24,7 @@ from moonmind.workflows.tasks.runtime_defaults import (
     resolve_default_task_runtime,
     resolve_runtime_defaults,
 )
+from moonmind.workflows.tasks.task_contract import build_runtime_command_preview_config
 
 logger = logging.getLogger(__name__)
 
@@ -688,6 +689,7 @@ def build_runtime_config(
             "workerRuntimeEnv": "MOONMIND_WORKER_RUNTIME",
             "supportedTaskRuntimes": supported_task_runtimes,
             "supportedWorkerRuntimes": list(_SUPPORTED_WORKER_RUNTIMES),
+            "runtimeCommandPreview": build_runtime_command_preview_config(),
             "taskTemplateCatalog": {
                 "enabled": bool(settings.feature_flags.task_template_catalog_enabled),
                 "templateSaveEnabled": bool(

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -15568,6 +15568,12 @@ describe("Task Create runtime command previews", () => {
       ),
     ).toBeTruthy();
     expect(screen.queryByText(/does not pass through slash commands/i)).toBeNull();
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "/provider.command now\nUse provider behavior." },
+    });
+
+    expect(await screen.findByText("Runtime command: /provider.command")).toBeTruthy();
   });
 
   it("recomputes unsupported runtime warnings without mutating instructions", async () => {
@@ -15617,6 +15623,18 @@ describe("Task Create runtime command previews", () => {
       target: { value: "/src/app.ts is broken" },
     });
     expect(await screen.findByText("Literal slash text")).toBeTruthy();
+
+    fireEvent.change(instructions, {
+      target: { value: "/review!\nTreat as text." },
+    });
+    expect(await screen.findByText("Literal slash text")).toBeTruthy();
+    expect(screen.queryByText("Runtime command: /review!")).toBeNull();
+
+    fireEvent.change(instructions, {
+      target: { value: "/ review\nTreat as text." },
+    });
+    expect(await screen.findByText("Literal slash text")).toBeTruthy();
+    expect(screen.queryByText(/Runtime command:/)).toBeNull();
   });
 
   it("submits authored slash instructions without preview-only runtime command metadata", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -167,6 +167,71 @@ function withAttachmentPolicy(payload: BootPayload = mockPayload): BootPayload {
   };
 }
 
+function withRuntimeCommandPreview(payload: BootPayload = mockPayload): BootPayload {
+  const initialData = payload.initialData as {
+    dashboardConfig: {
+      system?: Record<string, unknown>;
+    };
+  };
+  const system = initialData.dashboardConfig.system || {};
+  return {
+    ...payload,
+    initialData: {
+      ...initialData,
+      dashboardConfig: {
+        ...initialData.dashboardConfig,
+        system: {
+          ...system,
+          supportedTaskRuntimes: [
+            "codex_cli",
+            "gemini_cli",
+            "claude_code",
+            "codex_cloud",
+          ],
+          runtimeCommandPreview: {
+            capabilityVersion: "2026-05-13",
+            hintCatalogVersion: "2026-05-13",
+            runtimes: {
+              codex_cli: {
+                slashCommandPassthrough: true,
+                renderMode: "prompt_prefix",
+                commandHintsRef: "codex_cli",
+              },
+              claude_code: {
+                slashCommandPassthrough: true,
+                renderMode: "prompt_prefix",
+                commandHintsRef: "claude_code",
+              },
+              gemini_cli: {
+                slashCommandPassthrough: true,
+                renderMode: "prompt_prefix",
+                commandHintsRef: "gemini_cli",
+              },
+              codex_cloud: {
+                slashCommandPassthrough: false,
+                renderMode: "plain_prompt",
+              },
+            },
+            knownRuntimeCommandHints: {
+              review: {
+                label: "Review",
+                aliases: ["/review"],
+                description:
+                  "Ask the selected runtime to review the current task or code state.",
+              },
+              simplify: {
+                label: "Simplify",
+                aliases: ["/simplify"],
+                description: "Ask the selected runtime to simplify the implementation.",
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 function withRepositoryOptions(payload: BootPayload = mockPayload): BootPayload {
   const initialData = payload.initialData as {
     dashboardConfig: {
@@ -15403,6 +15468,184 @@ describe("Task Create governed Tool authoring", () => {
     });
     expect((within(step).getByLabelText("Tool ID") as HTMLInputElement).value)
       .toBe("jira.get_issue");
+  });
+});
+
+describe("Task Create runtime command previews", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.history.pushState({}, "Task Create", "/tasks/new");
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    vi.mocked(navigateTo).mockReset();
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/tasks/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: { worker: ["speckit-orchestrate"] },
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: [] }),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [],
+          } as Response);
+        }
+        if (url === "/api/executions") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:workflow-123",
+              runId: "run-123",
+              namespace: "moonmind",
+              redirectPath: "/tasks/mm:workflow-123?source=temporal",
+            }),
+          } as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({}),
+        } as Response);
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("previews known runtime commands for objective and step instructions", async () => {
+    renderWithClient(<TaskCreatePage payload={withRuntimeCommandPreview()} />);
+
+    const primaryStep = await screen.findByText("Step 1");
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "/review\nCheck this branch." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
+    const secondStep = await screen.findByText("Step 2");
+    fireEvent.change(
+      within(secondStep.closest("section") as HTMLElement).getByLabelText(
+        "Instructions",
+      ),
+      {
+        target: { value: "/review\nCheck step scope." },
+      },
+    );
+
+    expect(primaryStep).toBeTruthy();
+    expect(screen.getAllByText("Runtime command: /review")).toHaveLength(2);
+    expect(
+      screen.getAllByText(
+        "Ask the selected runtime to review the current task or code state.",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("previews unknown valid slash commands as opaque pass-through", async () => {
+    renderWithClient(<TaskCreatePage payload={withRuntimeCommandPreview()} />);
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "/foo\nUse provider behavior." },
+    });
+
+    expect(await screen.findByText("Runtime command: /foo")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Pass-through runtime command. No local hint is available; provider behavior will decide it.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/does not pass through slash commands/i)).toBeNull();
+  });
+
+  it("recomputes unsupported runtime warnings without mutating instructions", async () => {
+    renderWithClient(<TaskCreatePage payload={withRuntimeCommandPreview()} />);
+
+    const instructions = await screen.findByLabelText("Instructions");
+    fireEvent.change(instructions, {
+      target: { value: "/review\nKeep this exact text." },
+    });
+    fireEvent.change(screen.getByLabelText("Runtime"), {
+      target: { value: "codex_cloud" },
+    });
+
+    expect((instructions as HTMLTextAreaElement).value).toBe(
+      "/review\nKeep this exact text.",
+    );
+    expect(await screen.findByText("Unsupported runtime command: /review")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This runtime does not pass through slash commands. Choose a slash-command capable runtime or escape the slash for literal text.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("previews escaped and malformed slash text as literal without command markup", async () => {
+    renderWithClient(<TaskCreatePage payload={withRuntimeCommandPreview()} />);
+
+    const instructions = await screen.findByLabelText("Instructions");
+    fireEvent.change(instructions, {
+      target: { value: "\\/review\nTreat as text." },
+    });
+    expect(await screen.findByText("Literal text: /review")).toBeTruthy();
+    expect(screen.queryByText("Runtime command: /review")).toBeNull();
+
+    fireEvent.change(instructions, {
+      target: { value: " /review\nWhitespace means plain text." },
+    });
+    expect(screen.queryByText(/Runtime command:/)).toBeNull();
+    expect(screen.queryByText(/Literal text:/)).toBeNull();
+
+    fireEvent.change(instructions, {
+      target: { value: "Please run /review inside the sentence." },
+    });
+    expect(screen.queryByText(/Runtime command:/)).toBeNull();
+
+    fireEvent.change(instructions, {
+      target: { value: "/src/app.ts is broken" },
+    });
+    expect(await screen.findByText("Literal slash text")).toBeTruthy();
+  });
+
+  it("submits authored slash instructions without preview-only runtime command metadata", async () => {
+    renderWithClient(<TaskCreatePage payload={withRuntimeCommandPreview()} />);
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "/review\nCheck this branch." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo"), {
+      target: { value: "MoonLadderStudios/MoonMind" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+
+    expect(request.payload.task.instructions).toBe(
+      "/review\nCheck this branch.",
+    );
+    expect(request.payload.task.runtimeCommand).toBeUndefined();
+    expect(request.payload.task.steps?.[0]?.runtimeCommand).toBeUndefined();
   });
 });
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1317,7 +1317,7 @@ function createStepStateEntry(
 }
 
 const RUNTIME_COMMAND_TOKEN_PATTERN =
-  /^\/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$/;
+  /^\/([A-Za-z][A-Za-z0-9_-]*(?:(?::|\.)[A-Za-z0-9_-]+)?)(?:\s+(.*))?$/;
 
 function firstLineAndBody(value: string): { firstLine: string; body: string } {
   const lineEnd = value.indexOf("\n");
@@ -1436,7 +1436,7 @@ function deriveRuntimeCommandPreview({
     };
   }
   const command = match[1] || "";
-  const args = match[2] || "";
+  const args = command.includes(".") ? "" : match[2] || "";
   const hint = config.knownRuntimeCommandHints?.[command];
   const supportsPassthrough = Boolean(
     config.runtimes?.[runtime]?.slashCommandPassthrough,
@@ -8369,7 +8369,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 runtime,
                 sourcePath: index === 0
                   ? "objective.instructions"
-                  : `steps[${index}].instructions`,
+                  : `steps[${index - 1}].instructions`,
                 config: dashboardConfig.system?.runtimeCommandPreview,
                 storedRuntimeCommand: step.runtimeCommand,
               });

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1363,8 +1363,8 @@ function deriveRuntimeCommandPreview({
   instructions: string;
   runtime: string;
   sourcePath: string;
-  config?: RuntimeCommandPreviewConfig;
-  storedRuntimeCommand?: Record<string, unknown>;
+  config: RuntimeCommandPreviewConfig | undefined;
+  storedRuntimeCommand: Record<string, unknown> | undefined;
 }): RuntimeCommandPreviewState | null {
   if (!instructions || !config) {
     return null;

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -241,6 +241,7 @@ interface DashboardConfig {
       totalBytes?: number;
       allowedContentTypes?: string[];
     };
+    runtimeCommandPreview?: RuntimeCommandPreviewConfig;
     jiraIntegration?: {
       enabled?: boolean;
       defaultProjectKey?: string;
@@ -248,6 +249,48 @@ interface DashboardConfig {
       rememberLastBoardInSession?: boolean;
     };
   };
+}
+
+interface RuntimeCommandCapability {
+  slashCommandPassthrough?: boolean;
+  renderMode?: string;
+  commandHintsRef?: string;
+}
+
+interface RuntimeCommandHint {
+  label?: string;
+  aliases?: string[];
+  description?: string;
+  argumentPolicy?: Record<string, unknown>;
+  bodyPolicy?: Record<string, unknown>;
+}
+
+interface RuntimeCommandPreviewConfig {
+  capabilityVersion?: string;
+  hintCatalogVersion?: string;
+  runtimes?: Record<string, RuntimeCommandCapability>;
+  knownRuntimeCommandHints?: Record<string, RuntimeCommandHint>;
+}
+
+interface RuntimeCommandPreviewState {
+  sourcePath: string;
+  rawInstructions: string;
+  rawCommand: string;
+  command: string;
+  args: string;
+  instructionBody: string;
+  detectionStatus: "detected" | "escaped" | "malformed";
+  hintStatus: "hinted" | "opaque";
+  recognitionMode:
+    | "hinted_runtime_passthrough"
+    | "runtime_passthrough"
+    | "escaped_literal"
+    | "runtime_does_not_support_slash_commands";
+  requiresRuntimeRecognition: boolean;
+  messageSeverity: "info" | "warning" | "neutral";
+  label: string;
+  description: string;
+  source: "derived" | "snapshot";
 }
 
 interface JiraIntegrationConfig {
@@ -641,6 +684,7 @@ interface StepState {
   source?: Record<string, unknown>;
   storyOutput?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
+  runtimeCommand?: Record<string, unknown>;
 }
 
 interface PresetSubmitExpansionState {
@@ -1272,6 +1316,200 @@ function createStepStateEntry(
   };
 }
 
+const RUNTIME_COMMAND_TOKEN_PATTERN =
+  /^\/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$/;
+
+function firstLineAndBody(value: string): { firstLine: string; body: string } {
+  const lineEnd = value.indexOf("\n");
+  if (lineEnd === -1) {
+    return { firstLine: value, body: "" };
+  }
+  return {
+    firstLine: value.slice(0, lineEnd),
+    body: value.slice(lineEnd + 1),
+  };
+}
+
+function looksLikeOrdinarySlashPath(firstLine: string): boolean {
+  const token = firstLine.split(/\s+/, 1)[0] || "";
+  if (!token.startsWith("/")) {
+    return false;
+  }
+  const withoutSlash = token.slice(1);
+  return withoutSlash.includes("/") || withoutSlash.startsWith(".");
+}
+
+function runtimeCommandMatchesInstructions(
+  stored: Record<string, unknown> | undefined,
+  rawInstructions: string,
+  runtime: string,
+): boolean {
+  if (!stored) {
+    return false;
+  }
+  const { firstLine } = firstLineAndBody(rawInstructions);
+  const rawCommand = String(stored.rawCommand || "");
+  const targetRuntime = String(stored.targetRuntime || runtime || "");
+  return Boolean(rawCommand) && rawCommand === firstLine && targetRuntime === runtime;
+}
+
+function deriveRuntimeCommandPreview({
+  instructions,
+  runtime,
+  sourcePath,
+  config,
+  storedRuntimeCommand,
+}: {
+  instructions: string;
+  runtime: string;
+  sourcePath: string;
+  config?: RuntimeCommandPreviewConfig;
+  storedRuntimeCommand?: Record<string, unknown>;
+}): RuntimeCommandPreviewState | null {
+  if (!instructions || !config) {
+    return null;
+  }
+  if (instructions.startsWith("\\/")) {
+    const { firstLine } = firstLineAndBody(instructions);
+    return {
+      sourcePath,
+      rawInstructions: instructions,
+      rawCommand: firstLine,
+      command: "",
+      args: "",
+      instructionBody: instructions.slice(1),
+      detectionStatus: "escaped",
+      hintStatus: "opaque",
+      recognitionMode: "escaped_literal",
+      requiresRuntimeRecognition: false,
+      messageSeverity: "neutral",
+      label: `Literal text: ${firstLine.slice(1)}`,
+      description: "Escaped leading slash will be submitted as text.",
+      source: runtimeCommandMatchesInstructions(
+        storedRuntimeCommand,
+        instructions,
+        runtime,
+      )
+        ? "snapshot"
+        : "derived",
+    };
+  }
+  if (!instructions.startsWith("/")) {
+    return null;
+  }
+  const { firstLine, body } = firstLineAndBody(instructions);
+  if (looksLikeOrdinarySlashPath(firstLine)) {
+    return {
+      sourcePath,
+      rawInstructions: instructions,
+      rawCommand: firstLine,
+      command: "",
+      args: "",
+      instructionBody: instructions,
+      detectionStatus: "malformed",
+      hintStatus: "opaque",
+      recognitionMode: "escaped_literal",
+      requiresRuntimeRecognition: false,
+      messageSeverity: "neutral",
+      label: "Literal slash text",
+      description: "Path-like slash text will be submitted as written.",
+      source: "derived",
+    };
+  }
+  const match = RUNTIME_COMMAND_TOKEN_PATTERN.exec(firstLine);
+  if (!match) {
+    return {
+      sourcePath,
+      rawInstructions: instructions,
+      rawCommand: firstLine,
+      command: "",
+      args: "",
+      instructionBody: instructions,
+      detectionStatus: "malformed",
+      hintStatus: "opaque",
+      recognitionMode: "escaped_literal",
+      requiresRuntimeRecognition: false,
+      messageSeverity: "neutral",
+      label: "Literal slash text",
+      description: "Slash text does not match runtime command syntax.",
+      source: "derived",
+    };
+  }
+  const command = match[1] || "";
+  const args = match[2] || "";
+  const hint = config.knownRuntimeCommandHints?.[command];
+  const supportsPassthrough = Boolean(
+    config.runtimes?.[runtime]?.slashCommandPassthrough,
+  );
+  const source = runtimeCommandMatchesInstructions(
+    storedRuntimeCommand,
+    instructions,
+    runtime,
+  )
+    ? "snapshot"
+    : "derived";
+  if (!supportsPassthrough) {
+    return {
+      sourcePath,
+      rawInstructions: instructions,
+      rawCommand: firstLine,
+      command,
+      args,
+      instructionBody: body,
+      detectionStatus: "detected",
+      hintStatus: hint ? "hinted" : "opaque",
+      recognitionMode: "runtime_does_not_support_slash_commands",
+      requiresRuntimeRecognition: false,
+      messageSeverity: "warning",
+      label: `Unsupported runtime command: /${command}`,
+      description:
+        "This runtime does not pass through slash commands. Choose a slash-command capable runtime or escape the slash for literal text.",
+      source,
+    };
+  }
+  return {
+    sourcePath,
+    rawInstructions: instructions,
+    rawCommand: firstLine,
+    command,
+    args,
+    instructionBody: body,
+    detectionStatus: "detected",
+    hintStatus: hint ? "hinted" : "opaque",
+    recognitionMode: hint ? "hinted_runtime_passthrough" : "runtime_passthrough",
+    requiresRuntimeRecognition: true,
+    messageSeverity: "info",
+    label: `Runtime command: /${command}`,
+    description:
+      hint?.description ||
+      "Pass-through runtime command. No local hint is available; provider behavior will decide it.",
+    source,
+  };
+}
+
+function RuntimeCommandPreviewMessage({
+  preview,
+}: {
+  preview: RuntimeCommandPreviewState | null;
+}): ReactElement | null {
+  if (!preview) {
+    return null;
+  }
+  return (
+    <p
+      className={`runtime-command-preview runtime-command-preview--${preview.messageSeverity}`}
+      data-runtime-command-preview={preview.recognitionMode}
+      role={preview.messageSeverity === "warning" ? "alert" : "status"}
+      aria-live="polite"
+    >
+      <span className="runtime-command-preview-label">{preview.label}</span>
+      <span className="runtime-command-preview-description">
+        {preview.description}
+      </span>
+    </p>
+  );
+}
+
 function presetInputValuesFromPayload(
   inputValues: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
@@ -1380,6 +1618,9 @@ function createStepStateEntriesFromTemporalDraft(
         : {}),
       ...(hasJiraOrchestration
         ? { jiraOrchestration: step.jiraOrchestration }
+        : {}),
+      ...(step.runtimeCommand && Object.keys(step.runtimeCommand).length > 0
+        ? { runtimeCommand: step.runtimeCommand }
         : {}),
     });
   });
@@ -8123,6 +8364,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               const showJiraTransitionOptions =
                 step.stepType === "tool" &&
                 step.toolId.trim() === "jira.transition_issue";
+              const instructionPreview = deriveRuntimeCommandPreview({
+                instructions: step.instructions,
+                runtime,
+                sourcePath: index === 0
+                  ? "objective.instructions"
+                  : `steps[${index}].instructions`,
+                config: dashboardConfig.system?.runtimeCommandPreview,
+                storedRuntimeCommand: step.runtimeCommand,
+              });
               return (
                 <section
                   key={step.localId}
@@ -8523,6 +8773,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         )
                       }
                     />
+                    <RuntimeCommandPreviewMessage preview={instructionPreview} />
                     {attachmentPolicy.enabled ? (
                       <div className="queue-step-attachments">
                         <div className="queue-step-attachment-control">

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTemporalSubmissionDraftFromExecution } from "./temporalTaskEditing";
+
+describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", () => {
+  it("reconstructs objective and step runtime command metadata for preview restoration", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:slash-preview",
+        workflowType: "MoonMind.Run",
+        targetRuntime: "codex_cli",
+        inputParameters: {
+          task: {
+            instructions: "/review\nCheck the branch.",
+            runtime: { mode: "codex_cli" },
+          },
+        },
+      },
+      {
+        task: {
+          instructions: "/review\nCheck the branch.",
+          runtimeCommand: {
+            kind: "slash_command",
+            sourcePath: "objective.instructions",
+            command: "review",
+            rawCommand: "/review",
+            detectionStatus: "detected",
+            recognitionMode: "hinted_runtime_passthrough",
+          },
+          steps: [
+            {
+              id: "step-review",
+              instructions: "/simplify\nKeep the patch small.",
+              runtimeCommand: {
+                kind: "slash_command",
+                sourcePath: "steps[0].instructions",
+                targetStepId: "step-review",
+                command: "simplify",
+                rawCommand: "/simplify",
+                detectionStatus: "detected",
+                recognitionMode: "hinted_runtime_passthrough",
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(draft.runtimeCommand).toMatchObject({
+      command: "review",
+      rawCommand: "/review",
+      sourcePath: "objective.instructions",
+    });
+    expect(draft.steps[0].runtimeCommand).toMatchObject({
+      command: "simplify",
+      rawCommand: "/simplify",
+      targetStepId: "step-review",
+    });
+  });
+});

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -51,7 +51,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
       rawCommand: "/review",
       sourcePath: "objective.instructions",
     });
-    expect(draft.steps[0].runtimeCommand).toMatchObject({
+    expect(draft.steps[0]?.runtimeCommand).toMatchObject({
       command: "simplify",
       rawCommand: "/simplify",
       targetStepId: "step-review",

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -105,6 +105,7 @@ export type TemporalSubmissionDraft = {
   mergeAutomationEnabled: boolean;
   reportOutputEnabled: boolean;
   taskInstructions: string;
+  runtimeCommand?: Record<string, unknown>;
   primarySkill: string | null;
   inputAttachments: TemporalTaskInputAttachmentRef[];
   steps: Array<{
@@ -129,6 +130,7 @@ export type TemporalSubmissionDraft = {
     }>;
     storyOutput?: Record<string, unknown>;
     jiraOrchestration?: Record<string, unknown>;
+    runtimeCommand?: Record<string, unknown>;
   }>;
   appliedTemplates: Array<{
     slug: string;
@@ -456,6 +458,10 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     step.jiraOrchestration,
     step.jira_orchestration,
   );
+  const runtimeCommand = firstObjectValue(
+    step.runtimeCommand,
+    step.runtime_command,
+  );
   const inputAttachments = normalizeAttachmentRefs(step.inputAttachments);
   const templateAttachments = attachmentRefsValue(
     step.templateAttachments,
@@ -488,6 +494,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     ...(templateAttachments.length > 0 ? { templateAttachments } : {}),
     ...(Object.keys(storyOutput).length > 0 ? { storyOutput } : {}),
     ...(Object.keys(jiraOrchestration).length > 0 ? { jiraOrchestration } : {}),
+    ...(Object.keys(runtimeCommand).length > 0 ? { runtimeCommand } : {}),
   };
 
   const hasContent =
@@ -503,7 +510,8 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     inputAttachments.length > 0 ||
     templateAttachments.length > 0 ||
     Object.keys(storyOutput).length > 0 ||
-    Object.keys(jiraOrchestration).length > 0;
+    Object.keys(jiraOrchestration).length > 0 ||
+    Object.keys(runtimeCommand).length > 0;
   return hasContent ? result : null;
 }
 
@@ -775,6 +783,12 @@ export function buildTemporalSubmissionDraftFromExecution(
   const artifactSkill = objectValue(artifactTask.skill);
   const taskSteps = draftStepsFromTask(task);
   const artifactTaskSteps = draftStepsFromTask(artifactTask);
+  const runtimeCommand = firstObjectValue(
+    task.runtimeCommand,
+    task.runtime_command,
+    artifactTask.runtimeCommand,
+    artifactTask.runtime_command,
+  );
   assertSnapshotAttachmentBindings(
     artifactParams,
     artifactTask,
@@ -886,6 +900,7 @@ export function buildTemporalSubmissionDraftFromExecution(
       Object.keys(snapshotDraft).length > 0
         ? taskInstructionsFrom(artifactTask, task)
         : taskInstructionsFrom(task, artifactTask),
+    ...(Object.keys(runtimeCommand).length > 0 ? { runtimeCommand } : {}),
     primarySkill: nullableStringValue(
       execution.targetSkill,
       tool.name,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -4708,6 +4708,33 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   max-width: 72ch;
 }
 
+.runtime-command-preview {
+  display: grid;
+  gap: 0.18rem;
+  margin: 0.35rem 0 0;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid rgb(var(--mm-border) / 0.7);
+  border-radius: 8px;
+  background: rgb(var(--mm-panel) / 0.72);
+  color: rgb(var(--mm-ink));
+}
+
+.runtime-command-preview--warning {
+  border-color: rgb(var(--mm-warn) / 0.65);
+  background: rgb(var(--mm-warn) / 0.12);
+}
+
+.runtime-command-preview-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.runtime-command-preview-description {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: rgb(var(--mm-muted));
+}
+
 @media (max-width: 820px) {
   .td-hero-body {
     flex-direction: column;

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -41,9 +41,27 @@ _JIRA_ORCHESTRATE_PRESET_SLUGS = frozenset({"jira-orchestrate"})
 _RUNTIME_COMMAND_CAPABILITY_VERSION = "2026-05-13"
 _RUNTIME_COMMAND_HINT_CATALOG_VERSION = "2026-05-13"
 _SLASH_COMMAND_PASSTHROUGH_RUNTIMES = frozenset(
-    {"codex", "codex_cli", "claude", "gemini_cli", "universal"}
+    {"codex", "codex_cli", "claude", "claude_code", "gemini_cli", "universal"}
 )
 _KNOWN_RUNTIME_COMMAND_HINTS = frozenset({"review", "simplify"})
+_RUNTIME_COMMAND_HINT_DETAILS: dict[str, dict[str, Any]] = {
+    "review": {
+        "label": "Review",
+        "aliases": ["/review"],
+        "description": (
+            "Ask the selected runtime to review the current task or code state."
+        ),
+        "argumentPolicy": {"allowed": True, "required": False},
+        "bodyPolicy": {"allowed": True, "required": False},
+    },
+    "simplify": {
+        "label": "Simplify",
+        "aliases": ["/simplify"],
+        "description": "Ask the selected runtime to simplify the implementation.",
+        "argumentPolicy": {"allowed": True, "required": False},
+        "bodyPolicy": {"allowed": True, "required": False},
+    },
+}
 _RUNTIME_COMMAND_TOKEN_PATTERN = re.compile(
     r"^/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$"
 )
@@ -281,6 +299,33 @@ def _runtime_mode_from_task(
 
 def _runtime_supports_slash_passthrough(runtime_mode: str | None) -> bool:
     return (runtime_mode or DEFAULT_TASK_RUNTIME) in _SLASH_COMMAND_PASSTHROUGH_RUNTIMES
+
+
+def build_runtime_command_preview_config() -> dict[str, Any]:
+    """Return browser-safe slash-command preview capabilities and hints."""
+
+    runtime_ids = ("codex_cli", "gemini_cli", "claude_code", "codex_cloud")
+    runtimes: dict[str, dict[str, Any]] = {}
+    for runtime_id in runtime_ids:
+        supports_passthrough = _runtime_supports_slash_passthrough(runtime_id)
+        runtimes[runtime_id] = {
+            "slashCommandPassthrough": supports_passthrough,
+            "renderMode": "prompt_prefix" if supports_passthrough else "plain_prompt",
+            **(
+                {"commandHintsRef": runtime_id}
+                if supports_passthrough
+                else {}
+            ),
+        }
+    return {
+        "capabilityVersion": _RUNTIME_COMMAND_CAPABILITY_VERSION,
+        "hintCatalogVersion": _RUNTIME_COMMAND_HINT_CATALOG_VERSION,
+        "runtimes": runtimes,
+        "knownRuntimeCommandHints": {
+            command: dict(_RUNTIME_COMMAND_HINT_DETAILS[command])
+            for command in sorted(_KNOWN_RUNTIME_COMMAND_HINTS)
+        },
+    }
 
 
 def _runtime_command_hint_status(command: str) -> str:
@@ -2570,6 +2615,7 @@ __all__ = [
     "ResumeFromFailedStepRef",
     "TaskStepSource",
     "build_authoritative_task_input_snapshot",
+    "build_runtime_command_preview_config",
     "build_task_stage_plan",
     "build_canonical_task_view",
     "allows_repository_publish_for_skill_context",

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -63,7 +63,7 @@ _RUNTIME_COMMAND_HINT_DETAILS: dict[str, dict[str, Any]] = {
     },
 }
 _RUNTIME_COMMAND_TOKEN_PATTERN = re.compile(
-    r"^/([A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z0-9_-]+)?)(?:\s+(.*))?$"
+    r"^/([A-Za-z][A-Za-z0-9_-]*(?:(?::|\.)[A-Za-z0-9_-]+)?)(?:\s+(.*))?$"
 )
 _RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
     r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
@@ -304,7 +304,7 @@ def _runtime_supports_slash_passthrough(runtime_mode: str | None) -> bool:
 def build_runtime_command_preview_config() -> dict[str, Any]:
     """Return browser-safe slash-command preview capabilities and hints."""
 
-    runtime_ids = ("codex_cli", "gemini_cli", "claude_code", "codex_cloud")
+    runtime_ids = sorted(_SLASH_COMMAND_PASSTHROUGH_RUNTIMES | {"codex_cloud"})
     runtimes: dict[str, dict[str, Any]] = {}
     for runtime_id in runtime_ids:
         supports_passthrough = _runtime_supports_slash_passthrough(runtime_id)
@@ -417,26 +417,22 @@ def _build_runtime_command_metadata(
     match = _RUNTIME_COMMAND_TOKEN_PATTERN.fullmatch(first_line)
     if match:
         command = match.group(1)
-        args = match.group(2) or ""
+        args = "" if "." in command else match.group(2) or ""
     else:
-        command_parts = first_line[1:].split(maxsplit=1)
-        if not command_parts:
-            payload.update(
-                {
-                    "command": "",
-                    "rawCommand": first_line,
-                    "args": "",
-                    "instructionBody": raw_instructions,
-                    "detectionStatus": "malformed",
-                    "hintStatus": "opaque",
-                    "recognitionMode": "escaped_literal",
-                    "requiresRuntimeRecognition": False,
-                    "detectionPhase": "submit",
-                }
-            )
-            return payload
-        command = command_parts[0]
-        args = ""
+        payload.update(
+            {
+                "command": "",
+                "rawCommand": first_line,
+                "args": "",
+                "instructionBody": raw_instructions,
+                "detectionStatus": "malformed",
+                "hintStatus": "opaque",
+                "recognitionMode": "escaped_literal",
+                "requiresRuntimeRecognition": False,
+                "detectionPhase": "submit",
+            }
+        )
+        return payload
     hint_status = _runtime_command_hint_status(command)
     passthrough = _runtime_supports_slash_passthrough(target_runtime)
     if passthrough:

--- a/specs/355-slash-command-previews/checklists/requirements.md
+++ b/specs/355-slash-command-previews/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Provider-Neutral Slash Command Previews
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec defines one runtime user story for Create page preview behavior, preserves the `MM-685` Jira preset brief in `spec.md`, maps all in-scope source design requirements, and contains no clarification markers.

--- a/specs/355-slash-command-previews/contracts/runtime-command-preview.md
+++ b/specs/355-slash-command-previews/contracts/runtime-command-preview.md
@@ -1,0 +1,132 @@
+# Contract: Runtime Command Preview
+
+## Boot Payload Contract
+
+The Create page dashboard config exposes browser-safe preview metadata.
+
+```json
+{
+  "system": {
+    "runtimeCommandPreview": {
+      "capabilityVersion": "2026-05-13",
+      "hintCatalogVersion": "2026-05-13",
+      "runtimes": {
+        "codex_cli": {
+          "slashCommandPassthrough": true,
+          "renderMode": "prompt_prefix",
+          "commandHintsRef": "codex_cli"
+        },
+        "claude_code": {
+          "slashCommandPassthrough": true,
+          "renderMode": "prompt_prefix",
+          "commandHintsRef": "claude_code"
+        },
+        "gemini_cli": {
+          "slashCommandPassthrough": false,
+          "renderMode": "plain_prompt"
+        }
+      },
+      "knownRuntimeCommandHints": {
+        "review": {
+          "label": "Review",
+          "aliases": ["/review"],
+          "description": "Ask the selected runtime to review the current task or code state.",
+          "argumentPolicy": { "allowed": true, "required": false },
+          "bodyPolicy": { "allowed": true, "required": false }
+        },
+        "simplify": {
+          "label": "Simplify",
+          "aliases": ["/simplify"],
+          "description": "Ask the selected runtime to simplify the implementation.",
+          "argumentPolicy": { "allowed": true, "required": false },
+          "bodyPolicy": { "allowed": true, "required": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Contract rules:
+
+- The payload must not expose secrets, provider credentials, or executable command markup.
+- `knownRuntimeCommandHints` is optional enrichment, not an allowlist.
+- Missing runtime entries are treated as `slashCommandPassthrough: false`.
+- The Create page may cache this metadata for the current page load.
+
+## Preview Interaction Contract
+
+### Known command on slash-capable runtime
+
+Input:
+
+```text
+/review
+Check this branch.
+```
+
+Expected preview:
+
+- Status: runtime command.
+- Label includes `/review` or the known hint label.
+- Description may use known hint text.
+- No warning.
+- Authored instructions remain unchanged.
+
+### Unknown command on slash-capable runtime
+
+Input:
+
+```text
+/foo
+Use provider behavior.
+```
+
+Expected preview:
+
+- Status: pass-through runtime command.
+- Hint status: opaque.
+- No warning or error caused by missing hint.
+- Authored instructions remain unchanged.
+
+### Runtime without slash-command pass-through
+
+Input:
+
+```text
+/review
+Check this.
+```
+
+Expected preview:
+
+- Status: unsupported or warning.
+- Message tells the user to choose a slash-command capable runtime or escape the slash for literal text.
+- Authored instructions remain unchanged.
+
+### Escaped literal
+
+Input:
+
+```text
+\/review
+Treat as text.
+```
+
+Expected preview:
+
+- Status: literal text intent.
+- No executable command chip.
+- Authored instructions remain unchanged.
+
+### Edit mode with stored metadata
+
+Input:
+
+- Authoritative task input snapshot has authored instructions and `runtimeCommand` metadata.
+
+Expected preview:
+
+- Stored metadata is used for preview when it still corresponds to the restored instructions.
+- Re-detection is allowed only when stored metadata is absent or no longer corresponds to the current instructions.
+- Historical authored instructions are not rewritten.

--- a/specs/355-slash-command-previews/data-model.md
+++ b/specs/355-slash-command-previews/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Provider-Neutral Slash Command Previews
+
+## RuntimeCommandPreview
+
+Represents the Create page's user-visible interpretation of authored instructions.
+
+Fields:
+
+- `sourcePath`: `objective.instructions` or `steps[index].instructions`.
+- `rawInstructions`: current authored instruction text used for preview derivation.
+- `rawCommand`: first slash-leading line when applicable.
+- `command`: parsed command token when available.
+- `args`: command arguments when available.
+- `instructionBody`: authored body after the command line when applicable.
+- `detectionStatus`: `detected`, `escaped`, `not_detected`, or `malformed`.
+- `hintStatus`: `hinted` or `opaque`.
+- `recognitionMode`: `hinted_runtime_passthrough`, `runtime_passthrough`, `escaped_literal`, `runtime_does_not_support_slash_commands`, or `not_detected`.
+- `requiresRuntimeRecognition`: true when the selected runtime is expected to interpret the command.
+- `messageSeverity`: `info`, `warning`, or `neutral`.
+- `label`: user-facing concise preview label.
+- `description`: user-facing explanation.
+- `source`: `derived` for local preview derivation or `snapshot` for restored edit-mode metadata.
+
+Validation rules:
+
+- Leading whitespace before `/` yields `not_detected`.
+- `\/` yields `escaped` and `escaped_literal`.
+- Path-like slash-leading text yields `malformed` and literal/warning presentation.
+- Unknown valid commands are `opaque` but not warnings when runtime pass-through is supported.
+- Preview derivation must not mutate `rawInstructions`.
+
+## RuntimeCommandCapability
+
+Browser-safe runtime metadata for preview behavior.
+
+Fields:
+
+- `runtimeId`: runtime identifier used by task submission.
+- `slashCommandPassthrough`: whether slash-leading commands can pass through to the runtime.
+- `renderMode`: preview-safe render mode label, used for explanation only.
+- `commandHintsRef`: optional hint catalog identifier.
+- `capabilityVersion`: version string for audit and drift explanations.
+
+Validation rules:
+
+- Unknown runtimes default to no slash-command pass-through unless explicitly configured.
+- Capability values are declarative metadata, not provider-specific UI branches.
+
+## RuntimeCommandHint
+
+Optional metadata for known command previews.
+
+Fields:
+
+- `command`: canonical command token without the leading slash.
+- `aliases`: slash-leading display aliases.
+- `label`: concise human-readable command label.
+- `description`: user-facing hint text.
+- `argumentPolicy`: whether arguments are allowed or required.
+- `bodyPolicy`: whether body text is allowed or required.
+- `hintCatalogVersion`: version string.
+
+Validation rules:
+
+- Missing hints must not block preview or submission for slash-capable runtimes.
+- Hints may enrich labels and descriptions only.
+
+## AuthoredInstructionPreviewBinding
+
+Links preview state to the instruction control that produced it.
+
+Fields:
+
+- `targetKind`: `objective` or `step`.
+- `stepId`: step local or persisted identifier when target is a step.
+- `stepOrdinal`: zero-based step order when target is a step.
+- `instructions`: current authored instructions.
+- `storedRuntimeCommand`: optional metadata restored from a task input snapshot.
+- `preview`: current `RuntimeCommandPreview`.
+
+State transitions:
+
+- `empty` -> `not_detected` when text does not begin with `/`.
+- `not_detected` -> `detected` when the first character becomes `/` and command syntax is valid or opaque.
+- `detected` -> `runtime_does_not_support_slash_commands` when runtime changes to one without pass-through.
+- `detected` -> `escaped` when the first characters become `\/`.
+- `snapshot` -> `derived` only when stored metadata is absent or no longer matches the current authored text.

--- a/specs/355-slash-command-previews/moonspec_align_report.md
+++ b/specs/355-slash-command-previews/moonspec_align_report.md
@@ -1,0 +1,21 @@
+# MoonSpec Alignment Report: Provider-Neutral Slash Command Previews
+
+**Date**: 2026-05-15
+**Source**: `MM-685` canonical Jira preset brief preserved in `spec.md`
+
+## Findings
+
+| Finding | Severity | Resolution |
+| --- | --- | --- |
+| `DESIGN-REQ-012` was marked out of scope in `spec.md` but still mapped to `FR-008`, which made downstream coverage ambiguous. | Low | Updated `DESIGN-REQ-012` to remain out of scope with `Mapped Requirement` set to `None`; `FR-008` remains covered by in-scope provider-neutrality requirements `DESIGN-REQ-001` and `DESIGN-REQ-003`. |
+
+## Gate Re-Check
+
+- Specify gate: PASS. `spec.md` still has exactly one user story, preserves `MM-685`, preserves the original Jira preset brief, and has no clarification markers.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/runtime-command-preview.md` exist and remain consistent with the in-scope requirements.
+- Tasks gate: PASS. `tasks.md` has exactly one story phase, 35 sequential tasks, red-first unit tests, integration tests, implementation tasks, story validation, and final `/moonspec-verify` work.
+- Downstream regeneration: Not required. The only change removed an out-of-scope mapping, and `plan.md` plus `tasks.md` already cover in-scope `DESIGN-REQ-001` through `DESIGN-REQ-010` without relying on `DESIGN-REQ-012`.
+
+## Remaining Risks
+
+- None found in MoonSpec artifacts. Application implementation has not started yet.

--- a/specs/355-slash-command-previews/plan.md
+++ b/specs/355-slash-command-previews/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Provider-Neutral Slash Command Previews
+
+**Branch**: `run-jira-orchestrate-for-mm-685-show-pro-4537c34f` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:9f8378c1-5596-4d43-875b-8387e0bedb86/repo/specs/355-slash-command-previews/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` could not be used because the current managed branch name is not a numeric MoonSpec feature branch. The active feature directory was resolved from `.specify/feature.json` and existing `spec.md`.
+
+## Summary
+
+Deliver MM-685 by adding provider-neutral runtime slash-command preview behavior to the Mission Control Create page for objective and step instructions. Existing backend task snapshot normalization already detects and stores runtime command metadata, but the browser surface lacks preview state, declarative runtime command capability and hint data, unsupported-runtime warnings, and edit-mode restoration of stored command metadata. The implementation will expose a browser-safe runtime command preview catalog, add Create page preview parsing and rendering that preserves authored text, extend edit/rerun draft reconstruction to carry stored command metadata for preview, and verify behavior with frontend unit tests plus API/edit-boundary integration coverage.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | `frontend/src/entrypoints/task-create.tsx` has instruction fields but no `runtimeCommand` preview search hits. | Add objective and step preview state derived from authored instructions and selected runtime. | unit + integration |
+| FR-002 | missing | `api_service/api/routers/task_dashboard_view_model.py` exposes `supportedTaskRuntimes`, but no slash-command capability or hint catalog. | Expose browser-safe runtime command capability and hint metadata, then consume it in Create page preview labels. | unit + integration |
+| FR-003 | missing | Backend treats unknown commands as opaque pass-through in `tests/unit/workflows/tasks/test_task_contract.py`; Create page has no matching preview. | Add unknown valid command preview as pass-through for slash-capable runtimes without warning language. | unit |
+| FR-004 | missing | Runtime changes update model/profile state in `frontend/src/entrypoints/task-create.tsx`, but no preview recomputation exists. | Recompute preview from current instructions and runtime without mutating instruction state. | unit |
+| FR-005 | missing | Backend records escaped slash metadata; Create page has no escaped-literal preview. | Add escaped literal preview state with no executable command chip. | unit |
+| FR-006 | missing | Backend preserves whitespace-prefixed slash text as literal; Create page has no preview distinction. | Add preview parsing that ignores leading whitespace and inline slash text. | unit |
+| FR-007 | missing | Backend marks path-like slash input malformed literal; Create page has no preview distinction. | Add path-like or malformed preview state as literal/warning without rewriting text. | unit |
+| FR-008 | partial | Create page currently has runtime selection and no provider-specific slash markup, but it also lacks declarative preview behavior. | Keep rendering provider-neutral and source preview decisions from shared metadata rather than runtime-specific UI branches. | unit + integration |
+| FR-009 | partial | `buildTemporalSubmissionDraftFromExecution()` restores instructions, but draft step/task types do not carry `runtimeCommand` metadata. | Extend edit/rerun draft models to carry stored runtime command metadata for preview only. | unit + integration |
+| FR-010 | missing | Backend runtime command tests exist; frontend preview matrix and edit restoration tests are absent. | Add focused Vitest coverage for known, unknown, unsupported, escaped, whitespace, malformed, objective, step, runtime change, and edit-mode cases. | unit |
+| FR-011 | implemented_unverified | `spec.md` preserves `MM-685` and the original preset brief. | Preserve traceability through plan, research, quickstart, tasks, implementation, verification, commit text, and PR metadata. | final verify |
+| SCN-001 | missing | No Create page preview for `/review`. | Add known command preview with optional hint. | unit |
+| SCN-002 | missing | No Create page preview for `/foo`. | Add opaque pass-through preview. | unit |
+| SCN-003 | missing | No unsupported-runtime warning preview. | Add runtime capability recomputation and warning state. | unit |
+| SCN-004 | missing | No escaped-literal preview. | Add escaped state. | unit |
+| SCN-005 | partial | Edit mode restores instructions from task snapshots but not command metadata. | Preserve stored metadata for preview restoration, with re-detection only when absent. | unit + integration |
+| SC-001 | missing | No frontend preview tests for known commands. | Add tests for task and step known command previews. | unit |
+| SC-002 | missing | No frontend preview tests for unknown pass-through. | Add tests ensuring no warning/error language. | unit |
+| SC-003 | missing | No preview recomputation tests on runtime changes. | Add tests preserving exact text across runtime switches. | unit |
+| SC-004 | missing | No escaped preview tests. | Add tests for escaped literal state. | unit |
+| SC-005 | missing | No unsupported-runtime preview tests. | Add tests for runtime without pass-through. | unit |
+| SC-006 | implemented_unverified | `spec.md` and this plan preserve `MM-685`; final verification still pending. | Carry traceability into downstream artifacts and final verification. | final verify |
+| DESIGN-REQ-001 | partial | Backend preserves authored text; Create page preview and declarative metadata are missing. | Add provider-neutral preview driven by capability/hint metadata. | unit + integration |
+| DESIGN-REQ-002 | partial | Backend supports leading slash and escaped slash; Create page preview is missing. | Add preview states for detected and escaped text. | unit |
+| DESIGN-REQ-003 | partial | Backend does not block unknown commands; Create page preview is missing. | Add opaque pass-through preview without local allowlist behavior. | unit |
+| DESIGN-REQ-004 | partial | Backend distinguishes cases; Create page lacks equivalent preview. | Add browser-side preview classification aligned with backend semantics. | unit |
+| DESIGN-REQ-005 | partial | Backend unknown command behavior exists; Create page preview missing. | Add unknown command pass-through UI state. | unit |
+| DESIGN-REQ-006 | missing | No browser-safe slash capability or hint catalog in boot config. | Add declarative preview catalog to boot config and consume it in UI. | unit + integration |
+| DESIGN-REQ-007 | missing | Create page behavior not implemented. | Render command status, optional hints, pass-through status, and unsupported warnings. | unit |
+| DESIGN-REQ-008 | missing | Runtime changes do not affect preview because preview does not exist. | Recompute preview when runtime state changes. | unit |
+| DESIGN-REQ-009 | partial | Edit mode restores instructions but not stored `runtimeCommand` metadata. | Preserve command metadata for preview restoration; re-detect only when absent. | unit + integration |
+| DESIGN-REQ-010 | partial | Backend parser tests exist; frontend preview matrix missing. | Add Create page preview tests covering the required matrix. | unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control Create page; Python 3.12 for FastAPI boot payload and boundary tests  
+**Primary Dependencies**: React, TanStack Query, FastAPI, Pydantic v2, existing task dashboard view model, existing Temporal task snapshot helpers  
+**Storage**: No new persistent storage; preview state is derived from authored instructions, boot payload metadata, and existing task input snapshots  
+**Unit Testing**: Vitest and Testing Library for frontend preview behavior; pytest for Python boot-payload/schema helpers when changed  
+**Integration Testing**: Existing hermetic integration runner `./tools/test_integration.sh`, with focused API/edit-boundary tests where boot payload or task snapshot reconstruction is exposed  
+**Target Platform**: Mission Control web UI served by FastAPI in the existing local-first MoonMind deployment  
+**Project Type**: Full-stack web application with frontend Create page and Python API boot metadata  
+**Performance Goals**: Preview updates must be immediate for normal instruction editing and runtime changes, with no network call per keystroke  
+**Constraints**: Preserve authored instruction text exactly; do not hard-code provider-specific command markup in Create page; keep backend normalization authoritative at submit time; avoid new persistent storage  
+**Scale/Scope**: One Create page preview story covering objective and step instructions, edit-mode preview restoration, and runtime changes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Plan Evidence |
+| --- | --- | --- |
+| I. Orchestrate, Don't Recreate | PASS | Preview remains provider-neutral and delegates execution semantics to runtime capabilities and adapters. |
+| II. One-Click Agent Deployment | PASS | No new external services or required secrets. |
+| III. Avoid Vendor Lock-In | PASS | Capability/hint data is runtime-declarative; no Codex or Claude markup in Create page. |
+| IV. Own Your Data | PASS | Preview uses existing local boot payload and task input snapshots. |
+| V. Skills Are First-Class and Easy to Add | PASS | No skill runtime contract changes; task composition remains compatible with existing presets and steps. |
+| VI. Replaceable Scaffolding | PASS | Preview parsing is bounded and backed by tests; backend remains authoritative. |
+| VII. Runtime Configurability | PASS | Runtime command support is exposed as configuration/capability metadata rather than hard-coded UI behavior. |
+| VIII. Modular and Extensible Architecture | PASS | Changes are localized to boot metadata, Create page preview helpers, and edit draft reconstruction. |
+| IX. Resilient by Default | PASS | Submit-time backend normalization remains authoritative; preview does not mutate saved task input. |
+| X. Continuous Improvement | PASS | Traceability and final verification preserve `MM-685` and planned evidence. |
+| XI. Spec-Driven Development | PASS | This plan follows `spec.md` and keeps all requirements visible. |
+| XII. Canonical Docs vs Tmp | PASS | No canonical docs changes planned; implementation artifacts remain under `specs/355-slash-command-previews/`. |
+| XIII. Pre-release Compatibility Policy | PASS | No compatibility aliasing or migration layer planned; existing internal contracts will be updated directly where needed. |
+
+No constitution violations are present.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/355-slash-command-previews/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── runtime-command-preview.md
+└── tasks.md             # Created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── task_dashboard_view_model.py
+
+frontend/
+└── src/
+    ├── entrypoints/
+    │   ├── task-create.tsx
+    │   └── task-create.test.tsx
+    └── lib/
+        └── temporalTaskEditing.ts
+
+moonmind/
+└── workflows/
+    └── tasks/
+        └── task_contract.py
+
+tests/
+├── unit/
+│   └── workflows/
+│       └── tasks/
+│           └── test_task_contract.py
+└── integration/
+    └── api/
+        └── test_task_contract_normalization.py
+```
+
+**Structure Decision**: Use the existing Create page entrypoint for UI behavior, existing Temporal editing helper for edit/rerun draft reconstruction, and existing dashboard boot payload route for browser-safe runtime command preview metadata. Backend task contract normalization remains the authoritative submit boundary and should be reused or mirrored only through safe exported metadata.
+
+## Complexity Tracking
+
+No constitution violations or unusual complexity exceptions are required.

--- a/specs/355-slash-command-previews/quickstart.md
+++ b/specs/355-slash-command-previews/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Provider-Neutral Slash Command Previews
+
+## Scope
+
+Validate the single MM-685 story: Create page users see provider-neutral slash-command previews for objective and step instructions, with runtime changes, unknown commands, escaped literals, malformed/path-like input, and edit-mode restoration covered.
+
+## Test-First Flow
+
+1. Add failing frontend unit tests in `frontend/src/entrypoints/task-create.test.tsx`:
+   - `/review` on a slash-capable runtime shows runtime command preview for objective and step instructions.
+   - `/foo` on a slash-capable runtime shows pass-through status and no missing-hint warning.
+   - Changing runtime to one without slash pass-through shows an actionable warning and preserves the exact textarea value.
+   - `\/review` shows literal text intent and no executable command chip.
+   - ` /review`, inline slash text, and `/src/app.ts is broken` do not show executable command preview.
+   - Edit mode restores stored `runtimeCommand` metadata from the authoritative snapshot for preview.
+
+2. Add failing Python/API-boundary tests if boot payload metadata is changed:
+   - Dashboard boot payload includes browser-safe runtime command preview capabilities and known hints.
+   - No secret or provider credential fields are included in preview metadata.
+
+3. Implement the minimal code changes:
+   - Add or expose a browser-safe runtime command preview catalog.
+   - Render provider-neutral preview state in `TaskCreatePage` for objective and step instructions.
+   - Preserve stored runtime command metadata through `buildTemporalSubmissionDraftFromExecution()` for preview restoration.
+   - Keep submit-time backend normalization authoritative.
+
+## Focused Commands
+
+Prepare JS dependencies if needed through the standard test runner, then run focused frontend tests:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Run focused Python tests for backend/task-contract and boot payload changes:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_task_dashboard_view_model.py
+```
+
+Run hermetic integration coverage when API or task submission boundaries change:
+
+```bash
+./tools/test_integration.sh
+```
+
+Before final verification, run the required full unit suite:
+
+```bash
+./tools/test_unit.sh
+```
+
+## End-to-End Manual Check
+
+1. Open Mission Control Create page.
+2. Select a slash-capable runtime.
+3. Enter `/review` in objective instructions and verify a runtime command preview appears.
+4. Enter `/foo` and verify pass-through status appears without warning language.
+5. Switch to a runtime without slash-command pass-through and verify the warning updates without changing the instruction text.
+6. Enter `\/review` and verify literal text intent appears with no executable command chip.
+7. Add a step with `/simplify` and verify step-level preview.
+8. Open an editable task whose authoritative snapshot contains `runtimeCommand` metadata and verify the preview reflects stored metadata.
+
+## Completion Evidence
+
+- Unit tests cover the preview matrix from FR-010.
+- Integration/API tests cover boot metadata or edit-boundary changes if touched.
+- Final verification confirms `MM-685`, the original Jira preset brief, and all in-scope source design requirements remain preserved.

--- a/specs/355-slash-command-previews/research.md
+++ b/specs/355-slash-command-previews/research.md
@@ -1,0 +1,129 @@
+# Phase 0 Research: Provider-Neutral Slash Command Previews
+
+## Planning Setup
+
+Decision: Use `.specify/feature.json` and local templates instead of the setup script.
+Evidence: `.specify/scripts/bash/setup-plan.sh --json` failed because the managed branch `run-jira-orchestrate-for-mm-685-show-pro-4537c34f` is not named like a numeric MoonSpec feature branch; `.specify/feature.json` points to `specs/355-slash-command-previews`.
+Rationale: The active feature directory and valid single-story spec already exist, so planning can continue without creating a branch or another feature directory.
+Alternatives considered: Renaming or switching branches was rejected because this managed step is limited to planning artifacts.
+Test implications: None beyond final artifact verification.
+
+## Runtime Command Backend Baseline
+
+Decision: Treat backend runtime command normalization as partial existing support and keep it authoritative at submit time.
+Evidence: `moonmind/workflows/tasks/task_contract.py` builds `runtimeCommand` metadata for objective and step instructions, supports escaped literals, path-like malformed literals, hinted commands, opaque unknown commands, and unsupported runtime recognition modes. `tests/unit/workflows/tasks/test_task_contract.py` covers task-level `/review`, step-level `/simplify`, unknown `/future-command`, escaped `\/review`, path-like `/src/app.ts`, unsupported runtime, and leading whitespace.
+Rationale: The Create page preview should align with backend semantics, but backend coverage does not satisfy the user-facing preview story by itself.
+Alternatives considered: Moving all preview decisions to the backend on every keystroke was rejected because previews must update immediately without network calls.
+Test implications: Unit tests should continue to cover backend normalization; new frontend tests should prove preview parity for user-visible states.
+
+## Browser Capability And Hint Metadata
+
+Decision: Add browser-safe runtime command preview metadata to the existing dashboard boot payload.
+Evidence: `api_service/api/routers/task_dashboard_view_model.py` currently exposes `supportedTaskRuntimes`, default runtime/model/effort, provider profiles, and task template routes, but no slash-command capability or hint catalog. `frontend/src/entrypoints/task-create.tsx` reads dashboard config for runtime behavior.
+Rationale: The spec requires declarative runtime capability and hint data, and the Create page must not hard-code provider-specific command markup. The boot payload is the established path for Create page runtime metadata.
+Alternatives considered: Hard-coding slash-capable runtimes in `task-create.tsx` was rejected because it violates provider-neutral declarative behavior. Adding a new per-keystroke endpoint was rejected because preview should be local and responsive.
+Test implications: Add Python unit or integration coverage for boot payload shape, plus Vitest coverage proving the Create page consumes the metadata.
+
+## Create Page Preview Surface
+
+Decision: Add local preview derivation and rendering to objective and step instruction controls in `frontend/src/entrypoints/task-create.tsx`.
+Evidence: The Create page stores `runtime`, `steps`, objective text, and runtime-derived defaults, and submits task/step instructions. Repository search found no frontend `runtimeCommand`, `recognitionMode`, slash-command preview, `/review`, or escaped-slash preview implementation.
+Rationale: The story is explicitly about the Create page before submission. Existing backend normalization cannot provide immediate user feedback while composing.
+Alternatives considered: Waiting until submit validation was rejected because the acceptance criteria require preview before submission.
+Test implications: Add Vitest/Testing Library tests for objective and step previews, runtime switching, and exact instruction preservation.
+
+## Edit And Rerun Preview Restoration
+
+Decision: Extend Temporal task editing draft reconstruction to preserve stored `runtimeCommand` metadata for preview-only use.
+Evidence: `frontend/src/lib/temporalTaskEditing.ts` reconstructs instructions, runtime, steps, attachments, templates, and related task state, but the draft types and `draftStepFrom()` do not expose `runtimeCommand`. Edit tests cover instruction reconstruction but not runtime command metadata.
+Rationale: The spec requires edit mode to restore stored metadata when present and re-detect only for preview when absent. Carrying metadata through the draft avoids losing authoritative historical interpretation.
+Alternatives considered: Always re-detecting in edit mode was rejected because runtime capabilities and hints may have changed since the original run.
+Test implications: Add helper tests for draft reconstruction with objective and step `runtimeCommand` metadata, plus Create page edit-mode rendering tests.
+
+## Requirement FR-001
+
+Decision: Status `missing`; add objective and step preview state.
+Evidence: `task-create.tsx` contains objective/step instruction controls and runtime state, but no user-visible runtime command preview implementation.
+Rationale: Users cannot currently see whether slash-leading text will execute as a runtime command.
+Alternatives considered: Relying on backend task snapshot metadata was rejected because it is submit-time only.
+Test implications: Unit and integration tests.
+
+## Requirement FR-002
+
+Decision: Status `missing`; expose and consume runtime capability and hint data.
+Evidence: Dashboard boot config lacks slash command preview metadata; backend has private capability/hint constants.
+Rationale: Preview labels must be declarative and provider-neutral.
+Alternatives considered: UI-local runtime allowlist rejected as hard-coded provider logic.
+Test implications: Unit and integration tests.
+
+## Requirement FR-003
+
+Decision: Status `missing`; add unknown valid command pass-through preview.
+Evidence: Backend tests prove unknown commands are opaque pass-through, but frontend has no preview.
+Rationale: Missing hints must not become warning or error states.
+Alternatives considered: Requiring known hints for preview rejected by source design.
+Test implications: Unit tests.
+
+## Requirement FR-004
+
+Decision: Status `missing`; recompute previews on runtime changes without text mutation.
+Evidence: Runtime changes currently update model/profile defaults, but no runtime command preview depends on runtime.
+Rationale: Unsupported-runtime warnings and pass-through status depend on selected runtime.
+Alternatives considered: Recomputing only on submit rejected by acceptance criteria.
+Test implications: Unit tests.
+
+## Requirement FR-005
+
+Decision: Status `missing`; add escaped literal preview.
+Evidence: Backend has escaped metadata; frontend has no escaped-literal UI.
+Rationale: Users need a visible distinction between command execution and literal text.
+Alternatives considered: Showing no preview for escaped text was rejected because the spec requires literal text intent representation.
+Test implications: Unit tests.
+
+## Requirement FR-006
+
+Decision: Status `missing`; distinguish whitespace-prefixed and inline slash text.
+Evidence: Backend preserves leading-whitespace slash as ordinary instructions; frontend has no preview classifier.
+Rationale: Preview must avoid misleading users into thinking non-leading slash text is executable.
+Alternatives considered: Trimming before preview rejected because it would change semantics.
+Test implications: Unit tests.
+
+## Requirement FR-007
+
+Decision: Status `missing`; distinguish path-like or malformed slash input.
+Evidence: Backend marks path-like input as malformed literal; frontend has no equivalent display.
+Rationale: File paths should not look like runtime commands.
+Alternatives considered: Treating all slash-leading text as command rejected by source design.
+Test implications: Unit tests.
+
+## Requirement FR-008
+
+Decision: Status `partial`; preserve provider-neutral UI while adding declarative preview behavior.
+Evidence: No provider-specific command markup appears in Create page slash preview code because preview code does not exist; runtime-specific logic is absent rather than satisfied.
+Rationale: The implementation must add behavior without introducing provider-specific rendering decisions.
+Alternatives considered: Direct Codex/Claude preview branches rejected.
+Test implications: Unit and integration tests.
+
+## Requirement FR-009
+
+Decision: Status `partial`; edit mode restores instructions but drops runtime command metadata.
+Evidence: `buildTemporalSubmissionDraftFromExecution()` reconstructs instructions and steps from snapshots, but draft types do not carry `runtimeCommand`.
+Rationale: Edit preview should prefer stored metadata to avoid drift from changed capability or hint catalogs.
+Alternatives considered: Always re-detecting from restored instructions rejected by source design.
+Test implications: Unit and integration tests.
+
+## Requirement FR-010
+
+Decision: Status `missing`; add frontend preview test matrix.
+Evidence: Existing tests cover backend normalization, not Create page preview states.
+Rationale: The spec requires explicit frontend coverage for the user-facing matrix.
+Alternatives considered: Counting backend tests as sufficient rejected because UI behavior is the story.
+Test implications: Unit tests.
+
+## Requirement FR-011
+
+Decision: Status `implemented_unverified`; preserve traceability through downstream work.
+Evidence: `specs/355-slash-command-previews/spec.md` preserves `MM-685` and the original Jira preset brief. This plan also references `MM-685`.
+Rationale: Final verification has not happened yet, so traceability remains a planned verification item.
+Alternatives considered: Marking verified now rejected because final implementation artifacts do not exist.
+Test implications: Final verify.

--- a/specs/355-slash-command-previews/spec.md
+++ b/specs/355-slash-command-previews/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Provider-Neutral Slash Command Previews
+
+**Feature Branch**: `355-slash-command-previews`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**:
+
+```text
+# MM-685 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-685
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Show provider-neutral slash command previews on the Create page
+- Labels: `moonmind-workflow-mm-1c30567c-221e-4dc1-bc74-d1248e750656`
+- Trusted fetch tool: `jira.get_issue`
+- Trusted response artifact: `/work/agent_jobs/mm:9f8378c1-5596-4d43-875b-8387e0bedb86/artifacts/moonspec-inputs/MM-685-trusted-jira-get-issue.json`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`; potentially related custom fields `Implementation plan`, `Backout plan`, and `Test plan` were present but empty.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-685 from MM project
+Summary: Show provider-neutral slash command previews on the Create page
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-685 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-685: Show provider-neutral slash command previews on the Create page
+
+Source Reference
+Source Document: docs/Steps/SlashCommands.md
+Source Title: Runtime Slash Commands on Create Task
+Source Sections:
+- Design Principles
+- Runtime Capabilities and Command Hints
+- Create Page Behavior
+- Edit mode
+- Non-goals
+- Testing Strategy
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-007
+- DESIGN-REQ-008
+- DESIGN-REQ-009
+- DESIGN-REQ-018
+- DESIGN-REQ-019
+
+As a user composing a task, I want the Create page to preview whether my leading slash text will be treated as a runtime command, literal text, or unsupported runtime case, so I can submit the task intentionally without MoonMind hard-coding provider command markup.
+
+Acceptance Criteria
+- Leading /review shows a runtime command status for a slash-capable runtime and may include hint text when available.
+- Unknown valid /foo shows pass-through status rather than a warning or error when the selected runtime supports slash commands.
+- Selecting a runtime without slash-command pass-through recomputes recognition mode and shows an actionable warning without mutating authored instructions.
+- Escaped \/review does not show an executable command chip and is represented as literal text intent.
+- Create page code consumes declarative capability and hint metadata and does not embed Codex-specific or Claude-specific command markup.
+
+Requirements
+- Surface runtimeCommand preview state for objective and step instructions when the first character is /.
+- Use runtime capability catalog data and hint catalog data for preview labels and descriptions.
+- Recompute preview when selected runtime changes without altering the underlying instruction value.
+- Keep provider-specific rendering decisions out of the Create page.
+
+## Orchestration Constraints
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path: `docs/Steps/SlashCommands.md`.
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+Preserved source Jira preset brief: `MM-685` from the trusted `jira.get_issue` response, reproduced in the `**Input**` field above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-685` and local handoff `/work/agent_jobs/mm:9f8378c1-5596-4d43-875b-8387e0bedb86/artifacts/moonspec-inputs/MM-685-canonical-moonspec-input.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserving the `MM-685` implementation brief was found under `specs/`; `Specify` is the first incomplete stage.
+
+## User Story - Preview Slash Command Intent
+
+**Summary**: As a user composing a task, I want the Create page to preview whether slash-leading instructions will run as a runtime command, literal text, or an unsupported runtime case so that I can submit task instructions intentionally.
+
+**Goal**: Users can see a provider-neutral interpretation of leading slash text before submission, including known-command hints when available, opaque pass-through for unknown valid commands, unsupported-runtime warnings, and escaped-literal behavior.
+
+**Independent Test**: Can be fully tested by composing task-level and step-level instructions that begin with known, unknown, unsupported, and escaped slash text, switching between slash-capable and non-slash-capable runtimes, and verifying that preview state and authored instructions remain correct without submitting a task.
+
+**Acceptance Scenarios**:
+
+1. **Given** a slash-capable runtime is selected, **When** the user enters `/review` as the first characters of task or step instructions, **Then** the Create page shows a runtime command preview and may show known-command hint text when hint data exists.
+2. **Given** a slash-capable runtime is selected, **When** the user enters an unknown valid command such as `/foo`, **Then** the Create page shows pass-through runtime command status without treating the missing hint as a warning or error.
+3. **Given** a runtime without slash-command pass-through is selected, **When** the user enters slash-leading instructions, **Then** the Create page recomputes recognition mode and shows an actionable warning without changing the authored text.
+4. **Given** the user enters escaped slash text such as `\/review`, **When** the preview is evaluated, **Then** the Create page does not show an executable command chip and presents the input as literal text intent.
+5. **Given** a task is opened for edit, **When** authored instructions and any stored runtime command metadata are available, **Then** the Create page restores the preview from authoritative task input data or re-detects for preview only without altering historical authored instructions.
+
+### Edge Cases
+
+- Slash text preceded by whitespace is treated as normal text rather than a detected leading command.
+- Path-like text such as `/src/app.ts is broken` is treated as malformed or literal text rather than a pass-through command preview.
+- A command token with no local hint remains previewable as opaque pass-through when the runtime supports slash commands.
+- Runtime changes recompute only preview state and must not mutate the instruction field.
+- Missing or stale stored command metadata during edit mode may be used for preview re-detection only and must not rewrite saved instructions.
+
+## Assumptions
+
+- The runtime capability catalog and optional command hint catalog are the authoritative sources for preview labels, descriptions, and slash-command support state.
+- The preview behavior applies to both task-level objective instructions and individual step instructions because the Jira brief names both objective and step instructions.
+- This story covers Create page preview and edit-mode presentation only; backend normalization, final runtime rendering, workflow submission behavior, and runtime adapter execution are separate source-design slices.
+
+## Source Design Requirements
+
+| Requirement ID | Source Citation | Requirement Summary | Scope | Mapped Requirement |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Steps/SlashCommands.md` lines 50-70, Design Principles | The Create page must preserve authored slash-leading text exactly, use declarative runtime capability and hint data, and avoid provider-specific command markup or per-provider conditionals. | In scope | FR-001, FR-002, FR-008 |
+| DESIGN-REQ-002 | `docs/Steps/SlashCommands.md` lines 78-87, Goals | Users must be able to compose slash-leading task instructions, see detection based on the first character, and use an escape hatch for literal slash text. | In scope | FR-001, FR-005, FR-006 |
+| DESIGN-REQ-003 | `docs/Steps/SlashCommands.md` lines 91-99, Non-goals | The preview must not require MoonMind to know every runtime command, must not replace runtime-native command systems, and must not block unknown commands only because no local hint exists. | In scope | FR-003, FR-008 |
+| DESIGN-REQ-004 | `docs/Steps/SlashCommands.md` lines 287-316, Detection Rules | Preview detection must distinguish detected commands, whitespace-prefixed non-commands, escaped literals, path-like malformed text, unknown valid commands, and inline slash text. | In scope | FR-001, FR-003, FR-005, FR-006, FR-007 |
+| DESIGN-REQ-005 | `docs/Steps/SlashCommands.md` lines 318-329, Unknown Command Contract | Unknown valid slash commands must be first-class pass-through invocations for runtimes with slash-command pass-through and must not produce warnings or errors because of missing hints. | In scope | FR-003 |
+| DESIGN-REQ-006 | `docs/Steps/SlashCommands.md` lines 372-391, Runtime Capabilities and Command Hints | Slash-command support is runtime-level capability data, and known-command hints may enrich labels, descriptions, autocomplete, and examples without becoming validation gates. | In scope | FR-002, FR-003, FR-004 |
+| DESIGN-REQ-007 | `docs/Steps/SlashCommands.md` lines 499-532, Create Page Behavior | The Create page must show runtime command status, optional known-command hints, pass-through status for unknown commands, and actionable warnings for runtimes without slash-command pass-through. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-008 | `docs/Steps/SlashCommands.md` lines 534-538, Runtime changes | Changing the selected runtime must recompute recognition mode without changing authored instructions. | In scope | FR-004, FR-008 |
+| DESIGN-REQ-009 | `docs/Steps/SlashCommands.md` lines 540-547, Edit mode | Edit mode must restore authored instructions and command metadata from the task input snapshot when present, and re-detection must not silently alter the historical raw instruction value. | In scope | FR-009 |
+| DESIGN-REQ-010 | `docs/Steps/SlashCommands.md` lines 861-895, Testing Strategy | Parser and Create page validation must cover known commands, unknown commands, whitespace-prefixed input, escaped literals, malformed path-like text, runtime changes, and preservation of authored instructions. | In scope | FR-010 |
+| DESIGN-REQ-011 | `docs/Steps/SlashCommands.md` lines 555-638, Backend behavior and runtime preparation pipeline | Backend authoritative normalization and final runtime rendering after context preparation are required by the broader design. | Out of scope for this Create page preview story; handled by separate runtime/backend slices. | None |
+| DESIGN-REQ-012 | `docs/Steps/SlashCommands.md` lines 672-717, Runtime strategy integration | Runtime-specific Codex and Claude renderers decide how to make slash commands recognized during execution. | Out of scope for this Create page preview story; the Create page must remain provider-neutral. | FR-008 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Create page MUST surface runtime command preview state for task-level objective instructions and step instructions when the first character is `/`.
+- **FR-002**: The preview MUST use runtime capability data and optional known-command hint data to determine preview labels, descriptions, and slash-command support state.
+- **FR-003**: For slash-capable runtimes, an unknown valid command such as `/foo` MUST show pass-through status and MUST NOT be presented as a warning, error, or blocked submission solely because no hint exists.
+- **FR-004**: When the selected runtime changes, the preview MUST recompute recognition mode and any unsupported-runtime warning without changing the authored instruction value.
+- **FR-005**: Escaped slash-leading text such as `\/review` MUST be represented as literal text intent and MUST NOT show an executable command chip.
+- **FR-006**: The preview MUST distinguish whitespace-prefixed slash text and inline slash text from leading slash commands.
+- **FR-007**: The preview MUST distinguish path-like or malformed slash-leading text from valid pass-through runtime commands and present the resulting literal or warning state without rewriting the user's text.
+- **FR-008**: The Create page MUST NOT embed Codex-specific, Claude-specific, or provider-specific command markup or rendering decisions in preview behavior.
+- **FR-009**: In edit mode, the Create page MUST restore authored instructions and stored runtime command metadata from the authoritative task input snapshot when present, and preview-only re-detection MUST NOT alter the historical instruction value.
+- **FR-010**: Verification coverage MUST include known commands, unknown valid commands, non-slash-capable runtimes, escaped literals, runtime changes, whitespace-prefixed input, path-like malformed input, task-level instructions, step-level instructions, and edit-mode restoration.
+- **FR-011**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-685` and the original Jira preset brief.
+
+### Key Entities
+
+- **Runtime Command Preview**: The user-visible interpretation of slash-leading authored instructions, including detection status, hint status, recognition mode, literal status, warning status, and source location.
+- **Runtime Capability**: Declarative runtime metadata indicating whether slash-command pass-through is supported and which hint catalog may enrich previews.
+- **Command Hint**: Optional declarative metadata for a known command, including user-facing labels and descriptions that enrich previews without acting as an allowlist.
+- **Authored Instructions**: The task-level or step-level instruction text exactly as entered or restored for editing.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of tested known slash-command examples at task and step level show a runtime command preview for slash-capable runtimes.
+- **SC-002**: 100% of tested unknown valid slash-command examples for slash-capable runtimes show pass-through status without warning or error language caused by missing hints.
+- **SC-003**: 100% of tested runtime changes recompute preview state while preserving the exact authored instruction text.
+- **SC-004**: 100% of tested escaped slash-leading examples are represented as literal text intent and do not show an executable command chip.
+- **SC-005**: 100% of tested non-slash-capable runtime cases show an actionable unsupported-runtime warning without changing authored instructions.
+- **SC-006**: Traceability review confirms `MM-685`, the original Jira preset brief, and all in-scope source design requirements remain present in MoonSpec artifacts and final verification evidence.

--- a/specs/355-slash-command-previews/spec.md
+++ b/specs/355-slash-command-previews/spec.md
@@ -126,7 +126,7 @@ Resume decision: no existing Moon Spec feature directory preserving the `MM-685`
 | DESIGN-REQ-009 | `docs/Steps/SlashCommands.md` lines 540-547, Edit mode | Edit mode must restore authored instructions and command metadata from the task input snapshot when present, and re-detection must not silently alter the historical raw instruction value. | In scope | FR-009 |
 | DESIGN-REQ-010 | `docs/Steps/SlashCommands.md` lines 861-895, Testing Strategy | Parser and Create page validation must cover known commands, unknown commands, whitespace-prefixed input, escaped literals, malformed path-like text, runtime changes, and preservation of authored instructions. | In scope | FR-010 |
 | DESIGN-REQ-011 | `docs/Steps/SlashCommands.md` lines 555-638, Backend behavior and runtime preparation pipeline | Backend authoritative normalization and final runtime rendering after context preparation are required by the broader design. | Out of scope for this Create page preview story; handled by separate runtime/backend slices. | None |
-| DESIGN-REQ-012 | `docs/Steps/SlashCommands.md` lines 672-717, Runtime strategy integration | Runtime-specific Codex and Claude renderers decide how to make slash commands recognized during execution. | Out of scope for this Create page preview story; the Create page must remain provider-neutral. | FR-008 |
+| DESIGN-REQ-012 | `docs/Steps/SlashCommands.md` lines 672-717, Runtime strategy integration | Runtime-specific Codex and Claude renderers decide how to make slash commands recognized during execution. | Out of scope for this Create page preview story; handled by separate runtime adapter slices while this story keeps the Create page provider-neutral. | None |
 
 ## Requirements *(mandatory)*
 

--- a/specs/355-slash-command-previews/tasks.md
+++ b/specs/355-slash-command-previews/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Provider-Neutral Slash Command Previews
+
+**Input**: Design documents from `/work/agent_jobs/mm:9f8378c1-5596-4d43-875b-8387e0bedb86/repo/specs/355-slash-command-previews/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/runtime-command-preview.md](./contracts/runtime-command-preview.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around exactly one story: `Preview Slash Command Intent`.
+
+**Source Traceability**: `MM-685` and the original Jira preset brief are preserved in `spec.md`. Tasks cover FR-001 through FR-011, SCN-001 through SCN-005, SC-001 through SC-006, and in-scope DESIGN-REQ-001 through DESIGN-REQ-010.
+
+**Requirement Status Summary**: Code-and-test work is required for FR-001 through FR-010. FR-011 is implemented_unverified traceability and is covered by preservation checks plus final `/moonspec-verify`.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts`
+- Python unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on incomplete tasks.
+- Each task names exact file paths and requirement, scenario, success criterion, or source-design IDs.
+- This task list covers one story only.
+
+## Phase 1: Setup
+
+**Purpose**: Confirm active artifacts and test tooling before test-first work.
+
+- [ ] T001 Confirm `specs/355-slash-command-previews/spec.md`, `specs/355-slash-command-previews/plan.md`, `specs/355-slash-command-previews/research.md`, `specs/355-slash-command-previews/data-model.md`, `specs/355-slash-command-previews/contracts/runtime-command-preview.md`, and `specs/355-slash-command-previews/quickstart.md` are present and preserve `MM-685` for FR-011/SC-006.
+- [ ] T002 Confirm existing frontend and Python test tooling commands in `package.json`, `./tools/test_unit.sh`, and `./tools/test_integration.sh` match the commands listed in `specs/355-slash-command-previews/quickstart.md`.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared assumptions before writing story tests. No production story implementation occurs in this phase.
+
+- [ ] T003 Inspect existing backend runtime command normalization in `moonmind/workflows/tasks/task_contract.py` and existing coverage in `tests/unit/workflows/tasks/test_task_contract.py` to align frontend preview semantics for DESIGN-REQ-001 through DESIGN-REQ-005.
+- [ ] T004 Inspect existing Create page runtime, objective, step, and edit-mode state paths in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` to identify exact insertion points for FR-001, FR-004, and FR-009.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Preview Slash Command Intent
+
+**Summary**: As a user composing a task, I want the Create page to preview whether slash-leading instructions will run as a runtime command, literal text, or an unsupported runtime case so that I can submit task instructions intentionally.
+
+**Independent Test**: Compose task-level and step-level instructions that begin with known, unknown, unsupported, escaped, whitespace-prefixed, inline, and malformed slash text; switch runtimes; and open edit mode with stored command metadata to verify preview state while authored instructions remain unchanged.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, SCN-001, SCN-002, SCN-003, SCN-004, SCN-005, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010
+
+**Unit Test Plan**:
+
+- Frontend unit tests cover objective and step preview rendering, known hints, unknown opaque pass-through, unsupported runtimes, escaped literals, whitespace-prefixed text, path-like malformed text, runtime switching, no text mutation, and edit-mode preview restoration.
+- Python unit tests cover browser-safe boot payload metadata and keep backend normalization traceability intact.
+
+**Integration Test Plan**:
+
+- API integration coverage verifies the Create page boot payload exposes browser-safe runtime command preview capability and hint metadata.
+- Browser or task-create integration coverage verifies the preview journey from rendered Create page controls without relying on submit-time backend normalization.
+
+### Unit Tests (write first)
+
+- [ ] T005 Add failing frontend unit tests for objective and step known command previews covering FR-001, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [ ] T006 Add failing frontend unit tests for unknown valid `/foo` pass-through previews covering FR-003, SCN-002, SC-002, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [ ] T007 Add failing frontend unit tests for unsupported runtime warnings and runtime switching text preservation covering FR-004, SCN-003, SC-003, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [ ] T008 Add failing frontend unit tests for escaped literals, whitespace-prefixed slash text, inline slash text, and path-like malformed slash text covering FR-005, FR-006, FR-007, SCN-004, SC-004, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [ ] T009 [P] Add failing frontend unit tests for edit-mode runtime command metadata reconstruction covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.test.ts`.
+- [ ] T010 [P] Add failing Python unit tests for browser-safe runtime command preview boot metadata covering FR-002, FR-008, and DESIGN-REQ-006 in `tests/unit/api/routers/test_task_dashboard_view_model.py`.
+
+### Integration Tests (write first)
+
+- [ ] T011 [P] Add failing API integration test for dashboard boot payload runtime command preview metadata covering FR-002, SCN-001, SCN-002, DESIGN-REQ-006, and the contract in `specs/355-slash-command-previews/contracts/runtime-command-preview.md` in `tests/integration/api/test_task_runtime_command_preview_boot_payload.py`.
+- [ ] T012 [P] Add failing Create page browser integration test for visible objective and step preview behavior covering FR-001, FR-003, FR-004, FR-005, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `tests/e2e/test_task_create_submit_browser.py`.
+
+### Red-First Confirmation
+
+- [ ] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and confirm T005-T009 fail for missing preview behavior before production code changes.
+- [ ] T014 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T010 fails for missing boot metadata while existing backend runtime command tests still pass.
+- [ ] T015 Run `./tools/test_integration.sh` or the narrowest available integration command for `tests/integration/api/test_task_runtime_command_preview_boot_payload.py` and `tests/e2e/test_task_create_submit_browser.py`, then confirm T011-T012 fail for missing preview/metadata behavior.
+
+### Conditional Fallback For Implemented-Unverified Traceability
+
+- [ ] T016 If traceability checks fail, update `specs/355-slash-command-previews/spec.md`, `specs/355-slash-command-previews/plan.md`, `specs/355-slash-command-previews/research.md`, `specs/355-slash-command-previews/data-model.md`, `specs/355-slash-command-previews/contracts/runtime-command-preview.md`, `specs/355-slash-command-previews/quickstart.md`, and `specs/355-slash-command-previews/tasks.md` to preserve `MM-685` and the original Jira preset brief for FR-011/SC-006.
+
+### Implementation
+
+- [ ] T017 Export a browser-safe runtime command preview capability and hint catalog aligned with backend normalization semantics for FR-002, FR-003, FR-008, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-006 in `moonmind/workflows/tasks/task_contract.py`.
+- [ ] T018 Add runtime command preview metadata to the dashboard boot payload for FR-002, FR-008, DESIGN-REQ-006, and the contract in `api_service/api/routers/task_dashboard_view_model.py`.
+- [ ] T019 Add TaskCreatePage dashboard config typing for runtime command preview metadata covering FR-002 and DESIGN-REQ-006 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T020 Implement provider-neutral runtime command preview derivation for detected, unknown, unsupported, escaped, whitespace-prefixed, inline, and path-like malformed states covering FR-001, FR-003, FR-005, FR-006, FR-007, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T021 Render objective instruction runtime command preview status, hint text, pass-through text, literal text intent, and unsupported-runtime warning for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T022 Render step instruction runtime command previews for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T023 Wire runtime change recomputation without mutating authored instructions for FR-004, FR-008, SC-003, SC-005, DESIGN-REQ-001, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T024 Extend Temporal edit/rerun draft types and reconstruction to carry objective and step `runtimeCommand` metadata for preview-only restoration covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.ts`.
+- [ ] T025 Ensure task submission payloads remain authored-instruction based and do not submit preview-only provider markup for FR-008, FR-009, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T026 Add or adjust minimal Create page styling for preview status, warning, and literal states while preserving mobile layout for FR-001, FR-004, FR-005, and SC-005 in `frontend/src/styles/mission-control.css`.
+
+### Story Validation
+
+- [ ] T027 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and verify all frontend preview unit tests pass for FR-001 through FR-010.
+- [ ] T028 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and verify Python boot metadata and backend normalization tests pass for FR-002, FR-008, DESIGN-REQ-006, and DESIGN-REQ-010.
+- [ ] T029 Run `./tools/test_integration.sh` and verify integration coverage passes for SCN-001 through SCN-005 and the runtime command preview contract.
+- [ ] T030 Manually execute `specs/355-slash-command-previews/quickstart.md` Create page checks and record evidence for SC-001 through SC-006 in `specs/355-slash-command-previews/verification.md`.
+
+**Checkpoint**: The single story is fully functional, covered by unit and integration tests, and independently validated.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T031 Review `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` for unnecessary duplication and refactor only within the preview helpers for FR-008 and DESIGN-REQ-001.
+- [ ] T032 [P] Review `frontend/src/styles/mission-control.css` preview styles for text overflow, mobile layout, and accessible contrast covering SC-005.
+- [ ] T033 Confirm no Codex-specific or Claude-specific command markup was added to Create page preview behavior for FR-008, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
+- [ ] T034 Run `./tools/test_unit.sh` for the full required unit suite after focused tests pass.
+- [ ] T035 Run `/moonspec-verify` for `specs/355-slash-command-previews` after implementation and tests pass, preserving `MM-685`, original preset brief, test evidence, and requirement coverage for FR-011/SC-006.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish And Verification (Phase 4)**: Depends on story implementation and validation passing.
+
+### Within The Story
+
+- T005-T010 unit tests and T011-T012 integration tests must be written before production implementation.
+- T013-T015 red-first confirmation must complete before T017-T026 implementation.
+- T016 is conditional and only runs if traceability verification fails.
+- T017-T018 boot metadata work should precede T019-T023 Create page consumption.
+- T024 edit/rerun metadata work can proceed after T009 is written and before T027 validation.
+- T027-T030 story validation must pass before Phase 4.
+- T035 final `/moonspec-verify` runs only after implementation and tests pass.
+
+### Parallel Opportunities
+
+- T005-T010 can be authored in parallel where each task touches a different file; tasks touching `frontend/src/entrypoints/task-create.test.tsx` need coordination.
+- T011 and T012 can be authored in parallel because they touch different integration files.
+- T017 and T018 should be sequential because boot payload metadata consumes the exported catalog.
+- T020-T023 all touch `frontend/src/entrypoints/task-create.tsx` and should be coordinated sequentially.
+- T031-T033 can run in parallel after story validation.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent test authoring:
+Task: "T009 Add failing temporalTaskEditing metadata tests in frontend/src/lib/temporalTaskEditing.test.ts"
+Task: "T010 Add failing boot metadata tests in tests/unit/api/routers/test_task_dashboard_view_model.py"
+Task: "T011 Add failing API integration test in tests/integration/api/test_task_runtime_command_preview_boot_payload.py"
+
+# Launch independent polish reviews:
+Task: "T032 Review preview styles in frontend/src/styles/mission-control.css"
+Task: "T033 Confirm provider-neutral preview guardrails in frontend/src/entrypoints/task-create.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Setup and Foundational inspection tasks.
+2. Write the frontend, Python unit, and integration tests in T005-T012.
+3. Run T013-T015 and confirm red-first failures for missing preview behavior and metadata.
+4. Implement the browser-safe catalog and boot metadata in T017-T018.
+5. Implement Create page preview derivation, rendering, runtime recomputation, edit metadata restoration, payload guardrails, and minimal styles in T019-T026.
+6. Run focused unit and integration validation in T027-T029.
+7. Execute quickstart/manual story validation in T030.
+8. Complete polish and final full-suite verification in T031-T035.
+
+### Requirement Status Handling
+
+- `missing` and `partial` rows from `plan.md` receive red-first tests and implementation tasks: FR-001 through FR-010, SCN-001 through SCN-005, SC-001 through SC-005, DESIGN-REQ-001 through DESIGN-REQ-010.
+- `implemented_unverified` traceability rows receive validation and a conditional fallback artifact-update task: FR-011 and SC-006.
+- No in-scope requirement is treated as already verified by current evidence.
+
+---
+
+## Notes
+
+- Do not generate implementation code before red-first confirmation.
+- Keep Create page preview provider-neutral; runtime-specific execution rendering remains outside this story.
+- Keep backend submit-time normalization authoritative.
+- Do not add new persistent storage.
+- Preserve `MM-685` in implementation notes, verification output, commit text, and pull request metadata.

--- a/specs/355-slash-command-previews/tasks.md
+++ b/specs/355-slash-command-previews/tasks.md
@@ -28,8 +28,8 @@
 
 **Purpose**: Confirm active artifacts and test tooling before test-first work.
 
-- [ ] T001 Confirm `specs/355-slash-command-previews/spec.md`, `specs/355-slash-command-previews/plan.md`, `specs/355-slash-command-previews/research.md`, `specs/355-slash-command-previews/data-model.md`, `specs/355-slash-command-previews/contracts/runtime-command-preview.md`, and `specs/355-slash-command-previews/quickstart.md` are present and preserve `MM-685` for FR-011/SC-006.
-- [ ] T002 Confirm existing frontend and Python test tooling commands in `package.json`, `./tools/test_unit.sh`, and `./tools/test_integration.sh` match the commands listed in `specs/355-slash-command-previews/quickstart.md`.
+- [X] T001 Confirm `specs/355-slash-command-previews/spec.md`, `specs/355-slash-command-previews/plan.md`, `specs/355-slash-command-previews/research.md`, `specs/355-slash-command-previews/data-model.md`, `specs/355-slash-command-previews/contracts/runtime-command-preview.md`, and `specs/355-slash-command-previews/quickstart.md` are present and preserve `MM-685` for FR-011/SC-006.
+- [X] T002 Confirm existing frontend and Python test tooling commands in `package.json`, `./tools/test_unit.sh`, and `./tools/test_integration.sh` match the commands listed in `specs/355-slash-command-previews/quickstart.md`.
 
 ---
 
@@ -37,8 +37,8 @@
 
 **Purpose**: Establish shared assumptions before writing story tests. No production story implementation occurs in this phase.
 
-- [ ] T003 Inspect existing backend runtime command normalization in `moonmind/workflows/tasks/task_contract.py` and existing coverage in `tests/unit/workflows/tasks/test_task_contract.py` to align frontend preview semantics for DESIGN-REQ-001 through DESIGN-REQ-005.
-- [ ] T004 Inspect existing Create page runtime, objective, step, and edit-mode state paths in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` to identify exact insertion points for FR-001, FR-004, and FR-009.
+- [X] T003 Inspect existing backend runtime command normalization in `moonmind/workflows/tasks/task_contract.py` and existing coverage in `tests/unit/workflows/tasks/test_task_contract.py` to align frontend preview semantics for DESIGN-REQ-001 through DESIGN-REQ-005.
+- [X] T004 Inspect existing Create page runtime, objective, step, and edit-mode state paths in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` to identify exact insertion points for FR-001, FR-004, and FR-009.
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -64,22 +64,22 @@
 
 ### Unit Tests (write first)
 
-- [ ] T005 Add failing frontend unit tests for objective and step known command previews covering FR-001, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
-- [ ] T006 Add failing frontend unit tests for unknown valid `/foo` pass-through previews covering FR-003, SCN-002, SC-002, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
-- [ ] T007 Add failing frontend unit tests for unsupported runtime warnings and runtime switching text preservation covering FR-004, SCN-003, SC-003, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.test.tsx`.
-- [ ] T008 Add failing frontend unit tests for escaped literals, whitespace-prefixed slash text, inline slash text, and path-like malformed slash text covering FR-005, FR-006, FR-007, SCN-004, SC-004, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.test.tsx`.
-- [ ] T009 [P] Add failing frontend unit tests for edit-mode runtime command metadata reconstruction covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.test.ts`.
-- [ ] T010 [P] Add failing Python unit tests for browser-safe runtime command preview boot metadata covering FR-002, FR-008, and DESIGN-REQ-006 in `tests/unit/api/routers/test_task_dashboard_view_model.py`.
+- [X] T005 Add failing frontend unit tests for objective and step known command previews covering FR-001, SCN-001, SC-001, DESIGN-REQ-001, DESIGN-REQ-002, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [X] T006 Add failing frontend unit tests for unknown valid `/foo` pass-through previews covering FR-003, SCN-002, SC-002, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [X] T007 Add failing frontend unit tests for unsupported runtime warnings and runtime switching text preservation covering FR-004, SCN-003, SC-003, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [X] T008 Add failing frontend unit tests for escaped literals, whitespace-prefixed slash text, inline slash text, and path-like malformed slash text covering FR-005, FR-006, FR-007, SCN-004, SC-004, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.test.tsx`.
+- [X] T009 [P] Add failing frontend unit tests for edit-mode runtime command metadata reconstruction covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.test.ts`.
+- [X] T010 [P] Add failing Python unit tests for browser-safe runtime command preview boot metadata covering FR-002, FR-008, and DESIGN-REQ-006 in `tests/unit/api/routers/test_task_dashboard_view_model.py`.
 
 ### Integration Tests (write first)
 
-- [ ] T011 [P] Add failing API integration test for dashboard boot payload runtime command preview metadata covering FR-002, SCN-001, SCN-002, DESIGN-REQ-006, and the contract in `specs/355-slash-command-previews/contracts/runtime-command-preview.md` in `tests/integration/api/test_task_runtime_command_preview_boot_payload.py`.
-- [ ] T012 [P] Add failing Create page browser integration test for visible objective and step preview behavior covering FR-001, FR-003, FR-004, FR-005, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `tests/e2e/test_task_create_submit_browser.py`.
+- [X] T011 [P] Add failing API integration test for dashboard boot payload runtime command preview metadata covering FR-002, SCN-001, SCN-002, DESIGN-REQ-006, and the contract in `specs/355-slash-command-previews/contracts/runtime-command-preview.md` in `tests/integration/api/test_task_runtime_command_preview_boot_payload.py`.
+- [X] T012 [P] Add failing Create page browser integration test for visible objective and step preview behavior covering FR-001, FR-003, FR-004, FR-005, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `tests/e2e/test_task_create_submit_browser.py`.
 
 ### Red-First Confirmation
 
-- [ ] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and confirm T005-T009 fail for missing preview behavior before production code changes.
-- [ ] T014 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T010 fails for missing boot metadata while existing backend runtime command tests still pass.
+- [X] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and confirm T005-T009 fail for missing preview behavior before production code changes.
+- [X] T014 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T010 fails for missing boot metadata while existing backend runtime command tests still pass.
 - [ ] T015 Run `./tools/test_integration.sh` or the narrowest available integration command for `tests/integration/api/test_task_runtime_command_preview_boot_payload.py` and `tests/e2e/test_task_create_submit_browser.py`, then confirm T011-T012 fail for missing preview/metadata behavior.
 
 ### Conditional Fallback For Implemented-Unverified Traceability
@@ -88,21 +88,21 @@
 
 ### Implementation
 
-- [ ] T017 Export a browser-safe runtime command preview capability and hint catalog aligned with backend normalization semantics for FR-002, FR-003, FR-008, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-006 in `moonmind/workflows/tasks/task_contract.py`.
-- [ ] T018 Add runtime command preview metadata to the dashboard boot payload for FR-002, FR-008, DESIGN-REQ-006, and the contract in `api_service/api/routers/task_dashboard_view_model.py`.
-- [ ] T019 Add TaskCreatePage dashboard config typing for runtime command preview metadata covering FR-002 and DESIGN-REQ-006 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T020 Implement provider-neutral runtime command preview derivation for detected, unknown, unsupported, escaped, whitespace-prefixed, inline, and path-like malformed states covering FR-001, FR-003, FR-005, FR-006, FR-007, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T021 Render objective instruction runtime command preview status, hint text, pass-through text, literal text intent, and unsupported-runtime warning for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T022 Render step instruction runtime command previews for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T023 Wire runtime change recomputation without mutating authored instructions for FR-004, FR-008, SC-003, SC-005, DESIGN-REQ-001, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T024 Extend Temporal edit/rerun draft types and reconstruction to carry objective and step `runtimeCommand` metadata for preview-only restoration covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.ts`.
-- [ ] T025 Ensure task submission payloads remain authored-instruction based and do not submit preview-only provider markup for FR-008, FR-009, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T026 Add or adjust minimal Create page styling for preview status, warning, and literal states while preserving mobile layout for FR-001, FR-004, FR-005, and SC-005 in `frontend/src/styles/mission-control.css`.
+- [X] T017 Export a browser-safe runtime command preview capability and hint catalog aligned with backend normalization semantics for FR-002, FR-003, FR-008, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-005, and DESIGN-REQ-006 in `moonmind/workflows/tasks/task_contract.py`.
+- [X] T018 Add runtime command preview metadata to the dashboard boot payload for FR-002, FR-008, DESIGN-REQ-006, and the contract in `api_service/api/routers/task_dashboard_view_model.py`.
+- [X] T019 Add TaskCreatePage dashboard config typing for runtime command preview metadata covering FR-002 and DESIGN-REQ-006 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T020 Implement provider-neutral runtime command preview derivation for detected, unknown, unsupported, escaped, whitespace-prefixed, inline, and path-like malformed states covering FR-001, FR-003, FR-005, FR-006, FR-007, DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-010 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T021 Render objective instruction runtime command preview status, hint text, pass-through text, literal text intent, and unsupported-runtime warning for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T022 Render step instruction runtime command previews for FR-001, FR-002, FR-003, FR-005, FR-007, SCN-001, SCN-002, SCN-003, SCN-004, and DESIGN-REQ-007 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T023 Wire runtime change recomputation without mutating authored instructions for FR-004, FR-008, SC-003, SC-005, DESIGN-REQ-001, and DESIGN-REQ-008 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T024 Extend Temporal edit/rerun draft types and reconstruction to carry objective and step `runtimeCommand` metadata for preview-only restoration covering FR-009, SCN-005, DESIGN-REQ-009, and SC-006 in `frontend/src/lib/temporalTaskEditing.ts`.
+- [X] T025 Ensure task submission payloads remain authored-instruction based and do not submit preview-only provider markup for FR-008, FR-009, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T026 Add or adjust minimal Create page styling for preview status, warning, and literal states while preserving mobile layout for FR-001, FR-004, FR-005, and SC-005 in `frontend/src/styles/mission-control.css`.
 
 ### Story Validation
 
-- [ ] T027 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and verify all frontend preview unit tests pass for FR-001 through FR-010.
-- [ ] T028 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and verify Python boot metadata and backend normalization tests pass for FR-002, FR-008, DESIGN-REQ-006, and DESIGN-REQ-010.
+- [X] T027 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` and verify all frontend preview unit tests pass for FR-001 through FR-010.
+- [X] T028 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py` and verify Python boot metadata and backend normalization tests pass for FR-002, FR-008, DESIGN-REQ-006, and DESIGN-REQ-010.
 - [ ] T029 Run `./tools/test_integration.sh` and verify integration coverage passes for SCN-001 through SCN-005 and the runtime command preview contract.
 - [ ] T030 Manually execute `specs/355-slash-command-previews/quickstart.md` Create page checks and record evidence for SC-001 through SC-006 in `specs/355-slash-command-previews/verification.md`.
 
@@ -114,10 +114,10 @@
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T031 Review `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` for unnecessary duplication and refactor only within the preview helpers for FR-008 and DESIGN-REQ-001.
-- [ ] T032 [P] Review `frontend/src/styles/mission-control.css` preview styles for text overflow, mobile layout, and accessible contrast covering SC-005.
-- [ ] T033 Confirm no Codex-specific or Claude-specific command markup was added to Create page preview behavior for FR-008, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
-- [ ] T034 Run `./tools/test_unit.sh` for the full required unit suite after focused tests pass.
+- [X] T031 Review `frontend/src/entrypoints/task-create.tsx` and `frontend/src/lib/temporalTaskEditing.ts` for unnecessary duplication and refactor only within the preview helpers for FR-008 and DESIGN-REQ-001.
+- [X] T032 [P] Review `frontend/src/styles/mission-control.css` preview styles for text overflow, mobile layout, and accessible contrast covering SC-005.
+- [X] T033 Confirm no Codex-specific or Claude-specific command markup was added to Create page preview behavior for FR-008, DESIGN-REQ-001, and DESIGN-REQ-003 in `frontend/src/entrypoints/task-create.tsx`.
+- [X] T034 Run `./tools/test_unit.sh` for the full required unit suite after focused tests pass.
 - [ ] T035 Run `/moonspec-verify` for `specs/355-slash-command-previews` after implementation and tests pass, preserving `MM-685`, original preset brief, test evidence, and requirement coverage for FR-011/SC-006.
 
 ---

--- a/specs/355-slash-command-previews/verification.md
+++ b/specs/355-slash-command-previews/verification.md
@@ -1,0 +1,40 @@
+# Verification Evidence: Provider-Neutral Slash Command Previews
+
+## Automated Evidence
+
+- Red-first frontend unit evidence:
+  - `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts`
+  - Initial failure: `draft.runtimeCommand` was `undefined` before edit/rerun metadata restoration was implemented.
+- Red-first Python/API evidence:
+  - `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts`
+  - Initial failure: `runtimeCommandPreview` was missing from dashboard boot config.
+  - `python -m pytest -q tests/integration/api/test_task_runtime_command_preview_boot_payload.py tests/e2e/test_task_create_submit_browser.py -q`
+  - Initial failure: API integration raised `KeyError: 'runtimeCommandPreview'`.
+- Focused frontend validation:
+  - `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx frontend/src/lib/temporalTaskEditing.test.ts`
+  - Result: PASS, 44 passed and 229 skipped.
+- Focused Python validation:
+  - `./tools/test_unit.sh --python-only tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/workflows/tasks/test_task_contract.py`
+  - Result: PASS, 142 passed.
+- Focused API integration validation:
+  - `python -m pytest -q tests/integration/api/test_task_runtime_command_preview_boot_payload.py tests/e2e/test_task_create_submit_browser.py -q`
+  - Result: PASS for API integration; e2e module skipped unless `RUN_E2E_TESTS` is set.
+- Full unit validation:
+  - `./tools/test_unit.sh`
+  - Result: PASS, Python 5072 passed, 1 xpassed, 16 subtests passed; frontend 351 passed and 229 skipped.
+
+## Blocked Manual/E2E Evidence
+
+- `RUN_E2E_TESTS=1 python -m pytest -q tests/e2e/test_task_create_submit_browser.py::test_create_page_shows_runtime_command_previews -q`
+  - Blocked: Python `playwright` package is not installed in the managed container.
+- `./tools/test_integration.sh`
+  - Blocked: Docker compose image build failed with administrative `403 Forbidden` while building `repo-pytest`.
+
+## Quickstart Scenario Coverage
+
+- SC-001 `/review` preview on a slash-capable runtime: covered by frontend unit tests.
+- SC-002 unknown `/foo` pass-through preview: covered by frontend unit tests.
+- SC-003 unsupported runtime warning without text mutation: covered by frontend unit tests using `codex_cloud`.
+- SC-004 escaped `\/review` literal text intent: covered by frontend unit tests.
+- SC-005 mobile-safe, non-mutating preview states: covered by focused frontend unit and CSS review; live browser e2e blocked by missing Playwright.
+- SC-006 edit-mode metadata restoration: covered by `frontend/src/lib/temporalTaskEditing.test.ts`.

--- a/specs/355-slash-command-previews/verification.md
+++ b/specs/355-slash-command-previews/verification.md
@@ -19,16 +19,18 @@
 - Focused API integration validation:
   - `python -m pytest -q tests/integration/api/test_task_runtime_command_preview_boot_payload.py tests/e2e/test_task_create_submit_browser.py -q`
   - Result: PASS for API integration; e2e module skipped unless `RUN_E2E_TESTS` is set.
+- Focused browser validation:
+  - `RUN_E2E_TESTS=1 python -m pytest -q tests/e2e/test_task_create_submit_browser.py::test_create_page_shows_runtime_command_previews -q`
+  - Remediation setup: installed Python Playwright packages, installed Chromium, extracted missing Debian browser runtime libraries into `/tmp/mm-playwright-deps`, and rebuilt the stale Vite UI bundle with `./node_modules/.bin/vite build --config frontend/vite.config.ts && bash tools/run_repo_python.sh tools/verify_vite_manifest.py`.
+  - Result: PASS.
 - Full unit validation:
   - `./tools/test_unit.sh`
   - Result: PASS, Python 5072 passed, 1 xpassed, 16 subtests passed; frontend 351 passed and 229 skipped.
 
-## Blocked Manual/E2E Evidence
+## Blocked Integration Evidence
 
-- `RUN_E2E_TESTS=1 python -m pytest -q tests/e2e/test_task_create_submit_browser.py::test_create_page_shows_runtime_command_previews -q`
-  - Blocked: Python `playwright` package is not installed in the managed container.
 - `./tools/test_integration.sh`
-  - Blocked: Docker compose image build failed with administrative `403 Forbidden` while building `repo-pytest`.
+  - Blocked: Docker compose image build still fails with administrative `403 Forbidden` while building `repo-pytest`.
 
 ## Quickstart Scenario Coverage
 
@@ -36,5 +38,5 @@
 - SC-002 unknown `/foo` pass-through preview: covered by frontend unit tests.
 - SC-003 unsupported runtime warning without text mutation: covered by frontend unit tests using `codex_cloud`.
 - SC-004 escaped `\/review` literal text intent: covered by frontend unit tests.
-- SC-005 mobile-safe, non-mutating preview states: covered by focused frontend unit and CSS review; live browser e2e blocked by missing Playwright.
+- SC-005 mobile-safe, non-mutating preview states: covered by focused frontend unit and CSS review; live browser preview validation passes after rebuilding the Vite bundle for the managed runtime.
 - SC-006 edit-mode metadata restoration: covered by `frontend/src/lib/temporalTaskEditing.test.ts`.

--- a/tests/e2e/test_task_create_submit_browser.py
+++ b/tests/e2e/test_task_create_submit_browser.py
@@ -558,6 +558,48 @@ def test_create_page_shows_provider_profiles_for_selected_runtime(server):
         ]
         browser.close()
 
+def test_create_page_shows_runtime_command_previews(server):
+    base_url = server
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        _route_handlers(
+            page,
+            base_url=base_url,
+            create_status=201,
+            create_body=json.dumps(
+                {
+                    "workflowId": "mm:unused",
+                    "runId": "run-unused",
+                    "namespace": "moonmind",
+                    "redirectPath": "/tasks/mm:unused?source=temporal",
+                }
+            ),
+        )
+
+        page.goto(f"{base_url}/tasks/create")
+        page.wait_for_selector("#queue-submit-form")
+        instructions = page.locator(
+            'textarea[data-step-field="instructions"][data-step-index="0"]'
+        )
+        instructions.fill("/review\nCheck this branch.")
+        page.wait_for_selector("text=Runtime command: /review")
+        assert instructions.input_value() == "/review\nCheck this branch."
+
+        instructions.fill("/foo\nUse provider behavior.")
+        page.wait_for_selector("text=Runtime command: /foo")
+        page.wait_for_selector("text=Pass-through runtime command.")
+
+        page.select_option('select[name="runtime"]', "codex_cloud")
+        page.wait_for_selector("text=Unsupported runtime command: /foo")
+        assert instructions.input_value() == "/foo\nUse provider behavior."
+
+        instructions.fill("\\/review\nTreat as text.")
+        page.wait_for_selector("text=Literal text: /review")
+        assert page.locator("text=Runtime command: /review").count() == 0
+
+        browser.close()
+
 def test_temporal_submit_redirects_without_exposing_runtime_picker(server):
     base_url = server
     original_submit_enabled = settings.temporal_dashboard.submit_enabled

--- a/tests/integration/api/test_task_runtime_command_preview_boot_payload.py
+++ b/tests/integration/api/test_task_runtime_command_preview_boot_payload.py
@@ -1,0 +1,26 @@
+"""Integration contract tests for Create page runtime command preview metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+from api_service.api.routers.task_dashboard_view_model import build_runtime_config
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def test_dashboard_boot_payload_exposes_runtime_command_preview_contract() -> None:
+    config = build_runtime_config("/tasks/create")
+
+    preview = config["system"]["runtimeCommandPreview"]
+
+    assert preview["capabilityVersion"] == "2026-05-13"
+    assert preview["hintCatalogVersion"] == "2026-05-13"
+    assert preview["runtimes"]["codex_cli"]["slashCommandPassthrough"] is True
+    assert preview["runtimes"]["claude_code"]["slashCommandPassthrough"] is True
+    assert preview["runtimes"]["codex_cloud"]["slashCommandPassthrough"] is False
+    assert preview["runtimes"]["codex_cloud"]["renderMode"] == "plain_prompt"
+    assert preview["knownRuntimeCommandHints"]["review"]["aliases"] == ["/review"]
+    assert preview["knownRuntimeCommandHints"]["simplify"]["aliases"] == [
+        "/simplify"
+    ]

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -134,6 +134,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     assert "defaultTaskEffortByRuntime" in config["system"]
     assert config["system"]["workerRuntimeEnv"] == "MOONMIND_WORKER_RUNTIME"
     assert config["system"]["supportedTaskRuntimes"] == ["codex_cli", "gemini_cli", "claude_code", "codex_cloud"]
+    assert "runtimeCommandPreview" in config["system"]
     assert "claude_code" in config["system"]["supportedWorkerRuntimes"]
     assert "taskTemplateCatalog" in config["system"]
     assert "enabled" in config["system"]["taskTemplateCatalog"]
@@ -147,6 +148,32 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     assert attachment_policy["maxBytes"] >= 1
     assert attachment_policy["totalBytes"] >= attachment_policy["maxBytes"]
     assert "image/png" in attachment_policy["allowedContentTypes"]
+
+
+def test_build_runtime_config_exposes_browser_safe_runtime_command_preview_metadata() -> None:
+    config = dashboard_view_model.build_runtime_config("/tasks/new")
+
+    preview = config["system"]["runtimeCommandPreview"]
+
+    assert preview["capabilityVersion"] == "2026-05-13"
+    assert preview["hintCatalogVersion"] == "2026-05-13"
+    assert preview["runtimes"]["codex_cli"] == {
+        "slashCommandPassthrough": True,
+        "renderMode": "prompt_prefix",
+        "commandHintsRef": "codex_cli",
+    }
+    assert preview["runtimes"]["claude_code"] == {
+        "slashCommandPassthrough": True,
+        "renderMode": "prompt_prefix",
+        "commandHintsRef": "claude_code",
+    }
+    assert preview["runtimes"]["codex_cloud"]["slashCommandPassthrough"] is False
+    assert "review" in preview["knownRuntimeCommandHints"]
+    assert preview["knownRuntimeCommandHints"]["review"]["aliases"] == ["/review"]
+    serialized = repr(preview).lower()
+    assert "token" not in serialized
+    assert "password" not in serialized
+    assert "secret" not in serialized
 
 def test_build_runtime_config_omits_jira_ui_when_disabled(monkeypatch) -> None:
     monkeypatch.setattr(settings.feature_flags, "jira_create_page_enabled", False)

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -7,6 +7,7 @@ from moonmind.workflows.tasks.task_contract import (
     build_canonical_task_view,
     build_authoritative_task_input_snapshot,
     build_effective_task_skill_selectors,
+    build_runtime_command_preview_config,
     CanonicalTaskPayload,
     ResumeFromFailedStepRef,
     resolve_publish_mode_for_skill,
@@ -181,6 +182,25 @@ def test_runtime_command_preserves_opaque_provider_command_lines() -> None:
     assert command["hintStatus"] == "opaque"
 
 
+@pytest.mark.parametrize(
+    "instructions", ["/ review\nKeep literal.", "/review!\nKeep literal."]
+)
+def test_runtime_command_malformed_token_input_is_literal(instructions: str) -> None:
+    snapshot = build_authoritative_task_input_snapshot(
+        task_payload={
+            "instructions": instructions,
+            "runtime": {"mode": "codex"},
+        }
+    )
+
+    command = snapshot["objective"]["runtimeCommand"]
+    assert command["detectionStatus"] == "malformed"
+    assert command["recognitionMode"] == "escaped_literal"
+    assert command["requiresRuntimeRecognition"] is False
+    assert command["command"] == ""
+    assert command["instructionBody"] == instructions
+
+
 def test_runtime_command_escaped_slash_records_literal_metadata() -> None:
     snapshot = build_authoritative_task_input_snapshot(
         task_payload={
@@ -256,6 +276,18 @@ def test_runtime_command_unsupported_runtime_does_not_require_recognition() -> N
     assert command["detectionStatus"] == "detected"
     assert command["recognitionMode"] == "runtime_does_not_support_slash_commands"
     assert command["requiresRuntimeRecognition"] is False
+
+
+def test_runtime_command_preview_config_includes_all_passthrough_runtime_ids() -> None:
+    config = build_runtime_command_preview_config()
+
+    assert config["runtimes"]["codex"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["codex_cli"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["claude"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["claude_code"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["gemini_cli"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["universal"]["slashCommandPassthrough"] is True
+    assert config["runtimes"]["codex_cloud"]["slashCommandPassthrough"] is False
 
 
 def test_runtime_command_leading_whitespace_is_not_detected() -> None:


### PR DESCRIPTION
Run Jira Orchestrate for MM-685.

Source story: STORY-002.
Source summary: Show provider-neutral slash command previews on the Create page.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.