### PR TITLE
[codex] Fix provider edits during slot cooldown

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
         AgentRunHandle,
         AgentRunResult,
         AgentRunStatus as AgentRunStatusModel,
+        ProfileSelector,
         _MAX_SUMMARY_CHARS,
     )
     from moonmind.schemas.temporal_activity_models import (
@@ -1092,6 +1093,11 @@ class MoonMindAgentRun:
         )
         if isinstance(parameters_patch, Mapping):
             update_payload["parametersPatch"] = dict(parameters_patch)
+        profile_selector = payload.get("profileSelector") or payload.get(
+            "profile_selector"
+        )
+        if isinstance(profile_selector, Mapping):
+            update_payload["profileSelector"] = dict(profile_selector)
         if update_payload:
             self._pending_runtime_selection_update = update_payload
             self.runtime_selection_updated_event.set()
@@ -1164,9 +1170,77 @@ class MoonMindAgentRun:
 
         target_runtime = str(payload.get("targetRuntime") or "").strip()
         if target_runtime:
+            request.agent_id = target_runtime
             params["targetRuntime"] = target_runtime
             task_runtime["mode"] = target_runtime
             authored_runtime["mode"] = target_runtime
+
+        profile_selector_payload = payload.get("profileSelector")
+        if not isinstance(profile_selector_payload, Mapping):
+            candidate_selector = (
+                parameters_patch.get("profileSelector")
+                or parameters_patch.get("profile_selector")
+                if isinstance(parameters_patch, Mapping)
+                else None
+            )
+            if isinstance(candidate_selector, Mapping):
+                profile_selector_payload = candidate_selector
+        if not isinstance(profile_selector_payload, Mapping):
+            task_patch = (
+                parameters_patch.get("task")
+                if isinstance(parameters_patch, Mapping)
+                else None
+            )
+            task_runtime_patch = (
+                task_patch.get("runtime") if isinstance(task_patch, Mapping) else None
+            )
+            task_selector = (
+                task_runtime_patch.get("profileSelector")
+                or task_runtime_patch.get("profile_selector")
+                if isinstance(task_runtime_patch, Mapping)
+                else None
+            )
+            if isinstance(task_selector, Mapping):
+                profile_selector_payload = task_selector
+        if not isinstance(profile_selector_payload, Mapping):
+            authored_patch = (
+                parameters_patch.get("authoredTaskInput")
+                if isinstance(parameters_patch, Mapping)
+                else None
+            )
+            authored_runtime_patch = (
+                authored_patch.get("runtime")
+                if isinstance(authored_patch, Mapping)
+                else None
+            )
+            authored_selector = (
+                authored_runtime_patch.get("profileSelector")
+                or authored_runtime_patch.get("profile_selector")
+                if isinstance(authored_runtime_patch, Mapping)
+                else None
+            )
+            if isinstance(authored_selector, Mapping):
+                profile_selector_payload = authored_selector
+
+        if isinstance(profile_selector_payload, Mapping):
+            request.profile_selector = ProfileSelector.model_validate(
+                dict(profile_selector_payload)
+            )
+            selector_params = request.profile_selector.model_dump(
+                by_alias=True,
+                exclude_none=True,
+            )
+            params["profileSelector"] = selector_params
+            task_runtime["profileSelector"] = selector_params
+            authored_runtime["profileSelector"] = selector_params
+        elif profile_id:
+            request.profile_selector = ProfileSelector()
+            params.pop("profileSelector", None)
+            params.pop("profile_selector", None)
+            task_runtime.pop("profileSelector", None)
+            task_runtime.pop("profile_selector", None)
+            authored_runtime.pop("profileSelector", None)
+            authored_runtime.pop("profile_selector", None)
 
         if task_runtime:
             task_payload["runtime"] = task_runtime
@@ -1176,21 +1250,80 @@ class MoonMindAgentRun:
             params["authoredTaskInput"] = authored_payload
         request.parameters = params
 
+    def _validate_synced_profile_selection(
+        self,
+        *,
+        profile_count: int,
+        runtime_id: str,
+        request: AgentExecutionRequest,
+    ) -> None:
+        if profile_count == 0:
+            raise ApplicationError(
+                f"No enabled provider profiles found for runtime_id='{runtime_id}'",
+                type="ProfileResolutionError",
+                non_retryable=True,
+            )
+        if request.execution_profile_ref:
+            requested_profile_id = str(request.execution_profile_ref).strip()
+            if (
+                requested_profile_id
+                and self._profile_snapshots
+                and requested_profile_id not in self._profile_snapshots
+            ):
+                raise ApplicationError(
+                    f"Provider profile '{requested_profile_id}' not found for runtime_id='{runtime_id}'",
+                    type="ProfileResolutionError",
+                    non_retryable=True,
+                )
+
     async def _consume_runtime_selection_update_for_slot_wait(
         self,
         *,
         request: AgentExecutionRequest,
         manager_id: str,
         runtime_id: str,
-    ) -> workflow.ExternalWorkflowHandle:
+    ) -> tuple[workflow.ExternalWorkflowHandle, str, str]:
         payload = self._pending_runtime_selection_update
         self._pending_runtime_selection_update = None
         self.runtime_selection_updated_event.clear()
+        previous_manager_id = manager_id
         if payload:
             self._apply_runtime_selection_update(request, payload)
+        runtime_id = self._managed_runtime_id(request.agent_id)
+        manager_id = self._manager_workflow_id(runtime_id)
+        if manager_id != previous_manager_id:
+            previous_manager_handle = workflow.get_external_workflow_handle(
+                previous_manager_id
+            )
+            try:
+                await previous_manager_handle.signal(
+                    "release_slot",
+                    self._release_slot_payload(
+                        profile_id=self._assigned_profile_id,
+                        request=request,
+                    ),
+                )
+            except ApplicationError as exc:
+                if "ExternalWorkflowExecutionNotFound" not in (
+                    getattr(exc, "type", None) or str(exc)
+                ):
+                    raise
+            self.slot_assigned_event.clear()
+            self._assigned_profile_id = None
         selector_payload = request.profile_selector.model_dump(
             by_alias=True,
             exclude_none=True,
+        )
+        manager_handle = await self._ensure_manager_started(manager_id, runtime_id)
+        profile_count = await self._sync_manager_profiles(
+            manager_id=manager_id,
+            manager_handle=manager_handle,
+            runtime_id=runtime_id,
+        )
+        self._validate_synced_profile_selection(
+            profile_count=profile_count,
+            runtime_id=runtime_id,
+            request=request,
         )
         manager_handle = await self._ensure_manager_and_signal(
             manager_id,
@@ -1199,14 +1332,9 @@ class MoonMindAgentRun:
             execution_profile_ref=request.execution_profile_ref,
             profile_selector=selector_payload,
         )
-        await self._sync_manager_profiles(
-            manager_id=manager_id,
-            manager_handle=manager_handle,
-            runtime_id=runtime_id,
-        )
         self._awaiting_slot_reason_override = None
         self._slot_wait_timeout_override_seconds = None
-        return manager_handle
+        return manager_handle, manager_id, runtime_id
 
     @staticmethod
     def _normalize_external_status(
@@ -1480,24 +1608,11 @@ class MoonMindAgentRun:
                             manager_handle=manager_handle,
                             runtime_id=runtime_id,
                         )
-                    if profile_count == 0:
-                        raise ApplicationError(
-                            f"No enabled provider profiles found for runtime_id='{runtime_id}'",
-                            type="ProfileResolutionError",
-                            non_retryable=True,
-                        )
-                    if request.execution_profile_ref:
-                        requested_profile_id = str(request.execution_profile_ref).strip()
-                        if (
-                            requested_profile_id
-                            and self._profile_snapshots
-                            and requested_profile_id not in self._profile_snapshots
-                        ):
-                            raise ApplicationError(
-                                f"Provider profile '{requested_profile_id}' not found for runtime_id='{runtime_id}'",
-                                type="ProfileResolutionError",
-                                non_retryable=True,
-                            )
+                    self._validate_synced_profile_selection(
+                        profile_count=profile_count,
+                        runtime_id=runtime_id,
+                        request=request,
+                    )
 
                     # Wait for a provider-profile slot.
                     # Awaiting time does not count against the execution timeout;
@@ -1546,7 +1661,11 @@ class MoonMindAgentRun:
                                     self.runtime_selection_updated_event.is_set()
                                     and not self.slot_assigned_event.is_set()
                                 ):
-                                    manager_handle = await self._consume_runtime_selection_update_for_slot_wait(
+                                    (
+                                        manager_handle,
+                                        manager_id,
+                                        runtime_id,
+                                    ) = await self._consume_runtime_selection_update_for_slot_wait(
                                         request=request,
                                         manager_id=manager_id,
                                         runtime_id=runtime_id,
@@ -1636,7 +1755,11 @@ class MoonMindAgentRun:
                                 self.runtime_selection_updated_event.is_set()
                                 and not self.slot_assigned_event.is_set()
                             ):
-                                manager_handle = await self._consume_runtime_selection_update_for_slot_wait(
+                                (
+                                    manager_handle,
+                                    manager_id,
+                                    runtime_id,
+                                ) = await self._consume_runtime_selection_update_for_slot_wait(
                                     request=request,
                                     manager_id=manager_id,
                                     runtime_id=runtime_id,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -346,6 +346,8 @@ class MoonMindAgentRun:
         self._profile_snapshots: dict[str, dict[str, Any]] = {}
         self._awaiting_slot_reason_override: str | None = None
         self._slot_wait_timeout_override_seconds: int | None = None
+        self.runtime_selection_updated_event = asyncio.Event()
+        self._pending_runtime_selection_update: dict[str, Any] | None = None
 
     # --- Deterministic catalog-based routing (new path) ---
 
@@ -1061,6 +1063,40 @@ class MoonMindAgentRun:
         self.slot_assigned_event.set()
 
     @workflow.signal
+    def update_runtime_selection(self, payload: dict[str, Any] | None = None) -> None:
+        payload = payload or {}
+        update_payload: dict[str, Any] = {}
+        for source_key, target_key in (
+            ("executionProfileRef", "executionProfileRef"),
+            ("execution_profile_ref", "executionProfileRef"),
+            ("profileId", "executionProfileRef"),
+            ("profile_id", "executionProfileRef"),
+            ("providerProfile", "executionProfileRef"),
+            ("model", "model"),
+            ("requestedModel", "model"),
+            ("requested_model", "model"),
+            ("effort", "effort"),
+            ("targetRuntime", "targetRuntime"),
+            ("target_runtime", "targetRuntime"),
+        ):
+            value = payload.get(source_key)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    continue
+            update_payload[target_key] = value
+        parameters_patch = payload.get("parametersPatch") or payload.get(
+            "parameters_patch"
+        )
+        if isinstance(parameters_patch, Mapping):
+            update_payload["parametersPatch"] = dict(parameters_patch)
+        if update_payload:
+            self._pending_runtime_selection_update = update_payload
+            self.runtime_selection_updated_event.set()
+
+    @workflow.signal
     def operator_message(self, payload: dict[str, Any] | None = None) -> None:
         payload = payload or {}
         message = str(
@@ -1071,6 +1107,106 @@ class MoonMindAgentRun:
         ).strip()
         if message:
             self._pending_operator_messages.append(message)
+
+    @staticmethod
+    def _mapping_copy(value: Any) -> dict[str, Any]:
+        return dict(value) if isinstance(value, Mapping) else {}
+
+    def _apply_runtime_selection_update(
+        self,
+        request: AgentExecutionRequest,
+        payload: Mapping[str, Any],
+    ) -> None:
+        params = dict(request.parameters or {})
+        parameters_patch = payload.get("parametersPatch")
+        if isinstance(parameters_patch, Mapping):
+            for key, value in parameters_patch.items():
+                if key in {"task", "authoredTaskInput"} and isinstance(value, Mapping):
+                    existing_payload = self._mapping_copy(params.get(key))
+                    runtime_patch = value.get("runtime")
+                    if isinstance(runtime_patch, Mapping):
+                        existing_runtime = self._mapping_copy(
+                            existing_payload.get("runtime")
+                        )
+                        existing_runtime.update(dict(runtime_patch))
+                        existing_payload.update(dict(value))
+                        existing_payload["runtime"] = existing_runtime
+                    else:
+                        existing_payload.update(dict(value))
+                    params[key] = existing_payload
+                else:
+                    params[key] = value
+
+        task_payload = self._mapping_copy(params.get("task"))
+        task_runtime = self._mapping_copy(task_payload.get("runtime"))
+        authored_payload = self._mapping_copy(params.get("authoredTaskInput"))
+        authored_runtime = self._mapping_copy(authored_payload.get("runtime"))
+
+        profile_id = str(payload.get("executionProfileRef") or "").strip()
+        if profile_id:
+            request.execution_profile_ref = profile_id
+            params["profileId"] = profile_id
+            task_runtime["profileId"] = profile_id
+            authored_runtime["profileId"] = profile_id
+
+        model = str(payload.get("model") or "").strip()
+        if model:
+            params["model"] = model
+            params["requestedModel"] = model
+            task_runtime["model"] = model
+            authored_runtime["model"] = model
+
+        effort = str(payload.get("effort") or "").strip()
+        if effort:
+            params["effort"] = effort
+            task_runtime["effort"] = effort
+            authored_runtime["effort"] = effort
+
+        target_runtime = str(payload.get("targetRuntime") or "").strip()
+        if target_runtime:
+            params["targetRuntime"] = target_runtime
+            task_runtime["mode"] = target_runtime
+            authored_runtime["mode"] = target_runtime
+
+        if task_runtime:
+            task_payload["runtime"] = task_runtime
+            params["task"] = task_payload
+        if authored_runtime:
+            authored_payload["runtime"] = authored_runtime
+            params["authoredTaskInput"] = authored_payload
+        request.parameters = params
+
+    async def _consume_runtime_selection_update_for_slot_wait(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        manager_id: str,
+        runtime_id: str,
+    ) -> workflow.ExternalWorkflowHandle:
+        payload = self._pending_runtime_selection_update
+        self._pending_runtime_selection_update = None
+        self.runtime_selection_updated_event.clear()
+        if payload:
+            self._apply_runtime_selection_update(request, payload)
+        selector_payload = request.profile_selector.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
+        manager_handle = await self._ensure_manager_and_signal(
+            manager_id,
+            runtime_id,
+            request_slot=True,
+            execution_profile_ref=request.execution_profile_ref,
+            profile_selector=selector_payload,
+        )
+        await self._sync_manager_profiles(
+            manager_id=manager_id,
+            manager_handle=manager_handle,
+            runtime_id=runtime_id,
+        )
+        self._awaiting_slot_reason_override = None
+        self._slot_wait_timeout_override_seconds = None
+        return manager_handle
 
     @staticmethod
     def _normalize_external_status(
@@ -1402,9 +1538,20 @@ class MoonMindAgentRun:
                                     or _SLOT_WAIT_TIMEOUT_SECONDS
                                 )
                                 await workflow.wait_condition(
-                                    lambda: self.slot_assigned_event.is_set(),
+                                    lambda: self.slot_assigned_event.is_set()
+                                    or self.runtime_selection_updated_event.is_set(),
                                     timeout=timedelta(seconds=slot_wait_timeout_seconds),
                                 )
+                                if (
+                                    self.runtime_selection_updated_event.is_set()
+                                    and not self.slot_assigned_event.is_set()
+                                ):
+                                    manager_handle = await self._consume_runtime_selection_update_for_slot_wait(
+                                        request=request,
+                                        manager_id=manager_id,
+                                        runtime_id=runtime_id,
+                                    )
+                                    continue
                             except TimeoutError:
                                 if slot_resets >= _SLOT_WAIT_MAX_RESETS:
                                     raise ApplicationError(
@@ -1480,9 +1627,20 @@ class MoonMindAgentRun:
                                 )
                                 slot_resets += 1
                     else:
-                        await workflow.wait_condition(
-                            lambda: self.slot_assigned_event.is_set(),
-                        )
+                        while not self.slot_assigned_event.is_set():
+                            await workflow.wait_condition(
+                                lambda: self.slot_assigned_event.is_set()
+                                or self.runtime_selection_updated_event.is_set(),
+                            )
+                            if (
+                                self.runtime_selection_updated_event.is_set()
+                                and not self.slot_assigned_event.is_set()
+                            ):
+                                manager_handle = await self._consume_runtime_selection_update_for_slot_wait(
+                                    request=request,
+                                    manager_id=manager_id,
+                                    runtime_id=runtime_id,
+                                )
 
                     # Reset the execution clock so the timeout budget starts
                     # from slot acquisition, not from workflow start.

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -7283,6 +7283,94 @@ class MoonMindRunWorkflow:
         self._update_memo()
         return True
 
+    @staticmethod
+    def _runtime_selection_from_source(
+        source: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not isinstance(source, Mapping):
+            return {}
+        selection: dict[str, Any] = {}
+        for source_key, target_key in (
+            ("executionProfileRef", "executionProfileRef"),
+            ("execution_profile_ref", "executionProfileRef"),
+            ("profileId", "executionProfileRef"),
+            ("profile_id", "executionProfileRef"),
+            ("providerProfile", "executionProfileRef"),
+            ("model", "model"),
+            ("requestedModel", "model"),
+            ("requested_model", "model"),
+            ("effort", "effort"),
+            ("targetRuntime", "targetRuntime"),
+            ("target_runtime", "targetRuntime"),
+            ("mode", "targetRuntime"),
+        ):
+            value = source.get(source_key)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    continue
+            selection[target_key] = value
+        return selection
+
+    def _runtime_selection_update_payload(
+        self, payload: Mapping[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if not isinstance(payload, Mapping):
+            return None
+        parameters_patch = payload.get("parameters_patch") or payload.get(
+            "parametersPatch"
+        )
+        if not isinstance(parameters_patch, Mapping):
+            return None
+
+        selection: dict[str, Any] = {}
+        for source in (parameters_patch,):
+            selection.update(self._runtime_selection_from_source(source))
+
+        runtime_block = parameters_patch.get("runtime")
+        if isinstance(runtime_block, Mapping):
+            selection.update(self._runtime_selection_from_source(runtime_block))
+
+        task_payload = parameters_patch.get("task")
+        if isinstance(task_payload, Mapping):
+            task_runtime = task_payload.get("runtime")
+            if isinstance(task_runtime, Mapping):
+                selection.update(self._runtime_selection_from_source(task_runtime))
+
+        authored_payload = parameters_patch.get("authoredTaskInput")
+        if isinstance(authored_payload, Mapping):
+            authored_runtime = authored_payload.get("runtime")
+            if isinstance(authored_runtime, Mapping):
+                selection.update(self._runtime_selection_from_source(authored_runtime))
+
+        if not selection:
+            return None
+        selection["parametersPatch"] = dict(parameters_patch)
+        return selection
+
+    async def _forward_runtime_selection_update_to_active_child(
+        self, payload: Mapping[str, Any] | None
+    ) -> bool:
+        if not self._active_agent_child_workflow_id:
+            return False
+        if str(self._active_agent_id or "").strip().lower() in {
+            "jules",
+            "jules_api",
+        }:
+            return False
+        runtime_update = self._runtime_selection_update_payload(payload)
+        if runtime_update is None:
+            return False
+        handle = workflow.get_external_workflow_handle(
+            self._active_agent_child_workflow_id
+        )
+        await handle.signal("update_runtime_selection", runtime_update)
+        self._summary = "Runtime selection update sent to active agent."
+        self._update_memo()
+        return True
+
     @workflow.update
     def update_title(self, new_title: str) -> None:
         self._title = new_title
@@ -7303,8 +7391,15 @@ class MoonMindRunWorkflow:
         if isinstance(parameters_patch, Mapping):
             self._parameters_updated = True
             self._updated_parameters = dict(parameters_patch)
+        forwarded_runtime_update = (
+            await self._forward_runtime_selection_update_to_active_child(payload)
+        )
         forwarded = await self._forward_operator_message_to_active_child(payload)
-        return {"accepted": True, "forwardedOperatorMessage": forwarded}
+        return {
+            "accepted": True,
+            "forwardedOperatorMessage": forwarded,
+            "forwardedRuntimeSelectionUpdate": forwarded_runtime_update,
+        }
 
     @workflow.query
     def get_status(self) -> dict[str, Any]:

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -76,6 +76,23 @@ async def mock_provider_profile_list(request: dict) -> dict:
                 "max_lease_duration_seconds": 7200,
                 "enabled": True,
             },
+            {
+                "profile_id": "alternate-managed",
+                "runtime_id": request.get("runtime_id", "test-agent"),
+                "provider_id": "anthropic",
+                "auth_mode": "volume",
+                "volume_ref": "test-volume",
+                "volume_mount_path": "/tmp/auth",
+                "account_label": "alternate",
+                "api_key_ref": None,
+                "runtime_env_overrides": {},
+                "api_key_env_var": None,
+                "max_parallel_runs": 1,
+                "cooldown_after_429_seconds": 900,
+                "rate_limit_policy": "pause_and_retry",
+                "max_lease_duration_seconds": 7200,
+                "enabled": True,
+            },
         ]
     }
 
@@ -106,6 +123,17 @@ async def mock_agent_runtime_launch(request: dict) -> dict:
         "agent_id": request.get("agent_id", "test-agent"),
     }
 
+@_activity.defn(name="agent_runtime.build_launch_context")
+async def mock_agent_runtime_build_launch_context(request: dict) -> dict:
+    profile = request["profile"]
+    return {
+        "profile_id": profile["profile_id"],
+        "credential_source": "volume",
+        "delta_env_overrides": {},
+        "passthrough_env_keys": [],
+        "env_keys_count": 0,
+    }
+
 @_activity.defn(name="agent_runtime.status")
 async def mock_agent_runtime_status(request: dict) -> dict:
     """Simulate polling the agent's execution status."""
@@ -125,6 +153,7 @@ async def mock_agent_runtime_fetch_result(request: dict) -> dict:
 # Add launch/status/fetch_result to the common activities list
 _COMMON_AGENT_RUN_ACTIVITIES.extend([
     mock_agent_runtime_launch,
+    mock_agent_runtime_build_launch_context,
     mock_agent_runtime_status,
     mock_agent_runtime_fetch_result,
 ])
@@ -307,6 +336,61 @@ class TestAgentRunParent:
             id=f"{workflow.info().workflow_id}:child",
             task_queue="agent-run-task-queue",
         )
+
+@workflow.defn(name="MoonMind.ProviderProfileManager")
+class RuntimeUpdateProviderProfileManager:
+    def __init__(self) -> None:
+        self.pending_requests: list[dict] = []
+        self.assignable_profile_id = "alternate-managed"
+
+    @workflow.signal
+    def request_slot(self, payload: dict) -> None:
+        requester = payload["requester_workflow_id"]
+        self.pending_requests = [
+            req
+            for req in self.pending_requests
+            if req.get("requester_workflow_id") != requester
+        ]
+        self.pending_requests.append(dict(payload))
+
+    @workflow.signal
+    def release_slot(self, payload: dict) -> None:
+        requester = payload.get("requester_workflow_id")
+        self.pending_requests = [
+            req
+            for req in self.pending_requests
+            if req.get("requester_workflow_id") != requester
+        ]
+
+    @workflow.signal
+    def report_cooldown(self, payload: dict) -> None:
+        return None
+
+    @workflow.signal
+    def sync_profiles(self, payload: dict) -> None:
+        return None
+
+    @workflow.query
+    def get_state(self) -> dict:
+        return {"pending_requests": list(self.pending_requests)}
+
+    @workflow.run
+    async def run(self, input_payload: dict) -> dict:
+        while True:
+            await workflow.wait_condition(lambda: bool(self.pending_requests))
+            req = self.pending_requests[0]
+            if req.get("execution_profile_ref") != self.assignable_profile_id:
+                await workflow.sleep(1)
+                continue
+            self.pending_requests.pop(0)
+            handle = workflow.get_external_workflow_handle(
+                req["requester_workflow_id"]
+            )
+            await handle.signal(
+                "slot_assigned",
+                {"profile_id": self.assignable_profile_id},
+            )
+            await workflow.sleep(3600)
 
 @_activity.defn(name="agent_runtime.status")
 async def mock_agent_runtime_status_rate_limited(request: dict) -> dict:
@@ -498,6 +582,89 @@ async def test_agent_run_reports_managed_429_retry_summary_to_parent():
                 await parent_handle.cancel()
                 with pytest.raises(WorkflowFailureError):
                     await parent_handle.result()
+
+@pytest.mark.asyncio
+async def test_managed_agent_runtime_selection_update_replaces_slot_wait_request():
+    """Provider/model edits while awaiting slot should affect the active child."""
+    _managed_launch_requests.clear()
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with (
+            Worker(
+                env.client,
+                task_queue="agent-run-task-queue-runtime-update",
+                workflows=[MoonMindAgentRun, RuntimeUpdateProviderProfileManager],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.artifacts",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.agent_runtime",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+        ):
+            manager_id = "provider-profile-manager:gemini_cli"
+            await env.client.start_workflow(
+                RuntimeUpdateProviderProfileManager.run,
+                {"runtime_id": "gemini_cli"},
+                id=manager_id,
+                task_queue="agent-run-task-queue-runtime-update",
+            )
+            manager_handle = env.client.get_workflow_handle(manager_id)
+            child_id = "test-agent-runtime-selection-update"
+            child_handle = await env.client.start_workflow(
+                MoonMindAgentRun.run,
+                AgentExecutionRequest(
+                    agent_kind="managed",
+                    agent_id="gemini_cli",
+                    execution_profile_ref="default-managed",
+                    correlation_id="corr-runtime-update",
+                    idempotency_key="idem-runtime-update",
+                    parameters={
+                        "model": "old-model",
+                        "profileId": "default-managed",
+                    },
+                ),
+                id=child_id,
+                task_queue="agent-run-task-queue-runtime-update",
+            )
+            await asyncio.sleep(0.1)
+
+            await child_handle.signal(
+                "update_runtime_selection",
+                {
+                    "executionProfileRef": "alternate-managed",
+                    "model": "new-model",
+                    "parametersPatch": {
+                        "model": "new-model",
+                        "profileId": "alternate-managed",
+                    },
+                },
+            )
+
+            for _ in range(80):
+                if _managed_launch_requests:
+                    break
+                await asyncio.sleep(0.1)
+            manager_state = await manager_handle.query(
+                RuntimeUpdateProviderProfileManager.get_state
+            )
+            assert _managed_launch_requests, manager_state
+            launched_request = _managed_launch_requests[-1]["request"]
+            assert launched_request["executionProfileRef"] == "alternate-managed"
+            assert launched_request["parameters"]["model"] == "new-model"
+            assert launched_request["parameters"]["profileId"] == "alternate-managed"
+
+            await child_handle.signal(
+                MoonMindAgentRun.completion_signal,
+                {"summary": "completed after runtime update"},
+            )
+            result = await child_handle.result()
+            assert result.summary == "completed after runtime update"
 
 @pytest.mark.asyncio
 async def test_agent_run_binds_managed_launch_to_parent_workflow_for_new_histories():

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -11,7 +11,37 @@ import ast
 import inspect
 import textwrap
 
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+def _agent_request(**overrides):
+    payload = {
+        "agentKind": "managed",
+        "agentId": "codex_cli",
+        "executionProfileRef": "codex-openrouter",
+        "correlationId": "corr-1",
+        "idempotencyKey": "idem-1",
+        "parameters": {
+            "targetRuntime": "codex_cli",
+            "profileSelector": {"providerId": "openrouter"},
+            "task": {
+                "runtime": {
+                    "mode": "codex_cli",
+                    "profileSelector": {"providerId": "openrouter"},
+                }
+            },
+            "authoredTaskInput": {
+                "runtime": {
+                    "mode": "codex_cli",
+                    "profileSelector": {"providerId": "openrouter"},
+                }
+            },
+        },
+        "profileSelector": {"providerId": "openrouter"},
+    }
+    payload.update(overrides)
+    return AgentExecutionRequest.model_validate(payload)
 
 class TestEnsureManagerAutoStart:
     """Verify request_slot is routed through the auto-start fallback."""
@@ -277,6 +307,105 @@ class TestEnsureManagerAutoStart:
         raise AssertionError(
             "Could not find _ensure_manager_and_signal call in MoonMindAgentRun.run"
         )
+
+    def test_runtime_selection_update_refreshes_agent_id_and_clears_stale_selector(self):
+        """Exact profile edits must not keep selector constraints from the old provider."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request()
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "executionProfileRef": "claude-anthropic",
+                "model": "claude-opus-4-7",
+            },
+        )
+
+        assert request.agent_id == "claude_code"
+        assert request.execution_profile_ref == "claude-anthropic"
+        assert request.profile_selector.provider_id is None
+        assert request.parameters["targetRuntime"] == "claude_code"
+        assert request.parameters["task"]["runtime"]["mode"] == "claude_code"
+        assert "profileSelector" not in request.parameters
+        assert "profileSelector" not in request.parameters["task"]["runtime"]
+
+    def test_runtime_selection_update_uses_explicit_profile_selector_patch(self):
+        """A supplied selector must replace stale criteria for the new slot request."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(executionProfileRef=None)
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "codex_cli",
+                "parametersPatch": {
+                    "profileSelector": {"providerId": "openai"},
+                    "task": {"runtime": {"profileSelector": {"providerId": "openai"}}},
+                },
+            },
+        )
+
+        assert request.profile_selector.provider_id == "openai"
+        assert request.parameters["profileSelector"]["providerId"] == "openai"
+        assert request.parameters["task"]["runtime"]["profileSelector"] == {
+            "providerId": "openai",
+            "tagsAny": [],
+            "tagsAll": [],
+        }
+
+    def test_slot_wait_runtime_update_returns_refreshed_manager_and_runtime_ids(self):
+        """The slot-wait caller must update local manager/runtime identifiers."""
+        source = textwrap.dedent(
+            inspect.getsource(
+                MoonMindAgentRun._consume_runtime_selection_update_for_slot_wait
+            )
+        )
+
+        assert "runtime_id = self._managed_runtime_id(request.agent_id)" in source
+        assert "manager_id = self._manager_workflow_id(runtime_id)" in source
+        assert "return manager_handle, manager_id, runtime_id" in source
+
+        run_source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        tree = ast.parse(run_source)
+        tuple_assignment_count = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not isinstance(node.value, ast.Await):
+                continue
+            call = node.value.value
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "_consume_runtime_selection_update_for_slot_wait"
+            ):
+                continue
+            if not node.targets or not isinstance(node.targets[0], ast.Tuple):
+                continue
+            names = [
+                elt.id for elt in node.targets[0].elts if isinstance(elt, ast.Name)
+            ]
+            if names == ["manager_handle", "manager_id", "runtime_id"]:
+                tuple_assignment_count += 1
+
+        assert tuple_assignment_count == 2
+
+    def test_slot_wait_runtime_update_validates_after_profile_sync(self):
+        """Edited exact profiles must fail fast after the refreshed profile snapshot."""
+        source = textwrap.dedent(
+            inspect.getsource(
+                MoonMindAgentRun._consume_runtime_selection_update_for_slot_wait
+            )
+        )
+
+        sync_index = source.index("_sync_manager_profiles")
+        validate_index = source.index("_validate_synced_profile_selection")
+        request_index = source.index(
+            "manager_handle = await self._ensure_manager_and_signal"
+        )
+
+        assert sync_index < validate_index < request_index
 
     def test_manager_signal_payload_carries_execution_profile_ref(self):
         """The auto-start helper must include execution_profile_ref in request_slot payloads."""

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -235,6 +235,57 @@ async def test_send_message_forwards_operator_message_without_resuming(monkeypat
     assert workflow_instance._resume_requested is False
 
 @pytest.mark.asyncio
+async def test_update_inputs_forwards_runtime_selection_to_active_managed_child(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._active_agent_child_workflow_id = "wf:child"
+    workflow_instance._active_agent_id = "claude_code"
+
+    mock_handle = type("MockHandle", (), {"signal": AsyncMock()})()
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: mock_handle,
+    )
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+
+    result = await workflow_instance.update_inputs(
+        {
+            "parametersPatch": {
+                "model": "claude-opus-4-7",
+                "profileId": "claude_anthropic",
+                "task": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "model": "claude-opus-4-7",
+                        "profileId": "claude_anthropic",
+                    }
+                },
+            }
+        }
+    )
+
+    mock_handle.signal.assert_awaited_once_with(
+        "update_runtime_selection",
+        {
+            "model": "claude-opus-4-7",
+            "executionProfileRef": "claude_anthropic",
+            "targetRuntime": "claude_code",
+            "parametersPatch": {
+                "model": "claude-opus-4-7",
+                "profileId": "claude_anthropic",
+                "task": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "model": "claude-opus-4-7",
+                        "profileId": "claude_anthropic",
+                    }
+                },
+            },
+        },
+    )
+    assert result["forwardedRuntimeSelectionUpdate"] is True
+
+@pytest.mark.asyncio
 async def test_run_workflow_send_message_update_uses_temporal_boundary(
     mock_run_environment, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- forwards runtime provider/model edits from the parent run workflow to the active managed child
- lets managed agent children consume runtime-selection updates while waiting for a provider slot, re-requesting capacity with the edited profile
- adds workflow-boundary coverage for provider edits during slot cooldown and unit coverage for parent signal forwarding

## Root cause

Task edits updated the parent execution parameters, but an already-running managed child that was blocked in provider-capacity slot waiting kept its original profile and model request. The slot manager therefore continued retrying the exhausted provider profile even after the operator changed the provider.

## Validation

- git diff --check
- .venv/bin/pytest tests/integration/services/temporal/workflows/test_agent_run.py -k runtime_selection_update_replaces_slot_wait_request -q --tb=short
- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
