### PR TITLE
[codex] Recheck temporary Jira blockers

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3118,6 +3118,7 @@ class MoonMindRunWorkflow:
                                 node_id=node_id,
                                 tool_name=tool_name,
                                 tool_type=tool_type,
+                                failure_mode=failure_mode,
                             )
                         )
                         if self._cancel_requested:
@@ -3868,6 +3869,9 @@ class MoonMindRunWorkflow:
 
     def _clear_jira_blocker_wait(self) -> None:
         self._jira_blocker_wait_active = False
+        self._jira_blocker_wait_started_at = None
+        self._jira_blocker_wait_issue_keys = []
+        self._jira_blocker_wait_summary = None
         if self._waiting_reason == "jira_blocker_wait":
             self._waiting_reason = None
         self._attention_required = False
@@ -3881,6 +3885,7 @@ class MoonMindRunWorkflow:
         node_id: str,
         tool_name: str,
         tool_type: str,
+        failure_mode: str,
     ) -> tuple[Any, bool]:
         skipped = False
         recheck_count = 0
@@ -3896,10 +3901,15 @@ class MoonMindRunWorkflow:
             )
             try:
                 await workflow.wait_condition(
-                    lambda: self._cancel_requested or self._jira_blocker_wait_skipped,
+                    lambda: (
+                        self._cancel_requested
+                        or self._jira_blocker_wait_skipped
+                        or self._paused
+                    ),
                     timeout=DEPENDENCY_RECONCILE_INTERVAL,
                 )
             except asyncio.TimeoutError:
+                # Timeout is the expected path for periodic blocker rechecks.
                 pass
             if self._cancel_requested:
                 return current_result, skipped
@@ -3909,6 +3919,9 @@ class MoonMindRunWorkflow:
 
             recheck_count += 1
             self._clear_jira_blocker_wait()
+            await self._wait_if_paused_at_safe_boundary()
+            if self._cancel_requested:
+                return current_result, skipped
             self._set_state(STATE_EXECUTING, summary="Re-checking Jira blockers.")
             self._mark_step_running(
                 node_id,
@@ -3921,12 +3934,24 @@ class MoonMindRunWorkflow:
                 recheck_payload["idempotency_key"] = (
                     f"{idempotency_key}_jira_blocker_recheck_{recheck_count}"
                 )
-            current_result = await workflow.execute_activity(
-                route.activity_type,
-                recheck_payload,
-                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                **self._execute_kwargs_for_route(route),
-            )
+            try:
+                current_result = await workflow.execute_activity(
+                    route.activity_type,
+                    recheck_payload,
+                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                    **self._execute_kwargs_for_route(route),
+                )
+            except Exception:
+                self._mark_step_terminal(
+                    node_id,
+                    status="failed",
+                    updated_at=workflow.now(),
+                    summary=f"Re-check of Jira blockers for {tool_name} failed",
+                    last_error="execution_error",
+                )
+                if failure_mode == "FAIL_FAST":
+                    raise
+                break
             self._record_step_result_evidence(
                 node_id,
                 execution_result=current_result,
@@ -7358,8 +7383,6 @@ class MoonMindRunWorkflow:
         if self._state != STATE_WAITING_ON_DEPENDENCIES:
             raise ValueError("Workflow is not waiting on dependencies.")
         if self._jira_blocker_wait_active:
-            if not self._jira_blocker_wait_issue_keys:
-                raise ValueError("Workflow has no unresolved Jira blockers.")
             return
         if self._dependency_failure is not None:
             raise ValueError("Cannot skip dependency wait after dependency failure.")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -52,6 +52,9 @@ with workflow.unsafe.imports_passed_through():
         JIRA_AGENT_SKILLS,
         JIRA_BACKED_AGENT_SKILLS,
     )
+    from moonmind.workflows.temporal.story_output_tools import (
+        JIRA_CHECK_BLOCKERS_TOOL_NAME,
+    )
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.tasks.task_contract import (
         build_effective_task_skill_selectors,
@@ -186,6 +189,7 @@ RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release
 # Replay-stable patch id for task-scoped Codex terminate activity+signal finalization.
 RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
 RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH = "run-blocked-outcome-short-circuit-v1"
+RUN_JIRA_BLOCKER_RECHECK_PATCH = "run-jira-blocker-recheck-v1"
 # Replay-stable patch id for the v2 task-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
@@ -338,6 +342,11 @@ class MoonMindRunWorkflow:
         self._awaiting_external: bool = False
         self._waiting_reason: Optional[str] = None
         self._attention_required: bool = False
+        self._jira_blocker_wait_active: bool = False
+        self._jira_blocker_wait_skipped: bool = False
+        self._jira_blocker_wait_started_at: datetime | None = None
+        self._jira_blocker_wait_issue_keys: list[str] = []
+        self._jira_blocker_wait_summary: str | None = None
 
         # Action flags
         self._cancel_requested = False
@@ -2865,6 +2874,7 @@ class MoonMindRunWorkflow:
             result_status: str | None = None
             execution_result = None
             accepted_execution = False
+            blocked_outcome_wait_skipped = False
             current_review_attempt = 1
 
             while current_review_attempt <= (max_review_attempts + 1):
@@ -3091,6 +3101,35 @@ class MoonMindRunWorkflow:
                         execution_result=execution_result,
                         updated_at=workflow.now(),
                     )
+                    if (
+                        result_status == "COMPLETED"
+                        and workflow.patched(RUN_JIRA_BLOCKER_RECHECK_PATCH)
+                        and self._jira_blocker_waitable_result(
+                            execution_result,
+                            tool_type=tool_type,
+                            tool_name=tool_name,
+                        )
+                    ):
+                        execution_result, blocked_outcome_wait_skipped = (
+                            await self._wait_for_jira_blocker_resolution(
+                                execution_result=execution_result,
+                                route=route,
+                                execute_payload=execute_payload,
+                                node_id=node_id,
+                                tool_name=tool_name,
+                                tool_type=tool_type,
+                            )
+                        )
+                        if self._cancel_requested:
+                            return
+                        result_status = self._activity_result_status(execution_result)
+                        if result_status is None:
+                            if failure_mode == "FAIL_FAST":
+                                raise ValueError(
+                                    "plan node execution result is missing required "
+                                    "status field"
+                                )
+                            break
                     if result_status != "COMPLETED":
                         failure_message = self._activity_result_failure_message(
                             execution_result
@@ -3294,7 +3333,11 @@ class MoonMindRunWorkflow:
                 node_id=node_id,
                 execution_result=execution_result,
             )
-            blocked_message = self._blocked_outcome_message(execution_result)
+            blocked_message = (
+                None
+                if blocked_outcome_wait_skipped
+                else self._blocked_outcome_message(execution_result)
+            )
             if (
                 blocked_message
                 and workflow.patched(RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH)
@@ -3750,6 +3793,152 @@ class MoonMindRunWorkflow:
                     return message
 
         return None
+
+    def _jira_blocker_waitable_result(
+        self,
+        execution_result: Any,
+        *,
+        tool_type: str,
+        tool_name: str,
+    ) -> bool:
+        if tool_type != "skill" or tool_name != JIRA_CHECK_BLOCKERS_TOOL_NAME:
+            return False
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return False
+        return self._is_blocked_outcome_value(outputs.get("decision"))
+
+    def _jira_blocker_issue_keys(self, execution_result: Any) -> list[str]:
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return []
+        issue_keys: list[str] = []
+        blockers = outputs.get("blockingIssues")
+        if blockers is None:
+            blockers = outputs.get("blocking_issues")
+        if isinstance(blockers, Sequence) and not isinstance(blockers, (str, bytes)):
+            for blocker in blockers:
+                if not isinstance(blocker, Mapping):
+                    continue
+                issue_key = self._coerce_text(
+                    blocker.get("issueKey") or blocker.get("issue_key"),
+                    max_chars=80,
+                )
+                if issue_key and issue_key not in issue_keys:
+                    issue_keys.append(issue_key)
+        if issue_keys:
+            return issue_keys
+        target_issue_key = self._coerce_text(
+            outputs.get("targetIssueKey")
+            or outputs.get("target_issue_key")
+            or outputs.get("issueKey")
+            or outputs.get("jiraIssueKey"),
+            max_chars=80,
+        )
+        return [target_issue_key] if target_issue_key else []
+
+    def _enter_jira_blocker_wait(
+        self,
+        *,
+        node_id: str,
+        execution_result: Any,
+    ) -> None:
+        summary = self._blocked_outcome_message(execution_result) or (
+            "Waiting for Jira blocker resolution."
+        )
+        issue_keys = self._jira_blocker_issue_keys(execution_result)
+        if self._jira_blocker_wait_started_at is None:
+            self._jira_blocker_wait_started_at = workflow.now()
+        self._jira_blocker_wait_active = True
+        self._jira_blocker_wait_skipped = False
+        self._jira_blocker_wait_issue_keys = issue_keys
+        self._jira_blocker_wait_summary = summary
+        self._waiting_reason = "jira_blocker_wait"
+        self._attention_required = False
+        self._set_state(STATE_WAITING_ON_DEPENDENCIES, summary=summary)
+        self._mark_step_waiting(
+            node_id,
+            status="awaiting_external",
+            updated_at=workflow.now(),
+            waiting_reason="Waiting for Jira blocker resolution",
+            summary=summary,
+        )
+        self._update_search_attributes()
+        self._update_memo()
+
+    def _clear_jira_blocker_wait(self) -> None:
+        self._jira_blocker_wait_active = False
+        if self._waiting_reason == "jira_blocker_wait":
+            self._waiting_reason = None
+        self._attention_required = False
+
+    async def _wait_for_jira_blocker_resolution(
+        self,
+        *,
+        execution_result: Any,
+        route: Any,
+        execute_payload: Mapping[str, Any],
+        node_id: str,
+        tool_name: str,
+        tool_type: str,
+    ) -> tuple[Any, bool]:
+        skipped = False
+        recheck_count = 0
+        current_result = execution_result
+        while self._jira_blocker_waitable_result(
+            current_result,
+            tool_type=tool_type,
+            tool_name=tool_name,
+        ):
+            self._enter_jira_blocker_wait(
+                node_id=node_id,
+                execution_result=current_result,
+            )
+            try:
+                await workflow.wait_condition(
+                    lambda: self._cancel_requested or self._jira_blocker_wait_skipped,
+                    timeout=DEPENDENCY_RECONCILE_INTERVAL,
+                )
+            except asyncio.TimeoutError:
+                pass
+            if self._cancel_requested:
+                return current_result, skipped
+            if self._jira_blocker_wait_skipped:
+                skipped = True
+                break
+
+            recheck_count += 1
+            self._clear_jira_blocker_wait()
+            self._set_state(STATE_EXECUTING, summary="Re-checking Jira blockers.")
+            self._mark_step_running(
+                node_id,
+                updated_at=workflow.now(),
+                summary=f"Re-checking Jira blockers for {tool_name}",
+            )
+            recheck_payload = dict(execute_payload)
+            idempotency_key = recheck_payload.get("idempotency_key")
+            if isinstance(idempotency_key, str) and idempotency_key.strip():
+                recheck_payload["idempotency_key"] = (
+                    f"{idempotency_key}_jira_blocker_recheck_{recheck_count}"
+                )
+            current_result = await workflow.execute_activity(
+                route.activity_type,
+                recheck_payload,
+                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                **self._execute_kwargs_for_route(route),
+            )
+            self._record_step_result_evidence(
+                node_id,
+                execution_result=current_result,
+                updated_at=workflow.now(),
+            )
+            if self._activity_result_status(current_result) != "COMPLETED":
+                break
+
+        self._clear_jira_blocker_wait()
+        self._update_search_attributes()
+        self._update_memo()
+        return current_result, skipped
 
     def _mark_remaining_plan_steps_skipped(
         self,
@@ -6797,6 +6986,27 @@ class MoonMindRunWorkflow:
             metadata["dependency_failure"] = dict(self._dependency_failure)
         return metadata
 
+    def _jira_blocker_wait_metadata(self) -> dict[str, Any]:
+        if (
+            not self._jira_blocker_wait_active
+            and not self._jira_blocker_wait_issue_keys
+            and not self._jira_blocker_wait_summary
+        ):
+            return {}
+        wait_duration_ms = 0
+        if self._jira_blocker_wait_started_at is not None:
+            elapsed = workflow.now() - self._jira_blocker_wait_started_at
+            wait_duration_ms = max(0, int(elapsed.total_seconds() * 1000))
+        return {
+            "jira_blocker_wait": {
+                "active": self._jira_blocker_wait_active,
+                "skipped": self._jira_blocker_wait_skipped,
+                "issueKeys": list(self._jira_blocker_wait_issue_keys),
+                "summary": self._jira_blocker_wait_summary,
+                "waitDurationMs": wait_duration_ms,
+            }
+        }
+
     def _mark_real_work_started(self, *, now: datetime | None = None) -> None:
         """Stamp ``mm_started_at`` once, when the workflow first does real work.
 
@@ -6938,6 +7148,7 @@ class MoonMindRunWorkflow:
         if merge_automation_summary:
             memo_dict["merge_automation"] = merge_automation_summary
         memo_dict.update(self._dependency_metadata())
+        memo_dict.update(self._jira_blocker_wait_metadata())
 
         try:
             workflow.upsert_memo(memo_dict)
@@ -7120,6 +7331,13 @@ class MoonMindRunWorkflow:
 
     @workflow.update(name="SkipDependencyWait")
     def skip_dependency_wait(self) -> None:
+        if self._jira_blocker_wait_active:
+            self._jira_blocker_wait_skipped = True
+            self._paused = False
+            self._summary = "Jira blocker wait skipped by operator."
+            self._update_search_attributes()
+            self._update_memo()
+            return
         self._update_dependency_wait_duration()
         self._dependency_manual_override_unresolved_count = len(
             self._unresolved_dependency_ids
@@ -7139,6 +7357,10 @@ class MoonMindRunWorkflow:
             raise ValueError("Cannot skip dependency wait for a completed workflow.")
         if self._state != STATE_WAITING_ON_DEPENDENCIES:
             raise ValueError("Workflow is not waiting on dependencies.")
+        if self._jira_blocker_wait_active:
+            if not self._jira_blocker_wait_issue_keys:
+                raise ValueError("Workflow has no unresolved Jira blockers.")
+            return
         if self._dependency_failure is not None:
             raise ValueError("Cannot skip dependency wait after dependency failure.")
         if not self._unresolved_dependency_ids:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timezone
 from typing import Any, Callable
@@ -18,6 +19,13 @@ async def _immediate_wait_condition(
     **_kwargs: Any,
 ) -> None:
     assert predicate() is True
+
+async def _timeout_wait_condition(
+    predicate: Callable[[], bool],
+    **_kwargs: Any,
+) -> None:
+    assert predicate() is False
+    raise asyncio.TimeoutError
 
 def test_initialize_from_payload_captures_input_and_plan_refs(
     monkeypatch: pytest.MonkeyPatch,
@@ -677,6 +685,197 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
     assert workflow._publish_status == "not_required"
     assert steps[0]["status"] == "succeeded"
     assert steps[1]["status"] == "skipped"
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    skill_calls: list[tuple[str, str | None]] = []
+
+    registry_payload = {
+        "skills": [
+            {
+                "name": "jira.check_blockers",
+                "version": "1.0",
+                "description": "Check Jira blockers",
+                "inputs": {"schema": {"type": "object"}},
+                "outputs": {"schema": {"type": "object"}},
+                "executor": {
+                    "activity_type": "mm.skill.execute",
+                    "selector": {"mode": "by_capability"},
+                },
+                "requirements": {"capabilities": ["integration:jira"]},
+                "policies": {
+                    "timeouts": {
+                        "start_to_close_seconds": 60,
+                        "schedule_to_close_seconds": 120,
+                    },
+                    "retries": {"max_attempts": 1},
+                },
+            },
+            {
+                "name": "repo.run_tests",
+                "version": "1.0",
+                "description": "Run tests",
+                "inputs": {"schema": {"type": "object"}},
+                "outputs": {"schema": {"type": "object"}},
+                "executor": {
+                    "activity_type": "mm.skill.execute",
+                    "selector": {"mode": "by_capability"},
+                },
+                "requirements": {"capabilities": ["sandbox"]},
+                "policies": {
+                    "timeouts": {
+                        "start_to_close_seconds": 60,
+                        "schedule_to_close_seconds": 120,
+                    },
+                    "retries": {"max_attempts": 1},
+                },
+            },
+        ]
+    }
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        normalized = _normalize_payload(payload)
+        if activity_type == "artifact.read":
+            artifact_ref = normalized.get("artifact_ref")
+            if artifact_ref == "artifact://registry/jira":
+                return json.dumps(registry_payload).encode("utf-8")
+            assert artifact_ref == "art_plan_1"
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Jira Wait Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/jira",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "check-blockers",
+                            "tool": {
+                                "type": "skill",
+                                "name": "jira.check_blockers",
+                                "version": "1.0",
+                            },
+                            "inputs": {"targetIssueKey": "MM-686"},
+                        },
+                        {
+                            "id": "implement",
+                            "tool": {
+                                "type": "skill",
+                                "name": "repo.run_tests",
+                                "version": "1.0",
+                            },
+                            "inputs": {"instructions": "Continue after blockers."},
+                        },
+                    ],
+                    "edges": [{"from": "check-blockers", "to": "implement"}],
+                }
+            ).encode("utf-8")
+        if activity_type == "mm.skill.execute":
+            invocation = normalized["invocation_payload"]
+            tool_name = invocation["tool"]["name"]
+            skill_calls.append((tool_name, normalized.get("idempotency_key")))
+            if tool_name == "jira.check_blockers" and len(skill_calls) == 1:
+                return {
+                    "status": "COMPLETED",
+                    "outputs": {
+                        "targetIssueKey": "MM-686",
+                        "decision": "blocked",
+                        "blockingIssues": [
+                            {
+                                "issueKey": "MM-685",
+                                "status": "In Progress",
+                                "done": False,
+                            }
+                        ],
+                        "summary": (
+                            "MM-686 is blocked by unresolved Jira issue(s): "
+                            "MM-685 (In Progress)."
+                        ),
+                    },
+                }
+            if tool_name == "jira.check_blockers":
+                return {
+                    "status": "COMPLETED",
+                    "outputs": {
+                        "targetIssueKey": "MM-686",
+                        "decision": "continue",
+                        "blockingIssues": [],
+                        "summary": "All Jira blockers for MM-686 are Done.",
+                    },
+                }
+            return {"status": "COMPLETED", "outputs": {"summary": "Implemented."}}
+        raise AssertionError(f"unexpected activity {activity_type}")
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+            run_workflow_module.RUN_JIRA_BLOCKER_RECHECK_PATCH,
+            run_workflow_module.RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
+            "idempotency_key_phase3",
+        },
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _timeout_wait_condition,
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "none"},
+        plan_ref="art_plan_1",
+    )
+
+    steps = workflow.get_step_ledger()["steps"]
+    assert [call[0] for call in skill_calls] == [
+        "jira.check_blockers",
+        "jira.check_blockers",
+        "repo.run_tests",
+    ]
+    assert skill_calls[1][1] == "wf-1_check-blockers_execute_jira_blocker_recheck_1"
+    assert workflow._plan_blocked_message is None
+    assert workflow._jira_blocker_wait_active is False
+    assert workflow._waiting_reason is None
+    assert steps[0]["status"] == "succeeded"
+    assert steps[1]["status"] == "succeeded"
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_preserves_registry_read_for_unpatched_histories(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -878,6 +878,219 @@ async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
     assert steps[1]["status"] == "succeeded"
 
 @pytest.mark.asyncio
+async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    events: list[str] = []
+    route = type("Route", (), {"activity_type": "mm.skill.execute"})()
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "decision": "blocked",
+            "blockingIssues": [{"issueKey": "MM-685", "done": False}],
+            "summary": "Blocked by MM-685.",
+        },
+    }
+    continue_result = {
+        "status": "COMPLETED",
+        "outputs": {"decision": "continue", "blockingIssues": []},
+    }
+
+    async def fake_wait_condition(
+        predicate: Callable[[], bool],
+        **_kwargs: Any,
+    ) -> None:
+        assert predicate() is False
+        workflow._paused = True
+        assert predicate() is True
+        events.append("pause-observed")
+
+    async def fake_pause_boundary(self: MoonMindRunWorkflow) -> None:
+        assert self._paused is True
+        events.append("pause-boundary")
+        self._paused = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        events.append(f"activity:{activity_type}")
+        assert events[-2:] == ["pause-boundary", "activity:mm.skill.execute"]
+        assert _normalize_payload(payload)["idempotency_key"].endswith(
+            "_jira_blocker_recheck_1"
+        )
+        return continue_result
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        fake_wait_condition,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_pause_boundary,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_execute_kwargs_for_route",
+        lambda self, route: {},
+    )
+
+    result, skipped = await workflow._wait_for_jira_blocker_resolution(
+        execution_result=blocked_result,
+        route=route,
+        execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+        node_id="check-blockers",
+        tool_name="jira.check_blockers",
+        tool_type="skill",
+        failure_mode="FAIL_FAST",
+    )
+
+    assert result == continue_result
+    assert skipped is False
+    assert events == [
+        "pause-observed",
+        "pause-boundary",
+        "activity:mm.skill.execute",
+    ]
+    assert workflow._jira_blocker_wait_active is False
+    assert workflow._jira_blocker_wait_started_at is None
+    assert workflow._jira_blocker_wait_issue_keys == []
+    assert workflow._jira_blocker_wait_summary is None
+
+
+@pytest.mark.asyncio
+async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    route = type("Route", (), {"activity_type": "mm.skill.execute"})()
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "decision": "blocked",
+            "blockingIssues": [{"issueKey": "MM-685", "done": False}],
+            "summary": "Blocked by MM-685.",
+        },
+    }
+
+    async def fake_execute_activity(
+        _activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        raise RuntimeError("worker unavailable")
+
+    async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _timeout_wait_condition,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_noop_async,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_execute_kwargs_for_route",
+        lambda self, route: {},
+    )
+
+    result, skipped = await workflow._wait_for_jira_blocker_resolution(
+        execution_result=blocked_result,
+        route=route,
+        execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+        node_id="check-blockers",
+        tool_name="jira.check_blockers",
+        tool_type="skill",
+        failure_mode="CONTINUE",
+    )
+
+    assert result == blocked_result
+    assert skipped is False
+    assert workflow._jira_blocker_wait_active is False
+    assert workflow._jira_blocker_wait_started_at is None
+    assert workflow._jira_blocker_wait_issue_keys == []
+    assert workflow._jira_blocker_wait_summary is None
+
+    with pytest.raises(RuntimeError, match="worker unavailable"):
+        await workflow._wait_for_jira_blocker_resolution(
+            execution_result=blocked_result,
+            route=route,
+            execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+            node_id="check-blockers",
+            tool_name="jira.check_blockers",
+            tool_type="skill",
+            failure_mode="FAIL_FAST",
+        )
+
+
+def test_skip_dependency_wait_allows_active_jira_wait_without_issue_keys() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._state = run_workflow_module.STATE_WAITING_ON_DEPENDENCIES
+    workflow._jira_blocker_wait_active = True
+    workflow._jira_blocker_wait_issue_keys = []
+
+    workflow.validate_skip_dependency_wait()
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_preserves_registry_read_for_unpatched_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat trusted `jira.check_blockers` blocked results as temporary dependency waits instead of terminal run failures.
- Re-check Jira blockers on the dependency polling interval with recheck-scoped idempotency keys until blockers clear, the run is canceled, or the operator skips the wait.
- Preserve the existing terminal short-circuit behavior for other blocked outcomes.

## Validation
- `python3 -m pytest tests/unit/workflows/temporal/test_run_artifacts.py -q`
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py`

## Notes
- A full `./tools/test_unit.sh` run progressed through the Python target set, then failed in frontend Vitest because `frontend/src/vite-config.test.ts` requires missing `../../tailwind.config.cjs` in the current worktree. That file is unrelated to this PR and remains unstaged.
