### PR TITLE
Run Jira Orchestrate for MM-686: Render runtime commands after context preparation in managed runtime adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,8 @@ Key diagnostics:
 - Python 3.12; TypeScript/React for Mission Control task detail UI + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, generated OpenAPI types (350-operator-observability-diagnostics)
 - Existing Temporal execution records, execution parameters/memo/search attributes, task input snapshot artifacts, and Temporal artifact refs; no new persistent storage planned (350-operator-observability-diagnostics)
 - Python 3.12 (existing MoonMind runtime); no new module files are added for this one-shot run. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (353-transition-mm658-in-progress)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, existing managed runtime launcher/strategy stack, existing task contract runtime command metadata (356-runtime-command-rendering)
+- No new persistent storage; use existing task input snapshot data, `AgentExecutionRequest` payload fields/parameters, workflow history, and launcher diagnostics (356-runtime-command-rendering)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -250,6 +250,8 @@ Key diagnostics:
 - Python 3.12; TypeScript/React for Mission Control task detail UI + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, generated OpenAPI types (350-operator-observability-diagnostics)
 - Existing Temporal execution records, execution parameters/memo/search attributes, task input snapshot artifacts, and Temporal artifact refs; no new persistent storage planned (350-operator-observability-diagnostics)
 - Python 3.12 (existing MoonMind runtime); no new module files are added for this one-shot run. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (353-transition-mm658-in-progress)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, existing managed runtime launcher/strategy stack, existing task contract runtime command metadata (356-runtime-command-rendering)
+- No new persistent storage; use existing task input snapshot data, `AgentExecutionRequest` payload fields/parameters, workflow history, and launcher diagnostics (356-runtime-command-rendering)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -76,6 +76,18 @@ class RuntimeCommandInvocation(BaseModel):
     hint_catalog_version: str | None = Field(None, alias="hintCatalogVersion")
     detection_phase: str | None = Field(None, alias="detectionPhase")
 
+    @model_validator(mode="after")
+    def _recognized_runtime_command_has_text(self) -> "RuntimeCommandInvocation":
+        if (
+            self.requires_runtime_recognition
+            and not self.raw_command.strip()
+            and not self.command.strip()
+        ):
+            raise ValueError(
+                "runtime command recognition requires non-empty rawCommand or command"
+            )
+        return self
+
 
 class RuntimeCommandRenderResult(BaseModel):
     """Result of adapter-owned runtime command rendering before launch."""

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -37,6 +37,60 @@ FailureClass = Literal[
     "execution_error",
     "system_error",
 ]
+RuntimeCommandRenderStatus = Literal["ok", "unsupported", "failed", "fallback"]
+RuntimeCommandRenderMode = Literal[
+    "plain_prompt",
+    "prompt_prefix",
+    "native_command",
+    "materialized_command",
+    "unsupported",
+]
+
+class RuntimeCommandInvocation(BaseModel):
+    """Compact backend-normalized runtime command metadata for launch rendering."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    kind: str = Field(..., min_length=1)
+    source: str = Field(..., min_length=1)
+    source_path: str = Field(..., alias="sourcePath", min_length=1)
+    command: str = ""
+    raw_command: str = Field("", alias="rawCommand")
+    args: str = ""
+    instruction_body: str = Field("", alias="instructionBody")
+    target_runtime: str | None = Field(None, alias="targetRuntime")
+    target_step_id: str | None = Field(None, alias="targetStepId")
+    detection_status: str = Field(..., alias="detectionStatus", min_length=1)
+    hint_status: str = Field(..., alias="hintStatus", min_length=1)
+    recognition_mode: str = Field(..., alias="recognitionMode", min_length=1)
+    requires_runtime_recognition: bool = Field(
+        False, alias="requiresRuntimeRecognition"
+    )
+    runtime_capability_version: str | None = Field(
+        None, alias="runtimeCapabilityVersion"
+    )
+    hint_catalog_version: str | None = Field(None, alias="hintCatalogVersion")
+    detection_phase: str | None = Field(None, alias="detectionPhase")
+
+
+class RuntimeCommandRenderResult(BaseModel):
+    """Result of adapter-owned runtime command rendering before launch."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    status: RuntimeCommandRenderStatus
+    render_mode: RuntimeCommandRenderMode | None = Field(None, alias="renderMode")
+    rendered_instruction: str | None = Field(None, alias="renderedInstruction")
+    native_command_payload: dict[str, Any] | None = Field(
+        None, alias="nativeCommandPayload"
+    )
+    materialized_targets: list[dict[str, Any]] = Field(
+        default_factory=list, alias="materializedTargets"
+    )
+    failure_reason: str | None = Field(None, alias="failureReason")
+    fallback_event: dict[str, Any] | None = Field(None, alias="fallbackEvent")
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+    invocation: RuntimeCommandInvocation | None = None
 
 class UnsupportedStatusError(ValueError):
     """Raised when an unknown or unsupported provider status is encountered."""
@@ -217,6 +271,9 @@ class AgentExecutionRequest(BaseModel):
     correlation_id: str = Field(..., alias="correlationId", min_length=1)
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     instruction_ref: str | None = Field(None, alias="instructionRef")
+    runtime_command: RuntimeCommandInvocation | None = Field(
+        None, alias="runtimeCommand"
+    )
     resolved_skillset_ref: str | None = Field(None, alias="resolvedSkillsetRef")
     managed_session: CodexManagedSessionBinding | None = Field(
         None, alias="managedSession"
@@ -921,6 +978,10 @@ __all__ = [
     "AgentRunState",
     "AgentRunStatus",
     "FailureClass",
+    "RuntimeCommandInvocation",
+    "RuntimeCommandRenderMode",
+    "RuntimeCommandRenderResult",
+    "RuntimeCommandRenderStatus",
     "ManagedAgentProviderProfile",
     "ManagedRunRecord",
     "ManagedRuntimeProfile",

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -63,6 +63,10 @@ class RuntimeCommandInvocation(BaseModel):
     detection_status: str = Field(..., alias="detectionStatus", min_length=1)
     hint_status: str = Field(..., alias="hintStatus", min_length=1)
     recognition_mode: str = Field(..., alias="recognitionMode", min_length=1)
+    render_mode: RuntimeCommandRenderMode | None = Field(None, alias="renderMode")
+    materialized_command: dict[str, Any] | None = Field(
+        None, alias="materializedCommand"
+    )
     requires_runtime_recognition: bool = Field(
         False, alias="requiresRuntimeRecognition"
     )

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -951,52 +951,52 @@ class ManagedRuntimeLauncher:
                 },
             )
 
-        if strategy is not None:
-            self._apply_runtime_command_rendering(
-                request=request,
-                strategy=strategy,
-            )
-
-        cmd = self.build_command(profile, request, strategy=strategy)
-        self._reset_live_log_spool(resolved_workspace_path)
-
         run_root: Path | None = (
             Path(resolved_workspace_path).resolve().parent
             if resolved_workspace_path is not None
             else None
         )
-
-        for key in profile.passthrough_env_keys:
-            value = os.environ.get(key)
-            if value is None or not str(value).strip():
-                continue
-            env_overrides[key] = value
-
-        from moonmind.config.settings import settings as _mm_settings
-        _git_name = str(_mm_settings.workflow.git_user_name or "").strip() or None
-        _git_email = str(_mm_settings.workflow.git_user_email or "").strip() or None
-        if _git_name:
-            env_overrides.setdefault("GIT_AUTHOR_NAME", _git_name)
-            env_overrides.setdefault("GIT_COMMITTER_NAME", _git_name)
-        if _git_email:
-            env_overrides.setdefault("GIT_AUTHOR_EMAIL", _git_email)
-            env_overrides.setdefault("GIT_COMMITTER_EMAIL", _git_email)
-
-        github_token = await resolve_github_token_for_launch(env_overrides)
-        if not github_token:
-            github_token = launch_github_token
         cleanup_paths: list[str] = list(materializer.generated_files)
         cleanup_paths.extend(reversed(materializer.generated_dirs))
         deferred_cleanup_paths: list[str] = []
         github_socket_path: str | None = None
         real_gh_path = shutil.which("gh")
-        # The claude CLI refuses --dangerously-skip-permissions when running as root
-        # (security restriction). For claude_code runtime, drop to the app user.
-        _run_as_root = os.geteuid() == 0
-        _is_claude_code = profile.runtime_id == "claude_code"
-        _needs_priv_drop = _run_as_root and _is_claude_code
-        process: asyncio.subprocess.Process
+
         try:
+            if strategy is not None:
+                self._apply_runtime_command_rendering(
+                    request=request,
+                    strategy=strategy,
+                )
+
+            cmd = self.build_command(profile, request, strategy=strategy)
+            self._reset_live_log_spool(resolved_workspace_path)
+
+            for key in profile.passthrough_env_keys:
+                value = os.environ.get(key)
+                if value is None or not str(value).strip():
+                    continue
+                env_overrides[key] = value
+
+            from moonmind.config.settings import settings as _mm_settings
+            _git_name = str(_mm_settings.workflow.git_user_name or "").strip() or None
+            _git_email = str(_mm_settings.workflow.git_user_email or "").strip() or None
+            if _git_name:
+                env_overrides.setdefault("GIT_AUTHOR_NAME", _git_name)
+                env_overrides.setdefault("GIT_COMMITTER_NAME", _git_name)
+            if _git_email:
+                env_overrides.setdefault("GIT_AUTHOR_EMAIL", _git_email)
+                env_overrides.setdefault("GIT_COMMITTER_EMAIL", _git_email)
+
+            github_token = await resolve_github_token_for_launch(env_overrides)
+            if not github_token:
+                github_token = launch_github_token
+            # The claude CLI refuses --dangerously-skip-permissions when running as root
+            # (security restriction). For claude_code runtime, drop to the app user.
+            _run_as_root = os.geteuid() == 0
+            _is_claude_code = profile.runtime_id == "claude_code"
+            _needs_priv_drop = _run_as_root and _is_claude_code
+            process: asyncio.subprocess.Process
             if github_token and run_root is not None:
                 github_socket_path = self._build_github_socket_path(
                     run_id=run_id,
@@ -1108,7 +1108,8 @@ class ManagedRuntimeLauncher:
                     cwd=resolved_workspace_path,
                 )
         except Exception:
-            self._log_streamer.consume_annotations(run_id)
+            if self._log_streamer is not None:
+                self._log_streamer.consume_annotations(run_id)
             await self.cleanup_run_support(run_id)
             for path in [*cleanup_paths, *deferred_cleanup_paths]:
                 try:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -693,6 +693,39 @@ class ManagedRuntimeLauncher:
 
         return cmd
 
+    def _apply_runtime_command_rendering(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        strategy: Any,
+    ) -> None:
+        if strategy is None or not hasattr(strategy, "render_runtime_command"):
+            return
+        result = strategy.render_runtime_command(request)
+        if result.diagnostics:
+            redactor = SecretRedactor.from_environ()
+            result.diagnostics = {
+                str(key): redactor.scrub(str(value))
+                for key, value in result.diagnostics.items()
+            }
+        metadata = request.parameters.setdefault("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+            request.parameters["metadata"] = metadata
+        moonmind_metadata = metadata.setdefault("moonmind", {})
+        if not isinstance(moonmind_metadata, dict):
+            moonmind_metadata = {}
+            metadata["moonmind"] = moonmind_metadata
+        moonmind_metadata["runtimeCommandRender"] = result.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
+        if result.status == "failed":
+            reason = result.failure_reason or "runtime_command_render_failed"
+            raise RuntimeError(reason)
+        if result.rendered_instruction is not None:
+            request.instruction_ref = result.rendered_instruction
+
     async def _project_run_skill_snapshot(
         self,
         *,
@@ -916,6 +949,12 @@ class ManagedRuntimeLauncher:
                     ).lower(),
                     "reason": "skill_projection",
                 },
+            )
+
+        if strategy is not None:
+            self._apply_runtime_command_rendering(
+                request=request,
+                strategy=strategy,
             )
 
         cmd = self.build_command(profile, request, strategy=strategy)

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -720,7 +720,7 @@ class ManagedRuntimeLauncher:
             by_alias=True,
             exclude_none=True,
         )
-        if result.status == "failed":
+        if result.status in {"failed", "unsupported"}:
             reason = result.failure_reason or "runtime_command_render_failed"
             raise RuntimeError(reason)
         if result.rendered_instruction is not None:

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -87,6 +87,16 @@ class ManagedRuntimeStrategy(ABC):
 
         return False
 
+    def supports_native_command_transport(self) -> bool:
+        """Whether this runtime can receive a structured command payload."""
+
+        return False
+
+    def materialized_command_allowlist(self) -> Mapping[str, Mapping[str, str]]:
+        """Runtime-owned allowlist for known command materialization targets."""
+
+        return {}
+
     def render_runtime_command(self, request: Any) -> RuntimeCommandRenderResult:
         """Render final instruction text after MoonMind context preparation."""
 
@@ -113,6 +123,10 @@ class ManagedRuntimeStrategy(ABC):
                 failureReason="runtime_command_render_failed",
                 diagnostics={"message": "Invalid runtime command metadata."},
             )
+        if command.render_mode == "native_command":
+            return self._render_native_runtime_command(instruction, command)
+        if command.render_mode == "materialized_command":
+            return self._render_materialized_runtime_command(instruction, command)
         if command.recognition_mode == "escaped_literal" or not command.requires_runtime_recognition:
             literal = command.instruction_body or instruction
             prepared = self._prepared_context_after_runtime_command(
@@ -153,6 +167,88 @@ class ManagedRuntimeStrategy(ABC):
             status="ok",
             renderMode="prompt_prefix",
             renderedInstruction=rendered,
+            invocation=command,
+        )
+
+    def _render_native_runtime_command(
+        self,
+        instruction: str,
+        command: RuntimeCommandInvocation,
+    ) -> RuntimeCommandRenderResult:
+        if not self.supports_native_command_transport():
+            return RuntimeCommandRenderResult(
+                status="unsupported",
+                renderMode="unsupported",
+                renderedInstruction=instruction,
+                failureReason="runtime_command_render_failed",
+                diagnostics={
+                    "message": "Runtime does not support native command transport."
+                },
+                invocation=command,
+            )
+        prepared = self._prepared_context_after_runtime_command(instruction, command)
+        return RuntimeCommandRenderResult(
+            status="ok",
+            renderMode="native_command",
+            nativeCommandPayload={
+                "type": "runtime.command",
+                "command": command.command,
+                "args": command.args,
+                "rawCommand": command.raw_command,
+                "instructionBody": command.instruction_body,
+                "preparedContext": prepared,
+            },
+            invocation=command,
+        )
+
+    def _render_materialized_runtime_command(
+        self,
+        instruction: str,
+        command: RuntimeCommandInvocation,
+    ) -> RuntimeCommandRenderResult:
+        allowlist = self.materialized_command_allowlist()
+        target = allowlist.get(command.command)
+        materialized_command = command.materialized_command or {}
+        if command.hint_status != "hinted" or target is None:
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={
+                    "message": "Command is not allowlisted for materialized rendering."
+                },
+                invocation=command,
+            )
+        target_path = str(target.get("path") or "")
+        invocation = str(target.get("invocation") or "")
+        requested_path = str(materialized_command.get("path") or target_path)
+        requested_invocation = str(
+            materialized_command.get("invocation") or invocation
+        )
+        if requested_path != target_path or requested_invocation != invocation:
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={
+                    "message": "Materialized command target is outside the allowlist."
+                },
+                invocation=command,
+            )
+        prepared = self._prepared_context_after_runtime_command(instruction, command)
+        return RuntimeCommandRenderResult(
+            status="ok",
+            renderMode="materialized_command",
+            renderedInstruction=self._join_instruction_parts(
+                invocation,
+                command.instruction_body,
+                prepared,
+            ),
+            materializedTargets=[
+                {
+                    "path": target_path,
+                    "command": command.command,
+                    "invocation": invocation,
+                }
+            ],
             invocation=command,
         )
 

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -14,9 +14,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
 
+from pydantic import ValidationError
+
 from moonmind.schemas.agent_runtime_models import (
     AgentRunState,
     FailureClass as RuntimeFailureClass,
+    RuntimeCommandInvocation,
+    RuntimeCommandRenderResult,
 )
 from moonmind.workflows.temporal.runtime.output_parser import (
     ParsedOutput,
@@ -77,6 +81,114 @@ class ManagedRuntimeStrategy(ABC):
         in the interface definition.  Concrete implementations import
         the specific types they need.
         """
+
+    def supports_slash_passthrough(self) -> bool:
+        """Whether this runtime supports slash-leading command pass-through."""
+
+        return False
+
+    def render_runtime_command(self, request: Any) -> RuntimeCommandRenderResult:
+        """Render final instruction text after MoonMind context preparation."""
+
+        command = getattr(request, "runtime_command", None)
+        instruction = getattr(request, "instruction_ref", None) or ""
+        if command is None:
+            return RuntimeCommandRenderResult(
+                status="ok",
+                renderMode="plain_prompt",
+                renderedInstruction=instruction,
+            )
+        if isinstance(command, dict):
+            try:
+                command = RuntimeCommandInvocation.model_validate(command)
+            except ValidationError:
+                return RuntimeCommandRenderResult(
+                    status="failed",
+                    failureReason="runtime_command_render_failed",
+                    diagnostics={"message": "Invalid runtime command metadata."},
+                )
+        if not isinstance(command, RuntimeCommandInvocation):
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={"message": "Invalid runtime command metadata."},
+            )
+        if command.recognition_mode == "escaped_literal" or not command.requires_runtime_recognition:
+            literal = command.instruction_body or instruction
+            prepared = self._prepared_context_after_runtime_command(
+                instruction,
+                command,
+            )
+            rendered = self._render_literal_runtime_command(
+                literal=literal,
+                prepared_context=prepared,
+            )
+            return RuntimeCommandRenderResult(
+                status="ok",
+                renderMode="plain_prompt",
+                renderedInstruction=rendered,
+                invocation=command,
+            )
+        if not self.supports_slash_passthrough():
+            return RuntimeCommandRenderResult(
+                status="fallback",
+                renderMode="plain_prompt",
+                renderedInstruction=instruction,
+                fallbackEvent={
+                    "reason": "unsupported_runtime",
+                    "fallbackMode": "literal_prompt",
+                },
+                invocation=command,
+            )
+        raw_command = command.raw_command or (
+            f"/{command.command}{(' ' + command.args) if command.args else ''}"
+        )
+        prepared = self._prepared_context_after_runtime_command(instruction, command)
+        rendered = self._join_instruction_parts(
+            raw_command,
+            command.instruction_body,
+            prepared,
+        )
+        return RuntimeCommandRenderResult(
+            status="ok",
+            renderMode="prompt_prefix",
+            renderedInstruction=rendered,
+            invocation=command,
+        )
+
+    @staticmethod
+    def _join_instruction_parts(*parts: str | None) -> str:
+        return "\n\n".join(
+            str(part).strip() for part in parts if str(part or "").strip()
+        )
+
+    def _render_literal_runtime_command(
+        self,
+        *,
+        literal: str,
+        prepared_context: str,
+    ) -> str:
+        return self._join_instruction_parts(
+            "Literal runtime command text:",
+            literal,
+            prepared_context,
+        )
+
+    def _prepared_context_after_runtime_command(
+        self,
+        instruction: str,
+        command: RuntimeCommandInvocation,
+    ) -> str:
+        prepared = instruction or ""
+        raw_parts = [command.raw_command]
+        if command.instruction_body:
+            raw_parts.append(command.instruction_body)
+        raw_instruction = "\n".join(part for part in raw_parts if part)
+        for candidate in (raw_instruction, command.instruction_body):
+            if candidate and candidate in prepared:
+                prepared = prepared.replace(candidate, "", 1)
+                break
+        return prepared.strip()
 
     def get_model(self, profile: Any, request: Any) -> str | None:
         """Extract model from request parameters or profile default with overrides.

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -154,9 +154,19 @@ class ManagedRuntimeStrategy(ABC):
                 },
                 invocation=command,
             )
-        raw_command = command.raw_command or (
-            f"/{command.command}{(' ' + command.args) if command.args else ''}"
-        )
+        raw_command = self._runtime_command_text(command)
+        if raw_command is None:
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={
+                    "message": (
+                        "Runtime command metadata must include a non-empty "
+                        "rawCommand or command."
+                    )
+                },
+                invocation=command,
+            )
         prepared = self._prepared_context_after_runtime_command(instruction, command)
         rendered = self._join_instruction_parts(
             raw_command,
@@ -270,6 +280,17 @@ class ManagedRuntimeStrategy(ABC):
             prepared_context,
         )
 
+    @staticmethod
+    def _runtime_command_text(command: RuntimeCommandInvocation) -> str | None:
+        raw_command = command.raw_command.strip()
+        if raw_command:
+            return raw_command
+        command_name = command.command.strip()
+        if not command_name:
+            return None
+        args = command.args.strip()
+        return f"/{command_name}{(' ' + args) if args else ''}"
+
     def _prepared_context_after_runtime_command(
         self,
         instruction: str,
@@ -281,9 +302,15 @@ class ManagedRuntimeStrategy(ABC):
             raw_parts.append(command.instruction_body)
         raw_instruction = "\n".join(part for part in raw_parts if part)
         for candidate in (raw_instruction, command.instruction_body):
-            if candidate and candidate in prepared:
-                prepared = prepared.replace(candidate, "", 1)
-                break
+            candidate = str(candidate or "").strip()
+            if not candidate:
+                continue
+            if prepared == candidate:
+                return ""
+            for separator in ("\n\n", "\n"):
+                prefix = f"{candidate}{separator}"
+                if prepared.startswith(prefix):
+                    return prepared[len(prefix) :].strip()
         return prepared.strip()
 
     def get_model(self, profile: Any, request: Any) -> str | None:

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -29,6 +29,14 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     def supports_slash_passthrough(self) -> bool:
         return True
 
+    def materialized_command_allowlist(self) -> dict[str, dict[str, str]]:
+        return {
+            "review": {
+                "path": ".claude/commands/review.md",
+                "invocation": "/project:review",
+            }
+        }
+
     def build_command(
         self,
         profile: Any,

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -26,6 +26,9 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     def default_command_template(self) -> list[str]:
         return ["claude"]
 
+    def supports_slash_passthrough(self) -> bool:
+        return True
+
     def build_command(
         self,
         profile: Any,

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -129,6 +129,9 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             return _CODEX_PROGRESS_TIMEOUT_SECONDS
         return min(normalized_timeout, _CODEX_PROGRESS_TIMEOUT_SECONDS)
 
+    def supports_slash_passthrough(self) -> bool:
+        return True
+
     def build_command(
         self,
         profile: Any,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5701,6 +5701,8 @@ class MoonMindRunWorkflow:
             idempotency_key=idempotency_key,
             instruction_ref=node_inputs.get("instructions")
             or node_inputs.get("instructionRef"),
+            runtime_command=node_inputs.get("runtimeCommand")
+            or node_inputs.get("runtime_command"),
             resolved_skillset_ref=resolved_skillset_ref,
             input_refs=input_refs,
             workspace_spec=workspace_spec,

--- a/specs/356-runtime-command-rendering/checklists/requirements.md
+++ b/specs/356-runtime-command-rendering/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Runtime Command Rendering After Context Preparation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The specification preserves the trusted `MM-686` Jira preset brief in `spec.md` and maps all in-scope source design requirements to functional requirements.
+- PASS: Runtime names such as Codex CLI and Claude Code are product/runtime targets from the source brief, not implementation instructions.

--- a/specs/356-runtime-command-rendering/contracts/runtime-command-rendering.md
+++ b/specs/356-runtime-command-rendering/contracts/runtime-command-rendering.md
@@ -1,0 +1,110 @@
+# Runtime Command Rendering Contract
+
+## Scope
+
+This contract defines the managed-runtime boundary for MM-686. It is consumed by runtime strategies and the launcher after task input normalization and after context preparation.
+
+## Inputs
+
+A runtime renderer receives:
+
+```yaml
+runtimeId: codex_cli | claude_code | <future-runtime>
+rawInstructions: string
+runtimeCommand: RuntimeCommandInvocation | null
+instructionBody: string
+preparedContext:
+  retrievalContext: string | null
+  skillActivationSummary: string | null
+  managedRuntimeNotes: string | null
+  otherPreparedContext: string | null
+runtimeCapability:
+  slashCommandPassthrough: boolean
+  supportedRenderModes: [plain_prompt, prompt_prefix, native_command, materialized_command]
+  materializedCommandAllowlist: [string]
+  literalFallbackPolicy: reject | literal_prompt_allowed
+```
+
+Rules:
+- `runtimeCommand` is backend-normalized metadata, not frontend-supplied truth.
+- `command`, `args`, `rawCommand`, and `instructionBody` are untrusted authored text.
+- `preparedContext` is MoonMind-owned launch context and must not precede command text that requires first-position recognition.
+
+## Outcomes
+
+The renderer returns one of the following outcomes:
+
+```yaml
+status: ok
+renderMode: prompt_prefix
+renderedInstruction: |
+  /review
+
+  <instruction body>
+
+  <prepared context>
+```
+
+```yaml
+status: ok
+renderMode: plain_prompt
+renderedInstruction: string
+```
+
+```yaml
+status: ok
+renderMode: native_command
+nativeCommandPayload:
+  command: string
+  args: string
+  instructionBody: string
+  preparedContext: string
+```
+
+```yaml
+status: ok
+renderMode: materialized_command
+renderedInstruction: string
+materializedTargets:
+  - path: string
+    command: string
+```
+
+```yaml
+status: failed
+failureReason: runtime_command_render_failed
+diagnostics:
+  message: string
+```
+
+```yaml
+status: fallback
+renderMode: plain_prompt
+fallbackEvent:
+  reason: renderer_failed | unsupported_runtime
+  fallbackMode: literal_prompt
+renderedInstruction: string
+```
+
+## Required Behavior
+
+- Prompt-prefix output for `/review` starts with `/review` as the first runtime-visible text.
+- Prompt-prefix output appends instruction body before prepared context.
+- Retrieval context, skill summaries, and runtime notes never appear before the slash command when first-position recognition is required.
+- Unknown valid commands remain slash-leading for slash-capable runtimes.
+- Unknown valid commands are never materialized into files.
+- Escaped literal slash commands render as literal text through a non-command prefix, quote block, or runtime-specific literal wrapper.
+- Renderer failures stop launch unless an explicit policy-approved fallback event is returned.
+- Diagnostics and fallback events are redacted and do not expose secrets.
+
+## Test Matrix
+
+| Case | Runtime | Expected outcome |
+| --- | --- | --- |
+| `/review` with retrieval context | Codex CLI | prompt-prefix starts with `/review`; context follows body |
+| `/review` with skill summary and managed notes | Codex CLI | command remains first; summaries and notes follow |
+| `/review` with retrieval context | Claude Code | prompt-prefix starts with `/review`; context follows body |
+| `/future-command` without hint | Codex CLI or Claude Code | opaque prompt-prefix/native pass-through; no warning due to missing hint |
+| `\/review` escaped literal | Codex CLI or Claude Code | literal render; runtime does not execute `/review` |
+| unknown command with materialized mode requested | Any | failed outcome before file write |
+| renderer exception | Any | `runtime_command_render_failed` or approved fallback event before launch |

--- a/specs/356-runtime-command-rendering/data-model.md
+++ b/specs/356-runtime-command-rendering/data-model.md
@@ -1,0 +1,93 @@
+# Data Model: Runtime Command Rendering After Context Preparation
+
+## Runtime Command Invocation
+
+Represents the backend-normalized command metadata derived from authored instructions.
+
+Fields:
+- `kind`: fixed value for slash-command invocations.
+- `source`: how the invocation was detected, such as leading slash.
+- `sourcePath`: task field path where the authored command originated.
+- `targetRuntime`: selected runtime ID at submit time.
+- `targetStepId`: optional step identifier for step-level commands.
+- `command`: normalized command token, empty for escaped or malformed literals.
+- `rawCommand`: first authored command line exactly as preserved for audit.
+- `args`: command arguments when the grammar supports them.
+- `instructionBody`: authored body after the command line, or literal instruction body for escaped/malformed cases.
+- `detectionStatus`: detected, escaped, malformed, or equivalent normalized status.
+- `hintStatus`: hinted or opaque.
+- `recognitionMode`: runtime pass-through, hinted pass-through, escaped literal, unsupported runtime, or equivalent mode.
+- `requiresRuntimeRecognition`: whether the runtime must see a command in recognition position.
+- `runtimeCapabilityVersion`: capability metadata version used when detected.
+- `hintCatalogVersion`: hint metadata version used when detected.
+- `detectionPhase`: submit for backend normalization.
+
+Validation rules:
+- Command names, args, and bodies are untrusted authored text.
+- Unknown valid commands may be opaque but must remain valid for pass-through runtimes.
+- Escaped and malformed commands must not require runtime recognition.
+- Runtime launch must not trust frontend-supplied metadata without backend normalization.
+
+## Prepared Runtime Context
+
+Represents MoonMind-added context assembled after task submission and before process launch.
+
+Fields:
+- `instructionBody`: user-authored instruction body after command parsing.
+- `retrievalContext`: optional retrieved context text or reference produced during workspace preparation.
+- `skillActivationSummary`: optional active skill summary projected into runtime instructions.
+- `managedRuntimeNotes`: runtime-specific operational notes added by MoonMind.
+- `otherPreparedContext`: any future MoonMind-owned runtime prepended/appended context.
+
+Validation rules:
+- For prompt-prefix commands, prepared context must appear after command and instruction body.
+- Prepared context must not be interpreted as trusted instructions when source wrappers classify it as retrieved or system-owned reference data.
+- Empty context components must not alter command placement.
+
+## Runtime Render Outcome
+
+Represents the runtime strategy's final rendering decision before process launch or turn submission.
+
+Fields:
+- `status`: ok, unsupported, failed, or fallback.
+- `renderMode`: plain_prompt, prompt_prefix, native_command, materialized_command, or unsupported.
+- `renderedInstruction`: final runtime-visible instruction text when text transport is used.
+- `nativeCommandPayload`: optional structured runtime command payload for runtimes with native command transport.
+- `materializedTargets`: allowlisted files or artifacts produced by known-command materialization.
+- `failureReason`: typed failure reason such as runtime_command_render_failed.
+- `fallbackEvent`: auditable fallback metadata when policy permits literal fallback.
+- `diagnostics`: redacted operator-facing render diagnostics.
+
+Validation rules:
+- Failure outcomes stop launch unless an explicit fallback event is present and policy permits it.
+- Diagnostics must not expose secrets.
+- Unknown commands cannot produce materialized targets.
+- Prompt-prefix outcomes must start with the slash command for recognition-required invocations.
+
+## Runtime Capability
+
+Represents declarative runtime support for slash-command rendering.
+
+Fields:
+- `runtimeId`: canonical runtime identifier.
+- `slashCommandPassthrough`: whether opaque slash commands can pass through.
+- `supportedRenderModes`: render modes supported by this runtime.
+- `materializedCommandAllowlist`: optional known-command materialization capabilities.
+- `literalFallbackPolicy`: whether literal fallback is allowed for unsupported or failed rendering.
+- `capabilityVersion`: version used for audit and rerun explanation.
+
+Validation rules:
+- Capability data is runtime-level, not a per-command blocking allowlist.
+- Future runtimes can opt into supported modes without changing Create page behavior.
+- Unsupported values fail explicitly rather than silently changing command semantics.
+
+## State Transitions
+
+```text
+authored instructions
+  -> backend-normalized Runtime Command Invocation
+  -> workspace/context preparation mutates prepared context
+  -> runtime strategy produces Runtime Render Outcome
+  -> launcher starts process only when outcome is ok or approved fallback
+  -> diagnostics/history preserve render mode, failures, and MM-686 traceability
+```

--- a/specs/356-runtime-command-rendering/implementation-notes.md
+++ b/specs/356-runtime-command-rendering/implementation-notes.md
@@ -1,0 +1,60 @@
+# Implementation Notes: Runtime Command Rendering After Context Preparation
+
+Jira issue: MM-686
+
+This implementation preserves the original Jira preset brief in `spec.md` and
+adds the managed-runtime render boundary described by the MoonSpec artifacts.
+
+Original Jira preset brief summary: MM-686 requires managed runtime adapters to
+render runtime slash commands after MoonMind prepares retrieval context, skill
+activation summaries, and managed runtime notes, while keeping supported
+commands first in the runtime-visible input.
+
+## TDD Evidence
+
+- Red-first unit command:
+  `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py`
+- Red-first unit result:
+  failed before production changes because `RuntimeCommandInvocation` and
+  `RuntimeCommandRenderResult` were not available.
+- Red-first integration command:
+  `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short`
+- Red-first integration result:
+  failed before production changes because runtime command render metadata was
+  not available to the launcher path.
+
+## Passing Evidence
+
+- Targeted unit command:
+  `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
+- Targeted unit result:
+  `281 passed, 2 subtests passed`; frontend runner also passed with
+  `21 passed` test files and `351 passed | 229 skipped` tests.
+- Targeted integration command:
+  `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short`
+- Targeted integration result:
+  `8 passed`.
+- Full unit command:
+  `./tools/test_unit.sh`
+- Full unit result:
+  Python `5087 passed, 1 xpassed, 120 warnings, 16 subtests passed`;
+  frontend `21 passed` test files and `351 passed | 229 skipped` tests.
+
+## Integration Blocker
+
+- Full hermetic integration command:
+  `./tools/test_integration.sh`
+- Result:
+  blocked by the local Docker environment. The runner attempted to use Docker
+  Compose and the daemon returned `403 Forbidden` with the message
+  `Request forbidden by administrative rules`.
+
+## Scope Notes
+
+- The story remains limited to final managed-runtime command rendering after
+  context preparation.
+- Unknown opaque slash commands are passed through for slash-capable runtimes
+  and are not materialized.
+- Escaped slash literals render through a non-command literal wrapper.
+- Unsupported runtimes receive an audited literal fallback event.
+- Render diagnostics are redacted before being stored in runtime metadata.

--- a/specs/356-runtime-command-rendering/implementation-notes.md
+++ b/specs/356-runtime-command-rendering/implementation-notes.md
@@ -58,3 +58,23 @@ commands first in the runtime-visible input.
 - Escaped slash literals render through a non-command literal wrapper.
 - Unsupported runtimes receive an audited literal fallback event.
 - Render diagnostics are redacted before being stored in runtime metadata.
+
+## Remediation Evidence
+
+- Remediation source: `specs/356-runtime-command-rendering/moonspec_verify_report.md`
+  verdict `ADDITIONAL_WORK_NEEDED`.
+- Implemented bounded remediation for structured native command render outcomes,
+  Claude known-command materialized allowlist rendering, and opaque-command
+  materialization rejection.
+- Focused unit command:
+  `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
+- Focused unit result:
+  `285 passed, 2 subtests passed`; frontend runner also passed with
+  `21 passed` test files and `351 passed | 229 skipped` tests.
+- Focused integration command:
+  `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short`
+- Focused integration result:
+  `9 passed`.
+- Full hermetic integration remains blocked in this managed environment by
+  Docker daemon policy: `403 Forbidden` / `Request forbidden by administrative
+  rules`.

--- a/specs/356-runtime-command-rendering/moonspec_align_report.md
+++ b/specs/356-runtime-command-rendering/moonspec_align_report.md
@@ -1,0 +1,20 @@
+# MoonSpec Alignment Report: Runtime Command Rendering After Context Preparation
+
+**Source**: `MM-686` canonical Jira preset brief preserved in `spec.md`
+**Date**: 2026-05-15
+
+## Findings And Remediation
+
+- Aligned `plan.md` documentation structure now that `tasks.md` exists and added the unit test files introduced by the task breakdown.
+- Aligned `quickstart.md` unit validation commands with the generated task list and final `/moonspec-verify` wording.
+- Fixed a malformed TDD note in `tasks.md` without changing task scope or ordering.
+
+## Gate Recheck
+
+- Specify gate: PASS. `spec.md` contains one story, preserves `MM-686`, and has no clarification markers.
+- Plan gate: PASS. `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/runtime-command-rendering.md` exist with explicit unit and integration strategies.
+- Tasks gate: PASS. `tasks.md` contains one story phase, sequential tasks, red-first unit and integration tests, implementation tasks, story validation, and final `/moonspec-verify`.
+
+## Remaining Risks
+
+- No application code was evaluated or changed during alignment. Runtime behavior remains to be implemented and verified by the task list.

--- a/specs/356-runtime-command-rendering/moonspec_verify_report.md
+++ b/specs/356-runtime-command-rendering/moonspec_verify_report.md
@@ -1,0 +1,90 @@
+# MoonSpec Verification Report
+
+**Feature**: Runtime Command Rendering After Context Preparation  
+**Spec**: `/work/agent_jobs/mm:03ecc585-89e8-4589-8bdf-05bc41f57e4a/repo/specs/356-runtime-command-rendering/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving Jira issue `MM-686`  
+**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Targeted unit | `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` | PASS | `281 passed, 2 subtests passed`; frontend runner `21 passed`, `351 passed | 229 skipped`. |
+| Targeted integration | `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short` | PASS | `8 passed`. |
+| Full unit | `./tools/test_unit.sh` | PASS | Recorded in implementation notes: Python `5087 passed, 1 xpassed`; frontend `21 passed`. No code changes occurred after that full run before verification. |
+| Full integration | `./tools/test_integration.sh` | FAIL | Docker daemon returned `403 Forbidden` / `Request forbidden by administrative rules`; required hermetic integration suite is not verified in this environment. |
+| Diff hygiene | `git diff --check` | PASS | No whitespace errors. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `launcher.py` calls render after skill projection and before `build_command()`; targeted integration covers Codex/Claude context order. | VERIFIED | `moonmind/workflows/temporal/runtime/launcher.py:954`. |
+| FR-002 | `RuntimeCommandRenderResult` models all modes; strategy boundary exists. | PARTIAL | No production renderer produces native command or materialized command outcomes yet. |
+| FR-003 | Base renderer joins command, body, prepared context; strategy tests assert ordering. | VERIFIED | `base.py:143`, `test_remaining_strategies.py:207`. |
+| FR-004 | Escaped/non-recognition commands render through literal wrapper. | VERIFIED | `base.py:116`, `test_remaining_strategies.py:262`. |
+| FR-005 | Final renderer is invoked after preparation and before process launch. | VERIFIED | `launcher.py:954`, integration tests lines 116-301. |
+| FR-006 | Failed render results raise before launch; unsupported runtimes record fallback event. | VERIFIED | `launcher.py:723`, `base.py:132`, tests in launcher and strategy files. |
+| FR-007 | Codex CLI and Claude Code opt into slash passthrough. | VERIFIED | `codex_cli.py:132`, `claude_code.py:29`. |
+| FR-008 | Unknown opaque command remains slash-leading for slash-capable runtime. | VERIFIED | `test_remaining_strategies.py:241`, integration test lines 304-386. |
+| FR-009 | Unknown command materialized targets remain empty. | VERIFIED | `base.py:152`, integration test line 386. |
+| FR-010 | Escaped slash literals do not start with executable `/review`. | VERIFIED | `test_remaining_strategies.py:262`. |
+| FR-011 | Typed `runtime_command_render_failed` is surfaced before launch. | VERIFIED | `base.py:101`, `launcher.py:723`, integration test lines 389-410. |
+| FR-012 | Renderer treats command fields as text and only renders prompt strings. | VERIFIED | No shell construction uses command names or args; rendered prompt assembled in `base.py:143`. |
+| FR-013 | Render diagnostics are redacted before metadata storage. | VERIFIED | `launcher.py:705`, `test_launcher.py:142`. |
+| FR-014 | Backend hint tests preserve opaque pass-through; runtime consumes opaque metadata. | VERIFIED | `tests/unit/workflows/tasks/test_task_contract.py`, `test_remaining_strategies.py:241`. |
+| FR-015 | Targeted integration proves retrieved context follows command/body for Codex and Claude. | VERIFIED | `test_managed_session_retrieval_context.py:116`, `:210`. |
+| FR-016 | Jira key and brief are preserved in spec, implementation notes, and this report. | PARTIAL | Commit text and PR metadata are future steps; some design artifacts reference `MM-686` but not the full original brief. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| SCN-001 | Codex integration capture asserts `/review` before body and retrieved context. | VERIFIED | `test_managed_session_retrieval_context.py:116`. |
+| SCN-002 | Codex/Claude strategy and integration tests cover prompt-prefix without Create-page markup. | VERIFIED | `test_remaining_strategies.py:207`, `:226`. |
+| SCN-003 | Unknown valid command remains prompt-prefix and unmaterialized. | VERIFIED | `test_managed_session_retrieval_context.py:304`. |
+| SCN-004 / SC-006 | Unknown commands are not materialized. | PARTIAL | Known-command allowlisted materialized command mode is not implemented or tested. |
+| SCN-005 | Escaped slash literal wrapper covered. | VERIFIED | `test_remaining_strategies.py:262`. |
+| SCN-006 | Render failure prevents launch. | VERIFIED | `test_managed_session_retrieval_context.py:389`. |
+| SC-001 through SC-005 | Unit and targeted integration evidence. | VERIFIED | Focused suites pass. |
+| SC-007 | Traceability preserved in this report. | PARTIAL | Future commit/PR metadata still pending. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-006 | Schema includes render mode enum; base renders plain/prompt-prefix/fallback/failure. | PARTIAL | Native and materialized output paths are modeled but not behaviorally implemented. |
+| DESIGN-REQ-011 | Launcher order matches source design pipeline. | VERIFIED | `launcher.py:954`. |
+| DESIGN-REQ-012 | Strategy-owned render boundary exists. | VERIFIED | `base.py:90`. |
+| DESIGN-REQ-013 | Codex/Claude prompt-prefix covered. | VERIFIED | Tests and passthrough strategy methods. |
+| DESIGN-REQ-016 | Opaque unknown commands pass through and do not materialize. | VERIFIED | Unit and integration coverage. |
+| DESIGN-REQ-017 | Escaped literal commands render non-executable. | VERIFIED | Unit coverage. |
+| DESIGN-REQ-018 | Diagnostics redaction and untrusted text handling covered. | VERIFIED | `launcher.py:705`, `test_launcher.py:142`. |
+| DESIGN-REQ-019 | Failure and ordering tests exist, but full integration runner is blocked. | PARTIAL | Required hermetic integration suite did not complete. |
+| Constitution XI | Spec, plan, tasks, tests, and implementation notes exist. | VERIFIED | MoonSpec artifacts are present. |
+| Constitution IX | Runtime failure is explicit before launch. | VERIFIED | `runtime_command_render_failed` path. |
+
+## Original Request Alignment
+
+- The implemented boundary aligns with MM-686's main request: render slash commands after context preparation for managed runtime adapters and keep supported command text first.
+- The documented broader outcome set is not fully implemented because no native command transport or known-command materialized allowlist renderer exists.
+
+## Gaps
+
+- Native command and known-command materialized command outcomes are modeled but not implemented by any production runtime strategy.
+- Known-command materialized allowlist behavior is not tested; current tests only prove unknown commands are not materialized.
+- The required full hermetic integration suite could not run because Docker daemon access is blocked by administrative policy.
+- Final traceability cannot cover commit text or PR metadata until later publishing steps exist.
+
+## Remaining Work
+
+- Implement or explicitly descope native command and materialized command outcomes for this story, then update spec/contracts/tasks accordingly.
+- Add tests for known-command materialized allowlist behavior if materialized mode remains in scope.
+- Re-run `./tools/test_integration.sh` in an environment where Docker Compose/buildx can access the daemon.
+- Re-run MoonSpec verification after remediation; do not create a PR until the post-remediation verdict is `FULLY_IMPLEMENTED`.
+
+## Decision
+
+- Do not proceed to PR creation.
+- Use this report as the mandatory remediation input for the next step.

--- a/specs/356-runtime-command-rendering/plan.md
+++ b/specs/356-runtime-command-rendering/plan.md
@@ -94,7 +94,7 @@ specs/356-runtime-command-rendering/
 │   └── runtime-command-rendering.md
 ├── checklists/
 │   └── requirements.md
-└── tasks.md             # Created later by /speckit.tasks
+└── tasks.md
 ```
 
 ### Source Code (repository root)
@@ -117,6 +117,8 @@ moonmind/
 
 tests/
 ├── unit/
+│   ├── schemas/test_agent_runtime_models.py
+│   ├── workflows/temporal/workflows/test_run_agent_dispatch.py
 │   ├── workflows/tasks/test_task_contract.py
 │   ├── workflows/temporal/runtime/strategies/test_remaining_strategies.py
 │   └── services/temporal/runtime/test_launcher.py

--- a/specs/356-runtime-command-rendering/plan.md
+++ b/specs/356-runtime-command-rendering/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Runtime Command Rendering After Context Preparation
+
+**Branch**: `run-jira-orchestrate-for-mm-686-render-r-86f22e9e` | **Date**: 2026-05-15 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/work/agent_jobs/mm:03ecc585-89e8-4589-8bdf-05bc41f57e4a/repo/specs/356-runtime-command-rendering/spec.md`
+
+## Summary
+
+Deliver MM-686 by adding a managed-runtime command rendering boundary that runs after retrieval context injection, skill activation summary projection, and managed runtime note preparation, but before the final Codex CLI or Claude Code command is built. Existing task submission code already derives authoritative runtime command metadata, but managed runtime launch paths currently pass the mutated `instruction_ref` directly to runtimes, so prompt-prefix commands can be displaced by MoonMind-added context. The implementation should add red-first unit tests for render modes and strategy behavior, integration tests for launcher ordering, and code that keeps command recognition first while preserving prepared context and safe failure behavior.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` and `claude_code.py` mutate `request.instruction_ref` during preparation; no final renderer exists. | Add final render step after all context preparation. | unit + integration |
+| FR-002 | missing | `ManagedRuntimeStrategy` has `build_command()` and `prepare_workspace()` only; no render outcome boundary. | Add runtime-owned render contract and outcomes. | unit |
+| FR-003 | missing | Codex and Claude build commands append current `request.instruction_ref`; no prompt-prefix reordering after context injection or skill summary. | Render prompt-prefix command before body and prepared context. | unit + integration |
+| FR-004 | partial | Backend metadata records escaped/malformed literal cases in `moonmind/workflows/tasks/task_contract.py`; runtime launch has no literal render boundary. | Preserve literal outcomes in renderer. | unit |
+| FR-005 | missing | Existing tests verify injected context reaches CLI, but not that it stays after a slash command. | Add order-preserving render and regression tests. | integration |
+| FR-006 | missing | No typed runtime-command render failure or fallback event exists. | Add typed pre-launch failure/fallback handling through launcher-visible result. | unit + integration |
+| FR-007 | missing | Codex and Claude strategies append prompt text but do not render runtime command metadata. | Implement prompt-prefix rendering for both strategies through common contract. | unit + integration |
+| FR-008 | partial | Unknown valid commands are normalized as opaque pass-through in `task_contract.py`; runtime launch does not consume that metadata. | Carry opaque metadata to runtime rendering. | unit + integration |
+| FR-009 | implemented_unverified | No materialized command renderer exists, so unknown commands are not materialized today by absence rather than explicit policy. | Add explicit guard that unknown commands cannot use materialized mode. | unit |
+| FR-010 | partial | Escaped literal metadata exists in `task_contract.py`; launch path does not enforce non-command final rendering. | Add literal wrapper/prefix behavior at render time. | unit + integration |
+| FR-011 | missing | Launcher failure classifications exist generally, but not `runtime_command_render_failed` or fallback event handling. | Add render failure classification and fallback event path. | unit + integration |
+| FR-012 | partial | Submission normalization treats command text as data; runtime renderers do not yet exist. | Keep renderer inputs data-only and avoid shell construction from command fields. | unit |
+| FR-013 | implemented_unverified | Launcher uses `SecretRedactor` and env shaping, but render-specific diagnostics do not exist. | Add tests proving render diagnostics/fallbacks do not expose command-adjacent secrets. | unit |
+| FR-014 | implemented_verified | `task_contract.py` marks unknown valid commands as opaque pass-through instead of rejecting missing hints; tests cover this. | Preserve behavior through runtime render consumption. | final verify + targeted unit regression |
+| FR-015 | missing | Existing retrieval/skill projection tests assert context is injected/prepended, not that final command recognition order is preserved. | Add launcher integration tests for retrieval, skill summaries, and managed notes after command. | integration |
+| FR-016 | implemented_unverified | `spec.md` preserves MM-686 and original brief; later artifacts must keep it. | Preserve traceability in plan, tasks, implementation notes, and final verification. | final verify |
+| SCN-001 | missing | No test for prompt-prefix `/review` with all prepared context after command. | Add red-first launcher integration test and implementation contingency. | integration |
+| SCN-002 | missing | Codex/Claude strategy tests cover basic command building only. | Add strategy render tests for both runtimes without Create page provider markup. | unit |
+| SCN-003 | partial | Unknown command snapshot tests exist, but launch/render tests do not. | Add runtime render tests for opaque unknown commands. | unit + integration |
+| SCN-004 | implemented_unverified | No materialized command mode exists, so allowlist behavior needs explicit contract before future materialization. | Add contract and guard tests. | unit |
+| SCN-005 | partial | Escaped slash metadata exists; final runtime literal handling absent. | Add literal render tests. | unit + integration |
+| SCN-006 | missing | No render-specific failure/fallback event path exists. | Add failure/fallback tests and implementation. | unit + integration |
+| DESIGN-REQ-006 | missing | Runtime render modes are documented but not represented in runtime strategy contracts. | Add render mode model and strategy support. | unit |
+| DESIGN-REQ-011 | missing | Launcher order currently prepares context and skills before command build but lacks final command renderer. | Insert final renderer after all preparation and before process launch. | integration |
+| DESIGN-REQ-012 | missing | Strategy interface lacks render method/result. | Extend strategy boundary. | unit |
+| DESIGN-REQ-013 | missing | Codex/Claude prompt-prefix examples are not implemented. | Implement and test Codex/Claude prompt-prefix rendering. | unit + integration |
+| DESIGN-REQ-016 | partial | Opaque unknown detection exists; render consumption missing. | Preserve opaque pass-through at runtime. | unit + integration |
+| DESIGN-REQ-017 | partial | Escaped literal detection exists; literal runtime wrapping missing. | Add literal render behavior. | unit |
+| DESIGN-REQ-018 | partial | Security principles exist in normalization/launcher, but render boundary has no specific validation. | Add untrusted-text and no-secret render tests. | unit |
+| DESIGN-REQ-019 | missing | Failure and order tests are absent for runtime rendering. | Add failure, unsupported runtime, and ordering coverage. | unit + integration |
+| SC-001 | missing | No Codex/Claude prompt-prefix launch tests exist. | Add 100% scenario coverage for tested runtimes. | unit + integration |
+| SC-002 | missing | Retrieval/skill note tests do not assert order after slash command. | Add combined context-order integration tests. | integration |
+| SC-003 | partial | Snapshot tests cover unknown valid commands; launch/render tests do not. | Add opaque command render coverage. | unit + integration |
+| SC-004 | partial | Snapshot tests cover escaped slash; launch/render tests do not. | Add literal render coverage. | unit + integration |
+| SC-005 | missing | No render failure tests exist. | Add failure and fallback tests. | unit + integration |
+| SC-006 | implemented_unverified | No materialized command support exists; explicit future guard coverage missing. | Add materialization allowlist guard contract/tests. | unit |
+| SC-007 | implemented_unverified | Spec preserves MM-686; downstream artifacts must keep it. | Maintain traceability through tasks and verification. | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, existing managed runtime launcher/strategy stack, existing task contract runtime command metadata  
+**Storage**: No new persistent storage; use existing task input snapshot data, `AgentExecutionRequest` payload fields/parameters, workflow history, and launcher diagnostics  
+**Unit Testing**: pytest via `./tools/test_unit.sh` with targeted Python test paths  
+**Integration Testing**: pytest integration markers via `./tools/test_integration.sh`; targeted local iteration may use `pytest tests/integration/... -m integration_ci` where supported  
+**Target Platform**: Linux managed runtime workers launching Codex CLI, Claude Code, and future managed runtime adapters  
+**Project Type**: Python orchestration/runtime service  
+**Performance Goals**: Rendering adds no extra network calls and performs deterministic string/model transformation before launch; command construction remains negligible relative to process launch  
+**Constraints**: Runtime command metadata must remain compact at workflow boundaries; no raw secrets in rendered diagnostics; unsupported command values fail through explicit runtime policy instead of hidden fallbacks  
+**Scale/Scope**: One runtime story covering final render ordering and outcomes for command-leading task instructions across Codex CLI, Claude Code, and future adapter boundaries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Runtime adapters own command rendering while MoonMind orchestrates final input shape.
+- II. One-Click Agent Deployment: PASS. No new infrastructure or required external services.
+- III. Avoid Vendor Lock-In: PASS. The plan uses a runtime strategy contract with Codex/Claude implementations rather than Create page or launcher special cases.
+- IV. Own Your Data: PASS. Inputs and diagnostics remain in existing MoonMind-owned artifacts/history.
+- V. Skills Are First-Class and Easy to Add: PASS. Skill activation summaries remain context inputs; runtime commands are kept distinct from Agent Skills.
+- VI. Evolving Scaffolds: PASS. Rendering is behind a replaceable adapter boundary with tests.
+- VII. Runtime Configurability: PASS. Runtime capability and policy determine supported render modes.
+- VIII. Modular Architecture: PASS. Changes are scoped to task contract consumption, managed runtime strategy interfaces, launcher boundaries, and tests.
+- IX. Resilient by Default: PASS. Render failures stop before launch or publish an explicit policy-approved fallback event.
+- X. Continuous Improvement: PASS. Failures and fallbacks are observable.
+- XI. Spec-Driven Development: PASS. `spec.md` precedes implementation and this plan preserves requirement traceability.
+- XII. Canonical Docs Separation: PASS. Runtime work is tracked in MoonSpec artifacts; canonical docs are read as source requirements.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility aliases or hidden semantic transforms are planned; unsupported render outcomes fail explicitly.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/356-runtime-command-rendering/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── runtime-command-rendering.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/
+│   └── agent_runtime_models.py
+├── workflows/
+│   ├── tasks/
+│   │   └── task_contract.py
+│   └── temporal/runtime/
+│       ├── launcher.py
+│       └── strategies/
+│           ├── base.py
+│           ├── codex_cli.py
+│           └── claude_code.py
+└── rag/
+    └── context_injection.py
+
+tests/
+├── unit/
+│   ├── workflows/tasks/test_task_contract.py
+│   ├── workflows/temporal/runtime/strategies/test_remaining_strategies.py
+│   └── services/temporal/runtime/test_launcher.py
+└── integration/
+    └── workflows/temporal/test_managed_session_retrieval_context.py
+```
+
+**Structure Decision**: Use the existing Python managed runtime strategy and launcher structure. Runtime command parsing and metadata remain in `task_contract.py`; final rendering belongs at the runtime strategy/launcher boundary after RAG, skill projection, and managed runtime notes are prepared.
+
+## Complexity Tracking
+
+No constitution violations require complexity tracking.

--- a/specs/356-runtime-command-rendering/quickstart.md
+++ b/specs/356-runtime-command-rendering/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: Runtime Command Rendering After Context Preparation
+
+Use Jira issue `MM-686` and the original preset brief preserved in `spec.md` as the source of truth.
+
+## Red-First Unit Tests
+
+1. Add strategy/renderer tests before production changes:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py
+```
+
+Expected before implementation: new tests fail because no final runtime command renderer exists and command builders append the mutated instruction text directly.
+
+2. Cover these unit cases:
+- Codex CLI prompt-prefix render starts with `/review` before body and prepared context.
+- Claude Code prompt-prefix render starts with `/review` before body and prepared context.
+- Unknown valid `/future-command` remains opaque pass-through and is not materialized.
+- Escaped `\/review` renders as literal non-command text.
+- Renderer failure returns `runtime_command_render_failed` or an approved fallback event before launch.
+- Render diagnostics are redacted and command args/body are treated as untrusted text.
+
+## Red-First Integration Tests
+
+1. Add launcher boundary coverage before production changes:
+
+```bash
+./tools/test_integration.sh
+```
+
+For focused local iteration, use the relevant pytest path first, then rerun the integration runner:
+
+```bash
+pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short
+```
+
+Expected before implementation: new integration tests fail because retrieval context, skill summaries, or managed runtime notes can occupy the first prompt position instead of the slash command.
+
+2. Cover these integration cases:
+- Codex CLI launch with `/review`, retrieval context, skill activation summary, and managed runtime notes captures a prompt beginning with `/review`.
+- Claude Code launch with `/review` and retrieval context captures a prompt beginning with `/review`.
+- The same captured prompt places prepared context after the instruction body.
+- A hard render failure prevents subprocess launch.
+
+## Implementation Validation
+
+After production changes:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py
+./tools/test_integration.sh
+```
+
+Final verification should confirm:
+- `MM-686` remains in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`, later tasks, commit text, and pull request metadata.
+- Prompt-prefix commands remain first after all MoonMind-prepared context.
+- Unknown commands remain pass-through for slash-capable runtimes.
+- Escaped literal commands do not execute.
+- Render failures are typed or explicitly represented as approved fallback events.

--- a/specs/356-runtime-command-rendering/quickstart.md
+++ b/specs/356-runtime-command-rendering/quickstart.md
@@ -7,7 +7,7 @@ Use Jira issue `MM-686` and the original preset brief preserved in `spec.md` as 
 1. Add strategy/renderer tests before production changes:
 
 ```bash
-./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py
+./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py
 ```
 
 Expected before implementation: new tests fail because no final runtime command renderer exists and command builders append the mutated instruction text directly.
@@ -47,13 +47,14 @@ Expected before implementation: new integration tests fail because retrieval con
 After production changes:
 
 ```bash
-./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py
+./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py
 ./tools/test_integration.sh
 ```
 
 Final verification should confirm:
-- `MM-686` remains in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`, later tasks, commit text, and pull request metadata.
+- `MM-686` remains in `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`, `tasks.md`, commit text, and pull request metadata.
 - Prompt-prefix commands remain first after all MoonMind-prepared context.
 - Unknown commands remain pass-through for slash-capable runtimes.
 - Escaped literal commands do not execute.
 - Render failures are typed or explicitly represented as approved fallback events.
+- `/moonspec-verify` passes after implementation and required tests pass.

--- a/specs/356-runtime-command-rendering/research.md
+++ b/specs/356-runtime-command-rendering/research.md
@@ -1,0 +1,81 @@
+# Research: Runtime Command Rendering After Context Preparation
+
+## FR-001 / DESIGN-REQ-011: Final Render Ordering
+
+Decision: Missing; add a final render step after retrieval context injection, skill activation summary projection, and managed runtime notes, immediately before command construction/process launch.
+Evidence: `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` mutates `request.instruction_ref` in `prepare_workspace()` with retrieval context and managed notes. `moonmind/workflows/temporal/runtime/launcher.py` then prepends skill activation summary in `_project_run_skill_snapshot()` before calling `build_command()`. No renderer reorders slash commands after these mutations.
+Rationale: Parser-only behavior is insufficient because context and skill summaries can move the command away from the first runtime-visible character.
+Alternatives considered: Rendering during task normalization was rejected because later runtime preparation mutates the prompt. Rendering in the Create page was rejected because provider-specific behavior belongs to runtime adapters.
+Test implications: Unit tests for renderer order plus integration tests through launcher with retrieval and skill projection.
+
+## FR-002 / DESIGN-REQ-012: Runtime-Owned Render Contract
+
+Decision: Missing; extend the managed runtime strategy boundary with a render result model that reports render mode, final instruction text, unsupported state, fallback event, or failure reason.
+Evidence: `ManagedRuntimeStrategy` currently exposes `prepare_workspace()` and `build_command()` but no command render contract. Existing command builders append `request.instruction_ref` directly.
+Rationale: The contract keeps provider-specific command recognition out of Create page and central launcher branching.
+Alternatives considered: Adding launcher-only `if runtime_id` branches was rejected because it violates adapter modularity and would not support future runtimes cleanly.
+Test implications: Unit tests on base/default behavior and Codex/Claude strategy rendering.
+
+## FR-003 / FR-007 / DESIGN-REQ-013: Codex And Claude Prompt Prefix
+
+Decision: Missing; implement prompt-prefix rendering for Codex CLI and Claude Code so `/review` is first, followed by instruction body and prepared context.
+Evidence: `CodexCliStrategy.build_command()` and `ClaudeCodeStrategy.build_command()` append `request.instruction_ref` as the final prompt argument. Existing tests verify prompt passing but not slash-command first-position behavior.
+Rationale: Codex CLI and Claude Code are named in the Jira brief as required runtime targets.
+Alternatives considered: Materializing files for all commands was rejected because unknown commands must pass through as text and materialization is only safe for allowlisted known commands.
+Test implications: Unit strategy tests and launcher integration tests for both runtimes.
+
+## FR-004 / FR-010 / DESIGN-REQ-017: Literal And Escaped Commands
+
+Decision: Partial; escaped and malformed slash text is detected in `task_contract.py`, but runtime rendering must enforce non-executable literal output.
+Evidence: `tests/unit/workflows/tasks/test_task_contract.py` covers escaped slash metadata. No runtime launch test asserts literal slash wrapping/prefixing.
+Rationale: Preserving user intent requires that escaped commands never become executable after final rendering.
+Alternatives considered: Dropping command metadata for escaped input was rejected because audit surfaces need to know why slash text was literal.
+Test implications: Unit renderer tests and one launcher integration check for escaped literal behavior.
+
+## FR-006 / FR-011 / DESIGN-REQ-019: Failure And Fallback
+
+Decision: Missing; renderer failures must fail before launch or emit a policy-approved fallback event.
+Evidence: Launcher has general subprocess and strategy failure handling, but no `runtime_command_render_failed` pre-launch classification or render fallback annotation.
+Rationale: A renderer failure after command detection is user-actionable and must not silently launch with an unsafe prompt shape.
+Alternatives considered: Always falling back to literal prompt was rejected because the spec requires policy-approved fallback only.
+Test implications: Unit tests for render failure outcomes and launcher integration proving subprocess launch is skipped on hard failure.
+
+## FR-008 / FR-009 / DESIGN-REQ-016: Unknown Commands And Materialization Guard
+
+Decision: Partial to implemented_unverified; unknown valid commands are normalized as opaque pass-through, but final runtime rendering must consume that metadata and explicitly prevent unknown materialization.
+Evidence: `task_contract.py` returns `hintStatus = opaque` and `recognitionMode = runtime_passthrough` for unknown valid commands; existing unit tests cover normalization. No runtime renderer consumes these fields.
+Rationale: Unknown commands are valid for slash-capable runtimes and must remain first-class pass-through invocations.
+Alternatives considered: Requiring a known hint before execution was rejected because the source design forbids using hints as a blocking allowlist.
+Test implications: Unit tests for opaque prompt-prefix/native render and materialization guard.
+
+## FR-012 / FR-013 / FR-014 / DESIGN-REQ-018: Security And Trust Boundary
+
+Decision: Partial; existing normalization treats command text as data and launcher redaction exists, but renderer-specific no-secret and untrusted-text tests are needed.
+Evidence: `task_contract.py` validates supplied metadata against backend normalization. `ManagedRuntimeLauncher` imports `SecretRedactor` and shapes environment. Render-specific diagnostics do not exist yet.
+Rationale: The renderer will handle user-authored command text at a launch boundary, so tests must prove no shell construction or secret leakage is introduced.
+Alternatives considered: Trusting known-command hints as executable command definitions was rejected; hints enrich UX and must not authorize arbitrary shell behavior.
+Test implications: Unit security tests for command args/body and redacted failure/fallback diagnostics.
+
+## FR-015 / SC-002: Prepared Context Regression Coverage
+
+Decision: Missing; add coverage that retrieval context, skill activation summaries, and managed runtime notes are all positioned after commands requiring first-position recognition.
+Evidence: `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` proves context injection reaches Claude prompt. `tests/unit/services/temporal/runtime/test_launcher.py` proves skill summary is prepended. Neither proves final slash-command ordering.
+Rationale: This is the highest-risk behavioral gap named by MM-686.
+Alternatives considered: Testing only strategy methods was rejected because ordering depends on launcher sequencing.
+Test implications: Integration tests through `ManagedRuntimeLauncher.launch()` with patched subprocess capture.
+
+## FR-016 / SC-007: Jira Traceability
+
+Decision: Implemented_unverified; `spec.md` preserves MM-686 and the original preset brief, and planning artifacts must preserve it through final verification.
+Evidence: `specs/356-runtime-command-rendering/spec.md` contains `MM-686` in the input, FR-016, and SC-007.
+Rationale: Final verification and PR metadata must be able to compare implementation evidence back to Jira.
+Alternatives considered: Keeping only a local handoff artifact was rejected because committed spec artifacts need durable traceability.
+Test implications: Final MoonSpec verification checks traceability; no runtime test required.
+
+## Test Tooling
+
+Decision: Use pytest through `./tools/test_unit.sh` for unit coverage and `./tools/test_integration.sh` for hermetic integration coverage. Targeted iteration can use focused pytest paths before the final required runners.
+Evidence: Repository instructions define `./tools/test_unit.sh` and `./tools/test_integration.sh` as required runners. Existing runtime tests are pytest-based.
+Rationale: The change touches runtime strategy and launcher boundaries, so both unit and integration tests are required.
+Alternatives considered: Browser or provider verification tests were rejected because this story concerns backend managed runtime launch behavior and must remain hermetic.
+Test implications: Add red-first unit tests before code and at least one `integration_ci`-eligible launcher/runtime boundary test if possible.

--- a/specs/356-runtime-command-rendering/spec.md
+++ b/specs/356-runtime-command-rendering/spec.md
@@ -1,0 +1,181 @@
+# Feature Specification: Runtime Command Rendering After Context Preparation
+
+**Feature Branch**: `356-runtime-command-rendering`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**:
+
+```text
+# MM-686 MoonSpec Orchestration Input
+
+Use the Jira preset brief for MM-686 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Jira Orchestrate always runs as a runtime implementation workflow.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): docs/Steps/SlashCommands.md.
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-686 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-686
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Render runtime commands after context preparation in managed runtime adapters
+- Priority: Medium
+- Labels: `moonmind-workflow-mm-1c30567c-221e-4dc1-bc74-d1248e750656`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira issue fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, `presetInstructions`, or `recommendedPresetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-686 from MM project
+Summary: Render runtime commands after context preparation in managed runtime adapters
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-686 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-686: Render runtime commands after context preparation in managed runtime adapters
+
+Source Reference
+Source Document: docs/Steps/SlashCommands.md
+Source Title: Runtime Slash Commands on Create Task
+Source Sections:
+- Runtime Render Modes
+- Runtime Preparation Pipeline
+- Runtime Strategy Integration
+- Codex CLI rendering
+- Claude Code rendering
+- Failure Modes
+- Security Requirements
+- Testing Strategy
+
+Coverage IDs:
+- DESIGN-REQ-006
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-013
+- DESIGN-REQ-016
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-019
+
+As a managed runtime operator, I want Codex CLI, Claude Code, and future adapters to render slash commands only after MoonMind has prepared context, so runtime command recognition is preserved even when retrieval, skills, and runtime notes are added.
+
+Acceptance Criteria
+- Rendering occurs after retrieval context, skill activation summaries, and managed runtime notes are prepared.
+- Codex CLI prompt-prefix output starts with /review followed by the instruction body and prepared context.
+- Claude Code prompt-prefix output starts with /review and does not require the Create page to know its render mode.
+- Unknown valid commands remain slash-leading in prompt-prefix or generic native-command transports and are never materialized.
+- Materialized command mode writes only allowlisted files for commands with explicit known-command metadata.
+- Escaped literal commands render with a non-command prefix, quote block, or runtime-specific literal wrapper so the runtime does not execute the slash command.
+- Renderer failures produce typed user_error runtime_command_render_failed results or a policy-approved fallback event before launch.
+
+Requirements
+- Introduce an adapter-owned renderer contract that can produce RuntimeCommandRenderResult values.
+- Support plain_prompt, prompt_prefix, native_command, materialized_command, and unsupported outcomes as documented.
+- Ensure MoonMind-added context never precedes a command that requires first-character recognition.
+- Treat command names, args, and bodies as untrusted text and avoid direct shell command construction.
+```
+
+Preserved source Jira preset brief: `MM-686` from the trusted `jira.get_issue` response, reproduced in the `**Input**` field above for downstream verification.
+
+Original brief reference: trusted `jira.get_issue` MCP response for `MM-686` and local handoff `/work/agent_jobs/mm:03ecc585-89e8-4589-8bdf-05bc41f57e4a/artifacts/moonspec-orchestration-input-MM-686.md`.
+Classification: single-story runtime feature request.
+Resume decision: no existing Moon Spec feature directory preserving the `MM-686` runtime rendering brief was found under `specs/`; `Specify` is the first incomplete stage.
+
+## User Story - Preserve Slash Command Recognition At Runtime Launch
+
+**Summary**: As a managed runtime operator, I want slash commands to be rendered only after MoonMind has prepared retrieval context, skill summaries, and runtime notes so that supported runtimes still recognize the command as a command while preserving prepared context.
+
+**Goal**: Managed runtime launches keep the slash command in the runtime-required recognition position after all MoonMind context preparation is complete, while preserving literal-command escapes, safe fallback behavior, and runtime-specific rendering boundaries.
+
+**Independent Test**: Can be fully tested by submitting command-leading tasks for slash-capable runtimes, with retrieval context, skill activation summaries, and managed runtime notes present, then verifying that the final runtime-visible input starts with the command when required and that unsupported, escaped, unknown, materialized, and failure cases produce the documented outcomes before launch.
+
+**Acceptance Scenarios**:
+
+1. **Given** a slash-capable runtime using prompt-prefix command recognition and a task whose authored instructions start with `/review`, **When** MoonMind prepares retrieval context, skill activation summaries, and runtime notes, **Then** the final runtime-visible input starts with `/review`, followed by the instruction body and then prepared context.
+2. **Given** the same prompt-prefix command is launched through Codex CLI or Claude Code, **When** runtime-specific rendering occurs, **Then** the Create page does not need to know that runtime's command markup and the command remains the first runtime-visible text.
+3. **Given** an unknown valid slash command is submitted to a slash-capable runtime, **When** rendering occurs, **Then** the command remains slash-leading through prompt-prefix or native command transport and is not materialized into files.
+4. **Given** a known command supports materialized command mode, **When** rendering requires file materialization, **Then** only allowlisted materialization targets are written and unknown commands are excluded from materialized mode.
+5. **Given** the user escaped a slash-leading command to make it literal, **When** final rendering occurs, **Then** the runtime receives non-command literal instructions through a safe prefix, quote block, or equivalent runtime-specific literal wrapper.
+6. **Given** runtime-specific command rendering fails before launch, **When** policy does not allow silent literal submission, **Then** the launch stops with a typed user-facing runtime command rendering failure or records a policy-approved fallback event before the agent starts.
+
+### Edge Cases
+
+- Retrieval context, skill activation summaries, or managed runtime notes are empty; the renderer still preserves the correct command recognition position.
+- Prepared context is large or multi-part; it is appended after the command and instruction body for prompt-prefix recognition instead of being prepended.
+- The selected runtime does not support slash-command pass-through; rendering follows unsupported-runtime policy without pretending the command executed.
+- An unknown command looks valid but has no local hint; it remains an opaque pass-through command for slash-capable runtimes.
+- A command name, argument, or body contains text that resembles shell syntax; it is treated only as untrusted authored text unless an allowlisted renderer explicitly handles it.
+- A materialized command target is outside the allowlist; rendering fails before launch rather than writing the file.
+
+## Assumptions
+
+- Backend command normalization and Create page preview behavior from the preceding slash-command stories are available as inputs to this runtime rendering story.
+- The story covers managed runtime launch behavior for Codex CLI, Claude Code, and future runtimes with equivalent capability metadata; provider-specific internals remain owned by the runtime adapter boundary.
+- Literal fallback is allowed only when runtime policy explicitly permits it and the event remains auditable.
+
+## Source Design Requirements
+
+| Requirement ID | Source Citation | Requirement Summary | Scope | Mapped Requirement |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-006 | `docs/Steps/SlashCommands.md` lines 437-455, Runtime Render Modes | Runtime rendering must support literal prompt behavior, prompt-prefix command recognition, and structured native command transport as distinct outcomes. | In scope | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-011 | `docs/Steps/SlashCommands.md` lines 616-638, Runtime Preparation Pipeline | Runtime command rendering must happen after context preparation and before the command is passed to the runtime so prepared context cannot move the slash command out of recognition position. | In scope | FR-001, FR-005, FR-006 |
+| DESIGN-REQ-012 | `docs/Steps/SlashCommands.md` lines 639-671, Runtime Strategy Integration | Runtime strategies must own command rendering through a boundary that can report render mode, rendered content, unsupported outcomes, and failure state. | In scope | FR-002, FR-004, FR-011 |
+| DESIGN-REQ-013 | `docs/Steps/SlashCommands.md` lines 672-717, Codex CLI and Claude Code rendering | Codex CLI and Claude Code prompt-prefix rendering must put the slash command before instruction body and prepared context without requiring Create page provider markup. | In scope | FR-003, FR-007 |
+| DESIGN-REQ-016 | `docs/Steps/SlashCommands.md` lines 318-329 and 435-455, Unknown commands and render modes | Unknown valid commands must remain slash-leading for slash-capable runtimes and must not be materialized into command files. | In scope | FR-008, FR-009 |
+| DESIGN-REQ-017 | `docs/Steps/SlashCommands.md` lines 336-370 and 437-448, Escaped and literal slash text | Escaped slash-leading text must render as literal instructions and must not leave an executable command at the first runtime-visible position. | In scope | FR-010 |
+| DESIGN-REQ-018 | `docs/Steps/SlashCommands.md` lines 779-790, Security Requirements | Rendering must not expose secrets, must treat user command text as untrusted, must keep backend validation authoritative, and must not use hints as a blocking allowlist. | In scope | FR-012, FR-013, FR-014 |
+| DESIGN-REQ-019 | `docs/Steps/SlashCommands.md` lines 792-859 and 861-946, Failure Modes and Testing Strategy | Renderer failures, unsupported runtimes, context-order regressions, and runtime-specific prompt-prefix cases must be observable and covered by validation. | In scope | FR-006, FR-011, FR-015 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST render runtime commands only after retrieval context, skill activation summaries, managed runtime notes, and other MoonMind-prepared context are available.
+- **FR-002**: System MUST route runtime command rendering through a runtime-owned boundary that can produce plain prompt, prompt-prefix, native command, materialized command, unsupported, and failed outcomes.
+- **FR-003**: For prompt-prefix command recognition, System MUST place the slash command before the instruction body and any MoonMind-prepared context in the final runtime-visible input.
+- **FR-004**: For plain prompt outcomes, System MUST send literal instructions as normal text without presenting the text as an executable runtime command.
+- **FR-005**: System MUST ensure MoonMind-added context never precedes a command that requires first-character or first-token recognition by the selected runtime.
+- **FR-006**: System MUST fail before launching the agent or record a policy-approved fallback event when rendering cannot safely produce the requested runtime command outcome.
+- **FR-007**: Codex CLI and Claude Code runtime paths MUST support prompt-prefix slash-command rendering without requiring Create page logic to know provider-specific command markup.
+- **FR-008**: Unknown valid slash commands MUST remain slash-leading through prompt-prefix or native command transport for slash-capable runtimes.
+- **FR-009**: Unknown valid slash commands MUST NOT be rendered through materialized command mode or used to create runtime command files.
+- **FR-010**: Escaped literal slash commands MUST render with a non-command prefix, quote block, or runtime-specific literal wrapper so the runtime does not execute the slash command.
+- **FR-011**: Runtime command rendering failures MUST surface a typed user-facing failure reason or an auditable fallback event before process launch or turn submission.
+- **FR-012**: Runtime renderers MUST treat command names, command arguments, and instruction bodies as untrusted authored text.
+- **FR-013**: Runtime command rendering MUST NOT expose secrets in final rendered input, diagnostics, or audit output.
+- **FR-014**: Known-command hints MUST NOT become a blocking allowlist for pass-through runtimes.
+- **FR-015**: Validation coverage MUST prove that retrieval context, skill activation summaries, and managed runtime notes do not appear before slash commands that require first-position recognition.
+- **FR-016**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-686` and the original Jira preset brief.
+
+### Key Entities
+
+- **Runtime Command Invocation**: The structured interpretation of authored slash-leading instructions, including command token, arguments, instruction body, source location, and whether the command is known or opaque.
+- **Runtime Render Outcome**: The rendering result selected by a runtime boundary, including final user-visible input shape, render mode, unsupported-runtime state, failure reason, or fallback event.
+- **Prepared Runtime Context**: MoonMind-added retrieval context, skill activation summaries, managed runtime notes, and other launch-time context that must be positioned after slash commands requiring first-position recognition.
+- **Runtime Capability**: Declarative runtime metadata indicating whether slash-command pass-through, prompt-prefix rendering, native command transport, or materialized command rendering is supported.
+- **Materialized Command Target**: A runtime-owned file or artifact location where a known command may be written only when explicitly allowed by policy and renderer metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of tested prompt-prefix launches with `/review` for slash-capable Codex CLI and Claude Code paths begin with `/review` before instruction body and prepared context.
+- **SC-002**: 100% of tested launches with retrieval context, skill activation summaries, and managed runtime notes preserve command recognition order when the selected runtime requires first-position slash recognition.
+- **SC-003**: 100% of tested unknown valid slash commands for slash-capable runtimes remain slash-leading through prompt-prefix or native command transport and are not materialized.
+- **SC-004**: 100% of tested escaped literal slash commands render as non-executable literal instructions.
+- **SC-005**: 100% of tested rendering failure cases stop before launch with a typed failure or record an auditable policy-approved fallback event.
+- **SC-006**: 100% of tested materialized command cases write only allowlisted targets, and 0 unknown commands are materialized.
+- **SC-007**: Traceability review confirms `MM-686`, the original Jira preset brief, and all in-scope source design requirements remain present in MoonSpec artifacts and final verification evidence.

--- a/specs/356-runtime-command-rendering/tasks.md
+++ b/specs/356-runtime-command-rendering/tasks.md
@@ -50,7 +50,7 @@
 - [ ] T004 [P] Add or extend runtime strategy test helpers for render inputs and fake profiles in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-002, DESIGN-REQ-012.
 - [ ] T005 [P] Add or extend launcher subprocess-capture helpers for rendered prompt assertions in `tests/unit/services/temporal/runtime/test_launcher.py` covering SCN-001, SCN-006.
 - [ ] T006 [P] Add or extend integration launcher fixture helpers in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering retrieval context and prompt capture for SCN-001, SCN-002.
-- [ ] T007 Build the story traceability inventory in `specs/356-runtime-command-rendering/tasks.md` and keep all FR, SCN, SC, and DESIGN-REQ rows mapped to later tasks for FR-016/SC-007.
+- [ ] T007 Build the story traceability inventory in `specs/356-runtime-command-rendering/tasks.md` and keep all FR, SCN, SC, and DESIGN-REQ rows mapped throughout this task list for FR-016/SC-007.
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -71,7 +71,7 @@
 
 ### Unit Tests (write first) ⚠️
 
-> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
 
 - [ ] T008 [P] Add failing unit tests for Codex CLI prompt-prefix rendering, prepared-context ordering, and `/review` first-position recognition in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-001, FR-003, FR-007, SCN-001, SC-001, DESIGN-REQ-011, DESIGN-REQ-013.
 - [ ] T009 [P] Add failing unit tests for Claude Code prompt-prefix rendering, prepared-context ordering, and no Create-page provider markup dependency in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
@@ -200,4 +200,4 @@ Task: "Implement Claude Code runtime command rendering in moonmind/workflows/tem
 - Unit and integration tests are mandatory and precede implementation.
 - No provider verification tests are required; all planned integration coverage is hermetic.
 - Do not add Create page preview scope; MM-686 consumes existing preview/normalization behavior and focuses on managed runtime rendering.
-- Do not implement `tasks.md` work during task generation; this file is the handoff to `/speckit.implement`.
+- Do not implement `tasks.md` work during task generation; this file is the handoff to `/moonspec-implement`.

--- a/specs/356-runtime-command-rendering/tasks.md
+++ b/specs/356-runtime-command-rendering/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: Runtime Command Rendering After Context Preparation
+
+**Input**: Design documents from `/work/agent_jobs/mm:03ecc585-89e8-4589-8bdf-05bc41f57e4a/repo/specs/356-runtime-command-rendering/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around one user story: preserve slash-command recognition at runtime launch after MoonMind prepares context.
+
+**Source Traceability**: This task plan preserves `MM-686` and the original Jira preset brief from `spec.md`. It covers FR-001 through FR-016, SCN-001 through SCN-006, SC-001 through SC-007, DESIGN-REQ-006, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-018, and DESIGN-REQ-019. Requirement statuses from `plan.md`: 19 missing, 11 partial, 6 implemented_unverified, 1 implemented_verified.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Path Conventions
+
+- Runtime strategies: `moonmind/workflows/temporal/runtime/strategies/`
+- Runtime launcher: `moonmind/workflows/temporal/runtime/launcher.py`
+- Runtime request schema: `moonmind/schemas/agent_runtime_models.py`
+- Task contract metadata: `moonmind/workflows/tasks/task_contract.py`
+- Workflow request construction: `moonmind/workflows/temporal/workflows/run.py`
+- Unit tests: `tests/unit/`
+- Integration tests: `tests/integration/`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the one-story planning artifacts and test surfaces before writing red-first tests.
+
+- [ ] T001 Confirm `specs/356-runtime-command-rendering/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, and `quickstart.md` are present and preserve `MM-686` for FR-016/SC-007.
+- [ ] T002 Inspect existing runtime command normalization tests in `tests/unit/workflows/tasks/test_task_contract.py` and existing runtime strategy tests in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` to align new red-first tests with FR-008, FR-014, DESIGN-REQ-016.
+- [ ] T003 Inspect existing launcher context-order tests in `tests/unit/services/temporal/runtime/test_launcher.py` and `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` to reuse fixture patterns for FR-001, FR-005, FR-015, DESIGN-REQ-011.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the test harness and traceability inventory that story tasks depend on.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T004 [P] Add or extend runtime strategy test helpers for render inputs and fake profiles in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-002, DESIGN-REQ-012.
+- [ ] T005 [P] Add or extend launcher subprocess-capture helpers for rendered prompt assertions in `tests/unit/services/temporal/runtime/test_launcher.py` covering SCN-001, SCN-006.
+- [ ] T006 [P] Add or extend integration launcher fixture helpers in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering retrieval context and prompt capture for SCN-001, SCN-002.
+- [ ] T007 Build the story traceability inventory in `specs/356-runtime-command-rendering/tasks.md` and keep all FR, SCN, SC, and DESIGN-REQ rows mapped to later tasks for FR-016/SC-007.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Preserve Slash Command Recognition At Runtime Launch
+
+**Summary**: As a managed runtime operator, I want slash commands to be rendered only after MoonMind has prepared retrieval context, skill summaries, and runtime notes so that supported runtimes still recognize the command as a command while preserving prepared context.
+
+**Independent Test**: Submit command-leading tasks for slash-capable runtimes with retrieval context, skill activation summaries, and managed runtime notes present, then verify that the final runtime-visible input starts with the command when required and that unsupported, escaped, unknown, materialized, and failure cases produce the documented outcomes before launch.
+
+**Traceability**: FR-001 through FR-016; SCN-001 through SCN-006; SC-001 through SC-007; DESIGN-REQ-006, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-019.
+
+**Test Plan**:
+
+- Unit: runtime render outcome models, Codex/Claude strategy rendering, unknown command guardrails, escaped literal handling, failure/fallback classification, no-secret diagnostics, task/request metadata propagation.
+- Integration: launcher order with retrieval context, skill activation summaries, managed runtime notes, Codex/Claude prompt capture, and pre-launch hard render failure behavior.
+
+### Unit Tests (write first) ⚠️
+
+> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [ ] T008 [P] Add failing unit tests for Codex CLI prompt-prefix rendering, prepared-context ordering, and `/review` first-position recognition in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-001, FR-003, FR-007, SCN-001, SC-001, DESIGN-REQ-011, DESIGN-REQ-013.
+- [ ] T009 [P] Add failing unit tests for Claude Code prompt-prefix rendering, prepared-context ordering, and no Create-page provider markup dependency in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
+- [ ] T010 [P] Add failing unit tests for render outcome statuses and modes in `tests/unit/schemas/test_agent_runtime_models.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
+- [ ] T011 [P] Add failing unit tests for unknown opaque slash commands and explicit materialized-command guardrails in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
+- [ ] T012 [P] Add failing unit tests for escaped literal slash rendering and non-command wrapper behavior in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-010, SCN-005, SC-004, DESIGN-REQ-017.
+- [ ] T013 [P] Add failing unit tests for renderer failure, fallback event handling, and redacted diagnostics in `tests/unit/services/temporal/runtime/test_launcher.py` covering FR-006, FR-011, FR-013, SCN-006, SC-005, DESIGN-REQ-018, DESIGN-REQ-019.
+- [ ] T014 [P] Add failing unit tests for propagating backend-normalized runtime command metadata into `AgentExecutionRequest` construction in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` covering FR-001, FR-008, FR-016.
+- [ ] T015 [P] Add regression tests preserving existing backend normalization for unknown, escaped, malformed, and hinted commands in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
+- [ ] T016 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T008-T015 fail for missing runtime render behavior before production changes.
+
+### Integration Tests (write first) ⚠️
+
+- [ ] T017 [P] Add failing integration test for Codex CLI launch with `/review`, retrieval context, skill activation summary, and managed runtime notes in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SC-001, SC-002, DESIGN-REQ-011.
+- [ ] T018 [P] Add failing integration test for Claude Code launch with `/review` and retrieval context preserving slash-command first position in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
+- [ ] T019 [P] Add failing integration test for unknown valid slash command pass-through and no materialization in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
+- [ ] T020 [P] Add failing integration test that hard runtime render failure prevents subprocess launch in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
+- [ ] T021 Run `./tools/test_integration.sh` or targeted `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short` and confirm T017-T020 fail for missing runtime render behavior before production changes.
+
+### Implementation
+
+- [ ] T022 Implement runtime command invocation and render outcome models in `moonmind/schemas/agent_runtime_models.py` covering FR-002, FR-004, FR-006, FR-011, DESIGN-REQ-006, DESIGN-REQ-012.
+- [ ] T023 Implement propagation of objective runtime command metadata from task inputs or authoritative snapshots into `AgentExecutionRequest` in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
+- [ ] T024 Preserve and validate runtime command metadata compatibility in `moonmind/workflows/tasks/task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
+- [ ] T025 Extend `ManagedRuntimeStrategy` with runtime command rendering hooks and default plain-prompt behavior in `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
+- [ ] T026 Implement Codex CLI prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
+- [ ] T027 Implement Claude Code prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/claude_code.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
+- [ ] T028 Wire final runtime command rendering after workspace preparation and skill projection but before `build_command()` in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SCN-002, DESIGN-REQ-011.
+- [ ] T029 Implement pre-launch render failure classification and policy-approved fallback annotation in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
+- [ ] T030 Implement render diagnostic redaction and untrusted command text handling in `moonmind/workflows/temporal/runtime/launcher.py` and `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-012, FR-013, DESIGN-REQ-018.
+- [ ] T031 Conditional fallback: if T014 verification shows runtime command metadata is not available from task inputs, add compact runtime command metadata transport in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
+- [ ] T032 Conditional fallback: if T013 or T020 expose an incompatible existing failure taxonomy, add a supported `runtime_command_render_failed` classification path in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SC-005.
+- [ ] T033 Conditional fallback: if T015 existing backend normalization regression tests fail, repair normalization in `moonmind/workflows/tasks/task_contract.py` without changing authored instruction semantics covering FR-008, FR-010, FR-014.
+- [ ] T034 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and fix implementation until unit coverage passes.
+- [ ] T035 Run `./tools/test_integration.sh` and fix implementation until integration coverage passes for SCN-001 through SCN-006 and DESIGN-REQ-011 through DESIGN-REQ-019.
+- [ ] T036 Validate the single story end to end using `specs/356-runtime-command-rendering/quickstart.md` and record any command/output evidence in implementation notes for SC-001 through SC-007.
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed runtime rendering story without adding hidden scope.
+
+- [ ] T037 [P] Review `specs/356-runtime-command-rendering/contracts/runtime-command-rendering.md` against final implementation and update only if the implemented contract intentionally differs, preserving MM-686 and FR-016.
+- [ ] T038 [P] Review `specs/356-runtime-command-rendering/data-model.md` against final models and update entity fields or state transitions only if implementation changed them, preserving DESIGN-REQ mappings.
+- [ ] T039 [P] Add or adjust focused edge-case coverage in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` for empty prepared context, large prepared context, and unsupported runtime policy covering Edge Cases, SC-002, DESIGN-REQ-019.
+- [ ] T040 [P] Add or adjust security hardening assertions in `tests/unit/services/temporal/runtime/test_launcher.py` for secret redaction in render diagnostics covering FR-013, DESIGN-REQ-018.
+- [ ] T041 Run `./tools/test_unit.sh` for the full unit suite and resolve failures without widening MM-686 scope.
+- [ ] T042 Run `./tools/test_integration.sh` for the required hermetic integration suite and resolve failures without adding provider-verification dependencies.
+- [ ] T043 Confirm `MM-686` and the original Jira preset brief remain preserved in `specs/356-runtime-command-rendering/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`, and this `tasks.md` for FR-016/SC-007.
+- [ ] T044 Run `/moonspec-verify` for `specs/356-runtime-command-rendering` after implementation and tests pass, preserving MM-686, original preset brief, test evidence, and source-design coverage.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS story work.
+- **Story (Phase 3)**: Depends on Foundational phase completion.
+- **Polish (Phase 4)**: Depends on the story being functionally complete and tests passing.
+
+### Within The Story
+
+- T008-T015 unit tests must be written before T016 red-first confirmation.
+- T017-T020 integration tests must be written before T021 red-first confirmation.
+- T016 and T021 must confirm expected failures before implementation tasks T022-T033.
+- T022-T024 establish schema/metadata propagation before strategy and launcher wiring in T025-T030.
+- T025 must complete before runtime-specific strategy tasks T026-T027.
+- T026-T027 and T028-T030 must complete before validation tasks T034-T036.
+- Conditional fallback tasks T031-T033 run only when their corresponding verification tests fail.
+- T041-T044 run only after story validation passes.
+
+### Parallel Opportunities
+
+- T004-T006 can run in parallel because they touch different test fixtures.
+- T008-T015 can be drafted in parallel where they touch different test files; T008, T009, T011, and T012 share one file and require coordination.
+- T017-T020 share an integration file and should be coordinated rather than edited blindly in parallel.
+- T026 and T027 can run in parallel after T025 because they touch different runtime strategy files.
+- T037-T040 can run in parallel after implementation because they touch different docs/test files.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# After T004-T007 complete, these can be assigned separately:
+Task: "Add failing schema/render outcome tests in tests/unit/schemas/test_agent_runtime_models.py"
+Task: "Add failing launcher failure/redaction tests in tests/unit/services/temporal/runtime/test_launcher.py"
+Task: "Add failing request metadata propagation tests in tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py"
+
+# After T025 completes, runtime strategy implementation can split:
+Task: "Implement Codex CLI runtime command rendering in moonmind/workflows/temporal/runtime/strategies/codex_cli.py"
+Task: "Implement Claude Code runtime command rendering in moonmind/workflows/temporal/runtime/strategies/claude_code.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 to confirm traceability and fixtures.
+2. Write unit tests T008-T015 and confirm they fail with T016.
+3. Write integration tests T017-T020 and confirm they fail with T021.
+4. Implement schema, metadata propagation, strategy rendering, launcher wiring, failure/fallback behavior, and security handling in T022-T030.
+5. Run conditional fallback implementation tasks T031-T033 only if verification tests reveal those gaps.
+6. Run targeted unit and integration validation T034-T036.
+7. Complete polish, full unit/integration validation, traceability review, and `/moonspec-verify` in T037-T044.
+
+### Requirement Status Handling
+
+- Code-and-test work: missing and partial rows from `plan.md`, including FR-001 through FR-013, FR-015, SCN-001 through SCN-006, SC-001 through SC-006, and DESIGN-REQ-006, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-019.
+- Verification-only with preservation: implemented_verified row FR-014 remains covered by existing task-contract evidence plus regression and final verification.
+- Conditional fallback work: implemented_unverified rows FR-009, FR-013, FR-016, SCN-004, SC-006, and SC-007 include explicit fallback or preservation tasks.
+- Traceability: every final artifact and verification output must preserve MM-686 and the original Jira preset brief.
+
+---
+
+## Notes
+
+- This task list covers exactly one story: preserve slash-command recognition at runtime launch after context preparation.
+- Unit and integration tests are mandatory and precede implementation.
+- No provider verification tests are required; all planned integration coverage is hermetic.
+- Do not add Create page preview scope; MM-686 consumes existing preview/normalization behavior and focuses on managed runtime rendering.
+- Do not implement `tasks.md` work during task generation; this file is the handoff to `/speckit.implement`.

--- a/specs/356-runtime-command-rendering/tasks.md
+++ b/specs/356-runtime-command-rendering/tasks.md
@@ -203,3 +203,4 @@ Task: "Implement Claude Code runtime command rendering in moonmind/workflows/tem
 - Do not implement `tasks.md` work during task generation; this file is the handoff to `/moonspec-implement`.
 - Implementation evidence is recorded in `specs/356-runtime-command-rendering/implementation-notes.md`.
 - `./tools/test_integration.sh` is blocked in this managed environment by Docker daemon policy: `403 Forbidden` / `Request forbidden by administrative rules`. Targeted hermetic integration coverage for the modified launcher path passes with `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short`.
+- Remediation for the `ADDITIONAL_WORK_NEEDED` verification report added structured native-command render support at the strategy boundary, Claude known-command materialized allowlist rendering, and focused unit/integration coverage. Full hermetic integration remains blocked by the same Docker daemon policy.

--- a/specs/356-runtime-command-rendering/tasks.md
+++ b/specs/356-runtime-command-rendering/tasks.md
@@ -35,9 +35,9 @@
 
 **Purpose**: Confirm the one-story planning artifacts and test surfaces before writing red-first tests.
 
-- [ ] T001 Confirm `specs/356-runtime-command-rendering/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, and `quickstart.md` are present and preserve `MM-686` for FR-016/SC-007.
-- [ ] T002 Inspect existing runtime command normalization tests in `tests/unit/workflows/tasks/test_task_contract.py` and existing runtime strategy tests in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` to align new red-first tests with FR-008, FR-014, DESIGN-REQ-016.
-- [ ] T003 Inspect existing launcher context-order tests in `tests/unit/services/temporal/runtime/test_launcher.py` and `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` to reuse fixture patterns for FR-001, FR-005, FR-015, DESIGN-REQ-011.
+- [X] T001 Confirm `specs/356-runtime-command-rendering/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, and `quickstart.md` are present and preserve `MM-686` for FR-016/SC-007.
+- [X] T002 Inspect existing runtime command normalization tests in `tests/unit/workflows/tasks/test_task_contract.py` and existing runtime strategy tests in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` to align new red-first tests with FR-008, FR-014, DESIGN-REQ-016.
+- [X] T003 Inspect existing launcher context-order tests in `tests/unit/services/temporal/runtime/test_launcher.py` and `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` to reuse fixture patterns for FR-001, FR-005, FR-015, DESIGN-REQ-011.
 
 ---
 
@@ -47,10 +47,10 @@
 
 **CRITICAL**: No story implementation work can begin until this phase is complete.
 
-- [ ] T004 [P] Add or extend runtime strategy test helpers for render inputs and fake profiles in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-002, DESIGN-REQ-012.
-- [ ] T005 [P] Add or extend launcher subprocess-capture helpers for rendered prompt assertions in `tests/unit/services/temporal/runtime/test_launcher.py` covering SCN-001, SCN-006.
-- [ ] T006 [P] Add or extend integration launcher fixture helpers in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering retrieval context and prompt capture for SCN-001, SCN-002.
-- [ ] T007 Build the story traceability inventory in `specs/356-runtime-command-rendering/tasks.md` and keep all FR, SCN, SC, and DESIGN-REQ rows mapped throughout this task list for FR-016/SC-007.
+- [X] T004 [P] Add or extend runtime strategy test helpers for render inputs and fake profiles in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-002, DESIGN-REQ-012.
+- [X] T005 [P] Add or extend launcher subprocess-capture helpers for rendered prompt assertions in `tests/unit/services/temporal/runtime/test_launcher.py` covering SCN-001, SCN-006.
+- [X] T006 [P] Add or extend integration launcher fixture helpers in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering retrieval context and prompt capture for SCN-001, SCN-002.
+- [X] T007 Build the story traceability inventory in `specs/356-runtime-command-rendering/tasks.md` and keep all FR, SCN, SC, and DESIGN-REQ rows mapped throughout this task list for FR-016/SC-007.
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin.
 
@@ -73,39 +73,39 @@
 
 > **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
 
-- [ ] T008 [P] Add failing unit tests for Codex CLI prompt-prefix rendering, prepared-context ordering, and `/review` first-position recognition in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-001, FR-003, FR-007, SCN-001, SC-001, DESIGN-REQ-011, DESIGN-REQ-013.
-- [ ] T009 [P] Add failing unit tests for Claude Code prompt-prefix rendering, prepared-context ordering, and no Create-page provider markup dependency in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
-- [ ] T010 [P] Add failing unit tests for render outcome statuses and modes in `tests/unit/schemas/test_agent_runtime_models.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
-- [ ] T011 [P] Add failing unit tests for unknown opaque slash commands and explicit materialized-command guardrails in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
-- [ ] T012 [P] Add failing unit tests for escaped literal slash rendering and non-command wrapper behavior in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-010, SCN-005, SC-004, DESIGN-REQ-017.
-- [ ] T013 [P] Add failing unit tests for renderer failure, fallback event handling, and redacted diagnostics in `tests/unit/services/temporal/runtime/test_launcher.py` covering FR-006, FR-011, FR-013, SCN-006, SC-005, DESIGN-REQ-018, DESIGN-REQ-019.
-- [ ] T014 [P] Add failing unit tests for propagating backend-normalized runtime command metadata into `AgentExecutionRequest` construction in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` covering FR-001, FR-008, FR-016.
-- [ ] T015 [P] Add regression tests preserving existing backend normalization for unknown, escaped, malformed, and hinted commands in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
-- [ ] T016 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T008-T015 fail for missing runtime render behavior before production changes.
+- [X] T008 [P] Add failing unit tests for Codex CLI prompt-prefix rendering, prepared-context ordering, and `/review` first-position recognition in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-001, FR-003, FR-007, SCN-001, SC-001, DESIGN-REQ-011, DESIGN-REQ-013.
+- [X] T009 [P] Add failing unit tests for Claude Code prompt-prefix rendering, prepared-context ordering, and no Create-page provider markup dependency in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
+- [X] T010 [P] Add failing unit tests for render outcome statuses and modes in `tests/unit/schemas/test_agent_runtime_models.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
+- [X] T011 [P] Add failing unit tests for unknown opaque slash commands and explicit materialized-command guardrails in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
+- [X] T012 [P] Add failing unit tests for escaped literal slash rendering and non-command wrapper behavior in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` covering FR-010, SCN-005, SC-004, DESIGN-REQ-017.
+- [X] T013 [P] Add failing unit tests for renderer failure, fallback event handling, and redacted diagnostics in `tests/unit/services/temporal/runtime/test_launcher.py` covering FR-006, FR-011, FR-013, SCN-006, SC-005, DESIGN-REQ-018, DESIGN-REQ-019.
+- [X] T014 [P] Add failing unit tests for propagating backend-normalized runtime command metadata into `AgentExecutionRequest` construction in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` covering FR-001, FR-008, FR-016.
+- [X] T015 [P] Add regression tests preserving existing backend normalization for unknown, escaped, malformed, and hinted commands in `tests/unit/workflows/tasks/test_task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
+- [X] T016 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and confirm T008-T015 fail for missing runtime render behavior before production changes.
 
 ### Integration Tests (write first) ⚠️
 
-- [ ] T017 [P] Add failing integration test for Codex CLI launch with `/review`, retrieval context, skill activation summary, and managed runtime notes in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SC-001, SC-002, DESIGN-REQ-011.
-- [ ] T018 [P] Add failing integration test for Claude Code launch with `/review` and retrieval context preserving slash-command first position in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
-- [ ] T019 [P] Add failing integration test for unknown valid slash command pass-through and no materialization in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
-- [ ] T020 [P] Add failing integration test that hard runtime render failure prevents subprocess launch in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
-- [ ] T021 Run `./tools/test_integration.sh` or targeted `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short` and confirm T017-T020 fail for missing runtime render behavior before production changes.
+- [X] T017 [P] Add failing integration test for Codex CLI launch with `/review`, retrieval context, skill activation summary, and managed runtime notes in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SC-001, SC-002, DESIGN-REQ-011.
+- [X] T018 [P] Add failing integration test for Claude Code launch with `/review` and retrieval context preserving slash-command first position in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-003, FR-007, SCN-002, SC-001, DESIGN-REQ-013.
+- [X] T019 [P] Add failing integration test for unknown valid slash command pass-through and no materialization in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-008, FR-009, SCN-003, SCN-004, SC-003, SC-006, DESIGN-REQ-016.
+- [X] T020 [P] Add failing integration test that hard runtime render failure prevents subprocess launch in `tests/integration/workflows/temporal/test_managed_session_retrieval_context.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
+- [X] T021 Run `./tools/test_integration.sh` or targeted `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short` and confirm T017-T020 fail for missing runtime render behavior before production changes.
 
 ### Implementation
 
-- [ ] T022 Implement runtime command invocation and render outcome models in `moonmind/schemas/agent_runtime_models.py` covering FR-002, FR-004, FR-006, FR-011, DESIGN-REQ-006, DESIGN-REQ-012.
-- [ ] T023 Implement propagation of objective runtime command metadata from task inputs or authoritative snapshots into `AgentExecutionRequest` in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
-- [ ] T024 Preserve and validate runtime command metadata compatibility in `moonmind/workflows/tasks/task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
-- [ ] T025 Extend `ManagedRuntimeStrategy` with runtime command rendering hooks and default plain-prompt behavior in `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
-- [ ] T026 Implement Codex CLI prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
-- [ ] T027 Implement Claude Code prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/claude_code.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
-- [ ] T028 Wire final runtime command rendering after workspace preparation and skill projection but before `build_command()` in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SCN-002, DESIGN-REQ-011.
-- [ ] T029 Implement pre-launch render failure classification and policy-approved fallback annotation in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
-- [ ] T030 Implement render diagnostic redaction and untrusted command text handling in `moonmind/workflows/temporal/runtime/launcher.py` and `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-012, FR-013, DESIGN-REQ-018.
-- [ ] T031 Conditional fallback: if T014 verification shows runtime command metadata is not available from task inputs, add compact runtime command metadata transport in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
-- [ ] T032 Conditional fallback: if T013 or T020 expose an incompatible existing failure taxonomy, add a supported `runtime_command_render_failed` classification path in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SC-005.
-- [ ] T033 Conditional fallback: if T015 existing backend normalization regression tests fail, repair normalization in `moonmind/workflows/tasks/task_contract.py` without changing authored instruction semantics covering FR-008, FR-010, FR-014.
-- [ ] T034 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and fix implementation until unit coverage passes.
+- [X] T022 Implement runtime command invocation and render outcome models in `moonmind/schemas/agent_runtime_models.py` covering FR-002, FR-004, FR-006, FR-011, DESIGN-REQ-006, DESIGN-REQ-012.
+- [X] T023 Implement propagation of objective runtime command metadata from task inputs or authoritative snapshots into `AgentExecutionRequest` in `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
+- [X] T024 Preserve and validate runtime command metadata compatibility in `moonmind/workflows/tasks/task_contract.py` covering FR-008, FR-010, FR-014, DESIGN-REQ-016, DESIGN-REQ-017.
+- [X] T025 Extend `ManagedRuntimeStrategy` with runtime command rendering hooks and default plain-prompt behavior in `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-002, FR-004, DESIGN-REQ-006, DESIGN-REQ-012.
+- [X] T026 Implement Codex CLI prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
+- [X] T027 Implement Claude Code prompt-prefix, opaque pass-through, escaped literal, and unknown-materialization guard behavior in `moonmind/workflows/temporal/runtime/strategies/claude_code.py` covering FR-003, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-013, DESIGN-REQ-016, DESIGN-REQ-017.
+- [X] T028 Wire final runtime command rendering after workspace preparation and skill projection but before `build_command()` in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-001, FR-003, FR-005, FR-015, SCN-001, SCN-002, DESIGN-REQ-011.
+- [X] T029 Implement pre-launch render failure classification and policy-approved fallback annotation in `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SCN-006, SC-005, DESIGN-REQ-019.
+- [X] T030 Implement render diagnostic redaction and untrusted command text handling in `moonmind/workflows/temporal/runtime/launcher.py` and `moonmind/workflows/temporal/runtime/strategies/base.py` covering FR-012, FR-013, DESIGN-REQ-018.
+- [X] T031 Conditional fallback evaluated: T014 verified runtime command metadata propagation is available from task inputs; compact metadata transport is present in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/workflows/run.py` covering FR-001, FR-008, FR-016.
+- [X] T032 Conditional fallback: if T013 or T020 expose an incompatible existing failure taxonomy, add a supported `runtime_command_render_failed` classification path in `moonmind/schemas/agent_runtime_models.py` and `moonmind/workflows/temporal/runtime/launcher.py` covering FR-006, FR-011, SC-005.
+- [X] T033 Conditional fallback evaluated: T015 backend normalization regressions passed, so no repair was required in `moonmind/workflows/tasks/task_contract.py`; authored instruction semantics remain unchanged for FR-008, FR-010, FR-014.
+- [X] T034 Run `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/tasks/test_task_contract.py` and fix implementation until unit coverage passes.
 - [ ] T035 Run `./tools/test_integration.sh` and fix implementation until integration coverage passes for SCN-001 through SCN-006 and DESIGN-REQ-011 through DESIGN-REQ-019.
 - [ ] T036 Validate the single story end to end using `specs/356-runtime-command-rendering/quickstart.md` and record any command/output evidence in implementation notes for SC-001 through SC-007.
 
@@ -117,11 +117,11 @@
 
 **Purpose**: Strengthen the completed runtime rendering story without adding hidden scope.
 
-- [ ] T037 [P] Review `specs/356-runtime-command-rendering/contracts/runtime-command-rendering.md` against final implementation and update only if the implemented contract intentionally differs, preserving MM-686 and FR-016.
-- [ ] T038 [P] Review `specs/356-runtime-command-rendering/data-model.md` against final models and update entity fields or state transitions only if implementation changed them, preserving DESIGN-REQ mappings.
-- [ ] T039 [P] Add or adjust focused edge-case coverage in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` for empty prepared context, large prepared context, and unsupported runtime policy covering Edge Cases, SC-002, DESIGN-REQ-019.
-- [ ] T040 [P] Add or adjust security hardening assertions in `tests/unit/services/temporal/runtime/test_launcher.py` for secret redaction in render diagnostics covering FR-013, DESIGN-REQ-018.
-- [ ] T041 Run `./tools/test_unit.sh` for the full unit suite and resolve failures without widening MM-686 scope.
+- [X] T037 [P] Review `specs/356-runtime-command-rendering/contracts/runtime-command-rendering.md` against final implementation and update only if the implemented contract intentionally differs, preserving MM-686 and FR-016.
+- [X] T038 [P] Review `specs/356-runtime-command-rendering/data-model.md` against final models and update entity fields or state transitions only if implementation changed them, preserving DESIGN-REQ mappings.
+- [X] T039 [P] Add or adjust focused edge-case coverage in `tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` for empty prepared context, large prepared context, and unsupported runtime policy covering Edge Cases, SC-002, DESIGN-REQ-019.
+- [X] T040 [P] Add or adjust security hardening assertions in `tests/unit/services/temporal/runtime/test_launcher.py` for secret redaction in render diagnostics covering FR-013, DESIGN-REQ-018.
+- [X] T041 Run `./tools/test_unit.sh` for the full unit suite and resolve failures without widening MM-686 scope.
 - [ ] T042 Run `./tools/test_integration.sh` for the required hermetic integration suite and resolve failures without adding provider-verification dependencies.
 - [ ] T043 Confirm `MM-686` and the original Jira preset brief remain preserved in `specs/356-runtime-command-rendering/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/runtime-command-rendering.md`, `quickstart.md`, and this `tasks.md` for FR-016/SC-007.
 - [ ] T044 Run `/moonspec-verify` for `specs/356-runtime-command-rendering` after implementation and tests pass, preserving MM-686, original preset brief, test evidence, and source-design coverage.
@@ -201,3 +201,5 @@ Task: "Implement Claude Code runtime command rendering in moonmind/workflows/tem
 - No provider verification tests are required; all planned integration coverage is hermetic.
 - Do not add Create page preview scope; MM-686 consumes existing preview/normalization behavior and focuses on managed runtime rendering.
 - Do not implement `tasks.md` work during task generation; this file is the handoff to `/moonspec-implement`.
+- Implementation evidence is recorded in `specs/356-runtime-command-rendering/implementation-notes.md`.
+- `./tools/test_integration.sh` is blocked in this managed environment by Docker daemon policy: `403 Forbidden` / `Request forbidden by administrative rules`. Targeted hermetic integration coverage for the modified launcher path passes with `pytest tests/integration/workflows/temporal/test_managed_session_retrieval_context.py -q --tb=short`.

--- a/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
+++ b/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
@@ -7,6 +7,7 @@ import pytest
 
 from moonmind.rag.context_pack import ContextItem, ContextPack
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, ManagedRuntimeProfile
+from moonmind.schemas.agent_runtime_models import RuntimeCommandInvocation
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
@@ -109,6 +110,304 @@ async def test_claude_launcher_uses_shared_context_injection_for_prompt(
     # is never written by the launcher.
     assert any(arg == "Injected retrieval context" for arg in captured_args)
     assert not (workspace / "CLAUDE.md").exists()
+
+
+@patch("moonmind.rag.context_injection.ContextInjectionService")
+async def test_codex_runtime_command_rendering_keeps_command_before_context(
+    mock_service_class,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    mock_service = mock_service_class.return_value
+
+    async def _inject_context(*, request, workspace_path):
+        assert workspace_path == workspace
+        request.instruction_ref = "Check this branch.\n\nRetrieved context."
+
+    mock_service.inject_context = AsyncMock(side_effect=_inject_context)
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 892) -> None:
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        command_template=["codex", "exec"],
+        default_model="gpt-5.4",
+    )
+    request = _make_request(
+        instruction_ref="/review\nCheck this branch.",
+        runtimeCommand=RuntimeCommandInvocation(
+            kind="slash_command",
+            source="leading_slash",
+            sourcePath="objective.instructions",
+            command="review",
+            rawCommand="/review",
+            args="",
+            instructionBody="Check this branch.",
+            targetRuntime="codex_cli",
+            detectionStatus="detected",
+            hintStatus="hinted",
+            recognitionMode="hinted_runtime_passthrough",
+            requiresRuntimeRecognition=True,
+            runtimeCapabilityVersion="2026-05-13",
+            hintCatalogVersion="2026-05-13",
+            detectionPhase="submit",
+        ),
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-codex-runtime-command-render",
+        request=request,
+        profile=profile,
+        workspace_path=workspace,
+    )
+    await process.wait()
+
+    prompts = [arg for arg in captured_args if isinstance(arg, str)]
+    rendered = next(arg for arg in prompts if arg.startswith("/review"))
+    assert rendered.index("/review") < rendered.index("Check this branch.")
+    assert rendered.index("Check this branch.") < rendered.index("Retrieved context.")
+
+
+@patch("moonmind.rag.context_injection.ContextInjectionService")
+async def test_claude_runtime_command_rendering_keeps_command_before_context(
+    mock_service_class,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+    monkeypatch.setattr("os.geteuid", lambda: 1000)
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    mock_service = mock_service_class.return_value
+
+    async def _inject_context(*, request, workspace_path):
+        assert workspace_path == workspace
+        request.instruction_ref = "Check this branch.\n\nRetrieved context."
+
+    mock_service.inject_context = AsyncMock(side_effect=_inject_context)
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 893) -> None:
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=["claude"],
+        default_model="claude-sonnet-4-6",
+    )
+    request = _make_request(
+        instruction_ref="/review\nCheck this branch.",
+        runtimeCommand=RuntimeCommandInvocation(
+            kind="slash_command",
+            source="leading_slash",
+            sourcePath="objective.instructions",
+            command="review",
+            rawCommand="/review",
+            args="",
+            instructionBody="Check this branch.",
+            targetRuntime="claude_code",
+            detectionStatus="detected",
+            hintStatus="hinted",
+            recognitionMode="hinted_runtime_passthrough",
+            requiresRuntimeRecognition=True,
+            runtimeCapabilityVersion="2026-05-13",
+            hintCatalogVersion="2026-05-13",
+            detectionPhase="submit",
+        ),
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-claude-runtime-command-render",
+        request=request,
+        profile=profile,
+        workspace_path=workspace,
+    )
+    await process.wait()
+
+    prompts = [arg for arg in captured_args if isinstance(arg, str)]
+    rendered = next(arg for arg in prompts if arg.startswith("/review"))
+    assert rendered.index("/review") < rendered.index("Check this branch.")
+    assert rendered.index("Check this branch.") < rendered.index("Retrieved context.")
+
+
+async def test_unknown_runtime_command_remains_prompt_prefix_and_unmaterialized(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 894) -> None:
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        command_template=["codex", "exec"],
+        default_model="gpt-5.4",
+    )
+    request = _make_request(
+        instruction_ref="/future-command now\nUse provider command.",
+        runtimeCommand=RuntimeCommandInvocation(
+            kind="slash_command",
+            source="leading_slash",
+            sourcePath="objective.instructions",
+            command="future-command",
+            rawCommand="/future-command now",
+            args="now",
+            instructionBody="Use provider command.",
+            targetRuntime="codex_cli",
+            detectionStatus="detected",
+            hintStatus="opaque",
+            recognitionMode="runtime_passthrough",
+            requiresRuntimeRecognition=True,
+            runtimeCapabilityVersion="2026-05-13",
+            hintCatalogVersion="2026-05-13",
+            detectionPhase="submit",
+        ),
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-codex-unknown-runtime-command",
+        request=request,
+        profile=profile,
+        workspace_path=workspace,
+    )
+    await process.wait()
+
+    prompts = [arg for arg in captured_args if isinstance(arg, str)]
+    rendered = next(arg for arg in prompts if arg.startswith("/future-command now"))
+    render_metadata = request.parameters["metadata"]["moonmind"]["runtimeCommandRender"]
+    assert rendered.startswith("/future-command now")
+    assert render_metadata["materializedTargets"] == []
+
+
+async def test_runtime_command_render_failure_prevents_launch(tmp_path) -> None:
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    request = _make_request(instruction_ref="/review\nCheck this.")
+
+    class FailingStrategy:
+        runtime_id = "codex_cli"
+
+        def render_runtime_command(self, request):
+            from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
+
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={"message": "redacted"},
+            )
+
+    with pytest.raises(RuntimeError, match="runtime_command_render_failed"):
+        launcher._apply_runtime_command_rendering(
+            request=request,
+            strategy=FailingStrategy(),
+        )
 
 
 @pytest.mark.parametrize("transport", ["direct", "gateway"])

--- a/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
+++ b/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
@@ -386,6 +386,103 @@ async def test_unknown_runtime_command_remains_prompt_prefix_and_unmaterialized(
     assert render_metadata["materializedTargets"] == []
 
 
+async def test_claude_materialized_runtime_command_uses_allowlisted_target(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 895) -> None:
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=["claude"],
+        default_model="claude-sonnet-4-6",
+    )
+    request = _make_request(
+        instruction_ref="Focus on regressions.\n\nPrepared context.",
+        runtimeCommand=RuntimeCommandInvocation(
+            kind="slash_command",
+            source="leading_slash",
+            sourcePath="objective.instructions",
+            command="review",
+            rawCommand="/review",
+            args="",
+            instructionBody="Focus on regressions.",
+            targetRuntime="claude_code",
+            detectionStatus="detected",
+            hintStatus="hinted",
+            recognitionMode="hinted_runtime_passthrough",
+            renderMode="materialized_command",
+            materializedCommand={
+                "path": ".claude/commands/review.md",
+                "invocation": "/project:review",
+            },
+            requiresRuntimeRecognition=True,
+            runtimeCapabilityVersion="2026-05-13",
+            hintCatalogVersion="2026-05-13",
+            detectionPhase="submit",
+        ),
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-claude-materialized-runtime-command",
+        request=request,
+        profile=profile,
+        workspace_path=workspace,
+    )
+    await process.wait()
+
+    prompts = [arg for arg in captured_args if isinstance(arg, str)]
+    rendered = next(arg for arg in prompts if arg.startswith("/project:review"))
+    render_metadata = request.parameters["metadata"]["moonmind"]["runtimeCommandRender"]
+    assert rendered.index("/project:review") < rendered.index("Focus on regressions.")
+    assert rendered.index("Focus on regressions.") < rendered.index("Prepared context.")
+    assert render_metadata["materializedTargets"] == [
+        {
+            "path": ".claude/commands/review.md",
+            "command": "review",
+            "invocation": "/project:review",
+        }
+    ]
+
+
 async def test_runtime_command_render_failure_prevents_launch(tmp_path) -> None:
     store = ManagedRunStore(tmp_path)
     launcher = ManagedRuntimeLauncher(store)

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -12,6 +12,8 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedAgentProviderProfile,
     ManagedRuntimeProfile,
     LiveLogChunk,
+    RuntimeCommandInvocation,
+    RuntimeCommandRenderResult,
     extract_durable_retrieval_metadata,
     is_terminal_agent_run_state,
 )
@@ -57,6 +59,71 @@ def test_agent_execution_request_accepts_codex_managed_session_binding() -> None
     assert request.managed_session is not None
     assert request.managed_session.runtime_id == "codex_cli"
     assert request.managed_session.session_id == "sess:wf-run-1:codex_cli"
+
+def test_agent_execution_request_accepts_runtime_command_metadata() -> None:
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        instructionRef="/review\nCheck this.",
+        runtimeCommand={
+            "kind": "slash_command",
+            "source": "leading_slash",
+            "sourcePath": "objective.instructions",
+            "command": "review",
+            "rawCommand": "/review",
+            "args": "",
+            "instructionBody": "Check this.",
+            "targetRuntime": "codex_cli",
+            "detectionStatus": "detected",
+            "hintStatus": "hinted",
+            "recognitionMode": "hinted_runtime_passthrough",
+            "requiresRuntimeRecognition": True,
+            "runtimeCapabilityVersion": "2026-05-13",
+            "hintCatalogVersion": "2026-05-13",
+            "detectionPhase": "submit",
+        },
+    )
+
+    assert request.runtime_command is not None
+    assert request.runtime_command.command == "review"
+    assert request.model_dump(by_alias=True)["runtimeCommand"]["rawCommand"] == "/review"
+
+def test_runtime_command_render_result_supports_failure_and_prompt_prefix() -> None:
+    invocation = RuntimeCommandInvocation(
+        kind="slash_command",
+        source="leading_slash",
+        sourcePath="objective.instructions",
+        command="review",
+        rawCommand="/review",
+        args="",
+        instructionBody="Check this.",
+        targetRuntime="codex_cli",
+        detectionStatus="detected",
+        hintStatus="hinted",
+        recognitionMode="hinted_runtime_passthrough",
+        requiresRuntimeRecognition=True,
+        runtimeCapabilityVersion="2026-05-13",
+        hintCatalogVersion="2026-05-13",
+        detectionPhase="submit",
+    )
+
+    ok = RuntimeCommandRenderResult(
+        status="ok",
+        renderMode="prompt_prefix",
+        renderedInstruction="/review\n\nCheck this.",
+        invocation=invocation,
+    )
+    failed = RuntimeCommandRenderResult(
+        status="failed",
+        failureReason="runtime_command_render_failed",
+        diagnostics={"message": "redacted"},
+    )
+
+    assert ok.render_mode == "prompt_prefix"
+    assert ok.rendered_instruction.startswith("/review")
+    assert failed.failure_reason == "runtime_command_render_failed"
 
 def test_agent_execution_request_rejects_managed_session_for_non_codex_runtime() -> None:
     with pytest.raises(

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -79,6 +79,11 @@ def test_agent_execution_request_accepts_runtime_command_metadata() -> None:
             "detectionStatus": "detected",
             "hintStatus": "hinted",
             "recognitionMode": "hinted_runtime_passthrough",
+            "renderMode": "materialized_command",
+            "materializedCommand": {
+                "path": ".claude/commands/review.md",
+                "invocation": "/project:review",
+            },
             "requiresRuntimeRecognition": True,
             "runtimeCapabilityVersion": "2026-05-13",
             "hintCatalogVersion": "2026-05-13",
@@ -88,6 +93,11 @@ def test_agent_execution_request_accepts_runtime_command_metadata() -> None:
 
     assert request.runtime_command is not None
     assert request.runtime_command.command == "review"
+    assert request.runtime_command.render_mode == "materialized_command"
+    assert request.runtime_command.materialized_command == {
+        "path": ".claude/commands/review.md",
+        "invocation": "/project:review",
+    }
     assert request.model_dump(by_alias=True)["runtimeCommand"]["rawCommand"] == "/review"
 
 def test_runtime_command_render_result_supports_failure_and_prompt_prefix() -> None:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -8,6 +8,7 @@ import pytest
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.agent_runtime_models import ManagedRuntimeProfile
+from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
 from moonmind.workflows.temporal.runtime.launcher import (
     ManagedRuntimeLauncher,
 )
@@ -116,6 +117,53 @@ def test_build_command_gemini_cli():
     # Gemini CLI does not support --effort
     assert "--effort" not in cmd
     assert "Fix the bug" in cmd
+
+def test_apply_runtime_command_rendering_raises_before_launch_on_failure():
+    store = ManagedRunStore("/tmp/test-store")
+    launcher = ManagedRuntimeLauncher(store)
+    request = _make_request(instruction_ref="/review\nCheck this.")
+
+    class FailingStrategy:
+        runtime_id = "codex_cli"
+
+        def render_runtime_command(self, request):
+            return RuntimeCommandRenderResult(
+                status="failed",
+                failureReason="runtime_command_render_failed",
+                diagnostics={"message": "token=REDACTED"},
+            )
+
+    with pytest.raises(RuntimeError, match="runtime_command_render_failed"):
+        launcher._apply_runtime_command_rendering(
+            request=request,
+            strategy=FailingStrategy(),
+        )
+
+def test_apply_runtime_command_rendering_redacts_diagnostics(monkeypatch):
+    monkeypatch.setenv("MOONMIND_RUNTIME_RENDER_TOKEN", "render-secret-value")
+    store = ManagedRunStore("/tmp/test-store")
+    launcher = ManagedRuntimeLauncher(store)
+    request = _make_request(instruction_ref="/review\nCheck this.")
+
+    class DiagnosticStrategy:
+        runtime_id = "codex_cli"
+
+        def render_runtime_command(self, request):
+            return RuntimeCommandRenderResult(
+                status="ok",
+                renderMode="prompt_prefix",
+                renderedInstruction="/review\nCheck this.",
+                diagnostics={"message": "saw render-secret-value"},
+            )
+
+    launcher._apply_runtime_command_rendering(
+        request=request,
+        strategy=DiagnosticStrategy(),
+    )
+
+    render_metadata = request.parameters["metadata"]["moonmind"]["runtimeCommandRender"]
+    assert render_metadata["diagnostics"]["message"] == "saw ***"
+    assert "render-secret-value" not in str(render_metadata)
 
 def test_build_command_per_runtime():
     store = ManagedRunStore("/tmp/test-store")

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -444,6 +444,74 @@ async def test_launch_registers_generated_support_dir_for_cleanup(tmp_path, monk
     assert str(support_dir / "codex-home" / "config.toml") in cleanup_path_set
 
 @pytest.mark.asyncio
+async def test_launch_cleans_materialized_support_files_on_render_failure(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        command_template=["codex", "exec"],
+        secret_refs={"provider_api_key": "env://OPENROUTER_API_KEY"},
+        env_template={"OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}},
+        file_templates=[
+            {
+                "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                "format": "toml",
+                "mergeStrategy": "replace",
+                "contentTemplate": {"model_provider": "openrouter"},
+            }
+        ],
+        home_path_overrides={"CODEX_HOME": "{{runtime_support_dir}}/codex-home"},
+    )
+    request = _make_request(
+        instruction_ref="/future-command\nMalformed command.",
+        runtime_command={
+            "kind": "slash_command",
+            "source": "leading_slash",
+            "sourcePath": "objective.instructions",
+            "command": "future-command",
+            "rawCommand": "/future-command",
+            "args": "",
+            "instructionBody": "Malformed command.",
+            "detectionStatus": "detected",
+            "hintStatus": "opaque",
+            "recognitionMode": "runtime_passthrough",
+            "renderMode": "materialized_command",
+            "requiresRuntimeRecognition": True,
+            "materializedCommand": {
+                "path": ".claude/commands/future-command.md",
+                "invocation": "/project:future-command",
+            },
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="runtime_command_render_failed"):
+        await launcher.launch(
+            run_id="run-render-failure-cleanup",
+            request=request,
+            profile=profile,
+            workspace_path=workspace,
+        )
+
+    support_root = tmp_path / ".moonmind"
+    assert not any(support_root.glob("mm_profile_support_*"))
+
+@pytest.mark.asyncio
 @patch("moonmind.rag.context_injection.ContextInjectionService")
 async def test_launch_builds_codex_command_after_workspace_preparation(
     mock_service_class,

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from moonmind.schemas.agent_runtime_models import RuntimeCommandInvocation
 from moonmind.workflows.temporal.runtime.strategies import (
     RUNTIME_STRATEGIES,
 )
@@ -17,6 +19,9 @@ from moonmind.workflows.temporal.runtime.strategies.claude_code import (
 )
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     CodexCliStrategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.gemini_cli import (
+    GeminiCliStrategy,
 )
 
 # ---------------------------------------------------------------------------
@@ -43,10 +48,40 @@ def _make_request(
     *,
     instruction_ref: str | None = None,
     parameters: dict | None = None,
+    runtime_command: Any = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         instruction_ref=instruction_ref,
         parameters=parameters or {},
+        runtime_command=runtime_command,
+    )
+
+
+def _runtime_command(
+    *,
+    raw_command: str = "/review",
+    instruction_body: str = "Check this branch.",
+    command: str = "review",
+    hint_status: str = "hinted",
+    recognition_mode: str = "hinted_runtime_passthrough",
+    requires_runtime_recognition: bool = True,
+) -> RuntimeCommandInvocation:
+    return RuntimeCommandInvocation(
+        kind="slash_command",
+        source="leading_slash",
+        sourcePath="objective.instructions",
+        command=command,
+        rawCommand=raw_command,
+        args="",
+        instructionBody=instruction_body,
+        targetRuntime="codex_cli",
+        detectionStatus="detected",
+        hintStatus=hint_status,
+        recognitionMode=recognition_mode,
+        requiresRuntimeRecognition=requires_runtime_recognition,
+        runtimeCapabilityVersion="2026-05-13",
+        hintCatalogVersion="2026-05-13",
+        detectionPhase="submit",
     )
 
 # ---------------------------------------------------------------------------
@@ -167,6 +202,129 @@ class TestClaudeCodeBuildCommand:
         cmd = s.build_command(profile, request)
         assert "--model" in cmd
         assert "claude-sonnet-4-6" in cmd
+
+class TestRuntimeCommandRendering:
+    def test_codex_prompt_prefix_keeps_command_before_prepared_context(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref=(
+                "Check this branch.\n\n"
+                "MoonMind retrieval capability:\n- Retrieved context follows."
+            ),
+            runtime_command=_runtime_command(instruction_body="Check this branch."),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "prompt_prefix"
+        assert result.rendered_instruction is not None
+        assert result.rendered_instruction.startswith("/review")
+        assert result.rendered_instruction.index("/review") < result.rendered_instruction.index("Check this branch.")
+        assert result.rendered_instruction.index("Check this branch.") < result.rendered_instruction.index("MoonMind retrieval capability")
+
+    def test_claude_prompt_prefix_keeps_command_before_prepared_context(self) -> None:
+        strategy = ClaudeCodeStrategy()
+        request = _make_request(
+            instruction_ref="Check this branch.\n\nRetrieved context.",
+            runtime_command=_runtime_command(instruction_body="Check this branch."),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "prompt_prefix"
+        assert result.rendered_instruction is not None
+        assert result.rendered_instruction.startswith("/review")
+        assert "Retrieved context." in result.rendered_instruction
+
+    def test_unknown_opaque_command_passes_through_without_materialization(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref="Use provider feature.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                raw_command="/future-command now",
+                command="future-command",
+                instruction_body="Use provider feature.",
+                hint_status="opaque",
+                recognition_mode="runtime_passthrough",
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "prompt_prefix"
+        assert result.rendered_instruction is not None
+        assert result.rendered_instruction.startswith("/future-command now")
+        assert result.materialized_targets == []
+
+    def test_escaped_literal_does_not_start_with_executable_command(self) -> None:
+        strategy = ClaudeCodeStrategy()
+        request = _make_request(
+            instruction_ref="\\/review\nTreat this as ordinary text.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                raw_command="\\/review",
+                command="",
+                instruction_body="/review\nTreat this as ordinary text.",
+                hint_status="opaque",
+                recognition_mode="escaped_literal",
+                requires_runtime_recognition=False,
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "plain_prompt"
+        assert result.rendered_instruction is not None
+        assert not result.rendered_instruction.startswith("/review")
+        assert "/review\nTreat this as ordinary text." in result.rendered_instruction
+
+    def test_empty_prepared_context_keeps_prompt_prefix_compact(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref="/review\nCheck this branch.",
+            runtime_command=_runtime_command(),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.rendered_instruction == "/review\n\nCheck this branch."
+
+    def test_unsupported_runtime_falls_back_without_materializing_command(self) -> None:
+        strategy = GeminiCliStrategy()
+        request = _make_request(
+            instruction_ref="/review\nCheck this branch.\n\nPrepared context.",
+            runtime_command=_runtime_command(),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "fallback"
+        assert result.render_mode == "plain_prompt"
+        assert result.rendered_instruction == request.instruction_ref
+        assert result.fallback_event == {
+            "reason": "unsupported_runtime",
+            "fallbackMode": "literal_prompt",
+        }
+        assert result.materialized_targets == []
+
+    def test_malformed_runtime_command_metadata_fails_typed(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref="/review\nCheck this branch.",
+            runtime_command={"kind": "slash_command"},
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "failed"
+        assert result.failure_reason == "runtime_command_render_failed"
+        assert result.diagnostics == {
+            "message": "Invalid runtime command metadata.",
+        }
 
 # ---------------------------------------------------------------------------
 # ClaudeCodeStrategy.prepare_workspace

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -62,17 +62,20 @@ def _runtime_command(
     raw_command: str = "/review",
     instruction_body: str = "Check this branch.",
     command: str = "review",
+    args: str = "",
     hint_status: str = "hinted",
     recognition_mode: str = "hinted_runtime_passthrough",
     requires_runtime_recognition: bool = True,
+    render_mode: str | None = None,
+    materialized_command: dict[str, Any] | None = None,
 ) -> RuntimeCommandInvocation:
-    return RuntimeCommandInvocation(
+    payload: dict[str, Any] = dict(
         kind="slash_command",
         source="leading_slash",
         sourcePath="objective.instructions",
         command=command,
         rawCommand=raw_command,
-        args="",
+        args=args,
         instructionBody=instruction_body,
         targetRuntime="codex_cli",
         detectionStatus="detected",
@@ -83,6 +86,11 @@ def _runtime_command(
         hintCatalogVersion="2026-05-13",
         detectionPhase="submit",
     )
+    if render_mode is not None:
+        payload["renderMode"] = render_mode
+    if materialized_command is not None:
+        payload["materializedCommand"] = materialized_command
+    return RuntimeCommandInvocation(**payload)
 
 # ---------------------------------------------------------------------------
 # Registry completeness
@@ -325,6 +333,115 @@ class TestRuntimeCommandRendering:
         assert result.diagnostics == {
             "message": "Invalid runtime command metadata.",
         }
+
+    def test_native_command_strategy_returns_structured_payload(self) -> None:
+        class NativeGeminiStrategy(GeminiCliStrategy):
+            def supports_native_command_transport(self) -> bool:
+                return True
+
+        strategy = NativeGeminiStrategy()
+        request = _make_request(
+            instruction_ref="Inspect changes.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                raw_command="/review staged",
+                args="staged",
+                instruction_body="Inspect changes.",
+                render_mode="native_command",
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "native_command"
+        assert result.rendered_instruction is None
+        assert result.native_command_payload == {
+            "type": "runtime.command",
+            "command": "review",
+            "args": "staged",
+            "rawCommand": "/review staged",
+            "instructionBody": "Inspect changes.",
+            "preparedContext": "Prepared context.",
+        }
+        assert result.materialized_targets == []
+
+    def test_claude_materialized_review_uses_allowlisted_project_command(self) -> None:
+        strategy = ClaudeCodeStrategy()
+        request = _make_request(
+            instruction_ref="Focus on regressions.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                instruction_body="Focus on regressions.",
+                render_mode="materialized_command",
+                materialized_command={
+                    "path": ".claude/commands/review.md",
+                    "invocation": "/project:review",
+                },
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.render_mode == "materialized_command"
+        assert result.rendered_instruction is not None
+        assert result.rendered_instruction.startswith("/project:review")
+        assert "Focus on regressions." in result.rendered_instruction
+        assert "Prepared context." in result.rendered_instruction
+        assert result.materialized_targets == [
+            {
+                "path": ".claude/commands/review.md",
+                "command": "review",
+                "invocation": "/project:review",
+            }
+        ]
+
+    def test_opaque_command_requested_for_materialization_fails_before_target(self) -> None:
+        strategy = ClaudeCodeStrategy()
+        request = _make_request(
+            instruction_ref="Use provider feature.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                raw_command="/future-command now",
+                command="future-command",
+                args="now",
+                instruction_body="Use provider feature.",
+                hint_status="opaque",
+                recognition_mode="runtime_passthrough",
+                render_mode="materialized_command",
+                materialized_command={
+                    "path": ".claude/commands/future-command.md",
+                    "invocation": "/project:future-command",
+                },
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "failed"
+        assert result.failure_reason == "runtime_command_render_failed"
+        assert result.materialized_targets == []
+
+    def test_materialized_command_rejects_target_outside_allowlist(self) -> None:
+        strategy = ClaudeCodeStrategy()
+        request = _make_request(
+            instruction_ref="Focus on regressions.\n\nPrepared context.",
+            runtime_command=_runtime_command(
+                instruction_body="Focus on regressions.",
+                render_mode="materialized_command",
+                materialized_command={
+                    "path": ".claude/commands/other.md",
+                    "invocation": "/project:review",
+                },
+            ),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "failed"
+        assert result.failure_reason == "runtime_command_render_failed"
+        assert result.diagnostics == {
+            "message": "Materialized command target is outside the allowlist."
+        }
+        assert result.materialized_targets == []
 
 # ---------------------------------------------------------------------------
 # ClaudeCodeStrategy.prepare_workspace

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -301,6 +301,49 @@ class TestRuntimeCommandRendering:
         assert result.status == "ok"
         assert result.rendered_instruction == "/review\n\nCheck this branch."
 
+    def test_prepared_context_removes_only_leading_runtime_command_block(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref=(
+                "/review\nCheck this branch.\n\n"
+                "Inspect path/to/review.py before changing behavior.\n"
+                "Check this branch remains part of retrieved context."
+            ),
+            runtime_command=_runtime_command(),
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "ok"
+        assert result.rendered_instruction is not None
+        assert result.rendered_instruction.startswith("/review\n\nCheck this branch.")
+        assert "path/to/review.py" in result.rendered_instruction
+        assert "Check this branch remains part of retrieved context." in result.rendered_instruction
+
+    def test_blank_recognized_command_metadata_fails_typed(self) -> None:
+        strategy = CodexCliStrategy()
+        request = _make_request(
+            instruction_ref="Prepared context.",
+            runtime_command={
+                "kind": "slash_command",
+                "source": "leading_slash",
+                "sourcePath": "objective.instructions",
+                "command": "",
+                "rawCommand": "",
+                "args": "",
+                "instructionBody": "Prepared context.",
+                "detectionStatus": "detected",
+                "hintStatus": "hinted",
+                "recognitionMode": "hinted_runtime_passthrough",
+                "requiresRuntimeRecognition": True,
+            },
+        )
+
+        result = strategy.render_runtime_command(request)
+
+        assert result.status == "failed"
+        assert result.failure_reason == "runtime_command_render_failed"
+
     def test_unsupported_runtime_falls_back_without_materializing_command(self) -> None:
         strategy = GeminiCliStrategy()
         request = _make_request(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -698,6 +698,52 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             {"id": "step-2", "instructions": "Do part B"}
         ])
 
+    def test_build_agent_execution_request_propagates_runtime_command_metadata(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        runtime_command = {
+            "kind": "slash_command",
+            "source": "leading_slash",
+            "sourcePath": "objective.instructions",
+            "command": "review",
+            "rawCommand": "/review",
+            "args": "",
+            "instructionBody": "Check this branch.",
+            "targetRuntime": "codex_cli",
+            "detectionStatus": "detected",
+            "hintStatus": "hinted",
+            "recognitionMode": "hinted_runtime_passthrough",
+            "requiresRuntimeRecognition": True,
+            "runtimeCapabilityVersion": "2026-05-13",
+            "hintCatalogVersion": "2026-05-13",
+            "detectionPhase": "submit",
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "instructions": "/review\nCheck this branch.",
+                    "runtime": {"mode": "codex_cli"},
+                    "runtimeCommand": runtime_command,
+                },
+                node_id="node-runtime-command",
+                tool_name="codex_cli",
+            )
+
+        self.assertEqual(request.instruction_ref, "/review\nCheck this branch.")
+        self.assertIsNotNone(request.runtime_command)
+        self.assertEqual(request.runtime_command.command, "review")
+        self.assertEqual(request.runtime_command.raw_command, "/review")
+
     def test_build_agent_execution_request_propagates_story_output_handoff(self) -> None:
         from unittest.mock import patch
 


### PR DESCRIPTION
Run Jira Orchestrate for MM-686.

Source story: STORY-003.
Source summary: Render runtime commands after context preparation in managed runtime adapters.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.