### PR TITLE
When you choose to edit a task (or any of the other buttons that may take you to the create page in a non-traditional mode), we should keep the green…

### DIFF
--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7954,7 +7954,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       : pageMode.mode === "rerun"
         ? "Rerun Task"
         : "Create";
-  const showPrimaryCtaArrow = pageMode.mode === "create";
+  const showPrimaryCtaArrow = true;
   const primaryCtaTooltip =
     pageMode.intent === "edit"
       ? "Save changes to this task draft"


### PR DESCRIPTION
When you choose to edit a task (or any of the other buttons that may take you to the create page in a non-traditional mode), we should keep the green arrow button instead of adapting what the button says. We can possibly adapt the tooltip for the button instead if that is simple, although don't do that if it's complicated, and keep the page header changed as we already do, but we don't want the basic aesthetic of the create / submit button to change.