### PR TITLE
Choosing jira-verify or jira-pr-verify should automatically switch publish mode to None in the create task page UI

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6210,6 +6210,9 @@ describe.skip("Task Create Entrypoint", () => {
       ).toBe("none");
     });
 
+    fireEvent.change(publishSelect, { target: { value: "pr" } });
+    expect(publishSelect.value).toBe("pr");
+
     fireEvent.change(
       within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
       {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6159,6 +6159,70 @@ describe.skip("Task Create Entrypoint", () => {
     });
   });
 
+  it("defaults publish mode to none when selecting jira-verify or jira-pr-verify skills", async () => {
+    type MockInitialData = {
+      dashboardConfig: {
+        system: {
+          defaultPublishMode: string;
+        };
+      };
+    };
+
+    const payload: BootPayload = {
+      ...mockPayload,
+      initialData: {
+        ...(mockPayload.initialData as MockInitialData),
+        dashboardConfig: {
+          ...(mockPayload.initialData as MockInitialData).dashboardConfig,
+          system: {
+            ...(mockPayload.initialData as MockInitialData).dashboardConfig
+              .system,
+            defaultPublishMode: "pr",
+          },
+        },
+      },
+    };
+
+    renderWithClient(<TaskCreatePage payload={payload} />);
+
+    const primaryStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+
+    const publishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(publishSelect.value).toBe(
+      (payload.initialData as MockInitialData).dashboardConfig.system
+        .defaultPublishMode,
+    );
+
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "jira-verify" },
+      },
+    );
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
+    });
+
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "jira-pr-verify" },
+      },
+    );
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
+    });
+  });
+
   it("defaults publish mode to none when selecting the Jira Breakdown preset", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -34,6 +34,8 @@ const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   ...PR_RESOLVER_SKILLS,
   JIRA_BREAKDOWN_PRESET_SLUG,
   JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
+  "jira-verify",
+  "jira-pr-verify",
 ]);
 const MOONSPEC_ORCHESTRATE_PRESET_SLUG = "moonspec-orchestrate";
 const HIDDEN_PRESET_INPUT_KEYS: Record<string, Set<string>> = {


### PR DESCRIPTION
Choosing jira-verify or jira-pr-verify should automatically switch publish mode to None in the create task page UI