### PR TITLE
Recover orphan workspace git-object stores before commit

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5524,6 +5524,9 @@ class TemporalAgentRuntimeActivities:
             if record is not None:
                 if record.workspace_path:
                     self._normalize_workspace_git_alternates(record.workspace_path)
+                    self._recover_orphan_workspace_object_stores(
+                        record.workspace_path
+                    )
                 result = self._maybe_enrich_gemini_failure_result(
                     result=result,
                     record=record,
@@ -6237,6 +6240,171 @@ class TemporalAgentRuntimeActivities:
             )
 
     @staticmethod
+    def _looks_like_git_loose_objects_dir(directory: Path) -> bool:
+        """Return True when ``directory`` contains git-style loose objects.
+
+        A git loose-objects directory has two-character hex subdirectories
+        (e.g. ``6d/``) whose children are 38-character hex blob filenames.
+        Also accepted as a positive signal: a ``pack/`` subdirectory with at
+        least one ``.pack`` file. Both signals are evaluated cheaply without
+        walking the full tree.
+        """
+        if not directory.is_dir():
+            return False
+        try:
+            entries = list(directory.iterdir())
+        except OSError:
+            return False
+
+        hex_chars = set("0123456789abcdef")
+        for entry in entries:
+            name = entry.name
+            if entry.is_dir() and name == "pack":
+                try:
+                    for child in entry.iterdir():
+                        if child.is_file() and child.name.endswith(".pack"):
+                            return True
+                except OSError:
+                    continue
+                continue
+            if (
+                entry.is_dir()
+                and len(name) == 2
+                and all(c in hex_chars for c in name.lower())
+            ):
+                try:
+                    for child in entry.iterdir():
+                        cname = child.name
+                        if (
+                            child.is_file()
+                            and len(cname) == 38
+                            and all(c in hex_chars for c in cname.lower())
+                        ):
+                            return True
+                except OSError:
+                    continue
+        return False
+
+    @staticmethod
+    def _recover_orphan_workspace_object_stores(workspace: str) -> None:
+        """Register sibling object-stores as Git alternates before commit.
+
+        Some managed-runtime images stage loose objects in a directory that
+        sits *next to* the workspace ``.git`` directory (for example
+        ``<workspace_parent>/git-objects``) without writing a corresponding
+        ``.git/objects/info/alternates`` entry. When that happens, ``git
+        commit`` later fails with ``error: invalid object ... Error building
+        trees`` because the index references blobs the object database cannot
+        resolve.
+
+        This helper finds such sibling directories, verifies they look like
+        git object stores, and appends them to ``info/alternates`` using a
+        path relative to ``.git/objects`` (so that ``:`` characters in
+        managed run ids do not break alternate parsing).
+        """
+        workspace_path = Path(workspace)
+        git_dir = workspace_path / ".git"
+        objects_dir = git_dir / "objects"
+        if not git_dir.is_dir() or not objects_dir.is_dir():
+            return
+
+        try:
+            workspace_resolved = workspace_path.resolve()
+        except OSError:
+            return
+        workspace_parent = workspace_resolved.parent
+
+        alternates_path = objects_dir / "info" / "alternates"
+        existing_lines: list[str] = []
+        if alternates_path.is_file():
+            try:
+                existing_lines = [
+                    line.strip()
+                    for line in alternates_path.read_text(
+                        encoding="utf-8"
+                    ).splitlines()
+                    if line.strip()
+                ]
+            except OSError:
+                existing_lines = []
+
+        try:
+            objects_dir_resolved = objects_dir.resolve()
+        except OSError:
+            return
+
+        registered: set[Path] = set()
+        for raw in existing_lines:
+            candidate = (
+                Path(raw)
+                if Path(raw).is_absolute()
+                else (objects_dir / raw)
+            )
+            try:
+                registered.add(candidate.resolve())
+            except OSError:
+                continue
+
+        try:
+            siblings = list(workspace_parent.iterdir())
+        except OSError:
+            return
+
+        additions: list[str] = []
+        for sibling in siblings:
+            try:
+                sibling_resolved = sibling.resolve()
+            except OSError:
+                continue
+            if sibling_resolved == workspace_resolved:
+                continue
+            if sibling_resolved == objects_dir_resolved:
+                continue
+            if sibling_resolved in registered:
+                continue
+            if (
+                not TemporalAgentRuntimeActivities
+                ._looks_like_git_loose_objects_dir(sibling)
+            ):
+                continue
+            try:
+                relative = os.path.relpath(sibling_resolved, objects_dir_resolved)
+            except ValueError:
+                relative = str(sibling_resolved)
+            additions.append(relative)
+            registered.add(sibling_resolved)
+
+        if not additions:
+            return
+
+        merged: list[str] = []
+        seen: set[str] = set()
+        for line in existing_lines + additions:
+            if line not in seen:
+                seen.add(line)
+                merged.append(line)
+
+        try:
+            (objects_dir / "info").mkdir(parents=True, exist_ok=True)
+            alternates_path.write_text(
+                "\n".join(merged) + "\n",
+                encoding="utf-8",
+            )
+            logger.info(
+                "Registered %d sibling object store(s) as Git alternates for "
+                "workspace %s: %s",
+                len(additions),
+                workspace,
+                ", ".join(additions),
+            )
+        except OSError:
+            logger.warning(
+                "Unable to register sibling object stores for workspace %s",
+                workspace,
+                exc_info=True,
+            )
+
+    @staticmethod
     def _workspace_command_env(workspace: str) -> dict[str, str]:
         """Build a subprocess env that exposes workspace-local command shims."""
         env = dict(os.environ)
@@ -6535,6 +6703,7 @@ class TemporalAgentRuntimeActivities:
         workspace = record.workspace_path
         try:
             self._normalize_workspace_git_alternates(workspace)
+            self._recover_orphan_workspace_object_stores(workspace)
             command_env = self._workspace_command_env(workspace)
             branch_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6244,7 +6244,7 @@ class TemporalAgentRuntimeActivities:
         """Return True when ``directory`` contains git-style loose objects.
 
         A git loose-objects directory has two-character hex subdirectories
-        (e.g. ``6d/``) whose children are 38-character hex blob filenames.
+        (e.g. ``6d/``) whose children are SHA-1 or SHA-256 hex blob filenames.
         Also accepted as a positive signal: a ``pack/`` subdirectory with at
         least one ``.pack`` file. Both signals are evaluated cheaply without
         walking the full tree.
@@ -6257,6 +6257,7 @@ class TemporalAgentRuntimeActivities:
             return False
 
         hex_chars = set("0123456789abcdef")
+        loose_object_name_lengths = {38, 62}
         for entry in entries:
             name = entry.name
             if entry.is_dir() and name == "pack":
@@ -6277,7 +6278,7 @@ class TemporalAgentRuntimeActivities:
                         cname = child.name
                         if (
                             child.is_file()
-                            and len(cname) == 38
+                            and len(cname) in loose_object_name_lengths
                             and all(c in hex_chars for c in cname.lower())
                         ):
                             return True
@@ -6345,34 +6346,36 @@ class TemporalAgentRuntimeActivities:
             except OSError:
                 continue
 
+        additions: list[str] = []
         try:
-            siblings = list(workspace_parent.iterdir())
+            siblings = workspace_parent.iterdir()
+            for sibling in siblings:
+                try:
+                    sibling_resolved = sibling.resolve()
+                except OSError:
+                    continue
+                if sibling_resolved == workspace_resolved:
+                    continue
+                if sibling_resolved == objects_dir_resolved:
+                    continue
+                if sibling_resolved in registered:
+                    continue
+                if (
+                    not TemporalAgentRuntimeActivities
+                    ._looks_like_git_loose_objects_dir(sibling)
+                ):
+                    continue
+                try:
+                    relative = os.path.relpath(
+                        sibling_resolved,
+                        objects_dir_resolved,
+                    )
+                except ValueError:
+                    relative = str(sibling_resolved)
+                additions.append(relative)
+                registered.add(sibling_resolved)
         except OSError:
             return
-
-        additions: list[str] = []
-        for sibling in siblings:
-            try:
-                sibling_resolved = sibling.resolve()
-            except OSError:
-                continue
-            if sibling_resolved == workspace_resolved:
-                continue
-            if sibling_resolved == objects_dir_resolved:
-                continue
-            if sibling_resolved in registered:
-                continue
-            if (
-                not TemporalAgentRuntimeActivities
-                ._looks_like_git_loose_objects_dir(sibling)
-            ):
-                continue
-            try:
-                relative = os.path.relpath(sibling_resolved, objects_dir_resolved)
-            except ValueError:
-                relative = str(sibling_resolved)
-            additions.append(relative)
-            registered.add(sibling_resolved)
 
         if not additions:
             return

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -245,6 +245,27 @@ class TestPushWorkspaceBranch:
         # Path must be relative so that ':' in run ids does not break parsing.
         assert contents == ["../../../git-objects"]
 
+    def test_recover_orphan_object_stores_accepts_sha256_loose_objects(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        sibling = tmp_path / "mm:run-1" / "git-objects-sha256"
+        (sibling / "6d").mkdir(parents=True)
+        (sibling / "6d" / ("9" * 62)).write_bytes(b"x")
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        assert alternates_path.is_file()
+        assert (
+            alternates_path.read_text(encoding="utf-8").splitlines()
+            == ["../../../git-objects-sha256"]
+        )
+
     def test_recover_orphan_object_stores_appends_without_duplicating(
         self,
         tmp_path: Path,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -224,6 +224,118 @@ class TestPushWorkspaceBranch:
 
         assert alternates_path.read_text(encoding="utf-8") == "../objects_app\n"
 
+    def test_recover_orphan_object_stores_registers_sibling_with_loose_objects(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        sibling = tmp_path / "mm:run-1" / "git-objects"
+        (sibling / "6d").mkdir(parents=True)
+        # 38-char hex blob filename mimics the real loose-object layout.
+        (sibling / "6d" / "93a9ea32d2cf97dca48c5bf139829fc28516c5").write_bytes(b"x")
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        assert alternates_path.is_file()
+        contents = alternates_path.read_text(encoding="utf-8").splitlines()
+        # Path must be relative so that ':' in run ids does not break parsing.
+        assert contents == ["../../../git-objects"]
+
+    def test_recover_orphan_object_stores_appends_without_duplicating(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        objects_info = workspace / ".git" / "objects" / "info"
+        objects_info.mkdir(parents=True)
+        alternates_path = objects_info / "alternates"
+        alternates_path.write_text("../../../git-objects\n", encoding="utf-8")
+        sibling = tmp_path / "mm:run-1" / "git-objects"
+        (sibling / "6d").mkdir(parents=True)
+        (sibling / "6d" / "93a9ea32d2cf97dca48c5bf139829fc28516c5").write_bytes(b"x")
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        assert (
+            alternates_path.read_text(encoding="utf-8").splitlines()
+            == ["../../../git-objects"]
+        )
+
+    def test_recover_orphan_object_stores_ignores_non_object_siblings(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        # A sibling that exists but is not a git object store.
+        (tmp_path / "mm:run-1" / "artifacts").mkdir()
+        (tmp_path / "mm:run-1" / "artifacts" / "notes.txt").write_text("hi")
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        assert not alternates_path.exists()
+
+    def test_recover_orphan_object_stores_accepts_pack_only_sibling(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        sibling = tmp_path / "mm:run-1" / "shared-objects"
+        (sibling / "pack").mkdir(parents=True)
+        (sibling / "pack" / "pack-abc.pack").write_bytes(b"\x00")
+        (sibling / "pack" / "pack-abc.idx").write_bytes(b"\x00")
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        assert alternates_path.is_file()
+        assert (
+            alternates_path.read_text(encoding="utf-8").splitlines()
+            == ["../../../shared-objects"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_push_recovers_orphan_object_store_before_branch_detection(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        sibling = tmp_path / "mm:run-1" / "git-objects"
+        (sibling / "6d").mkdir(parents=True)
+        (sibling / "6d" / "93a9ea32d2cf97dca48c5bf139829fc28516c5").write_bytes(b"x")
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        store = _make_mock_store(workspace_path=str(workspace))
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        async def _mock_exec(*args, **kwargs):
+            # The orphan-object recovery must have already written alternates
+            # by the time any git subprocess is invoked.
+            assert alternates_path.is_file()
+            contents = alternates_path.read_text(encoding="utf-8").splitlines()
+            assert contents == ["../../../git-objects"]
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "protected_branch"
+
     @pytest.mark.asyncio
     async def test_push_normalizes_git_alternates_before_branch_detection(
         self,


### PR DESCRIPTION
## Summary

- When managed runs land loose Git objects in a sibling of the workspace `.git/` (e.g. `<workspace_parent>/git-objects/`) without registering an alternates entry, the post-agent "commit any remaining workspace changes" hook fails with `error: invalid object ... Error building trees`, and the run is marked `publish_status=failed` even when the agent already pushed a valid PR.
- Add `_recover_orphan_workspace_object_stores` to detect sibling object stores (loose-objects or pack-shaped) and register them in `.git/objects/info/alternates` using a relative path so that `:` characters in run ids do not break alternate parsing.
- Call it after `_normalize_workspace_git_alternates` in both `_push_workspace_branch` and the `fetch_result` post-processing path, so agent-written entries are normalized first and orphans are appended cleanly afterwards.

### Repro reference

Task `mm:e1afde4a-fc92-48d9-811d-6ca6df9c1b32` (MM-687): step 14 created PR #2137 successfully, then the post-step finalization commit failed with:

\`\`\`
could not commit workspace changes: error: invalid object 100644 6d93a9ea... for 'tests/unit/workflows/temporal/runtime/test_runtime_command_audit_events.py'
error: Error building trees
\`\`\`

Inspection of the workspace volume showed the blob present at \`<workspace_parent>/git-objects/6d/93a9...\` but no \`.git/objects/info/alternates\` pointer.

## Test plan

- [x] \`./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py\` — 62 passed (includes 4 new tests for orphan recovery plus 1 new integration-style test that asserts recovery runs before the first git subprocess call inside \`_push_workspace_branch\`).
- [ ] Targeted re-run of a failing Jira Orchestrate run after merge to confirm finalization commits succeed when an orphan \`git-objects/\` sibling is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)