### PR TITLE
Update the jira-verify skill. It CAN work off of a branch, but it should also be capable of working off of main and just checking if the story is prop

### DIFF
--- a/.agents/skills/jira-verify/SKILL.md
+++ b/.agents/skills/jira-verify/SKILL.md
@@ -52,13 +52,13 @@ Never print raw environment variables. Use targeted checks such as `test -n "$MO
    - Record `git branch --show-current`, `git rev-parse HEAD`, and `git status --short`.
    - Determine the candidate base ref from user input, upstream tracking branch, `origin/main`, `origin/master`, `main`, or `master`. Fetch the base ref only when needed and safe.
    - Decide the mode:
-     - **Branch mode** when the current checkout is NOT the default branch AND `git rev-list --left-right --count <base>...HEAD` shows commits ahead of base.
+     - **Branch mode** when the current checkout is NOT the default branch AND `git rev-list --count <base>..HEAD` is greater than 0.
      - **Main/trunk mode** when the current checkout IS the default branch, when HEAD already equals the base ref, when `git rev-list --count <base>..HEAD` is `0`, or when the user explicitly requested `main` mode.
      - If a user-supplied mode hint is provided, honor it unless it is impossible (e.g. branch mode requested but no distinct branch exists — then block with a clear reason).
    - For branch mode: use `git merge-base <base> HEAD`, then inspect `git diff --stat <merge-base>..HEAD`, `git diff --name-status <merge-base>..HEAD`, and relevant hunks as the primary evidence set.
    - For main/trunk mode: do NOT block on the empty diff. The repository state at HEAD is itself the evidence. Additionally locate the merge(s) that implemented the issue:
-     - `git log --grep '<ISSUE-KEY>' --oneline -n 200` to find commits that reference the key in the message.
-     - `git log --all --oneline -n 200 -- <likely paths>` for paths matched by issue keywords when no key reference is found.
+     - `git log -i --grep '<ISSUE-KEY>' --oneline -n 200` to find commits that reference the key in the message.
+     - `git log --oneline -n 200 -- <likely paths>` for paths matched by issue keywords when no key reference is found.
      - `gh pr list --search '<ISSUE-KEY>' --state merged --limit 20` when `gh` is authenticated, to locate the merged PR(s) for the issue.
      - For each candidate merge commit, inspect `git show --stat <sha>` and `git diff <sha>^..<sha>` to extract the implementation diff, and treat that as the diff under verification.
      - If multiple merges plausibly implement parts of the issue, aggregate them and note each in the evidence ledger.
@@ -67,7 +67,7 @@ Never print raw environment variables. Use targeted checks such as `test -n "$MO
 3. Inspect implementation evidence.
    - In branch mode: read changed source, tests, docs, workflow/config, migrations, and generated artifacts within `<merge-base>..HEAD`.
    - In main/trunk mode: read the current state of files relevant to the Jira ledger AND, when available, the implementing merge commit(s) diffs identified above. The "current state on main" is acceptable evidence on its own when it clearly satisfies a requirement; the historical diff is supplementary.
-   - In both modes: search the repository with `rg` for Jira terms, feature names, acceptance criteria keywords, old behavior, and new behavior. In main/trunk mode, also `rg` the issue key itself (`MM-555`, etc.) across source, tests, specs, docs, changelog, and `specs/<feature>/` folders.
+   - In both modes: search the repository with `rg -i` for Jira terms, feature names, acceptance criteria keywords, old behavior, and new behavior. In main/trunk mode, also `rg -i -w` the issue key itself (`MM-555`, etc.) across source, tests, specs, docs, changelog, and `specs/<feature>/` folders.
    - Identify deleted or superseded paths so the verdict accounts for removals as well as additions.
    - Run local tests when required by repo instructions, user request, or when the verdict depends on unproven behavior. If tests cannot run, record exactly why.
    - In main/trunk mode, if no implementing commits, no issue-key references, and no code matching the requirements can be found, then — and only then — record the verdict as `FAIL` (not implemented on main) or `BLOCKED` (requirements too ambiguous to tell), with a clear distinction between the two.

--- a/.agents/skills/jira-verify/SKILL.md
+++ b/.agents/skills/jira-verify/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: jira-verify
-description: Verify the current repository branch against a Jira issue's goals, requirements, and acceptance criteria, then post a Jira comment with a PASS, PARTIAL, FAIL, or BLOCKED verdict. Use when a user asks whether the current branch completes a Jira ticket, wants Jira issue completion checked from local branch changes, or needs a Jira-visible verification comment.
+description: Verify a Jira issue against the current repository state, then post a Jira comment with a PASS, PARTIAL, FAIL, or BLOCKED verdict. Works in two modes: (a) feature-branch mode, comparing a checked-out branch to its base ref; or (b) main/trunk mode, verifying that an issue is already implemented on the current default branch (typical for stories that have already merged). Use when a user asks whether a branch or merged change completes a Jira ticket, or needs a Jira-visible verification comment.
 ---
 
 # Jira Verify
 
-Verify whether the current checkout/branch satisfies a Jira issue, then publish a concise Jira comment with the result.
+Verify whether the repository satisfies a Jira issue, then publish a concise Jira comment with the result. This skill supports two equally valid verification modes:
+
+- **Branch mode** — a feature branch is checked out, distinct from the base ref; verification compares the diff `<base>..HEAD` to the Jira requirements.
+- **Main/trunk mode** — the current checkout is the default branch itself (e.g. `main` at `origin/main`), or there is no meaningful diff against the base ref. In this mode, verify that the issue is already implemented in the codebase as it stands. This is the expected mode when the work has already merged and the user just wants confirmation that the story landed.
+
+Choose the mode automatically based on observed repository state. Do not treat "no feature branch / no diff vs. base" as an immediate `BLOCKED` — fall back to main/trunk verification first, and only block if even main/trunk evidence is missing.
 
 ## Inputs
 
@@ -14,7 +19,9 @@ Verify whether the current checkout/branch satisfies a Jira issue, then publish 
 - Required for Jira content and posting: MoonMind's trusted Jira tool surface, normally `jira.get_issue` and `jira.add_comment`.
 - Optional: update status, boolean, default `false`. When `true`, and only when the final verification verdict is `PASS`, the skill may move the Jira issue to a terminal done state through MoonMind's trusted Jira tool surface.
 - Optional: transition ID, transition name, or transition fields. Use these to disambiguate or satisfy required fields when moving the issue to a terminal state.
-- Optional: base branch or comparison ref. If omitted, infer from upstream, `origin/main`, `origin/master`, `main`, or `master`.
+- Optional: base branch or comparison ref. If omitted, infer from upstream, `origin/main`, `origin/master`, `main`, or `master`. When the checkout is already on the default branch or the diff against the inferred base is empty, switch to main/trunk verification (see Workflow) instead of blocking.
+- Optional: explicit verification mode hint (`branch`, `main`, or `auto`). Default `auto`.
+- Optional: history search window (commit count or date range) for locating prior merges that implement the issue on the default branch. Default: scan the last ~200 commits and any commits in the last ~90 days.
 - Optional: required test commands, scope limits, or explicit non-goals.
 
 ## MoonMind Jira Access Model
@@ -41,18 +48,29 @@ Never print raw environment variables. Use targeted checks such as `test -n "$MO
    - Extract a requirements ledger: summary, description goals, acceptance criteria, constraints, explicit non-goals, linked issue dependencies, and any test or deployment expectations.
    - If requirements are ambiguous, mark them `unverifiable` instead of inventing criteria.
 
-2. Resolve the branch comparison.
+2. Choose a verification mode and resolve the comparison.
    - Record `git branch --show-current`, `git rev-parse HEAD`, and `git status --short`.
-   - Determine the comparison ref from user input, upstream tracking branch, `origin/main`, `origin/master`, `main`, or `master`.
-   - Fetch the comparison ref only when needed and safe.
-   - Use `git merge-base <base> HEAD`, then inspect `git diff --stat <merge-base>..HEAD`, `git diff --name-status <merge-base>..HEAD`, and relevant hunks.
-   - If no meaningful diff exists, the likely verdict is `FAIL` or `BLOCKED` unless the Jira issue explicitly requires only verification/no code change.
+   - Determine the candidate base ref from user input, upstream tracking branch, `origin/main`, `origin/master`, `main`, or `master`. Fetch the base ref only when needed and safe.
+   - Decide the mode:
+     - **Branch mode** when the current checkout is NOT the default branch AND `git rev-list --left-right --count <base>...HEAD` shows commits ahead of base.
+     - **Main/trunk mode** when the current checkout IS the default branch, when HEAD already equals the base ref, when `git rev-list --count <base>..HEAD` is `0`, or when the user explicitly requested `main` mode.
+     - If a user-supplied mode hint is provided, honor it unless it is impossible (e.g. branch mode requested but no distinct branch exists — then block with a clear reason).
+   - For branch mode: use `git merge-base <base> HEAD`, then inspect `git diff --stat <merge-base>..HEAD`, `git diff --name-status <merge-base>..HEAD`, and relevant hunks as the primary evidence set.
+   - For main/trunk mode: do NOT block on the empty diff. The repository state at HEAD is itself the evidence. Additionally locate the merge(s) that implemented the issue:
+     - `git log --grep '<ISSUE-KEY>' --oneline -n 200` to find commits that reference the key in the message.
+     - `git log --all --oneline -n 200 -- <likely paths>` for paths matched by issue keywords when no key reference is found.
+     - `gh pr list --search '<ISSUE-KEY>' --state merged --limit 20` when `gh` is authenticated, to locate the merged PR(s) for the issue.
+     - For each candidate merge commit, inspect `git show --stat <sha>` and `git diff <sha>^..<sha>` to extract the implementation diff, and treat that as the diff under verification.
+     - If multiple merges plausibly implement parts of the issue, aggregate them and note each in the evidence ledger.
+   - Branch-mode reminder: if no meaningful diff exists against base AND the checkout is not the default branch, fall back to main/trunk mode rather than declaring `BLOCKED` — the work may already have merged. Only mark `BLOCKED` after both modes fail to yield evidence.
 
 3. Inspect implementation evidence.
-   - Read changed source, tests, docs, workflow/config, migrations, and generated artifacts relevant to the Jira ledger.
-   - Search the repository with `rg` for Jira terms, feature names, acceptance criteria keywords, old behavior, and new behavior.
+   - In branch mode: read changed source, tests, docs, workflow/config, migrations, and generated artifacts within `<merge-base>..HEAD`.
+   - In main/trunk mode: read the current state of files relevant to the Jira ledger AND, when available, the implementing merge commit(s) diffs identified above. The "current state on main" is acceptable evidence on its own when it clearly satisfies a requirement; the historical diff is supplementary.
+   - In both modes: search the repository with `rg` for Jira terms, feature names, acceptance criteria keywords, old behavior, and new behavior. In main/trunk mode, also `rg` the issue key itself (`MM-555`, etc.) across source, tests, specs, docs, changelog, and `specs/<feature>/` folders.
    - Identify deleted or superseded paths so the verdict accounts for removals as well as additions.
    - Run local tests when required by repo instructions, user request, or when the verdict depends on unproven behavior. If tests cannot run, record exactly why.
+   - In main/trunk mode, if no implementing commits, no issue-key references, and no code matching the requirements can be found, then — and only then — record the verdict as `FAIL` (not implemented on main) or `BLOCKED` (requirements too ambiguous to tell), with a clear distinction between the two.
 
 4. Build a traceability ledger before commenting.
    - For each Jira item, assign exactly one status:
@@ -65,10 +83,10 @@ Never print raw environment variables. Use targeted checks such as `test -n "$MO
    - Keep non-repo requirements separate from branch-verifiable requirements.
 
 5. Decide the overall result.
-   - `PASS`: all in-scope, branch-verifiable Jira requirements are `met`.
+   - `PASS`: all in-scope Jira requirements are `met`, whether evidence comes from the branch diff (branch mode) or from the current state of the default branch and prior merge(s) (main/trunk mode).
    - `PARTIAL`: at least one in-scope item is `partially_met` or `unverifiable`, but no clear in-scope miss exists.
-   - `FAIL`: at least one in-scope item is `not_met`.
-   - `BLOCKED`: trusted Jira content, branch comparison, or Jira comment access is unavailable.
+   - `FAIL`: at least one in-scope item is `not_met` — including the main/trunk case where no implementing change can be found and the requirements are concrete enough to expect one.
+   - `BLOCKED`: trusted Jira content or Jira comment access is unavailable, OR both branch mode and main/trunk mode failed to produce any usable evidence and the requirements are too ambiguous to assess from repository state alone. Simply being on `main` with a clean tree is NOT, by itself, a `BLOCKED` condition.
 
 6. If `update status` is true, decide whether to update Jira status.
    - Do not attempt any status update unless the overall verification result is `PASS`.
@@ -81,24 +99,50 @@ Never print raw environment variables. Use targeted checks such as `test -n "$MO
    - If transition execution fails, keep the verification verdict as decided above but report the status update failure separately. Do not claim the issue was moved.
 
 7. Draft the Jira comment.
-   - Start with the verdict, issue key, branch name, commit SHA, and comparison ref.
+   - Start with the verdict, issue key, the verification mode used (`branch` or `main/trunk`), branch name, commit SHA, and comparison ref (or "verified against current state of default branch" for main/trunk mode).
+   - In main/trunk mode, list the merge commit SHA(s) or merged PR number(s) identified as the implementation evidence, when known.
    - Include blockers or gaps first for `PARTIAL`, `FAIL`, or `BLOCKED`.
    - Include a compact coverage table and evidence references.
    - Include validation observed, clearly separating passing tests from tests not run.
    - Include status update outcome when `update status` is true: skipped because verdict was not `PASS`, already done, transitioned with selected transition, or blocked/failed with sanitized reason.
    - Do not paste long private Jira text, raw command dumps, credentials, auth headers, cookies, or full environment/config dumps.
 
-Suggested comment shape:
+Suggested comment shape (branch mode):
 
 ```markdown
 Branch verification for `<ISSUE>`: **<PASS|PARTIAL|FAIL|BLOCKED>**
 
+Mode: branch
 Branch: `<branch>` at `<short-sha>`
 Compared against: `<base-ref>`
 
 | Jira item | Status | Evidence |
 | --- | --- | --- |
 | <goal / AC summary> | met | `<file>` / `<test>` |
+
+Gaps / blockers:
+- <only when applicable>
+
+Validation:
+- Tests run: `<command>` -> `<result>`
+- Tests not run: <reason>
+
+Status update:
+- <omitted when `update status` is false; otherwise already done / transitioned / skipped / blocked>
+```
+
+Suggested comment shape (main/trunk mode, work already merged):
+
+```markdown
+Implementation verification for `<ISSUE>`: **<PASS|PARTIAL|FAIL|BLOCKED>**
+
+Mode: main/trunk
+Default branch: `<branch>` at `<short-sha>`
+Implementing change(s): `<merge-sha>` (PR #<num>), `<merge-sha-2>` (PR #<num-2>)
+
+| Jira item | Status | Evidence |
+| --- | --- | --- |
+| <goal / AC summary> | met | `<file:line>` at `<sha>` / `<test>` |
 
 Gaps / blockers:
 - <only when applicable>
@@ -127,7 +171,7 @@ Status update:
 ## Outputs
 
 - Jira comment result or URL/ID when posting succeeds.
-- Verification ledger path, preferably `var/jira_verify/<ISSUE>-<branch>.json`.
+- Verification ledger path, preferably `var/jira_verify/<ISSUE>-<branch>.json`. Include the verification mode (`branch` or `main/trunk`) and, in main/trunk mode, the implementing merge SHA(s)/PR number(s) when identified.
 - Comment body path, preferably `var/jira_verify/<ISSUE>-<branch>.md`.
 - Status update result: `not_requested` when `update status` is false; otherwise `skipped`, `already_done`, `transitioned`, `blocked`, or `failed`, including selected transition evidence when applicable.
 - Final status: `PASS`, `PARTIAL`, `FAIL`, or `BLOCKED`.
@@ -136,7 +180,9 @@ Status update:
 
 - Missing trusted Jira content: `BLOCKED`; request a trusted Jira fetch/import or working `jira.get_issue` tool.
 - Jira issue inaccessible: `BLOCKED`; include issue key and sanitized tool error.
-- Branch comparison unavailable: `BLOCKED`; identify the missing base ref or repository state.
+- Branch comparison unavailable AND main/trunk mode also yields no usable evidence: `BLOCKED`; identify the missing base ref, missing history, or unsearchable repository state.
+- Current checkout is the default branch with a clean tree: do NOT block. Run main/trunk verification — search the repository state and recent merge history for the issue. Block only if that also produces no evidence and the requirements are too ambiguous to assess.
+- Default-branch checkout with no diff and no Jira-keyed merge found: prefer `FAIL` ("not implemented on `<default-branch>`") over `BLOCKED` when the Jira requirements are concrete enough to expect a code change. Reserve `BLOCKED` for ambiguous requirements.
 - Tests unavailable: continue only if evidence is otherwise sufficient; otherwise mark affected items `unverifiable`.
 - Jira comment cannot be posted: return the draft comment artifact and the sanitized posting error.
 - Jira status update cannot be attempted safely: do not transition the issue; report status update as `blocked` or `failed` separately from the verification verdict.


### PR DESCRIPTION
Update the jira-verify skill. It CAN work off of a branch, but it should also be capable of working off of main and just checking if the story is properly implemented on main. Right now it's hitting issues or failing with comments like this where it doesn't seem to check the code on main which could be already merged and we're just trying to verify:

Branch verification for `MM-555`: **BLOCKED**

Branch: `main` at `7a404cbc`
Compared against: `origin/main` (same ref — no feature branch checked out)

| Jira item | Status | Evidence |
| --- | --- | --- |
| Summary: "Claude Code login would ideally not send the message 'login' to the agent after login" | unverifiable | No description, acceptance criteria, or linked branch on the issue; no diff between current checkout and `origin/main` |

Gaps / blockers:
- Current checkout is `main` at `7a404cbc` with a clean working tree; there is no feature branch with candidate changes to verify against MM-555.
- MM-555 has no description, acceptance criteria, or linked PR/branch identified on the issue, so the requirements ledger cannot be built into concrete branch-verifiable items.
- Repo search for `MM-555` returns no references in source, tests, or specs on `main`. The Claude bootstrap command in `moonmind/workflows/temporal/runtime/providers/registry.py` still resolves to `["claude", "auth", "login"]`, which is plausibly related to the issue summary but is not yet exercised by any branch under review.

Validation:
- Tests run: none — no candidate change set to validate.
- Tests not run: full unit/integration suite skipped because there is no diff to attribute behavior to.

Status update:
- Not requested (`update status` is false); issue remains in `Code Review`.

Next steps to unblock:
- Check out the feature branch / PR that implements MM-555, or attach acceptance criteria to the Jira issue, then re-run `jira-verify`.