### PR TITLE
Morph create-task arrow into a check on submit

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -13230,15 +13230,21 @@ describe("Task Create submit arrow animation", () => {
     );
   });
 
-  it("exits the create arrow to the right on click while preserving the shockwave", async () => {
+  it("morphs the create arrow into a check on click while preserving the shockwave", async () => {
     expect(css).toMatch(
-      /\.queue-submit-primary--icon\.queue-submit-primary--arrow-exit\s*\.queue-submit-primary-arrow\s*svg\s*\{[^}]*animation:\s*queue-submit-primary-arrow-exit\s+230ms\s+cubic-bezier\(0\.33,\s*0,\s*0\.2,\s*1\)\s+both;/s,
+      /\.queue-submit-primary--icon\.queue-submit-primary--arrow-exit\s*\.queue-submit-primary-arrow-glyph\[data-submit-icon="arrow"\]\s*\{[^}]*animation:\s*queue-submit-primary-arrow-exit\s+230ms\s+cubic-bezier\(0\.33,\s*0,\s*0\.2,\s*1\)\s+both;/s,
+    );
+    expect(css).toMatch(
+      /\.queue-submit-primary--icon\.queue-submit-primary--arrow-exit\s*\.queue-submit-primary-arrow-glyph\[data-submit-icon="check"\]\s*\{[^}]*animation:\s*queue-submit-primary-check-pop\s+260ms\s+cubic-bezier\(0\.34,\s*1\.56,\s*0\.64,\s*1\)\s+both;/s,
     );
     expect(css).not.toMatch(
       /\.queue-submit-primary--icon[^{]*:active\s*\.queue-submit-primary-arrow\s*svg\s*\{[^}]*queue-submit-primary-arrow-exit/s,
     );
     expect(css).toMatch(
-      /@keyframes queue-submit-primary-arrow-exit\s*\{[\s\S]*0%\s*\{[\s\S]*transform:\s*translateX\(0\);[\s\S]*100%\s*\{[\s\S]*transform:\s*translateX\(145%\);/,
+      /@keyframes queue-submit-primary-arrow-exit\s*\{[\s\S]*0%\s*\{[\s\S]*opacity:\s*1;[\s\S]*transform:\s*scale\(1\);[\s\S]*100%\s*\{[\s\S]*opacity:\s*0;[\s\S]*transform:\s*scale\(0\.6\);/,
+    );
+    expect(css).toMatch(
+      /@keyframes queue-submit-primary-check-pop\s*\{[\s\S]*0%\s*\{[\s\S]*opacity:\s*0;[\s\S]*60%\s*\{[\s\S]*transform:\s*scale\(1\.15\);[\s\S]*100%\s*\{[\s\S]*transform:\s*scale\(1\);/,
     );
     expect(css).toMatch(
       /\.queue-submit-primary-ripple\s*\{[^}]*animation:\s*queue-submit-primary-ripple\s+620ms\s+cubic-bezier\(0\.22,\s*0\.61,\s*0\.36,\s*1\)\s+forwards;/s,

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3511,6 +3511,14 @@ function ArrowRightIcon() {
   );
 }
 
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M5 12.5 10 17.5 19 7.5" />
+    </svg>
+  );
+}
+
 function BranchIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -9679,7 +9687,18 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   data-submit-arrow="right"
                   onAnimationEnd={clearSubmitArrowExit}
                 >
-                  <ArrowRightIcon />
+                  <span
+                    className="queue-submit-primary-arrow-glyph"
+                    data-submit-icon="arrow"
+                  >
+                    <ArrowRightIcon />
+                  </span>
+                  <span
+                    className="queue-submit-primary-arrow-glyph queue-submit-primary-arrow-glyph--check"
+                    data-submit-icon="check"
+                  >
+                    <CheckIcon />
+                  </span>
                 </span>
               ) : (
                 <span>{primaryCta}</span>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3642,6 +3642,23 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   stroke-width: 3;
 }
 
+.queue-submit-primary--icon .queue-submit-primary-arrow-glyph {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  transition:
+    opacity 180ms ease-out,
+    transform 180ms ease-out;
+}
+
+.queue-submit-primary--icon .queue-submit-primary-arrow-glyph--check {
+  opacity: 0;
+  transform: scale(0.6);
+}
+
 .queue-submit-primary--icon:not(.queue-submit-primary--arrow-exit):not(:disabled):not([aria-disabled="true"]):hover
   .queue-submit-primary-arrow
   svg {
@@ -3649,9 +3666,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-submit-primary--icon.queue-submit-primary--arrow-exit
-  .queue-submit-primary-arrow
-  svg {
+  .queue-submit-primary-arrow-glyph[data-submit-icon="arrow"] {
   animation: queue-submit-primary-arrow-exit 230ms cubic-bezier(0.33, 0, 0.2, 1) both;
+}
+
+.queue-submit-primary--icon.queue-submit-primary--arrow-exit
+  .queue-submit-primary-arrow-glyph[data-submit-icon="check"] {
+  animation: queue-submit-primary-check-pop 260ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
 .queue-submit-primary--icon:hover {
@@ -3696,10 +3717,27 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 @keyframes queue-submit-primary-arrow-exit {
   0% {
-    transform: translateX(0);
+    opacity: 1;
+    transform: scale(1);
   }
   100% {
-    transform: translateX(145%);
+    opacity: 0;
+    transform: scale(0.6);
+  }
+}
+
+@keyframes queue-submit-primary-check-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
@@ -3754,6 +3792,22 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   .queue-submit-primary--icon .queue-submit-primary-arrow svg {
     animation: none !important;
     transform: none !important;
+  }
+
+  .queue-submit-primary--icon .queue-submit-primary-arrow-glyph {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .queue-submit-primary--icon.queue-submit-primary--arrow-exit
+    .queue-submit-primary-arrow-glyph[data-submit-icon="arrow"] {
+    opacity: 0;
+  }
+
+  .queue-submit-primary--icon.queue-submit-primary--arrow-exit
+    .queue-submit-primary-arrow-glyph[data-submit-icon="check"] {
+    opacity: 1;
+    transform: scale(1);
   }
 
   .queue-submit-primary-ripple {


### PR DESCRIPTION
## Summary
- Replace the create-task button's translate-off arrow exit with an in-place morph: the arrow fades out and a check pops in, layered inside the existing shockwave.
- Add a `CheckIcon` and a `.queue-submit-primary-arrow-glyph` wrapper so both glyphs stack and crossfade in the same slot — no more blank-button frame.
- Reuse the existing submit state machine unchanged: validation failures still revert via `releaseSubmitArrowExit()` (now driven by the 180ms glyph transition), and successful submissions hold the check via `holdSubmitArrowExitUntilNavigation()` until the page navigates.
- Refresh the reduced-motion block to snap the two glyph states instead of animating.

## Test plan
- [x] `./tools/test_unit.sh` — full suite passes (5122 Python + 357 frontend)
- [x] Updated CSS-assertion tests in `task-create.test.tsx` to cover the new `queue-submit-primary-arrow-exit` (fade) and `queue-submit-primary-check-pop` keyframes
- [ ] Manual smoke in `npm run ui:dev`: press the Create button, confirm the arrow fades and the check pops in over the shockwave; confirm a validation error reverts cleanly to the arrow
- [ ] Manual check with `prefers-reduced-motion: reduce` to confirm the snap behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)