### PR TITLE
I want to update the Jira Implement preset so that it checks the state of the implementation of the Jira issue early on

### DIFF
--- a/api_service/data/task_step_templates/jira-implement.yaml
+++ b/api_service/data/task_step_templates/jira-implement.yaml
@@ -63,31 +63,6 @@ inputs:
     required: false
     default: ""
 steps:
-  - title: Check Jira blockers before implementation
-    type: tool
-    instructions: |-
-      Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any implementation work starts.
-
-      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as outwardIssue and the link type says the outward relationship is "blocks", that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as inwardIssue and the link type says the inward relationship is "is blocked by", {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this implementation.
-
-      Ignore non-blocker issue links for the blocker decision.
-
-      Continue only when no blocker links exist or every detected blocking issue is status Done.
-
-      If any blocking issue is not Done, or if a blocker relationship exists but blocker status cannot be determined from trusted Jira data, stop the implementation immediately. Report a blocked outcome in the required JSON format (targetIssueKey, decision, blockingIssues, summary) and do not proceed to any subsequent steps, including brief loading or implementation. Include {{ inputs.jira_issue_key }} as the targetIssueKey.
-
-      Do not use raw Jira credentials, web scraping, hardcoded transition IDs, or prompt text alone to decide blocker state.
-    targetIssueKey: "{{ inputs.jira_issue_key }}"
-    blockerPreflight:
-      targetIssueKey: "{{ inputs.jira_issue_key }}"
-      linkType: Blocks
-    tool:
-      id: jira.check_blockers
-      args:
-        targetIssueKey: "{{ inputs.jira_issue_key }}"
-        blockerPreflight:
-          targetIssueKey: "{{ inputs.jira_issue_key }}"
-          linkType: Blocks
   - title: Load Jira preset brief
     type: tool
     instructions: |-
@@ -120,12 +95,41 @@ steps:
 
       Record the verdict and a concise list of met/partially-met/unmet requirements in the step result AND in a local handoff artifact at artifacts/jira-implement-assessment.json with keys jira_issue_key, verdict, branch, base_ref, mode, summary, and requirements (list of objects with description and status of met, partially_met, not_met, or unverifiable).
 
-      The verdict written here is the controlling input for every later step in this preset: the In Progress transition, the implementation step, the verification step, the pull request step, and the final Jira transition all gate on this verdict. Be conservative — only choose FULLY_IMPLEMENTED when the evidence clearly supports it.
+      The verdict written here is the controlling input for every later step in this preset: the blocker preflight, the In Progress transition, the implementation step, the verification step, the pull request step, and the final Jira transition all gate on this verdict. Be conservative — only choose FULLY_IMPLEMENTED when the evidence clearly supports it.
     skill:
       id: auto
       args: {}
       requiredCapabilities:
         - git
+  - title: Check Jira blockers before implementation
+    type: tool
+    instructions: |-
+      Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before deciding how to apply blocker results.
+
+      Check Jira issue {{ inputs.jira_issue_key }} through the deterministic trusted Jira blocker preflight before any new implementation work starts.
+
+      Jira Blocks direction is strict for Jira GET issue responses: when the target issue response exposes the other issue as outwardIssue and the link type says the outward relationship is "blocks", that other issue blocks {{ inputs.jira_issue_key }}. When the target issue response exposes the other issue as inwardIssue and the link type says the inward relationship is "is blocked by", {{ inputs.jira_issue_key }} blocks a later issue and that link MUST NOT block this implementation.
+
+      Ignore non-blocker issue links for the blocker decision.
+
+      Continue only when no blocker links exist or every detected blocking issue is status Done.
+
+      If the recorded verdict is FULLY_IMPLEMENTED, the implementation work is already done in the repository, so unresolved blockers must not stop the preset from advancing the issue to Done in the final step. Report the blocker preflight result for the record, but do not short-circuit subsequent steps based on it.
+
+      Otherwise (PARTIALLY_IMPLEMENTED or NOT_IMPLEMENTED), if any blocking issue is not Done, or if a blocker relationship exists but blocker status cannot be determined from trusted Jira data, stop the implementation immediately. Report a blocked outcome in the required JSON format (targetIssueKey, decision, blockingIssues, summary) and do not proceed to any subsequent steps, including implementation. Include {{ inputs.jira_issue_key }} as the targetIssueKey.
+
+      Do not use raw Jira credentials, web scraping, hardcoded transition IDs, or prompt text alone to decide blocker state.
+    targetIssueKey: "{{ inputs.jira_issue_key }}"
+    blockerPreflight:
+      targetIssueKey: "{{ inputs.jira_issue_key }}"
+      linkType: Blocks
+    tool:
+      id: jira.check_blockers
+      args:
+        targetIssueKey: "{{ inputs.jira_issue_key }}"
+        blockerPreflight:
+          targetIssueKey: "{{ inputs.jira_issue_key }}"
+          linkType: Blocks
   - title: Move Jira issue to In Progress
     instructions: |-
       Read artifacts/jira-implement-assessment.json (or the previous step's recorded verdict) before doing anything.
@@ -169,6 +173,8 @@ steps:
 
       If the recorded verdict is FULLY_IMPLEMENTED and the implementation step did no code changes, report verification as already satisfied by the initial assessment and skip rerunning verification.
 
+      If the recorded verdict is BLOCKED, stop without running verification and report the blocking evidence from the assessment.
+
       Otherwise verify that the implementation for Jira issue {{ inputs.jira_issue_key }} satisfies the loaded preset brief and acceptance criteria.
 
       Re-read the Jira preset brief and confirm every required behavior change is implemented and covered by tests. Run the focused unit and integration checks named by the brief or implied by the changed code paths.
@@ -186,6 +192,8 @@ steps:
       Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before doing anything.
 
       If the recorded verdict is FULLY_IMPLEMENTED and the implementation step did no code changes, skip pull request creation entirely and report it as skipped because there is nothing new to publish. Do not write artifacts/jira-implement-pr.json in this case. The final step will move {{ inputs.jira_issue_key }} directly to Done.
+
+      If the recorded verdict is BLOCKED, stop without creating a pull request and report the blocking evidence from the assessment.
 
       Otherwise create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
 
@@ -212,6 +220,8 @@ steps:
       jiraImplementRole: final-transition
     instructions: |-
       Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before changing Jira.
+
+      If the recorded verdict is BLOCKED, stop without changing Jira and report the blocking evidence from the assessment.
 
       Decide the target Jira status based on the recorded initial-assessment verdict:
 

--- a/api_service/data/task_step_templates/jira-implement.yaml
+++ b/api_service/data/task_step_templates/jira-implement.yaml
@@ -1,6 +1,6 @@
 slug: jira-implement
 title: Jira Implement
-description: Move a Jira issue through implementation by using its preset brief as the implementation input, creating a PR, and advancing the issue to Code Review. When PR merge automation is enabled the issue advances to Done automatically after merge.
+description: Move a Jira issue through implementation by first assessing the current state of the branch against the issue. If the issue is already fully implemented, advance it directly to Done. Otherwise, finish any partial work, create a PR, and advance the issue to Code Review. When PR merge automation is enabled the issue advances to Done automatically after merge.
 scope: global
 version: 1.0.0
 tags:
@@ -63,14 +63,6 @@ inputs:
     required: false
     default: ""
 steps:
-  - title: Move Jira issue to In Progress
-    instructions: |-
-      Change Jira issue {{ inputs.jira_issue_key }} to status In Progress before implementation starts.
-
-      Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
-    skill:
-      id: jira-issue-updater
-      args: {}
   - title: Check Jira blockers before implementation
     type: tool
     instructions: |-
@@ -109,9 +101,54 @@ steps:
       args: {}
       inputs:
         issueKey: "{{ inputs.jira_issue_key }}"
+  - title: Assess existing implementation state
+    annotations:
+      jiraImplementRole: initial-assessment
+    instructions: |-
+      Before changing Jira or writing any code, assess whether Jira issue {{ inputs.jira_issue_key }} is already implemented against the current state of the repository checkout.
+
+      Use the jira-verify approach as the model: pick branch mode when a feature branch is checked out with commits ahead of its base ref, otherwise use main/trunk mode. Compare the loaded Jira preset brief and acceptance criteria against the actual repository contents (and, in branch mode, against the diff between the current branch and its base ref). In main/trunk mode also search recent merge history for the issue key.
+
+      Do not edit any code, do not run long verification suites, and do not mutate Jira during this step. Read-only inspection only.
+
+      Classify the result into exactly one verdict:
+
+      - FULLY_IMPLEMENTED: every in-scope requirement in the Jira preset brief is already satisfied by the current repository state (or by an identified merged change on the default branch). No new code work is needed.
+      - PARTIALLY_IMPLEMENTED: some in-scope requirements are met but at least one is missing or only partially satisfied. New code work is required to complete the issue.
+      - NOT_IMPLEMENTED: none of the in-scope requirements are reflected in the current repository state. A full implementation pass is required.
+      - BLOCKED: the requirements are too ambiguous to assess, or required Jira/repo evidence is unavailable. Do not guess; report BLOCKED with the exact missing evidence and stop the preset.
+
+      Record the verdict and a concise list of met/partially-met/unmet requirements in the step result AND in a local handoff artifact at artifacts/jira-implement-assessment.json with keys jira_issue_key, verdict, branch, base_ref, mode, summary, and requirements (list of objects with description and status of met, partially_met, not_met, or unverifiable).
+
+      The verdict written here is the controlling input for every later step in this preset: the In Progress transition, the implementation step, the verification step, the pull request step, and the final Jira transition all gate on this verdict. Be conservative — only choose FULLY_IMPLEMENTED when the evidence clearly supports it.
+    skill:
+      id: auto
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Move Jira issue to In Progress
+    instructions: |-
+      Read artifacts/jira-implement-assessment.json (or the previous step's recorded verdict) before doing anything.
+
+      If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress transition entirely and report it as skipped because the issue is already implemented; do not move a likely-Done issue back into In Progress. The final step in this preset will move {{ inputs.jira_issue_key }} directly to Done.
+
+      If the recorded verdict is BLOCKED, stop without changing Jira and report that the preset is blocked by the initial assessment.
+
+      Otherwise (PARTIALLY_IMPLEMENTED or NOT_IMPLEMENTED), change Jira issue {{ inputs.jira_issue_key }} to status In Progress before implementation starts. Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
+    skill:
+      id: jira-issue-updater
+      args: {}
   - title: Implement the Jira issue
     instructions: |-
-      Implement the work described by Jira issue {{ inputs.jira_issue_key }} using the loaded Jira preset brief as the authoritative implementation input.
+      Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before doing anything.
+
+      If the recorded verdict is FULLY_IMPLEMENTED, make no code changes and report that implementation is skipped because the issue is already implemented in the current repository state.
+
+      If the recorded verdict is BLOCKED, stop without changing code and report the blocking evidence from the assessment.
+
+      If the recorded verdict is PARTIALLY_IMPLEMENTED, treat the assessment's unmet and partially-met requirements as the authoritative bounded backlog. Finish only the remaining gaps. Do not redo work that is already satisfied and do not broaden scope.
+
+      If the recorded verdict is NOT_IMPLEMENTED, implement the work described by Jira issue {{ inputs.jira_issue_key }} using the loaded Jira preset brief as the authoritative implementation input.
 
       Additional constraints:
       {{ inputs.constraints }}
@@ -128,7 +165,11 @@ steps:
         - git
   - title: Verify implementation
     instructions: |-
-      Verify that the implementation for Jira issue {{ inputs.jira_issue_key }} satisfies the loaded preset brief and acceptance criteria.
+      Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before doing anything.
+
+      If the recorded verdict is FULLY_IMPLEMENTED and the implementation step did no code changes, report verification as already satisfied by the initial assessment and skip rerunning verification.
+
+      Otherwise verify that the implementation for Jira issue {{ inputs.jira_issue_key }} satisfies the loaded preset brief and acceptance criteria.
 
       Re-read the Jira preset brief and confirm every required behavior change is implemented and covered by tests. Run the focused unit and integration checks named by the brief or implied by the changed code paths.
 
@@ -142,7 +183,11 @@ steps:
     annotations:
       jiraImplementRole: pull-request-handoff
     instructions: |-
-      Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
+      Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before doing anything.
+
+      If the recorded verdict is FULLY_IMPLEMENTED and the implementation step did no code changes, skip pull request creation entirely and report it as skipped because there is nothing new to publish. Do not write artifacts/jira-implement-pr.json in this case. The final step will move {{ inputs.jira_issue_key }} directly to Done.
+
+      Otherwise create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
 
       This Jira Implement handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Code Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR; on a successful merge the parent workflow will transition Jira issue {{ inputs.jira_issue_key }} to Done automatically. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
 
@@ -162,15 +207,21 @@ steps:
       args: {}
       requiredCapabilities:
         - git
-  - title: Move Jira issue to Code Review
+  - title: Finalize Jira status
+    annotations:
+      jiraImplementRole: final-transition
     instructions: |-
-      Change Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists.
+      Read artifacts/jira-implement-assessment.json (or the recorded verdict from the assess step) before changing Jira.
 
-      Before using any Jira transition tool, read the previous pull request creation result or artifacts/jira-implement-pr.json and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key }}. If no confirmed pull request URL is available, stop without changing Jira and report that Code Review is blocked until PR creation succeeds.
+      Decide the target Jira status based on the recorded initial-assessment verdict:
 
-      Use the trusted Jira issue updater workflow and Jira transition tools. Match Code Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
+      - If the recorded verdict is FULLY_IMPLEMENTED, transition Jira issue {{ inputs.jira_issue_key }} to status Done. The issue was already implemented at the start of this preset, so no pull request is required. If the issue is already in a Done-category status, treat the transition as already satisfied and report it as such. Do not require artifacts/jira-implement-pr.json in this branch.
 
-      Note: when this task was submitted with PR merge automation enabled, the parent workflow will transition Jira issue {{ inputs.jira_issue_key }} to Done automatically after the pull request merges. This in-task step only owns the Code Review transition.
+      - Otherwise (the initial verdict was PARTIALLY_IMPLEMENTED or NOT_IMPLEMENTED), transition Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists. Read the previous pull request creation result or artifacts/jira-implement-pr.json and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key }}. If no confirmed pull request URL is available, stop without changing Jira and report that Code Review is blocked until PR creation succeeds. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools.
+
+      In both cases, use the trusted Jira issue updater workflow and Jira transition tools. Match the target status against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
+
+      Note: when this task was submitted with PR merge automation enabled and the work followed the Code Review path, the parent workflow will transition Jira issue {{ inputs.jira_issue_key }} to Done automatically after the pull request merges. This in-task step only owns the explicit Done transition for the already-implemented case and the Code Review transition for the freshly-implemented case.
     skill:
       id: jira-issue-updater
       args: {}

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -212,28 +212,68 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             (step.get("skill") or step.get("tool"))["id"]
             for step in jira_implement_template.latest_version.steps
         ]
-        assert jira_implement_steps[0] == "jira-issue-updater"
-        assert jira_implement_steps[1] == "jira.check_blockers"
-        assert jira_implement_steps[2] == "jira.load_preset_brief"
+        assert jira_implement_steps[0] == "jira.check_blockers"
+        assert jira_implement_steps[1] == "jira.load_preset_brief"
         assert jira_implement_steps[-1] == "jira-issue-updater"
-        assert len(jira_implement_steps) == 7
+        assert len(jira_implement_steps) == 8
         implement_step_titles = [
             step["title"] for step in jira_implement_template.latest_version.steps
         ]
-        assert implement_step_titles[0] == "Move Jira issue to In Progress"
+        assert implement_step_titles[0] == "Check Jira blockers before implementation"
+        assert implement_step_titles[1] == "Load Jira preset brief"
+        assert implement_step_titles[2] == "Assess existing implementation state"
+        assert implement_step_titles[3] == "Move Jira issue to In Progress"
         assert "Implement the Jira issue" in implement_step_titles
+        assert "Verify implementation" in implement_step_titles
         assert "Create pull request" in implement_step_titles
-        assert implement_step_titles[-1] == "Move Jira issue to Code Review"
-        implement_blocker_step = jira_implement_template.latest_version.steps[1]
+        assert implement_step_titles[-1] == "Finalize Jira status"
+        implement_blocker_step = jira_implement_template.latest_version.steps[0]
         assert implement_blocker_step["type"] == "tool"
         assert implement_blocker_step["tool"]["id"] == "jira.check_blockers"
         assert (
             "deterministic trusted Jira blocker preflight"
             in implement_blocker_step["instructions"]
         )
-        implement_brief_step = jira_implement_template.latest_version.steps[2]
+        implement_brief_step = jira_implement_template.latest_version.steps[1]
         assert implement_brief_step["type"] == "tool"
         assert implement_brief_step["tool"]["id"] == "jira.load_preset_brief"
+        implement_assessment_step = jira_implement_template.latest_version.steps[2]
+        assert implement_assessment_step["title"] == "Assess existing implementation state"
+        assert implement_assessment_step["skill"]["id"] == "auto"
+        assert (
+            "FULLY_IMPLEMENTED" in implement_assessment_step["instructions"]
+        )
+        assert (
+            "PARTIALLY_IMPLEMENTED" in implement_assessment_step["instructions"]
+        )
+        assert (
+            "NOT_IMPLEMENTED" in implement_assessment_step["instructions"]
+        )
+        assert (
+            "artifacts/jira-implement-assessment.json"
+            in implement_assessment_step["instructions"]
+        )
+        implement_in_progress_step = jira_implement_template.latest_version.steps[3]
+        assert implement_in_progress_step["title"] == "Move Jira issue to In Progress"
+        assert implement_in_progress_step["skill"]["id"] == "jira-issue-updater"
+        assert (
+            "FULLY_IMPLEMENTED" in implement_in_progress_step["instructions"]
+        )
+        assert (
+            "skip the In Progress transition"
+            in implement_in_progress_step["instructions"]
+        )
+        implement_step = next(
+            step
+            for step in jira_implement_template.latest_version.steps
+            if step["title"] == "Implement the Jira issue"
+        )
+        assert "FULLY_IMPLEMENTED" in implement_step["instructions"]
+        assert "PARTIALLY_IMPLEMENTED" in implement_step["instructions"]
+        assert (
+            "artifacts/jira-implement-assessment.json"
+            in implement_step["instructions"]
+        )
         implement_pr_step = next(
             step
             for step in jira_implement_template.latest_version.steps
@@ -242,10 +282,16 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "merge automation" in implement_pr_step["instructions"]
         assert "Done automatically" in implement_pr_step["instructions"]
         assert "artifacts/jira-implement-pr.json" in implement_pr_step["instructions"]
-        implement_code_review_step = jira_implement_template.latest_version.steps[-1]
-        assert implement_code_review_step["title"] == "Move Jira issue to Code Review"
-        assert "Code Review" in implement_code_review_step["instructions"]
-        assert "pull_request_url" in implement_code_review_step["instructions"]
+        assert "FULLY_IMPLEMENTED" in implement_pr_step["instructions"]
+        implement_finalize_step = jira_implement_template.latest_version.steps[-1]
+        assert implement_finalize_step["title"] == "Finalize Jira status"
+        assert implement_finalize_step["skill"]["id"] == "jira-issue-updater"
+        assert "Done" in implement_finalize_step["instructions"]
+        assert "Code Review" in implement_finalize_step["instructions"]
+        assert "pull_request_url" in implement_finalize_step["instructions"]
+        assert (
+            "FULLY_IMPLEMENTED" in implement_finalize_step["instructions"]
+        )
 
         result = await session.execute(
             select(TaskStepTemplate)

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -212,33 +212,37 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             (step.get("skill") or step.get("tool"))["id"]
             for step in jira_implement_template.latest_version.steps
         ]
-        assert jira_implement_steps[0] == "jira.check_blockers"
-        assert jira_implement_steps[1] == "jira.load_preset_brief"
+        assert jira_implement_steps[0] == "jira.load_preset_brief"
+        assert jira_implement_steps[1] == "auto"
+        assert jira_implement_steps[2] == "jira.check_blockers"
         assert jira_implement_steps[-1] == "jira-issue-updater"
         assert len(jira_implement_steps) == 8
         implement_step_titles = [
             step["title"] for step in jira_implement_template.latest_version.steps
         ]
-        assert implement_step_titles[0] == "Check Jira blockers before implementation"
-        assert implement_step_titles[1] == "Load Jira preset brief"
-        assert implement_step_titles[2] == "Assess existing implementation state"
+        assert implement_step_titles[0] == "Load Jira preset brief"
+        assert implement_step_titles[1] == "Assess existing implementation state"
+        assert implement_step_titles[2] == "Check Jira blockers before implementation"
         assert implement_step_titles[3] == "Move Jira issue to In Progress"
         assert "Implement the Jira issue" in implement_step_titles
         assert "Verify implementation" in implement_step_titles
         assert "Create pull request" in implement_step_titles
         assert implement_step_titles[-1] == "Finalize Jira status"
-        implement_blocker_step = jira_implement_template.latest_version.steps[0]
+        implement_brief_step = jira_implement_template.latest_version.steps[0]
+        assert implement_brief_step["type"] == "tool"
+        assert implement_brief_step["tool"]["id"] == "jira.load_preset_brief"
+        implement_assessment_step = jira_implement_template.latest_version.steps[1]
+        assert implement_assessment_step["title"] == "Assess existing implementation state"
+        implement_blocker_step = jira_implement_template.latest_version.steps[2]
         assert implement_blocker_step["type"] == "tool"
         assert implement_blocker_step["tool"]["id"] == "jira.check_blockers"
         assert (
             "deterministic trusted Jira blocker preflight"
             in implement_blocker_step["instructions"]
         )
-        implement_brief_step = jira_implement_template.latest_version.steps[1]
-        assert implement_brief_step["type"] == "tool"
-        assert implement_brief_step["tool"]["id"] == "jira.load_preset_brief"
-        implement_assessment_step = jira_implement_template.latest_version.steps[2]
-        assert implement_assessment_step["title"] == "Assess existing implementation state"
+        assert (
+            "FULLY_IMPLEMENTED" in implement_blocker_step["instructions"]
+        )
         assert implement_assessment_step["skill"]["id"] == "auto"
         assert (
             "FULLY_IMPLEMENTED" in implement_assessment_step["instructions"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2372,15 +2372,15 @@ async def test_seed_catalog_jira_implement_flattens_jira_issue_input(tmp_path):
             )
 
             assert "MM-742" in expanded["steps"][0]["instructions"]
-            assert expanded["steps"][1]["tool"]["id"] == "jira.check_blockers"
-            assert expanded["steps"][1]["tool"]["inputs"] == {
+            assert expanded["steps"][0]["tool"]["id"] == "jira.check_blockers"
+            assert expanded["steps"][0]["tool"]["inputs"] == {
                 "targetIssueKey": "MM-742",
                 "blockerPreflight": {
                     "targetIssueKey": "MM-742",
                     "linkType": "Blocks",
                 },
             }
-            assert expanded["steps"][2]["tool"]["inputs"] == {"issueKey": "MM-742"}
+            assert expanded["steps"][1]["tool"]["inputs"] == {"issueKey": "MM-742"}
             assert expanded["appliedTemplate"]["inputs"]["jira_issue_key"] == "MM-742"
 
 async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path):

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2371,16 +2371,21 @@ async def test_seed_catalog_jira_implement_flattens_jira_issue_input(tmp_path):
                 context={},
             )
 
-            assert "MM-742" in expanded["steps"][0]["instructions"]
-            assert expanded["steps"][0]["tool"]["id"] == "jira.check_blockers"
-            assert expanded["steps"][0]["tool"]["inputs"] == {
+            assert expanded["steps"][0]["tool"]["id"] == "jira.load_preset_brief"
+            assert expanded["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-742"}
+            assert expanded["steps"][1]["skill"]["id"] == "auto"
+            assert (
+                expanded["steps"][1]["title"] == "Assess existing implementation state"
+            )
+            assert "MM-742" in expanded["steps"][2]["instructions"]
+            assert expanded["steps"][2]["tool"]["id"] == "jira.check_blockers"
+            assert expanded["steps"][2]["tool"]["inputs"] == {
                 "targetIssueKey": "MM-742",
                 "blockerPreflight": {
                     "targetIssueKey": "MM-742",
                     "linkType": "Blocks",
                 },
             }
-            assert expanded["steps"][1]["tool"]["inputs"] == {"issueKey": "MM-742"}
             assert expanded["appliedTemplate"]["inputs"]["jira_issue_key"] == "MM-742"
 
 async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path):


### PR DESCRIPTION
I want to update the Jira Implement preset so that it checks the state of the implementation of the Jira issue early on
  against the state of the branch. If it's already fully implemented, it moves the issue to DONE. If it's partially
  implemented, it finishes the implementation. If the issue was not fully implemented at the start, it only moves the issue to DONE if PR with Merge Automation is enabled and the issue is finished.