### PR TITLE
[codex] Improve Codex turn observability

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -159,7 +159,7 @@ describe('Mission Control shared entry', () => {
 
     renderWithClient(<MissionControlApp payload={payload} />);
 
-    expect(await screen.findByText('Hello from Tasks Home!', {}, { timeout: 3000 })).toBeTruthy();
+    expect(await screen.findByText('Hello from Tasks Home!', {}, { timeout: 10000 })).toBeTruthy();
     expect(await screen.findByText(/First-Run Setup:/i)).toBeTruthy();
     await waitFor(() => {
       expect(document.querySelector('.panel--data-wide')).toBeTruthy();

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -62,6 +62,9 @@ from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
 )
+from moonmind.workflows.temporal.runtime.codex_session_runtime import (
+    EMPTY_ASSISTANT_FAILURE_CAUSE,
+)
 from moonmind.workflow_docker_mode import (
     DEFAULT_WORKFLOW_DOCKER_MODE,
     normalize_workflow_docker_mode,
@@ -226,6 +229,36 @@ def _jira_skill_blocker_summary(
             default=default_summary,
         )
     return None
+
+def _application_error_metadata(error: ApplicationError) -> dict[str, Any]:
+    for detail in error.details:
+        if isinstance(detail, Mapping):
+            return dict(detail)
+    return {}
+
+def _turn_failure_metadata_from_activity_error(error: ApplicationError) -> dict[str, Any]:
+    metadata = _application_error_metadata(error)
+    raw_reason = str(error.message or "").strip() or None
+    metadata.setdefault("reason", raw_reason)
+    metadata.setdefault(
+        "failureClass",
+        "permanent" if error.type == "CodexPermanentTurnError" else "transient",
+    )
+    return metadata
+
+def _is_empty_assistant_turn_failure(metadata: Mapping[str, Any] | None) -> bool:
+    if not isinstance(metadata, Mapping):
+        return False
+    if metadata.get("failureCause") == EMPTY_ASSISTANT_FAILURE_CAUSE:
+        return True
+    reason = str(metadata.get("reason") or "").strip()
+    return reason in {
+        "codex app-server task_complete produced no assistant output",
+        "codex app-server turn/completed produced no assistant output",
+    }
+
+def _reset_thread_id_for_empty_turn(locator: CodexManagedSessionLocator) -> str:
+    return f"{locator.thread_id}:empty-output-reset"
 
 class CodexSessionRunFailedError(RuntimeError):
     """Raised when a Codex session run persisted a structured failed result."""
@@ -408,8 +441,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     workspace_path=workspace_path,
                 )
             )
-            try:
-                turn_response = await self._coerce_turn_response(
+            session_interventions: list[dict[str, Any]] = []
+
+            async def _send_current_turn() -> CodexManagedSessionTurnResponse:
+                return await self._coerce_turn_response(
                     self._send_turn(
                         SendCodexManagedSessionTurnRequest(
                             sessionId=current_locator.session_id,
@@ -420,22 +455,16 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         )
                     )
                 )
-            except ActivityError as exc:
-                turn_error = exc.cause if isinstance(exc.cause, ApplicationError) else None
-                if turn_error is None or turn_error.type not in (
-                    "CodexTransientTurnError",
-                    "CodexPermanentTurnError",
-                ):
-                    raise
-                raw_reason = str(turn_error.message or "").strip() or None
+
+            def _publish_activity_error_result(
+                turn_error: ApplicationError,
+                metadata: Mapping[str, Any],
+                publication: CodexManagedSessionArtifactsPublication | None,
+            ) -> CodexSessionRunFailedError:
+                raw_reason = str(metadata.get("reason") or turn_error.message or "").strip() or None
                 reason = _clamp_agent_run_result_summary(
                     raw_reason,
                     default="Codex managed-session turn failed",
-                )
-                publication = await self._publish_failure_artifacts(
-                    locator=current_locator,
-                    managed_run_id=binding.task_run_id,
-                    run_id=run_id,
                 )
                 failure_result = self._persist_failed_run_state(
                     run_id=run_id,
@@ -464,17 +493,98 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         else None
                     ),
                     turn_status="failed",
-                    turn_metadata={
-                        "reason": raw_reason,
-                        "failureClass": (
-                            "permanent"
-                            if turn_error.type == "CodexPermanentTurnError"
-                            else "transient"
-                        ),
-                    },
+                    turn_metadata=metadata,
                 )
-                failed_state_persisted = True
-                raise CodexSessionRunFailedError(reason, result=failure_result) from exc
+                return CodexSessionRunFailedError(reason, result=failure_result)
+
+            try:
+                turn_response = await _send_current_turn()
+            except ActivityError as exc:
+                turn_error = exc.cause if isinstance(exc.cause, ApplicationError) else None
+                if turn_error is None or turn_error.type not in (
+                    "CodexTransientTurnError",
+                    "CodexPermanentTurnError",
+                ):
+                    raise
+                turn_metadata = _turn_failure_metadata_from_activity_error(turn_error)
+                if (
+                    turn_error.type == "CodexTransientTurnError"
+                    and _is_empty_assistant_turn_failure(turn_metadata)
+                ):
+                    previous_locator = current_locator
+                    reset_thread_id = _reset_thread_id_for_empty_turn(previous_locator)
+                    reset_handle = await self.clear_session(
+                        binding=binding,
+                        new_thread_id=reset_thread_id,
+                        reason="retry_after_empty_assistant_output",
+                    )
+                    current_locator = self._locator_from_state(
+                        session_state=reset_handle.session_state,
+                        runtime_epoch=reset_handle.session_state.session_epoch,
+                    )
+                    current_active_turn_id = reset_handle.session_state.active_turn_id
+                    session_interventions.append(
+                        {
+                            "action": "clear_session",
+                            "reason": "retry_after_empty_assistant_output",
+                            "fromThreadId": previous_locator.thread_id,
+                            "toThreadId": current_locator.thread_id,
+                            "fromSessionEpoch": previous_locator.session_epoch,
+                            "toSessionEpoch": current_locator.session_epoch,
+                        }
+                    )
+                    try:
+                        turn_response = await _send_current_turn()
+                    except ActivityError as retry_exc:
+                        retry_error = (
+                            retry_exc.cause
+                            if isinstance(retry_exc.cause, ApplicationError)
+                            else None
+                        )
+                        if retry_error is None or retry_error.type not in (
+                            "CodexTransientTurnError",
+                            "CodexPermanentTurnError",
+                        ):
+                            raise
+                        retry_metadata = _turn_failure_metadata_from_activity_error(
+                            retry_error
+                        )
+                        retry_metadata["sessionInterventions"] = session_interventions
+                        retry_metadata["priorTurnFailure"] = turn_metadata
+                        publication = await self._publish_failure_artifacts(
+                            locator=current_locator,
+                            managed_run_id=binding.task_run_id,
+                            run_id=run_id,
+                        )
+                        failure_error = _publish_activity_error_result(
+                            retry_error,
+                            retry_metadata,
+                            publication,
+                        )
+                        failed_state_persisted = True
+                        raise failure_error from retry_exc
+                else:
+                    publication = await self._publish_failure_artifacts(
+                        locator=current_locator,
+                        managed_run_id=binding.task_run_id,
+                        run_id=run_id,
+                    )
+                    failure_error = _publish_activity_error_result(
+                        turn_error,
+                        turn_metadata,
+                        publication,
+                    )
+                    failed_state_persisted = True
+                    raise failure_error from exc
+            if session_interventions:
+                turn_response = turn_response.model_copy(
+                    update={
+                        "metadata": {
+                            **dict(turn_response.metadata or {}),
+                            "sessionInterventions": session_interventions,
+                        }
+                    }
+                )
             turn_id = turn_response.turn_id
             current_locator = self._locator_from_state(
                 session_state=turn_response.session_state,
@@ -587,6 +697,13 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     result_metadata["outcomeDisposition"] = disposition
                     if disposition_reason:
                         result_metadata["outcomeReason"] = disposition_reason
+                success_turn_metadata = {
+                    key: value
+                    for key, value in dict(turn_response.metadata or {}).items()
+                    if key in {"sessionInterventions"}
+                }
+                if success_turn_metadata:
+                    result_metadata["turnMetadata"] = success_turn_metadata
                 result = AgentRunResult(
                     outputRefs=output_refs,
                     summary=assistant_text,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -436,16 +436,26 @@ def _docker_workflow_mode_forbidden_failure(*, workflow_docker_mode: str, tool_n
 CODEX_TRANSIENT_TURN_ERROR_TYPE = "CodexTransientTurnError"
 CODEX_PERMANENT_TURN_ERROR_TYPE = "CodexPermanentTurnError"
 
-def _codex_transient_turn_failure(reason: str) -> temporal_exceptions.ApplicationError:
+def _codex_transient_turn_failure(
+    reason: str,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> temporal_exceptions.ApplicationError:
     return temporal_exceptions.ApplicationError(
         reason or "codex turn produced no assistant output",
+        dict(metadata or {}),
         type=CODEX_TRANSIENT_TURN_ERROR_TYPE,
         non_retryable=False,
     )
 
-def _codex_permanent_turn_failure(reason: str) -> temporal_exceptions.ApplicationError:
+def _codex_permanent_turn_failure(
+    reason: str,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> temporal_exceptions.ApplicationError:
     return temporal_exceptions.ApplicationError(
         reason or "codex turn failed",
+        dict(metadata or {}),
         type=CODEX_PERMANENT_TURN_ERROR_TYPE,
         non_retryable=True,
     )
@@ -4948,6 +4958,10 @@ class TemporalAgentRuntimeActivities:
             instructions,
             parameters=parameters,
         )
+        prepared = cls._append_pr_resolver_initial_state_hint(
+            prepared,
+            parameters=parameters,
+        )
         prepared = cls._prepend_selected_skill_activation(
             prepared,
             parameters=parameters,
@@ -4959,6 +4973,192 @@ class TemporalAgentRuntimeActivities:
         )
         prepared = cls._append_managed_step_boundary(prepared)
         return append_managed_codex_runtime_note(prepared)
+
+    @staticmethod
+    def _first_mapping(*values: Any) -> Mapping[str, Any]:
+        for value in values:
+            if isinstance(value, Mapping):
+                return value
+        return {}
+
+    @staticmethod
+    def _state_value(
+        *mappings: Mapping[str, Any],
+        keys: tuple[str, ...],
+    ) -> Any:
+        for mapping in mappings:
+            for key in keys:
+                value = mapping.get(key)
+                if value is not None:
+                    return value
+        return None
+
+    @staticmethod
+    def _compact_state_value(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        text = str(value).strip()
+        if not text:
+            return None
+        return text[:200]
+
+    @classmethod
+    def _append_pr_resolver_initial_state_hint(
+        cls,
+        instructions: str,
+        *,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        params = parameters if isinstance(parameters, Mapping) else {}
+        if selected_agent_skill(params) != "pr-resolver":
+            return instructions
+        if "MoonMind PR resolver initial state:" in instructions:
+            return instructions
+
+        state = cls._first_mapping(
+            params.get("initialPrState"),
+            params.get("mergeGate"),
+            params.get("prResolverInitialState"),
+            params,
+        )
+        pr_state = cls._first_mapping(
+            state.get("pr"),
+            state.get("pullRequest"),
+            params.get("pr"),
+            params.get("pullRequest"),
+        )
+        ci_state = cls._first_mapping(
+            state.get("ci"),
+            state.get("checks"),
+            params.get("ci"),
+            params.get("checks"),
+        )
+        comments_state = cls._first_mapping(
+            state.get("commentsSummary"),
+            state.get("comments"),
+            params.get("commentsSummary"),
+            params.get("comments"),
+        )
+
+        pr_url = cls._state_value(
+            pr_state,
+            state,
+            params,
+            keys=("url", "htmlUrl", "pullRequestUrl", "prUrl"),
+        )
+        mergeable = cls._state_value(
+            pr_state,
+            state,
+            keys=("mergeable", "mergeableState"),
+        )
+        merge_state = cls._state_value(
+            pr_state,
+            state,
+            keys=("mergeStateStatus", "merge_state_status"),
+        )
+        ci_running = cls._state_value(ci_state, state, keys=("isRunning", "ciRunning"))
+        ci_failures = cls._state_value(ci_state, state, keys=("hasFailures", "ciFailed"))
+        ci_signal = cls._state_value(
+            ci_state,
+            state,
+            keys=("signalQuality", "statusCheckRollupQuality"),
+        )
+        rollup_count = cls._state_value(
+            ci_state,
+            state,
+            keys=("statusCheckRollupCount", "checkRunCount", "checksCount"),
+        )
+        comments_fetch = cls._state_value(
+            comments_state,
+            state,
+            keys=("fetchSucceeded", "succeeded", "commentsFetchSucceeded"),
+        )
+        actionable_comments = cls._state_value(
+            comments_state,
+            state,
+            keys=("hasActionableComments", "actionableComments"),
+        )
+
+        observed_values = (
+            pr_url,
+            mergeable,
+            merge_state,
+            ci_running,
+            ci_failures,
+            ci_signal,
+            rollup_count,
+            comments_fetch,
+            actionable_comments,
+        )
+        if all(value is None for value in observed_values):
+            return instructions
+
+        blockers: list[str] = []
+        mergeable_text = str(mergeable or "").strip().upper()
+        merge_state_text = str(merge_state or "").strip().upper()
+        if mergeable_text == "CONFLICTING" or merge_state_text in {"DIRTY", "BLOCKED"}:
+            blockers.append("merge_conflicts")
+        if ci_running is True:
+            blockers.append("ci_running")
+        if ci_failures is True:
+            blockers.append("ci_failures")
+        ci_signal_text = str(ci_signal or "").strip().lower()
+        if ci_signal_text in {"missing", "unavailable", "none", "empty"}:
+            blockers.append("ci_unavailable")
+        if rollup_count == 0:
+            blockers.append("ci_unavailable")
+        if actionable_comments is True:
+            blockers.append("actionable_comments")
+
+        lines = [
+            "MoonMind PR resolver initial state:",
+            "- Source: deterministic pre-agent launch context.",
+        ]
+        compact_pr_url = cls._compact_state_value(pr_url)
+        if compact_pr_url:
+            lines.append(f"- PR: {compact_pr_url}")
+        merge_parts = []
+        for label, value in (
+            ("mergeable", mergeable),
+            ("mergeStateStatus", merge_state),
+        ):
+            compact = cls._compact_state_value(value)
+            if compact is not None:
+                merge_parts.append(f"{label}={compact}")
+        if merge_parts:
+            lines.append("- Merge gate: " + ", ".join(merge_parts))
+        ci_parts = []
+        for label, value in (
+            ("isRunning", ci_running),
+            ("hasFailures", ci_failures),
+            ("signalQuality", ci_signal),
+            ("statusCheckRollupCount", rollup_count),
+        ):
+            compact = cls._compact_state_value(value)
+            if compact is not None:
+                ci_parts.append(f"{label}={compact}")
+        if ci_parts:
+            lines.append("- CI: " + ", ".join(ci_parts))
+        comment_parts = []
+        for label, value in (
+            ("fetchSucceeded", comments_fetch),
+            ("hasActionableComments", actionable_comments),
+        ):
+            compact = cls._compact_state_value(value)
+            if compact is not None:
+                comment_parts.append(f"{label}={compact}")
+        if comment_parts:
+            lines.append("- Comments: " + ", ".join(comment_parts))
+        lines.append(
+            "- Initial blocker hint: "
+            + (", ".join(dict.fromkeys(blockers)) if blockers else "none_detected")
+        )
+        lines.append(
+            "- Report this blocker explicitly if it prevents CI-dependent resolver work."
+        )
+        return instructions.rstrip() + "\n\n" + "\n".join(lines)
 
     @staticmethod
     def _append_skills_on_demand_disabled_notice(
@@ -5170,8 +5370,8 @@ class TemporalAgentRuntimeActivities:
             reason = str(metadata.get("reason") or "").strip()
             failure_class = str(metadata.get("failureClass") or "").strip()
             if failure_class == "transient":
-                raise _codex_transient_turn_failure(reason)
-            raise _codex_permanent_turn_failure(reason)
+                raise _codex_transient_turn_failure(reason, metadata=metadata)
+            raise _codex_permanent_turn_failure(reason, metadata=metadata)
         return validated_response
 
     async def agent_runtime_steer_turn(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import queue
+import re
 import shutil
 import signal
 import sqlite3
@@ -59,6 +60,25 @@ _LOG_RECOVERY_MAX_ROWS = 200
 _LOG_RECOVERY_PROVIDER_MAX_ROWS = 200
 _LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
 _LOG_RECOVERY_PROVIDER_MARKERS: tuple[str, ...] = provider_failure_search_markers()
+EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
+_EMPTY_ASSISTANT_FAILURE_REASONS: tuple[str, ...] = (
+    "codex app-server task_complete produced no assistant output",
+    "codex app-server turn/completed produced no assistant output",
+)
+_DIAGNOSTIC_TEXT_MAX_CHARS = 1000
+_RPC_TRACE_MAX_ENTRIES = 80
+_ROLLUP_EVENT_TYPES_MAX = 24
+_LOG_EXCERPT_MAX_ROWS = 20
+_SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"AIza[0-9A-Za-z_-]{20,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"ATATT[0-9A-Za-z_-]{20,}"),
+    re.compile(
+        r"(?i)(authorization|token|password|api[_-]?key|secret)(\s*[=:]\s*)([^\s,;]+)"
+    ),
+)
 
 @dataclass(frozen=True)
 class _RolloutTurnScan:
@@ -66,6 +86,10 @@ class _RolloutTurnScan:
     assistant_text: str = ""
     saw_task_complete: bool = False
     error_text: str | None = None
+    rollout_path: str | None = None
+    entries_scanned: int = 0
+    entries_referencing_turn: int = 0
+    event_types: tuple[str, ...] = ()
 
 @dataclass(frozen=True)
 class _CompletedTurnInspection:
@@ -151,7 +175,35 @@ class CodexAppServerRpcClient:
         self._next_id = 1
         self._notifications: list[dict[str, Any]] = []
         self._responses: dict[int, dict[str, Any]] = {}
+        self._trace: list[dict[str, Any]] = []
         self._initialize_result: dict[str, Any] | None = None
+
+    def _record_trace(self, entry: Mapping[str, Any]) -> None:
+        self._trace.append(dict(entry))
+        if len(self._trace) > _RPC_TRACE_MAX_ENTRIES:
+            del self._trace[: len(self._trace) - _RPC_TRACE_MAX_ENTRIES]
+
+    def trace_summary(self) -> list[dict[str, Any]]:
+        return list(self._trace)
+
+    @staticmethod
+    def _message_summary(message: Mapping[str, Any]) -> dict[str, Any]:
+        summary: dict[str, Any] = {}
+        method = str(message.get("method") or "").strip()
+        if method:
+            summary["method"] = method
+        raw_id = message.get("id")
+        if isinstance(raw_id, int):
+            summary["id"] = raw_id
+        if "error" in message:
+            summary["hasError"] = True
+        result = message.get("result")
+        if isinstance(result, Mapping):
+            summary["resultKeys"] = sorted(str(key) for key in result.keys())[:12]
+        params = message.get("params")
+        if isinstance(params, Mapping):
+            summary["paramKeys"] = sorted(str(key) for key in params.keys())[:12]
+        return summary
 
     def _ensure_started(self) -> None:
         if self._process is not None:
@@ -233,10 +285,14 @@ class CodexAppServerRpcClient:
 
     def _stash_message(self, message: Mapping[str, Any]) -> None:
         if "method" in message:
+            self._record_trace(
+                {"direction": "notification", **self._message_summary(message)}
+            )
             self._notifications.append(dict(message))
             return
         raw_id = message.get("id")
         if isinstance(raw_id, int):
+            self._record_trace({"direction": "response", **self._message_summary(message)})
             self._responses[raw_id] = dict(message)
 
     def request(
@@ -249,6 +305,14 @@ class CodexAppServerRpcClient:
 
         message_id = self._next_id
         self._next_id += 1
+        self._record_trace(
+            {
+                "direction": "request",
+                "method": method,
+                "id": message_id,
+                "paramKeys": sorted(str(key) for key in dict(params or {}).keys())[:12],
+            }
+        )
         self._write_message(
             {
                 "jsonrpc": "2.0",
@@ -266,6 +330,9 @@ class CodexAppServerRpcClient:
                 message = self._read_message()
 
             if "method" in message:
+                self._record_trace(
+                    {"direction": "notification", **self._message_summary(message)}
+                )
                 self._notifications.append(message)
                 continue
 
@@ -275,10 +342,14 @@ class CodexAppServerRpcClient:
                 continue
 
             if "error" in message:
+                self._record_trace(
+                    {"direction": "response", **self._message_summary(message)}
+                )
                 raise RuntimeError(
                     f"codex app-server request {method} failed: {message['error']}"
                 )
             result = message.get("result")
+            self._record_trace({"direction": "response", **self._message_summary(message)})
             return result if isinstance(result, dict) else {}
 
     def initialize(self) -> dict[str, Any]:
@@ -640,6 +711,38 @@ class CodexManagedSessionRuntime:
                 parts.append(text.strip())
         return "\n".join(parts).strip()
 
+    @staticmethod
+    def _redact_diagnostic_text(value: Any, *, max_chars: int = _DIAGNOSTIC_TEXT_MAX_CHARS) -> str:
+        text = str(value or "")
+        for pattern in _SECRET_REDACTION_PATTERNS:
+            text = pattern.sub(
+                lambda match: (
+                    f"{match.group(1)}{match.group(2)}[REDACTED]"
+                    if match.lastindex and match.lastindex >= 2
+                    else "[REDACTED]"
+                ),
+                text,
+            )
+        if len(text) > max_chars:
+            return text[:max_chars] + "...[truncated]"
+        return text
+
+    @classmethod
+    def _diagnostic_value(cls, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                str(key): cls._diagnostic_value(nested)
+                for key, nested in value.items()
+                if str(key).lower() not in {"input", "instructions", "text"}
+            }
+        if isinstance(value, list):
+            return [cls._diagnostic_value(item) for item in value[:20]]
+        if isinstance(value, tuple):
+            return tuple(cls._diagnostic_value(item) for item in value[:20])
+        if isinstance(value, str):
+            return cls._redact_diagnostic_text(value)
+        return value
+
     @classmethod
     def _error_text_from_value(cls, value: Any) -> str | None:
         if isinstance(value, str):
@@ -744,6 +847,9 @@ class CodexManagedSessionRuntime:
         terminal_text = ""
         terminal_cutoff = None
         references_active_turn = False
+        entries_scanned = 0
+        entries_referencing_turn = 0
+        event_types: list[str] = []
         saw_task_complete = False
         error_text: str | None = None
         if turn_started_at is not None:
@@ -761,9 +867,11 @@ class CodexManagedSessionRuntime:
                     continue
                 if not isinstance(payload, Mapping):
                     continue
+                entries_scanned += 1
                 references_turn = self._payload_references_turn(payload, vendor_turn_id)
                 if references_turn:
                     references_active_turn = True
+                    entries_referencing_turn += 1
                     text = self._assistant_text_from_rollout_entry(payload)
                     if text:
                         last_text = text
@@ -784,6 +892,8 @@ class CodexManagedSessionRuntime:
                 if not isinstance(event_payload, Mapping):
                     continue
                 event_type = str(event_payload.get("type") or "").strip().lower()
+                if event_type and event_type not in event_types:
+                    event_types.append(event_type)
                 if event_type != "task_complete":
                     continue
                 saw_task_complete = True
@@ -801,6 +911,10 @@ class CodexManagedSessionRuntime:
             assistant_text=last_text or terminal_text,
             saw_task_complete=saw_task_complete,
             error_text=error_text,
+            rollout_path=rollout_path,
+            entries_scanned=entries_scanned,
+            entries_referencing_turn=entries_referencing_turn,
+            event_types=tuple(event_types[:_ROLLUP_EVENT_TYPES_MAX]),
         )
 
     @staticmethod
@@ -1261,6 +1375,180 @@ class CodexManagedSessionRuntime:
             if provider_rows_remaining <= 0:
                 break
         return None
+
+    def _recent_runtime_log_excerpts(
+        self,
+        *,
+        vendor_turn_id: str,
+        turn_started_at: float | None = None,
+    ) -> list[dict[str, Any]]:
+        provider_timestamp_cutoff = self._sqlite_provider_timestamp_cutoff(
+            turn_started_at
+        )
+        excerpts: list[dict[str, Any]] = []
+        markers = (vendor_turn_id, "turn", "app-server", "error", "failed")
+        for log_path in sorted(
+            self._codex_home_path.glob("logs_*.sqlite"),
+            key=self._log_shard_sort_key,
+            reverse=True,
+        ):
+            if not log_path.is_file():
+                continue
+            try:
+                with sqlite3.connect(
+                    f"file:{log_path}?mode=ro",
+                    uri=True,
+                    timeout=_LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS,
+                ) as connection:
+                    column_rows = connection.execute("PRAGMA table_info(logs)").fetchall()
+                    if not column_rows:
+                        continue
+                    available_columns = {str(row[1]) for row in column_rows if len(row) > 1}
+                    text_column = next(
+                        (
+                            candidate
+                            for candidate in ("feedback_log_body", "message")
+                            if candidate in available_columns
+                        ),
+                        None,
+                    )
+                    if text_column is None:
+                        continue
+                    quoted_text_column = self._quoted_sqlite_identifier(text_column)
+                    where = ""
+                    params: list[Any] = []
+                    if provider_timestamp_cutoff is not None and "ts" in available_columns:
+                        quoted_ts_column = self._quoted_sqlite_identifier("ts")
+                        where = f"WHERE {quoted_ts_column} >= ?"
+                        params.append(provider_timestamp_cutoff)
+                    rows = connection.execute(
+                        (
+                            f"SELECT {quoted_text_column} FROM \"logs\" "
+                            f"{where} ORDER BY \"id\" DESC LIMIT ?"
+                        ),
+                        (*params, _LOG_RECOVERY_MAX_ROWS),
+                    ).fetchall()
+            except (ValueError, sqlite3.Error):
+                continue
+            for (raw_text,) in rows:
+                text = str(raw_text or "").strip()
+                lowered = text.lower()
+                if not any(marker and marker.lower() in lowered for marker in markers):
+                    continue
+                excerpts.append(
+                    {
+                        "source": log_path.name,
+                        "text": self._redact_diagnostic_text(text, max_chars=500),
+                    }
+                )
+                if len(excerpts) >= _LOG_EXCERPT_MAX_ROWS:
+                    return excerpts
+        return excerpts
+
+    @classmethod
+    def _thread_payload_summary(
+        cls,
+        thread_payload: Mapping[str, Any],
+        *,
+        vendor_turn_id: str,
+    ) -> dict[str, Any]:
+        thread = thread_payload.get("thread")
+        if not isinstance(thread, Mapping):
+            return {"hasThread": False}
+        turns = thread.get("turns")
+        turn_count = len(turns) if isinstance(turns, list) else None
+        turn_payload = cls._find_turn_payload(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        )
+        turn_summary: dict[str, Any] = {"found": isinstance(turn_payload, Mapping)}
+        if isinstance(turn_payload, Mapping):
+            items = turn_payload.get("items")
+            item_types: list[str] = []
+            assistant_items = 0
+            error_items = 0
+            if isinstance(items, list):
+                for item in items[:40]:
+                    if not isinstance(item, Mapping):
+                        continue
+                    item_type = str(item.get("type") or "").strip()
+                    if item_type:
+                        item_types.append(item_type)
+                    if item_type == "agentMessage":
+                        assistant_items += 1
+                    if "error" in item:
+                        error_items += 1
+            turn_summary.update(
+                {
+                    "status": cls._diagnostic_value(turn_payload.get("status")),
+                    "itemCount": len(items) if isinstance(items, list) else None,
+                    "itemTypes": item_types,
+                    "assistantItemCount": assistant_items,
+                    "errorItemCount": error_items,
+                    "errorText": cls._diagnostic_value(
+                        cls._error_text_from_value(turn_payload.get("error"))
+                    ),
+                }
+            )
+        return {
+            "hasThread": True,
+            "threadId": cls._diagnostic_value(thread.get("id")),
+            "threadStatusType": cls._thread_status_type(thread_payload),
+            "threadStatusReason": cls._diagnostic_value(
+                cls._thread_status_reason(thread_payload)
+            ),
+            "turnCount": turn_count,
+            "activeTurn": turn_summary,
+        }
+
+    @classmethod
+    def _rollout_scan_summary(cls, scan: _RolloutTurnScan | None) -> dict[str, Any] | None:
+        if scan is None:
+            return None
+        return {
+            "rolloutPath": cls._diagnostic_value(scan.rollout_path),
+            "entriesScanned": scan.entries_scanned,
+            "entriesReferencingTurn": scan.entries_referencing_turn,
+            "referencesTurn": scan.references_turn,
+            "sawTaskComplete": scan.saw_task_complete,
+            "eventTypes": list(scan.event_types),
+            "errorText": cls._diagnostic_value(scan.error_text),
+        }
+
+    def _turn_failure_evidence(
+        self,
+        *,
+        reason: str,
+        state: CodexSessionRuntimeState,
+        client: CodexAppServerRpcClient,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+        rollout_scan: _RolloutTurnScan | None,
+    ) -> dict[str, Any]:
+        return {
+            "schemaVersion": "v1",
+            "failureCause": EMPTY_ASSISTANT_FAILURE_CAUSE,
+            "reason": self._redact_diagnostic_text(reason),
+            "capturedAt": datetime.now(UTC).isoformat(),
+            "session": {
+                "sessionId": state.session_id,
+                "sessionEpoch": state.session_epoch,
+                "containerId": state.container_id,
+                "logicalThreadId": state.logical_thread_id,
+                "vendorThreadId": state.vendor_thread_id,
+                "vendorTurnId": vendor_turn_id,
+            },
+            "appServerRpcTrace": self._diagnostic_value(client.trace_summary()),
+            "threadPayloadSummary": self._thread_payload_summary(
+                thread_payload,
+                vendor_turn_id=vendor_turn_id,
+            ),
+            "rolloutScan": self._rollout_scan_summary(rollout_scan),
+            "runtimeLogExcerpts": self._recent_runtime_log_excerpts(
+                vendor_turn_id=vendor_turn_id,
+                turn_started_at=state.last_control_at,
+            ),
+        }
 
     def _reset_skill_outcome(self) -> None:
         """Remove any stale skill-outcome marker before a new turn begins.
@@ -1998,6 +2286,31 @@ class CodexManagedSessionRuntime:
             metadata["reason"] = error_text
         if status == "failed" and failure_class:
             metadata["failureClass"] = failure_class
+            if error_text in _EMPTY_ASSISTANT_FAILURE_REASONS:
+                evidence_rollout_scan = (
+                    completed_turn_inspection.rollout_scan
+                    if completed_turn_inspection is not None
+                    else None
+                )
+                if evidence_rollout_scan is None:
+                    evidence_rollout_scan = self._scan_rollout_for_turn(
+                        self._resolved_rollout_path(
+                            state=state,
+                            thread_payload=thread_payload,
+                        ),
+                        vendor_turn_id=vendor_turn_id,
+                        turn_started_at=state.last_control_at,
+                    )
+                metadata["failureCause"] = EMPTY_ASSISTANT_FAILURE_CAUSE
+                metadata["retryRecommendedAction"] = "clear_session"
+                metadata["turnFailureEvidence"] = self._turn_failure_evidence(
+                    reason=error_text,
+                    state=state,
+                    client=client,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=vendor_turn_id,
+                    rollout_scan=evidence_rollout_scan,
+                )
         if disposition:
             metadata["disposition"] = disposition
         self._finalize_turn(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1382,11 +1382,12 @@ class CodexManagedSessionRuntime:
         vendor_turn_id: str,
         turn_started_at: float | None = None,
     ) -> list[dict[str, Any]]:
+        if not vendor_turn_id:
+            return []
         provider_timestamp_cutoff = self._sqlite_provider_timestamp_cutoff(
             turn_started_at
         )
         excerpts: list[dict[str, Any]] = []
-        markers = (vendor_turn_id, "turn", "app-server", "error", "failed")
         for log_path in sorted(
             self._codex_home_path.glob("logs_*.sqlite"),
             key=self._log_shard_sort_key,
@@ -1415,12 +1416,14 @@ class CodexManagedSessionRuntime:
                     if text_column is None:
                         continue
                     quoted_text_column = self._quoted_sqlite_identifier(text_column)
-                    where = ""
+                    where_clauses = [f"{quoted_text_column} LIKE ?"]
                     params: list[Any] = []
                     if provider_timestamp_cutoff is not None and "ts" in available_columns:
                         quoted_ts_column = self._quoted_sqlite_identifier("ts")
-                        where = f"WHERE {quoted_ts_column} >= ?"
+                        where_clauses.insert(0, f"{quoted_ts_column} >= ?")
                         params.append(provider_timestamp_cutoff)
+                    params.append(f"%{vendor_turn_id}%")
+                    where = "WHERE " + " AND ".join(where_clauses)
                     rows = connection.execute(
                         (
                             f"SELECT {quoted_text_column} FROM \"logs\" "
@@ -1432,9 +1435,6 @@ class CodexManagedSessionRuntime:
                 continue
             for (raw_text,) in rows:
                 text = str(raw_text or "").strip()
-                lowered = text.lower()
-                if not any(marker and marker.lower() in lowered for marker in markers):
-                    continue
                 excerpts.append(
                     {
                         "source": log_path.name,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2117,6 +2117,41 @@ def test_runtime_extract_turn_error_from_logs_prefers_highest_numeric_shard(
 
     assert runtime._extract_turn_error_from_logs("vendor-turn-1") == "latest shard"
 
+def test_runtime_recent_log_excerpts_only_include_active_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "raise SystemExit(0)"),
+    )
+    _write_fake_codex_logs(
+        request.codex_home_path,
+        entries=[
+            (
+                "session_loop{thread_id=vendor-thread-1}:turn{turn.id=other-turn}: "
+                "Turn error: unrelated prior failure"
+            ),
+            (
+                "session_loop{thread_id=vendor-thread-1}:turn{turn.id=vendor-turn-1}: "
+                "Turn error: active failure"
+            ),
+        ],
+    )
+
+    excerpts = runtime._recent_runtime_log_excerpts(vendor_turn_id="vendor-turn-1")
+
+    assert [entry["text"] for entry in excerpts] == [
+        "session_loop{thread_id=vendor-thread-1}:turn{turn.id=vendor-turn-1}: "
+        "Turn error: active failure"
+    ]
+
 def test_runtime_extract_turn_error_from_logs_recovers_provider_error_message(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -439,6 +439,16 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"
     )
+    assert response.metadata["failureCause"] == "app_server_protocol_empty_turn"
+    assert response.metadata["retryRecommendedAction"] == "clear_session"
+    evidence = response.metadata["turnFailureEvidence"]
+    assert evidence["failureCause"] == "app_server_protocol_empty_turn"
+    assert evidence["session"]["vendorTurnId"] == response.turn_id
+    assert evidence["threadPayloadSummary"]["activeTurn"]["found"] is True
+    assert any(
+        entry["direction"] == "request" and entry["method"] == "turn/start"
+        for entry in evidence["appServerRpcTrace"]
+    )
 
     handle = runtime.session_status(
         CodexManagedSessionLocator(
@@ -766,10 +776,15 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
     )
 
     assert response.status == "failed"
-    assert response.metadata == {
-        "failureClass": "transient",
-        "reason": "codex app-server task_complete produced no assistant output",
-    }
+    assert response.metadata["failureClass"] == "transient"
+    assert (
+        response.metadata["reason"]
+        == "codex app-server task_complete produced no assistant output"
+    )
+    assert response.metadata["failureCause"] == "app_server_protocol_empty_turn"
+    evidence = response.metadata["turnFailureEvidence"]
+    assert evidence["rolloutScan"]["sawTaskComplete"] is True
+    assert evidence["rolloutScan"]["entriesReferencingTurn"] >= 1
     handle = runtime.session_status(
         CodexManagedSessionLocator(
             sessionId="sess-1",

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -805,7 +805,7 @@ async def test_start_preserves_completed_codex_turn_with_usage_limit_summary(
     assert "providerFailure" not in result.metadata
 
     persisted_record = run_store.load(binding.task_run_id)
-    result = await adapter.fetch_result(handle.run_id)
+    await adapter.fetch_result(handle.run_id)
     assert persisted_record is not None
     assert persisted_record.status == "completed"
     assert persisted_record.failure_class is None

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.exceptions import ActivityError, ApplicationError
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -56,6 +57,20 @@ async def _prepare_turn_instructions(payload: dict[str, Any]) -> str:
             if inline:
                 return f"{inline}\n\nManaged Codex CLI note:"
     return f"{instruction_ref}\n\nManaged Codex CLI note:"
+
+def _raise_activity_error_from_application_error(error: ApplicationError) -> None:
+    try:
+        raise error
+    except ApplicationError as exc:
+        raise ActivityError(
+            "activity failed",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="test-worker",
+            activity_type="agent_runtime.send_turn",
+            activity_id="activity-1",
+            retry_state=None,
+        ) from exc
 
 def _binding() -> CodexManagedSessionBinding:
     return CodexManagedSessionBinding(
@@ -790,6 +805,7 @@ async def test_start_preserves_completed_codex_turn_with_usage_limit_summary(
     assert "providerFailure" not in result.metadata
 
     persisted_record = run_store.load(binding.task_run_id)
+    result = await adapter.fetch_result(handle.run_id)
     assert persisted_record is not None
     assert persisted_record.status == "completed"
     assert persisted_record.failure_class is None
@@ -1421,6 +1437,141 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
     assert persisted_record.session_epoch == binding.session_epoch + 1
     assert persisted_record.container_id == "container-2"
     assert persisted_record.thread_id == "thread-2"
+
+async def test_start_resets_session_once_after_empty_assistant_activity_failure(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    send_turn_calls: list[Any] = []
+    clear_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    reset_thread_id = "thread-1:empty-output-reset"
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        if len(send_turn_calls) == 1:
+            metadata = {
+                "reason": "codex app-server turn/completed produced no assistant output",
+                "failureClass": "transient",
+                "failureCause": "app_server_protocol_empty_turn",
+                "turnFailureEvidence": {"schemaVersion": "v1"},
+            }
+            _raise_activity_error_from_application_error(
+                ApplicationError(
+                    metadata["reason"],
+                    metadata,
+                    type="CodexTransientTurnError",
+                    non_retryable=False,
+                )
+            )
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+            turn_id="turn-after-reset",
+            status="completed",
+            assistant_text="Recovered after session reset.",
+        )
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        clear_calls.append(request)
+        assert request.new_thread_id == reset_thread_id
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+            last_assistant_text="Recovered after session reset.",
+        )
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_clear_remote_session,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    assert handle.status == "completed"
+    assert len(send_turn_calls) == 2
+    assert len(clear_calls) == 1
+    assert send_turn_calls[1].thread_id == reset_thread_id
+    assert any(call["action"] == "clear_session" for call in control_calls)
+    persisted_record = run_store.load(binding.task_run_id)
+    result = await adapter.fetch_result(handle.run_id)
+    assert persisted_record is not None
+    assert persisted_record.status == "completed"
+    assert persisted_record.session_epoch == 2
+    assert persisted_record.thread_id == reset_thread_id
+    assert result.metadata["turnMetadata"]["sessionInterventions"] == [
+        {
+            "action": "clear_session",
+            "reason": "retry_after_empty_assistant_output",
+            "fromThreadId": "thread-1",
+            "toThreadId": reset_thread_id,
+            "fromSessionEpoch": 1,
+            "toSessionEpoch": 2,
+        }
+    ]
 
 async def test_start_classifies_codex_provider_capacity_failure_and_publishes_artifacts(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1218,6 +1218,46 @@ async def test_send_turn_delegates_to_remote_session_controller() -> None:
     assert isinstance(result, CodexManagedSessionTurnResponse)
     assert result.turn_id == "turn-1"
 
+async def test_send_turn_transient_failure_preserves_diagnostic_metadata() -> None:
+    failure_metadata = {
+        "reason": "codex app-server turn/completed produced no assistant output",
+        "failureClass": "transient",
+        "failureCause": "app_server_protocol_empty_turn",
+        "turnFailureEvidence": {"schemaVersion": "v1", "runtimeLogExcerpts": []},
+    }
+    controller = AsyncMock()
+    controller.send_turn = AsyncMock(
+        return_value=CodexManagedSessionTurnResponse(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+            },
+            turnId="turn-1",
+            status="failed",
+            metadata=failure_metadata,
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    with pytest.raises(
+        activity_runtime_module.temporal_exceptions.ApplicationError
+    ) as exc_info:
+        await activities.agent_runtime_send_turn(
+            {
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+                "instructions": "Inspect the workspace",
+            }
+        )
+
+    assert exc_info.value.type == "CodexTransientTurnError"
+    assert exc_info.value.details == (failure_metadata,)
+
 async def test_send_turn_heartbeats_while_waiting_for_remote_session_controller(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2492,6 +2532,50 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint(
     assert "`$MOONMIND_URL`" in result
     assert "POST $MOONMIND_URL/mcp/tools/call" in result
     assert "jira.create_issue" in result
+    assert "Managed Codex CLI note:" in result
+
+async def test_agent_runtime_prepare_turn_instructions_adds_pr_resolver_blocker_hint() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "skipSkillMaterialization": True,
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Resolve the pull request.",
+                    "publishMode": "none",
+                    "selectedSkill": "pr-resolver",
+                    "mergeGate": {
+                        "pullRequestUrl": "https://github.com/org/repo/pull/1791",
+                        "pr": {
+                            "mergeable": "CONFLICTING",
+                            "mergeStateStatus": "DIRTY",
+                        },
+                        "ci": {
+                            "isRunning": False,
+                            "hasFailures": False,
+                            "signalQuality": "missing",
+                            "statusCheckRollupCount": 0,
+                        },
+                        "commentsSummary": {
+                            "fetchSucceeded": True,
+                            "hasActionableComments": False,
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    assert "MoonMind PR resolver initial state:" in result
+    assert "https://github.com/org/repo/pull/1791" in result
+    assert "mergeable=CONFLICTING" in result
+    assert "mergeStateStatus=DIRTY" in result
+    assert "Initial blocker hint: merge_conflicts, ci_unavailable" in result
     assert "Managed Codex CLI note:" in result
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add structured, redacted evidence for empty Codex managed-session turns, including RPC trace summaries, thread payload summaries, rollout scan details, and runtime log excerpts.
- Preserve turn failure metadata through Temporal activity errors and managed-run failure artifacts.
- Add a bounded recovery path that clears the managed Codex session once after empty-output transient failures, then records the intervention.
- Inject deterministic PR resolver initial-state hints when merge-gate context is available before agent execution.
- Relax a Mission Control lazy-load assertion timeout so the canonical frontend suite is stable under full-suite load.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
