### PR TITLE
[codex] Add Jira story implementation reconciliation

### DIFF
--- a/.agents/skills/story-reconcile-implementation/SKILL.md
+++ b/.agents/skills/story-reconcile-implementation/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: story-reconcile-implementation
+description: Compare MoonSpec story breakdown output against the current repository implementation, preserve fully implemented stories as skipped, narrow partially implemented stories to remaining work, and rewrite the story breakdown handoff before Jira issue creation.
+---
+
+# Story Implementation Reconciliation
+
+Use this skill after `moonspec-breakdown` and before Jira issue creation when a breakdown may include work that is already fully or partially implemented.
+
+## Inputs
+
+- Required: a MoonSpec story breakdown JSON path. Prefer `storyBreakdownPath` from the runtime inputs.
+- Optional: `storyBreakdownMarkdownPath` for the human-readable reconciliation report.
+- Optional: source design path or text from the breakdown source.
+- Required: current repository checkout containing the implementation to inspect.
+
+If no readable story breakdown JSON path is available, stop with a clear blocker. Do not create Jira issues or implementation tasks.
+
+## Workflow
+
+1. Read the story breakdown JSON.
+2. For each story, inspect relevant source, tests, docs, migrations, contracts, and configuration in the repository.
+3. Compare repository evidence against the story acceptance criteria, requirements, source design coverage, and explicit non-goals.
+4. Classify every story with exactly one `implementationStatus`:
+   - `fully_implemented`
+   - `partially_implemented`
+   - `not_implemented`
+   - `unverifiable`
+5. Rewrite the JSON breakdown in place at `storyBreakdownPath` with the same top-level structure and story order.
+6. Write or update the markdown report at `storyBreakdownMarkdownPath` when provided.
+
+## Classification Rules
+
+- Use `fully_implemented` only when every in-scope acceptance criterion and requirement has concrete repository evidence and the behavior is testable.
+- Use `partially_implemented` when at least one in-scope criterion is implemented and at least one remains missing or insufficiently validated.
+- Use `not_implemented` when no meaningful in-scope implementation evidence exists.
+- Use `unverifiable` when the requirement is too ambiguous, depends on missing external context, or cannot be checked from the repository state available in this run.
+- Be conservative. If evidence is weak, do not mark a story fully implemented.
+
+## Story Output Contract
+
+Preserve the original story fields. Add reconciliation fields; do not delete source traceability.
+
+For a fully implemented story:
+
+```json
+{
+  "implementationStatus": "fully_implemented",
+  "implementedEvidence": [
+    {
+      "requirement": "DESIGN-REQ-001",
+      "status": "met",
+      "evidence": "tests/unit/example_test.py covers the acceptance path."
+    }
+  ],
+  "jiraCreation": {
+    "action": "skip",
+    "reason": "All acceptance criteria have repository evidence."
+  }
+}
+```
+
+For a partially implemented story:
+
+```json
+{
+  "implementationStatus": "partially_implemented",
+  "implementedEvidence": [
+    {
+      "requirement": "DESIGN-REQ-001",
+      "status": "met",
+      "evidence": "api_service/example.py implements the existing endpoint."
+    }
+  ],
+  "remainingWork": {
+    "summary": "Complete remaining behavior for the original story",
+    "description": "Only the unmet behavior should be implemented.",
+    "acceptanceCriteria": [
+      "Unmet acceptance criterion."
+    ],
+    "requirements": [
+      "Unmet requirement."
+    ]
+  },
+  "jiraCreation": {
+    "action": "create_remaining_work_issue",
+    "reason": "Some criteria are already implemented; Jira should track only the remaining work."
+  }
+}
+```
+
+For a not implemented story:
+
+```json
+{
+  "implementationStatus": "not_implemented",
+  "jiraCreation": {
+    "action": "create_issue",
+    "reason": "No implementation evidence found."
+  }
+}
+```
+
+For an unverifiable story:
+
+```json
+{
+  "implementationStatus": "unverifiable",
+  "jiraCreation": {
+    "action": "manual_review",
+    "reason": "Repository evidence is insufficient to safely create implementation work."
+  }
+}
+```
+
+## Markdown Report
+
+The markdown report must include:
+
+- Source design title or path.
+- Story ID, summary, and implementation status for every story.
+- Evidence for implemented requirements.
+- Remaining work for partially implemented stories.
+- Skipped fully implemented stories.
+- Unverifiable stories and the exact missing evidence or ambiguity.
+- Confirmation that Jira issue creation should consume the reconciled JSON, not the original unreconciled story list.
+
+## Key Rules
+
+- Do not create Jira issues.
+- Do not create downstream Jira Orchestrate tasks.
+- Do not implement code.
+- Do not create or modify `spec.md`.
+- Do not delete original story scope, source references, coverage IDs, dependencies, assumptions, or non-goals.
+- Fully implemented stories must use `jiraCreation.action = "skip"`.
+- Partially implemented stories must preserve original scope and define `remainingWork`.
+- Unverifiable stories must use `jiraCreation.action = "manual_review"` so deterministic Jira creation will not create work automatically.

--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -69,12 +69,29 @@ steps:
       args: {}
       requiredCapabilities:
         - git
+  - title: Reconcile stories with current implementation
+    instructions: |-
+      Use story-reconcile-implementation to compare the generated MoonSpec story breakdown against the current repository implementation before any Jira issue creation occurs.
+
+      Read the runtime-provided story breakdown JSON path and rewrite that same JSON handoff with implementationStatus and jiraCreation fields for every story.
+      Mark fully implemented stories with jiraCreation.action = "skip" so no Jira issue or downstream Jira Orchestrate task is created for completed work.
+      For partially implemented stories, preserve the original story scope and add remainingWork so Jira tracks only the unmet requirements.
+      Mark unverifiable stories with jiraCreation.action = "manual_review" so deterministic Jira creation will not create implementation work automatically.
+      Write the reconciliation report to the runtime-provided markdown breakdown path when available.
+      Do not create Jira issues, do not create implementation tasks, and do not implement code in this reconciliation step.
+    skill:
+      id: story-reconcile-implementation
+      args: {}
+      requiredCapabilities:
+        - git
   - title: Create Jira issues
     instructions: |-
-      Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each story from the generated MoonSpec breakdown.
+      Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each eligible story from the reconciled MoonSpec breakdown.
 
       Use the runtime-provided story breakdown JSON path.
       Every Jira issue must include the Source Document path from the story breakdown.
+      Do not create Jira issues for stories where jiraCreation.action is skip or manual_review.
+      For stories where jiraCreation.action is create_remaining_work_issue, create the Jira issue from the story's remainingWork while preserving the original story traceability.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.source_issue_key and inputs.jira_issue_type | lower in ["sub-task", "subtask", "sub task"] %}Create each generated Jira issue as a sub-task of {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
@@ -96,9 +113,10 @@ steps:
       args: {}
   - title: Create dependent Jira Orchestrate tasks
     instructions: |-
-      Create one Jira Orchestrate task for each generated Jira story from the trusted Jira story output.
+      Create one Jira Orchestrate task for each Jira issue created from the trusted Jira story output.
 
       Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream tasks.
+      Do not create downstream tasks for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
       Each downstream task must run Jira Orchestrate on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
       Create task dependencies with dependsOn so each later generated task waits for the immediately earlier generated task workflow ID.
       Preserve source Jira issue {{ inputs.source_issue_key }} and the original source brief in downstream task instructions and result traceability.

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -525,6 +525,19 @@ publication fallback; workflow-local story handoff should use inline stories or
 artifact refs so Jira creation does not depend on a protected branch push. It is
 not the default path for ambiguous Jira requests.
 
+When a breakdown has been reconciled against the current repository
+implementation, `story.create_jira_issues` honors per-story `jiraCreation`
+metadata. Stories marked `jiraCreation.action = "skip"` or
+`implementationStatus = "fully_implemented"` do not create Jira issues. Stories
+marked `jiraCreation.action = "manual_review"` or
+`implementationStatus = "unverifiable"` are reported as blocked manual-review
+items and do not create Jira issues. Stories marked
+`jiraCreation.action = "create_remaining_work_issue"` or
+`implementationStatus = "partially_implemented"` create Jira issues from their
+`remainingWork` payload while preserving original story traceability. The output
+reports `skippedStories`, `blockedStories`, and `partialStoriesAdjusted` so
+downstream orchestration can create tasks only for returned Jira issue mappings.
+
 For breakdown-driven Jira output, the canonical traceability shape is
 `sourceReference.path` on every story, with `source.referencePath` or
 `source.path` as a breakdown-level fallback. The tool also accepts path-only

--- a/docs/Tasks/TaskPresetsSystem.md
+++ b/docs/Tasks/TaskPresetsSystem.md
@@ -416,6 +416,24 @@ Rules:
 - Recursive expansion must detect cycles and fail safely.
 - Provenance records both parent and child preset ancestry.
 
+## Jira Breakdown Orchestrate Reconciliation
+
+`jira-breakdown-orchestrate` includes a repository reconciliation stage between
+MoonSpec breakdown and Jira creation. The reconciliation agent compares each
+generated story with the current repository state and annotates the story
+breakdown before any Jira mutation occurs:
+
+- fully implemented stories are marked for skip and do not create Jira issues or
+  downstream Jira Orchestrate tasks
+- partially implemented stories keep their original traceability but add
+  `remainingWork`, so Jira tracks only the unmet behavior
+- unverifiable stories are marked for manual review and are not automatically
+  converted into implementation work
+
+The deterministic Jira story-output tool consumes only eligible reconciled
+stories, then the downstream Jira Orchestrate task creator consumes only the
+Jira issue mappings that were actually created or reused.
+
 ## Submit-Time Auto-Expansion
 
 The user may click Create Task while one or more preset steps are still unexpanded. The submit path must:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -40,6 +40,39 @@ JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN = "linear_blocker_chain"
 JIRA_DEPENDENCY_MODES = frozenset(
     {JIRA_DEPENDENCY_MODE_NONE, JIRA_DEPENDENCY_MODE_LINEAR_BLOCKER_CHAIN}
 )
+STORY_IMPLEMENTATION_STATUS_FULLY_IMPLEMENTED = "fully_implemented"
+STORY_IMPLEMENTATION_STATUS_PARTIALLY_IMPLEMENTED = "partially_implemented"
+STORY_IMPLEMENTATION_STATUS_NOT_IMPLEMENTED = "not_implemented"
+STORY_IMPLEMENTATION_STATUS_UNVERIFIABLE = "unverifiable"
+STORY_JIRA_ACTION_CREATE_ISSUE = "create_issue"
+STORY_JIRA_ACTION_CREATE_REMAINING_WORK_ISSUE = "create_remaining_work_issue"
+STORY_JIRA_ACTION_SKIP = "skip"
+STORY_JIRA_ACTION_MANUAL_REVIEW = "manual_review"
+STORY_JIRA_SKIP_ACTIONS = frozenset(
+    {
+        STORY_JIRA_ACTION_SKIP,
+        "skip_issue",
+        "skip_jira",
+        "no_issue",
+        "none",
+    }
+)
+STORY_JIRA_BLOCK_ACTIONS = frozenset(
+    {
+        STORY_JIRA_ACTION_MANUAL_REVIEW,
+        "block",
+        "blocked",
+        "manual_review_required",
+        "do_not_create",
+    }
+)
+STORY_JIRA_CREATE_ACTIONS = frozenset(
+    {
+        STORY_JIRA_ACTION_CREATE_ISSUE,
+        "create",
+        "create_jira_issue",
+    }
+)
 _ACCEPTANCE_HEADING_RE = re.compile(
     r"(?im)^\s*(acceptance\s+criteria|acceptance|ac)\s*:?\s*$"
 )
@@ -493,6 +526,207 @@ def _story_description(story: Mapping[str, Any]) -> str:
         ),
     ]
     return (description + "".join(sections)).strip() or _story_summary(story, index=1)
+
+def _normalized_story_token(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", _string(value).lower()).strip("_")
+
+def _story_jira_creation(story: Mapping[str, Any]) -> dict[str, Any]:
+    value = story.get("jiraCreation") or story.get("jira_creation")
+    return dict(value) if isinstance(value, Mapping) else {}
+
+def _story_implementation_status(story: Mapping[str, Any]) -> str:
+    return _normalized_story_token(
+        story.get("implementationStatus")
+        or story.get("implementation_status")
+        or story.get("status")
+    )
+
+def _story_jira_creation_action(story: Mapping[str, Any]) -> str:
+    jira_creation = _story_jira_creation(story)
+    action = _normalized_story_token(
+        jira_creation.get("action")
+        or story.get("jiraCreationAction")
+        or story.get("jira_creation_action")
+    )
+    if action:
+        return action
+    status = _story_implementation_status(story)
+    if status == STORY_IMPLEMENTATION_STATUS_FULLY_IMPLEMENTED:
+        return STORY_JIRA_ACTION_SKIP
+    if status == STORY_IMPLEMENTATION_STATUS_PARTIALLY_IMPLEMENTED:
+        return STORY_JIRA_ACTION_CREATE_REMAINING_WORK_ISSUE
+    if status == STORY_IMPLEMENTATION_STATUS_UNVERIFIABLE:
+        return STORY_JIRA_ACTION_MANUAL_REVIEW
+    return STORY_JIRA_ACTION_CREATE_ISSUE
+
+def _story_jira_creation_reason(story: Mapping[str, Any]) -> str:
+    jira_creation = _story_jira_creation(story)
+    return _string(
+        jira_creation.get("reason")
+        or story.get("jiraCreationReason")
+        or story.get("jira_creation_reason")
+    )
+
+def _story_remaining_work(story: Mapping[str, Any]) -> dict[str, Any]:
+    value = story.get("remainingWork") or story.get("remaining_work")
+    return dict(value) if isinstance(value, Mapping) else {}
+
+def _story_implemented_evidence(story: Mapping[str, Any]) -> list[Any]:
+    return _list(
+        story.get("implementedEvidence")
+        or story.get("implemented_evidence")
+        or story.get("evidence")
+    )
+
+def _format_implemented_evidence_for_jira(story: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for item in _story_implemented_evidence(story):
+        if isinstance(item, Mapping):
+            requirement = _string(
+                item.get("requirement")
+                or item.get("coverageId")
+                or item.get("coverage_id")
+                or item.get("id")
+            )
+            status = _string(item.get("status"))
+            evidence = _string(item.get("evidence") or item.get("details"))
+            parts = [part for part in (requirement, status, evidence) if part]
+            if parts:
+                lines.append(" - ".join(parts))
+        else:
+            text = _string(item)
+            if text:
+                lines.append(text)
+    return lines
+
+def _remaining_work_list(
+    remaining_work: Mapping[str, Any],
+    *keys: str,
+) -> list[Any]:
+    for key in keys:
+        items = _list(remaining_work.get(key))
+        if items:
+            return items
+    return []
+
+def _story_for_remaining_jira_work(
+    story: Mapping[str, Any],
+    *,
+    index: int,
+) -> dict[str, Any]:
+    remaining_work = _story_remaining_work(story)
+    if not remaining_work:
+        return dict(story)
+
+    adjusted = dict(story)
+    original_summary = _story_summary(story, index=index)
+    adjusted["summary"] = _string(
+        remaining_work.get("summary")
+        or remaining_work.get("title")
+    ) or f"Complete remaining work for {original_summary}"
+
+    remaining_description = _string(
+        remaining_work.get("description")
+        or remaining_work.get("body")
+        or remaining_work.get("narrative")
+    )
+    original_description = _story_description(story)
+    evidence_lines = _format_implemented_evidence_for_jira(story)
+    description_parts = [
+        "Remaining Work\n" + (remaining_description or adjusted["summary"]),
+        _format_story_section("Already Implemented Evidence", evidence_lines),
+        _format_story_section("Original Story Scope", original_description),
+    ]
+    adjusted["description"] = "\n".join(
+        part for part in description_parts if part
+    ).strip()
+
+    acceptance = _remaining_work_list(
+        remaining_work,
+        "acceptanceCriteria",
+        "acceptance_criteria",
+        "remainingAcceptanceCriteria",
+        "remaining_acceptance_criteria",
+    )
+    if acceptance:
+        adjusted["acceptanceCriteria"] = acceptance
+    requirements = _remaining_work_list(
+        remaining_work,
+        "requirements",
+        "remainingRequirements",
+        "remaining_requirements",
+    )
+    if requirements:
+        adjusted["requirements"] = requirements
+    adjusted["originalStorySummary"] = original_summary
+    return adjusted
+
+def _story_reconciliation_record(
+    story: Mapping[str, Any],
+    *,
+    index: int,
+    action: str,
+) -> dict[str, Any]:
+    record = {
+        "storyId": _story_id(story, index=index),
+        "storyIndex": index,
+        "summary": _story_summary(story, index=index),
+        "implementationStatus": _story_implementation_status(story),
+        "jiraCreationAction": action,
+    }
+    reason = _story_jira_creation_reason(story)
+    if reason:
+        record["reason"] = reason
+    evidence = _story_implemented_evidence(story)
+    if evidence:
+        record["implementedEvidence"] = evidence
+    return record
+
+def _reconcile_stories_for_jira_creation(
+    stories: Sequence[Mapping[str, Any]],
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
+    eligible: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+    partial_adjusted: list[dict[str, Any]] = []
+
+    for index, story in enumerate(stories, start=1):
+        action = _story_jira_creation_action(story)
+        status = _story_implementation_status(story)
+        if action in STORY_JIRA_SKIP_ACTIONS or (
+            status == STORY_IMPLEMENTATION_STATUS_FULLY_IMPLEMENTED
+            and action not in STORY_JIRA_CREATE_ACTIONS
+        ):
+            skipped.append(
+                _story_reconciliation_record(story, index=index, action=action)
+            )
+            continue
+        if action in STORY_JIRA_BLOCK_ACTIONS or (
+            status == STORY_IMPLEMENTATION_STATUS_UNVERIFIABLE
+            and action not in STORY_JIRA_CREATE_ACTIONS
+        ):
+            blocked.append(
+                _story_reconciliation_record(story, index=index, action=action)
+            )
+            continue
+        if (
+            action == STORY_JIRA_ACTION_CREATE_REMAINING_WORK_ISSUE
+            or status == STORY_IMPLEMENTATION_STATUS_PARTIALLY_IMPLEMENTED
+        ):
+            adjusted = _story_for_remaining_jira_work(story, index=index)
+            partial_adjusted.append(
+                _story_reconciliation_record(story, index=index, action=action)
+            )
+            eligible.append(adjusted)
+            continue
+        eligible.append(dict(story))
+
+    return eligible, skipped, blocked, partial_adjusted
 
 def _breakdown_source_path(value: Any) -> str:
     if not isinstance(value, Mapping):
@@ -1524,6 +1758,48 @@ async def create_jira_issues_from_stories(
                 dependency_mode=dependency_mode,
             )
         raise ValueError("No stories were available for Jira issue creation.")
+
+    original_story_count = len(stories)
+    (
+        stories,
+        skipped_stories,
+        blocked_stories,
+        partial_stories_adjusted,
+    ) = _reconcile_stories_for_jira_creation(stories)
+    if not stories:
+        return ToolResult(
+            status="COMPLETED",
+            outputs={
+                "storyOutput": {
+                    "mode": "jira",
+                    "status": "jira_noop",
+                    "storyCount": original_story_count,
+                    "eligibleStoryCount": 0,
+                    "createdCount": 0,
+                    "dependencyMode": dependency_mode,
+                    "skippedStories": skipped_stories,
+                    "blockedStories": blocked_stories,
+                    "partialStoriesAdjusted": partial_stories_adjusted,
+                },
+                "jira": {
+                    "createdCount": 0,
+                    "createdIssues": [],
+                    "dependencyMode": dependency_mode,
+                    "issueMappings": [],
+                    "linkResults": [],
+                    "linkCount": 0,
+                    "dependencyChainComplete": (
+                        None
+                        if dependency_mode == JIRA_DEPENDENCY_MODE_NONE
+                        else True
+                    ),
+                    "skippedStories": skipped_stories,
+                    "blockedStories": blocked_stories,
+                    "partialStoriesAdjusted": partial_stories_adjusted,
+                },
+            },
+        )
+
     if not project_key:
         reason = (
             "Jira projectKey and issueTypeId are required."
@@ -1716,7 +1992,9 @@ async def create_jira_issues_from_stories(
     link_count = sum(
         1 for item in link_results if item.get("status") in {"created", "existing"}
     )
-    partial = any(item.get("status") == "failed" for item in link_results)
+    partial = bool(blocked_stories) or any(
+        item.get("status") == "failed" for item in link_results
+    )
     story_status = "jira_partial" if partial else "jira_created"
 
     return ToolResult(
@@ -1725,9 +2003,13 @@ async def create_jira_issues_from_stories(
             "storyOutput": {
                 "mode": "jira",
                 "status": story_status,
-                "storyCount": len(stories),
+                "storyCount": original_story_count,
+                "eligibleStoryCount": len(stories),
                 "createdCount": len(created),
                 "dependencyMode": dependency_mode,
+                "skippedStories": skipped_stories,
+                "blockedStories": blocked_stories,
+                "partialStoriesAdjusted": partial_stories_adjusted,
             },
             "jira": {
                 "createdCount": len(created),
@@ -1737,6 +2019,9 @@ async def create_jira_issues_from_stories(
                 "linkResults": link_results,
                 "linkCount": link_count,
                 "dependencyChainComplete": dependency_chain_complete,
+                "skippedStories": skipped_stories,
+                "blockedStories": blocked_stories,
+                "partialStoriesAdjusted": partial_stories_adjusted,
                 **({"partial": True} if partial else {}),
             },
         },

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -42,7 +42,6 @@ JIRA_DEPENDENCY_MODES = frozenset(
 )
 STORY_IMPLEMENTATION_STATUS_FULLY_IMPLEMENTED = "fully_implemented"
 STORY_IMPLEMENTATION_STATUS_PARTIALLY_IMPLEMENTED = "partially_implemented"
-STORY_IMPLEMENTATION_STATUS_NOT_IMPLEMENTED = "not_implemented"
 STORY_IMPLEMENTATION_STATUS_UNVERIFIABLE = "unverifiable"
 STORY_JIRA_ACTION_CREATE_ISSUE = "create_issue"
 STORY_JIRA_ACTION_CREATE_REMAINING_WORK_ISSUE = "create_remaining_work_issue"
@@ -613,10 +612,10 @@ def _story_for_remaining_jira_work(
     story: Mapping[str, Any],
     *,
     index: int,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     remaining_work = _story_remaining_work(story)
     if not remaining_work:
-        return dict(story)
+        return None
 
     adjusted = dict(story)
     original_summary = _story_summary(story, index=index)
@@ -650,6 +649,10 @@ def _story_for_remaining_jira_work(
     )
     if acceptance:
         adjusted["acceptanceCriteria"] = acceptance
+        adjusted.pop("acceptance_criteria", None)
+    else:
+        adjusted.pop("acceptanceCriteria", None)
+        adjusted.pop("acceptance_criteria", None)
     requirements = _remaining_work_list(
         remaining_work,
         "requirements",
@@ -658,6 +661,8 @@ def _story_for_remaining_jira_work(
     )
     if requirements:
         adjusted["requirements"] = requirements
+    else:
+        adjusted.pop("requirements", None)
     adjusted["originalStorySummary"] = original_summary
     return adjusted
 
@@ -719,6 +724,19 @@ def _reconcile_stories_for_jira_creation(
             or status == STORY_IMPLEMENTATION_STATUS_PARTIALLY_IMPLEMENTED
         ):
             adjusted = _story_for_remaining_jira_work(story, index=index)
+            if adjusted is None:
+                blocked_record = _story_reconciliation_record(
+                    story,
+                    index=index,
+                    action=STORY_JIRA_ACTION_MANUAL_REVIEW,
+                )
+                blocked_record.setdefault(
+                    "reason",
+                    "Partially implemented stories require remainingWork before "
+                    "Jira creation can safely narrow the issue scope.",
+                )
+                blocked.append(blocked_record)
+                continue
             partial_adjusted.append(
                 _story_reconciliation_record(story, index=index, action=action)
             )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4615,7 +4615,11 @@ class MoonMindRunWorkflow:
 
     @staticmethod
     def _is_successful_jira_story_output(*, mode: str, status: str) -> bool:
-        return mode == "jira" and status in {"jira_created", "jira_partial"}
+        return mode == "jira" and status in {
+            "jira_created",
+            "jira_partial",
+            "jira_noop",
+        }
 
     def _record_execution_context(self, *, node_id: str, execution_result: Any) -> None:
         outputs = self._get_from_result(execution_result, "outputs")

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -264,10 +264,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             for step in composite_template.latest_version.steps
         ] == [
             "moonspec-breakdown",
+            "story-reconcile-implementation",
             "story.create_jira_issues",
             "story.create_jira_orchestrate_tasks",
         ]
-        downstream_step = composite_template.latest_version.steps[2]
+        reconcile_step = composite_template.latest_version.steps[1]
+        assert "fully implemented stories" in reconcile_step["instructions"]
+        downstream_step = composite_template.latest_version.steps[3]
         assert "trusted Jira story output" in downstream_step["instructions"]
         assert "dependsOn" in downstream_step["instructions"]
         assert "orchestrationMode" not in downstream_step["jiraOrchestration"]["task"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2026,10 +2026,13 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 },
             )
 
-            assert "Jira Story issue in project GAME" in expanded["steps"][1][
+            jira_step = expanded["steps"][2]
+            downstream_step = expanded["steps"][3]
+
+            assert "Jira Story issue in project GAME" in jira_step[
                 "instructions"
             ]
-            assert expanded["steps"][1]["storyOutput"] == {
+            assert jira_step["storyOutput"] == {
                 "mode": "jira",
                 "fallback": "fail",
                 "jira": {
@@ -2040,13 +2043,13 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                     "dependencyMode": "linear_blocker_chain",
                 },
             }
-            assert expanded["steps"][2]["jiraOrchestration"]["task"]["repository"] == (
+            assert downstream_step["jiraOrchestration"]["task"]["repository"] == (
                 "ExampleOrg/Game"
             )
-            assert expanded["steps"][2]["jiraOrchestration"]["task"]["runtime"] == {
+            assert downstream_step["jiraOrchestration"]["task"]["runtime"] == {
                 "mode": "gemini_cli"
             }
-            assert expanded["steps"][2]["jiraOrchestration"]["task"]["publish"] == {
+            assert downstream_step["jiraOrchestration"]["task"]["publish"] == {
                 "mode": "pr",
                 "mergeAutomation": {"enabled": False},
             }
@@ -2139,11 +2142,11 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
                 },
             )
 
-            assert expanded["steps"][1]["storyOutput"]["jira"]["projectKey"] == "PLAT"
-            assert expanded["steps"][2]["jiraOrchestration"]["task"]["repository"] == (
+            assert expanded["steps"][2]["storyOutput"]["jira"]["projectKey"] == "PLAT"
+            assert expanded["steps"][3]["jiraOrchestration"]["task"]["repository"] == (
                 "ExampleOrg/Game"
             )
-            assert expanded["steps"][2]["jiraOrchestration"]["task"]["runtime"] == (
+            assert expanded["steps"][3]["jiraOrchestration"]["task"]["runtime"] == (
                 {"mode": "claude_code"}
             )
 

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -2413,6 +2413,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                 step["skill"]["id"] for step in template.latest_version.steps
             ] == [
                 "moonspec-breakdown",
+                "story-reconcile-implementation",
                 "story.create_jira_issues",
                 "story.create_jira_orchestrate_tasks",
             ]
@@ -2437,22 +2438,26 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                 },
             )
 
-            assert len(expanded["steps"]) == 3
+            assert len(expanded["steps"]) == 4
             assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
-            assert expanded["steps"][1]["skill"]["id"] == "story.create_jira_issues"
-            assert expanded["steps"][1]["storyOutput"]["jira"] == {
+            assert expanded["steps"][1]["skill"]["id"] == (
+                "story-reconcile-implementation"
+            )
+            assert "fully implemented stories" in expanded["steps"][1]["instructions"]
+            assert expanded["steps"][2]["skill"]["id"] == "story.create_jira_issues"
+            assert expanded["steps"][2]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
                 "boardId": "84",
                 "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
-            downstream = expanded["steps"][2]
+            downstream = expanded["steps"][3]
             assert downstream["skill"]["id"] == "story.create_jira_orchestrate_tasks"
             assert "Create one Jira Orchestrate task" in downstream["instructions"]
             assert "dependsOn" in downstream["instructions"]
             assert "MM-404" in downstream["instructions"]
-            assert "Selected Jira board ID: 84" in expanded["steps"][1]["instructions"]
+            assert "Selected Jira board ID: 84" in expanded["steps"][2]["instructions"]
             assert downstream["jiraOrchestration"]["task"] == {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},
@@ -2494,7 +2499,7 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(tmp_path):
                 },
             )
 
-            jira_step = expanded["steps"][1]
+            jira_step = expanded["steps"][2]
             assert "Create each generated Jira issue as a sub-task of MM-404" in (
                 jira_step["instructions"]
             )

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -136,6 +136,106 @@ async def test_create_jira_issues_from_inline_story_breakdown():
     assert "Intent is visible" in request.description
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_skips_completed_and_blocks_unverifiable_stories():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {"mode": "jira"},
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Already complete",
+                    "implementationStatus": "fully_implemented",
+                    "implementedEvidence": [
+                        {"requirement": "DESIGN-REQ-001", "evidence": "tests pass"}
+                    ],
+                    "jiraCreation": {
+                        "action": "skip",
+                        "reason": "All criteria already have evidence.",
+                    },
+                },
+                {
+                    "id": "STORY-002",
+                    "summary": "Needs manual review",
+                    "implementationStatus": "unverifiable",
+                    "jiraCreation": {
+                        "action": "manual_review",
+                        "reason": "External behavior cannot be verified locally.",
+                    },
+                },
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["storyOutput"]["status"] == "jira_noop"
+    assert result.outputs["storyOutput"]["storyCount"] == 2
+    assert result.outputs["storyOutput"]["eligibleStoryCount"] == 0
+    assert result.outputs["storyOutput"]["createdCount"] == 0
+    assert result.outputs["storyOutput"]["skippedStories"][0]["storyId"] == "STORY-001"
+    assert result.outputs["storyOutput"]["blockedStories"][0]["storyId"] == "STORY-002"
+    assert result.outputs["jira"]["issueMappings"] == []
+    assert service.requests == []
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_narrows_partially_implemented_story_to_remaining_work():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {"projectKey": "MM", "issueTypeId": "10001"},
+            },
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Publish report bundles",
+                    "description": "Original broad story.",
+                    "implementationStatus": "partially_implemented",
+                    "implementedEvidence": [
+                        {
+                            "requirement": "DESIGN-REQ-001",
+                            "status": "met",
+                            "evidence": "Report artifacts already persist.",
+                        }
+                    ],
+                    "remainingWork": {
+                        "summary": "Complete report bundle download UX",
+                        "description": "Add the missing Mission Control link.",
+                        "acceptanceCriteria": ["Bundle download link is visible."],
+                        "requirements": ["Expose bundle URL in the task details UI."],
+                    },
+                    "jiraCreation": {
+                        "action": "create_remaining_work_issue",
+                        "reason": "Only the UI work remains.",
+                    },
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert result.outputs["storyOutput"]["storyCount"] == 1
+    assert result.outputs["storyOutput"]["eligibleStoryCount"] == 1
+    assert result.outputs["storyOutput"]["partialStoriesAdjusted"][0]["storyId"] == (
+        "STORY-001"
+    )
+    assert len(service.requests) == 1
+    request = service.requests[0]
+    assert request.summary == "Complete report bundle download UX"
+    assert "Add the missing Mission Control link." in request.description
+    assert "Already Implemented Evidence" in request.description
+    assert "Report artifacts already persist." in request.description
+    assert "Original Story Scope" in request.description
+    assert "Original broad story." in request.description
+    assert "Bundle download link is visible." in request.description
+
+@pytest.mark.asyncio
 async def test_load_jira_preset_brief_uses_trusted_jira_issue_payload():
     service = _FakeJiraService()
     service.issue_responses["MM-657"] = {

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -236,6 +236,71 @@ async def test_create_jira_issues_narrows_partially_implemented_story_to_remaini
     assert "Bundle download link is visible." in request.description
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_blocks_partial_story_without_remaining_work():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {"projectKey": "MM", "issueTypeId": "10001"},
+            },
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Partially done without a remainder",
+                    "implementationStatus": "partially_implemented",
+                    "acceptanceCriteria": ["Original completed criterion."],
+                    "requirements": ["Original completed requirement."],
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["storyOutput"]["status"] == "jira_noop"
+    assert result.outputs["storyOutput"]["blockedStories"][0]["storyId"] == "STORY-001"
+    assert "remainingWork" in result.outputs["storyOutput"]["blockedStories"][0]["reason"]
+    assert result.outputs["storyOutput"]["partialStoriesAdjusted"] == []
+    assert service.requests == []
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_drops_original_criteria_when_partial_remaining_lists_missing():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {"projectKey": "MM", "issueTypeId": "10001"},
+            },
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Partially done",
+                    "description": "Original story description.",
+                    "implementationStatus": "partially_implemented",
+                    "acceptanceCriteria": ["Original completed criterion."],
+                    "requirements": ["Original completed requirement."],
+                    "remainingWork": {
+                        "summary": "Complete the missing behavior",
+                        "description": "Implement only the missing behavior.",
+                    },
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    request = service.requests[0]
+    assert request.summary == "Complete the missing behavior"
+    assert "Implement only the missing behavior." in request.description
+    assert "Acceptance Criteria\nOriginal completed criterion." not in request.description
+    assert "Requirements\nOriginal completed requirement." not in request.description
+
+@pytest.mark.asyncio
 async def test_load_jira_preset_brief_uses_trusted_jira_issue_payload():
     service = _FakeJiraService()
     service.issue_responses["MM-657"] = {

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1205,6 +1205,14 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
                         "instructions": "Extract MoonSpec stories.",
                     },
                     {
+                        "id": "reconcile",
+                        "tool": {
+                            "type": "skill",
+                            "name": "story-reconcile-implementation",
+                        },
+                        "instructions": "Reconcile stories with current implementation.",
+                    },
+                    {
                         "id": "jira",
                         "tool": {"type": "skill", "name": "story.create_jira_issues"},
                         "instructions": "Create Jira issues from the generated breakdown.",
@@ -1240,7 +1248,24 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
         snapshot=snapshot,
     )
 
-    orchestrate = plan["nodes"][2]
+    breakdown = plan["nodes"][0]
+    reconcile = plan["nodes"][1]
+    jira = plan["nodes"][2]
+    orchestrate = plan["nodes"][3]
+    assert reconcile["tool"] == {
+        "type": "agent_runtime",
+        "name": "story-reconcile-implementation",
+        "version": "1.0",
+    }
+    assert reconcile["inputs"]["selectedSkill"] == "story-reconcile-implementation"
+    assert (
+        reconcile["inputs"]["storyBreakdownPath"]
+        == breakdown["inputs"]["storyBreakdownPath"]
+    )
+    assert (
+        jira["inputs"]["storyBreakdownPath"]
+        == breakdown["inputs"]["storyBreakdownPath"]
+    )
     assert orchestrate["tool"] == {
         "type": "skill",
         "name": "story.create_jira_orchestrate_tasks",


### PR DESCRIPTION
## Summary
- add a story-reconcile-implementation agent skill and wire it into Jira Breakdown and Orchestrate before Jira creation
- teach story.create_jira_issues to skip fully implemented stories, block unverifiable stories, and create remaining-work issues for partially implemented stories
- update preset/tool docs and add boundary tests for template expansion, runtime planning, and Jira story output behavior

## Validation
- pytest tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step tests/unit/api/test_task_step_templates_service.py::test_seed_catalog_includes_jira_breakdown_orchestrate_preset tests/unit/api/test_task_step_templates_service.py::test_jira_breakdown_orchestrate_can_create_source_subtasks -q --tb=short
- pytest tests/integration/test_startup_task_template_seeding.py -q --tb=short
- PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3 -m py_compile moonmind/workflows/temporal/story_output_tools.py moonmind/workflows/temporal/workflows/run.py tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/test_task_step_templates_service.py tests/integration/test_startup_task_template_seeding.py
- git diff --check

## Notes
- ./tools/test_unit.sh was attempted with MOONMIND_FORCE_LOCAL_TESTS=1, but the local .venv uses Python 3.11 and fails during collection on a Python 3.12 f-string in tests/unit/services/temporal/runtime/test_managed_session_controller.py:2191 before reaching this change.
