### PR TITLE
It's problematic that the jira-issue-updater skill adds this error because then when it's a step in a larger workflow like Jira Implement preset, it r

### DIFF
--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -37,6 +37,7 @@ _SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
 _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
     {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
 )
+_REPOSITORY_PUBLISH_COMPATIBLE_SIDE_EFFECT_SKILLS = frozenset({"jira-issue-updater"})
 _JIRA_ORCHESTRATE_PRESET_SLUGS = frozenset({"jira-orchestrate"})
 _RUNTIME_COMMAND_CAPABILITY_VERSION = "2026-05-13"
 _RUNTIME_COMMAND_HINT_CATALOG_VERSION = "2026-05-13"
@@ -560,7 +561,10 @@ def resolve_publish_mode_for_skill(
         if requested_mode is None:
             return "none"
         publish_mode = _normalize_publish_mode(requested_mode)
-        if allow_repository_publish:
+        if (
+            allow_repository_publish
+            or normalized_skill_id in _REPOSITORY_PUBLISH_COMPATIBLE_SIDE_EFFECT_SKILLS
+        ):
             return publish_mode
         if publish_mode != "none":
             raise TaskContractError(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1803,10 +1803,11 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_p
     assert initial_parameters["task"]["skill"]["name"] == "jira-issue-updater"
 
 
-def test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater(
+def test_create_task_shaped_execution_allows_pr_publish_for_jira_updater(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -1833,15 +1834,12 @@ def test_create_task_shaped_execution_rejects_pr_publish_for_jira_updater(
         },
     )
 
-    assert response.status_code == 422
-    assert response.json()["detail"] == {
-        "code": "invalid_execution_request",
-        "message": (
-            "task.publish.mode must be 'none' when using non-repository skill "
-            "'jira-issue-updater'"
-        ),
-    }
-    service.create_execution.assert_not_awaited()
+    assert response.status_code == 201, response.json()
+    initial_parameters = service.create_execution.call_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["publishMode"] == "pr"
+    assert initial_parameters["task"]["publish"]["mode"] == "pr"
 
 
 def test_create_task_shaped_execution_defaults_jira_updater_publish_none(

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -904,7 +904,7 @@ def test_mm569_tool_validation_error_identifies_required_field_path() -> None:
 
 @pytest.mark.parametrize(
     "skill_id",
-    ["jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"],
+    ["jira-issue-creator", "jira-pr-verify", "jira-verify"],
 )
 def test_jira_side_effect_skills_reject_repository_publish_modes(
     skill_id: str,
@@ -914,6 +914,12 @@ def test_jira_side_effect_skills_reject_repository_publish_modes(
 
     assert resolve_publish_mode_for_skill(skill_id, None) == "none"
     assert resolve_publish_mode_for_skill(skill_id, "none") == "none"
+
+
+def test_jira_issue_updater_allows_explicit_repository_publish_modes() -> None:
+    assert resolve_publish_mode_for_skill("jira-issue-updater", "pr") == "pr"
+    assert resolve_publish_mode_for_skill("jira-issue-updater", "branch") == "branch"
+    assert resolve_publish_mode_for_skill("jira-issue-updater", None) == "none"
 
 
 def test_jira_orchestrate_preset_context_allows_first_step_skill_pr_publish() -> None:


### PR DESCRIPTION
It's problematic that the jira-issue-updater skill adds this error because then when it's a step in a larger workflow like Jira Implement preset, it restricts options in an undesirable way: "task.publish.mode must be 'none' when using non-repository skill 'jira-issue-updater'". It shouldn't have this restriction.