### PR TITLE
I get some kind of red warning toast when I click create task and I have a step that is a preset and the preset needs to expand into steps. I don't wa

### DIFF
--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
 import { createPortal } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -3855,12 +3855,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   >(null);
   const submitMessage = submitMessageState?.text ?? null;
   const submitMessageTone = submitMessageState?.tone ?? "error";
-  const setSubmitMessage = (
-    text: string | null,
-    tone: "error" | "pending" = "error",
-  ) => {
-    setSubmitMessageState(text === null ? null : { text, tone });
-  };
+  const setSubmitMessage = useCallback(
+    (text: string | null, tone: "error" | "pending" = "error") => {
+      setSubmitMessageState(text === null ? null : { text, tone });
+    },
+    [],
+  );
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isDeletingPreset, setIsDeletingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3850,7 +3850,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [previewFailureMessages, setPreviewFailureMessages] = useState<
     Record<string, string>
   >({});
-  const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const [submitMessageState, setSubmitMessageState] = useState<
+    { text: string; tone: "error" | "pending" } | null
+  >(null);
+  const submitMessage = submitMessageState?.text ?? null;
+  const submitMessageTone = submitMessageState?.tone ?? "error";
+  const setSubmitMessage = (
+    text: string | null,
+    tone: "error" | "pending" = "error",
+  ) => {
+    setSubmitMessageState(text === null ? null : { text, tone });
+  };
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isDeletingPreset, setIsDeletingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -6705,7 +6715,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           message: "Expanding preset...",
         },
       });
-      setSubmitMessage("Expanding preset...");
+      setSubmitMessage("Expanding preset...", "pending");
 
       try {
         const detail =
@@ -6912,9 +6922,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         submissionSteps = expanded.steps;
         submissionAppliedTemplates = expanded.appliedTemplates;
         if (expanded.warnings.length > 0) {
-          setSubmitMessage(expanded.warnings.join(" "));
+          setSubmitMessage(expanded.warnings.join(" "), "pending");
         } else {
-          setSubmitMessage("Creating task...");
+          setSubmitMessage("Creating task...", "pending");
         }
       } catch (error) {
         const failure =
@@ -9561,11 +9571,25 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         </label>
         <p
           id="queue-submit-message"
-          role={submitMessage ? "alert" : undefined}
-          aria-live={submitMessage ? "assertive" : undefined}
+          role={
+            submitMessage
+              ? submitMessageTone === "error"
+                ? "alert"
+                : "status"
+              : undefined
+          }
+          aria-live={
+            submitMessage
+              ? submitMessageTone === "error"
+                ? "assertive"
+                : "polite"
+              : undefined
+          }
           className={
             submitMessage
-              ? "queue-submit-message notice error"
+              ? submitMessageTone === "pending"
+                ? "queue-submit-message notice pending"
+                : "queue-submit-message notice error"
               : "queue-submit-message small"
           }
         >

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2218,6 +2218,12 @@ tr[data-proposal-id].proposal-consuming td {
   color: rgb(var(--mm-ok));
 }
 
+.notice.pending {
+  border-color: rgb(var(--mm-warn) / 0.5);
+  background: rgb(var(--mm-warn) / 0.1);
+  color: rgb(var(--mm-warn));
+}
+
 .proposal-action-feedback {
   min-height: 3.2rem;
 }


### PR DESCRIPTION
I get some kind of red warning toast when I click create task and I have a step that is a preset and the preset needs to expand into steps. I don't want this red toast to appear even if it is temporary because it makes it seem like something is wrong. If a message needs to be shown, it should be yellow and just indicate a pending action occurring of some kind.